### PR TITLE
chore: add more phpstan type specifier for DAL classes

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -805,12 +805,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: '#^Parameter \#1 \$entityName of method Shopware\\Core\\Framework\\DataAbstractionLayer\\DefinitionInstanceRegistry\:\:getByEntityName\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
-
-		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Type/EntityExistenceHasEntityNameSpecifyingExtension.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Type/EntityExistenceHasEntityNameSpecifyingExtension.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\TypeCombinator;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class EntityExistenceHasEntityNameSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+    private TypeSpecifier $typeSpecifier;
+
+    public function getClass(): string
+    {
+        return EntityExistence::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
+    {
+        $declaringClass = $methodReflection->getDeclaringClass();
+
+        return (
+            $declaringClass->getName() === EntityExistence::class
+            || $declaringClass->is(EntityExistence::class)
+        )
+            && $methodReflection->getName() === 'hasEntityName' && !$context->null();
+    }
+
+    public function specifyTypes(
+        MethodReflection $methodReflection,
+        MethodCall $node,
+        Scope $scope,
+        TypeSpecifierContext $context
+    ): SpecifiedTypes {
+        $getExpr = new MethodCall($node->var, 'getEntityName');
+
+        $getterTypes = $this->typeSpecifier->create(
+            $getExpr,
+            TypeCombinator::removeNull($scope->getType($getExpr)),
+            $context,
+            $scope
+        );
+
+        return $getterTypes->unionWith(
+            $this->typeSpecifier->create(
+                $getExpr,
+                new NullType(),
+                $context->negate(),
+                $scope
+            )
+        );
+    }
+
+    public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+    {
+        $this->typeSpecifier = $typeSpecifier;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class FieldIsSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+    private TypeSpecifier $typeSpecifier;
+
+    public function getClass(): string
+    {
+        return Field::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
+    {
+        $declaringClass = $methodReflection->getDeclaringClass();
+
+        if ((
+            $declaringClass->getName() !== Field::class
+                || !$declaringClass->is(Field::class)
+        ) || $methodReflection->getName() !== 'is' || $context->null()) {
+            return false;
+        }
+
+        $flagClass = $node->args[0];
+        // getFlag does not support variadic arguments, therefore, the first argument is always an Arg
+        \assert($flagClass instanceof Arg);
+        $value = $flagClass->value;
+
+        return
+            // case for $field->is('Some\Flag\Class')
+            $value instanceof String_
+            // case for $field->is(Some\Flag\Class::class), more complex cases are not supported
+            || (
+                $value instanceof ClassConstFetch
+                && $value->name->toString() === 'class'
+                && !$value->class instanceof Variable
+            );
+    }
+
+    public function specifyTypes(
+        MethodReflection $methodReflection,
+        MethodCall $node,
+        Scope $scope,
+        TypeSpecifierContext $context
+    ): SpecifiedTypes {
+        $getExpr = new MethodCall($node->var, 'getFlag', $node->args);
+
+        $flagClass = $node->args[0];
+        // getFlag does not support variadic arguments, therefore, the first argument is always an Arg
+        \assert($flagClass instanceof Arg);
+        $value = $flagClass->value;
+        // value was checked in isMethodSupported()
+        \assert($value instanceof String_ || $value instanceof ClassConstFetch);
+
+        if ($value instanceof String_) {
+            $className = $value->value;
+        } else {
+            $className = $value->class->toString();
+        }
+
+        $getterTypes = $this->typeSpecifier->create(
+            $getExpr,
+            new ObjectType($className),
+            $context,
+            $scope
+        );
+
+        return $getterTypes->unionWith(
+            $this->typeSpecifier->create(
+                $getExpr,
+                new NullType(),
+                $context->negate(),
+                $scope
+            )
+        );
+    }
+
+    public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+    {
+        $this->typeSpecifier = $typeSpecifier;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Type/FieldIsSpecifyingExtension.php
@@ -6,6 +6,8 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Analyser\SpecifiedTypes;
@@ -54,8 +56,9 @@ class FieldIsSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeS
             // case for $field->is(Some\Flag\Class::class), more complex cases are not supported
             || (
                 $value instanceof ClassConstFetch
+                && $value->name instanceof Identifier
                 && $value->name->toString() === 'class'
-                && !$value->class instanceof Variable
+                && $value->class instanceof Name
             );
     }
 
@@ -77,6 +80,8 @@ class FieldIsSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeS
         if ($value instanceof String_) {
             $className = $value->value;
         } else {
+            // value->class was checked in isMethodSupported()
+            \assert($value->class instanceof Name);
             $className = $value->class->toString();
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
@@ -3,3 +3,11 @@ services:
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type\CollectionHasSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type\EntityExistenceHasEntityNameSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Type\FieldIsSpecifyingExtension
+        tags:
+            - phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -318,12 +318,7 @@ class CriteriaPartResolver
             return self::escape($field->getReferenceField());
         }
 
-        $flag = $field->getFlag(ReverseInherited::class);
-        if ($flag === null) {
-            return self::escape($field->getReferenceField());
-        }
-
-        return self::escape($flag->getReversedPropertyName());
+        return self::escape($field->getFlag(ReverseInherited::class)->getReversedPropertyName());
     }
 
     private function buildMappingVersionWhere(EntityDefinition $definition, AssociationField $field): string

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToManyAssociationFieldResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToManyAssociationFieldResolver.php
@@ -108,12 +108,7 @@ class ManyToManyAssociationFieldResolver extends AbstractFieldResolver
             return EntityDefinitionQueryHelper::escape($field->getReferenceField());
         }
 
-        $flag = $field->getFlag(ReverseInherited::class);
-        if ($flag === null) {
-            return EntityDefinitionQueryHelper::escape($field->getReferenceField());
-        }
-
-        return EntityDefinitionQueryHelper::escape($flag->getReversedPropertyName());
+        return EntityDefinitionQueryHelper::escape($field->getFlag(ReverseInherited::class)->getReversedPropertyName());
     }
 
     private function buildVersionWhere(EntityDefinition $definition, ManyToManyAssociationField $field): string

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolver.php
@@ -209,12 +209,7 @@ class ManyToOneAssociationFieldResolver extends AbstractFieldResolver
     private function getReferenceColumn(AssociationField $field, Context $context): string
     {
         if ($field->is(ReverseInherited::class) && $context->considerInheritance()) {
-            $flag = $field->getFlag(ReverseInherited::class);
-            if ($flag === null) {
-                return EntityDefinitionQueryHelper::escape($field->getReferenceField());
-            }
-
-            return EntityDefinitionQueryHelper::escape($flag->getReversedPropertyName());
+            return EntityDefinitionQueryHelper::escape($field->getFlag(ReverseInherited::class)->getReversedPropertyName());
         }
 
         return EntityDefinitionQueryHelper::escape($field->getReferenceField());

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/OneToManyAssociationFieldResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/OneToManyAssociationFieldResolver.php
@@ -94,12 +94,7 @@ class OneToManyAssociationFieldResolver extends AbstractFieldResolver
     private function getReferenceColumn(FieldResolverContext $context, OneToManyAssociationField $field): string
     {
         if ($field->is(ReverseInherited::class) && $context->getContext()->considerInheritance()) {
-            $flag = $field->getFlag(ReverseInherited::class);
-            if ($flag === null) {
-                return EntityDefinitionQueryHelper::escape($field->getReferenceField());
-            }
-
-            return EntityDefinitionQueryHelper::escape($flag->getReversedPropertyName());
+            return EntityDefinitionQueryHelper::escape($field->getFlag(ReverseInherited::class)->getReversedPropertyName());
         }
 
         return EntityDefinitionQueryHelper::escape($field->getReferenceField());

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
@@ -171,9 +171,7 @@ abstract class AbstractFieldSerializer implements FieldSerializerInterface
             return strip_tags((string) $data->getValue());
         }
 
-        $flag = $field->getFlag(AllowHtml::class);
-
-        if ($flag instanceof AllowHtml && $flag->isSanitized()) {
+        if ($field->getFlag(AllowHtml::class)->isSanitized()) {
             $fieldKey = \sprintf('%s.%s', (string) $existence->getEntityName(), $field->getPropertyName());
 
             return $sanitizer->sanitize((string) $data->getValue(), [], false, $fieldKey);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -968,7 +968,6 @@ class AttributeEntityIntegrationTest extends TestCase
         );
 
         $inheritedFlag = $inheritedWithForeignKeyField->getFlag(Inherited::class);
-        static::assertInstanceOf(Inherited::class, $inheritedFlag);
         static::assertSame('custom_fk', $inheritedFlag->getForeignKey());
 
         $productField = $definition->getFields()->get('product');


### PR DESCRIPTION

### 1. Why is this change necessary?
Having `is()` or `has()` functionalitly without phpstan knowing about it is useless, as you still need to do null checks whenever you use get 

### 2. What does this change do, exactly?
Add type specifier to let phpstan know when `field->is(Flag::class)` that the getter for the same flag will return an instance of that flag
also add a type specifier for `EntityExistence::hasEntityName()` to remove null for `EntityExistence::getEntityName()`

### 3. Describe each step to reproduce the issue or behaviour.
see wild code that i could remove here, where we needed to add if checks for cases we already know to never happen
