### PR TITLE
feat: add DB id to shopId fingerprinting

### DIFF
--- a/src/Core/Framework/App/ShopId/Fingerprint/DatabaseServerUid.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/DatabaseServerUid.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopId\Fingerprint;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
+use Shopware\Core\Framework\App\ShopId\Fingerprint;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @codeCoverageIgnore covered by Integration test: \Shopware\Tests\Integration\Core\Framework\App\ShopId\Fingerprint\DatabaseServerUidTest
+ */
+#[Package('framework')]
+readonly class DatabaseServerUid implements Fingerprint
+{
+    final public const IDENTIFIER = 'database_server_uid';
+
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    /**
+     * Changes to a new DB server or a new table space are a near certain indicator, that this is a different instance.
+     */
+    public function getScore(): int
+    {
+        return 100;
+    }
+
+    public function getStamp(): string
+    {
+        return $this->getDBServerUid() . $this->getTablespaceName();
+    }
+
+    private function getDBServerUid(): string
+    {
+        if ($this->connection instanceof PrimaryReadReplicaConnection) {
+            $this->connection->ensureConnectedToPrimary();
+        }
+
+        // MySQL uuid variable: https://dev.mysql.com/doc/refman/8.4/en/replication-options.html#sysvar_server_uuid
+        $serverId = $this->connection->fetchAssociative('SHOW VARIABLES WHERE Variable_name = "server_uuid"')['Value'] ?? '';
+
+        if ($serverId) {
+            return (string) $serverId;
+        }
+
+        // MariaDB uuid variable: https://mariadb.com/docs/server/server-management/variables-and-modes/server-system-variables#server_uid
+        $serverId = $this->connection->fetchAssociative('SHOW VARIABLES WHERE Variable_name = "server_uid"')['Value'] ?? '';
+
+        if ($serverId) {
+            return (string) $serverId;
+        }
+
+        // older maria DB versions do not have the server_uid variable
+        return '';
+    }
+
+    private function getTablespaceName(): string
+    {
+        return (string) $this->connection->fetchOne('SELECT database()');
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -684,6 +684,12 @@
             <argument type="service" id="Shopware\Core\Framework\App\Privileges\Privileges"/>
         </service>
 
+        <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\DatabaseServerUid">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+
+            <tag name="shopware.app_system.shop_id_fingerprint"/>
+        </service>
+
         <service id="Shopware\Core\Framework\App\ShopId\Fingerprint\SalesChannelDomainUrls">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
 

--- a/tests/integration/Core/Framework/App/ShopId/Fingerprint/DatabaseServerUidTest.php
+++ b/tests/integration/Core/Framework/App/ShopId/Fingerprint/DatabaseServerUidTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\App\ShopId\Fingerprint;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\Fingerprint\DatabaseServerUid;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class DatabaseServerUidTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private DatabaseServerUid $databaseServerUid;
+
+    protected function setUp(): void
+    {
+        $this->databaseServerUid = static::getContainer()->get(DatabaseServerUid::class);
+    }
+
+    public function testGetIdentifier(): void
+    {
+        static::assertSame(DatabaseServerUid::IDENTIFIER, $this->databaseServerUid->getIdentifier());
+    }
+
+    public function testGetScore(): void
+    {
+        static::assertSame(100, $this->databaseServerUid->getScore());
+    }
+
+    public function testGetStamp(): void
+    {
+        $stamp = $this->databaseServerUid->getStamp();
+        $dbUrlParts = parse_url($_SERVER['DATABASE_URL'] ?? '') ?: [];
+
+        $databaseName = trim($dbUrlParts['path'] ?? '', '/');
+        static::assertNotSame($databaseName, '');
+
+        static::assertStringEndsWith($databaseName, $stamp);
+        // expect server UID before table-space part
+        static::assertNotSame($stamp, $databaseName);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Fingerprinting of shopId is still flaky, we can't rely on APP_URL, as administrators need to actively change that.
Also we can't rely on installation path, as that stays the same on container based deploys, but might also change just between updates (e.g symlink based deploys).

### 2. What does this change do, exactly?
Try to get the server id from the DB server, if the DB server changed, it is pretty likely that we are running in a separate instance.

