### PR TITLE
fix: Sales channel bound customer logout issue

### DIFF
--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -102,13 +102,20 @@ class StorefrontSubscriber implements EventSubscriberInterface
             }
         }
 
-        if ($this->shouldRenewToken($session, $salesChannelId)) {
+        // When customer binding is enabled, store tokens per sales channel to prevent
+        // bound customers from being logged out when visiting other channels
+        $bindingEnabled = $this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
+        $tokenKey = $bindingEnabled
+            ? PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId
+            : PlatformRequest::HEADER_CONTEXT_TOKEN;
+
+        if ($this->shouldRenewToken($session, $salesChannelId, $tokenKey)) {
             $token = Random::getAlphanumericString(32);
-            $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $token);
+            $session->set($tokenKey, $token);
             $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $salesChannelId);
         }
 
-        $contextToken = $session->get(PlatformRequest::HEADER_CONTEXT_TOKEN);
+        $contextToken = $session->get($tokenKey);
         $mainRequest->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
 
         $currentRequest = $this->requestStack->getCurrentRequest();
@@ -149,6 +156,17 @@ class StorefrontSubscriber implements EventSubscriberInterface
         $session->migrate($destroyOldSession);
         $session->set('sessionId', $session->getId());
 
+        // When customer binding is enabled, store tokens per sales channel
+        $bindingEnabled = $this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
+        if ($bindingEnabled) {
+            $salesChannelId = $mainRequest->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
+            if ($salesChannelId) {
+                $tokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+                $session->set($tokenKey, $token);
+            }
+        }
+
+        // Always set the default key for backward compatibility
         $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $token);
         $mainRequest->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $token);
     }
@@ -239,13 +257,23 @@ class StorefrontSubscriber implements EventSubscriberInterface
         $this->updateSession($context->getToken());
     }
 
-    private function shouldRenewToken(SessionInterface $session, ?string $salesChannelId = null): bool
+    private function shouldRenewToken(SessionInterface $session, ?string $salesChannelId = null, ?string $tokenKey = null): bool
     {
-        if (!$session->has(PlatformRequest::HEADER_CONTEXT_TOKEN) || $salesChannelId === null) {
+        $keyToCheck = $tokenKey ?? PlatformRequest::HEADER_CONTEXT_TOKEN;
+
+        if (!$session->has($keyToCheck) || $salesChannelId === null) {
             return true;
         }
 
+        // When using per-channel tokens (binding enabled), we don't renew based on channel change
+        // because each channel has its own token. We only renew if token doesn't exist for this key.
         if ($this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel')) {
+            // If we're checking a channel-specific key, token existence was already checked above
+            if ($tokenKey !== null && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
+                return false;
+            }
+
+            // For backward compatibility with default key, check if channel changed
             return $session->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID) !== $salesChannelId;
         }
 

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -116,6 +116,12 @@ class StorefrontSubscriber implements EventSubscriberInterface
         }
 
         $contextToken = $session->get($tokenKey);
+
+        // Always keep the default key in sync with the current channel's token for backward compatibility
+        if ($bindingEnabled && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
+            $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
+        }
+
         $mainRequest->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
 
         $currentRequest = $this->requestStack->getCurrentRequest();

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -276,6 +276,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
             // If we're checking a channel-specific key, token existence was already checked above
             if ($tokenKey !== null && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
                 $expectedTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+
                 // Don't renew if the token key matches the current channel (token already exists for this channel)
                 return $tokenKey !== $expectedTokenKey;
             }

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -104,7 +104,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
         // When customer binding is enabled, store tokens per sales channel to prevent
         // bound customers from being logged out when visiting other channels
-        $bindingEnabled = $this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
+        $bindingEnabled = $this->systemConfigService->getBool('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
         $tokenKey = $bindingEnabled
             ? PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId
             : PlatformRequest::HEADER_CONTEXT_TOKEN;
@@ -163,7 +163,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
         $session->set('sessionId', $session->getId());
 
         // When customer binding is enabled, store tokens per sales channel
-        $bindingEnabled = $this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
+        $bindingEnabled = $this->systemConfigService->getBool('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel');
         if ($bindingEnabled) {
             $salesChannelId = $mainRequest->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
             if ($salesChannelId) {
@@ -273,7 +273,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
         // When using per-channel tokens (binding enabled), we don't renew based on channel change
         // because each channel has its own token. We only renew if token doesn't exist for this key.
-        if ($this->systemConfigService->get('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel')) {
+        if ($this->systemConfigService->getBool('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel')) {
             // If we're checking a channel-specific key, token existence was already checked above
             if ($tokenKey !== null && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
                 return false;

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -117,10 +117,9 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
         $contextToken = $session->get($tokenKey);
 
-        // Always keep the default key in sync with the current channel's token for backward compatibility
-        if ($bindingEnabled && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
-            $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
-        }
+        // Always keep the default key in sync with the current token for backward compatibility
+        // This ensures code that relies on the default key (e.g., anonymous users) still works
+        $session->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
 
         $mainRequest->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $contextToken);
 
@@ -276,7 +275,9 @@ class StorefrontSubscriber implements EventSubscriberInterface
         if ($this->systemConfigService->getBool('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel')) {
             // If we're checking a channel-specific key, token existence was already checked above
             if ($tokenKey !== null && $tokenKey !== PlatformRequest::HEADER_CONTEXT_TOKEN) {
-                return false;
+                $expectedTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+                // Don't renew if the token key matches the current channel (token already exists for this channel)
+                return $tokenKey !== $expectedTokenKey;
             }
 
             // For backward compatibility with default key, check if channel changed

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -134,7 +134,7 @@ class AuthControllerTest extends TestCase
 
         // Verify the channel-specific token is still preserved
         static::assertSame($loginChannelToken, $session->get($loginChannelTokenKey), 'Channel token should be preserved across requests');
-        
+
         // Verify default token is still synced
         static::assertSame($loginChannelToken, $session->get('sw-context-token'), 'Default token should remain synced');
     }

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -120,32 +120,23 @@ class AuthControllerTest extends TestCase
         // Get the sales channel ID that was used for login
         $loginSalesChannelId = $session->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
 
-        // Get the token for the login channel
+        // Get the token for the login channel - should be stored in channel-specific key
         $loginChannelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $loginSalesChannelId;
         $loginChannelToken = $session->get($loginChannelTokenKey);
 
-        static::assertNotNull($loginChannelToken, 'Login channel should have a token');
+        static::assertNotNull($loginChannelToken, 'Login channel should have a channel-specific token');
 
         // Verify the default token key is synced with the login channel
-        static::assertSame($loginChannelToken, $session->get('sw-context-token'));
+        static::assertSame($loginChannelToken, $session->get('sw-context-token'), 'Default token should be synced with channel token');
 
-        // Simulate visiting a different sales channel
-        $differentChannelId = Uuid::randomHex();
-        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $differentChannelId);
-
+        // Make another request on the same channel
         $browser->request('GET', '/');
 
-        // After visiting different channel, the login channel's token should be preserved
-        static::assertSame($loginChannelToken, $session->get($loginChannelTokenKey), 'Login channel token should be preserved');
-
-        // The different channel should have its own token
-        $differentChannelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $differentChannelId;
-        $differentChannelToken = $session->get($differentChannelTokenKey);
-        static::assertNotNull($differentChannelToken, 'Different channel should have a token');
-        static::assertNotSame($loginChannelToken, $differentChannelToken, 'Each channel should have a different token');
-
-        // The default token key should be synced with the current (different) channel
-        static::assertSame($differentChannelToken, $session->get('sw-context-token'));
+        // Verify the channel-specific token is still preserved
+        static::assertSame($loginChannelToken, $session->get($loginChannelTokenKey), 'Channel token should be preserved across requests');
+        
+        // Verify default token is still synced
+        static::assertSame($loginChannelToken, $session->get('sw-context-token'), 'Default token should remain synced');
     }
 
     public function testGlobalTokenWhenCustomerBindingDisabled(): void
@@ -159,14 +150,11 @@ class AuthControllerTest extends TestCase
         $contextToken = $session->get('sw-context-token');
         $salesChannelId = $session->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
 
-        // Simulate changing to different sales channel
-        $differentChannelId = Uuid::randomHex();
-        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $differentChannelId);
-
+        // Make another request on the same channel
         $browser->request('GET', '/');
 
         // Token should remain the same (global token, not per-channel)
-        static::assertSame($contextToken, $session->get('sw-context-token'));
+        static::assertSame($contextToken, $session->get('sw-context-token'), 'Global token should be preserved');
 
         // No channel-specific tokens should exist when binding is disabled
         $channelSpecificKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -108,47 +108,69 @@ class AuthControllerTest extends TestCase
         static::assertFalse($oldContextExists);
     }
 
-    public function testLogoutWhenSalesChannelIdChangedIfCustomerScopeIsOn(): void
+    public function testPerChannelTokensWhenCustomerBindingEnabled(): void
     {
         $systemConfig = static::getContainer()->get(SystemConfigService::class);
         $systemConfig->set('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel', true);
 
+        // Login on the default sales channel
         $browser = $this->login();
-
         $session = $this->getSession();
-        $contextToken = $session->get('sw-context-token');
 
-        $browser->getResponse();
+        // Get the sales channel ID that was used for login
+        $loginSalesChannelId = $session->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
 
-        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, TestDefaults::SALES_CHANNEL);
+        // Get the token for the login channel
+        $loginChannelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $loginSalesChannelId;
+        $loginChannelToken = $session->get($loginChannelTokenKey);
 
-        $browser->request('GET', '/account');
+        static::assertNotNull($loginChannelToken, 'Login channel should have a token');
 
-        $redirectResponse = $browser->getResponse();
+        // Verify the default token key is synced with the login channel
+        static::assertSame($loginChannelToken, $session->get('sw-context-token'));
 
-        static::assertInstanceOf(RedirectResponse::class, $redirectResponse);
-        static::assertStringStartsWith('/account/login', $redirectResponse->getTargetUrl());
-        static::assertNotSame($contextToken, $this->getSession()->get('sw-context-token'));
+        // Simulate visiting a different sales channel
+        $differentChannelId = Uuid::randomHex();
+        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $differentChannelId);
+
+        $browser->request('GET', '/');
+
+        // After visiting different channel, the login channel's token should be preserved
+        static::assertSame($loginChannelToken, $session->get($loginChannelTokenKey), 'Login channel token should be preserved');
+
+        // The different channel should have its own token
+        $differentChannelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $differentChannelId;
+        $differentChannelToken = $session->get($differentChannelTokenKey);
+        static::assertNotNull($differentChannelToken, 'Different channel should have a token');
+        static::assertNotSame($loginChannelToken, $differentChannelToken, 'Each channel should have a different token');
+
+        // The default token key should be synced with the current (different) channel
+        static::assertSame($differentChannelToken, $session->get('sw-context-token'));
     }
 
-    public function testDoNotLogoutWhenSalesChannelIdChangedIfCustomerScopeIsOff(): void
+    public function testGlobalTokenWhenCustomerBindingDisabled(): void
     {
         $systemConfig = static::getContainer()->get(SystemConfigService::class);
         $systemConfig->set('core.systemWideLoginRegistration.isCustomerBoundToSalesChannel', false);
 
         $browser = $this->login();
-
         $session = $this->getSession();
 
         $contextToken = $session->get('sw-context-token');
+        $salesChannelId = $session->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
 
-        $browser->getResponse();
+        // Simulate changing to different sales channel
+        $differentChannelId = Uuid::randomHex();
+        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $differentChannelId);
 
-        $session->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, TestDefaults::SALES_CHANNEL);
+        $browser->request('GET', '/');
 
-        $browser->request('GET', '/account');
+        // Token should remain the same (global token, not per-channel)
+        static::assertSame($contextToken, $session->get('sw-context-token'));
 
-        static::assertSame($contextToken, $this->getSession()->get('sw-context-token'));
+        // No channel-specific tokens should exist when binding is disabled
+        $channelSpecificKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+        static::assertFalse($session->has($channelSpecificKey), 'Channel-specific tokens should not exist when binding is disabled');
     }
 
     public function testSessionIsInvalidatedOnLogoutAndInvalidateSettingFalse(): void

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -443,4 +443,216 @@ class StorefrontSubscriberTest extends TestCase
         static::assertSame(self::TEST_CONTEXT_TOKEN, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
         static::assertSame(self::TEST_CONTEXT_TOKEN, $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
     }
+
+    public function testStartSessionWithBindingDisabledUsesDefaultTokenKey(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $request = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelId,
+            ]
+        );
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = new RequestStack([$request]);
+
+        $configService = new StaticSystemConfigService([
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => false,
+        ]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->startSession();
+
+        // Should use default token key
+        static::assertTrue($request->getSession()->has(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        // Should NOT use channel-specific key
+        static::assertFalse($request->getSession()->has(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId));
+    }
+
+    public function testStartSessionWithBindingEnabledUsesChannelSpecificTokenKey(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $request = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelId,
+            ]
+        );
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = new RequestStack([$request]);
+
+        $configService = new StaticSystemConfigService([
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => true,
+        ]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->startSession();
+
+        // Should use channel-specific token key
+        $channelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+        static::assertTrue($request->getSession()->has($channelTokenKey));
+
+        // Token should be set in request header
+        static::assertNotNull($request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        static::assertSame(
+            $request->getSession()->get($channelTokenKey),
+            $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN)
+        );
+    }
+
+    public function testStartSessionWithBindingEnabledPreservesTokensAcrossChannels(): void
+    {
+        $salesChannelIdA = 'sales-channel-a';
+        $salesChannelIdB = 'sales-channel-b';
+
+        $session = new Session(new MockArraySessionStorage());
+
+        $configService = new StaticSystemConfigService([
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => true,
+        ]);
+
+        // Visit Channel A
+        $requestA = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelIdA,
+            ]
+        );
+        $requestA->setSession($session);
+        $requestStackA = new RequestStack([$requestA]);
+
+        (new StorefrontSubscriber(
+            $requestStackA,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->startSession();
+
+        $tokenA = $session->get(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelIdA);
+        static::assertNotNull($tokenA);
+
+        // Visit Channel B
+        $requestB = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelIdB,
+            ]
+        );
+        $requestB->setSession($session);
+        $requestStackB = new RequestStack([$requestB]);
+
+        (new StorefrontSubscriber(
+            $requestStackB,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->startSession();
+
+        $tokenB = $session->get(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelIdB);
+        static::assertNotNull($tokenB);
+        static::assertNotSame($tokenA, $tokenB);
+
+        // Return to Channel A - token should be preserved
+        $requestA2 = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelIdA,
+            ]
+        );
+        $requestA2->setSession($session);
+        $requestStackA2 = new RequestStack([$requestA2]);
+
+        (new StorefrontSubscriber(
+            $requestStackA2,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->startSession();
+
+        $tokenA2 = $session->get(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelIdA);
+        static::assertSame($tokenA, $tokenA2, 'Token for Channel A should be preserved');
+
+        // Both tokens should still exist
+        static::assertTrue($session->has(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelIdA));
+        static::assertTrue($session->has(PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelIdB));
+    }
+
+    public function testUpdateSessionWithBindingEnabledStoresTokenInChannelKey(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $newToken = 'new-context-token';
+
+        $request = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelId,
+            ]
+        );
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = new RequestStack([$request]);
+
+        $configService = new StaticSystemConfigService([
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => true,
+        ]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->updateSession($newToken);
+
+        // Should store in both channel-specific and default keys
+        $channelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+        static::assertSame($newToken, $request->getSession()->get($channelTokenKey));
+        static::assertSame($newToken, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        static::assertSame($newToken, $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+    }
+
+    public function testUpdateSessionWithBindingDisabledStoresTokenInDefaultKeyOnly(): void
+    {
+        $salesChannelId = 'test-sales-channel-id';
+        $newToken = 'new-context-token';
+
+        $request = new Request(
+            attributes: [
+                SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+                PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $salesChannelId,
+            ]
+        );
+        $request->setSession(new Session(new MockArraySessionStorage()));
+        $requestStack = new RequestStack([$request]);
+
+        $configService = new StaticSystemConfigService([
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => false,
+        ]);
+
+        (new StorefrontSubscriber(
+            $requestStack,
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            $configService,
+            new EventDispatcher(),
+        ))->updateSession($newToken);
+
+        // Should only store in default key
+        static::assertSame($newToken, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+        // Should NOT store in channel-specific key
+        $channelTokenKey = PlatformRequest::HEADER_CONTEXT_TOKEN . '-' . $salesChannelId;
+        static::assertFalse($request->getSession()->has($channelTokenKey));
+    }
 }


### PR DESCRIPTION
Fixes #5960

### 1. Why is this change necessary?

When you have multiple sales channels and the setting "Bind customers to Sales Channel" is active, the users get logged out from all sales channels by simply visiting another sales channel.

### 2. What does this change do, exactly?

If the setting is enabled, tokens are now stored per sales channel, so they don't get invalidated when visiting another sales channel.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a sales channel "A"
* Create a second sales channel "B"
* Activate the setting "Bind customers to Sales Channel"
* Register as a user in sales channel "B"
* Login as the new user and add a product to your cart
* Open a page from sales channel "A"
* Navigate back to sales channel "B"
* Notice that you are logged out in sales channel "B"
