### PR TITLE
fix: fallback on invalid locale in twig number format filters

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -744,6 +744,11 @@ This method was moved to FocusHandler Helper. Use this instead.
 const lastFocusableEl = window.focusHandler.getLastFocusableElement();
 ```
 
+## Invalid locale codes no longer supported
+
+Passing invalid locale codes (esp non localized two letter codes like "US") to the default `format_number` and `format_currency` twig filters will now throw an error.
+Please use the proper localized codes like "en-US" instead. Additionally, you should use the shopware specific `currency`, instead of the native `format_currency` filter, to already handle configured rounding etc.
+
 ## Remove route `widgets.account.order.detail`
 
 Remove all references to `widgets.account.order.detail` and ensure that affected components handle navigation and display correctly

--- a/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
+++ b/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Feature;
 use Twig\Extension\AbstractExtension;
 use Twig\Extra\Intl\IntlExtension;
 use Twig\TwigFilter;
-use ValueError;
 
 /**
  * @internal

--- a/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
+++ b/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Adapter\Twig;
 
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Twig\Extension\AbstractExtension;
 use Twig\Extra\Intl\IntlExtension;
 use Twig\TwigFilter;
@@ -10,11 +11,12 @@ use Twig\TwigFilter;
 /**
  * @internal
  *
- * @deprecated tag:v6.8.0 - will be removed in 6.8.0, invalid locales won't be supported anymore
+ * @deprecated tag:v6.8.0 - reason:remove-decorator - will be removed in 6.8.0, invalid locales won't be supported anymore
  *
  * We overwrite the IntlExtension to make sure that invalid locales are still supported
  * Since php 8.4.1 invalid locales will throw an exception, which leads to a breaking change
  */
+#[Package('framework')]
 class BackwardCompatibleIntlExtension extends AbstractExtension
 {
     public function __construct(
@@ -26,15 +28,23 @@ class BackwardCompatibleIntlExtension extends AbstractExtension
     {
         return [
             // localized formatters
-            new TwigFilter('format_currency', [$this, 'formatCurrency']),
-            new TwigFilter('format_number', [$this, 'formatNumber']),
-            new TwigFilter('format_*_number', [$this, 'formatNumberStyle']),
+            new TwigFilter('format_currency', $this->formatCurrency(...)),
+            new TwigFilter('format_number', $this->formatNumber(...)),
+            new TwigFilter('format_*_number', $this->formatNumberStyle(...)),
         ];
     }
 
-    public function formatCurrency($amount, string $currency, array $attrs = [], ?string $locale = null): string
+    /**
+     * @param array<string, null> $attrs
+     */
+    public function formatCurrency(mixed $amount, string $currency, array $attrs = [], ?string $locale = null): string
     {
+        if ($locale === null) {
+            return $this->intlExtension->formatCurrency($amount, $currency, $attrs, $locale);
+        }
+
         try {
+            /** @phpstan-ignore new.resultUnused (just called to "validate" the locale) */
             new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
         } catch (\ValueError) {
             Feature::triggerDeprecationOrThrow(
@@ -48,9 +58,17 @@ class BackwardCompatibleIntlExtension extends AbstractExtension
         return $this->intlExtension->formatCurrency($amount, $currency, $attrs, $locale);
     }
 
-    public function formatNumber($number, array $attrs = [], string $style = 'decimal', string $type = 'default', ?string $locale = null): string
+    /**
+     * @param array<string, null> $attrs
+     */
+    public function formatNumber(mixed $number, array $attrs = [], string $style = 'decimal', string $type = 'default', ?string $locale = null): string
     {
+        if ($locale === null) {
+            return $this->intlExtension->formatNumber($number, $attrs, $style, $type, $locale);
+        }
+
         try {
+            /** @phpstan-ignore new.resultUnused (just called to "validate" the locale) */
             new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
         } catch (\ValueError) {
             Feature::triggerDeprecationOrThrow(
@@ -64,7 +82,10 @@ class BackwardCompatibleIntlExtension extends AbstractExtension
         return $this->intlExtension->formatNumber($number, $attrs, $style, $type, $locale);
     }
 
-    public function formatNumberStyle(string $style, $number, array $attrs = [], string $type = 'default', ?string $locale = null): string
+    /**
+     * @param array<string, null> $attrs
+     */
+    public function formatNumberStyle(string $style, mixed $number, array $attrs = [], string $type = 'default', ?string $locale = null): string
     {
         return $this->formatNumber($number, $attrs, $style, $type, $locale);
     }

--- a/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
+++ b/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig;
+
+use Shopware\Core\Framework\Feature;
+use Twig\Extension\AbstractExtension;
+use Twig\Extra\Intl\IntlExtension;
+use Twig\TwigFilter;
+use ValueError;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.8.0 - will be removed in 6.8.0, invalid locales won't be supported anymore
+ *
+ * We overwrite the IntlExtension to make sure that invalid locales are still supported
+ * Since php 8.4.1 invalid locales will throw an exception, which leads to a breaking change
+ */
+class BackwardCompatibleIntlExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly IntlExtension $intlExtension,
+    ) {
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            // localized formatters
+            new TwigFilter('format_currency', [$this, 'formatCurrency']),
+            new TwigFilter('format_number', [$this, 'formatNumber']),
+            new TwigFilter('format_*_number', [$this, 'formatNumberStyle']),
+        ];
+    }
+
+    public function formatCurrency($amount, string $currency, array $attrs = [], ?string $locale = null): string
+    {
+        try {
+            new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        } catch (\ValueError) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                'The locale "' . $locale . '" passed to "format_currency" twig filter is no valid PHP locale. Please use a valid locale.'
+            );
+
+            $locale = null;
+        }
+
+        return $this->intlExtension->formatCurrency($amount, $currency, $attrs, $locale);
+    }
+
+    public function formatNumber($number, array $attrs = [], string $style = 'decimal', string $type = 'default', ?string $locale = null): string
+    {
+        try {
+            new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
+        } catch (\ValueError) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                'The locale "' . $locale . '" passed to "format_number" twig filter is no valid PHP locale. Please use a valid locale.'
+            );
+
+            $locale = null;
+        }
+
+        return $this->intlExtension->formatNumber($number, $attrs, $style, $type, $locale);
+    }
+
+    public function formatNumberStyle(string $style, $number, array $attrs = [], string $type = 'default', ?string $locale = null): string
+    {
+        return $this->formatNumber($number, $attrs, $style, $type, $locale);
+    }
+}

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -428,6 +428,12 @@ frame-ancestors 'none';
             <tag name="twig.extension"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Adapter\Twig\BackwardCompatibleIntlExtension">
+            <argument type="service" id="twig.extension.intl"/>
+            <tag name="twig.extension"/>
+        </service>
+
+
         <service id="Shopware\Core\Framework\Adapter\Twig\SecurityExtension">
             <argument>%shopware.twig.allowed_php_functions%</argument>
             <tag name="twig.extension"/>

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
@@ -13,6 +14,13 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 class BackwardCompatibleIntlExtensionTest extends TestCase
 {
     use KernelTestBehaviour;
+
+    protected function setUp(): void
+    {
+        if (Feature::isActive('v6.8.0.0')) {
+            static::markTestSkipped('This test is only relevant for versions before v6.8.0');
+        }
+    }
 
     public function testNumberFormatWithInvalidLocaleFallsBackToDefault(): void
     {

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -33,6 +33,6 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
 
         $output = $template->render(['value' => 1234567.891]);
 
-        static::assertEquals('$ 1234567.89', $output);
+        static::assertEquals("\$\u{a0}1234567.89", $output);
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -22,7 +22,7 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
 
         $output = $template->render(['value' => 1234567.891]);
 
-        static::assertEquals('1234567.9', $output);
+        static::assertSame('1234567.9', $output);
     }
 
     public function testCurrencyFormatWithInvalidLocaleFallsBackToDefault(): void
@@ -33,6 +33,6 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
 
         $output = $template->render(['value' => 1234567.891]);
 
-        static::assertEquals("\$\u{a0}1234567.89", $output);
+        static::assertSame("\$\u{a0}1234567.89", $output);
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.8.0 - Will be removed, because we don't support invalid locales anymore
+ */
+class BackwardCompatibleIntlExtensionTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testNumberFormatWithInvalidLocaleFallsBackToDefault(): void
+    {
+        $twig = $this->getContainer()->get('twig');
+
+        $template = $twig->createTemplate('{{ value|format_number({fraction_digit: 1}, locale="us") }}');
+
+        $output = $template->render(['value' => 1234567.891]);
+
+        static::assertEquals('1234567.9', $output);
+    }
+
+    public function testCurrencyFormatWithInvalidLocaleFallsBackToDefault(): void
+    {
+        $twig = $this->getContainer()->get('twig');
+
+        $template = $twig->createTemplate('{{ value|format_currency("USD", locale="us") }}');
+
+        $output = $template->render(['value' => 1234567.891]);
+
+        static::assertEquals('$ 1234567.89', $output);
+    }
+}


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/14628


### 1. Why is this change necessary?
see issue: https://github.com/shopware/shopware/issues/14628

### 2. What does this change do, exactly?
Wrap native symfony/twig filters to check if locale is valid and if not use system fallback, to create backwards compatibility to older PHP versions

### 3. Describe each step to reproduce the issue or behaviour.
see added test cases

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/14628

