### PR TITLE
fix: Image zoom modal touch gestures

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -207,6 +207,9 @@ Fixes an issue on iOS Safari where the first tap does not trigger the desired ac
 The `touchmove` event listener was removed from `zoom-modal.plugin.js` because it stopped the tap/click event.
 A regular `click` event is used instead to open the Zoom-Modal. The browser itself can determine via the `click` event if the user is still scrolling or clicking/taping.
 
+### Image zoom on mobile devices
+There was an issue with the image zoom modal on mobile devices using touch gestures. Now the image can correctly be moved by touch gestures again. Also the active state of the zoom buttons is now updated correctly when switching between images.
+
 ### Google Analytics 4 Integration Update
 
 The Google Analytics integration has been updated to align with `GA4` standards, enhancing e-commerce tracking capabilities.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -207,9 +207,6 @@ Fixes an issue on iOS Safari where the first tap does not trigger the desired ac
 The `touchmove` event listener was removed from `zoom-modal.plugin.js` because it stopped the tap/click event.
 A regular `click` event is used instead to open the Zoom-Modal. The browser itself can determine via the `click` event if the user is still scrolling or clicking/taping.
 
-### Image zoom on mobile devices
-There was an issue with the image zoom modal on mobile devices using touch gestures. Now the image can correctly be moved by touch gestures again. Also the active state of the zoom buttons is now updated correctly when switching between images.
-
 ### Google Analytics 4 Integration Update
 
 The Google Analytics integration has been updated to align with `GA4` standards, enhancing e-commerce tracking capabilities.

--- a/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
@@ -136,12 +136,12 @@ export default class ImageZoomPlugin extends Plugin {
      */
     _initHammer() {
         this._hammer = new Hammer(this._image, {
-            touchAction: 'none'
+            touchAction: 'none',
         });
         this._hammer.get('pinch').set({ enable: true });
         this._hammer.get('pan').set({ 
             direction: Hammer.DIRECTION_ALL,
-            threshold: 0
+            threshold: 0,
         });
     }
 
@@ -151,7 +151,7 @@ export default class ImageZoomPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
-        this._hammer.on('panstart', event => {
+        this._hammer.on('panstart', () => {
             this._panStartTransform = new Vector3(this._storedTransform.x, this._storedTransform.y, this._storedTransform.z);
         });
         this._hammer.on('pan panend pancancel', event => this._onPan(event));
@@ -197,10 +197,10 @@ export default class ImageZoomPlugin extends Plugin {
                 this.$emitter.publish('onPan');
                 return;
             }
-            
+
             // Use the transform captured at panstart instead of storedTransform
             const baseTransform = this._panStartTransform || this._storedTransform;
-            
+
             this._transform = baseTransform.add(new Vector3(event.deltaX, event.deltaY, 0));
             this._unsetTransition();
             this._updateTransform();
@@ -552,7 +552,7 @@ export default class ImageZoomPlugin extends Plugin {
     _clampTransform() {
         const minVector = new Vector3(-this._translateRange.x, -this._translateRange.y, 1);
         const maxVector = new Vector3(this._translateRange.x, this._translateRange.y, this._getMaxZoomValue());
-        
+
         this._transform = this._transform.clamp(minVector, maxVector);
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/image-zoom/image-zoom.plugin.js
@@ -6,7 +6,6 @@ import { Vector2, Vector3 } from 'src/helper/vector.helper';
  * ImageZoomPlugin class
  */
 export default class ImageZoomPlugin extends Plugin {
-
     static options = {
 
         /**
@@ -66,7 +65,7 @@ export default class ImageZoomPlugin extends Plugin {
 
         /**
          * selector to determent if the image is active at the moment
-         * set to fall if this should be ignored
+         * set to false if this should be ignored
          *
          * @type string|boolean
          */
@@ -101,15 +100,33 @@ export default class ImageZoomPlugin extends Plugin {
         this._updateTranslateRange();
         this._initHammer();
         this._registerEvents();
-        this._setActionButtonState();
+        
+        // Set button state after a brief delay to ensure image is laid out
+        setTimeout(() => {
+            this._setActionButtonState();
+        }, 0);
     }
 
     /**
      * updates the zoom values
      */
     update() {
-        this._updateTransform();
-        this._setActionButtonState();
+        // Reset transform state when switching images
+        this._storedTransform = new Vector3(0, 0, 1);
+        this._transform = new Vector3(0, 0, 1);
+        
+        // Recalculate sizes for the new image
+        this._imageMaxSize = new Vector2(this._image.naturalWidth, this._image.naturalHeight).multiply(2);
+        this._imageSize = new Vector2(this._image.offsetWidth, this._image.offsetHeight);
+        this._containerSize = new Vector2(this.el.offsetWidth, this.el.offsetHeight);
+        
+        this._updateTranslateRange();
+        this._updateTransform(true);
+        
+        // Set button state after a brief delay to ensure image is laid out
+        setTimeout(() => {
+            this._setActionButtonState();
+        }, 0);
     }
 
     /**
@@ -118,9 +135,14 @@ export default class ImageZoomPlugin extends Plugin {
      * @private
      */
     _initHammer() {
-        this._hammer = new Hammer(this.el);
+        this._hammer = new Hammer(this._image, {
+            touchAction: 'none'
+        });
         this._hammer.get('pinch').set({ enable: true });
-        this._hammer.get('pan').set({ direction: Hammer.DIRECTION_ALL });
+        this._hammer.get('pan').set({ 
+            direction: Hammer.DIRECTION_ALL,
+            threshold: 0
+        });
     }
 
     /**
@@ -129,10 +151,12 @@ export default class ImageZoomPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
-        this._hammer.on('pan', event => this._onPan(event));
+        this._hammer.on('panstart', event => {
+            this._panStartTransform = new Vector3(this._storedTransform.x, this._storedTransform.y, this._storedTransform.z);
+        });
+        this._hammer.on('pan panend pancancel', event => this._onPan(event));
         this._hammer.on('pinch pinchmove', event => this._onPinch(event));
         this._hammer.on('doubletap', event => this._onDoubleTap(event));
-        this._hammer.on('panend pancancel pinchend pinchcancel', event => this._onInteractionEnd(event));
 
         this.el.addEventListener('wheel', event => this._onMouseWheel(event), false);
         this._image.addEventListener('mousedown', event => event.preventDefault(), false);
@@ -164,7 +188,20 @@ export default class ImageZoomPlugin extends Plugin {
      */
     _onPan(event) {
         if (this._isActive()) {
-            this._transform = this._storedTransform.add(new Vector3(event.deltaX, event.deltaY, 0));
+            // On isFinal event, just store the current transform without recalculating
+            if (event.isFinal) {
+                this._updateStoredTransformVector();
+                this._setActionButtonState();
+                this._setCursor('default');
+                this._panStartTransform = null;
+                this.$emitter.publish('onPan');
+                return;
+            }
+            
+            // Use the transform captured at panstart instead of storedTransform
+            const baseTransform = this._panStartTransform || this._storedTransform;
+            
+            this._transform = baseTransform.add(new Vector3(event.deltaX, event.deltaY, 0));
             this._unsetTransition();
             this._updateTransform();
             this._setCursor('move');
@@ -181,13 +218,17 @@ export default class ImageZoomPlugin extends Plugin {
      */
     _onPinch(event) {
         if (this._isActive()) {
-            const x = this._storedTransform.x + event.deltaX;
-            const y = this._storedTransform.x + event.deltaY;
+            // Pinch events may not have reliable deltaX/deltaY, use 0 as fallback
+            const deltaX = (typeof event.deltaX === 'number' && !isNaN(event.deltaX)) ? event.deltaX : 0;
+            const deltaY = (typeof event.deltaY === 'number' && !isNaN(event.deltaY)) ? event.deltaY : 0;
+
+            const x = this._storedTransform.x + deltaX;
+            const y = this._storedTransform.y + deltaY;
             const z = this._storedTransform.z * event.scale;
 
             this._transform = new Vector3(x, y, z);
             this._unsetTransition();
-            this._updateTransform();
+            this._updateTransform(event.isFinal);
             this._setCursor('move');
         }
 
@@ -334,7 +375,6 @@ export default class ImageZoomPlugin extends Plugin {
     _updateTransform(updateStoredTransform) {
         this._updateTranslateRange();
         this._clampTransform();
-        this._setActionButtonState();
 
         const translateX = `translateX(${Math.round(this._transform.x)}px)`;
         const translateY = `translateY(${Math.round(this._transform.y)}px)`;
@@ -347,6 +387,7 @@ export default class ImageZoomPlugin extends Plugin {
 
         if (updateStoredTransform) {
             this._updateStoredTransformVector();
+            this._setActionButtonState();
         }
 
         this.$emitter.publish('updateTransform');
@@ -358,19 +399,22 @@ export default class ImageZoomPlugin extends Plugin {
      * @private
      */
     _setActionButtonState() {
-        if (this._transform.z === 1 && this._getMaxZoomValue() === 1) {
+        const currentZoom = this._transform.z;
+        const maxZoom = this._getMaxZoomValue();
+
+        if (currentZoom === 1 && maxZoom === 1) {
             this._setButtonDisabledState(this._zoomResetActionElement);
             this._setButtonDisabledState(this._zoomOutActionElement);
             this._setButtonDisabledState(this._zoomInActionElement);
-        } else if (this._getMaxZoomValue() === this._transform.z && this._isTranslatable()) {
+        } else if (maxZoom === currentZoom && !this._isTranslatable()) {
             this._setButtonDisabledState(this._zoomResetActionElement);
             this._setButtonDisabledState(this._zoomOutActionElement);
             this._setButtonDisabledState(this._zoomInActionElement);
-        } else if (this._getMaxZoomValue() === this._transform.z) {
+        } else if (maxZoom === currentZoom) {
             this._unsetButtonDisabledState(this._zoomResetActionElement);
             this._unsetButtonDisabledState(this._zoomOutActionElement);
             this._setButtonDisabledState(this._zoomInActionElement);
-        } else if (this._transform.z === 1) {
+        } else if (currentZoom === 1) {
             this._setButtonDisabledState(this._zoomResetActionElement);
             this._setButtonDisabledState(this._zoomOutActionElement);
             this._unsetButtonDisabledState(this._zoomInActionElement);
@@ -389,7 +433,7 @@ export default class ImageZoomPlugin extends Plugin {
      * @private
      */
     _isTranslatable(){
-        return this._translateRange.x === 0 && this._translateRange.y === 0;
+        return this._translateRange.x > 0 || this._translateRange.y > 0;
     }
 
     /**
@@ -437,7 +481,7 @@ export default class ImageZoomPlugin extends Plugin {
         scaledImageSize.x = Math.round(scaledImageSize.x);
         scaledImageSize.y = Math.round(scaledImageSize.y);
 
-        this._translateRange = scaledImageSize.subtract(this._containerSize).clamp(0, scaledImageSize).divide(2);
+        this._translateRange = scaledImageSize.subtract(this._containerSize).clamp(0, Infinity).divide(2);
     }
 
     /**
@@ -453,7 +497,9 @@ export default class ImageZoomPlugin extends Plugin {
             return 1;
         }
 
-        const max = this._imageMaxSize.divide(this._imageSize);
+        // Always use current natural dimensions, not the cached _imageMaxSize
+        const currentImageMaxSize = new Vector2(this._image.naturalWidth, this._image.naturalHeight).multiply(2);
+        const max = currentImageMaxSize.divide(this._imageSize);
 
         return Math.max(max.x, max.y);
     }
@@ -506,7 +552,7 @@ export default class ImageZoomPlugin extends Plugin {
     _clampTransform() {
         const minVector = new Vector3(-this._translateRange.x, -this._translateRange.y, 1);
         const maxVector = new Vector3(this._translateRange.x, this._translateRange.y, this._getMaxZoomValue());
-
+        
         this._transform = this._transform.clamp(minVector, maxVector);
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
@@ -358,7 +358,9 @@ export default class ZoomModalPlugin extends Plugin {
         } else {
             window.PluginManager.register('ImageZoom', ImageZoomPlugin, this.options.imageZoomInitSelector);
 
-            window.PluginManager.initializePlugin('ImageZoom', this.options.imageZoomInitSelector);
+            window.PluginManager.initializePlugin('ImageZoom', this.options.imageZoomInitSelector, {
+                activeClassSelector: false,
+            });
         }
 
         this.imageZoomRegistered = true;

--- a/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
@@ -256,8 +256,6 @@ export default class ZoomModalPlugin extends Plugin {
         if (!this._showModalListener) {
             this._showModalListener = () => {
                 this._initSlider(modal);
-                this._registerImageZoom();
-
                 this.$emitter.publish('modalShow', { modal });
             };
         }
@@ -284,6 +282,8 @@ export default class ZoomModalPlugin extends Plugin {
         const slider = modal.querySelector(this.options.modalGallerySliderSelector);
 
         if (!slider) {
+            // No slider, but still need to register ImageZoom for single image
+            this._registerImageZoom();
             return;
         }
 
@@ -293,6 +293,9 @@ export default class ZoomModalPlugin extends Plugin {
         if (this.gallerySliderPlugin && this.gallerySliderPlugin._slider) {
             this.gallerySliderPlugin._slider.goTo(parentSliderIndex);
             window.focusHandler.setFocus(galleryImages.item(parentSliderIndex));
+
+            // Register ImageZoom if not already registered
+            this._registerImageZoom();
 
             return;
         }
@@ -323,6 +326,9 @@ export default class ZoomModalPlugin extends Plugin {
             this.gallerySliderPlugin._slider.goTo(parentSliderIndex);
             window.focusHandler.setFocus(galleryImages.item(parentSliderIndex));
 
+            // Register ImageZoom here after gallerySliderPlugin is ready
+            this._registerImageZoom();
+
             this.$emitter.publish('initSlider');
         });
     }
@@ -342,14 +348,17 @@ export default class ZoomModalPlugin extends Plugin {
 
             window.PluginManager.initializePlugin('ImageZoom', this.options.activeSlideSelector + ' ' + this.options.imageZoomInitSelector);
 
-            this.gallerySliderPlugin._slider.events.off('indexChanged', this._updateImageZoom.bind(this));
-            this.gallerySliderPlugin._slider.events.on('indexChanged',this._updateImageZoom.bind(this));
+            // Create bound function once and store it
+            if (!this._boundUpdateImageZoom) {
+                this._boundUpdateImageZoom = this._updateImageZoom.bind(this);
+            }
+
+            this.gallerySliderPlugin._slider.events.off('indexChanged', this._boundUpdateImageZoom);
+            this.gallerySliderPlugin._slider.events.on('indexChanged', this._boundUpdateImageZoom);
         } else {
             window.PluginManager.register('ImageZoom', ImageZoomPlugin, this.options.imageZoomInitSelector);
 
-            window.PluginManager.initializePlugin('ImageZoom', this.options.imageZoomInitSelector, {
-                activeClassSelector: false,
-            });
+            window.PluginManager.initializePlugin('ImageZoom', this.options.imageZoomInitSelector);
         }
 
         this.imageZoomRegistered = true;


### PR DESCRIPTION
Fixes: [#6446](https://github.com/shopware/shopware/issues/6446)

### 1. Why is this change necessary?

The image zoom modal from the product detail page is not working correctly with touch gestures. Also the state of the zoom buttons is not updated correctly when switching between images.


### 2. What does this change do, exactly?

It fixes the two described problems.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a product with several large images
* Go to the product detail page
* Click on one of the images in the image gallery to open the zoom modal
* Zoom in and move an image in the zoom modal with touch gestures
