### PR TITLE
feat: Add native HTML `pattern` attribute validation support

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -86,6 +86,28 @@ Previously, the clearable button was always hidden by default (`showClearableBut
 
 ## Storefront
 
+### Form validation now supports the native HTML `pattern` attribute
+
+The form validation helper (`FormValidation`) now automatically validates input fields with the native HTML `pattern` attribute. This allows you to specify regex patterns for input validation without additional JavaScript code.
+
+**Example usage:**
+```html
+<input
+    type="text"
+    name="zipCode"
+    pattern="[0-9]{5}"
+    data-validation="required,pattern"
+/>
+```
+
+The pattern validator will:
+- Automatically activate when a `pattern` attribute is present on an input field
+- Validate the input value against the specified regex pattern
+- Show the appropriate error message if validation fails
+- Skip validation for empty values (use the `required` validator to check for emptiness)
+
+**Note:** The pattern attribute is now automatically included in the validation rules when present, similar to how the `required` attribute works. You can explicitly add it to `data-validation` for clarity, but it's not required.
+
 ### Selling and packaging information in the product detail page
 
 * Display the selling and packaging information with the product that has advanced pricing.

--- a/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
@@ -180,7 +180,7 @@ export default class FormValidation {
         let fields = formFields;
 
         if (!formFields) {
-            fields = form.querySelectorAll('[data-validation], [required]');
+            fields = form.querySelectorAll('[data-validation], [required], [pattern]');
         }
 
         fields.forEach((field) => {

--- a/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/form-validation.helper.js
@@ -98,6 +98,7 @@ export default class FormValidation {
         this.addValidator('email', this.validateEmail, validationMessages['email']);
         this.addValidator('confirmation', this.validateConfirmation, validationMessages['confirmation']);
         this.addValidator('minLength', this.validateMinLength, validationMessages['minLength']);
+        this.addValidator('pattern', this.validatePattern, validationMessages['pattern']);
         this.addValidator('grecaptcha', this.validateGrecaptcha, validationMessages['grecaptcha']);
     }
 
@@ -231,10 +232,16 @@ export default class FormValidation {
         const validationConfig = field.getAttribute('data-validation');
         const validationRules = validationConfig ? validationConfig.split(',') : [];
         const hasRequiredAttribute = field.hasAttribute('required');
+        const hasPatternAttribute = field.hasAttribute('pattern');
 
         // Support for the native `required` attribute.
         if (hasRequiredAttribute && !validationRules.includes('required')) {
             validationRules.push('required');
+        }
+
+        // Support for the native `pattern` attribute.
+        if (hasPatternAttribute && !validationRules.includes('pattern')) {
+            validationRules.push('pattern');
         }
 
         // Field has no validation rules.
@@ -361,6 +368,42 @@ export default class FormValidation {
         const minLength = minLengthAttr ? minLengthAttr : this.config.defaultMinLength;
 
         return value.length >= minLength;
+    }
+
+    /**
+     * Validates the value against a regex pattern specified in the pattern attribute.
+     * The pattern attribute should contain a valid regex pattern.
+     * Empty values are considered valid (use the required validator for emptiness checks).
+     *
+     * @param {string} value
+     * @param {HTMLElement} field
+     * @return {boolean}
+     */
+    validatePattern(value, field) {
+        if (!(field instanceof HTMLElement)) {
+            console.error('[FormValidation]: Missing or invalid required parameter "field".');
+            return true;
+        }
+
+        const patternAttr = field.getAttribute('pattern');
+        if (!patternAttr) {
+            return true;
+        }
+
+        // Empty values are valid for pattern validation.
+        if (!value || value.length === 0) {
+            return true;
+        }
+
+        try {
+            const pattern = new RegExp(`^(?:${patternAttr})$`);
+
+            return pattern.test(value);
+        } catch (e) {
+            console.error(`[FormValidation]: Invalid regex pattern "${patternAttr}" for field.`, field, e);
+
+            return true;
+        }
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
@@ -772,8 +772,7 @@ describe('form-validation', () => {
             expect(result).toBe(true); // Should return true to not block form submission
             expect(consoleErrorSpy).toHaveBeenCalledWith(
                 expect.stringContaining('[FormValidation]: Invalid regex pattern'),
-                expect.any(String),
-                expect.any(String),
+                field,
                 expect.anything()
             );
 

--- a/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/form-validation.helper.test.js
@@ -10,6 +10,7 @@ describe('form-validation', () => {
             email: 'Invalid email address.',
             confirmation: 'Confirmation field does not match.',
             minLength: 'Input is too short.',
+            pattern: 'Input does not match the required pattern.',
         };
 
         formValidation = new FormValidation();
@@ -50,6 +51,7 @@ describe('form-validation', () => {
         expect(formValidation.validators.get('email')).toBeDefined();
         expect(formValidation.validators.get('confirmation')).toBeDefined();
         expect(formValidation.validators.get('minLength')).toBeDefined();
+        expect(formValidation.validators.get('pattern')).toBeDefined();
     });
 
     test('should add validator', () => {
@@ -563,6 +565,279 @@ describe('form-validation', () => {
             expect(eventArg.type).toBe('showCookieBar');
 
             mockGetItem.mockRestore();
+        });
+    });
+
+    describe('validatePattern', () => {
+        test('should validate field with valid pattern', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <div class="form-group">
+                        <label for="zipCode">Zip Code</label>
+                        <input
+                            type="text"
+                            id="zipCode"
+                            pattern="[0-9]{5}"
+                            data-validation="pattern"
+                            aria-describedby="zipCode-feedback"
+                        >
+                        <div id="zipCode-feedback" class="form-field-feedback"></div>
+                    </div>
+                </form>
+            `;
+
+            const field = document.getElementById('zipCode');
+            const feedback = document.getElementById('zipCode-feedback');
+
+            field.checkVisibility = jest.fn().mockReturnValue(true);
+
+            // Invalid pattern
+            field.value = '123';
+            let validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(1);
+            expect(validationErrors).toContain('pattern');
+            expect(field.classList).toContain(formValidation.config.invalidClass);
+            expect(feedback.textContent).toBe('Input does not match the required pattern.');
+
+            // Valid pattern
+            field.value = '12345';
+            validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(0);
+            expect(field.classList).not.toContain(formValidation.config.invalidClass);
+            expect(feedback.innerHTML).toBe('');
+        });
+
+        test('should validate field with native pattern attribute', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <input type="text" id="zipCode" pattern="[0-9]{5}">
+                    <input type="text" id="noPattern">
+                </form>
+            `;
+
+            const form = document.getElementById('testForm');
+            const formFields = form.querySelectorAll('input');
+
+            formFields.forEach((field) => {
+                field.checkVisibility = jest.fn().mockReturnValue(true);
+            });
+
+            const zipCodeField = document.getElementById('zipCode');
+            const noPatternField = document.getElementById('noPattern');
+
+            // Field with pattern attribute should be validated
+            zipCodeField.value = 'invalid';
+            let invalidFields = formValidation.validateForm(form);
+
+            expect(invalidFields.length).toBe(1);
+            expect(invalidFields).toContain(zipCodeField);
+
+            // Valid pattern
+            zipCodeField.value = '12345';
+            invalidFields = formValidation.validateForm(form);
+
+            expect(invalidFields.length).toBe(0);
+
+            // Field without pattern should not be validated
+            noPatternField.value = 'anything';
+            invalidFields = formValidation.validateForm(form);
+
+            expect(invalidFields.length).toBe(0);
+        });
+
+        test('should allow empty values for pattern validation', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <input
+                        type="text"
+                        id="optionalZip"
+                        pattern="[0-9]{5}"
+                        data-validation="pattern"
+                    >
+                </form>
+            `;
+
+            const field = document.getElementById('optionalZip');
+            field.checkVisibility = jest.fn().mockReturnValue(true);
+
+            // Empty value should be valid
+            field.value = '';
+            const validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(0);
+        });
+
+        test('should validate pattern with required validator', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <div class="form-group">
+                        <input
+                            type="text"
+                            id="requiredZip"
+                            pattern="[0-9]{5}"
+                            data-validation="required,pattern"
+                            aria-describedby="requiredZip-feedback"
+                        >
+                        <div id="requiredZip-feedback" class="form-field-feedback"></div>
+                    </div>
+                </form>
+            `;
+
+            const field = document.getElementById('requiredZip');
+            const feedback = document.getElementById('requiredZip-feedback');
+            field.checkVisibility = jest.fn().mockReturnValue(true);
+
+            // Empty value should fail required validation
+            field.value = '';
+            let validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(1);
+            expect(validationErrors).toContain('required');
+            expect(feedback.textContent).toBe('Input should not be empty.');
+
+            // Invalid pattern should fail pattern validation
+            field.value = 'abc';
+            validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(1);
+            expect(validationErrors).toContain('pattern');
+            expect(feedback.textContent).toBe('Input does not match the required pattern.');
+
+            // Valid value should pass both validations
+            field.value = '12345';
+            validationErrors = formValidation.validateField(field);
+
+            expect(validationErrors.length).toBe(0);
+            expect(feedback.innerHTML).toBe('');
+        });
+
+        test('should handle complex regex patterns', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <input type="text" id="email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}">
+                    <input type="text" id="phone" pattern="\\d{3}-\\d{3}-\\d{4}">
+                    <input type="text" id="username" pattern="[a-zA-Z0-9_]{3,16}">
+                </form>
+            `;
+
+            const form = document.getElementById('testForm');
+            const formFields = form.querySelectorAll('input');
+
+            formFields.forEach((field) => {
+                field.checkVisibility = jest.fn().mockReturnValue(true);
+            });
+
+            const emailField = document.getElementById('email');
+            const phoneField = document.getElementById('phone');
+            const usernameField = document.getElementById('username');
+
+            // Test email pattern
+            emailField.value = 'invalid';
+            let invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).toContain(emailField);
+
+            emailField.value = 'test@example.com';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(emailField);
+
+            // Test phone pattern
+            phoneField.value = '1234567890';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).toContain(phoneField);
+
+            phoneField.value = '123-456-7890';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(phoneField);
+
+            // Test username pattern
+            usernameField.value = 'ab';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).toContain(usernameField);
+
+            usernameField.value = 'user_123';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(usernameField);
+        });
+
+        test('should handle invalid regex pattern gracefully', () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+            const field = document.createElement('input');
+            field.setAttribute('pattern', '[invalid(');
+
+            const result = formValidation.validatePattern('test', field);
+
+            expect(result).toBe(true); // Should return true to not block form submission
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('[FormValidation]: Invalid regex pattern'),
+                expect.any(String),
+                expect.any(String),
+                expect.anything()
+            );
+
+            consoleErrorSpy.mockRestore();
+        });
+
+        test('should return true when field parameter is invalid', () => {
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = formValidation.validatePattern('test', null);
+
+            expect(result).toBe(true);
+            expect(consoleErrorSpy).toHaveBeenCalledWith('[FormValidation]: Missing or invalid required parameter "field".');
+
+            consoleErrorSpy.mockRestore();
+        });
+
+        test('should return true when field has no pattern attribute', () => {
+            const field = document.createElement('input');
+
+            const result = formValidation.validatePattern('test', field);
+
+            expect(result).toBe(true);
+        });
+
+        test('should validate patterns with special characters', () => {
+            document.body.innerHTML = `
+                <form id="testForm">
+                    <input type="text" id="hexColor" pattern="#?([a-f0-9]{6}|[a-f0-9]{3})">
+                    <input type="text" id="url" pattern="https?://.+">
+                </form>
+            `;
+
+            const form = document.getElementById('testForm');
+            const formFields = form.querySelectorAll('input');
+
+            formFields.forEach((field) => {
+                field.checkVisibility = jest.fn().mockReturnValue(true);
+            });
+
+            const hexColorField = document.getElementById('hexColor');
+            const urlField = document.getElementById('url');
+
+            // Test hex color pattern
+            hexColorField.value = 'invalid';
+            let invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).toContain(hexColorField);
+
+            hexColorField.value = '#ff0000';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(hexColorField);
+
+            hexColorField.value = 'abc';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(hexColorField);
+
+            // Test URL pattern
+            urlField.value = 'invalid';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).toContain(urlField);
+
+            urlField.value = 'https://example.com';
+            invalidFields = formValidation.validateForm(form);
+            expect(invalidFields).not.toContain(urlField);
         });
     });
 });

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -129,6 +129,7 @@
     "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "Die gewählte Zahlungsart konnte nicht gefunden werden.",
     "productNotFound": "Produkt \"%number%\" konnte nicht gefunden werden.",
     "VIOLATION::TOO_SHORT_ERROR": "Die Eingabe ist zu kurz.",
+    "VIOLATION::INVALID_PATTERN_ERROR": "Die Eingabe entspricht nicht dem erforderlichen Format.",
     "product-not-found": "Das Produkt wurde nicht gefunden.",
     "message-403-ajax": "Die Sitzung ist abgelaufen. Bitte laden Sie die Seite neu und versuchen Sie es erneut.",
     "message-403": "Die Sitzung ist abgelaufen. Bitte kehren Sie zur letzten Seite zurück neu und versuchen Sie  es erneut.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -129,6 +129,7 @@
     "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "The selected payment method does not exist.",
     "productNotFound": "Product \"%number%\" not found.",
     "VIOLATION::TOO_SHORT_ERROR": "Input is too short.",
+    "VIOLATION::INVALID_PATTERN_ERROR": "The input does not match the required pattern.",
     "product-not-found": "The product could not be found.",
     "message-403-ajax": "Your session has expired. Please reload the page and try again.",
     "message-403": "Your session has expired. Please return to the last page and try again.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -129,7 +129,7 @@
     "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "The selected payment method does not exist.",
     "productNotFound": "Product \"%number%\" not found.",
     "VIOLATION::TOO_SHORT_ERROR": "Input is too short.",
-    "VIOLATION::INVALID_PATTERN_ERROR": "The input does not match the required pattern.",
+    "VIOLATION::INVALID_PATTERN_ERROR": "The input does not match the required format.",
     "product-not-found": "The product could not be found.",
     "message-403-ajax": "Your session has expired. Please reload the page and try again.",
     "message-403": "Your session has expired. Please return to the last page and try again.",

--- a/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
@@ -4,6 +4,7 @@
         email: 'error.VIOLATION::INVALID_EMAIL_FORMAT_ERROR'|trans|sw_sanitize,
         confirmation: 'error.VIOLATION::NOT_EQUAL_ERROR'|trans|sw_sanitize,
         minLength: 'error.VIOLATION::TOO_SHORT_ERROR'|trans|sw_sanitize,
+        pattern: 'error.VIOLATION::INVALID_PATTERN_ERROR'|trans|sw_sanitize,
         grecaptcha: 'error.VIOLATION::RECAPTCHA_COOKIE_REQUIRED'|trans|sw_sanitize,
     } %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The pattern attribute on input fields is currently ignored by the form validation:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern

### 2. What does this change do, exactly?
Add the custom implementation to mimic the native form validation.

### 3. Describe each step to reproduce the issue or behaviour.
Use an input field with `pattern`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
