### PR TITLE
fix(snippet-sets): Toggle inlineEdit after snippet set creation

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
@@ -147,6 +147,31 @@ export default {
 
             await this.snippetSetRepository.save(newSnippetSet);
             await this.getList();
+
+            this.toggleInlineEdit(newSnippetSet.id);
+        },
+
+        toggleInlineEdit(id) {
+            if (!this.acl.can('snippet.editor')) {
+                return;
+            }
+
+            if (!this.$refs.snippetSetList) {
+                return;
+            }
+
+            if (!this.snippetSets.some((item) => item.id === id)) {
+                return;
+            }
+
+            this.$refs.snippetSetList.currentInlineEditId = id;
+
+            if (typeof this.$refs.snippetSetList.enableInlineEdit === 'function') {
+                this.$refs.snippetSetList.enableInlineEdit();
+                return;
+            }
+
+            this.$refs.snippetSetList.isInlineEditActive = true;
         },
 
         onInlineEditSave(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
@@ -46,6 +46,11 @@ function getSnippetSetData() {
 
 describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
     const saveSpy = jest.fn(() => Promise.resolve());
+    const createSnippetSetEntity = (overrides = {}) => ({
+        ...getSnippetSetData()[0],
+        ...overrides,
+    });
+
     async function createWrapper(privileges = []) {
         return mount(
             await wrapTestComponent('sw-settings-snippet-set-list', {
@@ -79,7 +84,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
                         },
                         repositoryFactory: {
                             create: () => ({
-                                create: () => Promise.resolve(getSnippetSetData()[0]),
+                                create: () => createSnippetSetEntity(),
                                 search: () => Promise.resolve(getSnippetSetData()),
                                 save: saveSpy,
                             }),
@@ -188,5 +193,21 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
         expect(saveSpy).toHaveBeenCalledWith(
             expect.objectContaining({ name: `sw-settings-snippet.setList.newSnippetName (2)` }),
         );
+    });
+
+    it('should activate inline edit after creating a snippet set', async () => {
+        const wrapper = await createWrapper([
+            'snippet.creator',
+            'snippet.editor',
+        ]);
+        await flushPromises();
+
+        const toggleSpy = jest.spyOn(wrapper.vm, 'toggleInlineEdit');
+
+        const createSetButton = wrapper.findByText('button', 'sw-settings-snippet.setList.buttonAddSet');
+        await createSetButton.trigger('click');
+        await flushPromises();
+
+        expect(toggleSpy).toHaveBeenCalledWith(getSnippetSetData()[0].id);
     });
 });


### PR DESCRIPTION
fixes #14280

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Changed behavior of snippet set creation. A new set was only created and could be edited afterwards

### 2. What does this change do, exactly?
After creation (necessary, since we're using an entity listing rn), inline edit will be toggled to immediately edit the new set, giving a similar feel to it was before

### 3. Describe each step to reproduce the issue or behaviour.
- Go to Snippet Set list
- Create a new snippet set

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
