### PR TITLE
feat: Refactor empty usage in tests to prepare its prohibition

### DIFF
--- a/tests/devops/Core/Test/AnnotationTagTest.php
+++ b/tests/devops/Core/Test/AnnotationTagTest.php
@@ -203,7 +203,7 @@ class AnnotationTagTest extends TestCase
     private function getCurrentManifestVersion(array $versions): string
     {
         $versions = array_filter($versions);
-        if (empty($versions)) {
+        if ($versions === []) {
             throw new \LogicException('no version applied');
         }
 

--- a/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
@@ -104,7 +104,7 @@ class AdminExtensionApiControllerTest extends TestCase
             return;
         }
 
-        if (empty($hosts)) {
+        if ($hosts === []) {
             static::assertIsString($targetUrl);
             $this->expectException(AppException::class);
             $this->expectExceptionMessage(\sprintf('The host "%s" you tried to call is not listed in the allowed hosts in the manifest file for app "%s".', $targetUrl, $appName));

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/DataAbstractionLayer/Indexer/PromotionExclusionIndexerTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/DataAbstractionLayer/Indexer/PromotionExclusionIndexerTest.php
@@ -103,7 +103,7 @@ class PromotionExclusionIndexerTest extends TestCase
             'name' => $name,
         ];
 
-        if (\count($exclusions) > 0) {
+        if ($exclusions !== []) {
             $data['exclusionIds'] = $exclusions;
         }
 

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/DeliveryPromotionCalculationTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/DeliveryPromotionCalculationTest.php
@@ -632,7 +632,7 @@ class DeliveryPromotionCalculationTest extends TestCase
             $data[]['id'] = $id;
         }
 
-        if (\count($data) === 0) {
+        if ($data === []) {
             return;
         }
         $this->promotionRepository->delete($data, $this->context->getContext());

--- a/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
@@ -235,7 +235,7 @@ class CreditNoteRendererTest extends TestCase
             'fileTypes' => [HtmlRenderer::FILE_EXTENSION, PdfRenderer::FILE_EXTENSION],
         ];
 
-        if (!empty($additionalConfig)) {
+        if ($additionalConfig !== []) {
             $config = array_merge($config, $additionalConfig);
         }
 

--- a/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
@@ -190,7 +190,7 @@ class StornoRendererTest extends TestCase
             'displayHeader' => true,
         ];
 
-        if (!empty($additionalConfig)) {
+        if ($additionalConfig !== []) {
             $config = array_merge($config, $additionalConfig);
         }
 

--- a/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
+++ b/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
@@ -133,7 +133,7 @@ class GenerateDocumentActionTest extends TestCase
         $subscriber->handleFlow($flow);
 
         $referenceDoctype = $documentType === StornoRenderer::TYPE || $documentType === CreditNoteRenderer::TYPE;
-        if ($referenceDoctype && !$autoGenInvoiceDoc && empty($multipleDoc)) {
+        if ($referenceDoctype && !$autoGenInvoiceDoc && $multipleDoc === false) {
             static::assertEmpty($this->getDocumentId($order->getId()));
         } else {
             static::assertNotEmpty($this->getDocumentId($order->getId()));

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportActionControllerTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportActionControllerTest.php
@@ -351,7 +351,7 @@ class ImportExportActionControllerTest extends TestCase
         }
         $fileSystem->dumpFile($file, $content);
 
-        if ($forceFileName !== '' && $forceFileName !== '0') {
+        if ($forceFileName !== '') {
             $fileName = $forceFileName;
         }
 

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportActionControllerTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportActionControllerTest.php
@@ -351,7 +351,7 @@ class ImportExportActionControllerTest extends TestCase
         }
         $fileSystem->dumpFile($file, $content);
 
-        if (!empty($forceFileName)) {
+        if ($forceFileName !== '' && $forceFileName !== '0') {
             $fileName = $forceFileName;
         }
 

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportFileApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportFileApiTest.php
@@ -84,7 +84,7 @@ class ImportExportFileApiTest extends TestCase
     {
         foreach ([0, 5] as $num) {
             $data = $this->prepareImportExportFileTestData($num);
-            if (!empty($data)) {
+            if ($data !== []) {
                 $this->repository->create(array_values($data), $this->context);
             }
 

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportLogApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportLogApiTest.php
@@ -82,7 +82,7 @@ class ImportExportLogApiTest extends TestCase
     {
         foreach ([0, 5] as $num) {
             $data = $this->prepareImportExportLogTestData($num);
-            if (!empty($data)) {
+            if ($data !== []) {
                 $this->logRepository->create(array_values($data), $this->context);
             }
 

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
@@ -94,7 +94,7 @@ class ImportExportProfileApiTest extends TestCase
         foreach ([0, 5] as $num) {
             // Create test data.
             $data = $this->prepareImportExportProfileTestData($num);
-            if (!empty($data)) {
+            if ($data !== []) {
                 $this->repository->create(array_values($data), $this->context);
             }
 

--- a/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
+++ b/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
@@ -163,7 +163,7 @@ class DeleteExpiredFilesServiceTest extends TestCase
     {
         // Ensure no files exist
         $allFiles = $this->fileRepository->searchIds(new Criteria(), $this->context)->getIds();
-        if (!empty($allFiles)) {
+        if ($allFiles !== []) {
             $deleteData = array_map(fn ($id) => ['id' => $id], $allFiles);
             $this->fileRepository->delete($deleteData, $this->context);
         }

--- a/tests/integration/Core/Content/Media/Command/GenerateThumbnailsCommandTest.php
+++ b/tests/integration/Core/Content/Media/Command/GenerateThumbnailsCommandTest.php
@@ -377,7 +377,7 @@ class GenerateThumbnailsCommandTest extends TestCase
 
     private function getNewMediaEntities(): MediaCollection
     {
-        if (!empty($this->initialMediaIds)) {
+        if ($this->initialMediaIds !== []) {
             $criteria = new Criteria($this->initialMediaIds);
             $result = $this->mediaRepository->searchIds($criteria, $this->context);
             static::assertSame(\count($this->initialMediaIds), $result->getTotal());
@@ -385,7 +385,7 @@ class GenerateThumbnailsCommandTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addAssociation('thumbnails');
-        if (!empty($this->initialMediaIds)) {
+        if ($this->initialMediaIds !== []) {
             $criteria->addFilter(new NotFilter(
                 NotFilter::CONNECTION_AND,
                 [

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListingFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListingFilterOutOfStockTest.php
@@ -220,7 +220,7 @@ class ProductListingFilterOutOfStockTest extends TestCase
             ],
         ];
 
-        if (!empty($options)) {
+        if ($options !== []) {
             foreach ($options as $index => $option) {
                 $combination = $option['combination'];
 

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
@@ -335,7 +335,7 @@ class ProductListingTest extends TestCase
             ],
         ];
 
-        if (!empty($options)) {
+        if ($options !== []) {
             foreach ($this->combos($options) as $index => $combination) {
                 $variantKey = $key . '-' . implode('-', $this->testData->getKeyList($combination));
 

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchFilterOutOfStockTest.php
@@ -226,7 +226,7 @@ class ProductSearchFilterOutOfStockTest extends TestCase
             ],
         ];
 
-        if (!empty($options)) {
+        if ($options !== []) {
             foreach ($options as $index => $option) {
                 // $combination = $this->combos($option['combination']);
                 $combination = $option['combination'];

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSuggestFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSuggestFilterOutOfStockTest.php
@@ -224,7 +224,7 @@ class ProductSuggestFilterOutOfStockTest extends TestCase
             ],
         ];
 
-        if (!empty($options)) {
+        if ($options !== []) {
             foreach ($options as $index => $option) {
                 // $combination = $this->combos($option['combination']);
                 $combination = $option['combination'];

--- a/tests/integration/Core/Content/Seo/SeoUrlGeneratorTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlGeneratorTest.php
@@ -135,7 +135,7 @@ class SeoUrlGeneratorTest extends TestCase
         static::assertIsIterable($urls);
 
         foreach ($urls as $url) {
-            if (!empty($pathInfo)) {
+            if ($pathInfo !== '' && $pathInfo !== '0') {
                 static::assertStringEndsWith($pathInfo, $url->getSeoPathInfo());
             }
         }

--- a/tests/integration/Core/Content/Seo/SeoUrlGeneratorTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlGeneratorTest.php
@@ -11,7 +11,6 @@ use Psr\Log\AbstractLogger;
 use Psr\Log\NullLogger;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlGenerator;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
@@ -95,7 +94,6 @@ class SeoUrlGeneratorTest extends TestCase
         $route = $this->seoUrlRouteRegistry->findByRouteName(TestNavigationSeoUrlRoute::ROUTE_NAME);
         static::assertInstanceOf(SeoUrlRouteInterface::class, $route);
 
-        /** @var \Traversable<SeoUrlEntity> $urls */
         $urls = $this->seoUrlGenerator->generate(
             [$id],
             $template,
@@ -123,7 +121,6 @@ class SeoUrlGeneratorTest extends TestCase
         $route = $this->seoUrlRouteRegistry->findByRouteName(TestNavigationSeoUrlRoute::ROUTE_NAME);
         static::assertInstanceOf(SeoUrlRouteInterface::class, $route);
 
-        /** @var SeoUrlEntity[] $urls */
         $urls = $this->seoUrlGenerator->generate(
             [$id],
             $template,
@@ -135,7 +132,7 @@ class SeoUrlGeneratorTest extends TestCase
         static::assertIsIterable($urls);
 
         foreach ($urls as $url) {
-            if ($pathInfo !== '' && $pathInfo !== '0') {
+            if ($pathInfo !== '') {
                 static::assertStringEndsWith($pathInfo, $url->getSeoPathInfo());
             }
         }
@@ -318,10 +315,9 @@ class SeoUrlGeneratorTest extends TestCase
 
         static::assertCount(2, $categoryIds, 'this is important for the test as you need more items to iterate for a context switch test');
 
-        /** @var SeoUrlRouteInterface $seoRoute */
         $seoRoute = $this->seoUrlRouteRegistry->findByRouteName(TestNavigationSeoUrlRoute::ROUTE_NAME);
+        static::assertNotNull($seoRoute);
 
-        /** @var \Generator<SeoUrlEntity> $firstRun */
         $firstRun = $this->seoUrlGenerator->generate(
             $categoryIds,
             'template first run',
@@ -329,7 +325,6 @@ class SeoUrlGeneratorTest extends TestCase
             $this->salesChannelContext->getContext(),
             $this->salesChannelContext->getSalesChannel()
         );
-        /** @var \Generator<SeoUrlEntity> $secondRun */
         $secondRun = $this->seoUrlGenerator->generate(
             $categoryIds,
             'template second run',
@@ -338,7 +333,6 @@ class SeoUrlGeneratorTest extends TestCase
             $this->salesChannelContext->getSalesChannel()
         );
 
-        /** @var SeoUrlEntity $url */
         foreach ($firstRun as $url) {
             static::assertSame('template first run', $url->getSeoPathInfo());
 
@@ -350,7 +344,6 @@ class SeoUrlGeneratorTest extends TestCase
             break;
         }
 
-        /** @var SeoUrlEntity $url */
         foreach ($firstRun as $url) {
             static::assertSame('template first run', $url->getSeoPathInfo());
         }
@@ -360,19 +353,19 @@ class SeoUrlGeneratorTest extends TestCase
     {
         $logger = new class extends AbstractLogger {
             /**
-             * @var mixed[]
+             * @var array<int|string, array<string, list<array<string, mixed>>>>
              */
             public array $logs = [];
 
             /**
              * @param int|string $level
-             * @param mixed[] $context
+             * @param array<string, mixed> $context
              *
              * @throws void
              */
             public function log(mixed $level, string|\Stringable $message, array $context = []): void
             {
-                $this->logs[$level][$message][] = $context;
+                $this->logs[$level][(string) $message][] = $context;
             }
         };
         $seoUrlGenerator = new SeoUrlGenerator(
@@ -384,8 +377,8 @@ class SeoUrlGeneratorTest extends TestCase
             $logger,
         );
 
-        /** @var SeoUrlRouteInterface $seoRoute */
         $seoRoute = $this->seoUrlRouteRegistry->findByRouteName(TestNavigationSeoUrlRoute::ROUTE_NAME);
+        static::assertNotNull($seoRoute);
 
         $urls = $seoUrlGenerator->generate(
             [$this->getValidCategoryId()],
@@ -404,7 +397,6 @@ class SeoUrlGeneratorTest extends TestCase
         static::assertNotSame([], $logger->logs);
         $logger->logs = [];
 
-        /** @var \Generator<SeoUrlEntity> $urls */
         $urls = $seoUrlGenerator->generate(
             [$this->getValidCategoryId()],
             // invalid twig context

--- a/tests/integration/Core/Framework/AdditionalPermissionValidationTest.php
+++ b/tests/integration/Core/Framework/AdditionalPermissionValidationTest.php
@@ -59,7 +59,7 @@ class AdditionalPermissionValidationTest extends TestCase
     {
         $additionalPermission = $this->getAdditionalPermissions();
 
-        if (empty($additionalPermission)) {
+        if ($additionalPermission === []) {
             return;
         }
 
@@ -93,7 +93,7 @@ class AdditionalPermissionValidationTest extends TestCase
             }
         }
 
-        if (!empty($regexParts)) {
+        if ($regexParts !== []) {
             static::fail(\sprintf(
                 'Found additional permission privileges not validated: %s',
                 implode(', ', array_keys($regexParts))

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
@@ -1403,7 +1403,7 @@ class EntityAggregatorTest extends TestCase
             'releaseDate' => $releaseDate,
         ];
 
-        if (!empty($categories)) {
+        if ($categories !== []) {
             $data['categories'] = $categories;
         }
 

--- a/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
@@ -77,7 +77,7 @@ class IdleFeatureFlagTest extends TestCase
             preg_match_all($regex, $contents, $keys);
             $availableFlag = array_unique($keys[0]);
 
-            if (!empty($availableFlag)) {
+            if ($availableFlag !== []) {
                 foreach ($availableFlag as $flag) {
                     if (\in_array($flag, self::EXCLUDE_BY_FLAG, true)) {
                         continue;

--- a/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
+++ b/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
@@ -903,7 +903,7 @@ class LanguageValidatorTest extends TestCase
         } catch (WriteException $exception) {
             $stack = $exception;
         }
-        if (!empty($expectedCodePathPairs)) {
+        if ($expectedCodePathPairs !== []) {
             static::assertInstanceOf(WriteException::class, $stack);
         }
 

--- a/tests/integration/Core/Framework/ServiceDefinitionTest.php
+++ b/tests/integration/Core/Framework/ServiceDefinitionTest.php
@@ -119,7 +119,7 @@ class ServiceDefinitionTest extends TestCase
             \PREG_OFFSET_CAPTURE | \PREG_SET_ORDER
         );
 
-        if (!$result || empty($matches)) {
+        if (!$result || $matches === []) {
             return [];
         }
 
@@ -152,7 +152,7 @@ class ServiceDefinitionTest extends TestCase
         );
 
         // only continue if a Shopware service definition doesn't start with class followed by id
-        if (!$result || empty($matches)) {
+        if (!$result || $matches === []) {
             return [];
         }
 

--- a/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
+++ b/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
@@ -49,7 +49,7 @@ class EntityDefinitionServiceTest extends TestCase
                     }
                 }
 
-                if (\count($missingIdFields) !== 0) {
+                if ($missingIdFields !== []) {
                     $problematicEntities[] = $entityDefinition->getEntityName();
                 }
             }

--- a/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
+++ b/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
@@ -170,7 +170,7 @@ class StorefrontRoutingTest extends TestCase
      */
     private static function generateCases(array $keys, array $config): array
     {
-        if (empty($keys)) {
+        if ($keys === []) {
             return [];
         }
 
@@ -183,7 +183,7 @@ class StorefrontRoutingTest extends TestCase
                 $base = array_merge($base, $childResult);
                 $results[] = $base;
             }
-            if (empty($childResults)) {
+            if ($childResults === []) {
                 $results[] = $base;
             }
         }

--- a/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
+++ b/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
@@ -42,7 +42,7 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         ));
 
         $stateMachineId = $this->connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || empty($stateMachineId)) {
+        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
             return;
         }
 
@@ -99,11 +99,11 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         ));
 
         $stateMachineId = $this->connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || empty($stateMachineId)) {
+        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
             return;
         }
 
-        if (!empty($germanIds)) {
+        if ($germanIds !== []) {
             $this->connection->executeStatement('UPDATE state_machine_translation SET name = :name WHERE state_machine_id = :stateMachineId AND language_id IN (:languageIds) AND updated_at IS NULL', [
                 'name' => 'Bestellstatus',
                 'stateMachineId' => $stateMachineId,
@@ -115,7 +115,7 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
             ]);
         }
 
-        if (!empty($englishIds)) {
+        if ($englishIds !== []) {
             $this->connection->executeStatement('UPDATE state_machine_translation SET name = :name WHERE state_machine_id = :stateMachineId AND language_id IN (:languageIds) AND updated_at IS NULL', [
                 'name' => 'Order state',
                 'stateMachineId' => $stateMachineId,

--- a/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
+++ b/tests/migration/Core/V6_6/Migration1739198249FixOrderDeliveryStateMachineNameTest.php
@@ -42,8 +42,8 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         ));
 
         $stateMachineId = $this->connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
-            return;
+        if (!\is_string($stateMachineId) || $stateMachineId === '') {
+            static::markTestSkipped('No valid state machine found.');
         }
 
         $germanNames = $this->connection->fetchFirstColumn(
@@ -82,7 +82,7 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
     private function executeMigration(): void
     {
         $migration = new Migration1739198249FixOrderDeliveryStateMachineName();
-        static::assertSame($migration->getCreationTimestamp(), 1739198249);
+        static::assertSame(1739198249, $migration->getCreationTimestamp());
 
         $this->rollback();
 
@@ -99,8 +99,8 @@ class Migration1739198249FixOrderDeliveryStateMachineNameTest extends TestCase
         ));
 
         $stateMachineId = $this->connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
-            return;
+        if (!\is_string($stateMachineId) || $stateMachineId === '') {
+            static::markTestSkipped('No valid state machine found.');
         }
 
         if ($germanIds !== []) {

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -57,7 +57,7 @@ class RemoteThumbnailLoaderTest extends TestCase
         static::assertArrayHasKey($ids->get('media'), $actual);
         static::assertSame($expected['media'], $actual[$ids->get('media')]);
 
-        if (\count($thumbnailSizes) > 0) {
+        if ($thumbnailSizes !== []) {
             static::assertIsIterable($entity->get('thumbnails'));
 
             foreach ($entity->get('thumbnails') as $thumbnail) {

--- a/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
@@ -235,7 +235,7 @@ class DownloadResponseGeneratorTest extends TestCase
             $response = new Response(null, 200, $headers);
 
             $locationPath = 'foobar.txt';
-            if ($strategy === DownloadResponseGenerator::X_ACCEL_REDIRECT && !empty($privateLocalPathPrefix)) {
+            if ($strategy === DownloadResponseGenerator::X_ACCEL_REDIRECT && ($privateLocalPathPrefix !== '' && $privateLocalPathPrefix !== '0')) {
                 $locationPath = $privateLocalPathPrefix . '/foobar.txt';
             }
 

--- a/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/File/DownloadResponseGeneratorTest.php
@@ -235,7 +235,7 @@ class DownloadResponseGeneratorTest extends TestCase
             $response = new Response(null, 200, $headers);
 
             $locationPath = 'foobar.txt';
-            if ($strategy === DownloadResponseGenerator::X_ACCEL_REDIRECT && ($privateLocalPathPrefix !== '' && $privateLocalPathPrefix !== '0')) {
+            if ($strategy === DownloadResponseGenerator::X_ACCEL_REDIRECT && $privateLocalPathPrefix !== '') {
                 $locationPath = $privateLocalPathPrefix . '/foobar.txt';
             }
 

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -300,7 +300,7 @@ class ProductStreamUpdaterTest extends TestCase
         $manyToManyFieldUpdater = $this->createMock(ManyToManyIdFieldUpdater::class);
 
         $manyToManyFieldUpdater
-            ->expects(empty($manyToManyUpdatedIds) ? $this->never() : $this->once())
+            ->expects($manyToManyUpdatedIds === [] ? $this->never() : $this->once())
             ->method('update')
             ->with($definition->getEntityName(), $manyToManyUpdatedIds, Context::createDefaultContext(), 'streamIds');
 

--- a/tests/unit/Core/Content/Product/Subscriber/ProductSubscriberTest.php
+++ b/tests/unit/Core/Content/Product/Subscriber/ProductSubscriberTest.php
@@ -735,7 +735,7 @@ class ProductSubscriberTest extends TestCase
     ): void {
         $measurementUnitConverter = $this->createMock(AbstractMeasurementUnitConverter::class);
 
-        if (!empty($expectedConversions)) {
+        if ($expectedConversions !== []) {
             $measurementUnitConverter->expects($this->exactly(\count($expectedConversions)))
                 ->method('convert')
                 ->willReturn(new ConvertedUnit(2.0, 'm'));
@@ -773,7 +773,7 @@ class ProductSubscriberTest extends TestCase
                 return $hasFieldReturns[$field] ?? false;
             });
 
-        if (!empty($expectedConversions)) {
+        if ($expectedConversions !== []) {
             $command->expects($this->exactly(\count($expectedConversions)))
                 ->method('addPayload');
         } else {

--- a/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
@@ -181,7 +181,7 @@ class HealthCheckControllerTest extends TestCase
                 $header = $request->headers->get(HealthCheckController::HEADER_AUTHORIZATION, '');
                 $jwt = \trim((string) \preg_replace('/^\s*Bearer\s/', '', $header));
 
-                if (empty($validBearer) || $jwt !== $validBearer) {
+                if ($validBearer === null || $validBearer === '' || $validBearer === '0' || $jwt !== $validBearer) {
                     throw OAuthServerException::accessDenied('Access token is invalid');
                 }
             }

--- a/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/HealthCheckControllerTest.php
@@ -30,8 +30,7 @@ class HealthCheckControllerTest extends TestCase
 
     public function testCheck(): void
     {
-        $controller = $this->createHealthCheckController();
-        $response = $controller->check(Context::createDefaultContext());
+        $response = $this->createHealthCheckController()->check(Context::createDefaultContext());
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertFalse($response->isCacheable());
@@ -74,15 +73,14 @@ class HealthCheckControllerTest extends TestCase
                 ],
             ],
         ];
-        static::assertIsString($response->getContent());
-        static::assertIsString(json_encode($expectedResponse));
-        static::assertJsonStringEqualsJsonString(json_encode($expectedResponse), $response->getContent());
+        $content = $response->getContent();
+        static::assertIsString($content);
+        static::assertJsonStringEqualsJsonString(json_encode($expectedResponse, \JSON_THROW_ON_ERROR), $content);
     }
 
     public function testEventIsDispatched(): void
     {
-        $controller = $this->createHealthCheckController();
-        $response = $controller->check(Context::createDefaultContext());
+        $response = $this->createHealthCheckController()->check(Context::createDefaultContext());
 
         static::assertCount(1, $this->eventDispatcher->getEvents());
         static::assertInstanceOf(HealthCheckEvent::class, $this->eventDispatcher->getEvents()[0]);
@@ -98,13 +96,13 @@ class HealthCheckControllerTest extends TestCase
         ?string $validBearer = null
     ): void {
         $controller = $this->createHealthCheckController($staticToken, $validBearer);
-        $request = Request::create('', 'GET', []);
+        $request = Request::create('');
         if ($headerValue !== null) {
             $request->headers->set(HealthCheckController::HEADER_AUTHORIZATION, $headerValue);
         }
 
         if ($expectedOAuthServerException) {
-            static::expectException(OAuthServerException::class);
+            $this->expectException(OAuthServerException::class);
         }
 
         $response = $controller->health($request);
@@ -181,7 +179,7 @@ class HealthCheckControllerTest extends TestCase
                 $header = $request->headers->get(HealthCheckController::HEADER_AUTHORIZATION, '');
                 $jwt = \trim((string) \preg_replace('/^\s*Bearer\s/', '', $header));
 
-                if ($validBearer === null || $validBearer === '' || $validBearer === '0' || $jwt !== $validBearer) {
+                if ($validBearer === null || $validBearer === '' || $jwt !== $validBearer) {
                     throw OAuthServerException::accessDenied('Access token is invalid');
                 }
             }

--- a/tests/unit/Core/Framework/Demodata/Generator/ProductGeneratorTest.php
+++ b/tests/unit/Core/Framework/Demodata/Generator/ProductGeneratorTest.php
@@ -213,7 +213,7 @@ class ProductGeneratorTest extends TestCase
             static::assertIsInt($product['stock']);
             static::assertIsArray($product['prices']);
 
-            if (\count($product['prices']) > 0) {
+            if ($product['prices'] !== []) {
                 foreach ($product['prices'] as $price) {
                     static::assertContains($price['ruleId'], $ruleIds);
                     static::assertIsInt($price['quantityStart']);
@@ -269,7 +269,7 @@ class ProductGeneratorTest extends TestCase
                 static::assertIsInt($child['stock']);
                 static::assertIsArray($child['prices']);
 
-                if (\count($child['prices']) > 0) {
+                if ($child['prices'] !== []) {
                     foreach ($child['prices'] as $price) {
                         static::assertContains($price['ruleId'], $ruleIds);
                         static::assertIsInt($price['quantityStart']);

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -575,7 +575,7 @@ class TokenQueryBuilderTest extends TestCase
             ],
         ];
 
-        if (!empty($explainPayload)) {
+        if ($explainPayload !== []) {
             $nested['nested'] = array_merge($nested['nested'], $explainPayload);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
