### PR TITLE
chore: improve messages in NoDropStatementInUpdateRule phpstan rule

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoDropStatementInUpdateRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoDropStatementInUpdateRule.php
@@ -152,9 +152,10 @@ class NoDropStatementInUpdateRule implements Rule
     private function inspectMethodCall(MethodCall $statement, Identifier $name, ClassMethod $node, array $errors): array
     {
         if (\in_array($name->name, self::$disallowedMethodCalls, true)) {
-            $message = $name->name === 'dropForeignKeyIfExists'
-                ? 'Usage of "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.'
-                : \sprintf('Usage of method "%s" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', $name->name);
+            $message = \sprintf('Usage of method "%s" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', $name->name);
+            if ($name->name === 'dropForeignKeyIfExists') {
+                $message .= ' Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.';
+            }
 
             $errors[] = RuleErrorBuilder::message($message)
                 ->identifier('shopware.dropStatement')

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoDropStatementInUpdateRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoDropStatementInUpdateRule.php
@@ -152,10 +152,11 @@ class NoDropStatementInUpdateRule implements Rule
     private function inspectMethodCall(MethodCall $statement, Identifier $name, ClassMethod $node, array $errors): array
     {
         if (\in_array($name->name, self::$disallowedMethodCalls, true)) {
-            $errors[] = RuleErrorBuilder::message(\sprintf(
-                'Usage of method "%s" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.',
-                $name->name
-            ))
+            $message = $name->name === 'dropForeignKeyIfExists'
+                ? 'Usage of "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.'
+                : \sprintf('Usage of method "%s" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', $name->name);
+
+            $errors[] = RuleErrorBuilder::message($message)
                 ->identifier('shopware.dropStatement')
                 ->line($statement->getStartLine())
                 ->build();
@@ -209,7 +210,7 @@ class NoDropStatementInUpdateRule implements Rule
         }
 
         if (preg_match(self::DROP_FOREIGN_KEY_REGEX_PATTERN, $sqlStatementToCheck) === 1) {
-            $errors[] = RuleErrorBuilder::message('Usage of "DROP FOREIGN KEY" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.')
+            $errors[] = RuleErrorBuilder::message('Usage of "DROP FOREIGN KEY" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.')
                 ->identifier('shopware.dropStatement')
                 ->line($statement->getStartLine())
                 ->build();

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
@@ -26,7 +26,7 @@ class NoDropStatementInUpdateRuleTest extends RuleTestCase
         ], [
             // Helper method calls
             ['Usage of method "dropColumnIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 19],
-            ['Usage of "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.', 20],
+            ['Usage of method "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.', 20],
             ['Usage of method "dropTableIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 21],
 
             // SQL statements

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
@@ -26,14 +26,14 @@ class NoDropStatementInUpdateRuleTest extends RuleTestCase
         ], [
             // Helper method calls
             ['Usage of method "dropColumnIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 19],
-            ['Usage of method "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 20],
+            ['Usage of "dropForeignKeyIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.', 20],
             ['Usage of method "dropTableIfExists" is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 21],
 
             // SQL statements
             ['Usage of "DROP COLUMN" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 25],
             ['Usage of "DROP COLUMN" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 26],
             ['Usage of "DROP" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 27],
-            ['Usage of "DROP FOREIGN KEY" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 28],
+            ['Usage of "DROP FOREIGN KEY" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks. Dropping FKs is OK if immediately re-added, or if not breaking old app version validation. Use @phpstan-ignore shopware.dropStatement if intentional.', 28],
             ['Usage of "DROP TABLE" statements is disallowed in the "update" method of a migration to avoid blue green compatibility breaks.', 29],
 
             // within private method


### PR DESCRIPTION
### 1. Why is this change necessary?

`NoDropStatementInUpdateRule` phpstan rule can report false positives in two cases:
- fk is removed and then created
- there is no dependency on fk for validation in older app version, so removing fk will keep old version working.

See https://github.com/shopware/shopware/issues/11612

### 2. What does this change do, exactly?

It still makes sense to draw developers attention, so second case is checked. Unfortunately phpstan does not allow to just warn user, it's either rule is passing or failing. At the same time implementing reliable check for the first case makes rule unnecessary complex. As we have not so much cases where we had to ignore this rule, the PR only updates error message to make risks clearer, but still keeps an error reporting in place.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/11612

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
