### PR TITLE
fix: prevent float steps for integer custom fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -479,7 +479,6 @@ const missingTests = [
     'src/module/sw-settings-custom-field/component/sw-custom-field-type-base/index.js',
     'src/module/sw-settings-custom-field/component/sw-custom-field-type-checkbox/index.js',
     'src/module/sw-settings-custom-field/component/sw-custom-field-type-date/index.js',
-    'src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js',
     'src/module/sw-settings-custom-field/component/sw-custom-field-type-text/index.js',
     'src/module/sw-settings-custom-field/component/sw-custom-field-type-text-editor/index.js',
     'src/module/sw-settings-custom-field/index.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
@@ -27,9 +27,27 @@ export default {
         };
     },
 
+    computed: {
+        isIntField() {
+            return this.currentCustomField.config.numberType === 'int';
+        },
+    },
+
     watch: {
         'currentCustomField.config.numberType'(value) {
             this.currentCustomField.type = value;
+
+            if (value === 'int') {
+                if (this.currentCustomField.config.step != null) {
+                    this.currentCustomField.config.step = Math.round(this.currentCustomField.config.step);
+                }
+                if (this.currentCustomField.config.min != null) {
+                    this.currentCustomField.config.min = Math.round(this.currentCustomField.config.min);
+                }
+                if (this.currentCustomField.config.max != null) {
+                    this.currentCustomField.config.max = Math.round(this.currentCustomField.config.max);
+                }
+            }
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
@@ -38,14 +38,14 @@ export default {
             this.currentCustomField.type = value;
 
             if (value === 'int') {
-                if (this.currentCustomField.config.step != null) {
+                if (this.currentCustomField.config.step !== null && this.currentCustomField.config.step !== undefined) {
                     const roundedStep = Math.round(this.currentCustomField.config.step);
                     this.currentCustomField.config.step = roundedStep >= 1 ? roundedStep : 1;
                 }
-                if (this.currentCustomField.config.min != null) {
+                if (this.currentCustomField.config.min !== null && this.currentCustomField.config.min !== undefined) {
                     this.currentCustomField.config.min = Math.round(this.currentCustomField.config.min);
                 }
-                if (this.currentCustomField.config.max != null) {
+                if (this.currentCustomField.config.max !== null && this.currentCustomField.config.max !== undefined) {
                     this.currentCustomField.config.max = Math.round(this.currentCustomField.config.max);
                 }
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
@@ -40,9 +40,7 @@ export default {
             if (value === 'int') {
                 if (this.currentCustomField.config.step != null) {
                     const roundedStep = Math.round(this.currentCustomField.config.step);
-                    this.currentCustomField.config.step = roundedStep >= 1
-                        ? roundedStep
-                        : 1;
+                    this.currentCustomField.config.step = roundedStep >= 1 ? roundedStep : 1;
                 }
                 if (this.currentCustomField.config.min != null) {
                     this.currentCustomField.config.min = Math.round(this.currentCustomField.config.min);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/index.js
@@ -39,7 +39,10 @@ export default {
 
             if (value === 'int') {
                 if (this.currentCustomField.config.step != null) {
-                    this.currentCustomField.config.step = Math.round(this.currentCustomField.config.step);
+                    const roundedStep = Math.round(this.currentCustomField.config.step);
+                    this.currentCustomField.config.step = roundedStep >= 1
+                        ? roundedStep
+                        : 1;
                 }
                 if (this.currentCustomField.config.min != null) {
                     this.currentCustomField.config.min = Math.round(this.currentCustomField.config.min);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
@@ -19,8 +19,6 @@
         v-model="currentCustomField.config.step"
         :label="$tc('sw-settings-custom-field.customField.detail.labelStep')"
         :number-type="isIntField ? 'int' : 'float'"
-        :step="isIntField ? 1 : 0.01"
-        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 
@@ -29,8 +27,6 @@
         v-model="currentCustomField.config.min"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMin')"
         :number-type="isIntField ? 'int' : 'float'"
-        :step="isIntField ? 1 : 0.01"
-        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 
@@ -39,8 +35,6 @@
         v-model="currentCustomField.config.max"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMax')"
         :number-type="isIntField ? 'int' : 'float'"
-        :step="isIntField ? 1 : 0.01"
-        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
@@ -18,6 +18,9 @@
     <mt-number-field
         v-model="currentCustomField.config.step"
         :label="$tc('sw-settings-custom-field.customField.detail.labelStep')"
+        :number-type="isIntField ? 'int' : 'float'"
+        :step="isIntField ? 1 : 0.01"
+        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 
@@ -25,6 +28,9 @@
     <mt-number-field
         v-model="currentCustomField.config.min"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMin')"
+        :number-type="isIntField ? 'int' : 'float'"
+        :step="isIntField ? 1 : 0.01"
+        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 
@@ -32,6 +38,9 @@
     <mt-number-field
         v-model="currentCustomField.config.max"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMax')"
+        :number-type="isIntField ? 'int' : 'float'"
+        :step="isIntField ? 1 : 0.01"
+        :digits="isIntField ? 0 : 2"
     />
     {% endblock %}
 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.html.twig
@@ -18,7 +18,7 @@
     <mt-number-field
         v-model="currentCustomField.config.step"
         :label="$tc('sw-settings-custom-field.customField.detail.labelStep')"
-        :number-type="isIntField ? 'int' : 'float'"
+        :number-type="currentCustomField.config.numberType"
     />
     {% endblock %}
 
@@ -26,7 +26,7 @@
     <mt-number-field
         v-model="currentCustomField.config.min"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMin')"
-        :number-type="isIntField ? 'int' : 'float'"
+        :number-type="currentCustomField.config.numberType"
     />
     {% endblock %}
 
@@ -34,7 +34,7 @@
     <mt-number-field
         v-model="currentCustomField.config.max"
         :label="$tc('sw-settings-custom-field.customField.detail.labelMax')"
-        :number-type="isIntField ? 'int' : 'float'"
+        :number-type="currentCustomField.config.numberType"
     />
     {% endblock %}
 </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
@@ -143,6 +143,18 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-num
         expect(wrapper.vm.currentCustomField.config.max).toBe(10);
     });
 
+    it('should clamp rounded step to a minimum of 1 when switching numberType to int', async () => {
+        const wrapper = await createWrapper({
+            numberType: 'float',
+            step: 0.1,
+        });
+
+        wrapper.vm.currentCustomField.config.numberType = 'int';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.config.step).toBe(1);
+    });
+
     it('should update type property when switching numberType', async () => {
         const wrapper = await createWrapper({ numberType: 'int' });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
@@ -1,0 +1,214 @@
+/**
+ * @sw-package framework
+ */
+import { mount } from '@vue/test-utils';
+
+function createCustomField(overrides = {}) {
+    return {
+        name: 'technical_test',
+        type: 'int',
+        config: {
+            label: { 'en-GB': null },
+            helpText: { 'en-GB': null },
+            placeholder: { 'en-GB': null },
+            componentName: 'sw-number-field',
+            customFieldType: 'number',
+            customFieldPosition: 1,
+            numberType: 'int',
+            step: null,
+            min: null,
+            max: null,
+            ...overrides,
+        },
+        active: true,
+        customFieldSetId: 'd2667dfae415440592a0944fbea2d3ce',
+        id: '8e1ab96faf374836a4d68febc8d4f1e1',
+    };
+}
+
+const defaultSet = {
+    name: 'technical_test',
+    config: { label: { 'en-GB': 'test_label' } },
+    active: true,
+    global: false,
+    position: 1,
+    id: 'd2667dfae415440592a0944fbea2d3ce',
+};
+
+async function createWrapper(customFieldOverrides = {}) {
+    return mount(await wrapTestComponent('sw-custom-field-type-number', { sync: true }), {
+        props: {
+            currentCustomField: createCustomField(customFieldOverrides),
+            set: defaultSet,
+        },
+        global: {
+            mocks: {
+                $tc: (key) => key,
+            },
+            stubs: {
+                'sw-custom-field-translated-labels': true,
+                'sw-container': {
+                    template: '<div class="sw-container"><slot /></div>',
+                },
+                'mt-select': {
+                    template: '<div class="mt-select" />',
+                    props: ['modelValue', 'options'],
+                },
+                'mt-number-field': {
+                    template: '<div class="mt-number-field" />',
+                    props: ['modelValue', 'numberType', 'step', 'digits', 'label'],
+                },
+            },
+        },
+    });
+}
+
+describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-number', () => {
+    it('should provide correct property names for translations', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.propertyNames).toEqual({
+            label: 'sw-settings-custom-field.customField.detail.labelLabel',
+            placeholder: 'sw-settings-custom-field.customField.detail.labelPlaceholder',
+            helpText: 'sw-settings-custom-field.customField.detail.labelHelpText',
+        });
+    });
+
+    it('should default numberType to int when not set', async () => {
+        const wrapper = await createWrapper({ numberType: '' });
+
+        expect(wrapper.vm.currentCustomField.config.numberType).toBe('int');
+    });
+
+    it('should provide number type options to the select', async () => {
+        const wrapper = await createWrapper();
+
+        const select = wrapper.findComponent('.mt-select');
+
+        expect(select.props('options')).toEqual([
+            {
+                value: 'int',
+                label: 'sw-settings-custom-field.customField.detail.labelInt',
+            },
+            {
+                value: 'float',
+                label: 'sw-settings-custom-field.customField.detail.labelFloat',
+            },
+        ]);
+    });
+
+    it('should not override numberType when already set', async () => {
+        const wrapper = await createWrapper({ numberType: 'float' });
+
+        expect(wrapper.vm.currentCustomField.config.numberType).toBe('float');
+    });
+
+    it.each([
+        ['int', true],
+        ['float', false],
+    ])('should expose isIntField for numberType %s', async (numberType, expected) => {
+        const wrapper = await createWrapper({ numberType });
+
+        expect(wrapper.vm.isIntField).toBe(expected);
+    });
+
+    it('should round step, min, and max when switching numberType to int', async () => {
+        const wrapper = await createWrapper({
+            numberType: 'float',
+            step: 1.5,
+            min: 2.7,
+            max: 10.3,
+        });
+
+        wrapper.vm.currentCustomField.config.numberType = 'int';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.config.step).toBe(2);
+        expect(wrapper.vm.currentCustomField.config.min).toBe(3);
+        expect(wrapper.vm.currentCustomField.config.max).toBe(10);
+    });
+
+    it('should update type property when switching numberType', async () => {
+        const wrapper = await createWrapper({ numberType: 'int' });
+
+        expect(wrapper.vm.currentCustomField.type).toBe('int');
+
+        wrapper.vm.currentCustomField.config.numberType = 'float';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.type).toBe('float');
+    });
+
+    it('should update type property when switching numberType to int', async () => {
+        const wrapper = await createWrapper({ numberType: 'float' });
+
+        wrapper.vm.currentCustomField.type = 'float';
+        expect(wrapper.vm.currentCustomField.type).toBe('float');
+
+        wrapper.vm.currentCustomField.config.numberType = 'int';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.type).toBe('int');
+    });
+
+    it('should not round null values when switching numberType to int', async () => {
+        const wrapper = await createWrapper({
+            numberType: 'float',
+            step: null,
+            min: null,
+            max: null,
+        });
+
+        wrapper.vm.currentCustomField.config.numberType = 'int';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.config.step).toBeNull();
+        expect(wrapper.vm.currentCustomField.config.min).toBeNull();
+        expect(wrapper.vm.currentCustomField.config.max).toBeNull();
+    });
+
+    it('should not round values when switching numberType to float', async () => {
+        const wrapper = await createWrapper({
+            numberType: 'int',
+            step: 2,
+            min: 3,
+            max: 10,
+        });
+
+        wrapper.vm.currentCustomField.config.numberType = 'float';
+        await flushPromises();
+
+        expect(wrapper.vm.currentCustomField.config.step).toBe(2);
+        expect(wrapper.vm.currentCustomField.config.min).toBe(3);
+        expect(wrapper.vm.currentCustomField.config.max).toBe(10);
+    });
+
+    it('should pass number-type float to mt-number-field components when numberType is float', async () => {
+        const wrapper = await createWrapper({ numberType: 'float' });
+        await flushPromises();
+
+        const numberFields = wrapper.findAllComponents('.mt-number-field');
+
+        numberFields.forEach((field) => {
+            expect(field.props('numberType')).toBe('float');
+            expect(field.props('step')).toBe(0.01);
+            expect(field.props('digits')).toBe(2);
+        });
+    });
+
+    it('should update mt-number-field props when switching numberType from float to int', async () => {
+        const wrapper = await createWrapper({ numberType: 'float' });
+        await flushPromises();
+
+        wrapper.vm.currentCustomField.config.numberType = 'int';
+        await flushPromises();
+
+        const numberFields = wrapper.findAllComponents('.mt-number-field');
+
+        numberFields.forEach((field) => {
+            expect(field.props('numberType')).toBe('int');
+            expect(field.props('step')).toBe(1);
+            expect(field.props('digits')).toBe(0);
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
@@ -167,22 +167,6 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-num
         expect(wrapper.vm.currentCustomField.config.max).toBeNull();
     });
 
-    it('should not round values when switching numberType to float', async () => {
-        const wrapper = await createWrapper({
-            numberType: 'int',
-            step: 2,
-            min: 3,
-            max: 10,
-        });
-
-        wrapper.vm.currentCustomField.config.numberType = 'float';
-        await flushPromises();
-
-        expect(wrapper.vm.currentCustomField.config.step).toBe(2);
-        expect(wrapper.vm.currentCustomField.config.min).toBe(3);
-        expect(wrapper.vm.currentCustomField.config.max).toBe(10);
-    });
-
     it('should pass number-type float to mt-number-field components when numberType is float', async () => {
         const wrapper = await createWrapper({ numberType: 'float' });
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
@@ -52,11 +52,20 @@ async function createWrapper(customFieldOverrides = {}) {
                 },
                 'mt-select': {
                     template: '<div class="mt-select" />',
-                    props: ['modelValue', 'options'],
+                    props: [
+                        'modelValue',
+                        'options',
+                    ],
                 },
                 'mt-number-field': {
                     template: '<div class="mt-number-field" />',
-                    props: ['modelValue', 'numberType', 'step', 'digits', 'label'],
+                    props: [
+                        'modelValue',
+                        'numberType',
+                        'step',
+                        'digits',
+                        'label',
+                    ],
                 },
             },
         },
@@ -104,8 +113,14 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-num
     });
 
     it.each([
-        ['int', true],
-        ['float', false],
+        [
+            'int',
+            true,
+        ],
+        [
+            'float',
+            false,
+        ],
     ])('should expose isIntField for numberType %s', async (numberType, expected) => {
         const wrapper = await createWrapper({ numberType });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-number/sw-custom-field-type-number.spec.js
@@ -202,8 +202,6 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-num
 
         numberFields.forEach((field) => {
             expect(field.props('numberType')).toBe('float');
-            expect(field.props('step')).toBe(0.01);
-            expect(field.props('digits')).toBe(2);
         });
     });
 
@@ -218,8 +216,6 @@ describe('src/module/sw-settings-custom-field/component/sw-custom-field-type-num
 
         numberFields.forEach((field) => {
             expect(field.props('numberType')).toBe('int');
-            expect(field.props('step')).toBe(1);
-            expect(field.props('digits')).toBe(0);
         });
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

As reported in https://github.com/shopware/shopware/issues/14690, it is possible to set a float number as the step width for integer custom fields.

### 2. What does this change do, exactly?

- The values for max, min, and step are rounded when the field type is changed from float to int  
- The prop `numberType` for the step-width input field is set

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a number custom field of type integer and set the step width to 0.1  
2. The step arrow buttons won’t work when using the custom field

### 4. Please link to the relevant issues (if any).

Closes https://github.com/shopware/shopware/issues/14690
