### PR TITLE
chore: Fix mergeability check when we can't obtain token

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Check downstream mergeability
         uses: actions/github-script@v6
+        if: steps.sts.outputs.token
         with:
           github-token: ${{ steps.sts.outputs.token }}
           script: |


### PR DESCRIPTION
Follow up from https://github.com/shopware/shopware/pull/14927