### PR TITLE
fix: Google reCAPTCHA base plugin initialization and form validation feedback with multiple forms

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -3,13 +3,15 @@ import Plugin from 'src/plugin-system/plugin.class';
 export default class GoogleReCaptchaBasePlugin extends Plugin {
     init() {
         const recaptchaScript = document.getElementById('recaptcha-script');
-        if (!recaptchaScript || recaptchaScript.hasAttribute('src')) {
+        if (!recaptchaScript) {
             return;
         }
 
-        const dataSrc = recaptchaScript.getAttribute('data-src');
-        if (dataSrc && this._isValidUrl(dataSrc)) {
-            recaptchaScript.setAttribute('src', encodeURI(dataSrc));
+        if (!recaptchaScript.hasAttribute('src')) {
+            const dataSrc = recaptchaScript.getAttribute('data-src');
+            if (dataSrc && this._isValidUrl(dataSrc)) {
+                recaptchaScript.setAttribute('src', encodeURI(dataSrc));
+            }
         }
 
         // The shim script in main.js ensures window.grecaptcha and window.grecaptcha.ready exist.

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
@@ -6,6 +6,18 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
     let originalPluginManager;
     let mockRecaptchaScriptElement;
 
+    function createMockElement() {
+        const form = document.createElement('form');
+        const inputField = document.createElement('input');
+        inputField.className = 'grecaptcha-input';
+        form.appendChild(inputField);
+
+        form.submit = jest.fn();
+        form.checkValidity = jest.fn(() => true);
+
+        return form;
+    }
+
     beforeEach(() => {
         window.grecaptcha = {
             ready: jest.fn(),
@@ -13,14 +25,7 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
             execute: jest.fn(),
         };
 
-        mockElement = document.createElement('form');
-        const inputField = document.createElement('input');
-        inputField.className = 'grecaptcha-input';
-        mockElement.appendChild(inputField);
-
-        mockElement.submit = jest.fn();
-        mockElement.checkValidity = jest.fn(() => true);
-
+        mockElement = createMockElement();
         document.body.appendChild(mockElement);
 
         mockRecaptchaScriptElement = document.createElement('script');
@@ -82,29 +87,42 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
         }
     });
 
-    test('init returns early if recaptcha script already has src attribute', () => {
+    test('init sets global recaptcha script src attribute only once and calls grecaptcha.ready for each google-re-captcha plugin instance', () => {
         if (mockRecaptchaScriptElement?.parentElement) {
             mockRecaptchaScriptElement.parentElement.removeChild(mockRecaptchaScriptElement);
         }
 
         const script = document.createElement('script');
         script.id = 'recaptcha-script';
-        script.setAttribute('src', 'already-set.js');
         script.setAttribute('data-src', 'http://example.com/recaptcha.js');
         document.body.appendChild(script);
+        const setAttributeSpy = jest.spyOn(script, 'setAttribute');
 
-        // Mock grecaptcha.ready to track if it was called
+        // Mock grecaptcha.ready to track how many times it was called
         const mockReady = jest.fn();
         window.grecaptcha.ready = mockReady;
 
-        // eslint-disable-next-line no-unused-vars
-        const pluginWithExistingSrc = new GoogleReCaptchaBasePlugin(mockElement, {
+        new GoogleReCaptchaBasePlugin(mockElement, {
             grecaptchaInputSelector: '.grecaptcha-input',
         });
 
-        // Should not have changed the src and should not call grecaptcha.ready
-        expect(script.getAttribute('src')).toBe('already-set.js');
-        expect(mockReady).not.toHaveBeenCalled();
+        const mockElement2 = createMockElement();
+        document.body.appendChild(mockElement2);
+
+        new GoogleReCaptchaBasePlugin(mockElement2, {
+            grecaptchaInputSelector: '.grecaptcha-input',
+        });
+
+        const mockElement3 = createMockElement();
+        document.body.appendChild(mockElement3);
+
+        new GoogleReCaptchaBasePlugin(mockElement3, {
+            grecaptchaInputSelector: '.grecaptcha-input',
+        });
+
+        // Should set the src attribute only once and should call grecaptcha.ready once per plugin instance
+        expect(setAttributeSpy.mock.calls.filter(([attribute]) => attribute === 'src')).toHaveLength(1);
+        expect(mockReady).toHaveBeenCalledTimes(3);
 
         if (script.parentElement) {
             script.parentElement.removeChild(script);

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -4,6 +4,8 @@
         invisible: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV2.config.invisible')
     } %}
 
+    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+
     <div class="captcha-google-re-captcha-v2"
          data-google-re-captcha-v2="true"
          data-google-re-captcha-v2-options="{{ googleReCaptchaV2Options|json_encode }}">
@@ -13,7 +15,7 @@
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV2::CAPTCHA_REQUEST_PARAMETER') }}"
             data-validation="grecaptcha,required"
             data-validate-hidden="true"
-            aria-describedby="grecaptcha-feedback-container">
+            aria-describedby="{{ feedbackId }}">
 
         <div class="grecaptcha-v2-container"></div>
 
@@ -27,6 +29,6 @@
             {% endif %}
         {% endif %}
 
-        <div id="grecaptcha-feedback-container" class="form-field-feedback"></div>
+        <div id="{{ feedbackId }}" class="form-field-feedback"></div>
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -3,6 +3,8 @@
         siteKey: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV3.config.siteKey')
     } %}
 
+    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+
     <div class="captcha-google-re-captcha-v3"
          data-google-re-captcha-v3="true"
          data-google-re-captcha-v3-options="{{ googleReCaptchaV3Options|json_encode }}">
@@ -12,12 +14,12 @@
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV3::CAPTCHA_REQUEST_PARAMETER') }}"
             data-validation="grecaptcha,required"
             data-validate-hidden="true"
-            aria-describedby="grecaptcha-feedback-container">
+            aria-describedby="{{ feedbackId }}">
 
         <div class="data-protection-information grecaptcha-protection-information">
             {{ 'captcha.googleReCaptcha.dataProtectionInformation'|trans|sw_sanitize }}
         </div>
 
-        <div id="grecaptcha-feedback-container" class="form-field-feedback"></div>
+        <div id="{{ feedbackId }}" class="form-field-feedback"></div>
     </div>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Having multiple forms on one page with google recaptcha active and not accepting cookies, the error feedback always appears on the first form in the DOM because they all use the same feedback container id.

### 2. What does this change do, exactly?
Make use of the passed in `formId` variable from `captcha/base.html.twig` to create a unique feedback container id for each form.

### 3. Describe each step to reproduce the issue or behaviour.
Enable google recaptcha v3 > create a page with a newsletter form element >go to Storefront and do not accept cookies > open the page with the newsletter form element > click on the contact form link in the footer, fill in all necessary fields and try to submit it > the grecaptcha error is displayed inside the newsletter form instead of the currently opened contact form.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #14520

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
