### PR TITLE
refactor!: set default behavior of showClearableButton to true

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -14,6 +14,16 @@ Also, the generator now sets `CASCADE DELETE` on foreign keys for the translatio
 
 ## Administration
 
+### `sw-select-base` clearable button default behavior changed
+
+The `showClearableButton` prop in `sw-select-base` now defaults based on the `required` attribute:
+- When `required` is `false` or not set: clearable button is shown by default
+- When `required` is `true`: clearable button is hidden by default
+
+Previously, the clearable button was always hidden by default (`showClearableButton: false`).
+
+**Migration:** If you relied on the previous behavior where the clearable button was hidden by default, explicitly set `:show-clearable-button="false"` on your select components.
+
 ## Storefront
 
 ### Selling and packaging information in the product detail page

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
@@ -69,7 +69,8 @@ export default {
                 return this.showClearableButton;
             }
 
-            // Default: clearable when not required ('' case is for empty attribute like <form-field required> which should be treated as true)
+            // Default: clearable when not required
+            // '' case is for empty attribute like <form-field required> which should be treated as true
             return !this.$attrs.required && this.$attrs.required !== '';
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
@@ -69,8 +69,8 @@ export default {
                 return this.showClearableButton;
             }
 
-            // Default: clearable when not required
-            return !this.$attrs.required;
+            // Default: clearable when not required ('' case is for empty attribute like <form-field required> which should be treated as true)
+            return !this.$attrs.required && this.$attrs.required !== '';
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/index.js
@@ -33,10 +33,16 @@ export default {
             default: false,
         },
 
+        /**
+         * Controls visibility of the clear button.
+         * When undefined, defaults to true if not required, false if required.
+         * Explicit true/false overrides this default behavior.
+         * @see isClearable computed property
+         */
         showClearableButton: {
             type: Boolean,
             required: false,
-            default: false,
+            default: undefined,
         },
 
         size: {
@@ -55,6 +61,16 @@ export default {
     computed: {
         swFieldClasses() {
             return { 'has--focus': this.expanded };
+        },
+
+        isClearable() {
+            // If explicitly set, use the provided value
+            if (this.showClearableButton !== undefined) {
+                return this.showClearableButton;
+            }
+
+            // Default: clearable when not required
+            return !this.$attrs.required;
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -31,7 +31,7 @@
             />
 
             <button
-                v-if="!disabled && showClearableButton"
+                v-if="!disabled && isClearable"
                 class="sw-select__select-indicator-hitbox"
                 data-clearable-button
                 :aria-label="$tc('global.sw-select-base.buttonClear')"

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
@@ -6,8 +6,10 @@ import { mount } from '@vue/test-utils';
 
 import 'src/app/component/form/select/base/sw-single-select';
 
-const createWrapper = async () => {
+const createWrapper = async (props = {}, attrs = {}) => {
     const wrapper = mount(await wrapTestComponent('sw-select-base', { sync: true }), {
+        props,
+        attrs,
         global: {
             stubs: {
                 'sw-block-field': await wrapTestComponent('sw-block-field'),
@@ -27,30 +29,43 @@ const createWrapper = async () => {
 };
 
 describe('components/sw-select-base', () => {
-    it('should not show the clearable icon in the select base when prop is not set', async () => {
+    it('should show the clearable icon by default when required is not set', async () => {
         const wrapper = await createWrapper();
+
+        const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
+        expect(clearableIcon.exists()).toBe(true);
+    });
+
+    it('should not show the clearable icon by default when required is true', async () => {
+        const wrapper = await createWrapper({}, { required: true });
 
         const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
         expect(clearableIcon.exists()).toBe(false);
     });
 
-    it('should show the clearable icon in the select base when prop is set', async () => {
-        const wrapper = await createWrapper();
-
-        await wrapper.setProps({
-            showClearableButton: true,
-        });
+    it('should show the clearable icon when required is false', async () => {
+        const wrapper = await createWrapper({}, { required: false });
 
         const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
-        expect(clearableIcon.isVisible()).toBe(true);
+        expect(clearableIcon.exists()).toBe(true);
+    });
+
+    it('should show the clearable icon when explicitly set to true even if required', async () => {
+        const wrapper = await createWrapper({ showClearableButton: true }, { required: true });
+
+        const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
+        expect(clearableIcon.exists()).toBe(true);
+    });
+
+    it('should not show the clearable icon when explicitly set to false even if not required', async () => {
+        const wrapper = await createWrapper({ showClearableButton: false }, { required: false });
+
+        const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
+        expect(clearableIcon.exists()).toBe(false);
     });
 
     it('should trigger clear event when user clicks on clearable icon', async () => {
-        const wrapper = await createWrapper();
-
-        await wrapper.setProps({
-            showClearableButton: true,
-        });
+        const wrapper = await createWrapper({ showClearableButton: true });
 
         const clearableIcon = wrapper.find('.sw-select__select-indicator-clear');
 


### PR DESCRIPTION
Closes https://github.com/shopware/shopware/issues/14288 by implementing the 2nd proposed idea.

For `sw-select-*` components, the default behavior for `showClearableButton` gets changed to:
- `true`, if the field is not required
- `false`, if the field is required

By setting the `showClearableButton` property explicitly, it works the same as before.