### PR TITLE
fix: integrate sw-upload-listener component for media uploads

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.html.twig
@@ -89,6 +89,11 @@
                     {% endblock %}
 
                     {% block sw_media_field_upload_component %}
+                    <sw-upload-listener
+                        :upload-tag="uploadTag"
+                        auto-upload
+                        @media-upload-finish="exposeNewId"
+                    />
                     <sw-media-upload-v2
                         v-if="showUploadField"
                         variant="regular"

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
@@ -21,6 +21,7 @@ describe('src/app/component/media/sw-media-field', () => {
                     `,
                     },
                     'sw-media-upload-v2': true,
+                    'sw-upload-listener': true,
                     'sw-simple-search-field': true,
                     'sw-loader': true,
                     'sw-pagination': true,
@@ -140,5 +141,28 @@ describe('src/app/component/media/sw-media-field', () => {
         expect(config).toEqual({
             targetSelector: '.mt-modal__content-inner',
         });
+    });
+
+    it('should render sw-upload-listener with correct upload tag and auto-upload', async () => {
+        const wrapper = await createWrapper();
+        await wrapper.setData({ showPicker: true });
+
+        const uploadListener = wrapper.find('sw-upload-listener-stub');
+
+        expect(uploadListener.exists()).toBe(true);
+        expect(uploadListener.attributes('upload-tag')).toBe(wrapper.vm.uploadTag);
+        expect(uploadListener.attributes()).toHaveProperty('auto-upload');
+    });
+
+    it('should set media id and close picker when upload finishes', async () => {
+        const wrapper = await createWrapper();
+        await wrapper.setData({ showPicker: true, showUploadField: true });
+
+        const targetId = 'new-media-id-123';
+        wrapper.vm.exposeNewId({ targetId });
+
+        expect(wrapper.emitted('update:value')).toEqual([[targetId]]);
+        expect(wrapper.vm.showUploadField).toBe(false);
+        expect(wrapper.vm.showPicker).toBe(false);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

File uploads in media custom fields are broken — the upload gets stuck at 0% and never completes. This is because the `sw-media-field` component queues uploads via `mediaService.addUploads()` but never triggers their execution via `mediaService.runUploads()`.

### 2. What does this change do, exactly?

Adds an `sw-upload-listener` component to `sw-media-field` with `auto-upload` enabled, wired to the existing `exposeNewId` method. This follows the same pattern used in all other media upload contexts (e.g. `sw-manufacturer-detail`, `sw-media-modal-v2`). The listener triggers `runUploads()` when files are added and sets the resulting media ID on upload completion.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a custom field set with a media-type custom field
2. Assign it to an entity (e.g. products)
3. Open a product in the admin, navigate to the custom fields section
4. Click the media field, toggle to "Upload new", and select a file
5. Observe the upload is stuck at 0% and never completes

After the fix, the upload completes and the media ID is set on the custom field.

### 4. Please link to the relevant issues (if any).

- closes #14640

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them