### PR TITLE
fix: `createCriteria` in `AccountEditOrderPageLoader`

### DIFF
--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -124,11 +124,16 @@ class AccountEditOrderPageLoader
     private function createCriteria(Request $request, SalesChannelContext $context): Criteria
     {
         $orderId = $request->attributes->getString('orderId');
-        if (!$orderId) {
-            throw OrderException::invalidUuid($orderId);
+        if ($orderId) {
+            $criteria = new Criteria([$orderId]);
+        } else {
+            if (Feature::isActive('v6.8.0.0')) {
+                throw OrderException::invalidUuid($orderId);
+            }
+            $criteria = new Criteria();
         }
 
-        $criteria = (new Criteria([$orderId]))
+        $criteria
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.country')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.countryState')

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -123,12 +123,12 @@ class AccountEditOrderPageLoader
 
     private function createCriteria(Request $request, SalesChannelContext $context): Criteria
     {
-        if ($request->query->get('orderId')) {
-            $criteria = new Criteria([$request->query->get('orderId')]);
-        } else {
-            $criteria = new Criteria();
+        $orderId = $request->attributes->getString('orderId');
+        if (!$orderId) {
+            throw OrderException::invalidUuid($orderId);
         }
-        $criteria
+
+        $criteria = new Criteria([$orderId])
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.country')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.countryState')

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -128,7 +128,7 @@ class AccountEditOrderPageLoader
             throw OrderException::invalidUuid($orderId);
         }
 
-        $criteria = new Criteria([$orderId])
+        $criteria = (new Criteria([$orderId]))
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.country')
             ->addAssociation('primaryOrderDelivery.shippingOrderAddress.countryState')

--- a/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
+++ b/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
@@ -70,7 +70,7 @@ class EditOrderPageTest extends TestCase
         $event = null;
         $this->catchEvent(AccountEditOrderPageLoadedEvent::class, $event);
 
-        $request->request->set('orderId', $orderId);
+        $request->attributes->set('orderId', $orderId);
         $page = $this->getPageLoader()->load($request, $context);
 
         self::assertPageEvent(AccountEditOrderPageLoadedEvent::class, $event, $context, $request, $page);
@@ -89,7 +89,7 @@ class EditOrderPageTest extends TestCase
             $context->getContext()
         );
 
-        $request->request->set('orderId', $orderId);
+        $request->attributes->set('orderId', $orderId);
         $page = $this->getPageLoader()->load($request, $context);
 
         self::assertPageEvent(AccountEditOrderPageLoadedEvent::class, $event, $context, $request, $page);
@@ -106,7 +106,7 @@ class EditOrderPageTest extends TestCase
 
         $this->expectException(OrderException::class);
 
-        $request->request->set('orderId', $orderId);
+        $request->attributes->set('orderId', $orderId);
         $this->getPageLoader()->load($request, $context);
     }
 

--- a/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
+++ b/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
@@ -49,11 +49,11 @@ class EditOrderPageTest extends TestCase
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
 
         $event = null;
         $this->catchEvent(AccountEditOrderPageLoadedEvent::class, $event);
 
-        $request->request->set('orderId', $orderId);
         $page = $this->getPageLoader()->load($request, $context);
 
         self::assertPageEvent(AccountEditOrderPageLoadedEvent::class, $event, $context, $request, $page);
@@ -66,11 +66,11 @@ class EditOrderPageTest extends TestCase
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
 
         $event = null;
         $this->catchEvent(AccountEditOrderPageLoadedEvent::class, $event);
 
-        $request->attributes->set('orderId', $orderId);
         $page = $this->getPageLoader()->load($request, $context);
 
         self::assertPageEvent(AccountEditOrderPageLoadedEvent::class, $event, $context, $request, $page);
@@ -102,11 +102,12 @@ class EditOrderPageTest extends TestCase
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
+
         $this->setOrderToTransactionState($orderId, $context, StateMachineTransitionActions::ACTION_PAID);
 
         $this->expectException(OrderException::class);
 
-        $request->attributes->set('orderId', $orderId);
         $this->getPageLoader()->load($request, $context);
     }
 
@@ -115,6 +116,7 @@ class EditOrderPageTest extends TestCase
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
 
         // Get digital products rule
         $ruleCriteria = new Criteria();
@@ -141,7 +143,8 @@ class EditOrderPageTest extends TestCase
     {
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
-        $this->placeRandomOrder($context);
+        $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
 
         $primaryMethod = $this->createCustomPaymentMethod($context, ['position' => 1]);
 
@@ -162,6 +165,7 @@ class EditOrderPageTest extends TestCase
         $request = new Request();
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
+        $request->attributes->set('orderId', $orderId);
 
         $page = $this->getPageLoader()->load($request, $context);
 

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
@@ -135,7 +135,10 @@ class AccountOrderEditPageLoaderTest extends TestCase
                 new ErrorCollection(),
             ));
 
-        $page = $this->pageLoader->load(new Request(), Generator::generateSalesChannelContext());
+        $request = new Request();
+        $request->attributes->set('orderId', $order->getId());
+
+        $page = $this->pageLoader->load($request, Generator::generateSalesChannelContext());
 
         static::assertSame($order, $page->getOrder());
         $metaInformation = $page->getMetaInformation();
@@ -206,6 +209,7 @@ class AccountOrderEditPageLoaderTest extends TestCase
             ->willReturn($orderContext);
 
         $request = new Request();
+        $request->attributes->set('orderId', $order->getId());
         $request->query->set('onlyAvailable', 1);
         $this->checkoutGatewayRoute
             ->expects($this->once())
@@ -217,7 +221,7 @@ class AccountOrderEditPageLoaderTest extends TestCase
                 new ErrorCollection(),
             ));
 
-        $this->pageLoader->load(new Request(), Generator::generateSalesChannelContext());
+        $this->pageLoader->load($request, Generator::generateSalesChannelContext());
     }
 
     public function testLoadCancelled(): void
@@ -257,6 +261,10 @@ class AccountOrderEditPageLoaderTest extends TestCase
             ->willReturn($page);
 
         static::expectException(OrderException::class);
-        $page = $this->pageLoader->load(new Request(), Generator::generateSalesChannelContext());
+
+        $request = new Request();
+        $request->attributes->set('orderId', $order->getId());
+
+        $page = $this->pageLoader->load($request, Generator::generateSalesChannelContext());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently you can't finish a order payment in the customer account, because the order on the single order detail finish page isn't loaded correctly
- https://github.com/shopware/shopware/commit/0bd2c4bca761f22fc46b903244b439db63ed6abd#diff-d3703f4d83b72915202cd3e1936b1a9006782d5e9313f434097704db316aef0d

### 2. What does this change do, exactly?
- Use the orderId from the correct request data bag

### 3. Describe each step to reproduce the issue or behaviour.
Visit ".../account/order"
Click on any not fully paid order to finish the payment
The page loads no order at all or a random order

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/14735

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
