### PR TITLE
fix: skip VAT ID validation for non-EU company shipping countries

### DIFF
--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -56,21 +56,23 @@ class TaxDetector extends AbstractTaxDetector
             return false;
         }
 
-        if ($shippingLocationCountry->getIsEu()) {
-            $vatPattern = $shippingLocationCountry->getVatIdPattern();
-            $vatIds = array_filter($customer->getVatIds() ?? []);
+        if (!$shippingLocationCountry->getIsEu()) {
+            return true;
+        }
 
-            if ($vatIds === []) {
-                return false;
-            }
+        $vatPattern = $shippingLocationCountry->getVatIdPattern();
+        $vatIds = array_filter($customer->getVatIds() ?? []);
 
-            if ($vatPattern !== null && $vatPattern !== '' && $shippingLocationCountry->getCheckVatIdPattern()) {
-                $regex = '/^' . $vatPattern . '$/';
+        if ($vatIds === []) {
+            return false;
+        }
 
-                foreach ($vatIds as $vatId) {
-                    if (!preg_match($regex, $vatId)) {
-                        return false;
-                    }
+        if ($vatPattern !== null && $vatPattern !== '' && $shippingLocationCountry->getCheckVatIdPattern()) {
+            $regex = '/^' . $vatPattern . '$/';
+
+            foreach ($vatIds as $vatId) {
+                if (!preg_match($regex, $vatId)) {
+                    return false;
                 }
             }
         }

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -56,19 +56,21 @@ class TaxDetector extends AbstractTaxDetector
             return false;
         }
 
-        $vatPattern = $shippingLocationCountry->getVatIdPattern();
-        $vatIds = array_filter($customer->getVatIds() ?? []);
+        if ($shippingLocationCountry->getIsEu()) {
+            $vatPattern = $shippingLocationCountry->getVatIdPattern();
+            $vatIds = array_filter($customer->getVatIds() ?? []);
 
-        if ($vatIds === []) {
-            return false;
-        }
+            if ($vatIds === []) {
+                return false;
+            }
 
-        if ($vatPattern !== null && $vatPattern !== '' && $shippingLocationCountry->getCheckVatIdPattern()) {
-            $regex = '/^' . $vatPattern . '$/';
+            if ($vatPattern !== null && $vatPattern !== '' && $shippingLocationCountry->getCheckVatIdPattern()) {
+                $regex = '/^' . $vatPattern . '$/';
 
-            foreach ($vatIds as $vatId) {
-                if (!preg_match($regex, $vatId)) {
-                    return false;
+                foreach ($vatIds as $vatId) {
+                    if (!preg_match($regex, $vatId)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/tests/integration/Core/Checkout/Cart/CartRuleLoaderTest.php
+++ b/tests/integration/Core/Checkout/Cart/CartRuleLoaderTest.php
@@ -50,6 +50,7 @@ class CartRuleLoaderTest extends TestCase
         $country->setActive(true);
         $country->setShippingAvailable(true);
         $country->setCheckVatIdPattern(false);
+        $country->setIsEu(false);
 
         $currency = new CurrencyEntity();
         $currency->setId(Uuid::randomHex());

--- a/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -295,6 +295,58 @@ class TaxDetectorTest extends TestCase
         static::assertTrue($detector->isNetDelivery($context));
     }
 
+    public function testIsNetDeliveryWithCompanyFreeTaxAndEuCountryWithEmptyVatIdPattern(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => null,
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['DE123456789'],
+        ]);
+
+        $context->expects($this->once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($country)
+        );
+        $context->expects($this->once())->method('getCustomer')->willReturn($customer);
+
+        $detector = static::getContainer()->get(TaxDetector::class);
+        static::assertTrue($detector->isNetDelivery($context));
+    }
+
+    public function testIsNetDeliveryWithCompanyFreeTaxAndEuCountryWithEmptyStringVatIdPattern(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['FR12345678901'],
+        ]);
+
+        $context->expects($this->once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($country)
+        );
+        $context->expects($this->once())->method('getCustomer')->willReturn($customer);
+
+        $detector = static::getContainer()->get(TaxDetector::class);
+        static::assertTrue($detector->isNetDelivery($context));
+    }
+
     public function testIsNotNetDelivery(): void
     {
         $context = $this->createMock(SalesChannelContext::class);

--- a/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -347,6 +347,58 @@ class TaxDetectorTest extends TestCase
         static::assertTrue($detector->isNetDelivery($context));
     }
 
+    public function testIsNetDeliveryWithCompanyFreeTaxAndEuCountryWithValidVatIdMatchingPattern(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['DE123456789'],
+        ]);
+
+        $context->expects($this->once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($country)
+        );
+        $context->expects($this->once())->method('getCustomer')->willReturn($customer);
+
+        $detector = static::getContainer()->get(TaxDetector::class);
+        static::assertTrue($detector->isNetDelivery($context));
+    }
+
+    public function testIsNotNetDeliveryWithCompanyFreeTaxAndEuCountryWithInvalidVatIdPattern(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['INVALID-VAT'],
+        ]);
+
+        $context->expects($this->once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($country)
+        );
+        $context->expects($this->once())->method('getCustomer')->willReturn($customer);
+
+        $detector = static::getContainer()->get(TaxDetector::class);
+        static::assertFalse($detector->isNetDelivery($context));
+    }
+
     public function testIsNotNetDelivery(): void
     {
         $context = $this->createMock(SalesChannelContext::class);

--- a/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -201,6 +201,7 @@ class TaxDetectorTest extends TestCase
         $country = (new CountryEntity())->assign([
             'customerTax' => new TaxFreeConfig(false),
             'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
             'vatIdPattern' => '...',
             'checkVatIdPattern' => true,
         ]);
@@ -265,6 +266,30 @@ class TaxDetectorTest extends TestCase
         $context->expects($this->once())->method('getCustomer')->willReturn(
             $customer
         );
+
+        $detector = static::getContainer()->get(TaxDetector::class);
+        static::assertTrue($detector->isNetDelivery($context));
+    }
+
+    public function testIsNetDeliveryWithCompanyFreeTaxAndNonEuCountry(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => false,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'Non-EU Company',
+            'vatIds' => ['ANY-VAT-ID'],
+        ]);
+
+        $context->expects($this->once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($country)
+        );
+        $context->expects($this->once())->method('getCustomer')->willReturn($customer);
 
         $detector = static::getContainer()->get(TaxDetector::class);
         static::assertTrue($detector->isNetDelivery($context));

--- a/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Tax;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Tax\TaxDetector;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\TaxFreeConfig;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[CoversClass(TaxDetector::class)]
+#[Package('checkout')]
+class TaxDetectorTest extends TestCase
+{
+    public function testIsCompanyTaxFreeWithEuCountryAndValidVatIdMatchingPattern(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['DE123456789'],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertTrue($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeWithEuCountryAndInvalidVatIdPattern(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['INVALID-VAT'],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -123,6 +123,24 @@ class TaxDetectorTest extends TestCase
         static::assertSame(CartPrice::TAX_STATE_NET, $detector->getTaxState($context));
     }
 
+    public function testIsCompanyTaxFreeReturnsTrueWhenNonEuCountry(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => false,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'Non-EU Company',
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertTrue($detector->isCompanyTaxFree($context, $country));
+    }
+
     public function testIsCompanyTaxFreeReturnsFalseWhenCustomerIsNull(): void
     {
         $country = (new CountryEntity())->assign([
@@ -132,6 +150,27 @@ class TaxDetectorTest extends TestCase
 
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('getCustomer')->willReturn(null);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeReturnsFalseWhenEuCountryAndEmptyVatIds(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => [],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
 
         $detector = new TaxDetector();
         static::assertFalse($detector->isCompanyTaxFree($context, $country));

--- a/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Tax/TaxDetectorTest.php
@@ -4,10 +4,14 @@ namespace Shopware\Tests\Unit\Core\Checkout\Cart\Tax;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\TaxDetector;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\TaxFreeConfig;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -51,6 +55,158 @@ class TaxDetectorTest extends TestCase
         $customer = (new CustomerEntity())->assign([
             'company' => 'EU Company',
             'vatIds' => ['INVALID-VAT'],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testGetDecoratedThrowsDecorationPatternException(): void
+    {
+        $detector = new TaxDetector();
+
+        $this->expectException(DecorationPatternException::class);
+        $this->expectExceptionMessage('The getDecorated() function of core class ' . TaxDetector::class . ' cannot be used. This class is the base class.');
+
+        $detector->getDecorated();
+    }
+
+    public function testGetTaxStateReturnsFreeWhenNetDelivery(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(true),
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getShippingLocation')->willReturn(ShippingLocation::createFromCountry($country));
+
+        $detector = new TaxDetector();
+        static::assertSame(CartPrice::TAX_STATE_FREE, $detector->getTaxState($context));
+    }
+
+    public function testGetTaxStateReturnsGrossWhenNotNetDeliveryAndUseGross(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(false),
+        ]);
+
+        $customerGroup = new CustomerGroupEntity();
+        $customerGroup->setDisplayGross(true);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getShippingLocation')->willReturn(ShippingLocation::createFromCountry($country));
+        $context->method('getCurrentCustomerGroup')->willReturn($customerGroup);
+
+        $detector = new TaxDetector();
+        static::assertSame(CartPrice::TAX_STATE_GROSS, $detector->getTaxState($context));
+    }
+
+    public function testGetTaxStateReturnsNetWhenNotNetDeliveryAndNotUseGross(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'customerTax' => new TaxFreeConfig(false),
+            'companyTax' => new TaxFreeConfig(false),
+        ]);
+
+        $customerGroup = new CustomerGroupEntity();
+        $customerGroup->setDisplayGross(false);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getShippingLocation')->willReturn(ShippingLocation::createFromCountry($country));
+        $context->method('getCurrentCustomerGroup')->willReturn($customerGroup);
+
+        $detector = new TaxDetector();
+        static::assertSame(CartPrice::TAX_STATE_NET, $detector->getTaxState($context));
+    }
+
+    public function testIsCompanyTaxFreeReturnsFalseWhenCustomerIsNull(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => false,
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn(null);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeReturnsFalseWhenCustomerHasNoCompany(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => false,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => null,
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeReturnsFalseWhenCountryCompanyTaxDisabled(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(false),
+            'isEu' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'Test Company',
+            'vatIds' => ['DE123456789'],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertFalse($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeWithEuCountryAndMultipleValidVatIdsMatchingPattern(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['DE123456789', 'DE987654321'],
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+
+        $detector = new TaxDetector();
+        static::assertTrue($detector->isCompanyTaxFree($context, $country));
+    }
+
+    public function testIsCompanyTaxFreeWithEuCountryAndMultipleVatIdsOneInvalidReturnsFalse(): void
+    {
+        $country = (new CountryEntity())->assign([
+            'companyTax' => new TaxFreeConfig(true),
+            'isEu' => true,
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ]);
+
+        $customer = (new CustomerEntity())->assign([
+            'company' => 'EU Company',
+            'vatIds' => ['DE123456789', 'INVALID'],
         ]);
 
         $context = $this->createMock(SalesChannelContext::class);


### PR DESCRIPTION
### 1. Why is this change necessary?
Because VAT ID validation should only apply to EU countries. Requiring it for non-EU countries incorrectly prevents tax-free handling for business customers there.

### 2. What does this change do, exactly?
It enforces VAT ID checks only for EU countries and skips them for non-EU countries, allowing eligible non-EU business customers to remain tax-free.

### 3. Describe each step to reproduce the issue or behaviour.
1. Configure a non-EU country (e.g. United Kingdom) with both "Tax-free (B2C)" and "Tax-free (B2B)" enabled
2. Create a B2B customer (accountType = business) with a company name but no VAT ID (or empty vatIds)
3. Set the customer's shipping address to the UK
4. Add products to cart and go to checkout
5. Expected: No tax is calculated (country is tax-free)
6. Actual: 19% VAT is calculated

### 4. Please link to the relevant issues
- Fixes https://github.com/shopware/shopware/issues/14567

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
