### PR TITLE
fix: app flow actions custom headers are not sent

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -23,6 +23,10 @@ Also, the generator now sets `CASCADE DELETE` on foreign keys for the translatio
 
 ## App System
 
+### Fixed custom headers for app flow action webhooks in async mode
+
+Custom headers defined in app flow action configurations are now correctly sent when webhooks are processed asynchronously via message queue (when `admin_worker` is disabled). Previously, these headers were only sent when `admin_worker` was enabled (synchronous processing).
+
 ## Hosting & Configuration
 
 ## Critical Fixes

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -52,8 +52,13 @@ final readonly class WebhookEventMessageHandler
 
         $jsonPayload = json_encode($payload, \JSON_THROW_ON_ERROR);
 
-        $headers = ['Content-Type' => 'application/json',
-            'sw-version' => $shopwareVersion, ];
+        $headers = array_merge(
+            [
+                'Content-Type' => 'application/json',
+                'sw-version' => $shopwareVersion,
+            ],
+            $message->getWebhookHeaders()
+        );
 
         // LanguageId and UserLocale will be required from 6.5.0 onward
         if ($message->getLanguageId() && $message->getUserLocale()) {

--- a/src/Core/Framework/Webhook/Message/WebhookEventMessage.php
+++ b/src/Core/Framework/Webhook/Message/WebhookEventMessage.php
@@ -15,6 +15,7 @@ class WebhookEventMessage implements AsyncMessageInterface
      * @internal
      *
      * @param array<string, mixed> $payload
+     * @param array<string, string> $webhookHeaders
      **/
     public function __construct(
         private readonly string $webhookEventId,
@@ -25,7 +26,8 @@ class WebhookEventMessage implements AsyncMessageInterface
         private readonly string $url,
         private readonly ?string $secret,
         private readonly string $languageId,
-        private readonly string $userLocale
+        private readonly string $userLocale,
+        private readonly array $webhookHeaders = [],
     ) {
     }
 
@@ -75,5 +77,13 @@ class WebhookEventMessage implements AsyncMessageInterface
     public function getUserLocale(): ?string
     {
         return $this->userLocale;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getWebhookHeaders(): array
+    {
+        return $this->webhookHeaders;
     }
 }

--- a/src/Core/Framework/Webhook/Service/WebhookManager.php
+++ b/src/Core/Framework/Webhook/Service/WebhookManager.php
@@ -147,6 +147,10 @@ class WebhookManager implements ResetInterface
                 continue;
             }
 
+            $webhookHeaders = $event instanceof AppFlowActionEvent
+                ? $event->getWebhookHeaders()
+                : [];
+
             $webhookEventMessage = new WebhookEventMessage(
                 $webhookData['source']['eventId'],
                 $webhookData,
@@ -156,7 +160,8 @@ class WebhookManager implements ResetInterface
                 $webhook->url,
                 $webhook->appSecret,
                 $languageId,
-                $userLocale
+                $userLocale,
+                $webhookHeaders
             );
 
             $this->logWebhookWithEvent($webhook, $webhookEventMessage);

--- a/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
@@ -230,7 +230,11 @@ class WebhookEventMessageHandlerTest extends TestCase
         ]], Context::createDefaultContext());
 
         $webhookEventId = Uuid::randomHex();
-        $webhookEventMessage = new WebhookEventMessage($webhookEventId, ['body' => 'payload'], $appId, $webhookId, '6.4', 'http://test.com', 's3cr3t', Defaults::LANGUAGE_SYSTEM, 'en-GB');
+        $customHeaders = [
+            'X-Custom-Header' => 'custom-value',
+            'X-Another-Header' => 'another-value',
+        ];
+        $webhookEventMessage = new WebhookEventMessage($webhookEventId, ['body' => 'payload'], $appId, $webhookId, '6.4', 'http://test.com', 's3cr3t', Defaults::LANGUAGE_SYSTEM, 'en-GB', $customHeaders);
 
         $this->appendNewResponse(new Response(200));
 
@@ -254,6 +258,9 @@ class WebhookEventMessageHandlerTest extends TestCase
             hash_hmac('sha256', $payload, 's3cr3t'),
             $request->getHeaderLine('shopware-shop-signature')
         );
+        // Verify custom webhook headers are sent
+        static::assertSame('custom-value', $request->getHeaderLine('X-Custom-Header'));
+        static::assertSame('another-value', $request->getHeaderLine('X-Another-Header'));
     }
 
     public function testNonJsonErrorResponse(): void

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -69,8 +69,8 @@ class WebhookManagerTest extends TestCase
 
     public function testDispatchesTwoConsecutiveEventsCorrectly(): void
     {
-        $event1 = new AppFlowActionEvent('foobar', ['foo' => 'bar'], ['foo' => 'bar']);
-        $event2 = new class('foobar.event', ['foo' => 'bar'], ['foo' => 'bar']) extends AppFlowActionEvent {};
+        $event1 = new AppFlowActionEvent('foobar', ['x-test-header' => 'test-header-val'], ['foo' => 'bar']);
+        $event2 = new class('foobar.event', ['x-test-header' => 'test-header-val'], ['foo' => 'bar']) extends AppFlowActionEvent {};
 
         $this->eventFactory
             ->expects($this->exactly(2))
@@ -130,6 +130,7 @@ class WebhookManagerTest extends TestCase
         static::assertSame($message->getShopwareVersion(), '0.0.0');
         static::assertSame($message->getUrl(), 'https://foo.bar');
         static::assertSame($message->getWebhookId(), $webhook->id);
+        static::assertSame(['x-test-header' => 'test-header-val'], $message->getWebhookHeaders());
     }
 
     public function testWebhookSettingForLiveVersionOnlyIsIgnoredIfEventTypeDoesNotMatch(): void
@@ -313,7 +314,7 @@ class WebhookManagerTest extends TestCase
             'POST',
             $webhook->url,
             [
-                'foo' => 'bar',
+                'x-test-header' => 'test-header-val',
                 'Content-Type' => 'application/json',
                 'sw-version' => '0.0.0',
                 'sw-context-language' => [Defaults::LANGUAGE_SYSTEM],
@@ -356,7 +357,7 @@ class WebhookManagerTest extends TestCase
 
     private function prepareEvent(): AppFlowActionEvent
     {
-        $event = new AppFlowActionEvent('foobar', ['foo' => 'bar'], ['foo' => 'bar']);
+        $event = new AppFlowActionEvent('foobar', ['x-test-header' => 'test-header-val'], ['foo' => 'bar']);
 
         $this->eventFactory
             ->expects($this->once())


### PR DESCRIPTION
### 1. Why is this change necessary?

When custom app workflow action webhooks are processed asynchronously via the message queue (when `admin_worker` is disabled), custom headers defined in the app's `flow.xml` are not sent with the webhook HTTP request. The headers work correctly when `admin_worker` is enabled (synchronous processing).

### 2. What does this change do, exactly?

The fix adds support for transferring custom webhook headers through the message queue by adding `webhookHeaders` to the `WebhookEventMessage`

### 3. Describe each step to reproduce the issue or behaviour.

### Steps to reproduce

1. Create an app with a custom flow action that defines headers

   Follow the [App Flow Actions documentation](https://developer.shopware.com/docs/guides/plugins/apps/flow-builder/add-custom-flow-actions-from-app.html) to create an app.

   Example `Resources/flow.xml`:

   ```xml
    <flow-extensions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Framework/App/Flow/Schema/flow-1.0.xsd">
        <flow-actions>
            <flow-action>
                <meta>
                    <name>my-app.testing-action</name>
                    <label>My custom app action</label>
                    <url>https://...</url>
                    <requirements>orderAware</requirements>
                    <requirements>customerAware</requirements>
                    <requirements>customerGroupAware</requirements>
                    <requirements>delayAware</requirements>
                    <requirements>mailAware</requirements>
                    <requirements>salesChannelAware</requirements>
                    <requirements>userAware</requirements>
                </meta>
                <headers>
                    <parameter type="string" name="sw-test-header" value="category-update"/>
                </headers>
            </flow-action>
        </flow-actions>
    </flow-extensions>
   ```

2. Install the app and create a flow using this action

3.  Go to Settings > Automation > Flow Builder and create a flow that triggers your custom action (e.g., on "Review placed")

4. Trigger the flow and inspect the webhook request 

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/3478

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
