### PR TITLE
fix: Product Stream should have default value for internal field

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -79,6 +79,7 @@ return [
         'Type of property Shopware\\\\.*\\\\OrderTransactionCaptureEntity#$stateMachineState changed .* to Shopware\\\\.*\\\\StateMachineStateEntity|null',
         'The return type of Shopware\\\\.*\\\\OrderTransactionCaptureEntity#getStateMachineState() changed .* Shopware\\\\.*\\\\StateMachineStateEntity|null',
         'The parameter $stateMachineState of Shopware\\\\.*\\\\OrderTransactionCaptureEntity#setStateMachineState() changed .* Shopware\\\\.*\\\\StateMachineStateEntity|null',
-        'Property Shopware\\\\.*\\\\ProductStreamEntity#$internal changed default value from NULL to false'
+
+        preg_quote('CHANGED: Property Shopware\Core\Content\ProductStream\ProductStreamEntity#$internal changed default value from NULL to false', '/'),
     ],
 ];

--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -79,5 +79,6 @@ return [
         'Type of property Shopware\\\\.*\\\\OrderTransactionCaptureEntity#$stateMachineState changed .* to Shopware\\\\.*\\\\StateMachineStateEntity|null',
         'The return type of Shopware\\\\.*\\\\OrderTransactionCaptureEntity#getStateMachineState() changed .* Shopware\\\\.*\\\\StateMachineStateEntity|null',
         'The parameter $stateMachineState of Shopware\\\\.*\\\\OrderTransactionCaptureEntity#setStateMachineState() changed .* Shopware\\\\.*\\\\StateMachineStateEntity|null',
+        'Property Shopware\\\\.*\\\\ProductStreamEntity#$internal changed default value from NULL to false'
     ],
 ];

--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
+        "shopware/commercial": "7.4.0",
         "shopware/conflicts": "0.6.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.13.0",

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,6 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/commercial": "7.4.0",
         "shopware/conflicts": "0.6.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.13.0",

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-list/index.js
@@ -79,6 +79,7 @@ export default {
 
             let criteria = new Criteria(this.page, this.limit);
 
+            criteria.addFilter(Criteria.equals('internal', false));
             criteria.setTerm(this.term);
             if (this.acl.can('category:read')) {
                 criteria.addAggregation(

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
@@ -63,7 +63,9 @@ export default {
     methods: {
         createdComponent() {
             this.productStreamsLoading = true;
-            this.productStreamRepository.search(new Criteria(1, 1)).then((result) => {
+            const criteria = new Criteria(1, 1);
+            criteria.addFilter(Criteria.equals('internal', false));
+            this.productStreamRepository.search(criteria).then((result) => {
                 if (result.total > 0) {
                     this.productStreamsExist = true;
                 }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-dynamic-product-groups/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-dynamic-product-groups/index.js
@@ -74,6 +74,7 @@ export default {
         productStreamCriteria() {
             const criteria = new Criteria(this.page, this.limit);
 
+            criteria.addFilter(Criteria.equals('internal', false));
             if (this.term) {
                 criteria.setTerm(this.term);
             }

--- a/src/Core/Content/ProductStream/ProductStreamDefinition.php
+++ b/src/Core/Content/ProductStream/ProductStreamDefinition.php
@@ -33,6 +33,13 @@ class ProductStreamDefinition extends EntityDefinition
         return self::ENTITY_NAME;
     }
 
+    public function getDefaults(): array
+    {
+        return [
+            'internal' => false,
+        ];
+    }
+
     public function getCollectionClass(): string
     {
         return ProductStreamCollection::class;

--- a/src/Core/Content/ProductStream/ProductStreamEntity.php
+++ b/src/Core/Content/ProductStream/ProductStreamEntity.php
@@ -99,7 +99,7 @@ class ProductStreamEntity extends Entity
 
     public function isInternal(): bool
     {
-        return $this->internal ?: false;
+        return $this->internal;
     }
 
     public function setInternal(bool $internal): void

--- a/src/Core/Content/ProductStream/ProductStreamEntity.php
+++ b/src/Core/Content/ProductStream/ProductStreamEntity.php
@@ -31,7 +31,7 @@ class ProductStreamEntity extends Entity
 
     protected bool $invalid;
 
-    protected bool $internal;
+    protected bool $internal = false;
 
     protected ?ProductStreamTranslationCollection $translations = null;
 
@@ -99,7 +99,7 @@ class ProductStreamEntity extends Entity
 
     public function isInternal(): bool
     {
-        return $this->internal;
+        return $this->internal ?: false;
     }
 
     public function setInternal(bool $internal): void

--- a/src/Core/Migration/V6_7/Migration1768986102AddInternalColumnToProductStream.php
+++ b/src/Core/Migration/V6_7/Migration1768986102AddInternalColumnToProductStream.php
@@ -20,7 +20,7 @@ class Migration1768986102AddInternalColumnToProductStream extends MigrationStep
     public function update(Connection $connection): void
     {
         if (!$this->columnExists($connection, 'product_stream', 'internal')) {
-            $this->addColumn($connection, 'product_stream', 'internal', 'TINYINT(1)', false,  '0');
+            $this->addColumn($connection, 'product_stream', 'internal', 'TINYINT(1)', false, '0');
         }
     }
 }

--- a/src/Core/Migration/V6_7/Migration1768986102AddInternalColumnToProductStream.php
+++ b/src/Core/Migration/V6_7/Migration1768986102AddInternalColumnToProductStream.php
@@ -20,7 +20,7 @@ class Migration1768986102AddInternalColumnToProductStream extends MigrationStep
     public function update(Connection $connection): void
     {
         if (!$this->columnExists($connection, 'product_stream', 'internal')) {
-            $this->addColumn($connection, 'product_stream', 'internal', 'TINYINT(1) NOT NULL DEFAULT 0');
+            $this->addColumn($connection, 'product_stream', 'internal', 'TINYINT(1)', false,  '0');
         }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
- I found out an issue from this [PR](https://github.com/shopware/shopware/pull/14458)

### 2. What does this change do, exactly?
Since the previous PR was merged yesterday, I would like to update the existing Migration file to set the default value of the internal field from the product stream to 0.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
