### PR TITLE
fix: document footer placement (backport: 6.6.x)

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -73,6 +73,8 @@ merge 16.11.2020
 
     <body>
 
+    {{ block('footer') }}
+
     <main>
         {% block document_body %}
             {% set position = 1 %}
@@ -94,8 +96,6 @@ merge 16.11.2020
             {{ block('shipping_address')  }}
         {% endblock %}
     </main>
-
-    {{ block('footer') }}
 
     </body>
     </html>


### PR DESCRIPTION
backports the footer placement fix from #11176

resolves #7911
resolves #7996