### PR TITLE
fix: respect invoice selection in credit notes

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
@@ -48,6 +48,16 @@ export default {
             },
         },
 
+        invoices() {
+            return this.order.documents.filter((document) => {
+                return (
+                    document.documentType.technicalName === 'invoice' ||
+                    document.documentType.technicalName === 'zugferd_invoice' ||
+                    document.documentType.technicalName === 'zugferd_embedded_invoice'
+                );
+            });
+        },
+
         invoiceNumberOptions() {
             return this.invoiceNumbers.map((item) => {
                 return {
@@ -66,23 +76,19 @@ export default {
         createdComponent() {
             this.$super('createdComponent');
 
-            const invoiceNumbers = this.order.documents
-                .filter((document) => {
-                    return (
-                        document.documentType.technicalName === 'invoice' ||
-                        document.documentType.technicalName === 'zugferd_invoice' ||
-                        document.documentType.technicalName === 'zugferd_embedded_invoice'
-                    );
-                })
-                .map((item) => {
-                    return item.config.custom.invoiceNumber;
-                });
+            const invoiceNumbers = this.invoices.map((item) => {
+                return item.config.custom.invoiceNumber;
+            });
 
             this.invoiceNumbers = [...new Set(invoiceNumbers)].sort();
         },
 
         onCreateDocument(additionalAction = false) {
             this.$emit('loading-document');
+
+            const selectedInvoice = this.invoices.find((item) => {
+                return item.config.custom.invoiceNumber === this.documentConfig.custom.invoiceNumber;
+            });
 
             if (this.documentNumberPreview === this.documentConfig.documentNumber) {
                 this.numberRangeService
@@ -95,11 +101,11 @@ export default {
                             });
                         }
                         this.documentConfig.documentNumber = response.number;
-                        this.callDocumentCreate(additionalAction);
+                        this.callDocumentCreate(additionalAction, selectedInvoice?.id);
                     });
             } else {
                 this.documentConfig.custom.creditNoteNumber = this.documentConfig.documentNumber;
-                this.callDocumentCreate(additionalAction);
+                this.callDocumentCreate(additionalAction, selectedInvoice?.id);
             }
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
@@ -7,6 +7,7 @@ const orderFixture = {
     id: 'order1',
     documents: [
         {
+            id: 'invoice-doc-1000',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -23,6 +24,7 @@ const orderFixture = {
             },
         },
         {
+            id: 'invoice-doc-1001',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -39,6 +41,7 @@ const orderFixture = {
             },
         },
         {
+            id: 'delivery-note-doc-1001',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -370,6 +373,40 @@ describe('sw-order-document-settings-credit-note-modal', () => {
 
         expect(wrapper.vm.documentConfig.custom.creditNoteNumber).toBe('PREVIEW_NUM_002');
         expect(wrapper.emitted()['document-create']).toBeTruthy();
+    });
+
+    it('should reference the selected invoice when creating document', async () => {
+        await wrapper.setData({
+            documentNumberPreview: 'PREVIEW_NUM_001',
+            documentConfig: {
+                documentNumber: 'PREVIEW_NUM_002',
+                custom: {
+                    invoiceNumber: 1000,
+                },
+            },
+        });
+
+        await wrapper.vm.onCreateDocument();
+
+        expect(wrapper.emitted()['document-create']).toBeTruthy();
+        expect(wrapper.emitted()['document-create'][0][2]).toBe('invoice-doc-1000');
+    });
+
+    it('should reference the second invoice when it is selected', async () => {
+        await wrapper.setData({
+            documentNumberPreview: 'PREVIEW_NUM_001',
+            documentConfig: {
+                documentNumber: 'PREVIEW_NUM_002',
+                custom: {
+                    invoiceNumber: 1001,
+                },
+            },
+        });
+
+        await wrapper.vm.onCreateDocument();
+
+        expect(wrapper.emitted()['document-create']).toBeTruthy();
+        expect(wrapper.emitted()['document-create'][0][2]).toBe('invoice-doc-1001');
     });
 
     it('should show only invoice numbers in invoice number select field', async () => {


### PR DESCRIPTION
resolves #14169

Credit notes now correctly reference the invoice selected by the user, matching the existing storno behavior.