### PR TITLE
fix: Prepare test suite for Kernel service reset

### DIFF
--- a/src/Core/Framework/Increment/MySQLIncrementer.php
+++ b/src/Core/Framework/Increment/MySQLIncrementer.php
@@ -119,8 +119,13 @@ class MySQLIncrementer extends AbstractIncrementer
             ];
         }
 
-        /** @var array<string, array{count: int, key: string, cluster: string, pool: string}> $result */
+        /** @var array<string, array{count: string, key: string, cluster: string, pool: string}> $result */
         $result = $this->connection->fetchAllAssociativeIndexed($sql, $payload, $types);
+
+        // Cast count to int for consistency with ArrayIncrementer
+        foreach ($result as $key => $row) {
+            $result[$key]['count'] = max(0, (int) $row['count']);
+        }
 
         return $result;
     }

--- a/src/Core/Framework/Resources/config/packages/test/framework.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/framework.yaml
@@ -25,3 +25,12 @@ framework:
                 adapter: cache.adapter.array
             cache.property_access:
                 adapter: cache.adapter.array
+            # Rate limiter needs persistent storage because ArrayAdapter is reset between requests
+            cache.rate_limiter:
+                adapter: cache.adapter.filesystem
+            # HTTP and object caches need persistent storage because ArrayAdapter is reset between requests
+            # This ensures cache hit/miss tests work correctly with service reset enabled
+            cache.http:
+                adapter: cache.adapter.filesystem
+            cache.object:
+                adapter: cache.adapter.filesystem

--- a/src/Core/Framework/Resources/config/packages/test/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/test/shopware.yaml
@@ -14,14 +14,13 @@ shopware:
     cache:
         invalidation:
             delay_enabled: false
-            tag_invalidation_log_enabled: false
 
     increment:
         user_activity:
-            type: 'array'
+            type: 'mysql'
 
         message_queue:
-            type: 'array'
+            type: 'mysql'
 
     admin_worker:
         poll_interval: 1

--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -59,9 +59,9 @@ trait AppSystemTestBehaviour
     /**
      * @return array<string, mixed>
      */
-    protected function getScriptTraces(): array
+    protected function getScriptTraces(?ContainerInterface $container = null): array
     {
-        return static::getContainer()
+        return ($container ?? static::getContainer())
             ->get(ScriptTraces::class)
             ->getTraces();
     }

--- a/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Test\Controller;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,6 +26,15 @@ trait StorefrontControllerTestBehaviour
         $browser->request($method, EnvironmentHelper::getVariable('APP_URL') . '/' . $path, $data, $files, $server, $content, $changeHistory);
 
         return $browser->getResponse();
+    }
+
+    /**
+     * Create a browser for storefront requests.
+     * Use $browser->getContainer() to access services without triggering service reset.
+     */
+    public function createStorefrontBrowser(): TestBrowser
+    {
+        return KernelLifecycleManager::createBrowser($this->getKernel());
     }
 
     public function getSalesChannelId(): string

--- a/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
@@ -60,7 +60,7 @@ class PaymentMethodRouteTest extends TestCase
         static::assertContains($this->ids->get('payment2'), $ids);
         static::assertContains($this->ids->get('payment3'), $ids);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $this->browser->getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(PaymentMethodRouteHook::HOOK_NAME, $traces);
     }
 

--- a/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
@@ -65,7 +65,7 @@ class ShippingMethodRouteTest extends TestCase
         static::assertContains($this->ids->get('shipping2'), $ids);
         static::assertEmpty($response['elements'][0]['availabilityRule']);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $this->browser->getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(ShippingMethodRouteHook::HOOK_NAME, $traces);
     }
 

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -76,7 +76,7 @@ class CacheControllerTest extends TestCase
         static::assertArrayHasKey('httpCache', $decodedContent);
         static::assertIsBool($decodedContent['httpCache']);
         static::assertArrayHasKey('cacheAdapter', $decodedContent);
-        static::assertSame('Array', $decodedContent['cacheAdapter']);
+        static::assertSame('Filesystem', $decodedContent['cacheAdapter']);
     }
 
     public function testCacheIndexEndpoint(): void

--- a/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
+++ b/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -21,18 +22,10 @@ class IncrementApiControllerTest extends TestCase
     use AdminFunctionalTestBehaviour;
     use IntegrationTestBehaviour;
 
-    private AbstractIncrementer $gateway;
-
     private string $userId;
 
     protected function setUp(): void
     {
-        $gatewayRegistry = static::getContainer()->get('shopware.increment.gateway.registry');
-
-        $gateway = $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
-
-        $this->gateway = $gateway;
-
         /** @var Context $context */
         $context = $this->getBrowser()->getServerParameter(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
 
@@ -41,17 +34,19 @@ class IncrementApiControllerTest extends TestCase
         static::assertNotNull($source->getUserId());
         $this->userId = Uuid::fromBytesToHex($source->getUserId());
 
-        $this->gateway->reset($this->userId, 'foo');
+        $this->getGateway($this->getBrowser())->reset($this->userId, 'foo');
     }
 
     public function testListEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'bar');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
+
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'bar');
 
         $url = '/api/_action/increment/user_activity?cluster=' . $this->userId;
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         static::assertSame(200, $client->getResponse()->getStatusCode());
@@ -111,7 +106,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
@@ -119,16 +114,18 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDecrementEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/decrement/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'key' => 'foo',
             'cluster' => $this->userId,
@@ -140,7 +137,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(0, $entries['foo']['count']);
@@ -148,11 +145,14 @@ class IncrementApiControllerTest extends TestCase
 
     public function testResetEndpoint(): void
     {
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'bar');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
@@ -161,7 +161,6 @@ class IncrementApiControllerTest extends TestCase
 
         $url = '/api/_action/reset-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'cluster' => $this->userId,
         ]);
@@ -172,7 +171,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertArrayHasKey('bar', $entries);
@@ -183,11 +182,13 @@ class IncrementApiControllerTest extends TestCase
     public function testIncrementEndpointWithCustomCluster(): void
     {
         $clusterName = 'customer-cluster';
-        $this->gateway->reset($clusterName, 'foo');
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
+
+        $gateway->reset($clusterName, 'foo');
 
         $url = '/api/_action/increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('POST', $url, [
             'key' => 'foo',
             'cluster' => $clusterName,
@@ -199,14 +200,13 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertTrue($entries['success']);
 
-        $entries = $this->gateway->list($clusterName);
+        $entries = $this->getGateway($client)->list($clusterName);
 
         static::assertArrayHasKey('foo', $entries);
         static::assertSame(1, $entries['foo']['count']);
 
         $url = '/api/_action/increment/user_activity?cluster=' . $clusterName;
 
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         $entries = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -236,19 +236,21 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDeleteEndpointWithKeys(): void
     {
-        $this->gateway->reset($this->userId);
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'baz');
-        $this->gateway->increment($this->userId, 'bar');
+        $gateway->reset($this->userId);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'baz');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertCount(3, $entries);
 
         $url = '/api/_action/delete-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('DELETE', $url, [
             'cluster' => $this->userId,
             'keys' => ['foo', 'bar'],
@@ -256,7 +258,7 @@ class IncrementApiControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertCount(1, $entries);
 
@@ -267,29 +269,38 @@ class IncrementApiControllerTest extends TestCase
 
     public function testDeleteEndpointWithOnlyCluster(): void
     {
-        $this->gateway->reset($this->userId);
+        $client = $this->getBrowser();
+        $gateway = $this->getGateway($client);
 
-        $this->gateway->increment($this->userId, 'foo');
-        $this->gateway->increment($this->userId, 'baz');
-        $this->gateway->increment($this->userId, 'bar');
+        $gateway->reset($this->userId);
 
-        $entries = $this->gateway->list($this->userId);
+        $gateway->increment($this->userId, 'foo');
+        $gateway->increment($this->userId, 'baz');
+        $gateway->increment($this->userId, 'bar');
+
+        $entries = $gateway->list($this->userId);
 
         static::assertCount(3, $entries);
 
-        $this->gateway->reset($this->userId, 'foo');
+        $gateway->reset($this->userId, 'foo');
 
         $url = '/api/_action/delete-increment/user_activity';
 
-        $client = $this->getBrowser();
         $client->request('DELETE', $url, [
             'cluster' => $this->userId,
         ]);
 
         static::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
 
-        $entries = $this->gateway->list($this->userId);
+        $entries = $this->getGateway($client)->list($this->userId);
 
         static::assertEmpty($entries);
+    }
+
+    private function getGateway(KernelBrowser $browser): AbstractIncrementer
+    {
+        $gatewayRegistry = $browser->getContainer()->get('shopware.increment.gateway.registry');
+
+        return $gatewayRegistry->get(IncrementGatewayRegistry::USER_ACTIVITY_POOL);
     }
 }

--- a/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
@@ -29,13 +29,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
     }
 
     public function testDecrement(): void
@@ -46,13 +46,13 @@ class MySQLIncrementerTest extends TestCase
         $list = $this->mysqlIncrementer->list('test-user-1');
 
         static::assertNotNull($list['sw.product.index']);
-        static::assertSame('2', $list['sw.product.index']['count']);
+        static::assertSame(2, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->decrement('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
     }
 
     public function testList(): void
@@ -63,9 +63,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('2', array_values($list)[0]['count']);
+        static::assertSame(2, array_values($list)[0]['count']);
         static::assertSame('sw.product.index', array_values($list)[0]['key']);
-        static::assertSame('1', array_values($list)[1]['count']);
+        static::assertSame(1, array_values($list)[1]['count']);
 
         // List will return in DESC order of record's count
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
@@ -73,9 +73,9 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('3', array_values($list)[0]['count']);
+        static::assertSame(3, array_values($list)[0]['count']);
         static::assertSame('sw.order.index', array_values($list)[0]['key']);
-        static::assertSame('2', array_values($list)[1]['count']);
+        static::assertSame(2, array_values($list)[1]['count']);
     }
 
     public function testReset(): void
@@ -91,22 +91,22 @@ class MySQLIncrementerTest extends TestCase
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('0', $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.product.index']['count']);
 
         $this->mysqlIncrementer->increment('test-user-1', 'sw.order.index');
         $this->mysqlIncrementer->increment('test-user-1', 'sw.product.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('1', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(1, $list['sw.order.index']['count']);
 
         $this->mysqlIncrementer->reset('test-user-1', 'sw.order.index');
 
         $list = $this->mysqlIncrementer->list('test-user-1');
 
-        static::assertSame('1', $list['sw.product.index']['count']);
-        static::assertSame('0', $list['sw.order.index']['count']);
+        static::assertSame(1, $list['sw.product.index']['count']);
+        static::assertSame(0, $list['sw.order.index']['count']);
     }
 
     public function testDeleteKeys(): void
@@ -127,7 +127,7 @@ class MySQLIncrementerTest extends TestCase
                 'pool' => 'user-activity-pool',
                 'cluster' => 'test-user-1',
                 'key' => 'sw.product.create',
-                'count' => '1',
+                'count' => 1,
             ],
         ], $list);
     }

--- a/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexingMessage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
@@ -23,13 +22,6 @@ class ConsumeMessagesControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;
     use QueueTestBehaviour;
-
-    private AbstractIncrementer $incrementer;
-
-    protected function setUp(): void
-    {
-        $this->incrementer = static::getContainer()->get('shopware.increment.gateway.registry')->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
-    }
 
     public function testConsumeMessages(): void
     {
@@ -57,7 +49,6 @@ class ConsumeMessagesControllerTest extends TestCase
 
         // consume the queued task
         $url = '/api/_action/message-queue/consume';
-        $client = $this->getBrowser();
         $client->request('POST', $url, ['receiver' => 'async']);
 
         $response = json_decode((string) $client->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -69,21 +60,23 @@ class ConsumeMessagesControllerTest extends TestCase
 
     public function testMessageStatsDecrement(): void
     {
-        $messageBus = static::getContainer()->get('messenger.default_bus');
+        $client = $this->getBrowser();
+
+        $messageBus = $client->getContainer()->get('messenger.default_bus');
         $message = new ProductIndexingMessage([Uuid::randomHex()]);
         $messageBus->dispatch($message);
 
-        $gateway = static::getContainer()->get('shopware.increment.gateway.registry');
+        $gateway = $client->getContainer()->get('shopware.increment.gateway.registry');
         $entries = $gateway->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL)->list('message_queue_stats');
 
         static::assertArrayHasKey(ProductIndexingMessage::class, $entries);
         static::assertGreaterThan(0, $entries[ProductIndexingMessage::class]['count']);
 
         $url = '/api/_action/message-queue/consume';
-        $client = $this->getBrowser();
         $client->request('POST', $url, ['receiver' => 'async']);
 
-        $entries = $this->incrementer->list('message_queue_stats');
+        $incrementer = $client->getContainer()->get('shopware.increment.gateway.registry')->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
+        $entries = $incrementer->list('message_queue_stats');
 
         static::assertArrayHasKey(ProductIndexingMessage::class, $entries);
         static::assertSame(0, $entries[ProductIndexingMessage::class]['count']);

--- a/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Api/MessageQueueEndpointTest.php
@@ -19,7 +19,9 @@ class MessageQueueEndpointTest extends TestCase
 
     public function testEndpoint(): void
     {
-        $gatewayRegistry = static::getContainer()->get('shopware.increment.gateway.registry');
+        $client = $this->getBrowser();
+
+        $gatewayRegistry = $client->getContainer()->get('shopware.increment.gateway.registry');
 
         $gateway = $gatewayRegistry->get(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
 
@@ -30,7 +32,6 @@ class MessageQueueEndpointTest extends TestCase
         $gateway->increment('message_queue_stats', 'bar');
 
         $url = '/api/_info/queue.json';
-        $client = $this->getBrowser();
         $client->request('GET', $url);
 
         static::assertSame(200, $client->getResponse()->getStatusCode());

--- a/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
@@ -35,7 +35,7 @@ class ScriptApiRouteTest extends TestCase
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('api-simple-script', $traces);
         static::assertCount(1, $traces['api-simple-script']);
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);
@@ -55,7 +55,7 @@ class ScriptApiRouteTest extends TestCase
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('api-simple-script', $traces);
         static::assertCount(1, $traces['api-simple-script']);
         static::assertSame('some debug information', $traces['api-simple-script'][0]['output'][0]);

--- a/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
@@ -41,7 +41,7 @@ class ScriptStoreApiRouteTest extends TestCase
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-simple-script::response', $traces);
         static::assertCount(1, $traces['store-api-simple-script::response']);
         static::assertSame('some debug information', $traces['store-api-simple-script::response'][0]['output'][0]);
@@ -63,7 +63,7 @@ class ScriptStoreApiRouteTest extends TestCase
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-simple-script::response', $traces);
         static::assertCount(1, $traces['store-api-simple-script::response']);
         static::assertSame('some debug information', $traces['store-api-simple-script::response'][0]['output'][0]);
@@ -195,13 +195,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=1');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -216,16 +217,17 @@ class ScriptStoreApiRouteTest extends TestCase
             static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
 
+        // Second request with same query param - response should be cached, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=1');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        // traces should NOT have this key because script was not executed (cache hit)
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -237,16 +239,17 @@ class ScriptStoreApiRouteTest extends TestCase
             static::assertFalse($this->browser->getResponse()->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
 
+        // Third request with different query param - cache miss, script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script?query-param=2');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the query param changes the script is executed again
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the query param changes the script is executed again (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -259,13 +262,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -276,16 +280,16 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
+        // Second request - cache hit, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -294,19 +298,20 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
         // invalidate the custom cache tag
-        $cacheInvalidator = static::getContainer()->get(CacheInvalidator::class);
+        $cacheInvalidator = $this->browser->getContainer()->get(CacheInvalidator::class);
         $cacheInvalidator->invalidate(['my-custom-tag'], true);
 
+        // Third request after invalidation - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the cache tag was invalidated the script is executed again
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the cache tag was invalidated the script is executed again (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -319,13 +324,14 @@ class ScriptStoreApiRouteTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures');
 
+        // First request - script should be executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
         static::assertCount(1, $traces['store-api-cache-script::response']);
         static::assertSame('some debug information', $traces['store-api-cache-script::response'][0]['output'][0]);
@@ -336,16 +342,16 @@ class ScriptStoreApiRouteTest extends TestCase
         static::assertSame('bar', $response['foo']);
         static::assertSame('store_api_cache_script_response', $response['apiAlias']);
 
+        // Second request - cache hit, script NOT executed
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
-        static::assertArrayHasKey('store-api-cache-script::response', $traces);
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         // assert that the response was cached, and thus the script was not called again
-        static::assertCount(1, $traces['store-api-cache-script::response']);
+        static::assertArrayNotHasKey('store-api-cache-script::response', $traces);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);
@@ -356,16 +362,17 @@ class ScriptStoreApiRouteTest extends TestCase
         // Login to get the `logged-in` invalidation state
         $this->login();
 
+        // Third request after login - script should be executed due to invalidation state
         $this->browser->request('GET', '/store-api/script/cache-script');
         static::assertNotFalse($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), $this->browser->getResponse()->getContent());
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($this->browser->getContainer());
         static::assertArrayHasKey('store-api-cache-script::response', $traces);
-        // assert that when the invalidation state is present the response is not cached
-        static::assertCount(2, $traces['store-api-cache-script::response']);
+        // assert that when the invalidation state is present the response is not cached (1 execution in this request)
+        static::assertCount(1, $traces['store-api-cache-script::response']);
 
         static::assertIsArray($response);
         static::assertArrayHasKey('apiAlias', $response);

--- a/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
@@ -995,7 +995,7 @@ class CustomEntityTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), print_r($response, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('store-api-blog::response', $traces);
         static::assertCount(1, $traces['store-api-blog::response']);
         static::assertSame('some debug information', $traces['store-api-blog::response'][0]['output'][0]);

--- a/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
@@ -298,7 +298,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -326,7 +326,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -367,7 +367,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountOrderDetailPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -406,7 +406,7 @@ class AccountOrderControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), $url . $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountEditOrderPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
@@ -57,7 +57,7 @@ class AccountProfileControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('account-overview-page-loaded', $traces);
     }
@@ -74,7 +74,7 @@ class AccountProfileControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('account-profile-page-loaded', $traces);
     }

--- a/tests/integration/Storefront/Controller/AddressControllerTest.php
+++ b/tests/integration/Storefront/Controller/AddressControllerTest.php
@@ -119,7 +119,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-listing-page-loaded', $traces);
     }
@@ -133,7 +133,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-detail-page-loaded', $traces);
     }
@@ -147,7 +147,7 @@ class AddressControllerTest extends TestCase
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('address-detail-page-loaded', $traces);
     }

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -326,9 +326,10 @@ class AuthControllerTest extends TestCase
 
     public function testAccountLoginPageLoadedHookScriptsAreExecuted(): void
     {
-        $this->request('GET', '/account/login', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/login');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountLoginPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -588,9 +589,10 @@ class AuthControllerTest extends TestCase
 
     public function testAccountGuestLoginPageLoadedHookScriptsAreExecuted(): void
     {
-        $this->request('GET', '/account/guest/login', ['redirectTo' => 'foo']);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/guest/login?redirectTo=foo');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountGuestLoginPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -537,7 +537,7 @@ class CheckoutControllerTest extends TestCase
             '/checkout/cart'
         );
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CheckoutCartPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/CmsControllerTest.php
+++ b/tests/integration/Storefront/Controller/CmsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
@@ -31,30 +32,36 @@ class CmsControllerTest extends TestCase
 
     public function testCmsPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/cms/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/cms/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testCmsPageLoadedHookScriptsAreExecutedForFullPage(): void
     {
-        $response = $this->request('GET', '/page/cms/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/page/cms/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testCmsPageLoadedHookScriptsAreExecutedForCategory(): void
     {
-        $response = $this->request('GET', '/widgets/cms/navigation/' . $this->ids->get('category'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/cms/navigation/' . $this->ids->get('category'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CmsPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/LandingPageControllerTest.php
+++ b/tests/integration/Storefront/Controller/LandingPageControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -35,11 +36,12 @@ class LandingPageControllerTest extends TestCase
 
     public function testLandingPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/myUrl', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/myUrl');
 
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(LandingPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
+++ b/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
@@ -47,17 +47,19 @@ class MaintenanceControllerTest extends TestCase
 
         static::assertSame(503, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MaintenancePageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testMaintenancePageLoadedHookScriptsAreExecutedForSinglePage(): void
     {
-        $response = $this->request('GET', '/maintenance/singlepage/' . $this->ids->get('page'), []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/maintenance/singlepage/' . $this->ids->get('page'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MaintenancePageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -34,31 +35,36 @@ class NavigationControllerTest extends TestCase
 
     public function testNavigationPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(NavigationPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testNavigationPageLoadedHookScriptsAreExecutedForCategory(): void
     {
-        $response = $this->request('GET', '/my-navigation/', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/my-navigation/');
 
-        static::assertSame(200, $response->getStatusCode(), print_r($response->getContent(), true));
+        static::assertSame(200, $browser->getResponse()->getStatusCode(), print_r($browser->getResponse()->getContent(), true));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(NavigationPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testMenuOffcanvasPageletLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/menu/offcanvas', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/menu/offcanvas');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MenuOffcanvasPageletLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -314,15 +314,12 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/my-product/' . $productId,
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/my-product/' . $productId);
 
-        $this->checkStatusCode($response);
+        $this->checkStatusCode($browser->getResponse());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey('product-page-loaded', $traces);
     }
@@ -331,15 +328,12 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/quickview/' . $productId,
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/quickview/' . $productId);
 
-        $this->checkStatusCode($response);
+        $this->checkStatusCode($browser->getResponse());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(ProductQuickViewWidgetLoadedHook::HOOK_NAME, $traces);
     }
@@ -348,15 +342,13 @@ class ProductControllerTest extends TestCase
     {
         $productId = $this->createProduct();
 
-        $response = $this->request(
-            'GET',
-            '/product/' . $productId . '/reviews',
-            []
-        );
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/product/' . $productId . '/reviews');
 
+        $response = $browser->getResponse();
         $this->checkStatusCode($response);
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(ProductReviewsWidgetLoadedHook::HOOK_NAME, $traces);
 

--- a/tests/integration/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/integration/Storefront/Controller/RegisterControllerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -263,10 +264,12 @@ class RegisterControllerTest extends TestCase
 
     public function testAccountRegisterPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/account/register', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/account/register');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(AccountRegisterPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -276,10 +279,12 @@ class RegisterControllerTest extends TestCase
         $ids = new IdsCollection();
         $this->createCustomerGroup($ids);
 
-        $response = $this->request('GET', 'customer-group-registration/' . $ids->get('group'), []);
-        static::assertSame(200, $response->getStatusCode(), print_r($response->getContent(), true));
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/customer-group-registration/' . $ids->get('group'));
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode(), print_r($browser->getResponse()->getContent(), true));
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CustomerGroupRegistrationPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -290,18 +295,19 @@ class RegisterControllerTest extends TestCase
 
         $this->createProduct(Uuid::randomHex(), $productNumber);
 
-        $this->request(
+        $browser = $this->createStorefrontBrowser();
+        $browser->request(
             'POST',
-            '/checkout/product/add-by-number',
+            EnvironmentHelper::getVariable('APP_URL') . '/checkout/product/add-by-number',
             $this->tokenize('frontend.checkout.product.add-by-number', [
                 'number' => $productNumber,
             ])
         );
 
-        $response = $this->request('GET', '/checkout/register', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/checkout/register');
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(CheckoutRegisterPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/ScriptControllerTest.php
+++ b/tests/integration/Storefront/Controller/ScriptControllerTest.php
@@ -31,13 +31,15 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request('GET', '/storefront/script/json-response', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json-response');
+        $response = $browser->getResponse();
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
@@ -50,13 +52,15 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request('GET', '/storefront/script/json/response', []);
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json/response');
+        $response = $browser->getResponse();
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);
@@ -69,18 +73,20 @@ class ScriptControllerTest extends TestCase
     {
         $this->loadAppsFromDir(__DIR__ . '/fixtures/Apps');
 
-        $response = $this->request(
+        $browser = $this->createStorefrontBrowser();
+        $browser->request(
             'POST',
-            '/storefront/script/json-response',
+            EnvironmentHelper::getVariable('APP_URL') . '/storefront/script/json-response',
             $this->tokenize('frontend.script_endpoint', [])
         );
+        $response = $browser->getResponse();
 
         static::assertNotFalse($response->getContent());
 
         $body = \json_decode($response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($body, true));
 
-        $traces = $this->getScriptTraces();
+        $traces = $this->getScriptTraces($browser->getContainer());
         static::assertArrayHasKey('storefront-json-response', $traces);
         static::assertCount(1, $traces['storefront-json-response']);
         static::assertSame('some debug information', $traces['storefront-json-response'][0]['output'][0]);

--- a/tests/integration/Storefront/Controller/SearchControllerTest.php
+++ b/tests/integration/Storefront/Controller/SearchControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -51,30 +52,36 @@ class SearchControllerTest extends TestCase
 
     public function testSearchPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/search', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/search?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SearchPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testSuggestPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/suggest', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/suggest?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SuggestPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testSearchWidgetLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/widgets/search', ['search' => 'test']);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/widgets/search?search=test');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SearchWidgetLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/SitemapControllerTest.php
+++ b/tests/integration/Storefront/Controller/SitemapControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Sitemap\SitemapPageLoadedHook;
@@ -18,10 +19,12 @@ class SitemapControllerTest extends TestCase
 
     public function testSitemapPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/sitemap.xml', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/sitemap.xml');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(SitemapPageLoadedHook::HOOK_NAME, $traces);
     }

--- a/tests/integration/Storefront/Controller/WishlistControllerTest.php
+++ b/tests/integration/Storefront/Controller/WishlistControllerTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
@@ -90,7 +91,7 @@ class WishlistControllerTest extends TestCase
 
         $browser->request('GET', $_SERVER['APP_URL']);
 
-        $productId = $this->createProduct(TestDefaults::SALES_CHANNEL);
+        $productId = $this->createProduct($browser->getRequest()->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID));
 
         $browser->request('POST', $_SERVER['APP_URL'] . '/wishlist/guest-pagelet', $this->tokenize('frontend.wishlist.guestPage.pagelet', ['productIds' => [$productId]]));
 
@@ -240,17 +241,19 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistPageLoadedHook::HOOK_NAME, $traces);
     }
 
     public function testGuestWishlistPageLoadedHookScriptsAreExecuted(): void
     {
-        $response = $this->request('GET', '/wishlist', []);
-        static::assertSame(200, $response->getStatusCode());
+        $browser = $this->createStorefrontBrowser();
+        $browser->request('GET', EnvironmentHelper::getVariable('APP_URL') . '/wishlist');
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        static::assertSame(200, $browser->getResponse()->getStatusCode());
+
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(GuestWishlistPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -267,7 +270,7 @@ class WishlistControllerTest extends TestCase
 
         static::assertSame(200, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(GuestWishlistPageletLoadedHook::HOOK_NAME, $traces);
     }
@@ -280,7 +283,7 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistPageLoadedHook::HOOK_NAME, $traces);
     }
@@ -293,7 +296,7 @@ class WishlistControllerTest extends TestCase
         $response = $browser->getResponse();
         static::assertSame(200, $response->getStatusCode());
 
-        $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
+        $traces = $browser->getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(WishlistWidgetLoadedHook::HOOK_NAME, $traces);
     }


### PR DESCRIPTION
## 1. Why is this change necessary?

When running Shopware in long-running PHP environments (FrankenPHP worker mode, RoadRunner, Swoole), the Kernel and its services can be reset between requests while the PHP process stays alive. This causes issues with tests that rely on service state persisting within a single request but being fresh between requests.

Currently, several integration tests fail when service reset is enabled because:
- Array-based cache/increment adapters are reset, losing data mid-test
- Script traces are fetched from the wrong container instance
- Storefront browser tests use stale container references

## 2. What does this change do, exactly?

**Test configuration changes:**
- Switch increment storage from `array` to `mysql` (persists between service resets)
- Add `cache.adapter.filesystem` for `rate_limiter`, `http`, and `object` caches
- Remove `tag_invalidation_log_enabled: false` (not needed)

**Code changes:**
- `AppSystemTestBehaviour::getScriptTraces()` - Accept container parameter to get traces from correct container
- `StorefrontControllerTestBehaviour::createStorefrontBrowser()` - Create browser with fresh container reference
- `MySQLIncrementer::list()` - Cast count to int for type safety

**Test file updates:**
- All Storefront controller tests use `$browser->getContainer()` for script traces
- Increment, MessageQueue, Script API tests updated for new patterns

## 3. Describe each step to reproduce the issue or behaviour.

1. Enable Kernel service reset (will be part of #14456)
2. Run integration tests: `vendor/bin/phpunit tests/integration/Storefront/Controller/`
3. Tests fail with "service not found" or incorrect cache behavior

After this change:
1. Same setup
2. Run same tests
3. Tests pass

## 4. Please link to the relevant issues (if any).

closes #14455 
linked #13921 

## 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed related commits into one, where suitable
- [ ] I have updated developer-facing release notes if this change is relevant
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them