### PR TITLE
fix: Do not try to create a list price of `0`

### DIFF
--- a/src/Core/Checkout/Cart/Price/GrossPriceCalculator.php
+++ b/src/Core/Checkout/Cart/Price/GrossPriceCalculator.php
@@ -88,6 +88,10 @@ class GrossPriceCalculator
 
         $listPrice = $this->priceRounding->cashRound($price, $config);
 
+        if ($listPrice <= 0) {
+            return null;
+        }
+
         return ListPrice::createFromUnitPrice($unitPrice, $listPrice);
     }
 

--- a/src/Core/Checkout/Cart/Price/NetPriceCalculator.php
+++ b/src/Core/Checkout/Cart/Price/NetPriceCalculator.php
@@ -73,6 +73,10 @@ class NetPriceCalculator
             $listPrice = $this->round($listPrice, $config);
         }
 
+        if ($listPrice <= 0) {
+            return null;
+        }
+
         return ListPrice::createFromUnitPrice($unitPrice, $listPrice);
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
@@ -86,7 +86,7 @@ class CalculatedPriceFieldSerializer extends JsonFieldSerializer
         }
 
         $listPrice = null;
-        if (isset($decoded['listPrice']) && (float) $decoded['listPrice']['price'] > 0) {
+        if (isset($decoded['listPrice']) && ((float) ($decoded['listPrice']['price'] ?? 0)) > 0) {
             $listPrice = ListPrice::createFromUnitPrice(
                 (float) $decoded['unitPrice'],
                 (float) $decoded['listPrice']['price']

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializer.php
@@ -86,7 +86,7 @@ class CalculatedPriceFieldSerializer extends JsonFieldSerializer
         }
 
         $listPrice = null;
-        if (isset($decoded['listPrice'])) {
+        if (isset($decoded['listPrice']) && (float) $decoded['listPrice']['price'] > 0) {
             $listPrice = ListPrice::createFromUnitPrice(
                 (float) $decoded['unitPrice'],
                 (float) $decoded['listPrice']['price']

--- a/tests/unit/Core/Checkout/Cart/Price/GrossPriceCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/GrossPriceCalculatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\CashRounding;
 use Shopware\Core\Checkout\Cart\Price\GrossPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePriceDefinition;
@@ -106,6 +107,36 @@ class GrossPriceCalculatorTest extends TestCase
         yield 'test calculation with reference price' => [
             100,
             new RegulationPrice(100),
+        ];
+    }
+
+    #[DataProvider('listPriceCalculationProvider')]
+    public function testListPriceCalculation(?float $listPriceValue, ?ListPrice $expected): void
+    {
+        $definition = new QuantityPriceDefinition(100, new TaxRuleCollection(), 1);
+        $definition->setListPrice($listPriceValue);
+
+        $calculator = new GrossPriceCalculator(new TaxCalculator(), new CashRounding());
+        $price = $calculator->calculate($definition, new CashRoundingConfig(2, 0.01, true));
+
+        static::assertEquals($expected, $price->getListPrice());
+    }
+
+    public static function listPriceCalculationProvider(): \Generator
+    {
+        yield 'test calculation without list price' => [
+            null,
+            null,
+        ];
+
+        yield 'test calculation with zero list price' => [
+            0.0,
+            null,
+        ];
+
+        yield 'test calculation with valid list price' => [
+            200.0,
+            ListPrice::createFromUnitPrice(100, 200),
         ];
     }
 

--- a/tests/unit/Core/Checkout/Cart/Price/NetPriceCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/NetPriceCalculatorTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\CashRounding;
 use Shopware\Core\Checkout\Cart\Price\NetPriceCalculator;
+use Shopware\Core\Checkout\Cart\Price\Struct\ListPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePriceDefinition;
@@ -83,6 +84,36 @@ class NetPriceCalculatorTest extends TestCase
         yield 'test calculation with reference price' => [
             100,
             new RegulationPrice(100),
+        ];
+    }
+
+    #[DataProvider('listPriceCalculationProvider')]
+    public function testListPriceCalculation(?float $listPriceValue, ?ListPrice $expected): void
+    {
+        $definition = new QuantityPriceDefinition(100, new TaxRuleCollection(), 1);
+        $definition->setListPrice($listPriceValue);
+
+        $calculator = new NetPriceCalculator(new TaxCalculator(), new CashRounding());
+        $price = $calculator->calculate($definition, new CashRoundingConfig(2, 0.01, true));
+
+        static::assertEquals($expected, $price->getListPrice());
+    }
+
+    public static function listPriceCalculationProvider(): \Generator
+    {
+        yield 'test calculation without list price' => [
+            null,
+            null,
+        ];
+
+        yield 'test calculation with zero list price' => [
+            0.0,
+            null,
+        ];
+
+        yield 'test calculation with valid list price' => [
+            200.0,
+            ListPrice::createFromUnitPrice(100, 200),
         ];
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/CalculatedPriceFieldSerializerTest.php
@@ -224,4 +224,69 @@ class CalculatedPriceFieldSerializerTest extends TestCase
         static::assertInstanceOf(CalculatedTax::class, $first);
         static::assertSame('VAT 19%', $first->getLabel());
     }
+
+    public function testDecodeWithZeroListPrice(): void
+    {
+        $field = new CalculatedPriceField('price', 'price');
+
+        $data = [
+            'unitPrice' => 100,
+            'totalPrice' => 100,
+            'quantity' => 1,
+            'calculatedTaxes' => [],
+            'taxRules' => [],
+            'listPrice' => [
+                'price' => 0,
+                'discount' => 0,
+                'percentage' => 0,
+            ],
+        ];
+
+        $result = $this->serializer->decode($field, json_encode($data, \JSON_THROW_ON_ERROR));
+
+        static::assertInstanceOf(CalculatedPrice::class, $result);
+        static::assertNull($result->getListPrice());
+    }
+
+    public function testDecodeWithValidListPrice(): void
+    {
+        $field = new CalculatedPriceField('price', 'price');
+
+        $data = [
+            'unitPrice' => 100,
+            'totalPrice' => 100,
+            'quantity' => 1,
+            'calculatedTaxes' => [],
+            'taxRules' => [],
+            'listPrice' => [
+                'price' => 200,
+                'discount' => -100,
+                'percentage' => 50,
+            ],
+        ];
+
+        $result = $this->serializer->decode($field, json_encode($data, \JSON_THROW_ON_ERROR));
+
+        static::assertInstanceOf(CalculatedPrice::class, $result);
+        static::assertInstanceOf(ListPrice::class, $result->getListPrice());
+        static::assertSame(200.0, $result->getListPrice()->getPrice());
+    }
+
+    public function testDecodeWithoutListPrice(): void
+    {
+        $field = new CalculatedPriceField('price', 'price');
+
+        $data = [
+            'unitPrice' => 100,
+            'totalPrice' => 100,
+            'quantity' => 1,
+            'calculatedTaxes' => [],
+            'taxRules' => [],
+        ];
+
+        $result = $this->serializer->decode($field, json_encode($data, \JSON_THROW_ON_ERROR));
+
+        static::assertInstanceOf(CalculatedPrice::class, $result);
+        static::assertNull($result->getListPrice());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
In our case it was that an external system (Channable through Tiktok) create an order with a `listPrice.price` of "0.0". 

Then loading the order failed, as there occurred a division by zero.

### 2. What does this change do, exactly?
Check all calling places of the `ListPrice::createFromUnitPrice` that the list price is greater than zero.

### 3. Describe each step to reproduce the issue or behaviour.
Create an order with a `listPrice.price` of "0.0".

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
