### PR TITLE
fix: remove deprecated assert active option

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -47,7 +47,6 @@ in {
       ''}
       display_errors = On
       error_reporting = E_ALL
-      assert.active = 0
       opcache.memory_consumption = 256M
       opcache.interned_strings_buffer = 20
       zend.assertions = 0


### PR DESCRIPTION
### 1. Why is this change necessary?
While using the latest composer version, the error message occurs in devenv build process:

```
 > cp: cannot stat '/nix/store/say0zlqnnff6jks63yjl4pyqy2z3yyr4-composer-composer-vendor-2.9.2/'$'\n''Deprecated: PHP Startup: `assert.active` INI setting is deprecated in Unknown on line 0'$'\n''vendor': No such file or directory
```

### 2. What does this change do, exactly?
It deletes the deprecated `assert.active` option from the settings.

### 3. Describe each step to reproduce the issue or behaviour.
Add `assert.active` to `devenv.nix `and start devenv via `devenv up` with the latest composer version (2.9.2)


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
