### PR TITLE
fix: Upgrade dompdf to 3.1.4 to fix PHP 8.5 issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.0",
+        "dompdf/dompdf": "3.1.4",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -70,7 +70,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.3.1",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.0",
+        "dompdf/dompdf": "3.1.4",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the dompdf version is fixed at 3.1.0
- With PHP 8.5 there where new changes to functions like `getimagesize` which no longer work like before for e.g. svg images as this function for example now returns `false` instead of a empty size object which fails with dompdf 3.1.0
- dompdf 3.1.1 and newer patch versions fixed this PHP 8.5 issues
- See https://github.com/dompdf/dompdf/releases/tag/v3.1.1

### 2. What does this change do, exactly?
- Upgraded dompdf from 3.1.0 to 3.1.4

### 3. Describe each step to reproduce the issue or behaviour.
- Use PHP 8.5
- Use a SVG image in a PDF file
- Try to render it

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
