### PR TITLE
fix(notifications): Re-implement rendering of titles

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.html.twig
@@ -16,7 +16,7 @@
                 v-for="(notification, index) in notifications"
                 :key="notification.uuid"
                 :class="['sw-notifications__notification--' + index, 'sw-notification__alert']"
-                :title="$te(notification.title) ? $t(notification.title) : notification.title"
+                :title="$t(notification.title)"
                 :variant="getNotificationVariant(notification)"
                 :notification-index="notification.uuid"
                 :closable="true"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
<img width="423" height="218" alt="image" src="https://github.com/user-attachments/assets/eec49a5c-ffb9-4c13-ad25-70616f10a997" />

Notification titles are not translated

### 2. What does this change do, exactly?
Add `$t` to the title to render it.

### 3. Describe each step to reproduce the issue or behaviour.
Do something which creates a notification (like duplicating a snippet set or removing it)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
