### PR TITLE
fix: Mark TableHelperResetter as public

### DIFF
--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -626,7 +626,8 @@ frame-ancestors 'none';
             <tag name="kernel.reset" method="reset"/>
         </service>
 
-        <service id="Shopware\Core\Framework\Util\Database\TableHelperResetter">
+        <service id="Shopware\Core\Framework\Util\Database\TableHelperResetter" public="true">
+            <!-- Is not used anywhere, so marking it as public, otherwise it would be removed from the container -->
             <tag name="kernel.reset" method="reset"/>
         </service>
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Service will be removed from compiled container, as it is not used anywhere. 
So resetting the TableHelper does currently not work correctly

### 2. What does this change do, exactly?

Mark service as public in definition

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
