### PR TITLE
fix(theme-manager): Ensure general tab to be first in order

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -1,5 +1,6 @@
 import template from './sw-theme-manager-detail.html.twig';
 import './sw-theme-manager-detail.scss';
+
 /**
  * @package discovery
  */
@@ -145,16 +146,26 @@ Component.register('sw-theme-manager-detail', {
             return this.theme.id === this.defaultTheme.id;
         },
 
-        tabItems() {
+        orderedTabs() {
             const tabs = this.structuredThemeFields?.tabs || {};
-            const entries = Object.entries(tabs);
+            if (!Object.prototype.hasOwnProperty.call(tabs, 'default')) {
+                return tabs;
+            }
 
-            const items = entries.map(([name, tab]) => ({
+            const { default: defaultTab, ...nonDefaultTabs } = tabs;
+            return {
+                default: defaultTab,
+                ...nonDefaultTabs,
+            };
+        },
+
+        tabItems() {
+            const entries = Object.entries(this.orderedTabs);
+
+            return entries.map(([name, tab]) => ({
                 name,
                 label: this.getTabLabel(tab.labelSnippetKey, tab.label) || name,
             }));
-
-            return items;
         }
     },
 
@@ -798,7 +809,7 @@ Component.register('sw-theme-manager-detail', {
         selectionDisablingMethod(selection) {
             if (!this.isDefaultTheme) {
                 return false;
-        }
+            }
 
             return this.theme.getOrigin().salesChannels.has(selection.id);
         },

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -136,7 +136,7 @@
                         >
                             <sw-tabs-item
                                 v-if="hasMoreThanOneTab"
-                                v-for="(tab, tabName) in structuredThemeFields.tabs"
+                                v-for="(tab, tabName) in orderedTabs"
                                 :key="tabName"
                                 :title="getTabLabel(tab.labelSnippetKey, tab.label)"
                                 :name="tabName"

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.spec.js
@@ -160,6 +160,24 @@ describe('sw-theme-manager-detail', () => {
         expect(wrapper.vm.isDerived).toBe(true);
     });
 
+    it('should keep default tab first without reordering other tabs', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.structuredThemeFields = {
+            tabs: {
+                layout: { labelSnippetKey: 'layout' },
+                advanced: { labelSnippetKey: 'advanced' },
+                default: { labelSnippetKey: 'default' },
+            },
+        };
+
+        expect(Object.keys(wrapper.vm.orderedTabs)).toEqual([
+            'default',
+            'layout',
+            'advanced',
+        ]);
+    });
+
     it('sanitizes CSS values', async () => {
         const wrapper = await createWrapper();
 


### PR DESCRIPTION
fixes: #13218

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
General is not the first tab

### 2. What does this change do, exactly?
It should be the first tab

### 3. Describe each step to reproduce the issue or behaviour.
Try demo zip file from ticket and install it.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
