### PR TITLE
perf: Memoize twig env for script rules

### DIFF
--- a/src/Core/Framework/DependencyInjection/script.xml
+++ b/src/Core/Framework/DependencyInjection/script.xml
@@ -26,6 +26,8 @@
             <argument type="service" id="twig.extension.debug"/>
             <argument type="tagged_iterator" tag="shopware.app_script.twig.extension"/>
             <argument>%kernel.shopware_version%</argument>
+
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="Shopware\Core\Framework\Script\ScriptDefinition">

--- a/src/Core/Framework/Script/Execution/Script.php
+++ b/src/Core/Framework/Script/Execution/Script.php
@@ -4,12 +4,12 @@ namespace Shopware\Core\Framework\Script\Execution;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
-use Twig\Cache\FilesystemCache;
+use Twig\Cache\CacheInterface;
 
 /**
  * @internal only for use by the app-system
  *
- * @phpstan-type TwigOptions array{cache?: FilesystemCache, debug?: bool, auto_reload?: bool}
+ * @phpstan-type TwigOptions array{cache?: CacheInterface, debug?: bool, auto_reload?: bool}
  */
 #[Package('framework')]
 class Script extends Struct

--- a/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
+++ b/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
@@ -5,6 +5,8 @@ namespace Shopware\Core\Framework\Script\Execution;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Util\Hasher;
+use Symfony\Contracts\Service\ResetInterface;
 use Twig\Extension\DebugExtension;
 use Twig\Extension\ExtensionInterface;
 
@@ -12,8 +14,13 @@ use Twig\Extension\ExtensionInterface;
  * @internal
  */
 #[Package('framework')]
-class ScriptEnvironmentFactory
+class ScriptEnvironmentFactory implements ResetInterface
 {
+    /**
+     * @var array<string, TwigEnvironment>
+     */
+    private array $twigEnvs = [];
+
     /**
      * @param iterable<ExtensionInterface> $twigExtensions
      *
@@ -28,6 +35,12 @@ class ScriptEnvironmentFactory
 
     public function initEnv(Script $script): TwigEnvironment
     {
+        $scriptHash = Hasher::hash($script->getName() . $script->getScript());
+
+        if (isset($this->twigEnvs[$scriptHash])) {
+            return $this->twigEnvs[$scriptHash];
+        }
+
         $twig = new TwigEnvironment(
             new ScriptTwigLoader($script),
             $script->getTwigOptions()
@@ -45,6 +58,11 @@ class ScriptEnvironmentFactory
             'version' => $this->shopwareVersion,
         ]));
 
-        return $twig;
+        return $this->twigEnvs[$scriptHash] = $twig;
+    }
+
+    public function reset(): void
+    {
+        $this->twigEnvs = [];
     }
 }

--- a/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
+++ b/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
@@ -37,7 +37,7 @@ class ScriptEnvironmentFactory implements ResetInterface
 
     public function initEnv(Script $script): TwigEnvironment
     {
-        $scriptHash = Hasher::hash($script->getName() . $script->getScript());
+        $scriptHash = Hasher::hash($script->getName() . $script->getScript() . serialize($script->getTwigOptions()));
 
         if (isset($this->twigEnvs[$scriptHash])) {
             return $this->twigEnvs[$scriptHash];

--- a/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
+++ b/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
@@ -61,7 +61,7 @@ class ScriptEnvironmentFactory implements ResetInterface
         ]));
 
         // memoize 250 envs at max, to prevent memory leaks
-        if (count($this->twigEnvs) < self::CACHE_LIMIT) {
+        if (\count($this->twigEnvs) < self::CACHE_LIMIT) {
             $this->twigEnvs[$scriptHash] = $twig;
         }
 

--- a/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
+++ b/src/Core/Framework/Script/Execution/ScriptEnvironmentFactory.php
@@ -16,6 +16,8 @@ use Twig\Extension\ExtensionInterface;
 #[Package('framework')]
 class ScriptEnvironmentFactory implements ResetInterface
 {
+    private const CACHE_LIMIT = 250;
+
     /**
      * @var array<string, TwigEnvironment>
      */
@@ -58,7 +60,12 @@ class ScriptEnvironmentFactory implements ResetInterface
             'version' => $this->shopwareVersion,
         ]));
 
-        return $this->twigEnvs[$scriptHash] = $twig;
+        // memoize 250 envs at max, to prevent memory leaks
+        if (count($this->twigEnvs) < self::CACHE_LIMIT) {
+            $this->twigEnvs[$scriptHash] = $twig;
+        }
+
+        return $twig;
     }
 
     public function reset(): void

--- a/tests/unit/Core/Framework/Script/Execution/ScriptEnvironmentFactoryTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptEnvironmentFactoryTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Script\Execution;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\Extension\PhpSyntaxExtension;
+use Shopware\Core\Framework\Script\Execution\Script;
+use Shopware\Core\Framework\Script\Execution\ScriptEnvironmentFactory;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Twig\Cache\NullCache;
+use Twig\Extension\DebugExtension;
+
+/**
+ * @internal
+ */
+#[CoversClass(ScriptEnvironmentFactory::class)]
+class ScriptEnvironmentFactoryTest extends TestCase
+{
+    public function testInitEnv(): void
+    {
+        $debug = new DebugExtension();
+        $syntaxExtension = new PhpSyntaxExtension();
+        $factory = new ScriptEnvironmentFactory($debug, [$syntaxExtension], '6.7.0');
+
+        $script = new Script('s', '{{ 1 }}', new \DateTimeImmutable());
+        $cache = new NullCache();
+        $script->setTwigOptions(['cache' => $cache, 'debug' => false]);
+
+        $env = $factory->initEnv($script);
+
+        // globals
+        $globals = $env->getGlobals();
+        static::assertArrayHasKey('shopware', $globals);
+        static::assertInstanceOf(ArrayStruct::class, $globals['shopware']);
+        static::assertSame('6.7.0', $globals['shopware']->get('version'));
+
+        // extension added
+        static::assertSame($syntaxExtension, $env->getExtension(PhpSyntaxExtension::class));
+        // debug is false, therefore no debug extension
+        static::assertFalse($env->hasExtension(DebugExtension::class));
+
+        // cache is set
+        static::assertSame($cache, $env->getCache());
+    }
+
+    public function testCacheDistinctForDifferentScripts(): void
+    {
+        $factory = new ScriptEnvironmentFactory(new DebugExtension(), [], '6.7.0');
+
+        $script = new Script('s', '{{ 1 }}', new \DateTimeImmutable());
+        $env1 = $factory->initEnv($script);
+        $env2 = $factory->initEnv($script);
+
+        static::assertSame($env1, $env2);
+
+        $script2 = new Script('s', '{{ 2 }}', new \DateTimeImmutable());
+        $env3 = $factory->initEnv($script2);
+
+        static::assertNotSame($env1, $env3);
+    }
+
+    public function testReset(): void
+    {
+        $factory = new ScriptEnvironmentFactory(new DebugExtension(), [], '6.7.0');
+
+        $script = new Script('s', '{{ 1 }}', new \DateTimeImmutable());
+
+        $env1 = $factory->initEnv($script);
+        $env2 = $factory->initEnv($script);
+
+        static::assertSame($env1, $env2);
+
+        $factory->reset();
+
+        $env3 = $factory->initEnv($script);
+        static::assertNotSame($env1, $env3);
+    }
+
+    public function testAddsDebugExtensionWhenDebugOptionTrue(): void
+    {
+        $debug = new DebugExtension();
+        $factory = new ScriptEnvironmentFactory($debug, [], '6.7.0');
+
+        $script = new Script('s', '{{ 1 }}', new \DateTimeImmutable());
+        $script->setTwigOptions(['debug' => true]);
+
+        $env = $factory->initEnv($script);
+
+        static::assertSame($debug, $env->getExtension(DebugExtension::class));
+    }
+}


### PR DESCRIPTION

### 1. Why is this change necessary?
For every script we execute we always created a new twig environment, however setting up the environment can take up a considerable amount of time, see following trace: https://app.blackfire.io/profiles/5e471a11-2f94-407d-8945-685869fcaf4c/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=focused&settings%5BtabPane%5D=nodes&selected=Twig%5CEnvironment%3A%3AaddExtension%3Fe883a653b9cd4fdf23d4287099a1f7d9&callname=Shopware%5CCore%5CFramework%5CRule%5CScriptRule%3A%3Amatch

In that case there is only one script condition in there, but we execute that condition a few thousand times, and therefore create new twig envs a thousand times 

### 2. What does this change do, exactly?
Memoize twig environment, so we only create it once per script per request

### 3. Describe each step to reproduce the issue or behaviour.
See blackfire trace 

### 4. Please link to the relevant issues (if any).
Relates to https://github.com/shopware/shopware/issues/14861
ofc we should go forward and load rules only once per request as in the linked issue, but this will make loading of the rules also 
