### PR TITLE
fix: clear cache after creating categories

### DIFF
--- a/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
+++ b/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
@@ -12,6 +12,8 @@ test(
         const subCategory2 = await TestDataService.createCategory({ parentId: category2.id });
         const subCategory3 = await TestDataService.createCategory({ parentId: category3.id });
 
+        await TestDataService.clearCaches();
+
         await test.step('Verify if folder category has a sub category and the folder category in breadcrumb is a div element.', async () => {
             
             const mainCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(category1.name);


### PR DESCRIPTION
### 1. Why is this change necessary?

When running the ATS on SaaS we had some fails where the navigation did not look like as we expected it, probably because an old state was still cached

### 2. What does this change do, exactly?
Invalidate the cache once after we created new categories, before we check the storefront

### 3. Describe each step to reproduce the issue or behaviour.

The error occured in this test run: https://github.com/shopware/saas/actions/runs/21950189799?pr=359

I've seen other similiar once as well as part of the weekly deployment struggles
