### PR TITLE
chore(fix): userId must be an empty string and non null when signing the URI

### DIFF
--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -45,7 +45,7 @@ class QuerySigner
             'in-app-purchases' => \urlencode($this->inAppPurchase->getJWTByExtension($app->getName()) ?? ''),
             AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $context->getLanguageId(),
             AuthMiddleware::SHOPWARE_USER_LANGUAGE => $this->localeProvider->getLocaleFromContext($context),
-            'sw-user-id' => $context->getSource() instanceof AdminApiSource ? $context->getSource()->getUserId() : '',
+            'sw-user-id' => $context->getSource() instanceof AdminApiSource ? ($context->getSource()->getUserId() ?? '') : '',
         ]);
 
         return Uri::withQueryValue(

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Framework\App\Hmac;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -77,10 +78,9 @@ class QuerySignerTest extends TestCase
         static::assertSame($userId, $url['sw-user-id']);
     }
 
-    public function testUserIdIsEmptyStringWhenSourceIsNotAdminApiSource(): void
+    #[DataProvider('userIdDataProvider')]
+    public function testUserIdInSignedUri(Context $context, string $expectedUserId): void
     {
-        $context = Context::createDefaultContext();
-
         $localeProvider = $this->createMock(LocaleProvider::class);
         $localeProvider
             ->expects($this->once())
@@ -117,7 +117,7 @@ class QuerySignerTest extends TestCase
         \parse_str($signedQuery->getQuery(), $url);
 
         static::assertArrayHasKey('sw-user-id', $url);
-        static::assertSame('', $url['sw-user-id']);
+        static::assertSame($expectedUserId, $url['sw-user-id']);
     }
 
     public function testThrowsWithoutAppSecret(): void
@@ -138,5 +138,28 @@ class QuerySignerTest extends TestCase
         $this->expectExceptionMessage('App secret is missing for app Foo');
 
         $querySigner->signUri('http://app.url/?foo=bar', $app, Context::createDefaultContext());
+    }
+
+    /**
+     * @return \Generator<string, array{Context, string}>
+     */
+    public static function userIdDataProvider(): \Generator
+    {
+        $userId = Uuid::randomHex();
+
+        yield 'admin api source with user' => [
+            new Context(new AdminApiSource($userId)),
+            $userId,
+        ];
+
+        yield 'admin api source without user' => [
+            new Context(new AdminApiSource(null)),
+            '',
+        ];
+
+        yield 'non-admin api source' => [
+            Context::createDefaultContext(),
+            '',
+        ];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When the source is an `AdminApiSource` but the request comes from an integration (no user), `getUserId()` returns null.
In that case, `null` is passed as the query value instead of an empty string `''`.
Guzzle handles null query values differently (it renders the key without a value, e.g. `?sw-user-id` instead of `?sw-user-id=`), which could produce an inconsistent signature on the receiving end.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
