### PR TITLE
chore: fix mergeability check for external PRs

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: sts
+        continue-on-error: true
         uses: shopware/octo-sts-action@main
         with:
           scope: shopware


### PR DESCRIPTION
### 1. Why is this change necessary?
External contributors can not get a token to check our internal repos

therefore we already have the continue-on-error step on the rufus and commercial downstream jobs.
However currently the new mergeability job always fails for external contributors.

### 2. What does this change do, exactly?
Continue-on-error when we try to obtain a token and it fails, thus skipping the mergeability check
As externals can't contribute to the internal repos, the downstreams can not be used in those cases anyway

### 3. Describe each step to reproduce the issue or behaviour.
Create a PR as a external contributor, see https://github.com/shopware/shopware/actions/runs/21939432389/job/63361100754?pr=14602
