### PR TITLE
feat: Enforce only boolean values in conditions

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -22,7 +22,7 @@ parameters:
 
     # For stricter testing those should be set to true at some point
     strictRules:
-        booleansInConditions: false
+        booleansInConditions: true
         booleansInLoopConditions: false
         requireParentConstructorCall: false
         disallowedEmpty: false


### PR DESCRIPTION
### 1. Why is this change necessary?

Similar to the [prevention of `empty` usage](https://github.com/shopware/shopware/pull/13986), the implicit boolean cast in conditions should also be forbidden. 
Here the same reasoning applies, that it is better to check explicitly what type and value are expected.

### 2. What does this change do, exactly?

Enable PHPStan strict rule `booleansInConditions`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
