### PR TITLE
fix(customer): prevent failure when customer language is missing from sales channel

### DIFF
--- a/src/Core/Checkout/Customer/CustomerCollection.php
+++ b/src/Core/Checkout/Customer/CustomerCollection.php
@@ -44,6 +44,14 @@ class CustomerCollection extends EntityCollection
     /**
      * @return array<string>
      */
+    public function getLanguageIds(): array
+    {
+        return $this->fmap(fn (CustomerEntity $customer) => $customer->getLanguageId());
+    }
+
+    /**
+     * @return array<string>
+     */
     public function getLastPaymentMethodIds(): array
     {
         return $this->fmap(fn (CustomerEntity $customer) => $customer->getLastPaymentMethodId());

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -123,10 +123,6 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
         $languageIds = $customers->map(fn ($c) => $c->getLanguageId());
         $languageIds = array_filter(array_unique($languageIds));
 
-        if (empty($salesChannelIds)) {
-            return array_fill_keys($customers->getIds(), null);
-        }
-
         $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
         $criteria->getAssociation('languages')
             ->addFields(['id'])

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -117,61 +117,30 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
      */
     private function resolveEffectiveLanguageIds(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): array
     {
-        $salesChannelIdSet = [];
-        $languageIdSet = [];
+        $salesChannelIds = $customers->map(fn ($c) => $salesChannelIdFromSource ?? $c->getSalesChannelId());
+        $salesChannelIds = array_filter(array_unique($salesChannelIds));
 
-        foreach ($customers as $customer) {
-            $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
-            if ($scId) {
-                $salesChannelIdSet[$scId] = true;
-            }
+        $languageIds = $customers->map(fn ($c) => $c->getLanguageId());
+        $languageIds = array_filter(array_unique($languageIds));
 
-            $langId = $customer->getLanguageId();
-            if ($langId) {
-                $languageIdSet[$langId] = true;
-            }
+        if (empty($salesChannelIds)) {
+            return array_fill_keys($customers->getIds(), null);
         }
 
-        $salesChannelIds = array_keys($salesChannelIdSet);
-        $languageIds = array_keys($languageIdSet);
+        $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
+        $criteria->getAssociation('languages')
+            ->addFields(['id'])
+            ->addFilter(new EqualsAnyFilter('id', $languageIds));
 
-        $available = [];
-
-        if ($salesChannelIds !== [] && $languageIds !== []) {
-            $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
-            $criteria->getAssociation('languages')
-                ->addFields(['id'])
-                ->addFilter(new EqualsAnyFilter('id', $languageIds));
-
-            $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
-
-            foreach ($salesChannels as $salesChannel) {
-                $scId = $salesChannel->getId();
-                $languages = $salesChannel->getLanguages();
-
-                if ($languages === null || $languages->count() === 0) {
-                    continue;
-                }
-
-                foreach ($languages as $language) {
-                    $available[$scId][$language->getId()] = true;
-                }
-            }
-        }
+        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
 
         $result = [];
-
         foreach ($customers as $customer) {
-            $customerId = $customer->getId();
             $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
             $langId = $customer->getLanguageId();
+            $salesChannel = $salesChannels->get($scId);
 
-            if (!$scId || !$langId || !isset($available[$scId][$langId])) {
-                $result[$customerId] = null;
-                continue;
-            }
-
-            $result[$customerId] = $langId;
+            $result[$customer->getId()] = ($salesChannel?->getLanguages()?->has($langId)) ? $langId : null;
         }
 
         return $result;

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
+use Shopware\Core\System\SalesChannel\SalesChannelException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -78,16 +79,33 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 
         $event->addSuccess(function () use ($customers, $context, $salesChannelId, $criteria): void {
             foreach ($customers as $customer) {
-                $salesChannelContext = $this->salesChannelContextService->get(
-                    new SalesChannelContextServiceParameters(
-                        $salesChannelId ?? $customer->getSalesChannelId(),
-                        Random::getAlphanumericString(32),
-                        $customer->getLanguageId(),
-                        null,
-                        null,
-                        $context,
-                    )
-                );
+                try {
+                    $salesChannelContext = $this->salesChannelContextService->get(
+                        new SalesChannelContextServiceParameters(
+                            $salesChannelId ?? $customer->getSalesChannelId(),
+                            Random::getAlphanumericString(32),
+                            $customer->getLanguageId(),
+                            null,
+                            null,
+                            $context,
+                        )
+                    );
+                } catch (SalesChannelException $e) {
+                    if ($e->getErrorCode() === SalesChannelException::SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION) {
+                        $salesChannelContext = $this->salesChannelContextService->get(
+                            new SalesChannelContextServiceParameters(
+                                $salesChannelId ?? $customer->getSalesChannelId(),
+                                Random::getAlphanumericString(32),
+                                null,
+                                null,
+                                null,
+                                $context,
+                            )
+                        );
+                    } else {
+                        throw $e;
+                    }
+                }
 
                 $this->eventDispatcher->dispatch(new CustomerDeletedEvent(
                     $salesChannelContext,

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -81,17 +81,26 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 
         $customers = $this->customerRepository->search($criteria, $context)->getEntities();
 
-        $effectiveLanguageByCustomerId = $this->resolveEffectiveLanguageIds($customers, $salesChannelId, $context);
+        $salesChannelLanguages = $this->loadSalesChannelLanguages($customers, $salesChannelId, $context);
 
-        $event->addSuccess(function () use ($customers, $context, $salesChannelId, $criteria, $effectiveLanguageByCustomerId): void {
+        $event->addSuccess(function () use ($customers, $context, $salesChannelId, $criteria, $salesChannelLanguages): void {
             foreach ($customers as $customer) {
-                $languageId = $effectiveLanguageByCustomerId[$customer->getId()] ?? null;
+                $languageId = $customer->getLanguageId();
+
+                $effectiveSalesChannelId = $salesChannelId ?? $customer->getSalesChannelId();
+
+                $effectiveLanguageId = $salesChannelLanguages
+                    ->get($effectiveSalesChannelId)
+                    ?->getLanguages()
+                    ?->has($languageId)
+                        ? $languageId
+                        : null;
 
                 $salesChannelContext = $this->salesChannelContextService->get(
                     new SalesChannelContextServiceParameters(
-                        $salesChannelId ?? $customer->getSalesChannelId(),
+                        $effectiveSalesChannelId,
                         Random::getAlphanumericString(32),
-                        $languageId,
+                        $effectiveLanguageId,
                         null,
                         null,
                         $context,
@@ -112,33 +121,16 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
         });
     }
 
-    /**
-     * @return array<string, string|null>
-     */
-    private function resolveEffectiveLanguageIds(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): array
+    private function loadSalesChannelLanguages(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): SalesChannelCollection
     {
         $salesChannelIds = $customers->map(fn ($c) => $salesChannelIdFromSource ?? $c->getSalesChannelId());
-        $salesChannelIds = array_filter(array_unique($salesChannelIds));
-
         $languageIds = $customers->map(fn ($c) => $c->getLanguageId());
-        $languageIds = array_filter(array_unique($languageIds));
 
         $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
         $criteria->getAssociation('languages')
             ->addFields(['id'])
             ->addFilter(new EqualsAnyFilter('id', $languageIds));
 
-        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
-
-        $result = [];
-        foreach ($customers as $customer) {
-            $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
-            $langId = $customer->getLanguageId();
-            $salesChannel = $salesChannels->get($scId);
-
-            $result[$customer->getId()] = ($salesChannel?->getLanguages()?->has($langId)) ? $langId : null;
-        }
-
-        return $result;
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
 }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -117,54 +117,41 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
     private function resolveEffectiveLanguageIds(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): array
     {
         $salesChannelIds = [];
-        $pairsByCustomerId = [];
-
         foreach ($customers as $customer) {
             $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
-            $langId = $customer->getLanguageId();
-            if ($scId && $langId) {
+            if ($scId) {
                 $salesChannelIds[$scId] = true;
-                $pairsByCustomerId[$customer->getId()] = [$scId, $langId];
-            } else {
-                $pairsByCustomerId[$customer->getId()] = null;
             }
         }
 
         $salesChannelIds = array_keys($salesChannelIds);
-        if ($salesChannelIds === []) {
-            $result = [];
-            foreach ($pairsByCustomerId as $customerId => $pair) {
-                $result[$customerId] = null;
-            }
-
-            return $result;
-        }
-
-        $salesChannelCriteria = (new Criteria($salesChannelIds))
-            ->addAssociation('languages');
-        $salesChannelCriteria->getAssociation('languages')->addFields(['id']);
-
-        $salesChannels = $this->salesChannelRepository->search($salesChannelCriteria, $context)->getEntities();
-
         $availablePairs = [];
-        foreach ($salesChannels as $salesChannel) {
-            $scId = $salesChannel->getId();
-            $languages = $salesChannel->getLanguages();
-            if ($languages !== null) {
-                foreach ($languages as $language) {
-                    $availablePairs[$scId . '|' . $language->getId()] = true;
+        if ($salesChannelIds !== []) {
+            $salesChannelCriteria = (new Criteria($salesChannelIds))
+                ->addAssociation('languages');
+            $salesChannelCriteria->getAssociation('languages')->addFields(['id']);
+
+            $salesChannels = $this->salesChannelRepository->search($salesChannelCriteria, $context)->getEntities();
+            foreach ($salesChannels as $salesChannel) {
+                $scId = $salesChannel->getId();
+                $languages = $salesChannel->getLanguages();
+                if ($languages !== null) {
+                    foreach ($languages as $language) {
+                        $availablePairs[$scId . '|' . $language->getId()] = true;
+                    }
                 }
             }
         }
 
         $result = [];
-        foreach ($pairsByCustomerId as $customerId => $pair) {
-            if ($pair === null) {
-                $result[$customerId] = null;
-                continue;
+        foreach ($customers as $customer) {
+            $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
+            $langId = $customer->getLanguageId();
+            if ($scId && $langId && isset($availablePairs[$scId . '|' . $langId])) {
+                $result[$customer->getId()] = $langId;
+            } else {
+                $result[$customer->getId()] = null;
             }
-            [$scId, $langId] = $pair;
-            $result[$customerId] = isset($availablePairs[$scId . '|' . $langId]) ? $langId : null;
         }
 
         return $result;

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
@@ -116,42 +117,61 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
      */
     private function resolveEffectiveLanguageIds(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): array
     {
-        $salesChannelIds = [];
+        $salesChannelIdSet = [];
+        $languageIdSet = [];
+
         foreach ($customers as $customer) {
             $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
             if ($scId) {
-                $salesChannelIds[$scId] = true;
+                $salesChannelIdSet[$scId] = true;
+            }
+
+            $langId = $customer->getLanguageId();
+            if ($langId) {
+                $languageIdSet[$langId] = true;
             }
         }
 
-        $salesChannelIds = array_keys($salesChannelIds);
-        $availablePairs = [];
-        if ($salesChannelIds !== []) {
-            $salesChannelCriteria = (new Criteria($salesChannelIds))
-                ->addAssociation('languages');
-            $salesChannelCriteria->getAssociation('languages')->addFields(['id']);
+        $salesChannelIds = array_keys($salesChannelIdSet);
+        $languageIds = array_keys($languageIdSet);
 
-            $salesChannels = $this->salesChannelRepository->search($salesChannelCriteria, $context)->getEntities();
+        $available = [];
+
+        if ($salesChannelIds !== [] && $languageIds !== []) {
+            $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
+            $criteria->getAssociation('languages')
+                ->addFields(['id'])
+                ->addFilter(new EqualsAnyFilter('id', $languageIds));
+
+            $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
+
             foreach ($salesChannels as $salesChannel) {
                 $scId = $salesChannel->getId();
                 $languages = $salesChannel->getLanguages();
-                if ($languages !== null) {
-                    foreach ($languages as $language) {
-                        $availablePairs[$scId . '|' . $language->getId()] = true;
-                    }
+
+                if ($languages === null || $languages->count() === 0) {
+                    continue;
+                }
+
+                foreach ($languages as $language) {
+                    $available[$scId][$language->getId()] = true;
                 }
             }
         }
 
         $result = [];
+
         foreach ($customers as $customer) {
+            $customerId = $customer->getId();
             $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
             $langId = $customer->getLanguageId();
-            if ($scId && $langId && isset($availablePairs[$scId . '|' . $langId])) {
-                $result[$customer->getId()] = $langId;
-            } else {
-                $result[$customer->getId()] = null;
+
+            if (!$scId || !$langId || !isset($available[$scId][$langId])) {
+                $result[$customerId] = null;
+                continue;
             }
+
+            $result[$customerId] = $langId;
         }
 
         return $result;

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -123,13 +123,14 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 
     private function loadSalesChannelLanguages(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): SalesChannelCollection
     {
-        $salesChannelIds = $customers->map(fn ($c) => $salesChannelIdFromSource ?? $c->getSalesChannelId());
-        $languageIds = $customers->map(fn ($c) => $c->getLanguageId());
+        $salesChannelIds = $salesChannelIdFromSource ? [$salesChannelIdFromSource] : $customers->getSalesChannelIds();
 
-        $criteria = (new Criteria($salesChannelIds))->addAssociation('languages');
-        $criteria->getAssociation('languages')
+        $criteria = new Criteria($salesChannelIds);
+        $association = $criteria->getAssociation('languages');
+
+        $association
             ->addFields(['id'])
-            ->addFilter(new EqualsAnyFilter('id', $languageIds));
+            ->addFilter(new EqualsAnyFilter('id', $customers->getLanguageIds()));
 
         return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -14,7 +15,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
-use Shopware\Core\System\SalesChannel\SalesChannelException;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -26,11 +27,13 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 {
     /**
      * @param EntityRepository<CustomerCollection> $customerRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
      *
      * @internal
      */
     public function __construct(
         private readonly EntityRepository $customerRepository,
+        private readonly EntityRepository $salesChannelRepository,
         private readonly SalesChannelContextServiceInterface $salesChannelContextService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly JsonEntityEncoder $jsonEntityEncoder
@@ -77,35 +80,22 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 
         $customers = $this->customerRepository->search($criteria, $context)->getEntities();
 
-        $event->addSuccess(function () use ($customers, $context, $salesChannelId, $criteria): void {
+        $effectiveLanguageByCustomerId = $this->resolveEffectiveLanguageIds($customers, $salesChannelId, $context);
+
+        $event->addSuccess(function () use ($customers, $context, $salesChannelId, $criteria, $effectiveLanguageByCustomerId): void {
             foreach ($customers as $customer) {
-                try {
-                    $salesChannelContext = $this->salesChannelContextService->get(
-                        new SalesChannelContextServiceParameters(
-                            $salesChannelId ?? $customer->getSalesChannelId(),
-                            Random::getAlphanumericString(32),
-                            $customer->getLanguageId(),
-                            null,
-                            null,
-                            $context,
-                        )
-                    );
-                } catch (SalesChannelException $e) {
-                    if ($e->getErrorCode() === SalesChannelException::SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION) {
-                        $salesChannelContext = $this->salesChannelContextService->get(
-                            new SalesChannelContextServiceParameters(
-                                $salesChannelId ?? $customer->getSalesChannelId(),
-                                Random::getAlphanumericString(32),
-                                null,
-                                null,
-                                null,
-                                $context,
-                            )
-                        );
-                    } else {
-                        throw $e;
-                    }
-                }
+                $languageId = $effectiveLanguageByCustomerId[$customer->getId()] ?? null;
+
+                $salesChannelContext = $this->salesChannelContextService->get(
+                    new SalesChannelContextServiceParameters(
+                        $salesChannelId ?? $customer->getSalesChannelId(),
+                        Random::getAlphanumericString(32),
+                        $languageId,
+                        null,
+                        null,
+                        $context,
+                    )
+                );
 
                 $this->eventDispatcher->dispatch(new CustomerDeletedEvent(
                     $salesChannelContext,
@@ -119,5 +109,64 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
                 ));
             }
         });
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function resolveEffectiveLanguageIds(CustomerCollection $customers, ?string $salesChannelIdFromSource, Context $context): array
+    {
+        $salesChannelIds = [];
+        $pairsByCustomerId = [];
+
+        foreach ($customers as $customer) {
+            $scId = $salesChannelIdFromSource ?? $customer->getSalesChannelId();
+            $langId = $customer->getLanguageId();
+            if ($scId && $langId) {
+                $salesChannelIds[$scId] = true;
+                $pairsByCustomerId[$customer->getId()] = [$scId, $langId];
+            } else {
+                $pairsByCustomerId[$customer->getId()] = null;
+            }
+        }
+
+        $salesChannelIds = array_keys($salesChannelIds);
+        if ($salesChannelIds === []) {
+            $result = [];
+            foreach ($pairsByCustomerId as $customerId => $pair) {
+                $result[$customerId] = null;
+            }
+
+            return $result;
+        }
+
+        $salesChannelCriteria = (new Criteria($salesChannelIds))
+            ->addAssociation('languages');
+        $salesChannelCriteria->getAssociation('languages')->addFields(['id']);
+
+        $salesChannels = $this->salesChannelRepository->search($salesChannelCriteria, $context)->getEntities();
+
+        $availablePairs = [];
+        foreach ($salesChannels as $salesChannel) {
+            $scId = $salesChannel->getId();
+            $languages = $salesChannel->getLanguages();
+            if ($languages !== null) {
+                foreach ($languages as $language) {
+                    $availablePairs[$scId . '|' . $language->getId()] = true;
+                }
+            }
+        }
+
+        $result = [];
+        foreach ($pairsByCustomerId as $customerId => $pair) {
+            if ($pair === null) {
+                $result[$customerId] = null;
+                continue;
+            }
+            [$scId, $langId] = $pair;
+            $result[$customerId] = isset($availablePairs[$scId . '|' . $langId]) ? $langId : null;
+        }
+
+        return $result;
     }
 }

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -412,6 +412,7 @@
 
         <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerBeforeDeleteSubscriber">
             <argument type="service" id="customer.repository"/>
+            <argument type="service" id="sales_channel.repository"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService" />
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder"/>

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Tests\Integration\Core\Checkout\Customer\Subscriber;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent;
+use Shopware\Core\Checkout\Customer\Subscriber\CustomerBeforeDeleteSubscriber;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
@@ -17,6 +19,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  * @internal
  */
 #[Package('checkout')]
+#[CoversClass(CustomerBeforeDeleteSubscriber::class)]
 class CustomerBeforeDeleteSubscriberTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -2,11 +2,9 @@
 
 namespace Shopware\Tests\Integration\Core\Checkout\Customer\Subscriber;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent;
-use Shopware\Core\Checkout\Customer\Subscriber\CustomerBeforeDeleteSubscriber;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
@@ -19,7 +17,6 @@ use Symfony\Contracts\EventDispatcher\Event;
  * @internal
  */
 #[Package('checkout')]
-#[CoversClass(CustomerBeforeDeleteSubscriber::class)]
 class CustomerBeforeDeleteSubscriberTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -21,8 +21,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Serializer\StructNormalizer;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -191,5 +194,214 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $entityDeleteEvent->success();
 
         static::assertSame(0, $customerDeletedEventCount);
+    }
+
+    public function testResolveEffectiveLanguageIdsWithSalesChannelLanguages(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $customerId = Uuid::randomBytes();
+
+        $customer = (new CustomerEntity())
+            ->assign([
+                'id' => Uuid::fromBytesToHex($customerId),
+                'salesChannelId' => $salesChannelId,
+                'languageId' => $languageId,
+                'customerNumber' => 'SW1001',
+                'email' => 'baz@bar.com',
+                'firstName' => 'baz',
+                'lastName' => 'qux',
+            ]);
+
+        $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
+        $customerDefinition = new CustomerDefinition();
+        $customerDefinition->compile($definitionInstanceRegistry);
+
+        $criteria = (new Criteria([$customerId]))
+            ->addAssociations([
+                'salutation',
+                'defaultBillingAddress.country',
+                'defaultBillingAddress.countryState',
+                'defaultBillingAddress.salutation',
+                'defaultShippingAddress.country',
+                'defaultShippingAddress.countryState',
+                'defaultShippingAddress.salutation',
+            ]);
+
+        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
+        $customerRepository = new StaticEntityRepository([
+            new EntitySearchResult(
+                CustomerEntity::class,
+                1,
+                new CustomerCollection([$customer]),
+                null,
+                $criteria,
+                Context::createDefaultContext()
+            ),
+        ], $customerDefinition);
+
+        $languageEntity = (new LanguageEntity())->assign(['id' => $languageId]);
+        $salesChannel = (new SalesChannelEntity())->assign([
+            'id' => $salesChannelId,
+        ]);
+        $salesChannel->setLanguages(new LanguageCollection([$languageEntity]));
+
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
+        $salesChannelRepository = new StaticEntityRepository([
+            new SalesChannelCollection([$salesChannel]),
+        ]);
+
+        $salesChannelContextService = static::createMock(SalesChannelContextService::class);
+        $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
+
+        $eventDispatcher = new EventDispatcher();
+        $structNormalizer = new StructNormalizer();
+        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
+
+        $subscriber = new CustomerBeforeDeleteSubscriber(
+            $customerRepository,
+            $salesChannelRepository,
+            $salesChannelContextService,
+            $eventDispatcher,
+            $jsonEntityEncoder
+        );
+        $eventDispatcher->addSubscriber($subscriber);
+
+        $entityDeleteEvent = EntityDeleteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new DeleteCommand(
+                    $customerDefinition,
+                    ['id' => $customerId],
+                    new EntityExistence(
+                        'customer',
+                        ['id' => $customerId],
+                        true,
+                        false,
+                        false,
+                        [
+                            'exists' => true,
+                            'id' => $customerId,
+                        ]
+                    )
+                ),
+            ]
+        );
+
+        $customerDeletedEventCount = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$customerDeletedEventCount): void {
+                ++$customerDeletedEventCount;
+            }
+        );
+
+        $eventDispatcher->dispatch($entityDeleteEvent);
+        $entityDeleteEvent->success();
+
+        static::assertSame(1, $customerDeletedEventCount);
+    }
+
+    public function testResolveEffectiveLanguageIdsSkipsSalesChannelWithNoLanguages(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $customerId = Uuid::randomBytes();
+
+        $customer = (new CustomerEntity())
+            ->assign([
+                'id' => Uuid::fromBytesToHex($customerId),
+                'salesChannelId' => $salesChannelId,
+                'languageId' => $languageId,
+                'customerNumber' => 'SW1002',
+                'email' => 'qux@bar.com',
+                'firstName' => 'qux',
+                'lastName' => 'quux',
+            ]);
+
+        $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
+        $customerDefinition = new CustomerDefinition();
+        $customerDefinition->compile($definitionInstanceRegistry);
+
+        $criteria = (new Criteria([$customerId]))
+            ->addAssociations([
+                'salutation',
+                'defaultBillingAddress.country',
+                'defaultBillingAddress.countryState',
+                'defaultBillingAddress.salutation',
+                'defaultShippingAddress.country',
+                'defaultShippingAddress.countryState',
+                'defaultShippingAddress.salutation',
+            ]);
+
+        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
+        $customerRepository = new StaticEntityRepository([
+            new EntitySearchResult(
+                CustomerEntity::class,
+                1,
+                new CustomerCollection([$customer]),
+                null,
+                $criteria,
+                Context::createDefaultContext()
+            ),
+        ], $customerDefinition);
+
+        $salesChannel = (new SalesChannelEntity())->assign(['id' => $salesChannelId]);
+        $salesChannel->setLanguages(new LanguageCollection([]));
+
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
+        $salesChannelRepository = new StaticEntityRepository([
+            new SalesChannelCollection([$salesChannel]),
+        ]);
+
+        $salesChannelContextService = static::createMock(SalesChannelContextService::class);
+        $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
+
+        $eventDispatcher = new EventDispatcher();
+        $structNormalizer = new StructNormalizer();
+        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
+
+        $subscriber = new CustomerBeforeDeleteSubscriber(
+            $customerRepository,
+            $salesChannelRepository,
+            $salesChannelContextService,
+            $eventDispatcher,
+            $jsonEntityEncoder
+        );
+        $eventDispatcher->addSubscriber($subscriber);
+
+        $entityDeleteEvent = EntityDeleteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new DeleteCommand(
+                    $customerDefinition,
+                    ['id' => $customerId],
+                    new EntityExistence(
+                        'customer',
+                        ['id' => $customerId],
+                        true,
+                        false,
+                        false,
+                        [
+                            'exists' => true,
+                            'id' => $customerId,
+                        ]
+                    )
+                ),
+            ]
+        );
+
+        $customerDeletedEventCount = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$customerDeletedEventCount): void {
+                ++$customerDeletedEventCount;
+            }
+        );
+
+        $eventDispatcher->dispatch($entityDeleteEvent);
+        $entityDeleteEvent->success();
+
+        static::assertSame(1, $customerDeletedEventCount);
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -275,4 +275,92 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         static::assertSame(1, $dispatchedCount);
     }
+
+    public function testBeforeDeleteWhenSalesChannelDoesNotHaveCustomerLanguageUsesNullLanguageId(): void
+    {
+        $customerId = Uuid::randomBytes();
+        $salesChannelId = Uuid::randomHex();
+        $customerLanguageId = Uuid::randomHex();
+        $otherLanguageId = Uuid::randomHex();
+        $customer = (new CustomerEntity())
+            ->assign([
+                'id' => Uuid::fromBytesToHex($customerId),
+                'salesChannelId' => $salesChannelId,
+                'languageId' => $customerLanguageId,
+                'customerNumber' => 'SW1002',
+                'email' => 'nolang@test.com',
+                'firstName' => 'No',
+                'lastName' => 'Lang',
+            ]);
+
+        $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
+        $customerDefinition = new CustomerDefinition();
+        $customerDefinition->compile($definitionInstanceRegistry);
+
+        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
+        $customerRepository = new StaticEntityRepository([
+            new EntitySearchResult(
+                CustomerEntity::class,
+                1,
+                new CustomerCollection([$customer]),
+                null,
+                new Criteria([$customerId]),
+                Context::createDefaultContext()
+            ),
+        ], $customerDefinition);
+
+        $salesChannelHasOnlyOtherLanguage = (new LanguageEntity())->assign(['id' => $otherLanguageId]);
+        $salesChannel = (new SalesChannelEntity())->assign([
+            'id' => $salesChannelId,
+            'languages' => new LanguageCollection([$salesChannelHasOnlyOtherLanguage]),
+        ]);
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
+        $salesChannelRepository = new StaticEntityRepository([
+            new SalesChannelCollection([$salesChannel]),
+        ]);
+
+        $salesChannelContextService = static::createMock(SalesChannelContextService::class);
+        $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
+        $eventDispatcher = new EventDispatcher();
+        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([new StructNormalizer()], []));
+
+        $subscriber = new CustomerBeforeDeleteSubscriber(
+            $customerRepository,
+            $salesChannelRepository,
+            $salesChannelContextService,
+            $eventDispatcher,
+            $jsonEntityEncoder
+        );
+        $eventDispatcher->addSubscriber($subscriber);
+
+        $dispatchedCount = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$dispatchedCount): void {
+                ++$dispatchedCount;
+            }
+        );
+
+        $entityDeleteEvent = EntityDeleteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new DeleteCommand(
+                    $customerDefinition,
+                    ['id' => $customerId],
+                    new EntityExistence(
+                        'customer',
+                        ['id' => $customerId],
+                        true,
+                        false,
+                        false,
+                        ['exists' => true, 'id' => $customerId]
+                    )
+                ),
+            ]
+        );
+        $eventDispatcher->dispatch($entityDeleteEvent);
+        $entityDeleteEvent->success();
+
+        static::assertSame(1, $dispatchedCount);
+    }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Serializer\StructNormalizer;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -53,6 +54,17 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $customerDefinition = new CustomerDefinition();
         $customerDefinition->compile($definitionInstanceRegistry);
 
+        $criteria = (new Criteria([$customerId]))
+            ->addAssociations([
+                'salutation',
+                'defaultBillingAddress.country',
+                'defaultBillingAddress.countryState',
+                'defaultBillingAddress.salutation',
+                'defaultShippingAddress.country',
+                'defaultShippingAddress.countryState',
+                'defaultShippingAddress.salutation',
+            ]);
+
         /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
         $customerRepository = new StaticEntityRepository([
             new EntitySearchResult(
@@ -60,10 +72,13 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
                 1,
                 new CustomerCollection([$customer]),
                 null,
-                new Criteria([$customerId]),
+                $criteria,
                 Context::createDefaultContext()
             ),
         ], $customerDefinition);
+
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
+        $salesChannelRepository = new StaticEntityRepository([new SalesChannelCollection([])]);
 
         $salesChannelContextService = static::createMock(SalesChannelContextService::class);
         $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
@@ -76,6 +91,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         $subscriber = new CustomerBeforeDeleteSubscriber(
             $customerRepository,
+            $salesChannelRepository,
             $salesChannelContextService,
             $eventDispatcher,
             $jsonEntityEncoder
@@ -106,7 +122,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $customerDeletedEventCount = 0;
 
         $serializedCustomer = $jsonEntityEncoder->encode(
-            new Criteria(),
+            $criteria,
             $customerDefinition,
             $customer,
             '/api/customer'
@@ -128,5 +144,52 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $entityDeleteEvent->success();
 
         static::assertSame(1, $customerDeletedEventCount);
+    }
+
+    public function testBeforeDeleteDoesNotDispatchEventWhenNoCustomerIds(): void
+    {
+        $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
+        $customerDefinition = new CustomerDefinition();
+        $customerDefinition->compile($definitionInstanceRegistry);
+
+        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
+        $customerRepository = new StaticEntityRepository([], $customerDefinition);
+
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
+        $salesChannelRepository = new StaticEntityRepository([new SalesChannelCollection([])]);
+
+        $salesChannelContextService = static::createMock(SalesChannelContextService::class);
+        $salesChannelContextService->expects($this->never())->method('get');
+
+        $eventDispatcher = new EventDispatcher();
+        $structNormalizer = new StructNormalizer();
+        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
+
+        $subscriber = new CustomerBeforeDeleteSubscriber(
+            $customerRepository,
+            $salesChannelRepository,
+            $salesChannelContextService,
+            $eventDispatcher,
+            $jsonEntityEncoder
+        );
+        $eventDispatcher->addSubscriber($subscriber);
+
+        $entityDeleteEvent = EntityDeleteEvent::create(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            []
+        );
+
+        $customerDeletedEventCount = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$customerDeletedEventCount): void {
+                ++$customerDeletedEventCount;
+            }
+        );
+
+        $eventDispatcher->dispatch($entityDeleteEvent);
+        $entityDeleteEvent->success();
+
+        static::assertSame(0, $customerDeletedEventCount);
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriberTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent;
 use Shopware\Core\Checkout\Customer\Subscriber\CustomerBeforeDeleteSubscriber;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -57,17 +58,6 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $customerDefinition = new CustomerDefinition();
         $customerDefinition->compile($definitionInstanceRegistry);
 
-        $criteria = (new Criteria([$customerId]))
-            ->addAssociations([
-                'salutation',
-                'defaultBillingAddress.country',
-                'defaultBillingAddress.countryState',
-                'defaultBillingAddress.salutation',
-                'defaultShippingAddress.country',
-                'defaultShippingAddress.countryState',
-                'defaultShippingAddress.salutation',
-            ]);
-
         /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
         $customerRepository = new StaticEntityRepository([
             new EntitySearchResult(
@@ -75,13 +65,22 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
                 1,
                 new CustomerCollection([$customer]),
                 null,
-                $criteria,
+                new Criteria([$customerId]),
                 Context::createDefaultContext()
             ),
         ], $customerDefinition);
 
+        $salesChannelId = $customer->getSalesChannelId();
+        $languageId = $customer->getLanguageId();
+        $language = (new LanguageEntity())->assign(['id' => $languageId]);
+        $salesChannel = (new SalesChannelEntity())->assign([
+            'id' => $salesChannelId,
+            'languages' => new LanguageCollection([$language]),
+        ]);
         /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
-        $salesChannelRepository = new StaticEntityRepository([new SalesChannelCollection([])]);
+        $salesChannelRepository = new StaticEntityRepository([
+            new SalesChannelCollection([$salesChannel]),
+        ]);
 
         $salesChannelContextService = static::createMock(SalesChannelContextService::class);
         $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
@@ -125,7 +124,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         $customerDeletedEventCount = 0;
 
         $serializedCustomer = $jsonEntityEncoder->encode(
-            $criteria,
+            new Criteria(),
             $customerDefinition,
             $customer,
             '/api/customer'
@@ -136,10 +135,9 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
             function (CustomerDeletedEvent $event) use (&$customerDeletedEventCount, $customer, $serializedCustomer): void {
                 ++$customerDeletedEventCount;
                 static::assertSame($customer, $event->getCustomer());
-
-                static::assertSame([
-                    'customer' => $serializedCustomer,
-                ], $event->getValues());
+                $values = $event->getValues();
+                static::assertArrayHasKey('customer', $values);
+                static::assertSame($serializedCustomer, $values['customer']);
             }
         );
 
@@ -149,7 +147,7 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         static::assertSame(1, $customerDeletedEventCount);
     }
 
-    public function testBeforeDeleteDoesNotDispatchEventWhenNoCustomerIds(): void
+    public function testBeforeDeleteWithEmptyCustomerIdsDoesNotDispatch(): void
     {
         $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
         $customerDefinition = new CustomerDefinition();
@@ -157,16 +155,11 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
         $customerRepository = new StaticEntityRepository([], $customerDefinition);
-
         /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
-        $salesChannelRepository = new StaticEntityRepository([new SalesChannelCollection([])]);
-
+        $salesChannelRepository = new StaticEntityRepository([]);
         $salesChannelContextService = static::createMock(SalesChannelContextService::class);
-        $salesChannelContextService->expects($this->never())->method('get');
-
         $eventDispatcher = new EventDispatcher();
-        $structNormalizer = new StructNormalizer();
-        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
+        $jsonEntityEncoder = static::createMock(JsonEntityEncoder::class);
 
         $subscriber = new CustomerBeforeDeleteSubscriber(
             $customerRepository,
@@ -176,57 +169,44 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
             $jsonEntityEncoder
         );
         $eventDispatcher->addSubscriber($subscriber);
+
+        $caughtEvents = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$caughtEvents): void {
+                ++$caughtEvents;
+            }
+        );
 
         $entityDeleteEvent = EntityDeleteEvent::create(
             WriteContext::createFromContext(Context::createDefaultContext()),
             []
         );
-
-        $customerDeletedEventCount = 0;
-        $eventDispatcher->addListener(
-            CustomerDeletedEvent::class,
-            function () use (&$customerDeletedEventCount): void {
-                ++$customerDeletedEventCount;
-            }
-        );
-
         $eventDispatcher->dispatch($entityDeleteEvent);
         $entityDeleteEvent->success();
 
-        static::assertSame(0, $customerDeletedEventCount);
+        static::assertSame(0, $caughtEvents);
     }
 
-    public function testResolveEffectiveLanguageIdsWithSalesChannelLanguages(): void
+    public function testBeforeDeleteWithSalesChannelApiSourceUsesSourceSalesChannelId(): void
     {
-        $salesChannelId = Uuid::randomHex();
-        $languageId = Uuid::randomHex();
         $customerId = Uuid::randomBytes();
-
+        $salesChannelIdFromSource = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
         $customer = (new CustomerEntity())
             ->assign([
                 'id' => Uuid::fromBytesToHex($customerId),
-                'salesChannelId' => $salesChannelId,
+                'salesChannelId' => Uuid::randomHex(),
                 'languageId' => $languageId,
                 'customerNumber' => 'SW1001',
-                'email' => 'baz@bar.com',
-                'firstName' => 'baz',
-                'lastName' => 'qux',
+                'email' => 'bar@baz.com',
+                'firstName' => 'bar',
+                'lastName' => 'baz',
             ]);
 
         $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
         $customerDefinition = new CustomerDefinition();
         $customerDefinition->compile($definitionInstanceRegistry);
-
-        $criteria = (new Criteria([$customerId]))
-            ->addAssociations([
-                'salutation',
-                'defaultBillingAddress.country',
-                'defaultBillingAddress.countryState',
-                'defaultBillingAddress.salutation',
-                'defaultShippingAddress.country',
-                'defaultShippingAddress.countryState',
-                'defaultShippingAddress.salutation',
-            ]);
 
         /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
         $customerRepository = new StaticEntityRepository([
@@ -235,17 +215,16 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
                 1,
                 new CustomerCollection([$customer]),
                 null,
-                $criteria,
+                new Criteria([$customerId]),
                 Context::createDefaultContext()
             ),
         ], $customerDefinition);
 
-        $languageEntity = (new LanguageEntity())->assign(['id' => $languageId]);
+        $language = (new LanguageEntity())->assign(['id' => $languageId]);
         $salesChannel = (new SalesChannelEntity())->assign([
-            'id' => $salesChannelId,
+            'id' => $salesChannelIdFromSource,
+            'languages' => new LanguageCollection([$language]),
         ]);
-        $salesChannel->setLanguages(new LanguageCollection([$languageEntity]));
-
         /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = new StaticEntityRepository([
             new SalesChannelCollection([$salesChannel]),
@@ -253,10 +232,8 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
 
         $salesChannelContextService = static::createMock(SalesChannelContextService::class);
         $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
-
         $eventDispatcher = new EventDispatcher();
-        $structNormalizer = new StructNormalizer();
-        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
+        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([new StructNormalizer()], []));
 
         $subscriber = new CustomerBeforeDeleteSubscriber(
             $customerRepository,
@@ -267,8 +244,17 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
         );
         $eventDispatcher->addSubscriber($subscriber);
 
+        $dispatchedCount = 0;
+        $eventDispatcher->addListener(
+            CustomerDeletedEvent::class,
+            function () use (&$dispatchedCount): void {
+                ++$dispatchedCount;
+            }
+        );
+
+        $context = Context::createDefaultContext(new SalesChannelApiSource($salesChannelIdFromSource));
         $entityDeleteEvent = EntityDeleteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
+            WriteContext::createFromContext($context),
             [
                 new DeleteCommand(
                     $customerDefinition,
@@ -279,129 +265,14 @@ class CustomerBeforeDeleteSubscriberTest extends TestCase
                         true,
                         false,
                         false,
-                        [
-                            'exists' => true,
-                            'id' => $customerId,
-                        ]
+                        ['exists' => true, 'id' => $customerId]
                     )
                 ),
             ]
         );
-
-        $customerDeletedEventCount = 0;
-        $eventDispatcher->addListener(
-            CustomerDeletedEvent::class,
-            function () use (&$customerDeletedEventCount): void {
-                ++$customerDeletedEventCount;
-            }
-        );
-
         $eventDispatcher->dispatch($entityDeleteEvent);
         $entityDeleteEvent->success();
 
-        static::assertSame(1, $customerDeletedEventCount);
-    }
-
-    public function testResolveEffectiveLanguageIdsSkipsSalesChannelWithNoLanguages(): void
-    {
-        $salesChannelId = Uuid::randomHex();
-        $languageId = Uuid::randomHex();
-        $customerId = Uuid::randomBytes();
-
-        $customer = (new CustomerEntity())
-            ->assign([
-                'id' => Uuid::fromBytesToHex($customerId),
-                'salesChannelId' => $salesChannelId,
-                'languageId' => $languageId,
-                'customerNumber' => 'SW1002',
-                'email' => 'qux@bar.com',
-                'firstName' => 'qux',
-                'lastName' => 'quux',
-            ]);
-
-        $definitionInstanceRegistry = static::createMock(DefinitionInstanceRegistry::class);
-        $customerDefinition = new CustomerDefinition();
-        $customerDefinition->compile($definitionInstanceRegistry);
-
-        $criteria = (new Criteria([$customerId]))
-            ->addAssociations([
-                'salutation',
-                'defaultBillingAddress.country',
-                'defaultBillingAddress.countryState',
-                'defaultBillingAddress.salutation',
-                'defaultShippingAddress.country',
-                'defaultShippingAddress.countryState',
-                'defaultShippingAddress.salutation',
-            ]);
-
-        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
-        $customerRepository = new StaticEntityRepository([
-            new EntitySearchResult(
-                CustomerEntity::class,
-                1,
-                new CustomerCollection([$customer]),
-                null,
-                $criteria,
-                Context::createDefaultContext()
-            ),
-        ], $customerDefinition);
-
-        $salesChannel = (new SalesChannelEntity())->assign(['id' => $salesChannelId]);
-        $salesChannel->setLanguages(new LanguageCollection([]));
-
-        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
-        $salesChannelRepository = new StaticEntityRepository([
-            new SalesChannelCollection([$salesChannel]),
-        ]);
-
-        $salesChannelContextService = static::createMock(SalesChannelContextService::class);
-        $salesChannelContextService->method('get')->willReturn(Generator::generateSalesChannelContext());
-
-        $eventDispatcher = new EventDispatcher();
-        $structNormalizer = new StructNormalizer();
-        $jsonEntityEncoder = new JsonEntityEncoder(new Serializer([$structNormalizer], []));
-
-        $subscriber = new CustomerBeforeDeleteSubscriber(
-            $customerRepository,
-            $salesChannelRepository,
-            $salesChannelContextService,
-            $eventDispatcher,
-            $jsonEntityEncoder
-        );
-        $eventDispatcher->addSubscriber($subscriber);
-
-        $entityDeleteEvent = EntityDeleteEvent::create(
-            WriteContext::createFromContext(Context::createDefaultContext()),
-            [
-                new DeleteCommand(
-                    $customerDefinition,
-                    ['id' => $customerId],
-                    new EntityExistence(
-                        'customer',
-                        ['id' => $customerId],
-                        true,
-                        false,
-                        false,
-                        [
-                            'exists' => true,
-                            'id' => $customerId,
-                        ]
-                    )
-                ),
-            ]
-        );
-
-        $customerDeletedEventCount = 0;
-        $eventDispatcher->addListener(
-            CustomerDeletedEvent::class,
-            function () use (&$customerDeletedEventCount): void {
-                ++$customerDeletedEventCount;
-            }
-        );
-
-        $eventDispatcher->dispatch($entityDeleteEvent);
-        $entityDeleteEvent->success();
-
-        static::assertSame(1, $customerDeletedEventCount);
+        static::assertSame(1, $dispatchedCount);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Deleting a customer fails if the language assigned to the customer is no longer available in customer's sales channel.

### 2. What does this change do, exactly?
This fix handles the case where a customer’s language has been removed from the sales channel.
Instead of failing while creating the `SalesChannelContext`, the deletion process proceeds safely allowing the customer to be deleted without throwing a `SalesChannelException`.

### 3. Describe each step to reproduce the issue or behaviour:
1. Add multiple langauges to the sales channel (Storefront for instance).
2. Create a customer and assign them a language.
3. Remove that language from the sales channel configuration.
4. Attempt to delete the customer from the Administration.
5. An exception is thrown (_Provided language is not in list of available languages_) and the customer cannot be deleted.

### 4. Please link to the relevant issues.
- Fixes #7960 
- Fixed deletion part of #5767

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
