### PR TITLE
fix: handle uncaught errors during customer deletion

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
@@ -287,16 +287,19 @@ export default {
         onConfirmDelete(id) {
             this.showDeleteModal = false;
 
-            return this.customerRepository.delete(id).then(() => {
-                this.getList();
-            }).catch((errorResponse) => {
-                errorResponse?.response?.data?.errors?.forEach((error) => {
-                    this.createNotificationError({
-                        title: error.title,
-                        message: error.detail,
+            return this.customerRepository
+                .delete(id)
+                .then(() => {
+                    this.getList();
+                })
+                .catch((errorResponse) => {
+                    errorResponse?.response?.data?.errors?.forEach((error) => {
+                        this.createNotificationError({
+                            title: error.title,
+                            message: error.detail,
+                        });
                     });
                 });
-            });
         },
 
         async onChangeLanguage() {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
@@ -293,12 +293,21 @@ export default {
                     this.getList();
                 })
                 .catch((errorResponse) => {
-                    errorResponse?.response?.data?.errors?.forEach((error) => {
-                        this.createNotificationError({
-                            title: error.title,
-                            message: error.detail,
+                    const errors = errorResponse?.response?.data?.errors;
+
+                    if (Array.isArray(errors) && errors.length > 0) {
+                        errors.forEach((error) => {
+                            this.createNotificationError({
+                                title: error.title,
+                                message: error.detail,
+                            });
                         });
-                    });
+                    } else {
+                        this.createNotificationError({
+                            title: this.$tc('global.default.error'),
+                            message: this.$tc('global.notification.unspecifiedSaveErrorMessage'),
+                        });
+                    }
                 });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/index.js
@@ -289,6 +289,13 @@ export default {
 
             return this.customerRepository.delete(id).then(() => {
                 this.getList();
+            }).catch((errorResponse) => {
+                errorResponse?.response?.data?.errors?.forEach((error) => {
+                    this.createNotificationError({
+                        title: error.title,
+                        message: error.detail,
+                    });
+                });
             });
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If the customer deletion process in the administration area fails for any reason, no error is shown in the administration area, as initially reported in #12333

### 2. What does this change do, exactly?
It will show notifications if any error occurs during the customer deletion process in the administration area.
<img width="657" height="295" alt="Screenshot 2026-02-04 at 17 30 59" src="https://github.com/user-attachments/assets/618b14d3-5c88-4b8d-8370-fd787cd6b4e7" />

### 3. Please link to the relevant issues.
- Fixes #12333 