### PR TITLE
fix: conditionally hide product selection cms inherit wrapper as a whole in buy box cms element

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/config/sw-cms-el-config-buy-box.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/config/sw-cms-el-config-buy-box.html.twig
@@ -47,13 +47,13 @@
 
                 {% block sw_cms_element_buy_box_config_product_select %}
                 <sw-cms-inherit-wrapper
+                    v-if="!isProductPage"
                     field="product"
                     :element="element"
                     :label="$t('sw-cms.elements.buyBox.config.label.selection')"
                 >
                     <template #default="{ isInherited }">
                         <sw-entity-single-select
-                            v-if="!isProductPage"
                             ref="cmsProductSelection"
                             v-model:value="element.config.product.value"
                             entity="product"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The label fom the new cms inherit wrapper is shown even if the product selection is not there in buy box cms element.

<img width="1057" height="307" alt="Screenshot 2026-02-04 120826" src="https://github.com/user-attachments/assets/29550190-6900-422b-94c9-c7b460df63d0" />

### 2. What does this change do, exactly?
Move the `v-if` condition from the select component to the inherit wrapper component.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
