### PR TITLE
fix(promotion): redeemed when entering code in lowercase

### DIFF
--- a/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+++ b/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
@@ -81,7 +81,7 @@ class PromotionIndividualCodeRedeemer implements EventSubscriberInterface
                 /** @var string $code */
                 $code = $item->getPayload()['code'] ?? '';
 
-                if ($code !== $promotion->getCode()) {
+                if (strtolower($code) !== strtolower($promotion->getCode())) {
                     continue;
                 }
 


### PR DESCRIPTION
fixes: #14397 

Use `strtolower` to compare both strings in lowercase.