### PR TITLE
fix: Improve `sw-highlight-text` `escapeRegExp` method

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
@@ -123,9 +123,9 @@ export default {
 
             if (Context.app.adminEsEnable) {
                 string = string
-                    .replace(/(^|\s)[+-](?=\S)/g, '$1') // remove + and - at the beginning and end of words
+                    .replace(/(?<!\S)[+-]|[+-](?!\S)/g, '') // remove + and - which are not part of a word
                     .replace(/[.*~"|()]/g, '') // remove special elasticsearch characters
-                    .replace(/ AND | and | OR | or |  +/g, ' ') // remove AND and OR bool operators
+                    .replace(/\b(AND|OR)\b/gi, ' ') // remove AND and OR bool operators
                     .replace(/\s+/g, ' '); // replace multiple spaces with single space
 
                 return escapeRegex(string);

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
@@ -85,7 +85,7 @@ export default {
                 return [{ text: this.text, highlighted: false }];
             }
 
-            const regExp = new RegExp(this.escapeRegExp(this.searchTerm), 'ig');
+            const regExp = new RegExp(this.escapeRegExp(this.searchTerm).trim(), 'ig');
             const parts = [];
             let currentIndex = 0;
             let match = regExp.exec(this.text);
@@ -119,11 +119,16 @@ export default {
 
         // Remove regex special characters from search string
         escapeRegExp(string) {
-            const escapeRegex = RegExp.escape ?? ((value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+            const escapeRegex = RegExp.escape ?? ((value) => value.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'));
 
             if (Context.app.adminEsEnable) {
-                // remove simple query string syntax
-                return escapeRegex(string.replace(/[+-.*~"|()]/g, '').replace(/ AND | and | OR | or |  +/g, ' '));
+                string = string
+                    .replace(/(^|\s)[+-](?=\S)/g, '$1') // remove + and - at the beginning and end of words
+                    .replace(/[.*~"|()]/g, '') // remove special elasticsearch characters
+                    .replace(/ AND | and | OR | or |  +/g, ' ') // remove AND and OR bool operators
+                    .replace(/\s+/g, ' '); // replace multiple spaces with single space
+
+                return escapeRegex(string);
             }
 
             return escapeRegex(string);

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
@@ -46,16 +46,83 @@ describe('src/app/component/base/sw-highlight-text', () => {
         expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('Test');
     });
 
-    it('highlights text with special characters correctly when adminEsEnable is true', async () => {
+    it('highlights text with special characters in search term correctly when adminEsEnable is true', async () => {
         Shopware.Context.app.adminEsEnable = true;
 
         const wrapper = await createWrapper({
-            text: 'This is a test for order-number. Testing order-number, one, two, three.',
+            text: 'This is a test for special characters',
+            searchTerm: '.*special characters~"',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('special characters');
+    });
+
+    it('highlights text with duplicate spaces in search term correctly when adminEsEnable is true', async () => {
+        Shopware.Context.app.adminEsEnable = true;
+
+        const wrapper = await createWrapper({
+            text: 'This is a test for duplicate spaces.',
+            searchTerm: 'duplicate   spaces',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('duplicate spaces');
+    });
+
+    it('highlights text with AND/OR in search term correctly when adminEsEnable is true', async () => {
+        Shopware.Context.app.adminEsEnable = true;
+
+        const wrapper = await createWrapper({
+            text: 'This is a test for AND and OR operators.',
+            searchTerm: 'test AND OR',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('test');
+    });
+
+    it('highlights text with plus or minus in search term correctly when adminEsEnable is true', async () => {
+        Shopware.Context.app.adminEsEnable = true;
+
+        let wrapper = await createWrapper({
+            text: 'This is a test for plus at the start.',
+            searchTerm: '+plus',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('plus');
+
+        wrapper = await createWrapper({
+            text: 'This is a test for plus at the end.',
+            searchTerm: 'plus+',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('plus');
+
+        wrapper = await createWrapper({
+            text: 'This is a test for minus at the start.',
+            searchTerm: '-minus',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('minus');
+
+        wrapper = await createWrapper({
+            text: 'This is a test for minus at the end.',
+            searchTerm: 'minus-',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('minus');
+
+        wrapper = await createWrapper({
+            text: 'This is a test for plus and minus in a word. e.g. for order-number.',
             searchTerm: 'order-number',
         });
 
-        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(2);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(1);
         expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('order-number');
-        expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('order-number');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
@@ -41,7 +41,7 @@ describe('src/app/component/base/sw-highlight-text', () => {
             searchTerm: 'test',
         });
 
-        expect(wrapper.findAll('.sw-highlight-text__highlight').length).toBe(2);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(2);
         expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('test');
         expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('Test');
     });
@@ -54,7 +54,7 @@ describe('src/app/component/base/sw-highlight-text', () => {
             searchTerm: 'order-number',
         });
 
-        expect(wrapper.findAll('.sw-highlight-text__highlight').length).toBe(2);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')).toHaveLength(2);
         expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('order-number');
         expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('order-number');
     });

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/sw-highlight-text.spec.js
@@ -32,4 +32,30 @@ describe('src/app/component/base/sw-highlight-text', () => {
         expect(wrapper.find('.sw-highlight-text__highlight').text()).toBe('example');
         expect(wrapper.text()).toContain('<article>example</article>');
     });
+
+    it('highlights text correctly when adminEsEnable is true', async () => {
+        Shopware.Context.app.adminEsEnable = true;
+
+        const wrapper = await createWrapper({
+            text: 'This is a test. Testing, one, two, three.',
+            searchTerm: 'test',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight').length).toBe(2);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('test');
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('Test');
+    });
+
+    it('highlights text with special characters correctly when adminEsEnable is true', async () => {
+        Shopware.Context.app.adminEsEnable = true;
+
+        const wrapper = await createWrapper({
+            text: 'This is a test for order-number. Testing order-number, one, two, three.',
+            searchTerm: 'order-number',
+        });
+
+        expect(wrapper.findAll('.sw-highlight-text__highlight').length).toBe(2);
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[0].text()).toBe('order-number');
+        expect(wrapper.findAll('.sw-highlight-text__highlight')[1].text()).toBe('order-number');
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the highlight component breaks, if there is a minus or plus character inside of a word

### 2. What does this change do, exactly?
- Improved regex of sw-highlight-text to correctly display minus & plus character inside a word

### 3. Describe each step to reproduce the issue or behaviour.
- Use elasticsearch in the administration
- Search for a word which contains a minus or plus character
- The highlight isn't working correctly

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
