### PR TITLE
fix: rename product box action buy button label block

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -36,6 +36,10 @@ The class `\Shopware\Core\Content\Seo\SeoUrlTemplate\TemplateGroup` has been dep
 
 ## Storefront
 
+### Block renaming
+
+* Deprecated block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` which will be removed in v6.8.0. Use block `component_product_box_action_buy_button_label` instead.
+
 ### `HEAD`-requests do not trigger the registration double-opt-in
 
 As some mail clients send `HEAD` requests to links which are contained in emails, the registration double-opt-in was sometimes already confirmed, as Symfony treats `HEAD`-requests the same as `GET`-request. Now `HEAD`-requests do not trigger the registration double-opt-in anymore, only "real" `GET`-requests.
@@ -185,14 +189,6 @@ Previously, the clearable button was always hidden by default (`showClearableBut
 **Migration:** If you relied on the previous behavior where the clearable button was hidden by default, explicitly set `:show-clearable-button="false"` on your select components.
 
 ## Storefront
-
-### Block renaming
-
-* Deprecated block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` which will be removed in v6.8.0. Use block `component_product_box_action_buy_button_label` instead.
-
-### `HEAD`-requests do not trigger the registration double-opt-in
-
-As some mail clients send `HEAD` requests to links which are contained in emails, the registration double-opt-in was sometimes already confirmed, as Symfony treats `HEAD`-requests the same as `GET`-request. Now `HEAD`-requests do not trigger the registration double-opt-in anymore, only "real" `GET`-requests.
 
 ### Selling and packaging information in the product detail page
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -186,6 +186,14 @@ Previously, the clearable button was always hidden by default (`showClearableBut
 
 ## Storefront
 
+### Block renaming
+
+* Deprecated block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` which will be removed in v6.8.0. Use block `component_product_box_action_buy_button_label` instead.
+
+### `HEAD`-requests do not trigger the registration double-opt-in
+
+As some mail clients send `HEAD` requests to links which are contained in emails, the registration double-opt-in was sometimes already confirmed, as Symfony treats `HEAD`-requests the same as `GET`-request. Now `HEAD`-requests do not trigger the registration double-opt-in anymore, only "real" `GET`-requests.
+
 ### Selling and packaging information in the product detail page
 
 * Display the selling and packaging information with the product that has advanced pricing.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -34,7 +34,7 @@ The Store API route `/store-api/document/download` returns now a standard Shopwa
 ## Removal of `/api/_info/queue.json` endpoint
 
 The `/api/_info/queue.json` endpoint has been removed. You may `/api/_info/message-stats.json` as alternative to get statistics for message queues.
-  
+
 ## Newsletter route methods removed and response changed
 
 The following methods have been removed:
@@ -48,7 +48,7 @@ The following methods are now abstract and must be implemented by extensions. Th
 - `subscribeWithResponse()` returns `NewsletterSubscribeRouteResponse`
 - `confirmWithResponse()` returns `SuccessResponse`
 - `unsubscribeWithResponse()` returns `SuccessResponse`
-  
+
 </details>
 
 # Core
@@ -806,6 +806,10 @@ The indexing progress notifications in the Administration notification center ha
 # Storefront
 
 <details>
+
+## Removed block `page_product_detail_product_buy_button_label` from `@Storefront/storefront/component/product/card/action.html.twig`
+
+The block `page_product_detail_product_buy_button_label` has been removed. Use `component_product_box_action_buy_button_label` instead.
 
 ## TOS checkbox position update
 The Terms of Service (TOS) was relocated to the bottom of the order confirmation page. The checkbox is now hidden by default due to not being necessary and replaced with a descriptive label, while its visibility can be controlled using the new configuration option `core.cart.showTosCheckbox`.

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -56,8 +56,11 @@
                             {% block component_product_box_action_buy_button %}
                                 <div class="d-grid">
                                     <button class="btn btn-buy">
-                                        {% block page_product_detail_product_buy_button_label %}
-                                            {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
+                                        {% block component_product_box_action_buy_button_label %}
+                                            {# @deprecated tag:v6.8.0 - Block will be removed. Use component_product_box_action_buy_button_label instead. #}
+                                            {% block page_product_detail_product_buy_button_label %}
+                                                {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
+                                            {% endblock %}
                                         {% endblock %}
                                     </button>
                                 </div>

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -57,7 +57,7 @@
                                 <div class="d-grid">
                                     <button class="btn btn-buy">
                                         {% block component_product_box_action_buy_button_label %}
-                                            {# @deprecated tag:v6.8.0 - Block will be removed. Use component_product_box_action_buy_button_label instead. #}
+                                            {# @deprecated tag:v6.8.0 - Block page_product_detail_product_buy_button_label will be removed. Use component_product_box_action_buy_button_label instead. The default content will remain. #}
                                             {% block page_product_detail_product_buy_button_label %}
                                                 {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
                                             {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` is named wrong.

### 2. What does this change do, exactly?
Add new block `component_product_box_action_buy_button_label` and deprecate the old one.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
