### PR TITLE
fix: reset document selection state between bulk edits

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/store/sw-bulk-edit.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/sw-bulk-edit.store.spec.js
@@ -28,4 +28,24 @@ describe('src/app/store/sw-bulk-edit.store', () => {
         });
         expect(state.orderDocuments.invoice.isChanged).toBe(false);
     });
+
+    it('should be able to resetOrderDocumentsIsChanged', async () => {
+        const store = Shopware.Store.get('swBulkEdit');
+
+        store.setOrderDocumentsIsChanged({ type: 'invoice', isChanged: true });
+        store.setOrderDocumentsIsChanged({ type: 'delivery_note', isChanged: true });
+        store.setOrderDocumentsIsChanged({ type: 'storno', isChanged: true });
+
+        expect(store.orderDocuments.invoice.isChanged).toBe(true);
+        expect(store.orderDocuments.delivery_note.isChanged).toBe(true);
+        expect(store.orderDocuments.storno.isChanged).toBe(true);
+
+        store.resetOrderDocumentsIsChanged();
+
+        expect(store.orderDocuments.invoice.isChanged).toBe(false);
+        expect(store.orderDocuments.storno.isChanged).toBe(false);
+        expect(store.orderDocuments.delivery_note.isChanged).toBe(false);
+        expect(store.orderDocuments.credit_note.isChanged).toBe(false);
+        expect(store.orderDocuments.download.isChanged).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/store/sw-bulk-edit.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/sw-bulk-edit.store.ts
@@ -103,6 +103,14 @@ const swBulkStore = Shopware.Store.register('swBulkEdit', {
             | { type: 'download'; value: OrderDownloadDocument['value'] }) {
             this.orderDocuments[type].value = value;
         },
+        resetOrderDocumentsIsChanged() {
+            Object.keys(this.orderDocuments).forEach((type) => {
+                this.setOrderDocumentsIsChanged({
+                    type: type as keyof SwBulkState['orderDocuments'],
+                    isChanged: false,
+                });
+            });
+        },
     },
 
     getters: {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
@@ -251,6 +251,7 @@ export default {
     methods: {
         async createdComponent() {
             this.setRouteMetaModule();
+            this.resetOrderDocumentsIsChanged();
 
             this.isLoading = true;
 
@@ -560,6 +561,10 @@ export default {
                 type,
                 isChanged,
             });
+        },
+
+        resetOrderDocumentsIsChanged() {
+            Shopware.Store.get('swBulkEdit').resetOrderDocumentsIsChanged();
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
@@ -251,7 +251,7 @@ export default {
     methods: {
         async createdComponent() {
             this.setRouteMetaModule();
-            this.resetOrderDocumentsIsChanged();
+            Shopware.Store.get('swBulkEdit').resetOrderDocumentsIsChanged();
 
             this.isLoading = true;
 
@@ -561,10 +561,6 @@ export default {
                 type,
                 isChanged,
             });
-        },
-
-        resetOrderDocumentsIsChanged() {
-            Shopware.Store.get('swBulkEdit').resetOrderDocumentsIsChanged();
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
@@ -790,4 +790,14 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-order', () => {
         expect(wrapper.vm.statusFormFields).toHaveLength(4);
         expect(wrapper.vm.statusFormFields[1].name).not.toBe('orderDeliveries');
     });
+
+    it('should reset order documents isChanged on component creation', async () => {
+        const store = Shopware.Store.get('swBulkEdit');
+        const resetSpy = jest.spyOn(store, 'resetOrderDocumentsIsChanged');
+
+        wrapper = await createWrapper();
+        await flushPromises();
+
+        expect(resetSpy).toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
resolves #14360

Resets document type `isChanged` when entering bulk edit to prevent previous selections from persisting across sessions.