### PR TITLE
feat: add disposal of quickview in sw-model-viewer

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-viewer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-viewer/index.ts
@@ -1,8 +1,11 @@
+import { markRaw } from 'vue';
+import type Repository from 'src/core/data/repository.data';
 import { QuickView } from '@shopware-ag/dive/quickview';
 import template from './sw-model-viewer.html.twig';
 import './sw-model-viewer.scss';
 
 const { EventBus } = Shopware.Utils;
+const { Context } = Shopware;
 
 /**
  * @status ready
@@ -17,6 +20,8 @@ const { EventBus } = Shopware.Utils;
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default Shopware.Component.wrapComponentConfig({
     template,
+
+    inject: ['repositoryFactory'],
 
     props: {
         source: {
@@ -33,17 +38,20 @@ export default Shopware.Component.wrapComponentConfig({
             canvas: null,
             isLoading: false,
             modelEntity: null,
+            quickView: null,
         } as {
             canvas: HTMLCanvasElement | null;
             isLoading: boolean;
             modelEntity: EntitySchema.Entity<'media'> | null;
+            quickView: QuickView | null;
         };
     },
 
     watch: {
-        source() {
+        async source(): Promise<void> {
             this.modelEntity = this.source as EntitySchema.Entity<'media'>;
-            this.initializeQuickView();
+            await this.quickView?.dispose();
+            return this.initializeQuickView();
         },
     },
 
@@ -59,6 +67,12 @@ export default Shopware.Component.wrapComponentConfig({
         this.mountedComponent();
     },
 
+    computed: {
+        mediaRepository(): Repository<'media'> {
+            return this.repositoryFactory.create('media');
+        },
+    },
+
     methods: {
         createdComponent(): void {
             // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -68,6 +82,10 @@ export default Shopware.Component.wrapComponentConfig({
         beforeUnmountedComponent(): void {
             // eslint-disable-next-line @typescript-eslint/unbound-method
             EventBus.off('sw-media-library-item-updated', this.onMediaLibraryItemUpdated);
+
+            this.disposeQuickView().catch((error) => {
+                console.error(error);
+            });
         },
 
         mountedComponent(): void {
@@ -78,32 +96,55 @@ export default Shopware.Component.wrapComponentConfig({
             this.canvas = this.$el?.querySelector?.('.sw-model-viewer-canvas');
 
             this.modelEntity = this.source as EntitySchema.Entity<'media'>;
-            this.initializeQuickView();
+            this.initializeQuickView().catch((error) => {
+                console.error(error);
+            });
         },
 
-        initializeQuickView(): void {
-            if (!this.canvas || !this.modelEntity?.url) {
-                return;
+        async initializeQuickView(): Promise<void> {
+            if (!this.canvas) {
+                return Promise.reject(new Error('Canvas is missing'));
+            }
+
+            if (!this.modelEntity?.url) {
+                return Promise.reject(new Error('Model entity URL is missing'));
             }
 
             this.isLoading = true;
 
-            QuickView(this.modelEntity.url, {
-                canvas: this.canvas,
-            })
-                .catch((error) => {
-                    console.error(error);
+            this.quickView = markRaw(
+                await QuickView(this.modelEntity.url, {
+                    canvas: this.canvas,
                 })
-                .finally(() => {
-                    this.isLoading = false;
-                });
+                    .catch((error) => {
+                        console.error(error);
+                        return Promise.reject(error as Error);
+                    })
+                    .finally(() => {
+                        this.isLoading = false;
+                    }),
+            );
+
+            return Promise.resolve();
+        },
+
+        async disposeQuickView(): Promise<void> {
+            await this.quickView?.dispose();
         },
 
         onMediaLibraryItemUpdated(mediaId: string): void {
             if (!this.modelEntity?.id) return;
             if (this.modelEntity?.id !== mediaId) return;
 
-            this.initializeQuickView();
+            // Refetch media entity to get fresh URL with updated cache-busting timestamp
+            this.mediaRepository
+                .get(mediaId, Context.api)
+                .then((media) => {
+                    this.modelEntity = media;
+                })
+                .catch((error) => {
+                    console.error(error);
+                });
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-viewer/sw-model-viewer.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-viewer/sw-model-viewer.spec.ts
@@ -5,7 +5,10 @@ import type { QuickViewSettings } from '@shopware-ag/dive/quickview';
 import { mount } from '@vue/test-utils';
 
 // Mock QuickView from @shopware-ag/dive/quickview
-const mockQuickView = jest.fn().mockResolvedValue({});
+const mockQuickViewDispose = jest.fn();
+const mockQuickView = jest.fn().mockResolvedValue({
+    dispose: mockQuickViewDispose,
+});
 jest.mock('@shopware-ag/dive/quickview', () => ({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     QuickView: (...args: QuickViewSettings[]) => mockQuickView(...args),
@@ -45,7 +48,9 @@ describe('src/app/component/media/sw-model-viewer', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        mockQuickView.mockResolvedValue({});
+        mockQuickView.mockResolvedValue({
+            dispose: mockQuickViewDispose,
+        });
     });
 
     describe('Component Initialization', () => {
@@ -128,67 +133,72 @@ describe('src/app/component/media/sw-model-viewer', () => {
 
         it('should return early if canvas is null', async () => {
             const wrapper = await createWrapper();
+            await flushPromises();
+            const callCountBefore = mockQuickView.mock.calls.length;
+
             await wrapper.setData({ canvas: null });
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
                 @typescript-eslint/no-explicit-any,
                 @typescript-eslint/no-unsafe-member-access
             */
-            await (wrapper.vm as any).initializeQuickView();
+            await (wrapper.vm as any).initializeQuickView().catch(() => {});
             await flushPromises();
 
-            // QuickView should not be called if canvas is null
-            const callCountBefore = mockQuickView.mock.calls.length;
-            /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
-                @typescript-eslint/no-explicit-any,
-                @typescript-eslint/no-unsafe-member-access
-            */
-            await (wrapper.vm as any).initializeQuickView();
-            await flushPromises();
-
+            // QuickView should not be called again if canvas is null
             expect(mockQuickView.mock.calls).toHaveLength(callCountBefore);
-            expect(wrapper.vm.isLoading).toBe(false);
         });
 
         it('should return early if modelEntity is null', async () => {
             const wrapper = await createWrapper();
+            await flushPromises();
+            const callCountBefore = mockQuickView.mock.calls.length;
+
             await wrapper.setData({ modelEntity: null });
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
                 @typescript-eslint/no-explicit-any,
                 @typescript-eslint/no-unsafe-member-access
             */
-            await (wrapper.vm as any).initializeQuickView();
+            await (wrapper.vm as any).initializeQuickView().catch(() => {});
+            await flushPromises();
+
+            // QuickView should not be called again if modelEntity is null
+            expect(mockQuickView.mock.calls).toHaveLength(callCountBefore);
+        });
+
+        it('should return early if modelEntity.url is missing', async () => {
+            const wrapper = await createWrapper();
             await flushPromises();
 
             const callCountBefore = mockQuickView.mock.calls.length;
+
+            // Manually set URL to undefined and try to reinitialize
+            await wrapper.setData({
+                modelEntity: createMediaEntity({ url: undefined }),
+            });
             /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
                 @typescript-eslint/no-explicit-any,
                 @typescript-eslint/no-unsafe-member-access
             */
-            await (wrapper.vm as any).initializeQuickView();
+            await (wrapper.vm as any).initializeQuickView().catch(() => {});
             await flushPromises();
 
+            // QuickView should not be called again if URL is missing
             expect(mockQuickView.mock.calls).toHaveLength(callCountBefore);
-            expect(wrapper.vm.isLoading).toBe(false);
-        });
-
-        it('should return early if modelEntity.url is missing', async () => {
-            const mediaEntity = createMediaEntity({ url: undefined });
-            const wrapper = await createWrapper({
-                props: {
-                    source: mediaEntity,
-                },
-            });
-            await flushPromises();
-
-            expect(mockQuickView.mock.calls).toHaveLength(0);
-            expect(wrapper.vm.isLoading).toBe(false);
         });
 
         it('should handle QuickView errors gracefully', async () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-            mockQuickView.mockRejectedValueOnce(new Error('QuickView failed'));
 
             const wrapper = await createWrapper();
+            await flushPromises();
+
+            // Now reject for the next call
+            mockQuickView.mockRejectedValueOnce(new Error('QuickView failed'));
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
+                @typescript-eslint/no-explicit-any,
+                @typescript-eslint/no-unsafe-member-access
+            */
+            await (wrapper.vm as any).initializeQuickView().catch(() => {});
             await flushPromises();
 
             // Component should still exist and isLoading should be false
@@ -200,9 +210,17 @@ describe('src/app/component/media/sw-model-viewer', () => {
 
         it('should set isLoading to false even when QuickView fails', async () => {
             const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-            mockQuickView.mockRejectedValueOnce(new Error('QuickView failed'));
 
             const wrapper = await createWrapper();
+            await flushPromises();
+
+            // Now reject for the next call
+            mockQuickView.mockRejectedValueOnce(new Error('QuickView failed'));
+            /* eslint-disable-next-line @typescript-eslint/no-unsafe-call,
+                @typescript-eslint/no-explicit-any,
+                @typescript-eslint/no-unsafe-member-access
+            */
+            await (wrapper.vm as any).initializeQuickView().catch(() => {});
             await flushPromises();
 
             expect(wrapper.vm.isLoading).toBe(false);
@@ -244,28 +262,6 @@ describe('src/app/component/media/sw-model-viewer', () => {
             await flushPromises();
 
             expect(mockQuickView.mock.calls.length).toBeGreaterThan(initialCallCount);
-        });
-
-        it('should handle source prop change errors gracefully', async () => {
-            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
-            mockQuickView.mockRejectedValueOnce(new Error('QuickView failed'));
-
-            const wrapper = await createWrapper();
-            await flushPromises();
-
-            const newMediaEntity = createMediaEntity({
-                id: 'new-media-id',
-                url: 'https://example.com/new-model.glb',
-            });
-
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-            await wrapper.setProps({ source: newMediaEntity } as any);
-            await flushPromises();
-
-            expect(wrapper.exists()).toBe(true);
-            expect(consoleErrorSpy).toHaveBeenCalled();
-
-            consoleErrorSpy.mockRestore();
         });
     });
 
@@ -334,7 +330,35 @@ describe('src/app/component/media/sw-model-viewer', () => {
                 id: 'update-test-id',
                 url: 'https://example.com/original-model.glb',
             });
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
+            // Mock the API response for fetching updated media
+            /* eslint-disable @typescript-eslint/no-unsafe-assignment,
+                @typescript-eslint/no-explicit-any,
+                @typescript-eslint/no-unsafe-member-access,
+                @typescript-eslint/no-unsafe-call
+            */
+            const responses = (globalThis as any).repositoryFactoryMock.responses;
+            responses.addResponse(
+                /* eslint-enable */
+                {
+                    method: 'Post',
+                    url: '/search/media',
+                    status: 200,
+                    response: {
+                        data: [
+                            {
+                                id: 'update-test-id',
+                                attributes: {
+                                    id: 'update-test-id',
+                                    url: 'https://example.com/updated-model.glb',
+                                },
+                                relationships: [],
+                            },
+                        ],
+                    },
+                },
+            );
+
             const wrapper = await createWrapper({
                 props: {
                     source: mediaEntity,
@@ -342,13 +366,14 @@ describe('src/app/component/media/sw-model-viewer', () => {
             });
             await flushPromises();
 
-            const initialCallCount = mockQuickView.mock.calls.length;
-
-            // Simulate media update
+            // Simulate media update event
             Shopware.Utils.EventBus.emit('sw-media-library-item-updated', 'update-test-id');
             await flushPromises();
 
-            expect(mockQuickView.mock.calls.length).toBeGreaterThan(initialCallCount);
+            // Verify modelEntity was updated with new URL from API
+            expect(wrapper.vm.modelEntity).toBeTruthy();
+            const updatedEntity = wrapper.vm.modelEntity as EntitySchema.Entity<'media'>;
+            expect(updatedEntity?.url).toBe('https://example.com/updated-model.glb');
         });
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The new sw-model-viewer component does not dispose it's instances of dive correctly.

### 2. What does this change do, exactly?
Add correct disposal for dive instances.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
