### PR TITLE
chore: improve order edit tests

### DIFF
--- a/tests/acceptance/tests/Account/CancelOrder.spec.ts
+++ b/tests/acceptance/tests/Account/CancelOrder.spec.ts
@@ -8,10 +8,16 @@ test(
         const customer = await TestDataService.createCustomer();
         const order = await TestDataService.createOrder([{ product: product, quantity: 5 }], customer);
 
+        const untouchedOrder = await TestDataService.createOrder([{ product: product, quantity: 1 }], customer);
+
         await TestDataService.setSystemConfig({ 'core.cart.enableOrderRefunds': true });
 
         await ShopCustomer.attemptsTo(Login(customer));
         await ShopCustomer.goesTo(StorefrontAccountOrder.url());
+
+        const untouchedOrderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(untouchedOrder.orderNumber);
+        await ShopCustomer.expects(untouchedOrderItemLocators.orderStatus).toContainText('Open');
+
         const orderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(order.orderNumber);
         await ShopCustomer.expects(orderItemLocators.orderStatus).toContainText('Open');
         await ShopCustomer.presses(orderItemLocators.orderActionsButton);
@@ -24,6 +30,8 @@ test(
         await ShopCustomer.expects(orderItemLocators.orderShippingMethod).toContainText('Standard');
         await ShopCustomer.expects(orderItemLocators.orderStatus).toContainText('Cancelled');
         await ShopCustomer.expects(orderItemLocators.orderStatus).not.toContainText('Open');
+        // ensure other order is unaffected
+        await ShopCustomer.expects(untouchedOrderItemLocators.orderStatus).toContainText('Open');
     }
 );
 

--- a/tests/acceptance/tests/Account/ChangeOrderPaymentMethod.spec.ts
+++ b/tests/acceptance/tests/Account/ChangeOrderPaymentMethod.spec.ts
@@ -15,11 +15,20 @@ test('Customers can update the payment method for an existing order in the store
         customer
     );
 
+    const untouchedOrder = await TestDataService.createOrder(
+        [{ product: product, quantity: 1 }],
+        customer
+    )
+
     const newPaymentMethod = await TestDataService.createBasicPaymentMethod({ afterOrderEnabled: true });
     await TestDataService.assignSalesChannelPaymentMethod(TestDataService.defaultSalesChannel.id, newPaymentMethod.id);
 
     await ShopCustomer.attemptsTo(Login(customer));
     await ShopCustomer.goesTo(StorefrontAccountOrder.url());
+
+    const untouchedOrderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(untouchedOrder.orderNumber);
+    await ShopCustomer.expects(untouchedOrderItemLocators.orderPaymentMethod).toContainText('Invoice');
+
     const orderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(order.orderNumber);
     await ShopCustomer.expects(orderItemLocators.orderPaymentMethod).toContainText('Invoice');
 
@@ -31,4 +40,6 @@ test('Customers can update the payment method for an existing order in the store
 
     await ShopCustomer.goesTo(StorefrontAccountOrder.url());
     await ShopCustomer.expects(orderItemLocators.orderPaymentMethod).toContainText(newPaymentMethod.name);
+    // check that other order is not touched
+    await ShopCustomer.expects(untouchedOrderItemLocators.orderPaymentMethod).toContainText('Invoice');
 });

--- a/tests/acceptance/tests/Account/RepeatOrder.spec.ts
+++ b/tests/acceptance/tests/Account/RepeatOrder.spec.ts
@@ -16,6 +16,12 @@ test('As a customer, I want to repeat a previous order via the storefront accoun
         customer
     );
 
+    // create another order with different quantity to ensure that the correct order is repeated
+    await TestDataService.createOrder(
+        [{ product: product, quantity: 1 }],
+        customer
+    );
+
     await ShopCustomer.attemptsTo(Login(customer));
     await ShopCustomer.goesTo(StorefrontAccountOrder.url());
     const orderItemLocators = await StorefrontAccountOrder.getOrderByOrderNumber(order.orderNumber);


### PR DESCRIPTION

### 1. Why is this change necessary?

With 6.7.7.0 we introduced a bug that editing orders from the customer account in the storefront might lead to editing a random order and not the one you actually wanted to edit. We needed to release a patch release for that issue, that shouldn't happen again

### 2. What does this change do, exactly?

In the edit order testcases we create a second order to ensure that that order stays the same and the correct one will be edited.

