### PR TITLE
fix: tax rate is inconsistent with variant products

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/sw-product-price-form.html.twig
@@ -9,10 +9,11 @@
 
         {% block sw_product_price_form_tax_field %}
         <sw-inherit-wrapper
+            v-if="!isLoading"
             ref="taxIdInheritation"
             v-model:value="product.taxId"
             :inherited-value="parentProduct.taxId"
-            :has-parent="!!parentProduct.taxId"
+            :has-parent="!!parentProduct.id"
             :help-text="taxRateHelpText"
             :label="$tc('sw-product.priceForm.labelTaxRate')"
             class="sw-product-price-form__tax-rate"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -775,7 +775,7 @@ export default {
                     Shopware.Store.get('swProductDetail').product = product;
 
                     if (this.product.parentId) {
-                        this.loadParentProduct();
+                        await this.loadParentProduct();
                     } else {
                         Shopware.Store.get('swProductDetail').parentProduct = {};
                     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/store.ts
@@ -235,7 +235,8 @@ const swProductDetail = Shopware.Store.register({
         setTaxes(newTaxes: EntitySchema.tax[]) {
             this.taxes = newTaxes;
 
-            if (this.product && this.product.taxId === null && !this.parentProduct.id) {
+            // if product has no tax id and is not a child product, set the first tax id
+            if (this.product && this.product.taxId === null && !this.isChild) {
                 this.product.taxId = this.taxes[0]?.id;
             }
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This pull request introduces improvements to the product detail and price form components, focusing on more accurate handling of parent products and better initialization of tax fields. 

### 2. What does this change do, exactly?
**Product Parent Handling:**

* Updated the logic in `sw-product-price-form.html.twig` to use `parentProduct.id` instead of `parentProduct.taxId` for determining if a product has a parent, ensuring more reliable parent detection.
* Changed the parent product loading in `sw-product-detail/index.js` to await `loadParentProduct()`, ensuring the parent product data is fully loaded before proceeding.

**Tax Field Initialization:**

* Modified the tax initialization logic in the store (`sw-product-detail/store.ts`) to check if the product is a child using `isChild` instead of relying on the absence of `parentProduct.id`, improving the accuracy of when to set the default tax ID.

**UI Responsiveness:**

* Added a `v-if="!isLoading"` condition to the tax field wrapper in `sw-product-price-form.html.twig`, preventing the field from rendering while loading and improving user experience.

### 3. Describe each step to reproduce the issue or behaviour.
Follow the relevant issue below to reproduce.

### 4. Please link to the relevant issues (if any).
- closes #12974 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
