### PR TITLE
fix: update router link for user edit context menu item in user listing component

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -73,7 +73,7 @@
             <sw-context-menu-item
                 class="sw-settings-user-list__user-view-action"
                 :disabled="!acl.can('users_and_permissions.editor') || undefined"
-                :router-link="{ name: 'sw.users.permissions.user.sso.detail', params: { id: item.id } }"
+                :router-link="{ name: 'sw.users.permissions.user.detail', params: { id: item.id } }"
             >
                 {{ $tc('sw-users-permissions.users.user-grid.contextMenuEdit') }}
             </sw-context-menu-item>

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.spec.js
@@ -59,8 +59,13 @@ async function createWrapper(privileges = [], isSso = { isSso: false }) {
 `,
                     },
                     'sw-context-menu-item': {
-                        template: '<div class="sw-context-menu-item-stub" :disabled="disabled ? \'true\' : undefined"><slot /></div>',
-                        props: ['disabled', 'routerLink', 'variant'],
+                        template:
+                            '<div class="sw-context-menu-item-stub" :disabled="disabled ? \'true\' : undefined"><slot /></div>',
+                        props: [
+                            'disabled',
+                            'routerLink',
+                            'variant',
+                        ],
                     },
                     'sw-avatar': true,
                     'router-link': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.spec.js
@@ -58,7 +58,10 @@ async function createWrapper(privileges = [], isSso = { isSso: false }) {
 </div>
 `,
                     },
-                    'sw-context-menu-item': true,
+                    'sw-context-menu-item': {
+                        template: '<div class="sw-context-menu-item-stub" :disabled="disabled ? \'true\' : undefined"><slot /></div>',
+                        props: ['disabled', 'routerLink', 'variant'],
+                    },
                     'sw-avatar': true,
                     'router-link': true,
                     'sw-pagination': true,
@@ -230,5 +233,31 @@ describe('module/sw-users-permissions/components/sw-users-permissions-user-listi
 
         const addUserButton = wrapper.find('.sw-users-permissions-user-listing__add-user-button');
         expect(addUserButton.find('span').text()).toBe('sw-users-permissions.sso.inviteButtonLabel');
+    });
+
+    it('should use the correct route for the Edit context menu item', async () => {
+        wrapper = await createWrapper(['users_and_permissions.editor']);
+        await wrapper.vm.$nextTick();
+        await wrapper.setData({
+            user: [
+                {
+                    id: '019bff8c86e773e79ec5538c7b1ed571',
+                    username: 'admin',
+                    firstName: 'Admin',
+                    lastName: 'User',
+                    email: 'admin@example.com',
+                },
+            ],
+        });
+        await wrapper.vm.$nextTick();
+
+        const contextMenuEdit = wrapper.findComponent('.sw-settings-user-list__user-view-action');
+        expect(contextMenuEdit.exists()).toBe(true);
+
+        // Check that the router-link prop uses the correct route name
+        const routerLinkProp = contextMenuEdit.vm.$props.routerLink;
+        expect(routerLinkProp).toBeDefined();
+        expect(routerLinkProp.name).toBe('sw.users.permissions.user.detail');
+        expect(routerLinkProp.params.id).toBe('019bff8c86e773e79ec5538c7b1ed571');
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Fixes https://github.com/shopware/shopware/issues/13888

When trying to save the Shopware user in the backend 6.7.5.0, the following error message appears: 403 Forbidden FRAMEWORK__INVALID_SCOPE_ACCESS_TOKEN (This access token does not have the scope "user-verified" to process this Request). Apparently, the password prompt does not appear when saving.

### 2. What does this change do, exactly?

Change the wrong route to the correct one. With the correct route we can save the user correctly