### PR TITLE
fix: correct order date filter

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -132,6 +132,12 @@ export default {
                 return;
             }
 
+            if (this.dateValue.from) {
+                const from = new Date(this.dateValue.from);
+                from.setHours(0, 0, 0);
+                this.dateValue.from = from.toISOString();
+            }
+
             if (this.dateValue.to) {
                 const to = new Date(this.dateValue.to);
                 to.setHours(23, 59, 59);
@@ -194,7 +200,7 @@ export default {
             const date = new Date();
             const quarter = Math.floor(date.getMonth() / 3);
 
-            const startDate = new Date(date.getFullYear(), quarter * 3 - 3, 1);
+            const startDate = new Date(date.getFullYear(), quarter * 3 - 3, 1, 0, 0, 0);
             const endDate = new Date(date.getFullYear(), startDate.getMonth() + 3, 0, 23, 59, 59);
 
             return {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -66,7 +66,7 @@ describe('src/app/component/filter/sw-date-filter', () => {
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
             [Criteria.range('releaseDate', { gte: '2021-01-22' })],
-            { from: '2021-01-22', to: null, timeframe: 'custom' },
+            { from: '2021-01-22T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
     });
 
@@ -97,7 +97,14 @@ describe('src/app/component/filter/sw-date-filter', () => {
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
             [Criteria.range('releaseDate', { gte: '2021-01-19' })],
-            { from: '2021-01-19', to: null, timeframe: 'custom' },
+            { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
+        ]);
+
+        // [1] is a duplicate emission from sw-date-filter mutating dateValue.from to ISO (triggers sw-range-filter watch again)
+        expect(wrapper.emitted()['filter-update'][1]).toEqual([
+            'releaseDate',
+            [Criteria.range('releaseDate', { gte: '2021-01-19T00:00:00.000Z' })],
+            { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
 
         const toInput = wrapper.find('.sw-date-filter__to').find('input');
@@ -106,16 +113,16 @@ describe('src/app/component/filter/sw-date-filter', () => {
         await toInput.trigger('input');
         await flushPromises();
 
-        expect(wrapper.emitted()['filter-update'][1]).toEqual([
+        expect(wrapper.emitted()['filter-update'][2]).toEqual([
             'releaseDate',
             [
                 Criteria.range('releaseDate', {
-                    gte: '2021-01-19',
+                    gte: '2021-01-19T00:00:00.000Z',
                     lte: '2021-01-25',
                 }),
             ],
             {
-                from: '2021-01-19',
+                from: '2021-01-19T00:00:00.000Z',
                 to: '2021-01-25T23:59:59.000Z',
                 timeframe: 'custom',
             },


### PR DESCRIPTION
### 1. Why is this change necessary?
Filtering by today (single date or range starting today) does not return orders created earlier on the same day, resulting in incorrect results in the order overview.

### 2. What does this change do, exactly?
`sw-date-filter` uses the current time for the "from" date instead of `00:00:00` (start of the selected day).
This PR adjusts it to use `00:00:00` ensuring all orders from that date are included.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open the order overview in the admin.
2. Apply a filter for today’s date (single date) or a date range starting from today.
3. Observe that orders created earlier today are not shown in the results.

### 4. Please link to the relevant issues
- Fixes https://github.com/shopware/shopware/issues/13867

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them