### PR TITLE
chore: reorder shopId change strategy defaults

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1579,7 +1579,7 @@
         },
         "strategies": {
           "move-shop-permanently": {
-            "description": "Das ist in der Regel die richtige Option, wenn Du Deinen Shop dauerhaft in eine andere Infrastruktur oder Umgebung verschoben hast. Shopware benachrichtigt die Apps (d. h. erneute Registrierung bei den App-Servern) unter Verwendung derselben Shop-ID, und die Apps bleiben installiert. Dein Shop identifiziert sich weiterhin als derselbe wie zuvor.",
+            "description": "Das ist in der Regel die richtige Option, wenn Du Deinen Shop dauerhaft in eine andere Infrastruktur oder Umgebung verschoben hast. Shopware benachrichtigt die Apps (d. h. erneute Registrierung bei den App-Servern) unter Verwendung derselben Shop-ID, und die Apps bleiben installiert. Dein Shop identifiziert sich weiterhin als derselbe wie zuvor. Das bedeuted, dass die neue Instanz die App-Daten der alten Installation überschreibt.",
             "name": "Shop-ID beibehalten"
           },
           "reinstall-apps": {

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -1579,7 +1579,7 @@
         },
         "strategies": {
           "move-shop-permanently": {
-            "description": "This is typically the right option if you have permanently moved your shop to a different infrastructure or new environment. Shopware will notify apps (i.e. re-register at the app servers) using the same shop identifier and apps remain installed. Your shop will identify as the same shop as before.",
+            "description": "This is typically the right option if you have permanently moved your shop to a different infrastructure or new environment. Shopware will notify apps (i.e. re-register at the app servers) using the same shop identifier and apps remain installed. Your shop will identify as the same shop as before. This means, that this instance will override the app data of the original installation.",
             "name": "Keep the shop identifier"
           },
           "reinstall-apps": {

--- a/src/Core/Framework/App/ShopIdChangeResolver/AbstractShopIdChangeStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/AbstractShopIdChangeStrategy.php
@@ -31,6 +31,12 @@ abstract class AbstractShopIdChangeStrategy
 
     abstract public function getName(): string;
 
+    /**
+     * @return string the description of the strategy used to explain what the strategy does in CLI and API
+     *
+     * Note: in the administration we have separate snippets for this to localize the description, keep the descriptions in sync
+     * `sw-app.component.sw-app-shop-id-change-modal.strategies.${strategy-name}.description`
+     */
     abstract public function getDescription(): string;
 
     abstract public function resolve(Context $context): void;

--- a/src/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategy.php
@@ -49,7 +49,7 @@ class MoveShopPermanentlyStrategy extends AbstractShopIdChangeStrategy
 
     public function getDescription(): string
     {
-        return 'This is typically the right option if you have permanently moved your shop to a different infrastructure or new environment. Shopware will notify apps (i.e. re-register at the app servers) using the same shop identifier and apps remain installed. Your shop will identify as the same shop as before.';
+        return 'This is typically the right option if you have permanently moved your shop to a different infrastructure or new environment. Shopware will notify apps (i.e. re-register at the app servers) using the same shop identifier and apps remain installed. Your shop will identify as the same shop as before. This means, that this instance will override the app data of the original installation.';
     }
 
     public function resolve(Context $context): void

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -518,7 +518,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
 
-            <tag name="shopware.app_url_changed_resolver"/>
+            <tag name="shopware.app_url_changed_resolver" priority="-100"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\ReinstallAppsStrategy">
@@ -528,7 +528,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
             <argument type="service" id="event_dispatcher"/>
 
-            <tag name="shopware.app_url_changed_resolver"/>
+            <tag name="shopware.app_url_changed_resolver" priority="100"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy">
@@ -536,7 +536,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
             <argument type="service" id="Shopware\Storefront\Theme\ThemeAppLifecycleHandler" on-invalid="null"/>
 
-            <tag name="shopware.app_url_changed_resolver"/>
+            <tag name="shopware.app_url_changed_resolver" priority="0"/>
         </service>
 
         <!-- DELTA -->


### PR DESCRIPTION
### 1. Why is this change necessary?

We know a lot of folks click on `Keep shop identifier` in situation where they shouldn't and thus they mess up their production data 

### 2. What does this change do, exactly?
Reorder the order of the options, so that `generate new identifier` becomes the default:
<img width="900" height="683" alt="Screenshot 2026-02-12 at 17 17 58" src="https://github.com/user-attachments/assets/b322867b-4da6-4775-a980-412f88e72a6f" />


Additionally it adds a sentence for warning to the `keep shop id` option, mentioning that this will mess up the data of the previous installation. (Note screenshot above was taken before adjusting the description of that option)

