### PR TITLE
test: Update tests using StorefrontHeader.mainNavigationLink

### DIFF
--- a/tests/acceptance/tests/Categories/PageNotFound.spec.ts
+++ b/tests/acceptance/tests/Categories/PageNotFound.spec.ts
@@ -12,6 +12,7 @@ test(
             `We are sorry, the page you're looking for could not be found. It may no longer exist or may have been moved.`
         );
         await ShopCustomer.presses(StorefrontPageNotFound.backToShopButton);
-        await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).toContainText('Home');
+        const numOfLocators = await StorefrontHeader.mainNavigationLink.count();
+        ShopCustomer.expects(numOfLocators).toBeGreaterThan(0);
     }
 );

--- a/tests/acceptance/tests/Categories/PageNotFound.spec.ts
+++ b/tests/acceptance/tests/Categories/PageNotFound.spec.ts
@@ -12,6 +12,6 @@ test(
             `We are sorry, the page you're looking for could not be found. It may no longer exist or may have been moved.`
         );
         await ShopCustomer.presses(StorefrontPageNotFound.backToShopButton);
-        await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).toBeVisible();
+        await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).toContainText('Home');
     }
 );

--- a/tests/acceptance/tests/Categories/PageNotFound.spec.ts
+++ b/tests/acceptance/tests/Categories/PageNotFound.spec.ts
@@ -3,7 +3,7 @@ import { test } from '@fixtures/AcceptanceTest';
 test(
     'As a customer, I want to see 404 layout when I navigate to a non-existing page.',
     { tag: ['@Categories', '@Storefront'] },
-    async ({ ShopCustomer, StorefrontPageNotFound, StorefrontHome }) => {
+    async ({ ShopCustomer, StorefrontPageNotFound, StorefrontHeader }) => {
         await ShopCustomer.goesTo(StorefrontPageNotFound.url());
 
         await ShopCustomer.expects(StorefrontPageNotFound.pageNotFoundImage).toBeVisible();
@@ -12,6 +12,6 @@ test(
             `We are sorry, the page you're looking for could not be found. It may no longer exist or may have been moved.`
         );
         await ShopCustomer.presses(StorefrontPageNotFound.backToShopButton);
-        await ShopCustomer.expects(StorefrontHome.mainNavigationLink).toContainText('Home');
+        await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).toBeVisible();
     }
 );

--- a/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
+++ b/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
@@ -19,16 +19,17 @@ test(
         await test.step('Validate that the full header and footer are visible on the product detail page.', async () => {
             await ShopCustomer.goesTo(StorefrontProductDetail.url(basicProduct));
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).toBeVisible();
-            await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).toContainText('Home');
+            const numOfLocators = await StorefrontHeader.mainNavigationLink.count();
+            ShopCustomer.expects(numOfLocators).toBeGreaterThan(0);
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContent).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHotline).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContactForm).toBeVisible();
         });
-        
+
         await test.step('Validate that the full header and footer are not visible on the checkout page.', async () => {
             await ShopCustomer.attemptsTo(AddProductToCart(basicProduct));
-            await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());        
+            await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).not.toBeVisible();
             await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).not.toBeVisible();

--- a/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
+++ b/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
@@ -19,7 +19,7 @@ test(
         await test.step('Validate that the full header and footer are visible on the product detail page.', async () => {
             await ShopCustomer.goesTo(StorefrontProductDetail.url(basicProduct));
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).toBeVisible();
-            await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).toBeVisible();
+            await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContent).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHotline).toBeVisible();
@@ -30,7 +30,7 @@ test(
             await ShopCustomer.attemptsTo(AddProductToCart(basicProduct));
             await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());        
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).not.toBeVisible();
-            await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).not.toBeVisible();
+            await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContent).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHotline).not.toBeVisible();

--- a/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
+++ b/tests/acceptance/tests/Checkout/ReducedHeaderAndFooterDuringCheckout.spec.ts
@@ -19,7 +19,7 @@ test(
         await test.step('Validate that the full header and footer are visible on the product detail page.', async () => {
             await ShopCustomer.goesTo(StorefrontProductDetail.url(basicProduct));
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).toBeVisible();
-            await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).toBeVisible();
+            await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).toContainText('Home');
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContent).toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHotline).toBeVisible();
@@ -30,7 +30,7 @@ test(
             await ShopCustomer.attemptsTo(AddProductToCart(basicProduct));
             await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());        
             await ShopCustomer.expects(StorefrontSearchSuggest.searchInput).not.toBeVisible();
-            await ShopCustomer.expects(StorefrontHeader.page.getByRole('link', { name: 'Home', exact: true })).not.toBeVisible();
+            await ShopCustomer.expects(StorefrontHeader.mainNavigationLink).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHeadline).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerContent).not.toBeVisible();
             await ShopCustomer.expects(StorefrontFooter.footerHotline).not.toBeVisible();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The `StorefrontHeader.mainNavigationLink` locator resolves to multiple elements if there is more than 1 category. 

### 2. What does this change do, exactly?

Updates tests to check number of navigation links instead of locator visibility.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
