### PR TITLE
chore: deprecate default serializer for serialized field attribute

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -44,6 +44,11 @@ The `dal:validate` command now includes validation to detect mismatches between 
 This validation prevents silent failures where queries return correct `total` counts but empty `data` arrays due to entity hydration failures caused by inconsistent primary key definitions.
 When a mismatch is detected, the command provides a clear error message indicating which fields differ between the database schema and the entity definition.
 
+### Deprecation of default value for `serializer` in `#[Serialized]` field attribute
+
+When you use `#[Serialized]` field in your attribute entity you should always pass the serializer explicitly, as the default serializer does not work as expected.
+Additionally, the `SerializerField` will become internal in the next major release, as that field should be only used for attribute entities, but never directly in classic `EntityDefinitions`.
+
 ## Administration
 
 ### Deprecation of `items` prop in `sw-entity-listing` component

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -223,6 +223,12 @@ The `\Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TaskScheduler
 ## SnippetValidator becomes internal
 The class `Shopware\Core\System\Snippet\SnippetValidator` is now marked as internal and is supposed to be used for internal purposes only. Use on own risk as it may change without prior notice.
 
+## Removal of default value for `serializer` parameter in `#[Serialized]`field attribute
+
+The default value for the `serializer` parameter in the `#[Serialized]` field attribute was removed.
+You need to explicitly set the serializer to use for your field.
+Additionally, the `SerializedField` class is now internal, as you should not use it directly in classic `EntityDefinitions`. It's only intended use case is in combination with the `#[Serialized]` attribute in attribute entities.
+
 ## Removal of `EntityDefinition` constructor
 
 The constructor of the `EntityDefinition` has been removed, therefore the call of child classes to it need to be removed as well, i.e:

--- a/src/Core/Framework/DataAbstractionLayer/Attribute/Serialized.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/Serialized.php
@@ -2,21 +2,38 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Attribute;
 
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\FieldSerializerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\StringFieldSerializer;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * Use `#[Serialized]` to configure a custom field serializer. Note: for the default serializer, you should use the proper fields instead.
+ */
 #[Package('framework')]
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Serialized extends Field
 {
     public const TYPE = 'serialized';
 
+    /**
+     * @param class-string<FieldSerializerInterface> $serializer
+     *
+     * @deprecated tag:v6.8.0 - parameter $serializer will be required, as default serializer does not work
+     */
     public function __construct(
         public string $serializer = StringFieldSerializer::class,
         public bool|array $api = false,
         public bool $translated = false,
         public ?string $column = null
     ) {
+        if ($serializer === StringFieldSerializer::class) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                '$serializer parameter in `#[Serialized]` will be required in v6.8.0.0, as default serializer does not work.'
+            );
+        }
+
         parent::__construct(type: self::TYPE, translated: $translated, api: $api, column: $column);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Field/SerializedField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/SerializedField.php
@@ -4,12 +4,21 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\FieldSerializerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.8.0 - reason:becomes-internal - will be marked internal as it never should be used directly, but only over the #[Serialized] attribute
+ *
+ * General field to support custom serializes in attribute entities, should never be used directly, but only over the #[Serialized] attribute.
+ * If you use EntityDefinition classes you should add your own specific field for your custom serializer instead.
+ */
 #[Package('framework')]
 class SerializedField extends Field implements StorageAware
 {
     /**
+     * @deprecated tag:v6.8.0 - parameter $serializer will be required, as default serializer does not work
+     *
      * @param class-string<FieldSerializerInterface> $serializer
      */
     public function __construct(
@@ -17,6 +26,13 @@ class SerializedField extends Field implements StorageAware
         string $propertyName,
         private readonly string $serializer = JsonFieldSerializer::class
     ) {
+        if ($serializer === JsonFieldSerializer::class) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                '$serializer parameter in `SerializedField` will be required in v6.8.0.0, as default serializer does not work.'
+            );
+        }
+
         parent::__construct($propertyName);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Using serialized attribute or serialized field without specifiying a custom serializer won't work, as both default serializer have a check that they only run on the specific String or JSON fields, but not on serialized fields

additionally the SerializedField should never be used directly, it's only there to support custom serializer in attribute entities, as in attribute entities you can not easily add your own custom DAL fields with custom serializer as the AttributeEntityCompiler is not extendable

### 2. What does this change do, exactly?
Deprecates the broken default values and marks the SerializedField to become internal in the next major version.
Also adds code comments for how the classes are intended to use

