### PR TITLE
feat: Refactor empty usage in checkout area to prepare its prohibition

### DIFF
--- a/src/Core/Checkout/Cart/CartBehavior.php
+++ b/src/Core/Checkout/Cart/CartBehavior.php
@@ -23,7 +23,7 @@ class CartBehavior extends Struct
 
     public function hasPermission(string $permission): bool
     {
-        return !empty($this->permissions[$permission]);
+        return $this->permissions[$permission] ?? false;
     }
 
     public function getApiAlias(): string

--- a/src/Core/Checkout/Cart/Command/CartMigrateCommand.php
+++ b/src/Core/Checkout/Cart/Command/CartMigrateCommand.php
@@ -107,9 +107,7 @@ class CartMigrateCommand extends Command
         $this->io = new ShopwareStyle($input, $output);
 
         $keys = $this->redis->keys(RedisCartPersister::PREFIX . '*');
-        \assert(\is_array($keys));
-
-        if ($keys === []) {
+        if (!\is_array($keys) || $keys === []) {
             $this->io->success('No carts found in Redis');
 
             return self::SUCCESS;

--- a/src/Core/Checkout/Cart/Command/CartMigrateCommand.php
+++ b/src/Core/Checkout/Cart/Command/CartMigrateCommand.php
@@ -109,7 +109,7 @@ class CartMigrateCommand extends Command
         $keys = $this->redis->keys(RedisCartPersister::PREFIX . '*');
         \assert(\is_array($keys));
 
-        if (empty($keys)) {
+        if ($keys === []) {
             $this->io->success('No carts found in Redis');
 
             return self::SUCCESS;

--- a/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
@@ -70,7 +70,7 @@ class DeliveryProcessor implements CartProcessorInterface, CartDataCollectorInte
                 }
             }
 
-            if (empty($ids)) {
+            if ($ids === []) {
                 return;
             }
 

--- a/src/Core/Checkout/Cart/Exception/TaxProviderExceptions.php
+++ b/src/Core/Checkout/Cart/Exception/TaxProviderExceptions.php
@@ -47,7 +47,7 @@ class TaxProviderExceptions extends ShopwareHttpException
 
     public function hasExceptions(): bool
     {
-        return !empty($this->exceptions);
+        return $this->exceptions !== [];
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/LineItem/Group/LineItemGroupBuilder.php
+++ b/src/Core/Checkout/Cart/LineItem/Group/LineItemGroupBuilder.php
@@ -56,7 +56,7 @@ class LineItemGroupBuilder implements ResetInterface
             unset($groupDefinitions[$index]);
         }
 
-        if (empty($groupDefinitions)) {
+        if ($groupDefinitions === []) {
             return $result;
         }
 
@@ -150,7 +150,7 @@ class LineItemGroupBuilder implements ResetInterface
                 unset($lineItemsToRemove[$item->getId()]);
 
                 // If we have removed all items we wanted to remove, break the loop.
-                if (empty($lineItemsToRemove)) {
+                if ($lineItemsToRemove === []) {
                     break;
                 }
 

--- a/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
+++ b/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
@@ -45,10 +45,11 @@ class LineItemDownloadLoader
                 $isLineItemDownloadable = $isLineItemDownloadable || (\is_array($states) && \in_array(State::IS_DOWNLOAD, $states, true));
             }
 
+            $downloads = $lineItem['downloads'] ?? null;
             if (
                 !$productId
                 || !$isLineItemDownloadable
-                || !empty($lineItem['downloads'])
+                || ($downloads !== null && $downloads !== [])
             ) {
                 continue;
             }
@@ -56,7 +57,7 @@ class LineItemDownloadLoader
             $lineItemKeys[(string) $productId] = (int) $key;
         }
 
-        if (empty($lineItemKeys)) {
+        if ($lineItemKeys === []) {
             return [];
         }
 

--- a/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
+++ b/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
@@ -27,7 +27,7 @@ class LineItemDownloadLoader
     }
 
     /**
-     * @param mixed[][] $lineItems
+     * @param list<array<string, mixed>> $lineItems
      *
      * @return array<int, list<array{position: int, mediaId: string, accessGranted: bool}>>
      */
@@ -46,15 +46,11 @@ class LineItemDownloadLoader
             }
 
             $downloads = $lineItem['downloads'] ?? null;
-            if (
-                !$productId
-                || !$isLineItemDownloadable
-                || ($downloads !== null && $downloads !== [])
-            ) {
+            if (!$productId || !$isLineItemDownloadable || !$downloads) {
                 continue;
             }
 
-            $lineItemKeys[(string) $productId] = (int) $key;
+            $lineItemKeys[(string) $productId] = $key;
         }
 
         if ($lineItemKeys === []) {

--- a/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
+++ b/src/Core/Checkout/Cart/Order/LineItemDownloadLoader.php
@@ -46,7 +46,7 @@ class LineItemDownloadLoader
             }
 
             $downloads = $lineItem['downloads'] ?? null;
-            if (!$productId || !$isLineItemDownloadable || !$downloads) {
+            if (!$productId || !$isLineItemDownloadable || $downloads) {
                 continue;
             }
 

--- a/src/Core/Checkout/Cart/PriceActionController.php
+++ b/src/Core/Checkout/Cart/PriceActionController.php
@@ -86,11 +86,10 @@ class PriceActionController extends AbstractController
         $taxId = $request->request->getAlnum('taxId');
         $productPrices = $request->request->all('prices');
 
-        if (empty($productPrices)) {
+        if ($productPrices === []) {
             throw CartException::pricesParameterIsMissing();
         }
 
-        $taxRate = null;
         if (Feature::isActive('v6.8.0.0')) {
             $criteria = (new Criteria([$taxId]))
                 ->addFields(['taxRate']);

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -59,11 +59,11 @@ class TaxDetector extends AbstractTaxDetector
         $vatPattern = $shippingLocationCountry->getVatIdPattern();
         $vatIds = array_filter($customer->getVatIds() ?? []);
 
-        if (empty($vatIds)) {
+        if ($vatIds === []) {
             return false;
         }
 
-        if (!empty($vatPattern) && $shippingLocationCountry->getCheckVatIdPattern()) {
+        if ($vatPattern !== null && $vatPattern !== '' && $shippingLocationCountry->getCheckVatIdPattern()) {
             $regex = '/^' . $vatPattern . '$/';
 
             foreach ($vatIds as $vatId) {

--- a/src/Core/Checkout/Customer/Aggregate/CustomerAddress/CustomerAddressEntity.php
+++ b/src/Core/Checkout/Customer/Aggregate/CustomerAddress/CustomerAddressEntity.php
@@ -124,7 +124,7 @@ class CustomerAddressEntity extends Entity
 
     public function setZipcode(?string $zipcode): void
     {
-        $this->zipcode = empty($zipcode) ? null : $zipcode;
+        $this->zipcode = ($zipcode === null || $zipcode === '') ? null : $zipcode;
     }
 
     public function getCity(): string

--- a/src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
+++ b/src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
@@ -161,11 +161,11 @@ class CustomerGroupRegistrationActionController
     {
         $customerIds = $request->request->all('customerIds');
 
-        if (!empty($customerIds)) {
+        if ($customerIds !== []) {
             $customerIds = array_unique($customerIds);
         }
 
-        if (empty($customerIds)) {
+        if ($customerIds === []) {
             throw CustomerException::customerIdsParameterIsMissing();
         }
 

--- a/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerIndexer.php
+++ b/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerIndexer.php
@@ -52,7 +52,7 @@ class CustomerIndexer extends EntityIndexer
 
         $ids = $iterator->fetch();
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return null;
         }
 
@@ -63,7 +63,7 @@ class CustomerIndexer extends EntityIndexer
     {
         $updates = $event->getPrimaryKeys(CustomerDefinition::ENTITY_NAME);
 
-        if (empty($updates)) {
+        if ($updates === []) {
             return null;
         }
 
@@ -84,13 +84,13 @@ class CustomerIndexer extends EntityIndexer
         }
 
         $ids = array_unique(array_filter($ids));
-        if (empty($ids) || !$message instanceof CustomerIndexingMessage) {
+        if ($ids === [] || !$message instanceof CustomerIndexingMessage) {
             return;
         }
 
         $context = $message->getContext();
 
-        if (!empty($message->getIds())) {
+        if ($message->getIds() !== []) {
             $this->customerNewsletterSalesChannelsUpdater->updateCustomersRecipient($message->getIds());
         }
 

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
@@ -77,8 +77,11 @@ class ChangeCustomerProfileRoute extends AbstractChangeCustomerProfileRoute
     {
         $validation = $this->customerProfileValidationFactory->update($context);
 
-        if ($data->has('accountType') && empty($data->get('accountType'))) {
-            $data->remove('accountType');
+        if ($data->has('accountType')) {
+            $accountType = $data->get('accountType');
+            if ($accountType === null || $accountType === '') {
+                $data->remove('accountType');
+            }
         }
 
         if ($data->get('accountType') === CustomerEntity::ACCOUNT_TYPE_BUSINESS) {
@@ -95,7 +98,7 @@ class ChangeCustomerProfileRoute extends AbstractChangeCustomerProfileRoute
         $vatIds = $data->get('vatIds');
         if ($vatIds instanceof RequestDataBag) {
             $vatIds = \array_filter($vatIds->all());
-            $data->set('vatIds', empty($vatIds) ? null : $vatIds);
+            $data->set('vatIds', $vatIds === [] ? null : $vatIds);
         }
 
         if (!$data->get('salutationId')) {

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php
@@ -77,11 +77,8 @@ class ChangeCustomerProfileRoute extends AbstractChangeCustomerProfileRoute
     {
         $validation = $this->customerProfileValidationFactory->update($context);
 
-        if ($data->has('accountType')) {
-            $accountType = $data->get('accountType');
-            if ($accountType === null || $accountType === '') {
-                $data->remove('accountType');
-            }
+        if ($data->has('accountType') && $data->getString('accountType') === '') {
+            $data->remove('accountType');
         }
 
         if ($data->get('accountType') === CustomerEntity::ACCOUNT_TYPE_BUSINESS) {

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
@@ -82,7 +82,7 @@ class ChangeEmailRoute extends AbstractChangeEmailRoute
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('customerId', $customer->getId()));
         $ids = $this->customerRecoveryRepository->searchIds($criteria, $context->getContext())->getIds();
-        if (!empty($ids)) {
+        if ($ids !== []) {
             $this->customerRecoveryRepository->delete(array_map(fn ($id) => ['id' => $id], $ids), $context->getContext());
         }
 

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -109,8 +109,11 @@ class RegisterRoute extends AbstractRegisterRoute
 
         $isGuest = $data->getBoolean('guest');
 
-        if ($data->has('accountType') && empty($data->get('accountType'))) {
-            $data->remove('accountType');
+        if ($data->has('accountType')) {
+            $accountType = $data->get('accountType');
+            if ($accountType === null || $accountType === '') {
+                $data->remove('accountType');
+            }
         }
 
         if (!$data->get('salutationId')) {

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -109,11 +109,8 @@ class RegisterRoute extends AbstractRegisterRoute
 
         $isGuest = $data->getBoolean('guest');
 
-        if ($data->has('accountType')) {
-            $accountType = $data->get('accountType');
-            if ($accountType === null || $accountType === '') {
-                $data->remove('accountType');
-            }
+        if ($data->has('accountType') && $data->getString('accountType') === '') {
+            $data->remove('accountType');
         }
 
         if (!$data->get('salutationId')) {

--- a/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerBeforeDeleteSubscriber.php
@@ -57,7 +57,7 @@ class CustomerBeforeDeleteSubscriber implements EventSubscriberInterface
 
         $ids = $event->getIds(CustomerDefinition::ENTITY_NAME);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriber.php
@@ -36,7 +36,7 @@ class CustomerChangePasswordSubscriber implements EventSubscriberInterface
     {
         foreach ($event->getPayloads() as $payload) {
             $password = $payload['password'] ?? null;
-            if ($password !== null && $password !== '' && $password !== []) {
+            if ($password !== null && $password !== '') {
                 $this->clearLegacyPassword($payload['id']);
             }
         }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriber.php
@@ -34,9 +34,9 @@ class CustomerChangePasswordSubscriber implements EventSubscriberInterface
 
     public function onCustomerWritten(EntityWrittenEvent $event): void
     {
-        $payloads = $event->getPayloads();
-        foreach ($payloads as $payload) {
-            if (!empty($payload['password'])) {
+        foreach ($event->getPayloads() as $payload) {
+            $password = $payload['password'] ?? null;
+            if ($password !== null && $password !== '' && $password !== []) {
                 $this->clearLegacyPassword($payload['id']);
             }
         }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerFlowEventsSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerFlowEventsSubscriber.php
@@ -56,7 +56,7 @@ class CustomerFlowEventsSubscriber implements EventSubscriberInterface
         foreach ($payloads as $payload) {
             try {
                 $createdAt = $payload['createdAt'] ?? null;
-                if ($createdAt !== null && $createdAt !== '' && $createdAt !== []) {
+                if ($createdAt !== null && $createdAt !== '') {
                     $this->dispatchCustomerRegisterEvent($payload['id'], $event);
                 }
             } catch (SalesChannelException $exception) {

--- a/src/Core/Checkout/Customer/Subscriber/CustomerFlowEventsSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerFlowEventsSubscriber.php
@@ -55,7 +55,8 @@ class CustomerFlowEventsSubscriber implements EventSubscriberInterface
 
         foreach ($payloads as $payload) {
             try {
-                if (!empty($payload['createdAt'])) {
+                $createdAt = $payload['createdAt'] ?? null;
+                if ($createdAt !== null && $createdAt !== '' && $createdAt !== []) {
                     $this->dispatchCustomerRegisterEvent($payload['id'], $event);
                 }
             } catch (SalesChannelException $exception) {

--- a/src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
@@ -76,7 +76,7 @@ class CustomerMetaFieldSubscriber implements EventSubscriberInterface
      */
     private function updateCustomer(array $orderIds, bool $isDelete = false): void
     {
-        if (empty($orderIds)) {
+        if ($orderIds === []) {
             return;
         }
 
@@ -86,7 +86,7 @@ class CustomerMetaFieldSubscriber implements EventSubscriberInterface
             ['ids' => ArrayParameterType::BINARY]
         );
 
-        if (empty($customerIds)) {
+        if ($customerIds === []) {
             return;
         }
 
@@ -130,7 +130,7 @@ class CustomerMetaFieldSubscriber implements EventSubscriberInterface
 
         $data = $this->connection->fetchAllAssociative($select, $parameters, $types);
 
-        if (empty($data)) {
+        if ($data === []) {
             foreach ($customerIds as $customerId) {
                 $data[] = [
                     'id' => Uuid::fromHexToBytes($customerId),

--- a/src/Core/Checkout/Document/Controller/DocumentController.php
+++ b/src/Core/Checkout/Document/Controller/DocumentController.php
@@ -98,7 +98,7 @@ class DocumentController extends AbstractController
     {
         $documentIds = $request->request->all()['documentIds'] ?? [];
 
-        if (!\is_array($documentIds) || empty($documentIds)) {
+        if (!\is_array($documentIds) || $documentIds === []) {
             throw DocumentException::invalidRequestParameter('documentIds');
         }
 

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -307,7 +307,7 @@ class DocumentConfiguration extends Struct
             $this->getCompanyCountry()?->getTranslation('name') ?? '',
         ];
 
-        return array_filter($parts, static fn ($part) => !empty(\trim($part)));
+        return array_filter($parts, static fn (string $part): bool => \trim($part) !== '');
     }
 
     public function getId(): string

--- a/src/Core/Checkout/Document/DocumentGeneratorController.php
+++ b/src/Core/Checkout/Document/DocumentGeneratorController.php
@@ -45,7 +45,7 @@ class DocumentGeneratorController extends AbstractController
     {
         $documents = $this->serializer->decode($request->getContent(), 'json');
 
-        if (empty($documents) || !\is_array($documents)) {
+        if (!\is_array($documents) || $documents === []) {
             throw DocumentException::invalidRequestParameter('Request parameters must be an array of documents object');
         }
 

--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -52,7 +52,7 @@ abstract class AbstractDocumentRenderer
      */
     protected function isAllowIntraCommunityDelivery(array $config, OrderEntity $order): bool
     {
-        if ($config['displayAdditionalNoteDelivery'] ?? false) {
+        if (($config['displayAdditionalNoteDelivery'] ?? false) === false) {
             return false;
         }
 

--- a/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/AbstractDocumentRenderer.php
@@ -52,7 +52,7 @@ abstract class AbstractDocumentRenderer
      */
     protected function isAllowIntraCommunityDelivery(array $config, OrderEntity $order): bool
     {
-        if (empty($config['displayAdditionalNoteDelivery'])) {
+        if ($config['displayAdditionalNoteDelivery'] ?? false) {
             return false;
         }
 

--- a/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
@@ -75,7 +75,7 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
 
         $ids = \array_map(fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return $result;
         }
 
@@ -88,7 +88,7 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
                 $orderId = $operation->getOrderId();
                 $invoice = $this->referenceInvoiceLoader->load($orderId, $operation->getReferencedDocumentId(), $rendererConfig->deepLinkCode);
 
-                if (empty($invoice)) {
+                if ($invoice === []) {
                     throw DocumentException::generationError('Can not generate credit note document because no invoice document exists. OrderId: ' . $orderId);
                 }
 

--- a/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
@@ -53,7 +53,7 @@ final class DeliveryNoteRenderer extends AbstractDocumentRenderer
 
         $ids = \array_map(fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return $result;
         }
 

--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -54,7 +54,7 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
 
         $ids = \array_map(fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return $result;
         }
 

--- a/src/Core/Checkout/Document/Renderer/StornoRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/StornoRenderer.php
@@ -57,7 +57,7 @@ final class StornoRenderer extends AbstractDocumentRenderer
 
         $ids = \array_map(fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return $result;
         }
 
@@ -70,7 +70,7 @@ final class StornoRenderer extends AbstractDocumentRenderer
                 $orderId = $operation->getOrderId();
                 $invoice = $this->referenceInvoiceLoader->load($orderId, $operation->getReferencedDocumentId(), $rendererConfig->deepLinkCode);
 
-                if (empty($invoice)) {
+                if ($invoice === []) {
                     throw DocumentException::generationError('Can not generate cancellation invoice document because no invoice document exists. OrderId: ' . $operation->getOrderId());
                 }
 

--- a/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
@@ -57,7 +57,7 @@ class ZugferdRenderer extends AbstractDocumentRenderer
         $result = new RendererResult();
 
         $ids = \array_map(static fn (DocumentGenerateOperation $operation) => $operation->getOrderId(), $operations);
-        if (empty($ids)) {
+        if ($ids === []) {
             return $result;
         }
 

--- a/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
+++ b/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
@@ -142,7 +142,7 @@ final class DocumentRoute extends AbstractDocumentRoute
             \ARRAY_FILTER_USE_KEY
         );
 
-        if (empty($supportedRequestedFormats)) {
+        if ($supportedRequestedFormats === []) {
             throw DocumentException::documentAcceptHeaderMimeTypesNotSupported(
                 array_values($requestedTypesMapping),
                 array_values($supportedTypesMapping)
@@ -271,7 +271,7 @@ final class DocumentRoute extends AbstractDocumentRoute
         $requestedFileTypes = $request->getAcceptableContentTypes();
         $fileTypes = [];
 
-        if (empty($requestedFileTypes)) {
+        if ($requestedFileTypes === []) {
             return $this->getDefaultFileTypes();
         }
 

--- a/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
+++ b/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
@@ -48,8 +48,9 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
 
     public function load(string $documentType, string $salesChannelId, Context $context): DocumentConfiguration
     {
-        if (isset($this->configs[$documentType][$salesChannelId])) {
-            return $this->configs[$documentType][$salesChannelId];
+        $config = $this->configs[$documentType][$salesChannelId] ?? null;
+        if ($config instanceof DocumentConfiguration) {
+            return $config;
         }
 
         $criteria = (new Criteria())

--- a/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
+++ b/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
@@ -48,7 +48,7 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
 
     public function load(string $documentType, string $salesChannelId, Context $context): DocumentConfiguration
     {
-        if (!empty($this->configs[$documentType][$salesChannelId])) {
+        if (isset($this->configs[$documentType][$salesChannelId])) {
             return $this->configs[$documentType][$salesChannelId];
         }
 

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -91,8 +91,8 @@ class DocumentGenerator
         $config = new DocumentRendererConfig();
         $config->deepLinkCode = $deepLinkCode;
 
-        if (!empty($operation->getConfig()['custom']['invoiceNumber'])) {
-            $invoiceNumber = (string) $operation->getConfig()['custom']['invoiceNumber'];
+        $invoiceNumber = (string) ($operation->getConfig()['custom']['invoiceNumber'] ?? '');
+        if ($invoiceNumber !== '') {
             $operation->setReferencedDocumentId($this->getReferenceId($operation->getOrderId(), $invoiceNumber));
         }
 
@@ -216,7 +216,7 @@ class DocumentGenerator
      */
     private function writeRecords(array $records, Context $context): void
     {
-        if (empty($records)) {
+        if ($records === []) {
             return;
         }
 

--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -49,7 +49,7 @@ final class DocumentMerger
      */
     public function merge(array $documentIds, Context $context): ?RenderedDocument
     {
-        if (empty($documentIds)) {
+        if ($documentIds === []) {
             return null;
         }
 

--- a/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
+++ b/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
@@ -52,7 +52,7 @@ final readonly class ReferenceInvoiceLoader
         $builder->orderBy('`document`.`sent`', 'DESC');
         $builder->addOrderBy('`document`.`created_at`', 'DESC');
 
-        if ($referenceDocumentId !== null && $referenceDocumentId !== '') {
+        if ($referenceDocumentId && Uuid::isValid($referenceDocumentId)) {
             $builder->andWhere('`document`.`id` = :documentId');
             $builder->setParameter('documentId', Uuid::fromHexToBytes($referenceDocumentId));
         }
@@ -63,7 +63,7 @@ final readonly class ReferenceInvoiceLoader
             return [];
         }
 
-        $results = array_filter($documents, function (array $document) use ($deepLinkCodeRendererConfig) {
+        $results = array_filter($documents, static function (array $document) use ($deepLinkCodeRendererConfig) {
             if ($deepLinkCodeRendererConfig !== null && $deepLinkCodeRendererConfig !== '') {
                 return $document['orderVersionId'] === $document['versionId']
                     && $deepLinkCodeRendererConfig === $document['deepLinkCode'];

--- a/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
+++ b/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
@@ -52,19 +52,19 @@ final readonly class ReferenceInvoiceLoader
         $builder->orderBy('`document`.`sent`', 'DESC');
         $builder->addOrderBy('`document`.`created_at`', 'DESC');
 
-        if (!empty($referenceDocumentId)) {
+        if ($referenceDocumentId !== null && $referenceDocumentId !== '') {
             $builder->andWhere('`document`.`id` = :documentId');
             $builder->setParameter('documentId', Uuid::fromHexToBytes($referenceDocumentId));
         }
 
         $documents = $builder->executeQuery()->fetchAllAssociative();
 
-        if (empty($documents)) {
+        if ($documents === []) {
             return [];
         }
 
         $results = array_filter($documents, function (array $document) use ($deepLinkCodeRendererConfig) {
-            if (!empty($deepLinkCodeRendererConfig)) {
+            if ($deepLinkCodeRendererConfig !== null && $deepLinkCodeRendererConfig !== '') {
                 return $document['orderVersionId'] === $document['versionId']
                     && $deepLinkCodeRendererConfig === $document['deepLinkCode'];
             }
@@ -76,6 +76,6 @@ final readonly class ReferenceInvoiceLoader
         $documents[0]['orderVersionId'] = Defaults::LIVE_VERSION;
 
         // Return the first document from the filtered results, or the first document if no filter was applied
-        return empty($results) ? $documents[0] : reset($results);
+        return $results === [] ? $documents[0] : reset($results);
     }
 }

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexer.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexer.php
@@ -46,7 +46,7 @@ class PaymentMethodIndexer extends EntityIndexer
 
         $ids = $iterator->fetch();
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return null;
         }
 
@@ -57,7 +57,7 @@ class PaymentMethodIndexer extends EntityIndexer
     {
         $updates = $event->getPrimaryKeys(PaymentMethodDefinition::ENTITY_NAME);
 
-        if (empty($updates)) {
+        if ($updates === []) {
             return null;
         }
 
@@ -72,7 +72,7 @@ class PaymentMethodIndexer extends EntityIndexer
         }
 
         $ids = array_unique(array_filter($ids));
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
@@ -43,13 +43,13 @@ final readonly class PaymentMethodValidator implements EventSubscriberInterface
             return;
         }
 
-        $pluginIds = $this->connection->fetchOne(
+        $pluginId = $this->connection->fetchOne(
             'SELECT id FROM payment_method WHERE id IN (:ids) AND plugin_id IS NOT NULL',
             ['ids' => $ids],
             ['ids' => ArrayParameterType::BINARY]
         );
 
-        if ($pluginIds !== false) {
+        if ($pluginId !== false) {
             throw PaymentException::pluginPaymentMethodDeleteRestriction();
         }
     }

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidator.php
@@ -39,7 +39,7 @@ final readonly class PaymentMethodValidator implements EventSubscriberInterface
 
         $ids = \array_column($ids, 'id');
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 
@@ -49,7 +49,7 @@ final readonly class PaymentMethodValidator implements EventSubscriberInterface
             ['ids' => ArrayParameterType::BINARY]
         );
 
-        if (!empty($pluginIds)) {
+        if ($pluginIds !== false) {
             throw PaymentException::pluginPaymentMethodDeleteRestriction();
         }
     }

--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageFilter.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageFilter.php
@@ -89,15 +89,15 @@ class AdvancedPackageFilter extends PackageFilter
 
     private function hasFilterSettings(string $sorterKey, string $applierKey, string $countKey): bool
     {
-        if (empty($sorterKey)) {
+        if ($sorterKey === '') {
             return false;
         }
 
-        if (empty($applierKey)) {
+        if ($applierKey === '') {
             return false;
         }
 
-        if (empty($countKey)) {
+        if ($countKey === '') {
             return false;
         }
 
@@ -122,7 +122,7 @@ class AdvancedPackageFilter extends PackageFilter
             // if our indexes are empty, then
             // we use all items, otherwise do only use
             // the items of our pre calculated indexes
-            if (!empty($applierIndexes) && !\in_array($index, $applierIndexes, true)) {
+            if ($applierIndexes !== [] && !\in_array($index, $applierIndexes, true)) {
                 continue;
             }
 

--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackagePicker.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackagePicker.php
@@ -23,7 +23,7 @@ class AdvancedPackagePicker
         // we start by modifying our packages
         // with the currently set picker, if available
         // this restructures our packages
-        if (!empty($pickerKey)) {
+        if ($pickerKey !== '') {
             $picker = $this->registry->getPicker($pickerKey);
 
             // get the new list of packages to consider

--- a/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
+++ b/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
@@ -26,7 +26,7 @@ class CartExtension extends Struct
 
     public function addCode(string $code): void
     {
-        if (empty($code)) {
+        if ($code === '') {
             return;
         }
 
@@ -42,7 +42,7 @@ class CartExtension extends Struct
 
     public function removeCode(string $code): void
     {
-        if (empty($code)) {
+        if ($code === '') {
             return;
         }
 
@@ -67,7 +67,7 @@ class CartExtension extends Struct
 
     public function blockPromotion(string $id): void
     {
-        if (empty($id)) {
+        if ($id === '') {
             return;
         }
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -422,6 +422,8 @@ class PromotionCalculator
 
     private function isAutomaticDiscount(LineItem $discountItem): bool
     {
-        return empty($discountItem->getPayloadValue('code'));
+        $code = $discountItem->getPayloadValue('code');
+
+        return $code === null || $code === '';
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -551,6 +551,8 @@ class PromotionDeliveryCalculator
 
     private function isAutomaticDiscount(LineItem $discountItem): bool
     {
-        return empty($discountItem->getPayloadValue('code'));
+        $code = $discountItem->getPayloadValue('code');
+
+        return $code === null || $code === '';
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
@@ -61,7 +61,8 @@ class PromotionProcessor implements CartProcessorInterface
             if (!$data->has(self::DATA_KEY)) {
                 $lineItemPromotions = $original->getLineItems()->filterType(self::LINE_ITEM_TYPE);
                 foreach ($lineItemPromotions as $lineItemPromotion) {
-                    if (empty($lineItemPromotion->getReferencedId())) {
+                    $referencedId = $lineItemPromotion->getReferencedId();
+                    if ($referencedId === null || $referencedId === '') {
                         $toCalculate->addErrors(
                             new AutoPromotionNotFoundError($lineItemPromotion->getLabel() ?? $lineItemPromotion->getId())
                         );

--- a/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
@@ -61,7 +61,7 @@ class PromotionRedemptionLocker implements EventSubscriberInterface
             $locks[$key] = $lock;
         }
 
-        if (empty($locks)) {
+        if ($locks === []) {
             return;
         }
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
@@ -28,7 +28,7 @@ class PromotionExclusionUpdater
     public function update(array $ids): void
     {
         // if there are no ids, we don't have to do anything
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionIndexer.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionIndexer.php
@@ -50,7 +50,7 @@ class PromotionIndexer extends EntityIndexer
 
         $ids = $iterator->fetch();
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return null;
         }
 
@@ -61,7 +61,7 @@ class PromotionIndexer extends EntityIndexer
     {
         $updates = $event->getPrimaryKeys(PromotionDefinition::ENTITY_NAME);
 
-        if (empty($updates)) {
+        if ($updates === []) {
             return null;
         }
 
@@ -80,7 +80,7 @@ class PromotionIndexer extends EntityIndexer
         }
 
         $ids = array_unique(array_filter($ids));
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 
@@ -129,7 +129,7 @@ class PromotionIndexer extends EntityIndexer
 
         $promotionWrittenEvent = $event->getEventByEntityName(PromotionDefinition::ENTITY_NAME);
 
-        if ($promotionWrittenEvent === null || $promotionWrittenEvent->getName() !== 'promotion.written' || !empty($promotionWrittenEvent->getPayloads()[0])) {
+        if ($promotionWrittenEvent === null || $promotionWrittenEvent->getName() !== 'promotion.written' || $promotionWrittenEvent->getPayloads()[0] !== []) {
             return false;
         }
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -59,7 +59,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             }
         }
 
-        if (empty($lineItemsIds)) {
+        if ($lineItemsIds === []) {
             return;
         }
 
@@ -81,7 +81,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
 
     public function lineItemDeleted(EntityDeletedEvent $event): void
     {
-        if (!empty($this->promotionIds)) {
+        if ($this->promotionIds !== []) {
             // Update all promotions, we searched beforeDelete
             $this->update($this->promotionIds, $event->getContext());
 
@@ -113,7 +113,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
     {
         $ids = array_unique(array_filter($ids));
 
-        if (empty($ids) || $context->getVersionId() !== Defaults::LIVE_VERSION) {
+        if ($ids === [] || $context->getVersionId() !== Defaults::LIVE_VERSION) {
             return;
         }
 
@@ -148,7 +148,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             $update->execute([
                 'id' => Uuid::fromHexToBytes($id),
                 'count' => (int) array_sum($totals),
-                'customerCount' => !empty($totals) ? json_encode($totals, \JSON_THROW_ON_ERROR) : null,
+                'customerCount' => $totals !== [] ? json_encode($totals, \JSON_THROW_ON_ERROR) : null,
             ]);
         }
     }

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionValidator.php
@@ -39,7 +39,7 @@ class PromotionValidator implements EventSubscriberInterface
 
         $ids = \array_column($ids, 'id');
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 
@@ -49,7 +49,7 @@ class PromotionValidator implements EventSubscriberInterface
             ['ids' => ArrayParameterType::BINARY]
         );
 
-        if (!empty($promotionIds)) {
+        if ($promotionIds !== false) {
             throw PromotionException::promotionUsedDeleteRestriction();
         }
     }

--- a/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+++ b/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
@@ -70,7 +70,7 @@ class PromotionIndividualCodeRedeemer implements EventSubscriberInterface
             \iterator_to_array($lineItems)
         )));
 
-        if (empty($codes)) {
+        if ($codes === []) {
             return;
         }
 
@@ -99,7 +99,7 @@ class PromotionIndividualCodeRedeemer implements EventSubscriberInterface
             }
         }
 
-        if (!empty($update)) {
+        if ($update !== []) {
             $this->codesRepository->update($update, $context);
         }
     }

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -93,7 +93,7 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
 
         $code = $lineItem->getReferencedId();
 
-        if (!empty($code)) {
+        if ($code !== null && $code !== '') {
             // promotion with code
             $this->checkFixedDiscountItems($cart, $lineItem);
             // remove other discounts of the promotion that should be deleted

--- a/src/Core/Checkout/Promotion/Util/PromotionCodeService.php
+++ b/src/Core/Checkout/Promotion/Util/PromotionCodeService.php
@@ -102,7 +102,7 @@ class PromotionCodeService
 
         $pattern = $promotion->getIndividualCodePattern();
 
-        if (empty($pattern)) {
+        if ($pattern === null || $pattern === '') {
             throw PromotionException::patternNotComplexEnough();
         }
 

--- a/src/Core/Checkout/Promotion/Validator/PromotionValidator.php
+++ b/src/Core/Checkout/Promotion/Validator/PromotionValidator.php
@@ -160,7 +160,7 @@ class PromotionValidator implements EventSubscriberInterface
         // the database. all private getters should only access the local in-memory list
         // to avoid additional database queries.
         $this->databasePromotions = [];
-        if (!empty($promotionIds)) {
+        if ($promotionIds !== []) {
             $promotionQuery = $this->connection->executeQuery(
                 'SELECT * FROM `promotion` WHERE `id` IN (:ids)',
                 ['ids' => $promotionIds],
@@ -171,7 +171,7 @@ class PromotionValidator implements EventSubscriberInterface
         }
 
         $this->databaseDiscounts = [];
-        if (!empty($discountIds)) {
+        if ($discountIds !== []) {
             $discountQuery = $this->connection->executeQuery(
                 'SELECT * FROM `promotion_discount` WHERE `id` IN (:ids)',
                 ['ids' => $discountIds],

--- a/src/Core/Checkout/Shipping/SalesChannel/ShippingMethodRoute.php
+++ b/src/Core/Checkout/Shipping/SalesChannel/ShippingMethodRoute.php
@@ -67,7 +67,7 @@ class ShippingMethodRoute extends AbstractShippingMethodRoute
             ->addFilter(new EqualsFilter('active', true))
             ->addAssociation('media');
 
-        if (empty($criteria->getSorting())) {
+        if ($criteria->getSorting() === []) {
             $criteria->addSorting(new FieldSorting('position'), new FieldSorting('name', FieldSorting::ASCENDING));
         }
 

--- a/tests/unit/Core/Checkout/Cart/CartBehaviorTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartBehaviorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\CheckoutPermissions;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartBehavior::class)]
+class CartBehaviorTest extends TestCase
+{
+    public function testHasPermission(): void
+    {
+        $cartBehavior = new CartBehavior([CheckoutPermissions::ALLOW_PRODUCT_LABEL_OVERWRITES => true]);
+        static::assertTrue($cartBehavior->hasPermission(CheckoutPermissions::ALLOW_PRODUCT_LABEL_OVERWRITES));
+    }
+
+    public function testHasNoPermission(): void
+    {
+        $cartBehavior = new CartBehavior([CheckoutPermissions::ALLOW_PRODUCT_LABEL_OVERWRITES => true]);
+        static::assertFalse($cartBehavior->hasPermission(CheckoutPermissions::ALLOW_PRODUCT_PRICE_OVERWRITES));
+    }
+
+    public function testHasNoPermissionWithNoPermissionsSet(): void
+    {
+        $cartBehavior = new CartBehavior();
+        static::assertFalse($cartBehavior->hasPermission(CheckoutPermissions::ALLOW_PRODUCT_LABEL_OVERWRITES));
+    }
+}

--- a/tests/unit/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidatorTest.php
+++ b/tests/unit/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodValidatorTest.php
@@ -102,8 +102,7 @@ class PaymentMethodValidatorTest extends TestCase
             )
             ->willReturn('pluginId');
 
-        $this->expectException(PaymentException::class);
-        $this->expectExceptionMessage('Plugin payment methods can not be deleted via API.');
+        $this->expectExceptionObject(PaymentException::pluginPaymentMethodDeleteRestriction());
         $subscriber = new PaymentMethodValidator($connection);
         $subscriber->validate($event);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
