### PR TITLE
chore: immediately flush delay cache invalidation

### DIFF
--- a/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
@@ -7,6 +7,8 @@ use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\AbstractInvalidatorStorage;
+use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
+use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\ReverseProxyCache;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Backtrace\BacktraceCollector;
 use Shopware\Core\PlatformRequest;
@@ -38,7 +40,8 @@ class CacheInvalidator
         private readonly bool $softPurge,
         private readonly bool $useDelayedCache,
         private readonly bool $tagInvalidationLogEnabled,
-        private readonly BacktraceCollector $backtraceCollector
+        private readonly BacktraceCollector $backtraceCollector,
+        private readonly ?AbstractReverseProxyGateway $reverseProxyGateway = null
     ) {
         $this->httpCacheStore = new Psr16Cache($httpCacheStore);
     }
@@ -88,6 +91,14 @@ class CacheInvalidator
         }
 
         $this->purge($tags);
+
+        /**
+         * when we want to invalidate the expired cache tags, we also want to invalidate the reverse proxy cache immediately
+         * flush happens usually on __destruct, meaning after response was sent to the client
+         *
+         * @see ReverseProxyCache::__destruct
+         */
+        $this->reverseProxyGateway?->flush();
 
         return $tags;
     }

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -56,6 +56,7 @@
             <argument>%shopware.cache.invalidation.delay_enabled%</argument>
             <argument>%shopware.cache.invalidation.tag_invalidation_log_enabled%</argument>
             <argument type="service" id="Shopware\Core\Framework\Util\Backtrace\BacktraceCollector"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway" on-invalid="null"/>
         </service>
 
         <service id="Shopware\Core\Framework\Adapter\Cache\InvalidateCacheTask">

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -10,6 +10,7 @@ use Psr\Log\NullLogger;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorage;
+use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Util\Backtrace\BacktraceCollector;
 use Shopware\Core\Framework\Util\Backtrace\Frame;
@@ -54,7 +55,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate([]);
@@ -94,7 +96,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createBacktraceCollectorMock('Foo', 'a')
+            $this->createBacktraceCollectorMock('Foo', 'a'),
+            null
         );
 
         $invalidator->invalidate(['foo'], true);
@@ -134,7 +137,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             false,
             true,
-            $this->createBacktraceCollectorMock('Foo', 'a')
+            $this->createBacktraceCollectorMock('Foo', 'a'),
+            null
         );
 
         $invalidator->invalidate(['foo']);
@@ -169,7 +173,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             false,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate(['foo']);
@@ -197,7 +202,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate(['foo']);
@@ -228,7 +234,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             false,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidateExpired();
@@ -262,6 +269,9 @@ class CacheInvalidatorTest extends TestCase
                 ]
             );
 
+        $reverseProxyGateway = $this->createMock(AbstractReverseProxyGateway::class);
+        $reverseProxyGateway->expects($this->once())->method('flush');
+
         $invalidator = new CacheInvalidator(
             [
                 $tagAwareAdapter,
@@ -274,7 +284,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             false,
             true,
-            $this->createBacktraceCollectorMock(CacheInvalidationSubscriber::class, 'invalidatePropertyFilters')
+            $this->createBacktraceCollectorMock(CacheInvalidationSubscriber::class, 'invalidatePropertyFilters'),
+            $reverseProxyGateway
         );
 
         $invalidator->invalidateExpired();
@@ -312,7 +323,8 @@ class CacheInvalidatorTest extends TestCase
             true,
             true,
             true,
-            $this->createBacktraceCollectorMock(CacheInvalidationSubscriber::class, 'invalidatePropertyFilters')
+            $this->createBacktraceCollectorMock(CacheInvalidationSubscriber::class, 'invalidatePropertyFilters'),
+            null
         );
 
         $invalidator->invalidate(['foo'], true);
@@ -349,7 +361,8 @@ class CacheInvalidatorTest extends TestCase
             true,
             true,
             true,
-            $this->createBacktraceCollectorMock()
+            $this->createBacktraceCollectorMock(),
+            null
         );
 
         $invalidator->invalidate(['foo'], true);
@@ -374,7 +387,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate(['foo']);
@@ -414,7 +428,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate(['foo']);
@@ -452,7 +467,8 @@ class CacheInvalidatorTest extends TestCase
             false,
             true,
             true,
-            $this->createMock(BacktraceCollector::class)
+            $this->createMock(BacktraceCollector::class),
+            null
         );
 
         $invalidator->invalidate(['foo']);


### PR DESCRIPTION


### 1. Why is this change necessary?
ATS in SaaS v2 is failing

One reason: 
We change system config, invalidate delayed caches, check homepage for changes -> which might run into edge cases where the cache is not yet invalidated -> because by default the reverse proxy gateway will only send out the purge request after the client already got the 204 response, which is unexpected

### 2. What does this change do, exactly?
When we invalidate the delayed cache, we immedietly flush the reverse proxy gateway, so we actually send the purge requests to the reverse proxy before the operation/request finishes, this should limit edge cases

### 3. Describe each step to reproduce the issue or behaviour.

see ats fails in v2 infra
