### PR TITLE
fix: add branch alias for main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
             "forward-command": false
         },
         "branch-alias": {
+            "dev-main": "6.7.x-dev",
             "dev-master": "6.7.x-dev",
             "dev-trunk": "6.7.x-dev"
         },


### PR DESCRIPTION
### 1. Why is this change necessary?

I added a alias local for trunk to main, so I don't have to remember to merge / rebase against trunk. This seems to fuck up composer dependency resolving


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
