### PR TITLE
fix: translate notification titles

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
@@ -16,7 +16,7 @@
                 v-for="(notification, index) in notifications"
                 :key="notification.uuid"
                 :class="['sw-notifications__notification--' + index, 'sw-notification__alert']"
-                :title="notification.title"
+                :title="$te(notification.title) ? $tc(notification.title) : notification.title"
                 :variant="getNotificationVariant(notification)"
                 :notification-index="notification.uuid"
                 :closable="true"

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
@@ -16,7 +16,7 @@
                 v-for="(notification, index) in notifications"
                 :key="notification.uuid"
                 :class="['sw-notifications__notification--' + index, 'sw-notification__alert']"
-                :title="$te(notification.title) ? $tc(notification.title) : notification.title"
+                :title="$te(notification.title) ? $t(notification.title) : notification.title"
                 :variant="getNotificationVariant(notification)"
                 :notification-index="notification.uuid"
                 :closable="true"

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.spec.js
@@ -27,7 +27,7 @@ describe('src/app/component/utils/sw-notifications', () => {
                 },
                 mocks: {
                     $te: () => true,
-                    $tc: (key) => `Translated: ${key}`,
+                    $t: (key) => `Translated: ${key}`,
                     $sanitize: (value) => value,
                 },
             },

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.spec.js
@@ -1,0 +1,51 @@
+/**
+ * @sw-package framework
+ */
+
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+
+describe('src/app/component/utils/sw-notifications', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('should translate title when it is a translation key', async () => {
+        const wrapper = mount(await wrapTestComponent('sw-notifications', { sync: true }), {
+            global: {
+                stubs: {
+                    'mt-banner': {
+                        template: '<div class="mt-banner"><slot /></div>',
+                        props: [
+                            'title',
+                            'variant',
+                            'closable',
+                            'notificationIndex',
+                        ],
+                    },
+                    'mt-button': true,
+                },
+                mocks: {
+                    $te: () => true,
+                    $tc: (key) => `Translated: ${key}`,
+                    $sanitize: (value) => value,
+                },
+            },
+        });
+
+        const store = Shopware.Store.get('notification');
+        store.growlNotifications = {
+            'test-uuid': {
+                uuid: 'test-uuid',
+                title: 'global.default.error',
+                message: 'Test Message',
+                variant: 'error',
+                actions: [],
+            },
+        };
+
+        await flushPromises();
+
+        expect(wrapper.findComponent('.mt-banner').props('title')).toBe('Translated: global.default.error');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -91,7 +91,6 @@ const missingTests = [
     'src/app/component/utils/sw-color-badge/index.js',
     'src/app/component/utils/sw-ignore-class/index.js',
     'src/app/component/utils/sw-license-violation/index.js',
-    'src/app/component/utils/sw-notifications/index.js',
     'src/app/component/utils/sw-overlay/index.js',
     'src/app/component/utils/sw-popover-deprecated/index.js',
     'src/app/component/utils/sw-progress-bar/index.js',


### PR DESCRIPTION
Translates notification titles instead of displaying raw snippet keys like `global.default.error`:

<img width="431" height="153" src="https://github.com/user-attachments/assets/15e26cb9-d5bc-40af-870f-2746c817b033" />

Looks like this issue was introduced with #14590?
