### PR TITLE
feat: Update rector and add rules for refactoring empty

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -1,24 +1,23 @@
 <?php declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
+use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
+use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
+use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector;
+use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
-use Shopware\Commercial\Test\Annotation\ActiveFeatureToggles;
 use Rector\Config\RectorConfig;
-use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
-use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
     ->withSymfonyContainerXml(__DIR__ . '/var/cache/phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml')
     ->withPaths([
-        __DIR__ . '/config',
-        __DIR__ . '/custom',
-        __DIR__ . '/public',
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
     ->withFileExtensions(['php'])
     ->withSkip([
         __DIR__ . '/src/Core/Framework/Script/ServiceStubs.php',
-        __DIR__ . '/src/Recovery',
 
         '**/vendor/*',
         '**/node_modules/*',
@@ -26,7 +25,11 @@ return RectorConfig::configure()
     ])
     ->withRules([
         ClassConstantToSelfClassRector::class,
+        DisallowedEmptyRuleFixerRector::class,
+        CountArrayToEmptyArrayComparisonRector::class,
+        SimplifyEmptyArrayCheckRector::class,
+        SimplifyEmptyCheckOnEmptyArrayRector::class,
+        StrlenZeroToIdenticalEmptyStringRector::class,
+        TernaryEmptyArrayArrayDimFetchToCoalesceRector::class,
     ])
-    ->withConfiguredRule(AnnotationToAttributeRector::class, [
-        new AnnotationToAttribute(ActiveFeatureToggles::class),
-    ]);
+;

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "rector/rector": "^1.2.0"
+        "rector/rector": "^2.3.6"
     },
     "sort-packages": true
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Automatic refactoring in preparation for https://github.com/shopware/shopware/pull/13986

After that it should be clarified, if we want to use rector in CI

### 2. What does this change do, exactly?

- Update rector to latest version
- Add rules all related to refactoring the usage of `empty`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
