### PR TITLE
feat: Refactor empty usage in System area to prepare its prohibition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1309,12 +1309,6 @@ parameters:
 			path: src/Core/Profiling/Integration/Tideways.php
 
 		-
-			message: '#^Expected domain exception class Shopware\\Core\\System\\CustomEntity\\CustomEntityException, got Shopware\\Core\\System\\CustomEntity\\Xml\\Config\\CustomEntityConfigurationException$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
-
-		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 3

--- a/src/Core/System/Consent/Service/ConsentService.php
+++ b/src/Core/System/Consent/Service/ConsentService.php
@@ -213,7 +213,7 @@ class ConsentService
             }
         }
 
-        if (!empty($missingPermissions)) {
+        if ($missingPermissions !== []) {
             throw ConsentException::insufficientPermissions($consent->getName(), $missingPermissions);
         }
     }

--- a/src/Core/System/CustomEntity/CustomEntityException.php
+++ b/src/Core/System/CustomEntity/CustomEntityException.php
@@ -16,10 +16,11 @@ class CustomEntityException extends HttpException
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_NOT_DEFINED = 'LABEL_PROPERTY_NOT_DEFINED';
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_WRONG_TYPE = 'LABEL_PROPERTY_WRONG_TYPE';
     public const ASSOCIATION_REFERENCE_TABLE_NOT_FOUND = 'FRAMEWORK__CUSTOM_ENTITY_ASSOCIATION_REFERENCE_TABLE_NOT_FOUND';
-
     public const XML_PARSE_ERROR = 'SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR';
-
     public const NOT_FOUND = 'FRAMEWORK__CUSTOM_ENTITY_NOT_FOUND';
+    final public const ENTITY_NOT_GIVEN_CODE = 'SYSTEM__CUSTOM_ENTITY_NOT_GIVEN';
+    final public const DUPLICATE_REFERENCES = 'SYSTEM__CUSTOM_ENTITY_DUPLICATE_REFERENCES';
+    final public const INVALID_REFERENCES = 'SYSTEM__CUSTOM_ENTITY_INVALID_REFERENCES';
 
     public static function noLabelProperty(): self
     {
@@ -76,6 +77,82 @@ class CustomEntityException extends HttpException
             self::ASSOCIATION_REFERENCE_TABLE_NOT_FOUND,
             'Association reference table "{{ referenceName }}" not found',
             ['referenceName' => $referenceName]
+        );
+    }
+
+    /**
+     * @param list<string> $entities
+     */
+    public static function entityNotGiven(string $configFileName, array $entities): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::ENTITY_NOT_GIVEN_CODE,
+            \sprintf(
+                'The entities %s are not given in the entities.xml but are configured in %s',
+                implode(', ', $entities),
+                $configFileName
+            ),
+            [
+                'configFileName' => $configFileName,
+                'entities' => $entities,
+            ]
+        );
+    }
+
+    /**
+     * @param list<string> $duplicates
+     */
+    public static function duplicateReferences(
+        string $configFileName,
+        string $customEntityName,
+        string $xmlElement,
+        array $duplicates
+    ): self {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::DUPLICATE_REFERENCES,
+            \sprintf(
+                'In `%s`, the entity `%s` only allows unique fields per xml element, but found the following duplicates inside of `%s`: %s',
+                $configFileName,
+                $customEntityName,
+                $xmlElement,
+                \implode(', ', $duplicates)
+            ),
+            [
+                'configFileName' => $configFileName,
+                'customEntityName' => $customEntityName,
+                'area' => $xmlElement,
+                'duplicates' => $duplicates,
+            ]
+        );
+    }
+
+    /**
+     * @param list<string> $invalidRefs
+     */
+    public static function invalidReferences(
+        string $configFileName,
+        string $customEntityName,
+        string $xmlElement,
+        array $invalidRefs
+    ): self {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::INVALID_REFERENCES,
+            \sprintf(
+                'In `%s` the entity `%s` has invalid references (regarding `entities.xml`) inside of `%s`: %s',
+                $configFileName,
+                $customEntityName,
+                $xmlElement,
+                \implode(', ', $invalidRefs)
+            ),
+            [
+                'configFileName' => $configFileName,
+                'customEntityName' => $customEntityName,
+                'area' => $xmlElement,
+                'duplicates' => $invalidRefs,
+            ]
         );
     }
 }

--- a/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
+++ b/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
@@ -69,7 +69,7 @@ class DynamicFieldFactory
             self::defineField($field, $collection, $entityName, $container);
         }
 
-        if (empty($translated)) {
+        if ($translated === []) {
             return $collection;
         }
 

--- a/src/Core/System/CustomEntity/Schema/SchemaUpdater.php
+++ b/src/Core/System/CustomEntity/Schema/SchemaUpdater.php
@@ -94,7 +94,7 @@ class SchemaUpdater
 
         $translated = array_filter($fields, fn (array $field) => $field['translatable'] ?? false);
 
-        if (empty($translated)) {
+        if ($translated === []) {
             return;
         }
         $languageTable = $schema->getTable('language');

--- a/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
+++ b/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
@@ -94,7 +94,7 @@ class AdminUiXmlSchemaValidator
         }
 
         $invalidFields = array_diff($referencedFields, $entityFields);
-        if (!empty($invalidFields)) {
+        if ($invalidFields !== []) {
             throw CustomEntityConfigurationException::invalidReferences(
                 AdminUiXmlSchema::FILENAME,
                 $customEntityName,

--- a/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
+++ b/src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
@@ -3,13 +3,14 @@
 namespace Shopware\Core\System\CustomEntity\Xml\Config\AdminUi;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\CardField;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Column;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Detail;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Entity as AdminUiEntity;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Listing;
-use Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityConfigurationException;
 use Shopware\Core\System\CustomEntity\Xml\Entity;
+use Shopware\Core\System\CustomEntity\Xml\Field\Field;
 
 /**
  * @internal
@@ -20,7 +21,7 @@ class AdminUiXmlSchemaValidator
     public function validateConfigurations(AdminUiEntity $adminUiEntity, Entity $entity): void
     {
         $entityFields = \array_map(
-            fn ($arr) => $arr->getName(),
+            static fn (Field $arr): string => $arr->getName(),
             $entity->getFields()
         );
         $this->validateListingConfiguration(
@@ -36,7 +37,7 @@ class AdminUiXmlSchemaValidator
     }
 
     /**
-     * @param string[] $entityFields
+     * @param list<string> $entityFields
      */
     private function validateListingConfiguration(
         array $entityFields,
@@ -52,18 +53,15 @@ class AdminUiXmlSchemaValidator
     }
 
     /**
-     * @param string[] $entityFields
+     * @param list<string> $entityFields
      */
     private function validateDetailConfiguration(
         array $entityFields,
         Detail $detail,
         string $customEntityName
     ): void {
-        $tabs = $detail->getTabs()->getContent();
-
-        foreach ($tabs as $tab) {
-            $cards = $tab->getCards();
-            foreach ($cards as $card) {
+        foreach ($detail->getTabs()->getContent() as $tab) {
+            foreach ($tab->getCards() as $card) {
                 $this->checkReferences(
                     $entityFields,
                     $this->getRefsAsList($card->getFields()),
@@ -75,8 +73,8 @@ class AdminUiXmlSchemaValidator
     }
 
     /**
-     * @param string[] $entityFields
-     * @param string[] $referencedFields
+     * @param list<string> $entityFields
+     * @param list<string> $referencedFields
      */
     private function checkReferences(
         array $entityFields,
@@ -85,7 +83,7 @@ class AdminUiXmlSchemaValidator
         string $xmlElement
     ): void {
         if (\count($referencedFields) !== \count(\array_unique($referencedFields))) {
-            throw CustomEntityConfigurationException::duplicateReferences(
+            throw CustomEntityException::duplicateReferences(
                 AdminUiXmlSchema::FILENAME,
                 $customEntityName,
                 $xmlElement,
@@ -93,9 +91,9 @@ class AdminUiXmlSchemaValidator
             );
         }
 
-        $invalidFields = array_diff($referencedFields, $entityFields);
+        $invalidFields = array_values(array_diff($referencedFields, $entityFields));
         if ($invalidFields !== []) {
-            throw CustomEntityConfigurationException::invalidReferences(
+            throw CustomEntityException::invalidReferences(
                 AdminUiXmlSchema::FILENAME,
                 $customEntityName,
                 $xmlElement,
@@ -105,13 +103,13 @@ class AdminUiXmlSchemaValidator
     }
 
     /**
-     * @param string[] $entries
+     * @param list<string> $entries
      *
-     * @return string[]
+     * @return list<string>
      */
     private function getDuplicates(array $entries): array
     {
-        return array_unique(array_diff_assoc($entries, array_unique($entries)));
+        return array_values(array_unique(array_diff_assoc($entries, array_unique($entries))));
     }
 
     /**
@@ -122,7 +120,7 @@ class AdminUiXmlSchemaValidator
     private function getRefsAsList(array $listOfObjectsWithRefProperty): array
     {
         return \array_map(
-            fn ($object) => $object->getRef(),
+            static fn (Column|CardField $object): string => $object->getRef(),
             $listOfObjectsWithRefProperty
         );
     }

--- a/src/Core/System/CustomEntity/Xml/Config/CustomEntityConfigurationException.php
+++ b/src/Core/System/CustomEntity/Xml/Config/CustomEntityConfigurationException.php
@@ -2,10 +2,14 @@
 
 namespace Shopware\Core\System\CustomEntity\Xml\Config;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException} instead
+ */
 #[Package('framework')]
 class CustomEntityConfigurationException extends HttpException
 {
@@ -14,10 +18,17 @@ class CustomEntityConfigurationException extends HttpException
     final public const INVALID_REFERENCES = 'CUSTOM_ENTITY_INVALID_REFERENCES';
 
     /**
+     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::entityNotGiven} instead
+     *
      * @param string[] $entities
      */
     public static function entityNotGiven(string $configFileName, array $entities): self
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __FUNCTION__, 'v6.8.0.0', 'CustomEntityException::entityNotGiven')
+        );
+
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::ENTITY_NOT_GIVEN_CODE,
@@ -34,6 +45,8 @@ class CustomEntityConfigurationException extends HttpException
     }
 
     /**
+     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::duplicateReferences} instead
+     *
      * @param string[] $duplicates
      */
     public static function duplicateReferences(
@@ -42,6 +55,11 @@ class CustomEntityConfigurationException extends HttpException
         string $xmlElement,
         array $duplicates
     ): self {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __FUNCTION__, 'v6.8.0.0', 'CustomEntityException::duplicateReferences')
+        );
+
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DUPLICATE_REFERENCES,
@@ -62,6 +80,8 @@ class CustomEntityConfigurationException extends HttpException
     }
 
     /**
+     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::invalidReferences} instead
+     *
      * @param string[] $invalidRefs
      */
     public static function invalidReferences(
@@ -70,6 +90,11 @@ class CustomEntityConfigurationException extends HttpException
         string $xmlElement,
         array $invalidRefs
     ): self {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __FUNCTION__, 'v6.8.0.0', 'CustomEntityException::invalidReferences')
+        );
+
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INVALID_REFERENCES,

--- a/src/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentService.php
+++ b/src/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentService.php
@@ -74,7 +74,7 @@ class CustomEntityEnrichmentService
             unset($adminUiEntitiesConfig[$entity->getName()]);
         }
 
-        if (!empty($adminUiEntitiesConfig)) {
+        if ($adminUiEntitiesConfig !== []) {
             throw CustomEntityConfigurationException::entityNotGiven(
                 AdminUiXmlSchema::FILENAME,
                 array_keys($adminUiEntitiesConfig)

--- a/src/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentService.php
+++ b/src/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\CustomEntity\Xml\Config;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidator;
 use Shopware\Core\System\CustomEntity\Xml\Config\CmsAware\CmsAwareFields;
@@ -54,7 +55,7 @@ class CustomEntityEnrichmentService
     private function enrichAdminUi(CustomEntityXmlSchema $customEntityXmlSchema, AdminUiXmlSchema $adminUiXmlSchema): CustomEntityXmlSchema
     {
         $adminUiEntitiesConfig = $adminUiXmlSchema->getAdminUi()->getEntities();
-        if ($adminUiEntitiesConfig === null) {
+        if ($adminUiEntitiesConfig === []) {
             return $customEntityXmlSchema;
         }
 
@@ -75,7 +76,7 @@ class CustomEntityEnrichmentService
         }
 
         if ($adminUiEntitiesConfig !== []) {
-            throw CustomEntityConfigurationException::entityNotGiven(
+            throw CustomEntityException::entityNotGiven(
                 AdminUiXmlSchema::FILENAME,
                 array_keys($adminUiEntitiesConfig)
             );

--- a/src/Core/System/CustomField/CustomFieldService.php
+++ b/src/Core/System/CustomField/CustomFieldService.php
@@ -83,7 +83,7 @@ class CustomFieldService implements EventSubscriberInterface, ResetInterface
     {
         $commands = $event->getCommands();
 
-        if (empty($commands)) {
+        if ($commands === []) {
             return;
         }
 

--- a/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
+++ b/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
@@ -153,7 +153,7 @@ class SalesChannelEntityCompilerPass implements CompilerPassInterface
             $class = $service->getClass();
 
             if (\in_array($class, [AttributeEntityDefinition::class, AttributeTranslationDefinition::class, AttributeMappingDefinition::class], true)) {
-                if (empty($service->getArguments())) {
+                if ($service->getArguments() === []) {
                     continue;
                 }
 

--- a/src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
+++ b/src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
@@ -20,7 +20,7 @@ class LanguageForeignKeyDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )
@@ -38,7 +38,7 @@ class LanguageForeignKeyDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )
@@ -52,7 +52,7 @@ class LanguageForeignKeyDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )

--- a/src/Core/System/Language/LanguageValidator.php
+++ b/src/Core/System/Language/LanguageValidator.php
@@ -53,7 +53,7 @@ class LanguageValidator implements EventSubscriberInterface
     {
         $commands = $event->getCommands();
         $affectedIds = $this->getAffectedIds($commands);
-        if (\count($affectedIds) === 0) {
+        if ($affectedIds === []) {
             return;
         }
 

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/ValueGeneratorPatternDate.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/ValueGeneratorPatternDate.php
@@ -17,7 +17,7 @@ class ValueGeneratorPatternDate extends AbstractValueGenerator
 
     public function generate(array $config, ?array $args = null, ?bool $preview = false): string
     {
-        if ($args === null || \count($args) === 0) {
+        if ($args === null || $args === []) {
             $args[] = self::STANDARD_FORMAT;
         }
 

--- a/src/Core/System/SalesChannel/Context/CartRestorer.php
+++ b/src/Core/System/SalesChannel/Context/CartRestorer.php
@@ -48,7 +48,7 @@ class CartRestorer
             $currentContext->getSalesChannelId(),
         );
 
-        if (empty($customerPayload) || !empty($customerPayload['permissions'])) {
+        if ($customerPayload === [] || !empty($customerPayload['permissions'])) {
             return $this->replaceContextToken($customerId, $currentContext, $token);
         }
 
@@ -73,7 +73,7 @@ class CartRestorer
             $customerId
         );
 
-        if (empty($customerPayload) || !empty($customerPayload['permissions']) || !($customerPayload['expired'] ?? false) && $customerPayload['token'] === $currentContext->getToken()) {
+        if ($customerPayload === [] || !empty($customerPayload['permissions']) || !($customerPayload['expired'] ?? false) && $customerPayload['token'] === $currentContext->getToken()) {
             return $this->replaceContextToken($customerId, $currentContext);
         }
 

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextPersister.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextPersister.php
@@ -129,7 +129,7 @@ class SalesChannelContextPersister
 
         $data = $qb->executeQuery()->fetchAllAssociative();
 
-        if (empty($data)) {
+        if ($data === []) {
             return [];
         }
 

--- a/src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
+++ b/src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
@@ -44,7 +44,7 @@ class SalesChannelIndexer extends EntityIndexer
 
         $ids = $iterator->fetch();
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return null;
         }
 
@@ -55,7 +55,7 @@ class SalesChannelIndexer extends EntityIndexer
     {
         $updates = $event->getPrimaryKeys(SalesChannelDefinition::ENTITY_NAME);
 
-        if (empty($updates)) {
+        if ($updates === []) {
             return null;
         }
 
@@ -70,7 +70,7 @@ class SalesChannelIndexer extends EntityIndexer
         }
 
         $ids = array_unique(array_filter($ids));
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
@@ -101,7 +101,7 @@ class SalesChannelRepository
 
         $ids = $this->doSearch($criteria, $salesChannelContext);
 
-        if (empty($ids->getIds())) {
+        if ($ids->getIds() === []) {
             /** @var TEntityCollection $collection */
             $collection = $this->definition->getCollectionClass();
 
@@ -123,7 +123,7 @@ class SalesChannelRepository
                 $data = $search[$element->getUniqueIdentifier()];
                 unset($data['id']);
 
-                if (empty($data)) {
+                if ($data === []) {
                     continue;
                 }
 
@@ -215,7 +215,7 @@ class SalesChannelRepository
         $processed = [];
 
         // process all associations breadth-first
-        while (!empty($queue) && --$maxCount > 0) {
+        while ($queue !== [] && --$maxCount > 0) {
             $cur = array_shift($queue);
 
             $definition = $cur['definition'];

--- a/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
+++ b/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
@@ -139,7 +139,7 @@ class ContextSwitchRoute extends AbstractContextSwitchRoute
             $context->getToken(),
             $parameters,
             $salesChannelId,
-            $customer && empty($context->getPermissions()) ? $customer->getId() : null
+            $customer && $context->getPermissions() === [] ? $customer->getId() : null
         );
 
         // Language was switched - Check new Domain with old context

--- a/src/Core/System/SalesChannel/SalesChannelException.php
+++ b/src/Core/System/SalesChannel/SalesChannelException.php
@@ -157,7 +157,7 @@ class SalesChannelException extends HttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedMethodMessage(
-                __CLASS__,
+                self::class,
                 __METHOD__,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class

--- a/src/Core/System/Snippet/Command/Util/CountryAgnosticFileLinter.php
+++ b/src/Core/System/Snippet/Command/Util/CountryAgnosticFileLinter.php
@@ -78,7 +78,7 @@ class CountryAgnosticFileLinter
 
             $currentDomain = $currentFileData['domain'] ?? 'administration';
             $locale = str_replace('_', '-', $currentFileData['locale']);
-            $isBase = !$isAdminTranslationFile && (isset($currentFileData['isBase']) && ($currentFileData['isBase'] !== '' && $currentFileData['isBase'] !== '0'));
+            $isBase = !$isAdminTranslationFile && ($currentFileData['isBase'] ?? '') !== '';
 
             $translationFile = new TranslationFile(
                 $file->getFilename(),

--- a/src/Core/System/Snippet/Command/Util/CountryAgnosticFileLinter.php
+++ b/src/Core/System/Snippet/Command/Util/CountryAgnosticFileLinter.php
@@ -78,7 +78,7 @@ class CountryAgnosticFileLinter
 
             $currentDomain = $currentFileData['domain'] ?? 'administration';
             $locale = str_replace('_', '-', $currentFileData['locale']);
-            $isBase = !$isAdminTranslationFile && !empty($currentFileData['isBase']);
+            $isBase = !$isAdminTranslationFile && (isset($currentFileData['isBase']) && ($currentFileData['isBase'] !== '' && $currentFileData['isBase'] !== '0'));
 
             $translationFile = new TranslationFile(
                 $file->getFilename(),
@@ -154,7 +154,7 @@ class CountryAgnosticFileLinter
 
         if ($options->dir) {
             $this->finder->in($options->dir);
-        } elseif (empty($options->extensionPaths)) {
+        } elseif ($options->extensionPaths === []) {
             $this->finder->in('src');
 
             if ($options->isAll) {
@@ -183,7 +183,7 @@ class CountryAgnosticFileLinter
             ...$apps->fmap(static fn (AppEntity $app) => $app->getPath()),
         ];
 
-        if (empty($extensionPaths)) {
+        if ($extensionPaths === []) {
             throw SnippetException::invalidExtensions($options->extensionPaths);
         }
 

--- a/src/Core/System/Snippet/Files/SnippetFileLoader.php
+++ b/src/Core/System/Snippet/Files/SnippetFileLoader.php
@@ -248,7 +248,7 @@ class SnippetFileLoader implements SnippetFileLoaderInterface
     {
         $excludedLocales = $this->config->excludedLocales;
 
-        if (empty($excludedLocales)) {
+        if ($excludedLocales === []) {
             return null;
         }
 

--- a/src/Core/System/Snippet/Service/TranslationConfigLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationConfigLoader.php
@@ -100,7 +100,7 @@ class TranslationConfigLoader extends AbstractTranslationConfigLoader
             throw SnippetException::translationConfigurationFileDoesNotExist($this->getConfigFilename(), $e);
         }
 
-        if (in_array(\trim($content), ['', '0'], true)) {
+        if (\trim($content) === '') {
             throw SnippetException::translationConfigurationFileIsEmpty($this->getConfigFilename());
         }
 
@@ -152,7 +152,7 @@ class TranslationConfigLoader extends AbstractTranslationConfigLoader
 
     private function getValidatedUrl(string $urlString, string $type): Uri
     {
-        if (\mb_strlen(\trim($urlString)) < 1) {
+        if (\trim($urlString) === '') {
             throw SnippetException::invalidRepositoryUrl(
                 $urlString,
                 new \InvalidArgumentException(\sprintf('"%s" in the translation config must not be empty.', $type))
@@ -165,7 +165,7 @@ class TranslationConfigLoader extends AbstractTranslationConfigLoader
             throw SnippetException::invalidRepositoryUrl($urlString, $e);
         }
 
-        if (in_array($url->getScheme(), ['', '0'], true) || in_array($url->getHost(), ['', '0'], true)) {
+        if ($url->getScheme() === '' || $url->getHost() === '') {
             throw SnippetException::invalidRepositoryUrl(
                 $urlString,
                 new MalformedUriException(\sprintf('"%s" must contain a schema and a host.', $type))

--- a/src/Core/System/Snippet/Service/TranslationConfigLoader.php
+++ b/src/Core/System/Snippet/Service/TranslationConfigLoader.php
@@ -100,7 +100,7 @@ class TranslationConfigLoader extends AbstractTranslationConfigLoader
             throw SnippetException::translationConfigurationFileDoesNotExist($this->getConfigFilename(), $e);
         }
 
-        if (empty(\trim($content))) {
+        if (in_array(\trim($content), ['', '0'], true)) {
             throw SnippetException::translationConfigurationFileIsEmpty($this->getConfigFilename());
         }
 
@@ -165,7 +165,7 @@ class TranslationConfigLoader extends AbstractTranslationConfigLoader
             throw SnippetException::invalidRepositoryUrl($urlString, $e);
         }
 
-        if (empty($url->getScheme()) || empty($url->getHost())) {
+        if (in_array($url->getScheme(), ['', '0'], true) || in_array($url->getHost(), ['', '0'], true)) {
             throw SnippetException::invalidRepositoryUrl(
                 $urlString,
                 new MalformedUriException(\sprintf('"%s" must contain a schema and a host.', $type))

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -208,7 +208,7 @@ class SnippetService
 
         $aggregation = $this->snippetRepository->aggregate($criteria, $context)->get('distinct_author');
 
-        if (!$aggregation instanceof TermsResult || empty($aggregation->getBuckets())) {
+        if (!$aggregation instanceof TermsResult || $aggregation->getBuckets() === []) {
             $result = [];
         } else {
             $result = $aggregation->getKeys();
@@ -333,9 +333,9 @@ class SnippetService
             );
 
             // If the locale has a region (e.g., "es-AR"), try to load its base language ("es")
-            if (!empty($matchedPattern['region']) && strtolower($matchedPattern['region']) !== $iso) {
-                \assert(!empty($matchedPattern['language']));
-                \assert(!empty($matchedPattern['region']));
+            if (isset($matchedPattern['region']) && ($matchedPattern['region'] !== '' && $matchedPattern['region'] !== '0') && strtolower($matchedPattern['region']) !== $iso) {
+                \assert(isset($matchedPattern['language']) && ($matchedPattern['language'] !== '' && $matchedPattern['language'] !== '0'));
+                \assert(isset($matchedPattern['region']) && ($matchedPattern['region'] !== '' && $matchedPattern['region'] !== '0'));
                 $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($matchedPattern['language']);
                 // Prepend fallback files so region-specific ones override them
                 $files = [...$fallbackFiles, ...$files];
@@ -577,12 +577,12 @@ class SnippetService
     {
         $result = [];
         foreach ($array as $index => $value) {
-            $newIndex = $prefix . (empty($prefix) ? '' : '.') . $index;
+            $newIndex = $prefix . ($prefix === '' || $prefix === '0' ? '' : '.') . $index;
 
             if (\is_array($value)) {
                 $result = [...$result, ...$this->flatten($value, $newIndex, $additionalParameters)];
             } else {
-                if (!empty($additionalParameters)) {
+                if ($additionalParameters !== null && $additionalParameters !== []) {
                     $result[$newIndex] = array_merge([
                         'value' => $value,
                         'origin' => $value,

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -333,10 +333,11 @@ class SnippetService
             );
 
             // If the locale has a region (e.g., "es-AR"), try to load its base language ("es")
-            if (isset($matchedPattern['region']) && ($matchedPattern['region'] !== '' && $matchedPattern['region'] !== '0') && strtolower($matchedPattern['region']) !== $iso) {
-                \assert(isset($matchedPattern['language']) && ($matchedPattern['language'] !== '' && $matchedPattern['language'] !== '0'));
-                \assert(isset($matchedPattern['region']) && ($matchedPattern['region'] !== '' && $matchedPattern['region'] !== '0'));
-                $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($matchedPattern['language']);
+            $region = $matchedPattern['region'] ?? '';
+            if ($region !== '' && strtolower($region) !== $iso) {
+                $language = $matchedPattern['language'] ?? '';
+                \assert($language !== '');
+                $fallbackFiles = $this->snippetFileCollection->getSnippetFilesByIso($language);
                 // Prepend fallback files so region-specific ones override them
                 $files = [...$fallbackFiles, ...$files];
             }
@@ -577,7 +578,7 @@ class SnippetService
     {
         $result = [];
         foreach ($array as $index => $value) {
-            $newIndex = $prefix . ($prefix === '' || $prefix === '0' ? '' : '.') . $index;
+            $newIndex = $prefix . ($prefix === '' ? '' : '.') . $index;
 
             if (\is_array($value)) {
                 $result = [...$result, ...$this->flatten($value, $newIndex, $additionalParameters)];

--- a/src/Core/System/Snippet/Struct/LintedTranslationFileOptions.php
+++ b/src/Core/System/Snippet/Struct/LintedTranslationFileOptions.php
@@ -36,8 +36,8 @@ readonly class LintedTranslationFileOptions
         return new self(
             (bool) $input->getOption('fix'),
             (bool) $input->getOption('all'),
-            $extensions !== '' && $extensions !== '0' ? explode(',', $extensions) : [],
-            $ignoredPaths !== '' && $ignoredPaths !== '0' ? explode(',', $ignoredPaths) : [],
+            $extensions !== '' ? explode(',', $extensions) : [],
+            $ignoredPaths !== '' ? explode(',', $ignoredPaths) : [],
             (string) $input->getOption('dir') ?: null,
         );
     }

--- a/src/Core/System/Snippet/Struct/LintedTranslationFileOptions.php
+++ b/src/Core/System/Snippet/Struct/LintedTranslationFileOptions.php
@@ -36,8 +36,8 @@ readonly class LintedTranslationFileOptions
         return new self(
             (bool) $input->getOption('fix'),
             (bool) $input->getOption('all'),
-            !empty($extensions) ? explode(',', $extensions) : [],
-            !empty($ignoredPaths) ? explode(',', $ignoredPaths) : [],
+            $extensions !== '' && $extensions !== '0' ? explode(',', $extensions) : [],
+            $ignoredPaths !== '' && $ignoredPaths !== '0' ? explode(',', $ignoredPaths) : [],
             (string) $input->getOption('dir') ?: null,
         );
     }

--- a/src/Core/System/Snippet/Subscriber/CustomFieldSubscriber.php
+++ b/src/Core/System/Snippet/Subscriber/CustomFieldSubscriber.php
@@ -50,7 +50,7 @@ class CustomFieldSubscriber implements EventSubscriberInterface
                     $snippetSets = $this->connection->fetchAllAssociative('SELECT id, iso FROM snippet_set');
                 }
 
-                if (empty($snippetSets)) {
+                if ($snippetSets === []) {
                     return;
                 }
 
@@ -58,7 +58,7 @@ class CustomFieldSubscriber implements EventSubscriberInterface
             }
         }
 
-        if (empty($snippets)) {
+        if ($snippets === []) {
             return;
         }
 

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -126,9 +126,9 @@ class StateMachineRegistry implements ResetInterface
                 $repository
             );
 
-            if (in_array($transition->getTransitionName(), ['', '0'], true)) {
+            if ($transition->getTransitionName() === '') {
                 $transitions = $this->getAvailableTransitionsById($stateMachine->getTechnicalName(), $fromPlace->getId(), $context);
-                $transitionNames = array_map(fn (StateMachineTransitionEntity $transition) => $transition->getActionName(), $transitions);
+                $transitionNames = array_map(static fn (StateMachineTransitionEntity $transition) => $transition->getActionName(), $transitions);
 
                 throw StateMachineException::illegalStateTransition($fromPlace->getId(), '', $transitionNames);
             }

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -126,7 +126,7 @@ class StateMachineRegistry implements ResetInterface
                 $repository
             );
 
-            if (empty($transition->getTransitionName())) {
+            if (in_array($transition->getTransitionName(), ['', '0'], true)) {
                 $transitions = $this->getAvailableTransitionsById($stateMachine->getTechnicalName(), $fromPlace->getId(), $context);
                 $transitionNames = array_map(fn (StateMachineTransitionEntity $transition) => $transition->getActionName(), $transitions);
 

--- a/src/Core/System/SystemConfig/Api/SystemConfigController.php
+++ b/src/Core/System/SystemConfig/Api/SystemConfigController.php
@@ -84,7 +84,7 @@ class SystemConfigController extends AbstractController
         $inherit = $request->query->getBoolean('inherit');
 
         $values = $this->systemConfig->getDomain($domain, $salesChannelId, $inherit);
-        if (empty($values)) {
+        if ($values === []) {
             $json = '{}';
         } else {
             $json = json_encode($values, \JSON_PRESERVE_ZERO_FRACTION);

--- a/src/Core/System/SystemConfig/SymfonySystemConfigService.php
+++ b/src/Core/System/SystemConfig/SymfonySystemConfigService.php
@@ -104,7 +104,7 @@ readonly class SymfonySystemConfigService
             return $configValues;
         }
 
-        if (empty($keys)) {
+        if ($keys === []) {
             // Configs can be overwritten with sales_channel_id
             $inheritedValuePresent = \array_key_exists($key, $configValues);
             $valueConsideredEmpty = !\is_bool($value) && empty($value);

--- a/src/Core/System/SystemConfig/SystemConfigLoader.php
+++ b/src/Core/System/SystemConfig/SystemConfigLoader.php
@@ -88,7 +88,7 @@ class SystemConfigLoader extends AbstractSystemConfigLoader
     {
         $key = \array_shift($keys);
 
-        if (empty($keys)) {
+        if ($keys === []) {
             // Configs can be overwritten with sales_channel_id
             $inheritedValuePresent = \array_key_exists($key, $configValues);
             $valueConsideredEmpty = !\is_bool($value) && empty($value);

--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -305,7 +305,7 @@ class SystemConfigService implements ResetInterface
         }
 
         // Delete all null values
-        if (!empty($toBeDeleted)) {
+        if ($toBeDeleted !== []) {
             $qb = $this->connection
                 ->createQueryBuilder()
                 ->where('configuration_key IN (:keys)')
@@ -402,7 +402,7 @@ class SystemConfigService implements ResetInterface
             }
         }
 
-        if (empty($configKeys)) {
+        if ($configKeys === []) {
             return;
         }
 
@@ -437,7 +437,7 @@ class SystemConfigService implements ResetInterface
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
         );
 
         $result = $param();
@@ -454,7 +454,7 @@ class SystemConfigService implements ResetInterface
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0')
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
         );
 
         return [];

--- a/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
+++ b/src/Core/System/SystemConfig/Validation/SystemConfigValidator.php
@@ -59,7 +59,7 @@ class SystemConfigValidator
                 }
             }
 
-            if (empty($subDefinition->getProperties())) {
+            if ($subDefinition->getProperties() === []) {
                 continue;
             }
 

--- a/src/Core/System/UsageData/EntitySync/DispatchEntityMessageHandler.php
+++ b/src/Core/System/UsageData/EntitySync/DispatchEntityMessageHandler.php
@@ -169,7 +169,7 @@ final readonly class DispatchEntityMessageHandler
 
         $primaryKeys = $message->primaryKeys;
         $primaryKeyColumns = array_keys($primaryKeys[0]);
-        if (!empty($missingIdFields) && \count($primaryKeyColumns) > 1) {
+        if ($missingIdFields !== [] && \count($primaryKeyColumns) > 1) {
             self::throwUnrecoverableMessageHandlingException($message, 'Entity sync does not support composite primary keys');
         }
 
@@ -206,7 +206,7 @@ final readonly class DispatchEntityMessageHandler
             $serializedEntities[] = $serializedEntity;
         }
 
-        if (empty($serializedEntities)) {
+        if ($serializedEntities === []) {
             return;
         }
 

--- a/src/Core/System/UsageData/EntitySync/EntityDispatcher.php
+++ b/src/Core/System/UsageData/EntitySync/EntityDispatcher.php
@@ -47,7 +47,7 @@ class EntityDispatcher
             return;
         }
 
-        if (empty($entities)) {
+        if ($entities === []) {
             return;
         }
 

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\CustomEntity\Xml\Config\AdminUi;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\Exception\CustomEntityXmlParsingException;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\AdminUi;
@@ -142,17 +143,8 @@ class AdminUiXmlSchemaTest extends TestCase
 
     public function testThrowsExceptionWithInvalidPath(): void
     {
-        try {
-            AdminUiXmlSchema::createFromXmlFile('invalid_path');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityXmlParsingException $exception) {
-            static::assertSame(
-                'Unable to parse file "invalid_path". Message: Resource "invalid_path" is not a file.',
-                $exception->getMessage()
-            );
-            static::assertSame('SYSTEM_CUSTOM_ENTITY__XML_PARSE_ERROR', $exception->getErrorCode());
-            static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::xmlParsingException('invalid_path', 'Resource "invalid_path" is not a file.'));
+        AdminUiXmlSchema::createFromXmlFile('invalid_path');
     }
 
     public function testThrowsExceptionWithXmlFile(): void
@@ -193,7 +185,7 @@ class AdminUiXmlSchemaTest extends TestCase
     }
 
     /**
-     * @return Entity[]
+     * @return array<string, Entity>
      */
     private function getEntities(AdminUiXmlSchema $adminUiXmlSchema): array
     {
@@ -201,7 +193,7 @@ class AdminUiXmlSchemaTest extends TestCase
     }
 
     /**
-     * @param Entity[] $entities
+     * @param array<string, Entity> $entities
      */
     private function checkEntity(array $entities, string $name): Entity
     {
@@ -216,8 +208,7 @@ class AdminUiXmlSchemaTest extends TestCase
      */
     private function checkListing(Entity $entity, array $refs): void
     {
-        $listing = $entity->getListing();
-        $columns = $listing->getColumns();
+        $columns = $entity->getListing()->getColumns();
         static::assertCount(\count($refs), $columns->getContent());
 
         foreach ($columns->getContent() as $column) {
@@ -229,7 +220,7 @@ class AdminUiXmlSchemaTest extends TestCase
     }
 
     /**
-     * @return Card[]
+     * @return list<Card>
      */
     private function checkTab(
         Tab $tab,
@@ -241,7 +232,7 @@ class AdminUiXmlSchemaTest extends TestCase
     }
 
     /**
-     * @param string[] $refs
+     * @param list<string> $refs
      */
     private function checkCard(
         Card $card,

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
@@ -4,10 +4,10 @@ namespace Shopware\Tests\Unit\Core\System\CustomEntity\Xml\Config\AdminUi;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidator;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Entity as AdminUiEntity;
-use Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityConfigurationException;
 use Shopware\Core\System\CustomEntity\Xml\CustomEntityXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Entity;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
  * @internal
  */
 #[CoversClass(AdminUiXmlSchemaValidator::class)]
-#[CoversClass(CustomEntityConfigurationException::class)]
 class AdminUiXmlSchemaValidatorTest extends TestCase
 {
     public function testThatNoExceptionIsThrown(): void
@@ -30,12 +29,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('invalidReferences/inColumns');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_in_columns` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
@@ -45,12 +44,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('invalidReferences/inCard');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_in_card` has invalid references (regarding `entities.xml`) inside of `<detail>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
@@ -60,13 +59,13 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('invalidReferences/complex');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             // Exception is thrown in listing first
             static::assertSame(
                 'In `admin-ui.xml` the entity `ce_invalid_ref_complex` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::INVALID_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
@@ -76,12 +75,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('duplicateReferences/inColumns');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_columns` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_string',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
@@ -91,12 +90,12 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('duplicateReferences/inCard');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_card` only allows unique fields per xml element, but found the following duplicates inside of `<detail>`: test_string',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }
@@ -106,13 +105,13 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
         try {
             $this->validate('duplicateReferences/complex');
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             // Exception is thrown in listing first
             static::assertSame(
                 'In `admin-ui.xml`, the entity `ce_duplicate_ref_complex` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_float',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::DUPLICATE_REFERENCES, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidatorTest.php
@@ -10,7 +10,6 @@ use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidat
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Entity as AdminUiEntity;
 use Shopware\Core\System\CustomEntity\Xml\CustomEntityXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Entity;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -26,94 +25,38 @@ class AdminUiXmlSchemaValidatorTest extends TestCase
 
     public function testThatInvalidReferencesIsThrownCausedInColumns(): void
     {
-        try {
-            $this->validate('invalidReferences/inColumns');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            static::assertSame(
-                'In `admin-ui.xml` the entity `ce_invalid_ref_in_columns` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::invalidReferences('admin-ui.xml', 'ce_invalid_ref_in_columns', '<listing>', ['i_am_an_invalid_reference']));
+        $this->validate('invalidReferences/inColumns');
     }
 
     public function testThatInvalidReferencesIsThrownCausedInCard(): void
     {
-        try {
-            $this->validate('invalidReferences/inCard');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            static::assertSame(
-                'In `admin-ui.xml` the entity `ce_invalid_ref_in_card` has invalid references (regarding `entities.xml`) inside of `<detail>`: i_am_an_invalid_reference',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::invalidReferences('admin-ui.xml', 'ce_invalid_ref_in_card', '<detail>', ['i_am_an_invalid_reference']));
+        $this->validate('invalidReferences/inCard');
     }
 
     public function testThatInvalidReferencesIsThrownComplex(): void
     {
-        try {
-            $this->validate('invalidReferences/complex');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            // Exception is thrown in listing first
-            static::assertSame(
-                'In `admin-ui.xml` the entity `ce_invalid_ref_complex` has invalid references (regarding `entities.xml`) inside of `<listing>`: i_am_an_invalid_reference',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::INVALID_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::invalidReferences('admin-ui.xml', 'ce_invalid_ref_complex', '<listing>', ['i_am_an_invalid_reference']));
+        $this->validate('invalidReferences/complex');
     }
 
     public function testThatDuplicateReferencesIsThrownCausedInColumns(): void
     {
-        try {
-            $this->validate('duplicateReferences/inColumns');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            static::assertSame(
-                'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_columns` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_string',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::duplicateReferences('admin-ui.xml', 'ce_duplicate_ref_in_columns', '<listing>', ['test_string']));
+        $this->validate('duplicateReferences/inColumns');
     }
 
     public function testThatDuplicateReferencesIsThrownCausedInCard(): void
     {
-        try {
-            $this->validate('duplicateReferences/inCard');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            static::assertSame(
-                'In `admin-ui.xml`, the entity `ce_duplicate_ref_in_card` only allows unique fields per xml element, but found the following duplicates inside of `<detail>`: test_string',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::duplicateReferences('admin-ui.xml', 'ce_duplicate_ref_in_card', '<detail>', ['test_string']));
+        $this->validate('duplicateReferences/inCard');
     }
 
     public function testThatDuplicateReferencesIsThrownComplex(): void
     {
-        try {
-            $this->validate('duplicateReferences/complex');
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            // Exception is thrown in listing first
-            static::assertSame(
-                'In `admin-ui.xml`, the entity `ce_duplicate_ref_complex` only allows unique fields per xml element, but found the following duplicates inside of `<listing>`: test_float',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::DUPLICATE_REFERENCES, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::duplicateReferences('admin-ui.xml', 'ce_duplicate_ref_complex', '<listing>', ['test_float']));
+        $this->validate('duplicateReferences/complex');
     }
 
     private function validate(string $fixturePath): void

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
@@ -4,10 +4,10 @@ namespace Shopware\Tests\Unit\Core\System\CustomEntity\Xml\Config;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidator;
 use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Entity as AdminUiEntity;
-use Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityConfigurationException;
 use Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityEnrichmentService;
 use Shopware\Core\System\CustomEntity\Xml\CustomEntityXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Entity;
@@ -17,7 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
  * @internal
  */
 #[CoversClass(CustomEntityEnrichmentService::class)]
-#[CoversClass(CustomEntityConfigurationException::class)]
 class CustomEntityEnrichmentServiceTest extends TestCase
 {
     private const FIXTURE_PATH = '%s/../../_fixtures/CustomEntityEnrichmentServiceTest/%s';
@@ -435,12 +434,12 @@ class CustomEntityEnrichmentServiceTest extends TestCase
                 $this->getAdminUiXmlSchema('admin-ui.entity_not_given_exception.xml')
             );
             static::fail('no Exception was thrown');
-        } catch (CustomEntityConfigurationException $exception) {
+        } catch (CustomEntityException $exception) {
             static::assertSame(
                 'The entities ce_not_defined0, ce_not_defined1 are not given in the entities.xml but are configured in admin-ui.xml',
                 $exception->getMessage()
             );
-            static::assertSame(CustomEntityConfigurationException::ENTITY_NOT_GIVEN_CODE, $exception->getErrorCode());
+            static::assertSame(CustomEntityException::ENTITY_NOT_GIVEN_CODE, $exception->getErrorCode());
             static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
         }
     }

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/CustomEntityEnrichmentServiceTest.php
@@ -11,7 +11,6 @@ use Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\XmlElements\Entity as A
 use Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityEnrichmentService;
 use Shopware\Core\System\CustomEntity\Xml\CustomEntityXmlSchema;
 use Shopware\Core\System\CustomEntity\Xml\Entity;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -428,20 +427,11 @@ class CustomEntityEnrichmentServiceTest extends TestCase
 
     public function testThatEntityNotGivenInAdminUiIsThrown(): void
     {
-        try {
-            $this->customEntityEnrichmentService->enrich(
-                $this->entitySchema,
-                $this->getAdminUiXmlSchema('admin-ui.entity_not_given_exception.xml')
-            );
-            static::fail('no Exception was thrown');
-        } catch (CustomEntityException $exception) {
-            static::assertSame(
-                'The entities ce_not_defined0, ce_not_defined1 are not given in the entities.xml but are configured in admin-ui.xml',
-                $exception->getMessage()
-            );
-            static::assertSame(CustomEntityException::ENTITY_NOT_GIVEN_CODE, $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+        $this->expectExceptionObject(CustomEntityException::entityNotGiven('admin-ui.xml', ['ce_not_defined0', 'ce_not_defined1']));
+        $this->customEntityEnrichmentService->enrich(
+            $this->entitySchema,
+            $this->getAdminUiXmlSchema('admin-ui.entity_not_given_exception.xml')
+        );
     }
 
     private function getCustomEntities(): CustomEntityXmlSchema


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
