### PR TITLE
fix: Prevent admin search bar render issue with missing order customer

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar-item/sw-search-bar-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar-item/sw-search-bar-item.html.twig
@@ -138,7 +138,7 @@
                 {% block sw_search_bar_item_order_label_name %}
                 <sw-highlight-text
                     :search-term="searchTerm"
-                    :text="`${item.orderCustomer.firstName} ${item.orderCustomer.lastName}`"
+                    :text="`${item.orderCustomer?.firstName || ''} ${item.orderCustomer?.lastName || ''}`"
                 />
                 {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- If you search for a order in the administration which has a missing orderCustomer association the search bar item breaks, as the current template always expects a orderCustomer

### 2. What does this change do, exactly?
- Use a empty string fallback for missing orderCustomer association fields

### 3. Describe each step to reproduce the issue or behaviour.
- Search for a order in the administration which has a missing orderCustomer association

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
