### PR TITLE
fix(customer): validate language assignment before creation

### DIFF
--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -55,12 +54,12 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     {
         $context = $event->getContext();
 
-        // Skip validation for Store API requests, as this is already handled by the storefront and avoids unnecessary performance overhead.
+        // Skip validation for Sales Channel API requests, as this is already handled by the storefront and avoids unnecessary performance overhead.
         if ($context->getSource() instanceof SalesChannelApiSource) {
             return;
         }
 
-        $candidateCommands = [];
+        $candidates = [];
         foreach ($event->getCommands() as $command) {
             if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME) {
                 continue;
@@ -72,76 +71,67 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
             $extractedPayloads = $this->extractPayloads($command);
             if ($extractedPayloads) {
-                $candidateCommands[] = $extractedPayloads;
+                $candidates[] = $extractedPayloads;
             }
         }
 
-        if ($candidateCommands === []) {
+        if ($candidates === []) {
             return;
         }
 
         $customerPks = $event->getPrimaryKeys(CustomerDefinition::ENTITY_NAME);
-        $customersSalesChannels = $this->loadCustomersSalesChannels($customerPks, $context);
-        $salesChannels = $this->loadSalesChannels($customersSalesChannels, $candidateCommands, $context);
+        $customersSalesChannels = $this->getCustomersSalesChannelsIds($customerPks, $context);
+        $salesChannels = $this->loadSalesChannels($customersSalesChannels, $candidates, $context);
 
-        foreach ($candidateCommands as $candidate) {
-            $customerId = $candidate['customerId'];
-            $languageId = $candidate['languageId'];
-            $salesChannelId = $candidate['salesChannelId'] ?? $customersSalesChannels[$customerId] ?? null;
-
-            if ($languageId === null || $salesChannelId === null) {
+        foreach ($candidates as $candidate) {
+            $salesChannelId = $candidate['salesChannelId'] ?? ($customersSalesChannels[$candidate['customerId']] ?? null);
+            if ($salesChannelId === null) {
                 continue;
             }
 
-            if ($this->isLanguageInSalesChannel($salesChannelId, $languageId, $salesChannels)) {
+            if ($this->isLanguageInSalesChannel($salesChannelId, $candidate['languageId'], $salesChannels)) {
                 continue;
             }
 
             $event->getExceptions()->add(
-                $this->createLanguageNotInSalesChannelViolation($languageId, $candidate['path'])
+                $this->createLanguageNotInSalesChannelViolation($candidate['languageId'], $candidate['path'])
             );
         }
     }
 
     /**
-     * @return array{customerId: string|null, languageId: string|null, salesChannelId: string|null, path: string}|null
+     * @return array{customerId: string, languageId: string, salesChannelId: string|null, path: string}|null
      */
-    private function extractPayloads(WriteCommand|UpdateCommand $command): ?array
+    private function extractPayloads(InsertCommand|UpdateCommand $command): ?array
     {
         $payload = $command->getPayload();
 
-        $languageId = isset($payload['language_id'])
-            ? Uuid::fromBytesToHex($payload['language_id'])
-            : null;
-
-        if ($languageId === null) {
+        if (!isset($payload['language_id'])) {
             return null;
         }
 
-        $customerId = isset($command->getPrimaryKey()['id'])
-            ? Uuid::fromBytesToHex($command->getPrimaryKey()['id'])
-            : null;
-        $salesChannelId = isset($payload['sales_channel_id'])
-            ? Uuid::fromBytesToHex($payload['sales_channel_id'])
-            : null;
+        $pk = $command->getPrimaryKey();
+        if (!isset($pk['id'])) {
+            return null;
+        }
 
         return [
-            'customerId' => $customerId,
-            'languageId' => $languageId,
-            'salesChannelId' => $salesChannelId,
+            'customerId' => Uuid::fromBytesToHex($pk['id']),
+            'languageId' => Uuid::fromBytesToHex($payload['language_id']),
+            'salesChannelId' => isset($payload['sales_channel_id']) ? Uuid::fromBytesToHex($payload['sales_channel_id']) : null,
             'path' => $command->getPath(),
         ];
     }
 
     /**
-     * @param list<array<string, string>> $customerPks
+     * @param array<string, string> $customersPks
      *
      * @return array<string>
      */
-    private function loadCustomersSalesChannels(array $customersPks, Context $context): array
+    private function getCustomersSalesChannelsIds(array $customersPks, Context $context): array
     {
         $customersIds = array_values(array_filter(array_map(
-            fn (array $pk) => isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
+            static fn (array $pk) => isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
             $customersPks
         )));
         if ($customersIds === []) {
@@ -161,15 +151,15 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
      *
      * @return EntityCollection<SalesChannelEntity>
      */
-    private function loadSalesChannels(?array $customersSalesChannels, array $candidateCommands, Context $context): EntityCollection
+    private function loadSalesChannels(array $customersSalesChannels, array $candidateCommands, Context $context): EntityCollection
     {
-        $customersSalesChannelsIds = array_values($customersSalesChannels ?? []);
+        $customersSalesChannelsIds = array_values($customersSalesChannels);
         $salesChannelIds = array_map(
-            fn (array $candidate) => $candidate['salesChannelId'],
+            static fn (array $candidate) => $candidate['salesChannelId'],
             $candidateCommands
         );
         $languageIds = array_map(
-            fn (array $candidate) => $candidate['languageId'],
+            static fn (array $candidate) => $candidate['languageId'],
             $candidateCommands
         );
 
@@ -210,7 +200,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             \sprintf('The language "%s" is not assigned to the sales channel.', $languageId),
             'The language "{{ languageId }}" is not assigned to the sales channel.',
             ['{{ languageId }}' => $languageId],
-            $path,
+            null,
             '/languageId',
             $languageId,
             null,

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -95,10 +94,18 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            $candidate = $this->extractCandidatePayloads($command);
-            if ($candidate !== null) {
-                $candidates[] = $candidate;
+            $payload = $command->getPayload();
+            if (!isset($payload['language_id'])) {
+                continue;
             }
+
+            $pk = $command->getPrimaryKey();
+
+            $candidates[] = [
+                'customerId' => $command instanceof UpdateCommand && isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
+                'languageId' => Uuid::fromBytesToHex($payload['language_id']),
+                'salesChannelId' => isset($payload['sales_channel_id']) ? Uuid::fromBytesToHex($payload['sales_channel_id']) : null,
+            ];
         }
 
         return $candidates;
@@ -128,25 +135,6 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
         }
 
         return null;
-    }
-
-    /**
-     * @return array{customerId: string|null, languageId: string, salesChannelId: string|null}|null
-     */
-    private function extractCandidatePayloads(WriteCommand $command): ?array
-    {
-        $payload = $command->getPayload();
-        if (!isset($payload['language_id'])) {
-            return null;
-        }
-
-        $pk = $command->getPrimaryKey();
-
-        return [
-            'customerId' => $command instanceof UpdateCommand && isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
-            'languageId' => Uuid::fromBytesToHex($payload['language_id']),
-            'salesChannelId' => isset($payload['sales_channel_id']) ? Uuid::fromBytesToHex($payload['sales_channel_id']) : null,
-        ];
     }
 
     /**

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Checkout\Customer\Subscriber;
 
-use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
@@ -18,7 +17,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValida
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
-use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -123,12 +121,8 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
         }
 
         foreach ($salesChannels as $salesChannel) {
-            /** @var CustomerCollection|null $customers */
-            $customers = $salesChannel->get('customers');
-
-            $customer = $customers?->get($customerId);
-            if ($customer) {
-                return $customer->get('salesChannelId');
+            if ($salesChannel->get('customers')?->has($customerId)) {
+                return $salesChannel->getId();
             }
         }
 
@@ -168,7 +162,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             return new EntityCollection();
         }
 
-        $criteria = (new Criteria())->addFields(['id', 'languages.id', 'customers.id'])
+        $criteria = (new Criteria())->addFields(['id', 'languages.id'])
             ->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
                 new EqualsAnyFilter('id', $salesChannelIds),
                 new EqualsAnyFilter('customers.id', $customerIds),
@@ -176,6 +170,12 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
         $criteria->getAssociation('languages')
             ->addFilter(new EqualsAnyFilter('id', \array_column($candidates, 'languageId')));
+
+        if ($customerIds !== []) {
+            $criteria->addFields(['customers.id']);
+            $criteria->getAssociation('customers')
+                ->addFilter(new EqualsAnyFilter('id', $customerIds));
+        }
 
         return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
@@ -187,10 +187,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     {
         $salesChannel = $salesChannels->get($salesChannelId);
 
-        /** @var LanguageCollection|null $languages */
-        $languages = $salesChannel?->get('languages');
-
-        return $languages?->has($languageId) ?? false;
+        return $salesChannel?->get('languages')?->has($languageId) ?? false;
     }
 
     private function createLanguageNotInSalesChannelViolation(string $languageId): WriteConstraintViolationException

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -54,37 +54,21 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     {
         $context = $event->getContext();
 
-        // Skip validation for Sales Channel API requests, as this is already handled by the storefront and avoids unnecessary performance overhead.
+        // Skip validation for SalesChannel API requests to avoids unnecessary performance overhead
         if ($context->getSource() instanceof SalesChannelApiSource) {
             return;
         }
 
-        $candidates = [];
-        foreach ($event->getCommands() as $command) {
-            if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME) {
-                continue;
-            }
-
-            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
-                continue;
-            }
-
-            $extractedPayloads = $this->extractPayloads($command);
-            if ($extractedPayloads) {
-                $candidates[] = $extractedPayloads;
-            }
-        }
-
+        $candidates = $this->collectCandidatesCommands($event);
         if ($candidates === []) {
             return;
         }
 
-        $customerPks = $event->getPrimaryKeys(CustomerDefinition::ENTITY_NAME);
-        $customersSalesChannels = $this->getCustomersSalesChannelsIds($customerPks, $context);
-        $salesChannels = $this->loadSalesChannels($customersSalesChannels, $candidates, $context);
+        $customerSalesChannelMap = $this->getCustomersSalesChannelsIds($candidates, $context);
+        $salesChannels = $this->loadSalesChannels($customerSalesChannelMap, $candidates, $context);
 
         foreach ($candidates as $candidate) {
-            $salesChannelId = $candidate['salesChannelId'] ?? ($customersSalesChannels[$candidate['customerId']] ?? null);
+            $salesChannelId = $this->resolveSalesChannelId($candidate, $customerSalesChannelMap);
             if ($salesChannelId === null) {
                 continue;
             }
@@ -94,51 +78,90 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             }
 
             $event->getExceptions()->add(
-                $this->createLanguageNotInSalesChannelViolation($candidate['languageId'], $candidate['path'])
+                $this->createLanguageNotInSalesChannelViolation($candidate['languageId'], $candidate['customerId'])
             );
         }
     }
 
     /**
-     * @return array{customerId: string, languageId: string, salesChannelId: string|null, path: string}|null
+     * @return list<array{customerId: string|null, languageId: string, salesChannelId: string|null}>
      */
-    private function extractPayloads(InsertCommand|UpdateCommand $command): ?array
+    private function collectCandidatesCommands(PreWriteValidationEvent $event): array
+    {
+        $candidates = [];
+
+        foreach ($event->getCommands() as $command) {
+            if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME) {
+                continue;
+            }
+
+            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
+                continue;
+            }
+
+            $candidate = $this->extractCandidatePayloads($command);
+            if ($candidate !== null) {
+                $candidates[] = $candidate;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param array{customerId: string|null, languageId: string, salesChannelId: string|null} $candidate
+     * @param array<string, string> $customerSalesChannelMap
+     */
+    private function resolveSalesChannelId(array $candidate, array $customerSalesChannelMap): ?string
+    {
+        if ($candidate['salesChannelId'] !== null) {
+            return $candidate['salesChannelId'];
+        }
+
+        $customerId = $candidate['customerId'];
+        if ($customerId === null) {
+            return null;
+        }
+
+        return $customerSalesChannelMap[$customerId] ?? null;
+    }
+
+    /**
+     * @return array{customerId: string|null, languageId: string, salesChannelId: string|null}|null
+     */
+    private function extractCandidatePayloads(InsertCommand|UpdateCommand $command): ?array
     {
         $payload = $command->getPayload();
-
         if (!isset($payload['language_id'])) {
             return null;
         }
 
         $pk = $command->getPrimaryKey();
-        if (!isset($pk['id'])) {
-            return null;
-        }
 
         return [
-            'customerId' => Uuid::fromBytesToHex($pk['id']),
+            'customerId' => $command instanceof UpdateCommand && isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
             'languageId' => Uuid::fromBytesToHex($payload['language_id']),
             'salesChannelId' => isset($payload['sales_channel_id']) ? Uuid::fromBytesToHex($payload['sales_channel_id']) : null,
-            'path' => $command->getPath(),
         ];
     }
 
     /**
-     * @param list<array<string, string>> $customersPks
+     * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
      *
      * @return array<string, string>
      */
-    private function getCustomersSalesChannelsIds(array $customersPks, Context $context): array
+    private function getCustomersSalesChannelsIds(array $candidates, Context $context): array
     {
-        $customersIds = array_values(array_filter(array_map(
-            static fn (array $pk) => isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
-            $customersPks
+        $customerIds = \array_values(\array_filter(\array_map(
+            static fn (array $candidate) => $candidate['customerId'],
+            $candidates
         )));
-        if ($customersIds === []) {
+
+        if ($customerIds === []) {
             return [];
         }
 
-        $criteria = new Criteria($customersIds);
+        $criteria = new Criteria($customerIds);
         /** @var CustomerCollection $customers */
         $customers = $this->customerRepository->search($criteria, $context)->getEntities();
 
@@ -146,36 +169,38 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param array<string, string> $customersSalesChannels
-     * @param list<array{customerId: string, languageId: string, salesChannelId: string|null, path: string}> $candidateCommands
+     * @param array<string, string> $customerSalesChannelMap
+     * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
      *
      * @return EntityCollection<SalesChannelEntity>
      */
-    private function loadSalesChannels(array $customersSalesChannels, array $candidateCommands, Context $context): EntityCollection
+    private function loadSalesChannels(array $customerSalesChannelMap, array $candidates, Context $context): EntityCollection
     {
-        $customersSalesChannelsIds = array_values($customersSalesChannels);
-        $salesChannelIds = array_map(
-            static fn (array $candidate) => $candidate['salesChannelId'],
-            $candidateCommands
-        );
-        $languageIds = array_map(
-            static fn (array $candidate) => $candidate['languageId'],
-            $candidateCommands
-        );
+        $customerSalesChannelIds = \array_values($customerSalesChannelMap);
 
-        $ids = array_values(array_unique(array_filter([
-            ...$customersSalesChannelsIds,
-            ...$salesChannelIds,
+        $explicitSalesChannelIds = \array_values(\array_filter(\array_map(
+            static fn (array $candidate) => $candidate['salesChannelId'],
+            $candidates
+        )));
+
+        $languageIds = \array_values(\array_unique(\array_map(
+            static fn (array $candidate) => $candidate['languageId'],
+            $candidates
+        )));
+
+        $salesChannelIds = \array_values(\array_unique(\array_filter([
+            ...$customerSalesChannelIds,
+            ...$explicitSalesChannelIds,
         ])));
-        if ($ids === []) {
+
+        if ($salesChannelIds === []) {
             return new EntityCollection();
         }
 
-        $criteria = new Criteria($ids);
+        $criteria = new Criteria($salesChannelIds);
         $criteria->addFields(['id', 'languages.id']);
-
-        $association = $criteria->getAssociation('languages');
-        $association->addFilter(new EqualsAnyFilter('id', $languageIds));
+        $criteria->getAssociation('languages')
+            ->addFilter(new EqualsAnyFilter('id', $languageIds));
 
         return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
@@ -193,7 +218,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
         return $languages?->has($languageId) ?? false;
     }
 
-    private function createLanguageNotInSalesChannelViolation(string $languageId, string $path): WriteConstraintViolationException
+    private function createLanguageNotInSalesChannelViolation(string $languageId, ?string $customerId): WriteConstraintViolationException
     {
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
@@ -201,12 +226,12 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             'The language "{{ languageId }}" is not assigned to the sales channel.',
             ['{{ languageId }}' => $languageId],
             null,
-            '/languageId',
+            null,
             $languageId,
             null,
             self::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL
         ));
 
-        return new WriteConstraintViolationException($violations, $path);
+        return new WriteConstraintViolationException($violations, $customerId ?? $languageId);
     }
 }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -124,9 +124,9 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param array<string, string> $customersPks
+     * @param list<array<string, string>> $customersPks
      *
-     * @return array<string>
+     * @return array<string, string>
      */
     private function getCustomersSalesChannelsIds(array $customersPks, Context $context): array
     {
@@ -146,8 +146,8 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param array<string> $customersSalesChannels
-     * @param list<array{customerId: string|null, languageId: string|null, salesChannelId: string|null, path: string}> $candidateCommands
+     * @param array<string, string> $customersSalesChannels
+     * @param list<array{customerId: string, languageId: string, salesChannelId: string|null, path: string}> $candidateCommands
      *
      * @return EntityCollection<SalesChannelEntity>
      */

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Subscriber;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
+{
+    final public const VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL = 'customer_language_not_in_sales_channel';
+
+    /**
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     *
+     * @internal
+     */
+    public function __construct(
+        private readonly EntityRepository $salesChannelRepository,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'validate',
+        ];
+    }
+
+    public function validate(PreWriteValidationEvent $event): void
+    {
+        $context = $event->getContext();
+        if ($context->getSource() instanceof SalesChannelApiSource) {
+            return;
+        }
+
+        $salesChannels = $this->loadSalesChannels($context);
+
+        foreach ($event->getCommands() as $command) {
+            if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME || !$command instanceof InsertCommand) {
+                continue;
+            }
+
+            $payload = $command->getPayload();
+            $languageId = isset($payload['language_id']) && $payload['language_id'] !== ''
+                ? Uuid::fromBytesToHex($payload['language_id'])
+                : null;
+            $salesChannelId = isset($payload['sales_channel_id']) && $payload['sales_channel_id'] !== ''
+                ? Uuid::fromBytesToHex($payload['sales_channel_id'])
+                : null;
+
+            if ($languageId === null || $salesChannelId === null) {
+                continue;
+            }
+
+            if ($this->isLanguageInSalesChannel($salesChannelId, $languageId, $salesChannels)) {
+                continue;
+            }
+
+            $violations = new ConstraintViolationList();
+            $violations->add(new ConstraintViolation(
+                \sprintf('The language "%s" is not assigned to the sales channel.', $languageId),
+                'The language "{{ languageId }}" is not assigned to the sales channel.',
+                ['{{ languageId }}' => $languageId],
+                $command->getPath(),
+                '/languageId',
+                $languageId,
+                null,
+                self::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL
+            ));
+
+            $event->getExceptions()->add(new WriteConstraintViolationException($violations, $command->getPath()));
+        }
+    }
+
+    private function loadSalesChannels(Context $context): SalesChannelCollection
+    {
+        $criteria = new Criteria();
+
+        $association = $criteria->getAssociation('languages');
+        $association->addFields(['id']);
+
+        return $this->salesChannelRepository->search($criteria, $context)->getEntities();
+    }
+
+    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, SalesChannelCollection $salesChannels): bool
+    {
+        $salesChannel = $salesChannels->get($salesChannelId);
+
+        return $salesChannel
+            ?->getLanguages()
+            ?->has($languageId)
+            ?? false;
+    }
+}

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -138,17 +138,17 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
      *
      * @return array<string>
      */
-    private function loadCustomersSalesChannels(array $customerPks, Context $context): array
+    private function loadCustomersSalesChannels(array $customersPks, Context $context): array
     {
-        $customerIds = array_values(array_filter(array_map(
+        $customersIds = array_values(array_filter(array_map(
             fn (array $pk) => isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
-            $customerPks
+            $customersPks
         )));
-        if ($customerIds === []) {
+        if ($customersIds === []) {
             return [];
         }
 
-        $criteria = new Criteria($customerIds);
+        $criteria = new Criteria($customersIds);
         /** @var CustomerCollection $customers */
         $customers = $this->customerRepository->search($criteria, $context)->getEntities();
 

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
@@ -17,8 +18,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValida
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -32,7 +31,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     final public const VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL = 'customer_language_not_in_sales_channel';
 
     /**
-     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<EntityCollection<PartialEntity>> $salesChannelRepository
      *
      * @internal
      */
@@ -107,7 +106,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
     /**
      * @param array{customerId: string|null, languageId: string, salesChannelId: string|null} $candidate
-     * @param EntityCollection<SalesChannelEntity> $salesChannels
+     * @param EntityCollection<PartialEntity> $salesChannels
      */
     private function findSalesChannelIdForCustomer(array $candidate, EntityCollection $salesChannels): ?string
     {
@@ -121,7 +120,9 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
         }
 
         foreach ($salesChannels as $salesChannel) {
-            if ($salesChannel->get('customers')?->has($customerId)) {
+            /** @var EntityCollection<PartialEntity>|null $customers */
+            $customers = $salesChannel->get('customers');
+            if ($customers?->has($customerId)) {
                 return $salesChannel->getId();
             }
         }
@@ -151,7 +152,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     /**
      * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
      *
-     * @return EntityCollection<SalesChannelEntity>
+     * @return EntityCollection<PartialEntity>
      */
     private function fetchSalesChannels(array $candidates, Context $context): EntityCollection
     {
@@ -181,13 +182,16 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param EntityCollection<SalesChannelEntity> $salesChannels
+     * @param EntityCollection<PartialEntity> $salesChannels
      */
     private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, EntityCollection $salesChannels): bool
     {
         $salesChannel = $salesChannels->get($salesChannelId);
 
-        return $salesChannel?->get('languages')?->has($languageId) ?? false;
+        /** @var EntityCollection<PartialEntity>|null $languages */
+        $languages = $salesChannel?->get('languages');
+
+        return $languages?->has($languageId) ?? false;
     }
 
     private function createLanguageNotInSalesChannelViolation(string $languageId): WriteConstraintViolationException

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -2,17 +2,24 @@
 
 namespace Shopware\Core\Checkout\Customer\Subscriber;
 
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -27,11 +34,13 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
     /**
      * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<CustomerCollection> $customerRepository
      *
      * @internal
      */
     public function __construct(
         private readonly EntityRepository $salesChannelRepository,
+        private readonly EntityRepository $customerRepository
     ) {
     }
 
@@ -45,24 +54,40 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     public function validate(PreWriteValidationEvent $event): void
     {
         $context = $event->getContext();
+
+        // Skip validation for Store API requests, as this is already handled by the storefront and avoids unnecessary performance overhead.
         if ($context->getSource() instanceof SalesChannelApiSource) {
             return;
         }
 
-        $salesChannels = $this->loadSalesChannels($context);
-
+        $candidateCommands = [];
         foreach ($event->getCommands() as $command) {
-            if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME || !$command instanceof InsertCommand) {
+            if ($command->getEntityName() !== CustomerDefinition::ENTITY_NAME) {
                 continue;
             }
 
-            $payload = $command->getPayload();
-            $languageId = isset($payload['language_id']) && $payload['language_id'] !== ''
-                ? Uuid::fromBytesToHex($payload['language_id'])
-                : null;
-            $salesChannelId = isset($payload['sales_channel_id']) && $payload['sales_channel_id'] !== ''
-                ? Uuid::fromBytesToHex($payload['sales_channel_id'])
-                : null;
+            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
+                continue;
+            }
+
+            $extractedPayloads = $this->extractPayloads($command);
+            if ($extractedPayloads) {
+                $candidateCommands[] = $extractedPayloads;
+            }
+        }
+
+        if ($candidateCommands === []) {
+            return;
+        }
+
+        $customerPks = $event->getPrimaryKeys(CustomerDefinition::ENTITY_NAME);
+        $customersSalesChannels = $this->loadCustomersSalesChannels($customerPks, $context);
+        $salesChannels = $this->loadSalesChannels($customersSalesChannels, $candidateCommands, $context);
+
+        foreach ($candidateCommands as $candidate) {
+            $customerId = $candidate['customerId'];
+            $languageId = $candidate['languageId'];
+            $salesChannelId = $candidate['salesChannelId'] ?? $customersSalesChannels[$customerId] ?? null;
 
             if ($languageId === null || $salesChannelId === null) {
                 continue;
@@ -72,39 +97,126 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            $violations = new ConstraintViolationList();
-            $violations->add(new ConstraintViolation(
-                \sprintf('The language "%s" is not assigned to the sales channel.', $languageId),
-                'The language "{{ languageId }}" is not assigned to the sales channel.',
-                ['{{ languageId }}' => $languageId],
-                $command->getPath(),
-                '/languageId',
-                $languageId,
-                null,
-                self::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL
-            ));
-
-            $event->getExceptions()->add(new WriteConstraintViolationException($violations, $command->getPath()));
+            $event->getExceptions()->add(
+                $this->createLanguageNotInSalesChannelViolation($languageId, $candidate['path'])
+            );
         }
     }
 
-    private function loadSalesChannels(Context $context): SalesChannelCollection
+    /**
+     * @return array{customerId: string|null, languageId: string|null, salesChannelId: string|null, path: string}|null
+     */
+    private function extractPayloads(WriteCommand|UpdateCommand $command): ?array
     {
-        $criteria = new Criteria();
+        $payload = $command->getPayload();
+
+        $languageId = isset($payload['language_id'])
+            ? Uuid::fromBytesToHex($payload['language_id'])
+            : null;
+
+        if ($languageId === null) {
+            return null;
+        }
+
+        $customerId = isset($command->getPrimaryKey()['id'])
+            ? Uuid::fromBytesToHex($command->getPrimaryKey()['id'])
+            : null;
+        $salesChannelId = isset($payload['sales_channel_id'])
+            ? Uuid::fromBytesToHex($payload['sales_channel_id'])
+            : null;
+
+        return [
+            'customerId' => $customerId,
+            'languageId' => $languageId,
+            'salesChannelId' => $salesChannelId,
+            'path' => $command->getPath(),
+        ];
+    }
+
+    /**
+     * @param list<array<string, string>> $customerPks
+     *
+     * @return array<string>
+     */
+    private function loadCustomersSalesChannels(array $customerPks, Context $context): array
+    {
+        $customerIds = array_values(array_filter(array_map(
+            fn (array $pk) => isset($pk['id']) ? Uuid::fromBytesToHex($pk['id']) : null,
+            $customerPks
+        )));
+        if ($customerIds === []) {
+            return [];
+        }
+
+        $criteria = new Criteria($customerIds);
+        /** @var CustomerCollection $customers */
+        $customers = $this->customerRepository->search($criteria, $context)->getEntities();
+
+        return $customers->getSalesChannelIds();
+    }
+
+    /**
+     * @param array<string> $customersSalesChannels
+     * @param list<array{customerId: string|null, languageId: string|null, salesChannelId: string|null, path: string}> $candidateCommands
+     *
+     * @return EntityCollection<SalesChannelEntity>
+     */
+    private function loadSalesChannels(?array $customersSalesChannels, array $candidateCommands, Context $context): EntityCollection
+    {
+        $customersSalesChannelsIds = array_values($customersSalesChannels ?? []);
+        $salesChannelIds = array_map(
+            fn (array $candidate) => $candidate['salesChannelId'],
+            $candidateCommands
+        );
+        $languageIds = array_map(
+            fn (array $candidate) => $candidate['languageId'],
+            $candidateCommands
+        );
+
+        $ids = array_values(array_unique(array_filter([
+            ...$customersSalesChannelsIds,
+            ...$salesChannelIds,
+        ])));
+        if ($ids === []) {
+            return new EntityCollection();
+        }
+
+        $criteria = new Criteria($ids);
+        $criteria->addFields(['id', 'languages.id']);
 
         $association = $criteria->getAssociation('languages');
-        $association->addFields(['id']);
+        $association->addFilter(new EqualsAnyFilter('id', $languageIds));
 
         return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
 
-    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, SalesChannelCollection $salesChannels): bool
+    /**
+     * @param EntityCollection<SalesChannelEntity> $salesChannels
+     */
+    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, EntityCollection $salesChannels): bool
     {
         $salesChannel = $salesChannels->get($salesChannelId);
 
-        return $salesChannel
-            ?->getLanguages()
-            ?->has($languageId)
-            ?? false;
+        /** @var LanguageCollection|null $languages */
+        $languages = $salesChannel?->get('languages');
+
+        return $languages?->has($languageId) ?? false;
+    }
+
+    private function createLanguageNotInSalesChannelViolation(string $languageId, string $path): WriteConstraintViolationException
+    {
+        $violations = new ConstraintViolationList();
+        $violations->add(new ConstraintViolation(
+            \sprintf('The language "%s" is not assigned to the sales channel.', $languageId),
+            'The language "{{ languageId }}" is not assigned to the sales channel.',
+            ['{{ languageId }}' => $languageId],
+            $path,
+            '/languageId',
+            $languageId,
+            null,
+            self::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL
+        ));
+
+        return new WriteConstraintViolationException($violations, $path);
     }
 }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -10,7 +10,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
@@ -34,13 +35,11 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
     /**
      * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
-     * @param EntityRepository<CustomerCollection> $customerRepository
      *
      * @internal
      */
     public function __construct(
         private readonly EntityRepository $salesChannelRepository,
-        private readonly EntityRepository $customerRepository
     ) {
     }
 
@@ -65,11 +64,10 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $customerSalesChannelMap = $this->getCustomersSalesChannelsIds($candidates, $context);
-        $salesChannels = $this->loadSalesChannels($customerSalesChannelMap, $candidates, $context);
+        $salesChannels = $this->fetchSalesChannels($candidates, $context);
 
         foreach ($candidates as $candidate) {
-            $salesChannelId = $this->resolveSalesChannelId($candidate, $customerSalesChannelMap);
+            $salesChannelId = $this->findSalesChannelIdForCustomer($candidate, $salesChannels);
             if ($salesChannelId === null) {
                 continue;
             }
@@ -79,7 +77,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             }
 
             $event->getExceptions()->add(
-                $this->createLanguageNotInSalesChannelViolation($candidate['languageId'], $candidate['customerId'])
+                $this->createLanguageNotInSalesChannelViolation($candidate['languageId'])
             );
         }
     }
@@ -96,7 +94,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            if ($command instanceof DeleteCommand) {
+            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
                 continue;
             }
 
@@ -111,9 +109,9 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
 
     /**
      * @param array{customerId: string|null, languageId: string, salesChannelId: string|null} $candidate
-     * @param array<string, string> $customerSalesChannelMap
+     * @param EntityCollection<SalesChannelEntity> $salesChannels
      */
-    private function resolveSalesChannelId(array $candidate, array $customerSalesChannelMap): ?string
+    private function findSalesChannelIdForCustomer(array $candidate, EntityCollection $salesChannels): ?string
     {
         if ($candidate['salesChannelId'] !== null) {
             return $candidate['salesChannelId'];
@@ -124,7 +122,17 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
             return null;
         }
 
-        return $customerSalesChannelMap[$customerId] ?? null;
+        foreach ($salesChannels as $salesChannel) {
+            /** @var CustomerCollection|null $customers */
+            $customers = $salesChannel->get('customers');
+
+            $customer = $customers?->get($customerId);
+            if ($customer) {
+                return $customer->get('salesChannelId');
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -149,44 +157,23 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     /**
      * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
      *
-     * @return array<string, string>
+     * @return EntityCollection<SalesChannelEntity>
      */
-    private function getCustomersSalesChannelsIds(array $candidates, Context $context): array
+    private function fetchSalesChannels(array $candidates, Context $context): EntityCollection
     {
         $customerIds = \array_filter(\array_column($candidates, 'customerId'));
+        $salesChannelIds = \array_filter(\array_column($candidates, 'salesChannelId'));
 
-        if ($customerIds === []) {
-            return [];
+        if ($customerIds === [] && $salesChannelIds === []) {
+            return new EntityCollection();
         }
 
-        $criteria = new Criteria($customerIds);
-        /** @var CustomerCollection $customers */
-        $customers = $this->customerRepository->search($criteria, $context)->getEntities();
+        $criteria = (new Criteria())->addFields(['id', 'languages.id', 'customers.id'])
+            ->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
+                new EqualsAnyFilter('id', $salesChannelIds),
+                new EqualsAnyFilter('customers.id', $customerIds),
+            ]));
 
-        return $customers->getSalesChannelIds();
-    }
-
-    /**
-     * @param array<string, string> $customerSalesChannelMap
-     * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
-     *
-     * @return EntityCollection<SalesChannelEntity>|null
-     */
-    private function loadSalesChannels(array $customerSalesChannelMap, array $candidates, Context $context): ?EntityCollection
-    {
-        $customerSalesChannelIds = \array_values($customerSalesChannelMap);
-        $explicitSalesChannelIds = \array_column($candidates, 'salesChannelId');
-
-        $salesChannelIds = \array_unique(\array_filter([
-            ...$customerSalesChannelIds,
-            ...$explicitSalesChannelIds,
-        ]));
-
-        if ($salesChannelIds === []) {
-            return null;
-        }
-
-        $criteria = (new Criteria($salesChannelIds))->addFields(['id', 'languages.id']);
         $criteria->getAssociation('languages')
             ->addFilter(new EqualsAnyFilter('id', \array_column($candidates, 'languageId')));
 
@@ -194,11 +181,11 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param EntityCollection<SalesChannelEntity>|null $salesChannels
+     * @param EntityCollection<SalesChannelEntity> $salesChannels
      */
-    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, ?EntityCollection $salesChannels): bool
+    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, EntityCollection $salesChannels): bool
     {
-        $salesChannel = $salesChannels?->get($salesChannelId);
+        $salesChannel = $salesChannels->get($salesChannelId);
 
         /** @var LanguageCollection|null $languages */
         $languages = $salesChannel?->get('languages');
@@ -206,20 +193,20 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
         return $languages?->has($languageId) ?? false;
     }
 
-    private function createLanguageNotInSalesChannelViolation(string $languageId, ?string $customerId): WriteConstraintViolationException
+    private function createLanguageNotInSalesChannelViolation(string $languageId): WriteConstraintViolationException
     {
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
             \sprintf('The language "%s" is not assigned to the sales channel.', $languageId),
             'The language "{{ languageId }}" is not assigned to the sales channel.',
             ['{{ languageId }}' => $languageId],
-            null,
-            null,
+            '',
+            '/languageId',
             $languageId,
             null,
             self::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL
         ));
 
-        return new WriteConstraintViolationException($violations, $customerId ?? $languageId);
+        return new WriteConstraintViolationException($violations);
     }
 }

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriber.php
@@ -10,8 +10,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -95,7 +96,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
                 continue;
             }
 
-            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
+            if ($command instanceof DeleteCommand) {
                 continue;
             }
 
@@ -129,7 +130,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
     /**
      * @return array{customerId: string|null, languageId: string, salesChannelId: string|null}|null
      */
-    private function extractCandidatePayloads(InsertCommand|UpdateCommand $command): ?array
+    private function extractCandidatePayloads(WriteCommand $command): ?array
     {
         $payload = $command->getPayload();
         if (!isset($payload['language_id'])) {
@@ -152,10 +153,7 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
      */
     private function getCustomersSalesChannelsIds(array $candidates, Context $context): array
     {
-        $customerIds = \array_values(\array_filter(\array_map(
-            static fn (array $candidate) => $candidate['customerId'],
-            $candidates
-        )));
+        $customerIds = \array_filter(\array_column($candidates, 'customerId'));
 
         if ($customerIds === []) {
             return [];
@@ -172,45 +170,35 @@ class CustomerLanguageSalesChannelSubscriber implements EventSubscriberInterface
      * @param array<string, string> $customerSalesChannelMap
      * @param list<array{customerId: string|null, languageId: string, salesChannelId: string|null}> $candidates
      *
-     * @return EntityCollection<SalesChannelEntity>
+     * @return EntityCollection<SalesChannelEntity>|null
      */
-    private function loadSalesChannels(array $customerSalesChannelMap, array $candidates, Context $context): EntityCollection
+    private function loadSalesChannels(array $customerSalesChannelMap, array $candidates, Context $context): ?EntityCollection
     {
         $customerSalesChannelIds = \array_values($customerSalesChannelMap);
+        $explicitSalesChannelIds = \array_column($candidates, 'salesChannelId');
 
-        $explicitSalesChannelIds = \array_values(\array_filter(\array_map(
-            static fn (array $candidate) => $candidate['salesChannelId'],
-            $candidates
-        )));
-
-        $languageIds = \array_values(\array_unique(\array_map(
-            static fn (array $candidate) => $candidate['languageId'],
-            $candidates
-        )));
-
-        $salesChannelIds = \array_values(\array_unique(\array_filter([
+        $salesChannelIds = \array_unique(\array_filter([
             ...$customerSalesChannelIds,
             ...$explicitSalesChannelIds,
-        ])));
+        ]));
 
         if ($salesChannelIds === []) {
-            return new EntityCollection();
+            return null;
         }
 
-        $criteria = new Criteria($salesChannelIds);
-        $criteria->addFields(['id', 'languages.id']);
+        $criteria = (new Criteria($salesChannelIds))->addFields(['id', 'languages.id']);
         $criteria->getAssociation('languages')
-            ->addFilter(new EqualsAnyFilter('id', $languageIds));
+            ->addFilter(new EqualsAnyFilter('id', \array_column($candidates, 'languageId')));
 
         return $this->salesChannelRepository->search($criteria, $context)->getEntities();
     }
 
     /**
-     * @param EntityCollection<SalesChannelEntity> $salesChannels
+     * @param EntityCollection<SalesChannelEntity>|null $salesChannels
      */
-    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, EntityCollection $salesChannels): bool
+    private function isLanguageInSalesChannel(string $salesChannelId, string $languageId, ?EntityCollection $salesChannels): bool
     {
-        $salesChannel = $salesChannels->get($salesChannelId);
+        $salesChannel = $salesChannels?->get($salesChannelId);
 
         /** @var LanguageCollection|null $languages */
         $languages = $salesChannel?->get('languages');

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -420,6 +420,12 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber">
+            <argument type="service" id="sales_channel.repository"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\DownloadRoute" public="true">
             <argument type="service" id="order_line_item_download.repository"/>
             <argument type="service" id="Shopware\Core\Content\Media\File\DownloadResponseGenerator"/>

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -422,6 +422,7 @@
 
         <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber">
             <argument type="service" id="sales_channel.repository"/>
+            <argument type="service" id="customer.repository"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -422,7 +422,6 @@
 
         <service id="Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber">
             <argument type="service" id="sales_channel.repository"/>
-            <argument type="service" id="customer.repository"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -546,16 +546,9 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
-    public function testValidateInsertWithPrimaryKeyWithoutIdUsesPayloadSalesChannel(): void
+    public function testValidateSkipsWhenPrimaryKeyHasNoId(): void
     {
         $ids = new IdsCollection();
-        $language = new LanguageEntity();
-        $language->setId($ids->get('lang1'));
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($ids->get('sc1'));
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
         $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new InsertCommand(
@@ -570,19 +563,8 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())
-            ->method('search');
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        $this->customerRepository->expects($this->never())->method('search');
+        $this->salesChannelRepository->expects($this->never())->method('search');
 
         $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -330,12 +330,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame(
-            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
-            $exceptions[0]->getViolations()->get(0)->getCode()
-        );
-        static::assertSame('/languageId', $exceptions[0]->getViolations()->get(0)->getPropertyPath());
-        static::assertStringContainsString($ids->get('langOther'), (string) $exceptions[0]->getViolations()->get(0)->getMessage());
+        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('langOther'));
     }
 
     public function testValidateAddsViolationOnUpdateWhenLanguageNotInResolvedSalesChannel(): void
@@ -383,11 +378,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame(
-            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
-            $exceptions[0]->getViolations()->get(0)->getCode()
-        );
-        static::assertSame('/languageId', $exceptions[0]->getViolations()->get(0)->getPropertyPath());
+        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('langOther'));
     }
 
     /**
@@ -459,9 +450,13 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame(
-            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
-            $exceptions[0]->getViolations()->get(0)->getCode()
-        );
+        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('lang1'));
+    }
+
+    private function assertLanguageNotInSalesChannelViolation(WriteConstraintViolationException $e, string $languageId): void
+    {
+        static::assertSame(CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL, $e->getViolations()->get(0)->getCode());
+        static::assertSame('/languageId', $e->getViolations()->get(0)->getPropertyPath());
+        static::assertStringContainsString($languageId, (string) $e->getViolations()->get(0)->getMessage());
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\Tax\TaxDefinition;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -45,7 +47,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
     protected function setUp(): void
     {
         $this->definitionRegistry = new StaticDefinitionInstanceRegistry(
-            [CustomerDefinition::class],
+            [CustomerDefinition::class, TaxDefinition::class],
             $this->createMock(ValidatorInterface::class),
             $this->createMock(EntityWriteGatewayInterface::class)
         );
@@ -338,5 +340,127 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
             $exception->getViolations()->get(0)->getCode()
         );
+    }
+
+    public function testValidateSkipsCommandsForOtherEntities(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $taxDef = $this->definitionRegistry->get(TaxDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new InsertCommand(
+                    $taxDef,
+                    ['name' => 'test', 'tax_rate' => 19.0, 'position' => 1],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+                new InsertCommand(
+                    $customerDef,
+                    [
+                        'language_id' => Uuid::fromHexToBytes($languageId),
+                        'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/1/'
+                ),
+            ]
+        );
+
+        $language = new PartialEntity(['id' => $languageId]);
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([$language]),
+        ]);
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult('sales_channel', 1, new EntityCollection([$salesChannel]), null, new Criteria(), $context));
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateSkipsDeleteCommandForCustomer(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $customerIdBytes = Uuid::randomBytes();
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new DeleteCommand(
+                    $customerDef,
+                    ['id' => $customerIdBytes],
+                    EntityExistence::createForEntity(CustomerDefinition::ENTITY_NAME, ['id' => $customerIdBytes])
+                ),
+                new InsertCommand(
+                    $customerDef,
+                    [
+                        'language_id' => Uuid::fromHexToBytes($languageId),
+                        'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/1/'
+                ),
+            ]
+        );
+
+        $language = new PartialEntity(['id' => $languageId]);
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([$language]),
+        ]);
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult('sales_channel', 1, new EntityCollection([$salesChannel]), null, new Criteria(), $context));
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateSkipsWhenCustomerNotInAnyFetchedSalesChannel(): void
+    {
+        $customerId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $customerIdBytes = Uuid::fromHexToBytes($customerId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new UpdateCommand(
+                    $customerDef,
+                    ['language_id' => $languageIdBytes],
+                    ['id' => $customerIdBytes],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
+        );
+
+        $otherCustomerId = Uuid::randomHex();
+        $salesChannel = new PartialEntity([
+            'id' => Uuid::randomHex(),
+            'languages' => new EntityCollection([new PartialEntity(['id' => $languageId])]),
+            'customers' => new EntityCollection([new PartialEntity(['id' => $otherCustomerId])]),
+        ]);
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult('sales_channel', 1, new EntityCollection([$salesChannel]), null, new Criteria(), $context));
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -10,15 +10,15 @@ use Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubsc
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
@@ -68,7 +68,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $writeContext = WriteContext::createFromContext($context);
         $event = new PreWriteValidationEvent($writeContext, []);
 
-        $this->salesChannelRepository->expects(static::never())->method('search');
+        $this->salesChannelRepository->expects($this->never())->method('search');
 
         $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
@@ -88,7 +88,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects(static::once())
+        $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->with(static::callback(static fn (Criteria $c) => $c->getAssociation('languages') !== null))
             ->willReturn(new EntitySearchResult(
@@ -120,11 +120,57 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects(static::once())->method('search')
+        $this->salesChannelRepository->expects($this->once())->method('search')
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
                 0,
                 new SalesChannelCollection(),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateConvertsSalesChannelIdFromBytesToHex(): void
+    {
+        $ids = new IdsCollection();
+        $languageId = $ids->get('lang1');
+        $salesChannelId = $ids->get('sc1');
+
+        $language = new LanguageEntity();
+        $language->setId($languageId);
+        $languages = new LanguageCollection([$language]);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages($languages);
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
                 new AggregationResultCollection(),
                 new Criteria(),
                 $context
@@ -165,7 +211,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects(static::once())
+        $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
@@ -210,7 +256,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects(static::once())
+        $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
@@ -250,7 +296,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects(static::once())
+        $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
                 'sales_channel',

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -1,0 +1,271 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CustomerLanguageSalesChannelSubscriber::class)]
+class CustomerLanguageSalesChannelSubscriberTest extends TestCase
+{
+    private StaticDefinitionInstanceRegistry $definitionRegistry;
+
+    /**
+     * @var MockObject&EntityRepository<SalesChannelCollection>
+     */
+    private MockObject&EntityRepository $salesChannelRepository;
+
+    protected function setUp(): void
+    {
+        $this->definitionRegistry = new StaticDefinitionInstanceRegistry(
+            [CustomerDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+        $this->salesChannelRepository = $this->createMock(EntityRepository::class);
+    }
+
+    public function testGetSubscribedEvents(): void
+    {
+        static::assertSame(
+            [PreWriteValidationEvent::class => 'validate'],
+            CustomerLanguageSalesChannelSubscriber::getSubscribedEvents()
+        );
+    }
+
+    public function testValidateSkipsWhenContextIsSalesChannelApiSource(): void
+    {
+        $context = new Context(new SalesChannelApiSource(Uuid::randomHex()));
+        $writeContext = WriteContext::createFromContext($context);
+        $event = new PreWriteValidationEvent($writeContext, []);
+
+        $this->salesChannelRepository->expects(static::never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateSkipsCustomerUpdateCommand(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new UpdateCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['language_id' => $ids->getBytes('lang1'), 'sales_channel_id' => $ids->getBytes('sc1')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects(static::once())
+            ->method('search')
+            ->with(static::callback(static fn (Criteria $c) => $c->getAssociation('languages') !== null))
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                0,
+                new SalesChannelCollection(),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateSkipsWhenLanguageIdOrSalesChannelIdEmpty(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['language_id' => '', 'sales_channel_id' => $ids->getBytes('sc1')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects(static::once())->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                0,
+                new SalesChannelCollection(),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidatePassesWhenLanguageIsInSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $languageId = $ids->get('lang1');
+        $salesChannelId = $ids->get('sc1');
+
+        $language = new LanguageEntity();
+        $language->setId($languageId);
+        $languages = new LanguageCollection([$language]);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages($languages);
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateAddsViolationWhenLanguageNotInSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $salesChannelId = $ids->get('sc1');
+
+        $language = new LanguageEntity();
+        $language->setId($ids->get('lang1'));
+        $languages = new LanguageCollection([$language]);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages($languages);
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('langOther'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exceptions[0]->getViolations()->get(0)->getCode()
+        );
+    }
+
+    public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('scMissing'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                0,
+                new SalesChannelCollection(),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber->validate($event);
+
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -3,23 +3,19 @@
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
-use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
@@ -27,27 +23,24 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
-use Shopware\Core\System\Language\LanguageCollection;
-use Shopware\Core\System\Language\LanguageEntity;
-use Shopware\Core\System\SalesChannel\SalesChannelCollection;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
-use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @internal
  */
-#[Package('checkout')]
 #[CoversClass(CustomerLanguageSalesChannelSubscriber::class)]
+#[Package('checkout')]
 class CustomerLanguageSalesChannelSubscriberTest extends TestCase
 {
     private StaticDefinitionInstanceRegistry $definitionRegistry;
 
     /**
-     * @var MockObject&EntityRepository<SalesChannelCollection>
+     * @var MockObject&EntityRepository<EntityCollection<PartialEntity>>
      */
-    private MockObject&EntityRepository $salesChannelRepository;
+    private MockObject $salesChannelRepository;
+
+    private CustomerLanguageSalesChannelSubscriber $subscriber;
 
     protected function setUp(): void
     {
@@ -57,6 +50,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             $this->createMock(EntityWriteGatewayInterface::class)
         );
         $this->salesChannelRepository = $this->createMock(EntityRepository::class);
+        $this->subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
     }
 
     public function testGetSubscribedEvents(): void
@@ -67,396 +61,282 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
     }
 
-    public function testValidateSkipsWhenContextIsSalesChannelApiSource(): void
+    public function testValidateSkipsWhenSalesChannelApiSource(): void
     {
         $context = new Context(new SalesChannelApiSource(Uuid::randomHex()));
-        $writeContext = WriteContext::createFromContext($context);
-        $event = new PreWriteValidationEvent($writeContext, []);
+        $event = new PreWriteValidationEvent(WriteContext::createFromContext($context), []);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $this->subscriber->validate($event);
     }
 
-    public function testValidateSkipsWhenNoCommands(): void
+    public function testValidateSkipsWhenNoCustomerCommands(): void
     {
         $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $event = new PreWriteValidationEvent($writeContext, []);
+        $event = new PreWriteValidationEvent(WriteContext::createFromContext($context), []);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $this->subscriber->validate($event);
     }
 
-    public function testValidateSkipsWhenCommandIsNotCustomerEntity(): void
+    public function testValidateSkipsWhenCustomerCommandHasNoLanguageId(): void
     {
-        $command = $this->createMock(WriteCommand::class);
-        $command->method('getEntityName')->willReturn('product');
-
         $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->never())->method('search');
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-    }
-
-    public function testValidateSkipsWhenCommandIsDeleteCommand(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new DeleteCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['id' => $ids->getBytes('customer1')],
-            new EntityExistence('customer', ['id' => $ids->getBytes('customer1')], true, false, false, [])
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->never())->method('search');
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-    }
-
-    public function testValidateSkipsWhenPayloadHasNoLanguageId(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['sales_channel_id' => $ids->getBytes('sc1')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->never())->method('search');
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-    }
-
-    public function testValidateSkipsWhenInsertHasNoSalesChannelId(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => $ids->getBytes('lang1')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->never())->method('search');
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateSkipsWhenUpdateHasNoSalesChannelIdAndCustomerNotInAnyChannel(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new UpdateCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => $ids->getBytes('lang1')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                0,
-                new SalesChannelCollection(),
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateUpdateResolvesSalesChannelFromLoadedSalesChannelsCustomers(): void
-    {
-        $ids = new IdsCollection();
-        $languageId = $ids->get('lang1');
-        $salesChannelId = $ids->get('sc1');
-
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $salesChannelId,
-        ]);
-        $language = new LanguageEntity();
-        $language->setId($languageId);
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannel->assign(['customers' => new CustomerCollection([$customer])]);
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new UpdateCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => $ids->getBytes('lang1')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateInsertPassesWhenLanguageInSalesChannel(): void
-    {
-        $ids = new IdsCollection();
-        $languageId = $ids->get('lang1');
-        $salesChannelId = $ids->get('sc1');
-
-        $language = new LanguageEntity();
-        $language->setId($languageId);
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
             [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
+                new InsertCommand(
+                    $customerDef,
+                    ['sales_channel_id' => Uuid::randomBytes()],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
         );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
 
+        $this->salesChannelRepository->expects($this->never())->method('search');
+
+        $this->subscriber->validate($event);
+    }
+
+    public function testValidateSkipsWhenInsertHasNoSalesChannelIdAndNoCustomerId(): void
+    {
+        $languageIdBytes = Uuid::fromHexToBytes(Uuid::randomHex());
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new InsertCommand(
+                    $customerDef,
+                    ['language_id' => $languageIdBytes],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
+        );
+
+        $this->salesChannelRepository->expects($this->never())->method('search');
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateSkipsWhenLanguageInSalesChannel(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $salesChannelIdBytes = Uuid::fromHexToBytes($salesChannelId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new InsertCommand(
+                    $customerDef,
+                    [
+                        'language_id' => $languageIdBytes,
+                        'sales_channel_id' => $salesChannelIdBytes,
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
+        );
+
+        $language = new PartialEntity(['id' => $languageId]);
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([$language]),
+        ]);
+        $salesChannels = new EntityCollection([$salesChannel]);
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+            ->with(static::isInstanceOf(Criteria::class), $context)
+            ->willReturn(new EntitySearchResult('sales_channel', 1, $salesChannels, null, new Criteria(), $context));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $this->subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
     public function testValidateAddsViolationWhenLanguageNotInSalesChannel(): void
     {
-        $ids = new IdsCollection();
-        $salesChannelId = $ids->get('sc1');
-
-        $language = new LanguageEntity();
-        $language->setId($ids->get('lang1'));
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $salesChannelIdBytes = Uuid::fromHexToBytes($salesChannelId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
         $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
             [
-                'language_id' => $ids->getBytes('langOther'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
+                new InsertCommand(
+                    $customerDef,
+                    [
+                        'language_id' => $languageIdBytes,
+                        'sales_channel_id' => $salesChannelIdBytes,
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
         );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        $exceptions = $event->getExceptions()->getExceptions();
-        static::assertCount(1, $exceptions);
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('langOther'));
-    }
-
-    public function testValidateAddsViolationOnUpdateWhenLanguageNotInResolvedSalesChannel(): void
-    {
-        $ids = new IdsCollection();
-        $salesChannelId = $ids->get('sc1');
-
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $salesChannelId,
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([]),
         ]);
-        $language = new LanguageEntity();
-        $language->setId($ids->get('lang1'));
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannel->assign(['customers' => new CustomerCollection([$customer])]);
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new UpdateCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => $ids->getBytes('langOther')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
+        $salesChannels = new EntityCollection([$salesChannel]);
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+            ->with(static::isInstanceOf(Criteria::class), $context)
+            ->willReturn(new EntitySearchResult('sales_channel', 1, $salesChannels, null, new Criteria(), $context));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $this->subscriber->validate($event);
 
-        $exceptions = $event->getExceptions()->getExceptions();
-        static::assertCount(1, $exceptions);
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('langOther'));
+        static::assertCount(1, $event->getExceptions()->getExceptions());
+        $exception = $event->getExceptions()->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertCount(1, $exception->getViolations());
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exception->getViolations()->get(0)->getCode()
+        );
     }
 
-    /**
-     * @return iterable<string, array{SalesChannelCollection, Context, string}>
-     */
-    public static function provideLanguageNotInSalesChannelCases(): iterable
+    public function testValidateAddsViolationWhenSalesChannelNotInSearchResult(): void
     {
-        $ids = new IdsCollection();
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $salesChannelIdBytes = Uuid::fromHexToBytes($salesChannelId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
         $context = Context::createDefaultContext();
-
-        yield 'sales channel not in collection' => [
-            new SalesChannelCollection(),
-            $context,
-            $ids->getBytes('scMissing'),
-        ];
-
-        $salesChannelEmptyLangs = new SalesChannelEntity();
-        $salesChannelEmptyLangs->setId($ids->get('sc1'));
-        $salesChannelEmptyLangs->setLanguages(new LanguageCollection());
-        yield 'sales channel has no languages' => [
-            new SalesChannelCollection([$salesChannelEmptyLangs]),
-            $context,
-            $ids->getBytes('sc1'),
-        ];
-
-        $salesChannelNullLangs = new SalesChannelEntity();
-        $salesChannelNullLangs->setId($ids->get('sc1'));
-        yield 'sales channel languages is null' => [
-            new SalesChannelCollection([$salesChannelNullLangs]),
-            $context,
-            $ids->getBytes('sc1'),
-        ];
-    }
-
-    #[DataProvider('provideLanguageNotInSalesChannelCases')]
-    public function testValidateAddsViolationWhenLanguageNotAvailableInSalesChannel(
-        SalesChannelCollection $salesChannels,
-        Context $context,
-        string $salesChannelIdBytes
-    ): void {
-        $ids = new IdsCollection();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
             [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $salesChannelIdBytes,
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
+                new InsertCommand(
+                    $customerDef,
+                    [
+                        'language_id' => $languageIdBytes,
+                        'sales_channel_id' => $salesChannelIdBytes,
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
         );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                $salesChannels->count(),
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+            ->with(static::isInstanceOf(Criteria::class), $context)
+            ->willReturn(new EntitySearchResult('sales_channel', 0, new EntityCollection(), null, new Criteria(), $context));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $this->subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        $this->assertLanguageNotInSalesChannelViolation($exceptions[0], $ids->get('lang1'));
+        $exception = $exceptions[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exception->getViolations()->get(0)->getCode()
+        );
     }
 
-    private function assertLanguageNotInSalesChannelViolation(WriteConstraintViolationException $e, string $languageId): void
+    public function testValidateUpdateFindsSalesChannelByCustomerIdWhenSalesChannelIdNull(): void
     {
-        static::assertSame(CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL, $e->getViolations()->get(0)->getCode());
-        static::assertSame('/languageId', $e->getViolations()->get(0)->getPropertyPath());
-        static::assertStringContainsString($languageId, (string) $e->getViolations()->get(0)->getMessage());
+        $customerId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $customerIdBytes = Uuid::fromHexToBytes($customerId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new UpdateCommand(
+                    $customerDef,
+                    ['language_id' => $languageIdBytes],
+                    ['id' => $customerIdBytes],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
+        );
+
+        $customerRef = new PartialEntity(['id' => $customerId]);
+        $language = new PartialEntity(['id' => $languageId]);
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([$language]),
+            'customers' => new EntityCollection([$customerRef]),
+        ]);
+        $salesChannels = new EntityCollection([$salesChannel]);
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->with(static::isInstanceOf(Criteria::class), $context)
+            ->willReturn(new EntitySearchResult('sales_channel', 1, $salesChannels, null, new Criteria(), $context));
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateUpdateAddsViolationWhenLanguageNotInSalesChannelResolvedByCustomer(): void
+    {
+        $customerId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $customerIdBytes = Uuid::fromHexToBytes($customerId);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
+        $context = Context::createDefaultContext();
+        $customerDef = $this->definitionRegistry->get(CustomerDefinition::class);
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext($context),
+            [
+                new UpdateCommand(
+                    $customerDef,
+                    ['language_id' => $languageIdBytes],
+                    ['id' => $customerIdBytes],
+                    $this->createMock(EntityExistence::class),
+                    '/0/'
+                ),
+            ]
+        );
+
+        $customerRef = new PartialEntity(['id' => $customerId]);
+        $salesChannel = new PartialEntity([
+            'id' => $salesChannelId,
+            'languages' => new EntityCollection([]),
+            'customers' => new EntityCollection([$customerRef]),
+        ]);
+        $salesChannels = new EntityCollection([$salesChannel]);
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->with(static::isInstanceOf(Criteria::class), $context)
+            ->willReturn(new EntitySearchResult('sales_channel', 1, $salesChannels, null, new Criteria(), $context));
+
+        $this->subscriber->validate($event);
+
+        static::assertCount(1, $event->getExceptions()->getExceptions());
+        $exception = $event->getExceptions()->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exception->getViolations()->get(0)->getCode()
+        );
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -153,6 +153,29 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $subscriber->validate($event);
     }
 
+    public function testValidateSkipsWhenInsertHasNoSalesChannelId(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['language_id' => $ids->getBytes('lang1')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->never())->method('search');
+        $this->salesChannelRepository->expects($this->never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
     public function testValidateSkipsWhenLanguageIdOrSalesChannelIdNull(): void
     {
         $ids = new IdsCollection();
@@ -252,12 +275,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $languageId = $ids->get('lang1');
         $salesChannelId = $ids->get('sc1');
 
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $salesChannelId,
-        ]);
-        $customers = new CustomerCollection([$customer]);
-
         $language = new LanguageEntity();
         $language->setId($languageId);
         $salesChannel = new SalesChannelEntity();
@@ -279,16 +296,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                $customers,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        $this->customerRepository->expects($this->never())->method('search');
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
@@ -313,12 +321,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $ids = new IdsCollection();
         $salesChannelId = $ids->get('sc1');
 
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $salesChannelId,
-        ]);
-        $customers = new CustomerCollection([$customer]);
-
         $language = new LanguageEntity();
         $language->setId($ids->get('lang1'));
         $salesChannel = new SalesChannelEntity();
@@ -340,16 +342,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                $customers,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        $this->customerRepository->expects($this->never())->method('search');
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
@@ -372,20 +365,74 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
             $exceptions[0]->getViolations()->get(0)->getCode()
         );
-        static::assertSame('/0/', $exceptions[0]->getPath());
+        static::assertSame($ids->get('langOther'), $exceptions[0]->getPath());
         static::assertStringContainsString($ids->get('langOther'), (string) $exceptions[0]->getViolations()->get(0)->getMessage());
+    }
+
+    public function testValidateAddsViolationOnUpdateUsesCustomerIdAsPath(): void
+    {
+        $ids = new IdsCollection();
+        $salesChannelId = $ids->get('sc1');
+
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $salesChannelId,
+        ]);
+        $language = new LanguageEntity();
+        $language->setId($ids->get('lang1'));
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new UpdateCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['language_id' => $ids->getBytes('langOther')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                new CustomerCollection([$customer]),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+        static::assertSame($ids->get('customer1'), $exceptions[0]->getPath());
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exceptions[0]->getViolations()->get(0)->getCode()
+        );
     }
 
     public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void
     {
         $ids = new IdsCollection();
-
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $ids->get('sc1'),
-        ]);
-        $customers = new CustomerCollection([$customer]);
-
         $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new InsertCommand(
@@ -400,16 +447,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                $customers,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        $this->customerRepository->expects($this->never())->method('search');
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
@@ -428,18 +466,16 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exceptions[0]->getViolations()->get(0)->getCode()
+        );
     }
 
     public function testValidateAddsViolationWhenSalesChannelHasNoLanguages(): void
     {
         $ids = new IdsCollection();
         $salesChannelId = $ids->get('sc1');
-
-        $customer = (new CustomerEntity())->assign([
-            'id' => $ids->get('customer1'),
-            'salesChannelId' => $salesChannelId,
-        ]);
-        $customers = new CustomerCollection([$customer]);
 
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
@@ -460,16 +496,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                $customers,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        $this->customerRepository->expects($this->never())->method('search');
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
@@ -494,59 +521,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
     }
 
-    public function testValidateLoadCustomersSalesChannelsWithEmptyResult(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customerNew')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                0,
-                new CustomerCollection(),
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $language = new LanguageEntity();
-        $language->setId($ids->get('lang1'));
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($ids->get('sc1'));
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateWhenGetPrimaryKeysReturnsEmptyStillValidatesFromPayloadSalesChannel(): void
+    public function testValidateInsertWithEmptyPrimaryKeyStillValidatesFromPayload(): void
     {
         $ids = new IdsCollection();
         $language = new LanguageEntity();
@@ -556,52 +531,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $salesChannel->setLanguages(new LanguageCollection([$language]));
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-
-        $event = new class($writeContext, [$command]) extends PreWriteValidationEvent {
-            public function getPrimaryKeys(string $entity): array
-            {
-                if ($entity === CustomerDefinition::ENTITY_NAME) {
-                    return [];
-                }
-
-                return parent::getPrimaryKeys($entity);
-            }
-        };
-
-        $this->customerRepository->expects($this->never())->method('search');
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateSkipsWhenPrimaryKeyHasNoId(): void
-    {
-        $ids = new IdsCollection();
         $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new InsertCommand(
@@ -617,7 +546,17 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
         $this->customerRepository->expects($this->never())->method('search');
-        $this->salesChannelRepository->expects($this->never())->method('search');
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
 
         $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -48,11 +48,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
      */
     private MockObject&EntityRepository $salesChannelRepository;
 
-    /**
-     * @var MockObject&EntityRepository<CustomerCollection>
-     */
-    private MockObject&EntityRepository $customerRepository;
-
     protected function setUp(): void
     {
         $this->definitionRegistry = new StaticDefinitionInstanceRegistry(
@@ -61,7 +56,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             $this->createMock(EntityWriteGatewayInterface::class)
         );
         $this->salesChannelRepository = $this->createMock(EntityRepository::class);
-        $this->customerRepository = $this->createMock(EntityRepository::class);
     }
 
     public function testGetSubscribedEvents(): void
@@ -80,7 +74,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
 
         $this->salesChannelRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
     }
 
@@ -91,9 +85,8 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $event = new PreWriteValidationEvent($writeContext, []);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
-        $this->customerRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
     }
 
@@ -107,9 +100,8 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
-        $this->customerRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
     }
 
@@ -126,9 +118,8 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
-        $this->customerRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
     }
 
@@ -147,9 +138,8 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
         $this->salesChannelRepository->expects($this->never())->method('search');
-        $this->customerRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
     }
 
@@ -167,16 +157,15 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
         $this->salesChannelRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
-    public function testValidateSkipsWhenLanguageIdOrSalesChannelIdNull(): void
+    public function testValidateSkipsWhenUpdateHasNoSalesChannelIdAndCustomerNotInAnyChannel(): void
     {
         $ids = new IdsCollection();
         $context = Context::createDefaultContext();
@@ -190,28 +179,24 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
+        $this->salesChannelRepository->expects($this->once())
             ->method('search')
-            ->with(static::callback(static fn (Criteria $c) => $c->getIds() !== []))
             ->willReturn(new EntitySearchResult(
-                'customer',
+                'sales_channel',
                 0,
-                new CustomerCollection(),
+                new SalesChannelCollection(),
                 new AggregationResultCollection(),
                 new Criteria(),
                 $context
             ));
 
-        $this->salesChannelRepository->expects($this->never())
-            ->method('search');
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
-    public function testValidateUpdateUsesSalesChannelFromExistingCustomer(): void
+    public function testValidateUpdateResolvesSalesChannelFromLoadedSalesChannelsCustomers(): void
     {
         $ids = new IdsCollection();
         $languageId = $ids->get('lang1');
@@ -221,13 +206,12 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             'id' => $ids->get('customer1'),
             'salesChannelId' => $salesChannelId,
         ]);
-        $customers = new CustomerCollection([$customer]);
-
         $language = new LanguageEntity();
         $language->setId($languageId);
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
         $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannel->assign(['customers' => new CustomerCollection([$customer])]);
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
         $context = Context::createDefaultContext();
@@ -241,17 +225,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                $customers,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -263,7 +236,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
@@ -296,8 +269,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->with(static::callback(static fn (Criteria $c) => $c->hasAssociation('languages')))
@@ -310,7 +281,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
@@ -342,8 +313,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -355,7 +324,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
@@ -365,11 +334,11 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
             $exceptions[0]->getViolations()->get(0)->getCode()
         );
-        static::assertSame($ids->get('langOther'), $exceptions[0]->getPath());
+        static::assertSame('/languageId', $exceptions[0]->getViolations()->get(0)->getPropertyPath());
         static::assertStringContainsString($ids->get('langOther'), (string) $exceptions[0]->getViolations()->get(0)->getMessage());
     }
 
-    public function testValidateAddsViolationOnUpdateUsesCustomerIdAsPath(): void
+    public function testValidateAddsViolationOnUpdateWhenLanguageNotInResolvedSalesChannel(): void
     {
         $ids = new IdsCollection();
         $salesChannelId = $ids->get('sc1');
@@ -383,6 +352,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
         $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannel->assign(['customers' => new CustomerCollection([$customer])]);
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
         $context = Context::createDefaultContext();
@@ -396,16 +366,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'customer',
-                1,
-                new CustomerCollection([$customer]),
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -417,17 +377,17 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame($ids->get('customer1'), $exceptions[0]->getPath());
         static::assertSame(
             CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
             $exceptions[0]->getViolations()->get(0)->getCode()
         );
+        static::assertSame('/languageId', $exceptions[0]->getViolations()->get(0)->getPropertyPath());
     }
 
     public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void
@@ -447,8 +407,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -460,7 +418,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
@@ -496,8 +454,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -509,7 +465,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
@@ -544,8 +500,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->customerRepository->expects($this->never())->method('search');
-
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -557,7 +511,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -373,7 +373,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             $exceptions[0]->getViolations()->get(0)->getCode()
         );
         static::assertSame('/0/', $exceptions[0]->getPath());
-        static::assertStringContainsString($ids->get('langOther'), $exceptions[0]->getViolations()->get(0)->getMessage());
+        static::assertStringContainsString($ids->get('langOther'), (string) $exceptions[0]->getViolations()->get(0)->getMessage());
     }
 
     public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -5,7 +5,9 @@ namespace Shopware\Tests\Unit\Core\Checkout\Customer\Subscriber;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Subscriber\CustomerLanguageSalesChannelSubscriber;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
@@ -13,8 +15,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
@@ -44,6 +48,11 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
      */
     private MockObject&EntityRepository $salesChannelRepository;
 
+    /**
+     * @var MockObject&EntityRepository<CustomerCollection>
+     */
+    private MockObject&EntityRepository $customerRepository;
+
     protected function setUp(): void
     {
         $this->definitionRegistry = new StaticDefinitionInstanceRegistry(
@@ -52,6 +61,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             $this->createMock(EntityWriteGatewayInterface::class)
         );
         $this->salesChannelRepository = $this->createMock(EntityRepository::class);
+        $this->customerRepository = $this->createMock(EntityRepository::class);
     }
 
     public function testGetSubscribedEvents(): void
@@ -70,85 +80,189 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
 
         $this->salesChannelRepository->expects($this->never())->method('search');
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
     }
 
-    public function testValidateSkipsCustomerUpdateCommand(): void
+    public function testValidateSkipsWhenNoCommands(): void
+    {
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $event = new PreWriteValidationEvent($writeContext, []);
+
+        $this->salesChannelRepository->expects($this->never())->method('search');
+        $this->customerRepository->expects($this->never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateSkipsWhenCommandIsNotCustomerEntity(): void
+    {
+        $command = $this->createMock(WriteCommand::class);
+        $command->method('getEntityName')->willReturn('product');
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects($this->never())->method('search');
+        $this->customerRepository->expects($this->never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateSkipsWhenCommandIsDeleteCommand(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new DeleteCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['id' => $ids->getBytes('customer1')],
+            new EntityExistence('customer', ['id' => $ids->getBytes('customer1')], true, false, false, [])
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects($this->never())->method('search');
+        $this->customerRepository->expects($this->never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateSkipsWhenPayloadHasNoLanguageId(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['sales_channel_id' => $ids->getBytes('sc1')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->salesChannelRepository->expects($this->never())->method('search');
+        $this->customerRepository->expects($this->never())->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+    }
+
+    public function testValidateSkipsWhenLanguageIdOrSalesChannelIdNull(): void
     {
         $ids = new IdsCollection();
         $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new UpdateCommand(
             $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => $ids->getBytes('lang1'), 'sales_channel_id' => $ids->getBytes('sc1')],
+            ['language_id' => $ids->getBytes('lang1')],
             ['id' => $ids->getBytes('customer1')],
             $this->createMock(EntityExistence::class),
             '/0/'
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects($this->once())
+        $this->customerRepository->expects($this->once())
             ->method('search')
-            ->with(static::callback(static fn (Criteria $c) => $c->getAssociation('languages') !== null))
+            ->with(static::callback(static fn (Criteria $c) => $c->getIds() !== []))
             ->willReturn(new EntitySearchResult(
-                'sales_channel',
+                'customer',
                 0,
-                new SalesChannelCollection(),
+                new CustomerCollection(),
                 new AggregationResultCollection(),
                 new Criteria(),
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $this->salesChannelRepository->expects($this->never())
+            ->method('search');
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
-    public function testValidateSkipsWhenLanguageIdOrSalesChannelIdEmpty(): void
-    {
-        $ids = new IdsCollection();
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            ['language_id' => '', 'sales_channel_id' => $ids->getBytes('sc1')],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->once())->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                0,
-                new SalesChannelCollection(),
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidateConvertsSalesChannelIdFromBytesToHex(): void
+    public function testValidateUpdateUsesSalesChannelFromExistingCustomer(): void
     {
         $ids = new IdsCollection();
         $languageId = $ids->get('lang1');
         $salesChannelId = $ids->get('sc1');
 
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $salesChannelId,
+        ]);
+        $customers = new CustomerCollection([$customer]);
+
         $language = new LanguageEntity();
         $language->setId($languageId);
-        $languages = new LanguageCollection([$language]);
-
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages($languages);
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new UpdateCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            ['language_id' => $ids->getBytes('lang1')],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                $customers,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateInsertPassesWhenLanguageInSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $languageId = $ids->get('lang1');
+        $salesChannelId = $ids->get('sc1');
+
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $salesChannelId,
+        ]);
+        $customers = new CustomerCollection([$customer]);
+
+        $language = new LanguageEntity();
+        $language->setId($languageId);
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
         $context = Context::createDefaultContext();
@@ -165,8 +279,20 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                $customers,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
+            ->with(static::callback(static fn (Criteria $c) => $c->hasAssociation('languages')))
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
                 1,
@@ -176,53 +302,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        static::assertCount(0, $event->getExceptions()->getExceptions());
-    }
-
-    public function testValidatePassesWhenLanguageIsInSalesChannel(): void
-    {
-        $ids = new IdsCollection();
-        $languageId = $ids->get('lang1');
-        $salesChannelId = $ids->get('sc1');
-
-        $language = new LanguageEntity();
-        $language->setId($languageId);
-        $languages = new LanguageCollection([$language]);
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages($languages);
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
 
         static::assertCount(0, $event->getExceptions()->getExceptions());
@@ -233,13 +313,17 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $ids = new IdsCollection();
         $salesChannelId = $ids->get('sc1');
 
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $salesChannelId,
+        ]);
+        $customers = new CustomerCollection([$customer]);
+
         $language = new LanguageEntity();
         $language->setId($ids->get('lang1'));
-        $languages = new LanguageCollection([$language]);
-
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages($languages);
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
         $context = Context::createDefaultContext();
@@ -256,6 +340,17 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                $customers,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -267,7 +362,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
@@ -277,11 +372,20 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
             $exceptions[0]->getViolations()->get(0)->getCode()
         );
+        static::assertSame('/0/', $exceptions[0]->getPath());
+        static::assertStringContainsString($ids->get('langOther'), $exceptions[0]->getViolations()->get(0)->getMessage());
     }
 
     public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void
     {
         $ids = new IdsCollection();
+
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $ids->get('sc1'),
+        ]);
+        $customers = new CustomerCollection([$customer]);
+
         $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new InsertCommand(
@@ -296,6 +400,17 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
         $event = new PreWriteValidationEvent($writeContext, [$command]);
 
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                $customers,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
             ->willReturn(new EntitySearchResult(
@@ -307,11 +422,171 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 $context
             ));
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
 
         $exceptions = $event->getExceptions()->getExceptions();
         static::assertCount(1, $exceptions);
         static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+    }
+
+    public function testValidateAddsViolationWhenSalesChannelHasNoLanguages(): void
+    {
+        $ids = new IdsCollection();
+        $salesChannelId = $ids->get('sc1');
+
+        $customer = (new CustomerEntity())->assign([
+            'id' => $ids->get('customer1'),
+            'salesChannelId' => $salesChannelId,
+        ]);
+        $customers = new CustomerCollection([$customer]);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguages(new LanguageCollection());
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                1,
+                $customers,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exceptions[0]->getViolations()->get(0)->getCode()
+        );
+    }
+
+    public function testValidateLoadCustomersSalesChannelsWithEmptyResult(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customerNew')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'customer',
+                0,
+                new CustomerCollection(),
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $language = new LanguageEntity();
+        $language->setId($ids->get('lang1'));
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($ids->get('sc1'));
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testValidateInsertWithPrimaryKeyWithoutIdUsesPayloadSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $language = new LanguageEntity();
+        $language->setId($ids->get('lang1'));
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($ids->get('sc1'));
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            [],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+        $event = new PreWriteValidationEvent($writeContext, [$command]);
+
+        $this->customerRepository->expects($this->never())
+            ->method('search');
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -521,14 +521,13 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         );
     }
 
-    public function testValidateInsertWithEmptyPrimaryKeyStillValidatesFromPayload(): void
+    public function testValidateAddsViolationWhenSalesChannelLanguagesIsNull(): void
     {
         $ids = new IdsCollection();
-        $language = new LanguageEntity();
-        $language->setId($ids->get('lang1'));
+        $salesChannelId = $ids->get('sc1');
+
         $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($ids->get('sc1'));
-        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannel->setId($salesChannelId);
         $salesChannels = new SalesChannelCollection([$salesChannel]);
 
         $context = Context::createDefaultContext();
@@ -539,7 +538,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
                 'language_id' => $ids->getBytes('lang1'),
                 'sales_channel_id' => $ids->getBytes('sc1'),
             ],
-            [],
+            ['id' => $ids->getBytes('customer1')],
             $this->createMock(EntityExistence::class),
             '/0/'
         );
@@ -561,6 +560,12 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
         $subscriber->validate($event);
 
-        static::assertCount(0, $event->getExceptions()->getExceptions());
+        $exceptions = $event->getExceptions()->getExceptions();
+        static::assertCount(1, $exceptions);
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
+        static::assertSame(
+            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
+            $exceptions[0]->getViolations()->get(0)->getCode()
+        );
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -546,6 +546,59 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         static::assertCount(0, $event->getExceptions()->getExceptions());
     }
 
+    public function testValidateWhenGetPrimaryKeysReturnsEmptyStillValidatesFromPayloadSalesChannel(): void
+    {
+        $ids = new IdsCollection();
+        $language = new LanguageEntity();
+        $language->setId($ids->get('lang1'));
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($ids->get('sc1'));
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+        $salesChannels = new SalesChannelCollection([$salesChannel]);
+
+        $context = Context::createDefaultContext();
+        $writeContext = WriteContext::createFromContext($context);
+        $command = new InsertCommand(
+            $this->definitionRegistry->get(CustomerDefinition::class),
+            [
+                'language_id' => $ids->getBytes('lang1'),
+                'sales_channel_id' => $ids->getBytes('sc1'),
+            ],
+            ['id' => $ids->getBytes('customer1')],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+
+        $event = new class($writeContext, [$command]) extends PreWriteValidationEvent {
+            public function getPrimaryKeys(string $entity): array
+            {
+                if ($entity === CustomerDefinition::ENTITY_NAME) {
+                    return [];
+                }
+
+                return parent::getPrimaryKeys($entity);
+            }
+        };
+
+        $this->customerRepository->expects($this->never())->method('search');
+
+        $this->salesChannelRepository->expects($this->once())
+            ->method('search')
+            ->willReturn(new EntitySearchResult(
+                'sales_channel',
+                1,
+                $salesChannels,
+                new AggregationResultCollection(),
+                new Criteria(),
+                $context
+            ));
+
+        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository, $this->customerRepository);
+        $subscriber->validate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
     public function testValidateSkipsWhenPrimaryKeyHasNoId(): void
     {
         $ids = new IdsCollection();

--- a/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/CustomerLanguageSalesChannelSubscriberTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
@@ -271,7 +272,6 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
 
         $this->salesChannelRepository->expects($this->once())
             ->method('search')
-            ->with(static::callback(static fn (Criteria $c) => $c->hasAssociation('languages')))
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
                 1,
@@ -390,63 +390,51 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
         static::assertSame('/languageId', $exceptions[0]->getViolations()->get(0)->getPropertyPath());
     }
 
-    public function testValidateAddsViolationWhenSalesChannelNotInCollection(): void
+    /**
+     * @return iterable<string, array{SalesChannelCollection, Context, string}>
+     */
+    public static function provideLanguageNotInSalesChannelCases(): iterable
     {
         $ids = new IdsCollection();
         $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('scMissing'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
 
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                0,
-                new SalesChannelCollection(),
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
+        yield 'sales channel not in collection' => [
+            new SalesChannelCollection(),
+            $context,
+            $ids->getBytes('scMissing'),
+        ];
 
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
+        $salesChannelEmptyLangs = new SalesChannelEntity();
+        $salesChannelEmptyLangs->setId($ids->get('sc1'));
+        $salesChannelEmptyLangs->setLanguages(new LanguageCollection());
+        yield 'sales channel has no languages' => [
+            new SalesChannelCollection([$salesChannelEmptyLangs]),
+            $context,
+            $ids->getBytes('sc1'),
+        ];
 
-        $exceptions = $event->getExceptions()->getExceptions();
-        static::assertCount(1, $exceptions);
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame(
-            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
-            $exceptions[0]->getViolations()->get(0)->getCode()
-        );
+        $salesChannelNullLangs = new SalesChannelEntity();
+        $salesChannelNullLangs->setId($ids->get('sc1'));
+        yield 'sales channel languages is null' => [
+            new SalesChannelCollection([$salesChannelNullLangs]),
+            $context,
+            $ids->getBytes('sc1'),
+        ];
     }
 
-    public function testValidateAddsViolationWhenSalesChannelHasNoLanguages(): void
-    {
+    #[DataProvider('provideLanguageNotInSalesChannelCases')]
+    public function testValidateAddsViolationWhenLanguageNotAvailableInSalesChannel(
+        SalesChannelCollection $salesChannels,
+        Context $context,
+        string $salesChannelIdBytes
+    ): void {
         $ids = new IdsCollection();
-        $salesChannelId = $ids->get('sc1');
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setLanguages(new LanguageCollection());
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
         $writeContext = WriteContext::createFromContext($context);
         $command = new InsertCommand(
             $this->definitionRegistry->get(CustomerDefinition::class),
             [
                 'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
+                'sales_channel_id' => $salesChannelIdBytes,
             ],
             ['id' => $ids->getBytes('customer1')],
             $this->createMock(EntityExistence::class),
@@ -458,53 +446,7 @@ class CustomerLanguageSalesChannelSubscriberTest extends TestCase
             ->method('search')
             ->willReturn(new EntitySearchResult(
                 'sales_channel',
-                1,
-                $salesChannels,
-                new AggregationResultCollection(),
-                new Criteria(),
-                $context
-            ));
-
-        $subscriber = new CustomerLanguageSalesChannelSubscriber($this->salesChannelRepository);
-        $subscriber->validate($event);
-
-        $exceptions = $event->getExceptions()->getExceptions();
-        static::assertCount(1, $exceptions);
-        static::assertInstanceOf(WriteConstraintViolationException::class, $exceptions[0]);
-        static::assertSame(
-            CustomerLanguageSalesChannelSubscriber::VIOLATION_LANGUAGE_NOT_IN_SALES_CHANNEL,
-            $exceptions[0]->getViolations()->get(0)->getCode()
-        );
-    }
-
-    public function testValidateAddsViolationWhenSalesChannelLanguagesIsNull(): void
-    {
-        $ids = new IdsCollection();
-        $salesChannelId = $ids->get('sc1');
-
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannels = new SalesChannelCollection([$salesChannel]);
-
-        $context = Context::createDefaultContext();
-        $writeContext = WriteContext::createFromContext($context);
-        $command = new InsertCommand(
-            $this->definitionRegistry->get(CustomerDefinition::class),
-            [
-                'language_id' => $ids->getBytes('lang1'),
-                'sales_channel_id' => $ids->getBytes('sc1'),
-            ],
-            ['id' => $ids->getBytes('customer1')],
-            $this->createMock(EntityExistence::class),
-            '/0/'
-        );
-        $event = new PreWriteValidationEvent($writeContext, [$command]);
-
-        $this->salesChannelRepository->expects($this->once())
-            ->method('search')
-            ->willReturn(new EntitySearchResult(
-                'sales_channel',
-                1,
+                $salesChannels->count(),
                 $salesChannels,
                 new AggregationResultCollection(),
                 new Criteria(),


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this check, a customer could be created in the Admin with a language that is not assigned to the chosen sales channel. That leads to inconsistent data and can cause errors when the customer is used in that sales channel.

### 2. What does this change do, exactly?
On customer create (not via storefront), it validates that the chosen language is one of the languages of the customer’s sales channel. If not, the write is rejected with a constraint violation and the customer is not created.

### 3. Please link to the relevant issues
- Fixes the first part of https://github.com/shopware/shopware/issues/5767
- The second part was already fixed in https://github.com/shopware/shopware/issues/7960

### 4. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
