### PR TITLE
chore: add 6.7.8.0 section to release info

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,4 +1,33 @@
-# 6.7.7.0 (upcoming)
+# 6.7.8.0 (upcoming)
+
+## Features
+
+## API
+
+## Core
+
+### Migration generator improvements
+
+The migration generator previously used a fixed format: `fk.<table-name>.<column>` for foreign key names. Doctrine does not support this format and creates broken migrations; therefore, we changed to the format `fk__<table-name>__<column>` for foreign key names.
+
+Also, the generator now sets `CASCADE DELETE` on foreign keys for the translation table references.
+
+## Administration
+
+## Storefront
+
+### Selling and packaging information in the product detail page
+
+* Display the selling and packaging information with the product that has advanced pricing.
+* Deprecated block `buy_widget_price_unit` and it childrens in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
+
+## App System
+
+## Hosting & Configuration
+
+## Critical Fixes
+
+# 6.7.7.0
 
 ## Features
 
@@ -143,11 +172,6 @@ This affects the following exception factory methods:
 * `WebhookException::invalidDataMapping(...)`
 * `WebhookException::unknownEventDataType(...)`
 
-### Migration generator improvements
-
-The migration generator previously used a fixed format: `fk.<table-name>.<column>` for foreign key names. Doctrine does not support this format and creates broken migrations; therefore, we changed to the format `fk__<table-name>__<column>` for foreign key names.
-
-Also, the generator now sets `CASCADE DELETE` on foreign keys for the translation table references.
 ### More fine-grained caching control in `HttpCacheCookieEvent`
 
 A new `doNotStore` property was added to the `HttpCacheCookieEvent` to allow fine-grained control over caching behavior.
@@ -181,11 +205,6 @@ The following deprecations apply to `sw-mail-template-index`:
 * `onChangeLanguage` method: the if/else block will be replaced with just the if-branch logic in v6.8.0.0
 
 ## Storefront
-
-### Selling and packaging information in the product detail page
-
-* Display the selling and packaging information with the product that has advanced pricing.
-* Deprecated block `buy_widget_price_unit` and it childrens in `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`, will be moved into `Resources/views/storefront/component/buy-widget/buy-widget.html.twig`.
 
 ### Cookie consent now language-aware
 


### PR DESCRIPTION
### 1. Why is this change necessary?

6.7.7.x was already branched

### 2. What does this change do, exactly?

Adds 6.7.8.0 section and moves information for changes that will not get into 6.7.7.0

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
