### PR TITLE
chore: Link `CLAUDE.md` to `AGENTS.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,6 @@ app/config/parameters.yml
 *.tabnineignore.local
 
 # AI/LLM Documentation
-CLAUDE.md
 GEMINI.md
 
 /dev-ops/check_requirements.php

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### 1. Why is this change necessary?
Not sure if this is desired, as this file is explicitly on the `.gitignore`. But usually I just link the `CLAUDE.md` to the `AGENTS.md` as Anthropic decided on a different standard :shrug: 

### 2. What does this change do, exactly?
Link `CLAUDE.md` to `AGENTS.md`. 

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
