### PR TITLE
fix: `getAddress` in`AddressDetailPageLoader`

### DIFF
--- a/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
+++ b/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
@@ -122,7 +122,7 @@ class AddressDetailPageLoader
      */
     private function getAddress(Request $request, SalesChannelContext $context, CustomerEntity $customer): ?CustomerAddressEntity
     {
-        if (!$addressId = $request->query->get('addressId')) {
+        if (!$addressId = $request->attributes->get('addressId')) {
             return null;
         }
 

--- a/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
+++ b/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
@@ -123,7 +123,7 @@ class AddressDetailPageLoader
     private function getAddress(Request $request, SalesChannelContext $context, CustomerEntity $customer): ?CustomerAddressEntity
     {
         if (!$addressId = $request->attributes->getString('addressId')) {
-            throw CustomerException::addressNotFound($addressId);
+            return null;
         }
 
         if (!Uuid::isValid($addressId)) {

--- a/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
+++ b/src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
@@ -122,8 +122,8 @@ class AddressDetailPageLoader
      */
     private function getAddress(Request $request, SalesChannelContext $context, CustomerEntity $customer): ?CustomerAddressEntity
     {
-        if (!$addressId = $request->attributes->get('addressId')) {
-            return null;
+        if (!$addressId = $request->attributes->getString('addressId')) {
+            throw CustomerException::addressNotFound($addressId);
         }
 
         if (!Uuid::isValid($addressId)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you can't edit a address in the customer account, because the address on the address detail page isn't loaded correctly
- See https://github.com/shopware/shopware/commit/0bd2c4bca761f22fc46b903244b439db63ed6abd#diff-de6958f1de36b1f90f11f17a9953a2dad5444893f327c97884edf7d1d8c4cecb

### 2. What does this change do, exactly?
- Use the addressId from the correct request data bag

### 3. Describe each step to reproduce the issue or behaviour.
- Visit ".../account/address"
- Click on "edit address"
- The page opens without a loaded address

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
