### PR TITLE
fix: missing exclude regulation price extension when encoding calculated price

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\RegulationPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRule;
@@ -32,6 +33,10 @@ class CalculatedPriceFieldSerializer extends JsonFieldSerializer
         unset($value['extensions']);
         if (isset($value['listPrice'])) {
             unset($value['listPrice']['extensions']);
+        }
+
+        if (isset($value['regulationPrice'])) {
+            unset($value['regulationPrice']['extensions']);
         }
 
         $data->setValue($value);
@@ -88,6 +93,13 @@ class CalculatedPriceFieldSerializer extends JsonFieldSerializer
             );
         }
 
+        $regulationPrice = null;
+        if (isset($decoded['regulationPrice'])) {
+            $regulationPrice = new RegulationPrice(
+                (float) $decoded['regulationPrice']['price']
+            );
+        }
+
         return new CalculatedPrice(
             (float) $decoded['unitPrice'],
             (float) $decoded['totalPrice'],
@@ -95,7 +107,8 @@ class CalculatedPriceFieldSerializer extends JsonFieldSerializer
             new TaxRuleCollection($taxRules),
             (int) $decoded['quantity'],
             $referencePriceDefinition,
-            $listPrice
+            $listPrice,
+            $regulationPrice
         );
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\FieldSerializer;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\RegulationPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRule;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CalculatedPriceFieldSerializer;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Version\CalculatedPriceFieldTestDefinition;
+
+/**
+ * @internal
+ */
+class CalculatedPriceFieldSerializerTest extends TestCase
+{
+    use CacheTestBehaviour;
+    use DataAbstractionLayerFieldTestBehaviour;
+    use KernelTestBehaviour;
+
+    private CalculatedPriceFieldSerializer $serializer;
+
+    private CalculatedPriceField $field;
+
+    private EntityExistence $existence;
+
+    private WriteParameterBag $parameters;
+
+    protected function setUp(): void
+    {
+        $this->serializer = static::getContainer()->get(CalculatedPriceFieldSerializer::class);
+        $this->field = new CalculatedPriceField('calculatedPrice', 'calculatedPrice');
+
+        $definition = $this->registerDefinition(CalculatedPriceFieldTestDefinition::class);
+        $this->existence = new EntityExistence($definition->getEntityName(), [], false, false, false, []);
+
+        $this->parameters = new WriteParameterBag(
+            $definition,
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            '',
+            new WriteCommandQueue()
+        );
+    }
+
+    public function testEncodeRittou(): void
+    {
+        $listPriceWithExtensions = ListPrice::createFromUnitPrice(100, 100);
+        $listPriceWithExtensions->addArrayExtension('test', ['test' => 'test']);
+
+        $regulationPriceWithExtensions = new RegulationPrice(100);
+        $regulationPriceWithExtensions->addArrayExtension('test', ['test' => 'test']);
+
+        $calculatedPrice = new CalculatedPrice(
+            100,
+            100,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection([new TaxRule(19, 50), new TaxRule(7, 50)]),
+            1,
+            new ReferencePrice(100, 100, 100, 'reference unit'),
+            $listPriceWithExtensions,
+            $regulationPriceWithExtensions
+        );
+
+        $encoded = $this->serializer->encode(
+            $this->field,
+            $this->existence,
+            new KeyValuePair('calculatedPrice', $calculatedPrice, true),
+            $this->parameters
+        );
+
+        $arrayEncoded = \json_decode($encoded->current(), true);
+
+        // check if the listPrice and regulationPrice extensions are not encoded
+        static::assertArrayNotHasKey('extensions', $arrayEncoded);
+        static::assertArrayHasKey('listPrice', $arrayEncoded);
+        static::assertArrayNotHasKey('extensions', $arrayEncoded['listPrice']);
+        static::assertArrayHasKey('regulationPrice', $arrayEncoded);
+        static::assertArrayNotHasKey('extensions', $arrayEncoded['regulationPrice']);
+    }
+
+    public function testDecodeRittou(): void
+    {
+        $calculatedPrice = new CalculatedPrice(
+            100,
+            100,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection([new TaxRule(19, 50), new TaxRule(7, 50)]),
+            1,
+            new ReferencePrice(100, 100, 100, 'reference unit'),
+            ListPrice::createFromUnitPrice(100, 100),
+            new RegulationPrice(100)
+        );
+
+        $encoded = iterator_to_array($this->serializer->encode(
+            $this->field,
+            $this->existence,
+            new KeyValuePair('calculatedPrice', $calculatedPrice, true),
+            $this->parameters
+        ));
+
+        $decoded = $this->serializer->decode($this->field, $encoded['calculatedPrice']);
+        // to array to compare the values and ignore the object type, avoid phpstan errors
+        $calculatedPriceArray = json_decode(json_encode($calculatedPrice, \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        $decodedArray = json_decode(json_encode($decoded, \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertSame($calculatedPriceArray, $decodedArray);
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
@@ -1,12 +1,14 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\FieldSerializer;
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\RegulationPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRule;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
@@ -26,6 +28,7 @@ use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Version\Calcu
 /**
  * @internal
  */
+#[CoversClass(CalculatedPriceFieldSerializer::class)]
 class CalculatedPriceFieldSerializerTest extends TestCase
 {
     use CacheTestBehaviour;
@@ -56,7 +59,7 @@ class CalculatedPriceFieldSerializerTest extends TestCase
         );
     }
 
-    public function testEncodeRittou(): void
+    public function testEncodeStripsExtensionsFromCalculatedPriceListPriceAndRegulationPrice(): void
     {
         $listPriceWithExtensions = ListPrice::createFromUnitPrice(100, 100);
         $listPriceWithExtensions->addArrayExtension('test', ['test' => 'test']);
@@ -75,16 +78,15 @@ class CalculatedPriceFieldSerializerTest extends TestCase
             $regulationPriceWithExtensions
         );
 
-        $encoded = $this->serializer->encode(
+        $encoded = iterator_to_array($this->serializer->encode(
             $this->field,
             $this->existence,
             new KeyValuePair('calculatedPrice', $calculatedPrice, true),
             $this->parameters
-        );
+        ));
 
-        $arrayEncoded = \json_decode($encoded->current(), true);
+        $arrayEncoded = \json_decode($encoded['calculatedPrice'], true, 512, \JSON_THROW_ON_ERROR);
 
-        // check if the listPrice and regulationPrice extensions are not encoded
         static::assertArrayNotHasKey('extensions', $arrayEncoded);
         static::assertArrayHasKey('listPrice', $arrayEncoded);
         static::assertArrayNotHasKey('extensions', $arrayEncoded['listPrice']);
@@ -92,7 +94,59 @@ class CalculatedPriceFieldSerializerTest extends TestCase
         static::assertArrayNotHasKey('extensions', $arrayEncoded['regulationPrice']);
     }
 
-    public function testDecodeRittou(): void
+    public function testEncodeWithoutListPrice(): void
+    {
+        $calculatedPrice = new CalculatedPrice(
+            50,
+            50,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection([new TaxRule(19, 100)]),
+            1,
+            null,
+            null,
+            new RegulationPrice(50)
+        );
+
+        $encoded = iterator_to_array($this->serializer->encode(
+            $this->field,
+            $this->existence,
+            new KeyValuePair('calculatedPrice', $calculatedPrice, true),
+            $this->parameters
+        ));
+
+        $arrayEncoded = \json_decode($encoded['calculatedPrice'], true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertNull($arrayEncoded['listPrice'] ?? null);
+        static::assertArrayHasKey('regulationPrice', $arrayEncoded);
+    }
+
+    public function testEncodeWithoutRegulationPrice(): void
+    {
+        $calculatedPrice = new CalculatedPrice(
+            50,
+            50,
+            new CalculatedTaxCollection(),
+            new TaxRuleCollection([new TaxRule(19, 100)]),
+            1,
+            null,
+            ListPrice::createFromUnitPrice(50, 50),
+            null
+        );
+
+        $encoded = iterator_to_array($this->serializer->encode(
+            $this->field,
+            $this->existence,
+            new KeyValuePair('calculatedPrice', $calculatedPrice, true),
+            $this->parameters
+        ));
+
+        $arrayEncoded = \json_decode($encoded['calculatedPrice'], true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertArrayHasKey('listPrice', $arrayEncoded);
+        static::assertNull($arrayEncoded['regulationPrice'] ?? null);
+    }
+
+    public function testDecodeRoundtrip(): void
     {
         $calculatedPrice = new CalculatedPrice(
             100,
@@ -113,9 +167,61 @@ class CalculatedPriceFieldSerializerTest extends TestCase
         ));
 
         $decoded = $this->serializer->decode($this->field, $encoded['calculatedPrice']);
-        // to array to compare the values and ignore the object type, avoid phpstan errors
+
         $calculatedPriceArray = json_decode(json_encode($calculatedPrice, \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
         $decodedArray = json_decode(json_encode($decoded, \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
         static::assertSame($calculatedPriceArray, $decodedArray);
+    }
+
+    public function testDecodeReturnsNullForNull(): void
+    {
+        static::assertNull($this->serializer->decode($this->field, null));
+    }
+
+    public function testDecodeReturnsNullForNonArray(): void
+    {
+        static::assertNull($this->serializer->decode($this->field, '123'));
+    }
+
+    public function testDecodeWithMinimalDataWithoutReferencePriceListPriceAndRegulationPrice(): void
+    {
+        $minimalJson = json_encode([
+            'unitPrice' => 10.0,
+            'totalPrice' => 10.0,
+            'quantity' => 1,
+            'taxRules' => [['taxRate' => 19.0, 'percentage' => 100.0]],
+            'calculatedTaxes' => [['tax' => 1.6, 'taxRate' => 19.0, 'price' => 10.0]],
+        ], \JSON_THROW_ON_ERROR);
+
+        $decoded = $this->serializer->decode($this->field, $minimalJson);
+
+        static::assertInstanceOf(CalculatedPrice::class, $decoded);
+        static::assertSame(10.0, $decoded->getUnitPrice());
+        static::assertSame(10.0, $decoded->getTotalPrice());
+        static::assertNull($decoded->getReferencePrice());
+        static::assertNull($decoded->getListPrice());
+        static::assertNull($decoded->getRegulationPrice());
+    }
+
+    public function testDecodeWithCalculatedTaxLabel(): void
+    {
+        $jsonWithLabel = json_encode([
+            'unitPrice' => 100.0,
+            'totalPrice' => 100.0,
+            'quantity' => 1,
+            'taxRules' => [['taxRate' => 19.0, 'percentage' => 100.0]],
+            'calculatedTaxes' => [
+                ['tax' => 19.0, 'taxRate' => 19.0, 'price' => 100.0, 'label' => 'VAT 19%'],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $decoded = $this->serializer->decode($this->field, $jsonWithLabel);
+
+        static::assertInstanceOf(CalculatedPrice::class, $decoded);
+        $calculatedTaxes = $decoded->getCalculatedTaxes();
+        static::assertCount(1, $calculatedTaxes);
+        $first = $calculatedTaxes->first();
+        static::assertInstanceOf(CalculatedTax::class, $first);
+        static::assertSame('VAT 19%', $first->getLabel());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This pull request adds support for handling the `RegulationPrice` property in the `CalculatedPriceFieldSerializer`, ensuring it is properly encoded and decoded alongside existing price properties.


### 2. What does this change do, exactly?
**Fix to CalculatedPrice serialization:**

* Added import and handling for the `RegulationPrice` struct in `CalculatedPriceFieldSerializer.php`, ensuring it is included during both encoding and decoding processes [[1]](diffhunk://#diff-81236d2f975036d62d2e9e3df7e2ed59bde57a9554138b0ddeeb5fea69d138adR8) [[2]](diffhunk://#diff-81236d2f975036d62d2e9e3df7e2ed59bde57a9554138b0ddeeb5fea69d138adR96-R111).
* Updated the `encode` method to strip `extensions` from the `regulationPrice` field, similar to how it's done for `listPrice`.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a product that has a regulated price
- Add that product to the cart
- Check out with that cart -> Errors would be there

### 4. Please link to the relevant issues (if any).
- closes #14647 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
