### PR TITLE
fix: product reference unit inheritance switch

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-packaging-form/sw-product-packaging-form.html.twig
@@ -100,18 +100,21 @@
 
                 <mt-number-field
                     class="sw-product-packaging-form__reference-unit-field"
-                    :map-inheritance="props"
+                    :is-inheritance-field="props.isInheritField"
+                    :is-inherited="props.isInherited"
                     number-type="float"
                     allow-empty
                     :min="0"
                     :digits="3"
                     :error="productReferenceUnitError"
                     :disabled="props.isInherited || !allowEdit"
-                    :placeholder="$t('sw-product.packagingForm.placeholderBasicUnit')"
                     :label="$t('sw-product.priceForm.labelReferenceUnit')"
-                    :model-value="props.currentValue"
+                    :placeholder="$t('sw-product.packagingForm.placeholderBasicUnit')"
                     :help-text="$t('sw-product.packagingForm.helpTextBasicUnit')"
+                    :model-value="props.currentValue"
                     @update:model-value="props.updateCurrentValue"
+                    @inheritance-restore="props.restoreInheritance"
+                    @inheritance-remove="props.removeInheritance"
                 />
 
             </template>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The product reference unit cannot be changed on variants because the inheritance switch is missing and the field is disabled. The field was not adjusted in #8753 

<img width="966" height="393" alt="Screenshot 2026-02-09 154925" src="https://github.com/user-attachments/assets/9518955b-ea5f-4e01-9296-8c5c76238551" />

### 2. What does this change do, exactly?
Changed the field to use the correct inheritance props.

### 3. Describe each step to reproduce the issue or behaviour.
Create a variant product and try to change the reference unit on a variant.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
