### PR TITLE
chore: Reduce database calls in AdminSearchRegistry

### DIFF
--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -130,7 +130,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     public function refresh(EntityWrittenContainerEvent $event): void
     {
-        if (\count($this->indexer) === 0 || !$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
+        if ($this->indexer === [] || !$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
             return;
         }
 

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -92,6 +92,10 @@ class AdminSearchRegistry implements EventSubscriberInterface
         }
 
         $indexers = $this->getIndexersArray();
+        if ($indexers === []) {
+            return;
+        }
+
         /** @var list<string> $entities */
         $entities = array_keys($indexers);
 
@@ -130,7 +134,12 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     public function refresh(EntityWrittenContainerEvent $event): void
     {
-        if ($this->indexer === [] || !$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
+        if (!$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
+            return;
+        }
+
+        $indexers = $this->getIndexersArray();
+        if ($indexers === []) {
             return;
         }
 
@@ -150,7 +159,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
             return;
         }
 
-        foreach ($this->indexer as $indexer) {
+        foreach ($indexers as $indexer) {
             $ids = $indexer->getUpdatedIds($event);
             $deletedIds = $event->getDeletedPrimaryKeys($indexer->getEntity());
             $ids = array_values(array_diff($ids, $deletedIds));

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -325,7 +325,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     private function refreshIndices(): void
     {
-        $indexTasks = [];    
+        $indexTasks = [];
         $entities = [];
         foreach ($this->indexer as $indexer) {
             $alias = $this->adminEsHelper->getIndex($indexer->getName());

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -96,7 +96,6 @@ class AdminSearchRegistry implements EventSubscriberInterface
             return;
         }
 
-        /** @var list<string> $entities */
         $entities = array_keys($indexers);
 
         if ($indexingBehavior->getOnlyEntities()) {

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -306,7 +306,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
             ];
         }
 
-        if (\count($indices) === 0) {
+        if ($indices === []) {
             return $indices;
         }
 
@@ -349,7 +349,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
             ];
         }
 
-        if (\count($entities) === 0) {
+        if ($entities === []) {
             return;
         }
 

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -130,7 +130,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     public function refresh(EntityWrittenContainerEvent $event): void
     {
-        if (!$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
+        if (\count($this->indexer) === 0 || !$this->adminEsHelper->isEnabled() || !$this->isIndexedEntityWritten($event)) {
             return;
         }
 
@@ -146,7 +146,6 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
         /** @var array<string, string> $indices */
         $indices = $this->connection->fetchAllKeyValue('SELECT `alias`, `index` FROM admin_elasticsearch_index_task');
-
         if ($indices === []) {
             return;
         }
@@ -307,6 +306,10 @@ class AdminSearchRegistry implements EventSubscriberInterface
             ];
         }
 
+        if (\count($indices) === 0) {
+            return $indices;
+        }
+
         $this->connection->executeStatement(
             'DELETE FROM admin_elasticsearch_index_task WHERE `entity` IN (:entities)',
             ['entities' => $entities],
@@ -322,8 +325,8 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
     private function refreshIndices(): void
     {
+        $indexTasks = [];    
         $entities = [];
-        $indexTasks = [];
         foreach ($this->indexer as $indexer) {
             $alias = $this->adminEsHelper->getIndex($indexer->getName());
 
@@ -344,6 +347,10 @@ class AdminSearchRegistry implements EventSubscriberInterface
                 '`alias`' => $alias,
                 '`doc_count`' => $iterator->fetchCount(),
             ];
+        }
+
+        if (\count($entities) === 0) {
+            return;
         }
 
         $this->connection->executeStatement(

--- a/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -483,6 +483,43 @@ class AdminSearchRegistryTest extends TestCase
         ]), []));
     }
 
+    public function testRefreshIndicesNoEmptyDbCall(): void
+    {
+        $client = $this->createMock(Client::class);
+        $indices = $this->createMock(IndicesNamespace::class);
+        $indices->expects($this->never())->method('existsAlias');
+
+        $client->method('indices')->willReturn($indices);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeStatement');
+
+        $searchHelper = new AdminElasticsearchHelper(true, true, 'sw-admin', 'test', true, new NullLogger());
+        $index = new AdminSearchRegistry(
+            [],
+            $connection,
+            $this->createMock(MessageBusInterface::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $client,
+            $searchHelper,
+            $this->createMock(LoggerInterface::class),
+            [],
+            [],
+            'test'
+        );
+
+        $index->refresh(new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([
+            new EntityWrittenEvent('promotion', [
+                new EntityWriteResult(
+                    'c1a28776116d4431a2208eb2960ec340',
+                    [],
+                    'promotion',
+                    EntityWriteResult::OPERATION_INSERT
+                ),
+            ], Context::createDefaultContext()),
+        ]), []));
+    }
+
     public function testHandle(): void
     {
         $this->indexer->method('getName')->willReturn('promotion-listing');


### PR DESCRIPTION
### 1. Why is this change necessary?
- We can prevent a database call per refreshIndices function call, as we can early return, if there are no database actions required, so we don't call the database with an empty parameter array

### 2. What does this change do, exactly?
- Add a early return, if we don't have to call the database, because of an empty array

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
