### PR TITLE
fix: correct promotion rule evaluation

### DIFF
--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -53,7 +53,7 @@ class MatchAllLineItemsRule extends Container
 
         // When there are no line items of this type, the rule still passes (e.g. "none of promotion" with an empty cart).
         if (\count($flatItems) === 0) {
-            return !empty($this->types);
+            return $this->types !== null && $this->types !== [];
         }
 
         $context = $scope->getSalesChannelContext();

--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -51,8 +51,9 @@ class MatchAllLineItemsRule extends Container
 
         $flatItems = $this->filterAndFlatten($lineItems);
 
+        // When there are no line items of this type, the rule still passes (e.g. "none of promotion" with an empty cart).
         if (\count($flatItems) === 0) {
-            return false;
+            return !empty($this->types);
         }
 
         $context = $scope->getSalesChannelContext();

--- a/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Container\Container;
 use Shopware\Core\Framework\Rule\Container\MatchAllLineItemsRule;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleScope;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel\Helper\CartRuleHelperTrait;
 use Symfony\Component\Validator\Constraints\Type;
@@ -242,7 +243,16 @@ class MatchAllLineItemsRuleTest extends TestCase
         static::assertFalse($match);
     }
 
-    public function testShouldReturnFalseIfNoLineItemsOfTypeArePresent(): void
+    public function testShouldReturnFalseWhenScopeIsNotCartOrLineItemScope(): void
+    {
+        $rule = new MatchAllLineItemsRule();
+
+        $match = $rule->match($this->createMock(RuleScope::class));
+
+        static::assertFalse($match);
+    }
+
+    public function testShouldReturnTrueWhenNoLineItemsOfFilteredTypeExist(): void
     {
         $rule = new MatchAllLineItemsRule([], null, ['product']);
 
@@ -253,7 +263,7 @@ class MatchAllLineItemsRuleTest extends TestCase
             $this->createMock(SalesChannelContext::class)
         ));
 
-        static::assertFalse($match);
+        static::assertTrue($match);
     }
 
     public function testShouldEvaluateGivenItemsIfTypesAreNotSet(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Promotion rules are evaluated incorrectly when checking whether a specific promotion is present in the cart. As a result, conditions that depend on the absence of a promotion do not behave as expected.

### 2. What does this change do, exactly?
It fixes the cart rule evaluation so that promotion-based conditions correctly match when the promotion is not in the cart and do not match when it is present.
<img width="1557" height="1111" alt="Screenshot 2026-02-13 at 13 59 02" src="https://github.com/user-attachments/assets/2a468ea6-51e7-4249-b824-89182734119a" />
<img width="1313" height="1126" alt="Screenshot 2026-02-13 at 13 55 58" src="https://github.com/user-attachments/assets/42fa8494-eee0-4c55-98c6-132840a1e08b" />

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a rule with condition: Promotion -> select a specific promotion.
2. Assign this rule to a shipping method (or another cart-dependent feature).
3. Add products to the cart without adding the selected promotion.
4. Observe that the rule does not match and the shipping method is not available.
5. Add the selected promotion and observe inconsistent matching behavior.

### 4. Please link to the relevant issues
- Fixes https://github.com/shopware/shopware/issues/14555

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
