### PR TITLE
fix: use correct name translation for sales channel

### DIFF
--- a/src/Core/Migration/V6_3/Migration1536233560BasicData.php
+++ b/src/Core/Migration/V6_3/Migration1536233560BasicData.php
@@ -2085,7 +2085,7 @@ class Migration1536233560BasicData extends MigrationStep
                 'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
                 'subject' => 'Order confirmation',
                 'description' => '',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getHtmlTemplateEn(),
                 'content_plain' => $this->getPlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2099,7 +2099,7 @@ class Migration1536233560BasicData extends MigrationStep
                 'language_id' => Uuid::fromHexToBytes($this->getDeDeLanguageId()),
                 'subject' => 'Bestellbestätigung',
                 'description' => '',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getHtmlTemplateDe(),
                 'content_plain' => $this->getPlainTemplateDe(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2136,9 +2136,9 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'mail_template_id' => $customerRegistrationTemplateId,
                 'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
-                'subject' => 'Your Registration at {{ salesChannel.name }}',
+                'subject' => 'Your Registration at {{ salesChannel.translated.name }}',
                 'description' => 'Registration confirmation',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getRegistrationHtmlTemplateEn(),
                 'content_plain' => $this->getRegistrationPlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2150,9 +2150,9 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'mail_template_id' => $customerRegistrationTemplateId,
                 'language_id' => Uuid::fromHexToBytes($this->getDeDeLanguageId()),
-                'subject' => 'Deine Registrierung bei {{ salesChannel.name }}',
+                'subject' => 'Deine Registrierung bei {{ salesChannel.translated.name }}',
                 'description' => 'Registrierungsbestätigung',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getRegistrationHtmlTemplateDe(),
                 'content_plain' => $this->getRegistrationPlainTemplateDe(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2174,9 +2174,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Password reset - {{ salesChannel.name }}',
+                'subject' => 'Password reset - {{ salesChannel.translated.name }}',
                 'description' => 'Password reset request',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getPasswordChangeHtmlTemplateEn(),
                 'content_plain' => $this->getPasswordChangePlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2188,9 +2188,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Password zurücksetzen - {{ salesChannel.name }}',
+                'subject' => 'Password zurücksetzen - {{ salesChannel.translated.name }}',
                 'description' => 'Passwort zurücksetzen Anfrage',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getPasswordChangeHtmlTemplateDe(),
                 'content_plain' => $this->getPasswordChangePlainTemplateDe(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2214,9 +2214,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Your merchant account has been unlocked - {{ salesChannel.name }}',
+                'subject' => 'Your merchant account has been unlocked - {{ salesChannel.translated.name }}',
                 'description' => 'Customer Group Change accepted',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getCustomerGroupChangeAcceptedHtmlTemplateEn(),
                 'content_plain' => $this->getCustomerGroupChangeAcceptedPlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2228,9 +2228,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Ihr Händleraccount wurde freigeschaltet - {{ salesChannel.name }}',
+                'subject' => 'Ihr Händleraccount wurde freigeschaltet - {{ salesChannel.translated.name }}',
                 'description' => 'Kundengruppenwechsel freigeschaltet',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getCustomerGroupChangeAcceptedHtmlTemplateDe(),
                 'content_plain' => $this->getCustomerGroupChangeAcceptedPlainTemplateDe(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2254,9 +2254,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Your trader account has not been accepted - {{ salesChannel.name }}',
+                'subject' => 'Your trader account has not been accepted - {{ salesChannel.translated.name }}',
                 'description' => 'Customer Group Change rejected',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getCustomerGroupChangeRejectedHtmlTemplateEn(),
                 'content_plain' => $this->getCustomerGroupChangeRejectedPlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -2268,9 +2268,9 @@ class Migration1536233560BasicData extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Ihr Händleraccountantrag wurde abgelehnt - {{ salesChannel.name }}',
+                'subject' => 'Ihr Händleraccountantrag wurde abgelehnt - {{ salesChannel.translated.name }}',
                 'description' => 'Kundengruppenwechsel abgelehnt',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getCustomerGroupChangeRejectedHtmlTemplateDe(),
                 'content_plain' => $this->getCustomerGroupChangeRejectedPlainTemplateDe(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_3/Migration1567431050ContactFormTemplate.php
+++ b/src/Core/Migration/V6_3/Migration1567431050ContactFormTemplate.php
@@ -62,9 +62,9 @@ class Migration1567431050ContactFormTemplate extends MigrationStep
         $connection->insert(
             'mail_template_translation',
             [
-                'subject' => 'Contact form received - {{ salesChannel.name }}',
+                'subject' => 'Contact form received - {{ salesChannel.translated.name }}',
                 'description' => 'Contact form received',
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'content_html' => $this->getRegistrationHtmlTemplateEn(),
                 'content_plain' => $this->getRegistrationPlainTemplateEn(),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_3/Migration1571990395UpdateDefaultStatusMailTemplates.php
+++ b/src/Core/Migration/V6_3/Migration1571990395UpdateDefaultStatusMailTemplates.php
@@ -32,12 +32,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is partially delivered',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is partially delivered',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde teilweise ausgeliefert'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde teilweise ausgeliefert'
         );
 
         // update DELIVERY_STATE_RETURNED_PARTIALLY
@@ -46,12 +46,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is partially returned',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is partially returned',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde teilweise retourniert'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde teilweise retourniert'
         );
 
         // update DELIVERY_STATE_RETURNED
@@ -60,12 +60,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is returned',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is returned',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde retourniert'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde retourniert'
         );
 
         // update DELIVERY_STATE_CANCELLED
@@ -74,12 +74,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is cancelled',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is cancelled',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Stornierung der Bestellung bei {{ salesChannel.name }}'
+            '{{ salesChannel.translated.name }}',
+            'Stornierung der Bestellung bei {{ salesChannel.translated.name }}'
         );
 
         // update DELIVERY_STATE_SHIPPED
@@ -88,12 +88,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is delivered',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is delivered',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde ausgeliefert'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde ausgeliefert'
         );
 
         // update ORDER_STATE_OPEN
@@ -102,12 +102,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is open',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is open',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} ist offen'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} ist offen'
         );
 
         // update ORDER_STATE_IN_PROGRESS
@@ -116,12 +116,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is in process',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is in process',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} ist in Bearbeitung'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} ist in Bearbeitung'
         );
 
         // update ORDER_STATE_COMPLETED
@@ -130,12 +130,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is completed',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is completed',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} ist komplett abgeschlossen'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} ist komplett abgeschlossen'
         );
 
         // update ORDER_STATE_CANCELLED
@@ -144,12 +144,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED,
             $this->getOrderStatusUpdateHtmlTemplateEn(),
             $this->getOrderStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is cancelled',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is cancelled',
             $this->getOrderStatusUpdateHtmlTemplateDe(),
             $this->getOrderStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Stornierung der Bestellung bei {{ salesChannel.name }}'
+            '{{ salesChannel.translated.name }}',
+            'Stornierung der Bestellung bei {{ salesChannel.translated.name }}'
         );
 
         // update TRANSACTION_STATE_REFUNDED_PARTIALLY
@@ -158,12 +158,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is partially refunded',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is partially refunded',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde teilweise erstattet'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde teilweise erstattet'
         );
 
         // update TRANSACTION_STATE_REMINDED
@@ -172,12 +172,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Reminder for your order with {{ salesChannel.name }}',
+            '{{ salesChannel.translated.name }}',
+            'Reminder for your order with {{ salesChannel.translated.name }}',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Zahlungserinnerung für die Bestellung bei {{ salesChannel.name }}'
+            '{{ salesChannel.translated.name }}',
+            'Zahlungserinnerung für die Bestellung bei {{ salesChannel.translated.name }}'
         );
 
         // update TRANSACTION_STATE_OPEN
@@ -186,12 +186,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }}',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }}',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Deine Bestellung bei {{ salesChannel.name }}'
+            '{{ salesChannel.translated.name }}',
+            'Deine Bestellung bei {{ salesChannel.translated.name }}'
         );
 
         // update TRANSACTION_STATE_PAID
@@ -200,12 +200,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is completly paid',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is completly paid',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Deine Bestellung bei {{ salesChannel.name }} wurde komplett bezahlt'
+            '{{ salesChannel.translated.name }}',
+            'Deine Bestellung bei {{ salesChannel.translated.name }} wurde komplett bezahlt'
         );
 
         // update TRANSACTION_STATE_CANCELLED
@@ -214,12 +214,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'The payment for your order with {{ salesChannel.name }} is cancelled',
+            '{{ salesChannel.translated.name }}',
+            'The payment for your order with {{ salesChannel.translated.name }} is cancelled',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Die Zahlung für ihre Bestellung bei {{ salesChannel.name }} wurde storniert'
+            '{{ salesChannel.translated.name }}',
+            'Die Zahlung für ihre Bestellung bei {{ salesChannel.translated.name }} wurde storniert'
         );
 
         // update TRANSACTION_STATE_REFUNDED
@@ -228,12 +228,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is refunded',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is refunded',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Bestellung bei {{ salesChannel.name }} wurde erstattet'
+            '{{ salesChannel.translated.name }}',
+            'Bestellung bei {{ salesChannel.translated.name }} wurde erstattet'
         );
 
         // update TRANSACTION_STATE_PAID_PARTIALLY
@@ -242,12 +242,12 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
             MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY,
             $this->getOrderTransactionStatusUpdateHtmlTemplateEn(),
             $this->getOrderTransactionStatusUpdatePlainTemplateEn(),
-            '{{ salesChannel.name }}',
-            'Your order with {{ salesChannel.name }} is partially paid',
+            '{{ salesChannel.translated.name }}',
+            'Your order with {{ salesChannel.translated.name }} is partially paid',
             $this->getOrderTransactionStatusUpdateHtmlTemplateDe(),
             $this->getOrderTransactionStatusUpdatePlainTemplateDe(),
-            '{{ salesChannel.name }}',
-            'Deine Bestellung bei {{ salesChannel.name }} wurde teilweise bezahlt'
+            '{{ salesChannel.translated.name }}',
+            'Deine Bestellung bei {{ salesChannel.translated.name }} wurde teilweise bezahlt'
         );
     }
 
@@ -367,7 +367,7 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
                         'language_id' => $this->defaultLangId,
                         'subject' => $subjectEn,
                         'description' => $descriptionEn,
-                        'sender_name' => '{{ salesChannel.name }}',
+                        'sender_name' => '{{ salesChannel.translated.name }}',
                         'content_html' => $contentHtmlEn,
                         'content_plain' => $contentPlainEn,
                         'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -418,7 +418,7 @@ class Migration1571990395UpdateDefaultStatusMailTemplates extends MigrationStep
                         'mail_template_id' => $newTemplateId ?: $templateId,
                         'language_id' => $this->deLangId,
                         'subject' => $subjectDe,
-                        'sender_name' => '{{ salesChannel.name }}',
+                        'sender_name' => '{{ salesChannel.translated.name }}',
                         'description' => $descriptionDe,
                         'content_html' => $contentHtmlDe,
                         'content_plain' => $contentPlainDe,

--- a/src/Core/Migration/V6_3/Migration1573569685DoubleOptInGuestMailTemplate.php
+++ b/src/Core/Migration/V6_3/Migration1573569685DoubleOptInGuestMailTemplate.php
@@ -128,9 +128,9 @@ class Migration1573569685DoubleOptInGuestMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Please confirm your email address at {{ salesChannel.name }}',
+                    'subject' => 'Please confirm your email address at {{ salesChannel.translated.name }}',
                     'description' => 'Email confirmation at guest orders',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => $this->getHtmlTemplateEn(),
                     'content_plain' => $this->getPlainTemplateEn(),
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -144,9 +144,9 @@ class Migration1573569685DoubleOptInGuestMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Please confirm your email address at {{ salesChannel.name }}',
+                    'subject' => 'Please confirm your email address at {{ salesChannel.translated.name }}',
                     'description' => 'Email confirmation at guest orders',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => $this->getHtmlTemplateEn(),
                     'content_plain' => $this->getPlainTemplateEn(),
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -160,9 +160,9 @@ class Migration1573569685DoubleOptInGuestMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Bitte bestätigen Sie Ihre E-Mail-Adresse bei {{ salesChannel.name }}',
+                    'subject' => 'Bitte bestätigen Sie Ihre E-Mail-Adresse bei {{ salesChannel.translated.name }}',
                     'description' => 'Anmeldebestätigung bei Gastbestellungen',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => $this->getHtmlTemplateDe(),
                     'content_plain' => $this->getPlainTemplateDe(),
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_3/Migration1580808849AddGermanContactFormTranslation.php
+++ b/src/Core/Migration/V6_3/Migration1580808849AddGermanContactFormTranslation.php
@@ -50,8 +50,8 @@ class Migration1580808849AddGermanContactFormTranslation extends MigrationStep
             [
                 'mail_template_id' => $contactTemplateId,
                 'language_id' => $deLangId,
-                'sender_name' => '{{ salesChannel.name }}',
-                'subject' => 'Kontaktanfrage erhalten - {{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
+                'subject' => 'Kontaktanfrage erhalten - {{ salesChannel.translated.name }}',
                 'description' => 'Kontaktanfrage erhalten',
                 'content_html' => $this->getContactFormHtmlTemplateDe(),
                 'content_plain' => $this->getContactFormPlainTemplateDe(),

--- a/src/Core/Migration/V6_4/Migration1632721037OrderDocumentMailTemplate.php
+++ b/src/Core/Migration/V6_4/Migration1632721037OrderDocumentMailTemplate.php
@@ -100,14 +100,14 @@ class Migration1632721037OrderDocumentMailTemplate extends MigrationStep
             $translations = new Translations(
                 [
                     'mail_template_id' => $values['templateId'],
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'Neues Dokument für Ihre Bestellung',
                     'content_html' => $this->getMailTemplateContent($technicalName, self::LOCALE_DE_DE, true),
                     'content_plain' => $this->getMailTemplateContent($technicalName, self::LOCALE_DE_DE, false),
                 ],
                 [
                     'mail_template_id' => $values['templateId'],
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'New document for your order',
                     'content_html' => $this->getMailTemplateContent($technicalName, self::LOCALE_EN_GB, true),
                     'content_plain' => $this->getMailTemplateContent($technicalName, self::LOCALE_EN_GB, false),

--- a/src/Core/Migration/V6_4/Migration1657173907DownloadMailTemplate.php
+++ b/src/Core/Migration/V6_4/Migration1657173907DownloadMailTemplate.php
@@ -195,9 +195,9 @@ class Migration1657173907DownloadMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Your downloads from {{ salesChannel.name }} are ready',
+                    'subject' => 'Your downloads from {{ salesChannel.translated.name }} are ready',
                     'description' => 'Shopware Default Template',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -211,9 +211,9 @@ class Migration1657173907DownloadMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Your downloads from {{ salesChannel.name }} are ready',
+                    'subject' => 'Your downloads from {{ salesChannel.translated.name }} are ready',
                     'description' => 'Shopware Default Template',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -227,9 +227,9 @@ class Migration1657173907DownloadMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Ihre Dateien von {{ salesChannel.name }} stehen bereit',
+                    'subject' => 'Ihre Dateien von {{ salesChannel.translated.name }} stehen bereit',
                     'description' => 'Shopware Default Template',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_5/Migration1672931011ReviewFormMailTemplate.php
+++ b/src/Core/Migration/V6_5/Migration1672931011ReviewFormMailTemplate.php
@@ -75,14 +75,14 @@ class Migration1672931011ReviewFormMailTemplate extends MigrationStep
         $translations = new Translations(
             [
                 'mail_template_id' => $templateId,
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'subject' => 'Neue Produktbewertung',
                 'content_html' => $this->getMailTemplateContent(self::LOCALE_DE_DE, true),
                 'content_plain' => $this->getMailTemplateContent(self::LOCALE_DE_DE, false),
             ],
             [
                 'mail_template_id' => $templateId,
-                'sender_name' => '{{ salesChannel.name }}',
+                'sender_name' => '{{ salesChannel.translated.name }}',
                 'subject' => 'New product review',
                 'content_html' => $this->getMailTemplateContent(self::LOCALE_EN_GB, true),
                 'content_plain' => $this->getMailTemplateContent(self::LOCALE_EN_GB, false),

--- a/src/Core/Migration/V6_5/Migration1688106315AddMissingTransactionMailTemplates.php
+++ b/src/Core/Migration/V6_5/Migration1688106315AddMissingTransactionMailTemplates.php
@@ -57,12 +57,12 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 'translations' => [
                     'en' => [
                         'name' => 'Enter payment state: Authorized',
-                        'subject' => 'The order at {{ salesChannel.name }} was authorized',
+                        'subject' => 'The order at {{ salesChannel.translated.name }} was authorized',
                         'description' => 'Shopware Basis Template',
                     ],
                     'de' => [
                         'name' => 'Eintritt Zahlungsstatus: Autorisiert',
-                        'subject' => 'Die Bestellung bei {{ salesChannel.name }} wurde autorisiert',
+                        'subject' => 'Die Bestellung bei {{ salesChannel.translated.name }} wurde autorisiert',
                         'description' => 'Shopware Basis Template',
                     ],
                 ],
@@ -81,12 +81,12 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 'translations' => [
                     'en' => [
                         'name' => 'Enter payment state: Chargeback',
-                        'subject' => 'Chargeback for your order with {{ salesChannel.name }}',
+                        'subject' => 'Chargeback for your order with {{ salesChannel.translated.name }}',
                         'description' => 'Shopware Basis Template',
                     ],
                     'de' => [
                         'name' => 'Eintritt Zahlungsstatus: Rückbuchung',
-                        'subject' => 'Rückbuchung für Ihre Bestellung bei {{ salesChannel.name }}',
+                        'subject' => 'Rückbuchung für Ihre Bestellung bei {{ salesChannel.translated.name }}',
                         'description' => 'Shopware Basis Template',
                     ],
                 ],
@@ -105,11 +105,11 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 'translations' => [
                     'en' => [
                         'name' => 'Enter payment state: Unconfirmed',
-                        'subject' => 'Your order with {{ salesChannel.name }} is unconfirmed',
+                        'subject' => 'Your order with {{ salesChannel.translated.name }} is unconfirmed',
                         'description' => 'Shopware Basis Template',
                     ],
                     'de' => [
-                        'name' => 'Ihre Bestellung bei {{ salesChannel.name }} ist unbestätigt',
+                        'name' => 'Ihre Bestellung bei {{ salesChannel.translated.name }} ist unbestätigt',
                         'subject' => '',
                         'description' => 'Shopware Basis Template',
                     ],
@@ -241,7 +241,7 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 [
                     'subject' => $mail['translations']['en']['subject'],
                     'description' => $mail['translations']['en']['description'],
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -257,7 +257,7 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 [
                     'subject' => $mail['translations']['en']['subject'],
                     'description' => $mail['translations']['en']['description'],
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -273,7 +273,7 @@ class Migration1688106315AddMissingTransactionMailTemplates extends MigrationSte
                 [
                     'subject' => $mail['translations']['de']['subject'],
                     'description' => $mail['translations']['de']['description'],
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_6/Migration1736824370MigrationMailTemplateForDocument.php
+++ b/src/Core/Migration/V6_6/Migration1736824370MigrationMailTemplateForDocument.php
@@ -58,14 +58,14 @@ class Migration1736824370MigrationMailTemplateForDocument extends MigrationStep
             $translations = new Translations(
                 [
                     'mail_template_id' => $mailTemplateId,
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'Neues Dokument für Ihre Bestellung',
                     'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, true),
                     'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, false),
                 ],
                 [
                     'mail_template_id' => $mailTemplateId,
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'New document for your order',
                     'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, true),
                     'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, false),

--- a/src/Core/Migration/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11Y.php
+++ b/src/Core/Migration/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11Y.php
@@ -73,14 +73,14 @@ class Migration1737105721MigrateOrderStateChangeDocumentToA11Y extends Migration
             $translations = new Translations(
                 [
                     'mail_template_id' => $mailTemplateId,
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'Neues Dokument für Ihre Bestellung',
                     'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, true),
                     'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, false),
                 ],
                 [
                     'mail_template_id' => $mailTemplateId,
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'subject' => 'New document for your order',
                     'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, true),
                     'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, false),

--- a/src/Core/Migration/V6_7/Migration1763377570CreatePasswordChangeMailTemplate.php
+++ b/src/Core/Migration/V6_7/Migration1763377570CreatePasswordChangeMailTemplate.php
@@ -135,7 +135,7 @@ class Migration1763377570CreatePasswordChangeMailTemplate extends MigrationStep
                 'mail_template_translation',
                 [
                     'subject' => 'Customer password changed',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -150,7 +150,7 @@ class Migration1763377570CreatePasswordChangeMailTemplate extends MigrationStep
                 'mail_template_translation',
                 [
                     'subject' => 'Customer password changed',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -165,7 +165,7 @@ class Migration1763377570CreatePasswordChangeMailTemplate extends MigrationStep
                 'mail_template_translation',
                 [
                     'subject' => 'Kunden-Password geändert',
-                    'sender_name' => '{{ salesChannel.name }}',
+                    'sender_name' => '{{ salesChannel.translated.name }}',
                     'content_html' => '',
                     'content_plain' => '',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the sender name of mails is `{{ salesChannel.name }}`. This leads to the language inheritance chain not working. 

### 2. What does this change do, exactly?

Changed migrations to set sender name and subject to `{{ salesChannel.translated.name }}` to support lanugage inheritance.

This will obviously not change existing installations, but new installs will have correct values.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

fixes #1715 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
