### PR TITLE
fix: add filter for null path in CleanupCorruptedMediaHandler

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -45,14 +45,6 @@ shopware:
 
 **Note**: This is an opt-in fix for environments where Redis is not available. Using Redis for both sessions and cache is the recommended solution. Disabling stampede protection may increase database load under high concurrency when cache entries expire.
 
-### CleanupCorruptedMediaTask deleting valid media with path
-
-Fixed an issue where `CleanupCorruptedMediaTask` deleted valid media files with file_size `null` if they have a `path` provided.
-
-**Problem**: The task incorrectly identified media files with `file_size` as `null` but with a valid `path` as corrupted, leading to their deletion.
-
-**Solution**: The task now only deletes media files that have both `file_size` and `path` as `null`, ensuring that valid (cdn) media files are preserved.
-
 # 6.7.7.0
 
 ## Features

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -45,6 +45,14 @@ shopware:
 
 **Note**: This is an opt-in fix for environments where Redis is not available. Using Redis for both sessions and cache is the recommended solution. Disabling stampede protection may increase database load under high concurrency when cache entries expire.
 
+### CleanupCorruptedMediaTask deleting valid media with path
+
+Fixed an issue where `CleanupCorruptedMediaTask` deleted valid media files with file_size `null` if they have a `path` provided.
+
+**Problem**: The task incorrectly identified media files with `file_size` as `null` but with a valid `path` as corrupted, leading to their deletion.
+
+**Solution**: The task now only deletes media files that have both `file_size` and `path` as `null`, ensuring that valid (cdn) media files are preserved.
+
 # 6.7.7.0
 
 ## Features

--- a/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
+++ b/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
@@ -38,6 +38,7 @@ final class CleanupCorruptedMediaHandler extends ScheduledTaskHandler
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('fileSize', null));
+        $criteria->addFilter(new EqualsFilter('path', null));
 
         $ids = $this->mediaRepository->searchIds($criteria, $context)->getIds();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
See description in issue [#14634](https://github.com/shopware/shopware/issues/14634)

### 2. What does this change do, exactly?
Only delete media that have no file_size AND no path

### 3. Describe each step to reproduce the issue or behaviour.
- Upload/Add Media via POST api/media including a path
- Run the scheduled task
- See entry in media database gets removed 

### 4. Please link to the relevant issues (if any).
[#14634](https://github.com/shopware/shopware/issues/14634)
