### PR TITLE
chore: Deprecate unused class `TemplateGroup`

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -84,6 +84,7 @@ When a mismatch is detected, the command provides a clear error message indicati
 
 When you use `#[Serialized]` field in your attribute entity you should always pass the serializer explicitly, as the default serializer does not work as expected.
 Additionally, the `SerializerField` will become internal in the next major release, as that field should be only used for attribute entities, but never directly in classic `EntityDefinitions`.
+
 ### Deprecation of unused `TemplateGroup` class
 
 The class `\Shopware\Core\Content\Seo\SeoUrlTemplate\TemplateGroup` has been deprecated as it is unused and will be removed in the next major version v6.8.0.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -84,6 +84,9 @@ When a mismatch is detected, the command provides a clear error message indicati
 
 When you use `#[Serialized]` field in your attribute entity you should always pass the serializer explicitly, as the default serializer does not work as expected.
 Additionally, the `SerializerField` will become internal in the next major release, as that field should be only used for attribute entities, but never directly in classic `EntityDefinitions`.
+### Deprecation of unused `TemplateGroup` class
+
+The class `\Shopware\Core\Content\Seo\SeoUrlTemplate\TemplateGroup` has been deprecated as it is unused and will be removed in the next major version v6.8.0.
 
 ## Administration
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -492,6 +492,10 @@ Instead of using the `link` property of the `manufacturer` entity directly, the 
 
 The increment-based message queue statistics system (displayed indexing progress notifications in the Administration) has been removed.
 
+### Removed deprecated `TemplateGroup` class
+
+The deprecated class `\Shopware\Core\Content\Seo\SeoUrlTemplate\TemplateGroup` has been removed.
+
 **Removed components:**
 
 - `IncrementGatewayRegistry::MESSAGE_QUEUE_POOL` constant and related `message_queue` increment

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -427,30 +427,6 @@ parameters:
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteRegistry.php
 
 		-
-			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:__construct\(\) has parameter \$salesChannels with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
-
-		-
-			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:getSalesChannelIds\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
-
-		-
-			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:getSalesChannels\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
-
-		-
-			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:setSalesChannels\(\) has parameter \$salesChannels with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
-
-		-
 			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Provider\\CustomUrlProvider\:\:isAvailableForSalesChannel\(\) has parameter \$url with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
@@ -4,11 +4,15 @@ namespace Shopware\Core\Content\Seo\SeoUrlTemplate;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed with the next major version, as it is unused
+ */
 #[Package('inventory')]
 class TemplateGroup
 {
     /**
      * @param array<string> $salesChannelIds
+     * @param array<string, mixed> $salesChannels
      */
     public function __construct(
         private readonly string $languageId,
@@ -28,16 +32,25 @@ class TemplateGroup
         return $this->template;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getSalesChannelIds(): array
     {
         return $this->salesChannelIds;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getSalesChannels(): array
     {
         return $this->salesChannels;
     }
 
+    /**
+     * @param array<string, mixed> $salesChannels
+     */
     public function setSalesChannels(array $salesChannels): void
     {
         $this->salesChannels = $salesChannels;

--- a/src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
+++ b/src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Seo\SeoUrlTemplate;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -20,15 +21,20 @@ class TemplateGroup
         private readonly array $salesChannelIds,
         private array $salesChannels = []
     ) {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
     }
 
     public function getLanguageId(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
+
         return $this->languageId;
     }
 
     public function getTemplate(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
+
         return $this->template;
     }
 
@@ -37,6 +43,8 @@ class TemplateGroup
      */
     public function getSalesChannelIds(): array
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
+
         return $this->salesChannelIds;
     }
 
@@ -45,6 +53,8 @@ class TemplateGroup
      */
     public function getSalesChannels(): array
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
+
         return $this->salesChannels;
     }
 
@@ -53,6 +63,8 @@ class TemplateGroup
      */
     public function setSalesChannels(array $salesChannels): void
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'without replacement as it isn\'t used anymore.'));
+
         $this->salesChannels = $salesChannels;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Just I stumbled upon an unused class.

### 2. What does this change do, exactly?
Deprecate the class.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
