### PR TITLE
fix: add help text to custom field color picker configuration

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -14,6 +14,10 @@ Also, the generator now sets `CASCADE DELETE` on foreign keys for the translatio
 
 ## Administration
 
+### Help text support for color picker custom fields
+
+The color picker type for custom fields now supports adding a help text. When creating or editing a custom field of type "Colorpicker" in Settings > Content > Custom fields, you can now specify a help text that will be displayed to users in the Administration.
+
 ## Storefront
 
 ### Selling and packaging information in the product detail page

--- a/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
@@ -81,7 +81,7 @@ export default function createCustomFieldService() {
             },
         },
         colorpicker: {
-            configRenderComponent: 'sw-custom-field-type-base',
+            configRenderComponent: 'sw-custom-field-type-colorpicker',
             type: 'text',
             config: {
                 componentName: 'sw-field',

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/index.js
@@ -1,0 +1,14 @@
+/**
+ * @sw-package framework
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export default {
+    data() {
+        return {
+            propertyNames: {
+                label: this.$tc('sw-settings-custom-field.customField.detail.labelLabel'),
+                helpText: this.$tc('sw-settings-custom-field.customField.detail.labelHelpText'),
+            },
+        };
+    },
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/index.js
@@ -1,7 +1,7 @@
 /**
  * @sw-package framework
+ * @private
  */
-// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     data() {
         return {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/sw-custom-field-type-colorpicker.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/sw-custom-field-type-colorpicker.spec.js
@@ -1,0 +1,62 @@
+/**
+ * @sw-package framework
+ */
+import { mount } from '@vue/test-utils';
+
+const currentCustomField = {
+    name: 'technical_test',
+    type: 'colorpicker',
+    config: {
+        label: { 'en-GB': null },
+        helpText: { 'en-GB': null },
+        componentName: 'sw-colorpicker',
+        customFieldType: 'colorpicker',
+        customFieldPosition: 1,
+    },
+    active: true,
+    customFieldSetId: 'd2667dfae415440592a0944fbea2d3ce',
+    id: '8e1ab96faf374836a4d68febc8d4f1e1',
+};
+
+const defaultProps = {
+    currentCustomField,
+    set: {
+        name: 'technical_test',
+        config: { label: { 'en-GB': 'test_label' } },
+        active: true,
+        global: false,
+        position: 1,
+        id: 'd2667dfae415440592a0944fbea2d3ce',
+    },
+};
+
+async function createWrapper(props = defaultProps) {
+    return mount(await wrapTestComponent('sw-custom-field-type-colorpicker', { sync: true }), {
+        props,
+        global: {
+            mocks: {
+                $tc: (key) => key,
+            },
+            stubs: {
+                'sw-custom-field-translated-labels': true,
+            },
+        },
+    });
+}
+
+describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker', () => {
+    it('should be a Vue.js component', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should provide correct property names for translations', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.propertyNames).toEqual({
+            label: 'sw-settings-custom-field.customField.detail.labelLabel',
+            helpText: 'sw-settings-custom-field.customField.detail.labelHelpText',
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/sw-custom-field-type-colorpicker.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker/sw-custom-field-type-colorpicker.spec.js
@@ -45,12 +45,6 @@ async function createWrapper(props = defaultProps) {
 }
 
 describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-colorpicker', () => {
-    it('should be a Vue.js component', async () => {
-        const wrapper = await createWrapper();
-
-        expect(wrapper.vm).toBeTruthy();
-    });
-
     it('should provide correct property names for translations', async () => {
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/index.js
@@ -59,6 +59,11 @@ Shopware.Component.extend(
     'sw-custom-field-type-base',
     () => import('./component/sw-custom-field-type-text-editor'),
 );
+Shopware.Component.extend(
+    'sw-custom-field-type-colorpicker',
+    'sw-custom-field-type-base',
+    () => import('./component/sw-custom-field-type-colorpicker'),
+);
 /* eslint-enable max-len, sw-deprecation-rules/private-feature-declarations */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations


### PR DESCRIPTION
Closes https://github.com/shopware/shopware/issues/14287.

Adds a help text field to the color picker configuration, so that it can be configured as well.

### Before:
**Custom field configuration:**
<img width="536" height="696" alt="config without" src="https://github.com/user-attachments/assets/cef90816-d319-4aa7-94b5-5289ff20e502" />

**Rendered:**
<img width="467" height="341" alt="product without" src="https://github.com/user-attachments/assets/b41635ba-f31f-45c9-b526-c82f9f70d026" />

### After:
**Custom field configuration:**
<img width="542" height="704" alt="config with" src="https://github.com/user-attachments/assets/16b4b759-7664-45a5-99e2-18a28a1398e7" />


**Rendered:**
<img width="465" height="337" alt="product with" src="https://github.com/user-attachments/assets/7906344f-010c-4ede-8fe4-eaa1fc2c0533" />
