### PR TITLE
fix: load all existing property group in product variants

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -51,6 +51,13 @@ Additionally, the `SerializerField` will become internal in the next major relea
 
 ## Administration
 
+### Product detail variants: `configSettingGroups` as computed and deprecations
+
+In `sw-product-detail-variants`, the following changes were made:
+
+* **`configSettingGroups`** (now computed): Previously a `data()` property set by `loadConfigSettingGroups()`. It is now a computed property derived from `productEntity.configuratorSettings` and `groups`.
+* **`loadConfigSettingGroups()`** (deprecated): Marked as `@deprecated tag:v6.8.0`. It will be removed in 6.8.0 without replacement.
+
 ### Deprecation of `items` prop in `sw-entity-listing` component
 
 The `items` prop in the `sw-entity-listing` component has been deprecated and will be removed in v6.8.0.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -467,6 +467,13 @@ Instead of using the `link` property of the `manufacturer` entity directly, the 
 
 <details>
 
+## Removal of `loadConfigSettingGroups()` in `sw-product-detail-variants`
+
+The method `loadConfigSettingGroups()` in the product detail variants view has been removed without replacement since `configSettingGroups` became a computed property.
+
+* If your code called `loadConfigSettingGroups()`, remove that call.
+* `configSettingGroups` is derived automatically from `productEntity.configuratorSettings` and `groups`.
+
 ## Removal of `items` prop in `sw-entity-listing` component
 
 The `items` prop in the `sw-entity-listing` component has been removed.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -30,7 +30,6 @@ export default {
             showAddPropertiesModal: false,
             defaultTab: 'all',
             activeTab: 'all',
-            configSettingGroups: [],
             limit: 500,
         };
     },
@@ -93,6 +92,24 @@ export default {
 
             return criteria;
         },
+
+        /**
+         * @returns {Object[]}
+         */
+        configSettingGroups() {
+            const settings = this.productEntity?.configuratorSettings ?? [];
+            const groupIds = uniqBy(settings, 'option.groupId').map((item) => item.option.groupId);
+            if (groupIds.length === 0) {
+                return [];
+            }
+            const groupMap = new Map(
+                this.groups.map((group) => [
+                    group.id,
+                    group,
+                ]),
+            );
+            return groupIds.map((id) => groupMap.get(id)).filter(Boolean);
+        },
     },
 
     watch: {
@@ -134,29 +151,15 @@ export default {
 
         loadData() {
             if (!this.isStoreLoading && this.product?.id) {
-                this.loadOptions()
-                    .then(() => this.loadGroups())
-                    .then(() => this.loadConfigSettingGroups());
+                this.loadOptions().then(() => this.loadGroups());
             }
         },
 
-        loadConfigSettingGroups() {
-            const groupIds = uniqBy(this.productEntity.configuratorSettings, 'option.groupId').map(
-                (group) => group.option.groupId,
-            );
-
-            if (groupIds.length === 0) {
-                this.configSettingGroups = [];
-                return;
-            }
-
-            const groupMap = new Map(
-                this.groups.map((g) => [
-                    g.id,
-                    g,
-                ]),
-            );
-            this.configSettingGroups = groupIds.map((id) => groupMap.get(id)).filter(Boolean);
+        /**
+         * @deprecated tag:v6.8.0 - Will be removed without replacement.
+         */
+        async loadConfigSettingGroups() {
+            // No-op: configSettingGroups is computed from productEntity.configuratorSettings and groups.
         },
 
         loadOptions() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -7,7 +7,6 @@ import './sw-product-detail-variants.scss';
 
 const { Criteria, EntityCollection } = Shopware.Data;
 const { uniqBy } = Shopware.Utils.array;
-const { cloneDeep } = Shopware.Utils.object;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -136,27 +135,23 @@ export default {
         loadData() {
             if (!this.isStoreLoading && this.product?.id) {
                 this.loadOptions()
-                    .then(() => {
-                        return this.loadGroups();
-                    })
-                    .then(() => {
-                        return this.loadConfigSettingGroups();
-                    });
+                    .then(() => this.loadGroups())
+                    .then(() => this.loadConfigSettingGroups());
             }
         },
 
-        async loadConfigSettingGroups() {
+        loadConfigSettingGroups() {
             const groupIds = uniqBy(this.productEntity.configuratorSettings, 'option.groupId').map(
                 (group) => group.option.groupId,
             );
 
-            const criteria = cloneDeep(this.groupCriteria);
-
-            if (groupIds.length) {
-                criteria.addFilter(Criteria.equalsAny('id', groupIds));
+            if (groupIds.length === 0) {
+                this.configSettingGroups = [];
+                return;
             }
 
-            this.configSettingGroups = await this.loadAllPropertyGroups(criteria);
+            const groupMap = new Map(this.groups.map((g) => [g.id, g]));
+            this.configSettingGroups = groupIds.map((id) => groupMap.get(id)).filter(Boolean);
         },
 
         loadOptions() {
@@ -266,15 +261,15 @@ export default {
 
         async loadAllPropertyGroups(criteria) {
             const initialResult = await this.groupRepository.search(criteria);
-            const totalGroups = initialResult.total;
-            const limit = initialResult.length;
+            const totalGroups = initialResult.total ?? initialResult.length ?? 0;
+            const limit = initialResult.length || criteria.limit || 25;
 
             const totalPages = Math.ceil(totalGroups / limit);
 
             const promises = [];
             // eslint-disable-next-line no-plusplus
             for (let page = 2; page <= totalPages; page++) {
-                const nextCriteria = new Criteria(page, limit);
+                const nextCriteria = Criteria.fromCriteria(criteria).setPage(page).setLimit(limit);
                 promises.push(this.groupRepository.search(nextCriteria));
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -150,7 +150,12 @@ export default {
                 return;
             }
 
-            const groupMap = new Map(this.groups.map((g) => [g.id, g]));
+            const groupMap = new Map(
+                this.groups.map((g) => [
+                    g.id,
+                    g,
+                ]),
+            );
             this.configSettingGroups = groupIds.map((id) => groupMap.get(id)).filter(Boolean);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -254,7 +254,7 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         ]);
     });
 
-    it('should derive configSettingGroups from groups by configurator group ids', async () => {
+    it('should compute configSettingGroups from productEntity.configuratorSettings and groups', async () => {
         const wrapper = await createWrapper();
         wrapper.vm.groups = [
             { id: 'id-1', name: 'group-1' },
@@ -268,13 +268,52 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
             ],
         };
 
-        wrapper.vm.loadConfigSettingGroups();
-
-        // configSettingGroups is derived from this.groups (no second API call), in configurator order.
         expect(wrapper.vm.configSettingGroups).toEqual([
             { id: 'id-1', name: 'group-1' },
             { id: 'id-2', name: 'group-2' },
         ]);
+    });
+
+    it('should return empty configSettingGroups when product has no configurator settings', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.groups = [{ id: 'id-1', name: 'group-1' }];
+        wrapper.vm.productEntity = { configuratorSettings: [] };
+
+        expect(wrapper.vm.configSettingGroups).toEqual([]);
+    });
+
+    it('should filter out missing groups in configSettingGroups when id not in groups', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.groups = [{ id: 'id-1', name: 'group-1' }];
+        wrapper.vm.productEntity = {
+            configuratorSettings: [
+                { option: { groupId: 'id-1' } },
+                { option: { groupId: 'id-missing' } },
+            ],
+        };
+
+        expect(wrapper.vm.configSettingGroups).toEqual([{ id: 'id-1', name: 'group-1' }]);
+    });
+
+    it('should not call loadConfigSettingGroups in loadData (deprecated, now computed)', async () => {
+        const wrapper = await createWrapper();
+        const loadConfigSettingGroupsSpy = jest.spyOn(wrapper.vm, 'loadConfigSettingGroups');
+
+        wrapper.vm.loadData();
+        await flushPromises();
+
+        expect(loadConfigSettingGroupsSpy).not.toHaveBeenCalled();
+    });
+
+    it('should have loadConfigSettingGroups as no-op when called directly (deprecated)', async () => {
+        const wrapper = await createWrapper();
+        wrapper.vm.groups = [{ id: '1', name: 'g1' }];
+        wrapper.vm.productEntity = {
+            configuratorSettings: [{ option: { groupId: '1' } }],
+        };
+
+        expect(() => wrapper.vm.loadConfigSettingGroups()).not.toThrow();
+        expect(wrapper.vm.configSettingGroups).toEqual([{ id: '1', name: 'g1' }]);
     });
 
     it('should correctly load and merge paginated results', async () => {
@@ -320,8 +359,6 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
                     ].map(fn),
             });
 
-        wrapper.vm.loadConfigSettingGroups = jest.fn();
-
         await flushPromises();
 
         expect(wrapper.vm.groupRepository.search).toHaveBeenCalledTimes(3);
@@ -345,7 +382,6 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
                 ].map(fn),
         });
 
-        wrapper.vm.loadConfigSettingGroups = jest.fn();
         wrapper.vm.loadGroups = jest.fn();
 
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -255,36 +255,26 @@ describe('src/module/sw-product/view/sw-product-detail-variants', () => {
         ]);
     });
 
-    it('should be able to load configuration setting with group ids', async () => {
+    it('should derive configSettingGroups from groups by configurator group ids', async () => {
         const wrapper = await createWrapper();
-        await wrapper.setData({
-            groups: [
-                {
-                    id: 'group-1',
-                },
+        wrapper.vm.groups = [
+            { id: 'id-1', name: 'group-1' },
+            { id: 'id-2', name: 'group-2' },
+            { id: 'other', name: 'other' },
+        ];
+        wrapper.vm.productEntity = {
+            configuratorSettings: [
+                { option: { groupId: 'id-1' } },
+                { option: { groupId: 'id-2' } },
             ],
-            productEntity: {
-                configuratorSettings: [
-                    { option: { groupId: 'id-1' } },
-                    { option: { groupId: 'id-2' } },
-                ],
-            },
-        });
-        await flushPromises();
-        const criteria = new Criteria(1, 500);
-        criteria.addFields('name').addFilter(
-            Criteria.equalsAny('id', [
-                'id-1',
-                'id-2',
-            ]),
-        );
+        };
 
-        expect(wrapper.vm.groupRepository.search).toHaveBeenCalledWith(criteria);
+        wrapper.vm.loadConfigSettingGroups();
+
+        // configSettingGroups is derived from this.groups (no second API call), in configurator order.
         expect(wrapper.vm.configSettingGroups).toEqual([
-            {
-                id: '1',
-                name: 'group-1',
-            },
+            { id: 'id-1', name: 'group-1' },
+            { id: 'id-2', name: 'group-2' },
         ]);
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -6,7 +6,6 @@ import 'src/app/component/utils/sw-loader';
 import 'src/app/component/base/sw-button';
 import 'src/module/sw-product/component/sw-product-variants/sw-product-variants-overview';
 import ShopwareDiscountCampaignService from 'src/app/service/discount-campaign.service';
-import Criteria from 'src/core/data/criteria.data';
 
 async function createWrapper(privileges = []) {
     return mount(await wrapTestComponent('sw-product-detail-variants', { sync: true }), {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This pull request refactors how configuration setting groups are handled in the `sw-product-detail-variants` component, making `configSettingGroups` a computed property instead of a data property loaded by a method.

### 2. What does this change do, exactly?
**Product detail variants logic:**

* `configSettingGroups` is now a computed property derived from `productEntity.configuratorSettings` and `groups`, instead of being set via `data()` and loaded asynchronously. [[1]](diffhunk://#diff-68a2fc19800c9f1b97cf18b92e057a68185e40024cf6c2b46aa2bce3517a6ab5L34) [[2]](diffhunk://#diff-68a2fc19800c9f1b97cf18b92e057a68185e40024cf6c2b46aa2bce3517a6ab5R95-R112)
* The `loadConfigSettingGroups()` method is deprecated, now a no-op, and marked for removal in v6.8.0. Calls to this method should be removed. [[1]](diffhunk://#diff-68a2fc19800c9f1b97cf18b92e057a68185e40024cf6c2b46aa2bce3517a6ab5L138-R162) [[2]](diffhunk://#diff-5a6f4c7d1cc118800bd6f17fc8ba236b2629f6b166997a724d14de54d5dc1e20R464-R470)
* The `loadData()` method no longer calls `loadConfigSettingGroups()`, as the computation is now reactive.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes #14697 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
