### PR TITLE
feat: Refactor empty usage in migration, maintenance, etc to prepare its prohibition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1267,12 +1267,6 @@ parameters:
 			path: src/Core/Installer/InstallerKernel.php
 
 		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Installer/Requirements/Struct/RequirementCheck.php
-
-		-
 			message: '#^Method Shopware\\Core\\Profiling\\Integration\\Datadog\:\:start\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/Installer/Configuration/EnvConfigWriter.php
+++ b/src/Core/Installer/Configuration/EnvConfigWriter.php
@@ -98,15 +98,15 @@ EOT;
         $newEnv[] = 'APP_URL=' . $shop['schema'] . '://' . $shop['host'] . $shop['basePath'];
         $newEnv[] = 'DATABASE_URL=' . $info->asDsn();
 
-        if (!empty($info->getSslCaPath())) {
+        if (!in_array($info->getSslCaPath(), [null, '', '0'], true)) {
             $newEnv[] = 'DATABASE_SSL_CA=' . $info->getSslCaPath();
         }
 
-        if (!empty($info->getSslCertPath())) {
+        if (!in_array($info->getSslCertPath(), [null, '', '0'], true)) {
             $newEnv[] = 'DATABASE_SSL_CERT=' . $info->getSslCertPath();
         }
 
-        if (!empty($info->getSslCertKeyPath())) {
+        if (!in_array($info->getSslCertKeyPath(), [null, '', '0'], true)) {
             $newEnv[] = 'DATABASE_SSL_KEY=' . $info->getSslCertKeyPath();
         }
 

--- a/src/Core/Installer/Configuration/EnvConfigWriter.php
+++ b/src/Core/Installer/Configuration/EnvConfigWriter.php
@@ -106,7 +106,7 @@ EOT;
             $newEnv[] = 'DATABASE_SSL_CERT=' . $info->getSslCertPath();
         }
 
-        if (!($info->getSslCertKeyPath() ?? '') !== '') {
+        if (($info->getSslCertKeyPath() ?? '') !== '') {
             $newEnv[] = 'DATABASE_SSL_KEY=' . $info->getSslCertKeyPath();
         }
 

--- a/src/Core/Installer/Configuration/EnvConfigWriter.php
+++ b/src/Core/Installer/Configuration/EnvConfigWriter.php
@@ -98,15 +98,15 @@ EOT;
         $newEnv[] = 'APP_URL=' . $shop['schema'] . '://' . $shop['host'] . $shop['basePath'];
         $newEnv[] = 'DATABASE_URL=' . $info->asDsn();
 
-        if (!in_array($info->getSslCaPath(), [null, '', '0'], true)) {
+        if (($info->getSslCaPath() ?? '') !== '') {
             $newEnv[] = 'DATABASE_SSL_CA=' . $info->getSslCaPath();
         }
 
-        if (!in_array($info->getSslCertPath(), [null, '', '0'], true)) {
+        if (($info->getSslCertPath() ?? '') !== '') {
             $newEnv[] = 'DATABASE_SSL_CERT=' . $info->getSslCertPath();
         }
 
-        if (!in_array($info->getSslCertKeyPath(), [null, '', '0'], true)) {
+        if (!($info->getSslCertKeyPath() ?? '') !== '') {
             $newEnv[] = 'DATABASE_SSL_KEY=' . $info->getSslCertKeyPath();
         }
 

--- a/src/Core/Installer/Controller/ShopConfigurationController.php
+++ b/src/Core/Installer/Controller/ShopConfigurationController.php
@@ -125,7 +125,7 @@ class ShopConfigurationController extends InstallerController
                 $session->set('SELECTED_LANGUAGES', $selectedLanguages);
 
                 // Check if user selected any languages
-                if (empty($selectedLanguages)) {
+                if ($selectedLanguages === []) {
                     // No languages selected, go directly to finish page
                     $session->remove(DatabaseConnectionInformation::class);
 

--- a/src/Core/Installer/Database/DatabaseMigrator.php
+++ b/src/Core/Installer/Database/DatabaseMigrator.php
@@ -68,7 +68,7 @@ class DatabaseMigrator
         return [
             'offset' => $executedMigrations,
             'total' => $total,
-            'isFinished' => \count($coreMigrations->getExecutableDestructiveMigrations()) === 0,
+            'isFinished' => $coreMigrations->getExecutableDestructiveMigrations() === [],
         ];
     }
 }

--- a/src/Core/Installer/InstallerException.php
+++ b/src/Core/Installer/InstallerException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Installer;
+
+use Shopware\Core\Framework\HttpException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class InstallerException extends HttpException
+{
+    final public const INVALID_REQUIREMENT_CHECK = 'INSTALLER__INVALID_REQUIREMENT_CHECK';
+
+    public static function invalidRequirementCheck(string $message): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::INVALID_REQUIREMENT_CHECK,
+            $message,
+        );
+    }
+}

--- a/src/Core/Installer/Requirements/Struct/RequirementCheck.php
+++ b/src/Core/Installer/Requirements/Struct/RequirementCheck.php
@@ -25,7 +25,7 @@ abstract class RequirementCheck extends Struct
         string $name,
         string $status
     ) {
-        if (empty($name)) {
+        if ($name === '' || $name === '0') {
             throw new \RuntimeException('Empty name for RequirementCheck provided.');
         }
 

--- a/src/Core/Installer/Requirements/Struct/RequirementCheck.php
+++ b/src/Core/Installer/Requirements/Struct/RequirementCheck.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Installer\Requirements\Struct;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\Installer\InstallerException;
 
 /**
  * @internal
@@ -25,12 +26,12 @@ abstract class RequirementCheck extends Struct
         string $name,
         string $status
     ) {
-        if ($name === '' || $name === '0') {
-            throw new \RuntimeException('Empty name for RequirementCheck provided.');
+        if ($name === '') {
+            throw InstallerException::invalidRequirementCheck('Empty name for RequirementCheck provided.');
         }
 
         if (!\in_array($status, self::ALLOWED_STATUS, true)) {
-            throw new \RuntimeException(\sprintf(
+            throw InstallerException::invalidRequirementCheck(\sprintf(
                 'Invalid status for RequirementCheck, got "%s", allowed values are "%s".',
                 $status,
                 implode('", "', self::ALLOWED_STATUS)

--- a/src/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
+++ b/src/Core/Maintenance/SalesChannel/Command/SalesChannelMaintenanceEnableCommand.php
@@ -68,7 +68,7 @@ class SalesChannelMaintenanceEnableCommand extends Command
 
         $salesChannelIds = $this->salesChannelRepository->searchIds($criteria, $context)->getIds();
 
-        if (empty($salesChannelIds)) {
+        if ($salesChannelIds === []) {
             $output->write('No sales channels were updated');
 
             return self::SUCCESS;

--- a/src/Core/Maintenance/System/Service/SetupDatabaseAdapter.php
+++ b/src/Core/Maintenance/System/Service/SetupDatabaseAdapter.php
@@ -67,7 +67,7 @@ class SetupDatabaseAdapter
             ->select('SCHEMA_NAME')
             ->from('information_schema.SCHEMATA');
 
-        if (!empty($ignoredSchemas)) {
+        if ($ignoredSchemas !== []) {
             $query->andWhere('SCHEMA_NAME NOT IN (:ignoredSchemas)')
                 ->setParameter('ignoredSchemas', $ignoredSchemas, ArrayParameterType::STRING);
         }

--- a/src/Core/Maintenance/System/Service/ShopConfigurator.php
+++ b/src/Core/Maintenance/System/Service/ShopConfigurator.php
@@ -69,7 +69,7 @@ class ShopConfigurator
                 'languageId' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
             ]);
 
-            if (!empty($defaultCountryStateTranslations)) {
+            if ($defaultCountryStateTranslations !== []) {
                 $correctDeTranslations = [
                     'DE-BW' => 'Baden-Württemberg',
                     'DE-BY' => 'Bayern',
@@ -168,7 +168,7 @@ class ShopConfigurator
             'languageId' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
         ]);
 
-        if (empty($missingTranslations)) {
+        if ($missingTranslations === []) {
             return;
         }
 

--- a/src/Core/Migration/Traits/EnsureThumbnailSizesTrait.php
+++ b/src/Core/Migration/Traits/EnsureThumbnailSizesTrait.php
@@ -34,7 +34,7 @@ trait EnsureThumbnailSizesTrait
                 return (int) $var['width'] === $thumbnailSize['width'] && (int) $var['height'] === $thumbnailSize['height'];
             });
 
-            if (\count($result) > 0) {
+            if ($result !== []) {
                 $sizes[] = reset($result)['id'];
 
                 continue;

--- a/src/Core/Migration/Traits/TranslationWriteResult.php
+++ b/src/Core/Migration/Traits/TranslationWriteResult.php
@@ -35,11 +35,11 @@ class TranslationWriteResult
 
     public function hasWrittenEnglishTranslations(): bool
     {
-        return \count($this->englishLanguages) > 0;
+        return $this->englishLanguages !== [];
     }
 
     public function hasWrittenGermanTranslations(): bool
     {
-        return \count($this->getGermanLanguages()) > 0;
+        return $this->getGermanLanguages() !== [];
     }
 }

--- a/src/Core/Migration/Traits/UpdateMailTrait.php
+++ b/src/Core/Migration/Traits/UpdateMailTrait.php
@@ -60,7 +60,7 @@ trait UpdateMailTrait
         $languages = array_merge([Defaults::LANGUAGE_SYSTEM], $this->getLanguageIds($connection, 'en-GB'));
         $languages = array_unique(array_filter($languages));
 
-        if (empty($languages)) {
+        if ($languages === []) {
             return;
         }
 
@@ -89,7 +89,7 @@ trait UpdateMailTrait
         $languages = array_merge([Defaults::LANGUAGE_SYSTEM], $this->getLanguageIds($connection, 'en-GB'));
         $languages = array_unique(array_filter($languages));
 
-        if (empty($languages)) {
+        if ($languages === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_3/Migration1608624028RemoveDefaultSalesChannelAssignmentForCustomerRecoveryEvent.php
+++ b/src/Core/Migration/V6_3/Migration1608624028RemoveDefaultSalesChannelAssignmentForCustomerRecoveryEvent.php
@@ -27,7 +27,7 @@ class Migration1608624028RemoveDefaultSalesChannelAssignmentForCustomerRecoveryE
             AND updated_at IS NULL;
         ');
 
-        if (empty($customerRecoveryEvents)) {
+        if ($customerRecoveryEvents === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_4/Migration1611732852UpdateCmsPdpLayout.php
+++ b/src/Core/Migration/V6_4/Migration1611732852UpdateCmsPdpLayout.php
@@ -89,7 +89,7 @@ class Migration1611732852UpdateCmsPdpLayout extends MigrationStep
                 default => [],
             };
 
-            if (empty($configData)) {
+            if ($configData === []) {
                 return;
             }
 

--- a/src/Core/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
+++ b/src/Core/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
@@ -34,7 +34,7 @@ class Migration1612184092AddUrlLandingPage extends MigrationStep
             ['routeName' => 'frontend.landing.page']
         );
 
-        if (empty($seoUrlTemplate)) {
+        if ($seoUrlTemplate === []) {
             $connection->insert('seo_url_template', [
                 'id' => Uuid::randomBytes(),
                 /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Legacy usage in old migration) */

--- a/src/Core/Migration/V6_4/Migration1617356092UpdateCmsPdpLayoutSection.php
+++ b/src/Core/Migration/V6_4/Migration1617356092UpdateCmsPdpLayoutSection.php
@@ -118,7 +118,7 @@ class Migration1617356092UpdateCmsPdpLayoutSection extends MigrationStep
                 default => [],
             };
 
-            if (empty($configData)) {
+            if ($configData === []) {
                 return;
             }
 

--- a/src/Core/Migration/V6_4/Migration1620374229UpdateCustomFieldNameInProductStreamTable.php
+++ b/src/Core/Migration/V6_4/Migration1620374229UpdateCustomFieldNameInProductStreamTable.php
@@ -28,7 +28,7 @@ class Migration1620374229UpdateCustomFieldNameInProductStreamTable extends Migra
             ORDER BY custom_field.`name` ASC
         ');
 
-        if (empty($customFields)) {
+        if ($customFields === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_4/Migration1648803451FixInvalidMigrationOfBusinessEventToFlow.php
+++ b/src/Core/Migration/V6_4/Migration1648803451FixInvalidMigrationOfBusinessEventToFlow.php
@@ -146,7 +146,7 @@ class Migration1648803451FixInvalidMigrationOfBusinessEventToFlow extends Migrat
             );
         }
 
-        if (empty($this->sequenceDelete)) {
+        if ($this->sequenceDelete === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_4/Migration1661771388FixDefaultCountryStatesTranslationAreMissing.php
+++ b/src/Core/Migration/V6_4/Migration1661771388FixDefaultCountryStatesTranslationAreMissing.php
@@ -328,7 +328,7 @@ class Migration1661771388FixDefaultCountryStatesTranslationAreMissing extends Mi
             'languageId' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
         ]);
 
-        if (empty($missingTranslations)) {
+        if ($missingTranslations === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_4/Migration1665267882RenameCountryVat.php
+++ b/src/Core/Migration/V6_4/Migration1665267882RenameCountryVat.php
@@ -36,7 +36,7 @@ class Migration1665267882RenameCountryVat extends MigrationStep
                 WHERE country.iso = :iso AND country.iso3 = :iso3';
 
         $currentTranslations = $connection->fetchAllKeyValue($sql, ['iso' => 'VA', 'iso3' => 'VAT']);
-        if (empty($currentTranslations)) {
+        if ($currentTranslations === []) {
             return;
         }
 
@@ -47,14 +47,14 @@ class Migration1665267882RenameCountryVat extends MigrationStep
         if (($currentTranslations['de-DE'] ?? null) === 'Heiliger Stuhl') {
             $replacements['de-DE'] = 'Staat Vatikanstadt';
         }
-        if (empty($replacements)) {
+        if ($replacements === []) {
             return;
         }
 
         $sql = 'SELECT locale.code, language.id FROM language
                 LEFT JOIN locale ON locale.id = language.locale_id';
         $languageIds = $connection->fetchAllKeyValue($sql);
-        if (empty($languageIds)) {
+        if ($languageIds === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_4/Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate.php
+++ b/src/Core/Migration/V6_4/Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate.php
@@ -41,7 +41,7 @@ class Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate extend
 
         $flowTemplateConfig = json_decode((string) $flowTemplate['config'], true);
         $ruleIds = array_filter(array_column($flowTemplateConfig['sequences'], 'ruleId'));
-        $ruleId = !empty($ruleIds) ? $ruleIds[0] : null;
+        $ruleId = $ruleIds[0] ?? null;
 
         $ruleSequenceId = Uuid::randomHex();
         $sequenceConfig = [

--- a/src/Core/Migration/V6_5/Migration1673946817FixMediaFolderAssociationFields.php
+++ b/src/Core/Migration/V6_5/Migration1673946817FixMediaFolderAssociationFields.php
@@ -27,7 +27,7 @@ class Migration1673946817FixMediaFolderAssociationFields extends MigrationStep
 
         $fields = \json_decode((string) $data['association_fields'], true);
 
-        if (!\is_array($fields) || empty($fields)) {
+        if (!\is_array($fields) || $fields === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_5/Migration1676272001AddAccountTypeToCustomerProfileImportExport.php
+++ b/src/Core/Migration/V6_5/Migration1676272001AddAccountTypeToCustomerProfileImportExport.php
@@ -41,7 +41,7 @@ class Migration1676272001AddAccountTypeToCustomerProfileImportExport extends Mig
         $mappingFilterAccountType = array_filter($mapping, function ($mapping) {
             return $mapping['key'] === 'accountType';
         });
-        if (\count($mappingFilterAccountType)) {
+        if ($mappingFilterAccountType !== []) {
             return;
         }
 

--- a/src/Core/Migration/V6_6/Migration1673249981MigrateIsNewCustomerRule.php
+++ b/src/Core/Migration/V6_6/Migration1673249981MigrateIsNewCustomerRule.php
@@ -24,7 +24,7 @@ class Migration1673249981MigrateIsNewCustomerRule extends MigrationStep
         $ruleConditions = $connection->fetchAllAssociative('SELECT DISTINCT rule_id FROM rule_condition WHERE type = "customerIsNewCustomer"');
         $ruleIds = array_map(fn ($condition) => $condition['rule_id'], $ruleConditions);
 
-        if (empty($ruleIds)) {
+        if ($ruleIds === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_6/Migration1691662140MigrateAvailableStock.php
+++ b/src/Core/Migration/V6_6/Migration1691662140MigrateAvailableStock.php
@@ -35,6 +35,6 @@ class Migration1691662140MigrateAvailableStock extends MigrationStep
                 ['ids' => $ids],
                 ['ids' => ArrayParameterType::BINARY]
             );
-        } while (!empty($ids));
+        } while ($ids !== []);
     }
 }

--- a/src/Core/Migration/V6_6/Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlots.php
+++ b/src/Core/Migration/V6_6/Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlots.php
@@ -60,7 +60,7 @@ class Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlots 
                 }
             }
 
-            if (!empty($availableSortingIds)) {
+            if ($availableSortingIds !== []) {
                 $updatedConfig['availableSortings']['value'] = $availableSortingIds;
             }
 

--- a/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
+++ b/src/Core/Migration/V6_6/Migration1726049442UpdateVariantListingConfigInProductTable.php
@@ -31,7 +31,7 @@ class Migration1726049442UpdateVariantListingConfigInProductTable extends Migrat
                 (SELECT LOWER(HEX(`id`)) FROM `product` WHERE `parent_id` = `parent`.`id`)
         ');
 
-        if (empty($productIds)) {
+        if ($productIds === []) {
             return;
         }
 

--- a/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
+++ b/src/Core/Migration/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfig.php
@@ -40,7 +40,7 @@ class Migration1736831335AddGenerateDocumentTypesForDocumentConfig extends Migra
                 ['technicalName' => ArrayParameterType::STRING],
             )->fetchAllAssociative();
 
-            if (empty($documentConfig)) {
+            if ($documentConfig === []) {
                 return;
             }
 

--- a/src/Core/Migration/V6_6/Migration1739198249FixOrderDeliveryStateMachineName.php
+++ b/src/Core/Migration/V6_6/Migration1739198249FixOrderDeliveryStateMachineName.php
@@ -37,11 +37,11 @@ class Migration1739198249FixOrderDeliveryStateMachineName extends MigrationStep
         ));
 
         $stateMachineId = $connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || empty($stateMachineId)) {
+        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
             return;
         }
 
-        if (!empty($germanIds)) {
+        if ($germanIds !== []) {
             $connection->executeStatement('UPDATE state_machine_translation SET name = :name WHERE state_machine_id = :stateMachineId AND language_id IN (:languageIds) AND updated_at IS NULL', [
                 'name' => 'Versandstatus',
                 'stateMachineId' => $stateMachineId,
@@ -53,7 +53,7 @@ class Migration1739198249FixOrderDeliveryStateMachineName extends MigrationStep
             ]);
         }
 
-        if (!empty($englishIds)) {
+        if ($englishIds !== []) {
             $connection->executeStatement('UPDATE state_machine_translation SET name = :name WHERE state_machine_id = :stateMachineId AND language_id IN (:languageIds) AND updated_at IS NULL', [
                 'name' => 'Delivery state',
                 'stateMachineId' => $stateMachineId,

--- a/src/Core/Migration/V6_6/Migration1739198249FixOrderDeliveryStateMachineName.php
+++ b/src/Core/Migration/V6_6/Migration1739198249FixOrderDeliveryStateMachineName.php
@@ -37,7 +37,7 @@ class Migration1739198249FixOrderDeliveryStateMachineName extends MigrationStep
         ));
 
         $stateMachineId = $connection->fetchOne('SELECT id FROM state_machine WHERE technical_name = :technicalName', ['technicalName' => OrderDeliveryStates::STATE_MACHINE]);
-        if (!\is_string($stateMachineId) || ($stateMachineId === '' || $stateMachineId === '0')) {
+        if (!\is_string($stateMachineId) || $stateMachineId === '') {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1717573310ImportExportTechnicalNameRequired.php
+++ b/src/Core/Migration/V6_7/Migration1717573310ImportExportTechnicalNameRequired.php
@@ -63,7 +63,7 @@ class Migration1717573310ImportExportTechnicalNameRequired extends MigrationStep
     {
         $name = $name ?? 'Unnamed profile';
 
-        if (empty(trim($name))) {
+        if (in_array(trim($name), ['', '0'], true)) {
             $name = 'Unnamed profile';
         }
 

--- a/src/Core/Migration/V6_7/Migration1717573310ImportExportTechnicalNameRequired.php
+++ b/src/Core/Migration/V6_7/Migration1717573310ImportExportTechnicalNameRequired.php
@@ -63,7 +63,7 @@ class Migration1717573310ImportExportTechnicalNameRequired extends MigrationStep
     {
         $name = $name ?? 'Unnamed profile';
 
-        if (in_array(trim($name), ['', '0'], true)) {
+        if (trim($name) === '') {
             $name = 'Unnamed profile';
         }
 

--- a/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
+++ b/src/Core/Migration/V6_7/Migration1728040169AddPrimaryOrderDelivery.php
@@ -48,7 +48,7 @@ class Migration1728040169AddPrimaryOrderDelivery extends MigrationStep
                 ['limit' => ParameterType::INTEGER]
             );
 
-            if (empty($ids)) {
+            if ($ids === []) {
                 break;
             }
 

--- a/src/Core/Migration/V6_7/Migration1728040170AddPrimaryOrderTransaction.php
+++ b/src/Core/Migration/V6_7/Migration1728040170AddPrimaryOrderTransaction.php
@@ -48,7 +48,7 @@ class Migration1728040170AddPrimaryOrderTransaction extends MigrationStep
                 ['limit' => ParameterType::INTEGER]
             );
 
-            if (empty($ids)) {
+            if ($ids === []) {
                 break;
             }
 

--- a/src/Core/Migration/V6_7/Migration1742897274RegistrationSalutationToggleConfig.php
+++ b/src/Core/Migration/V6_7/Migration1742897274RegistrationSalutationToggleConfig.php
@@ -26,7 +26,7 @@ class Migration1742897274RegistrationSalutationToggleConfig extends MigrationSte
             ['core.loginRegistration.showSalutation']
         );
 
-        if (!empty($config)) {
+        if ($config !== []) {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1743064966CartConfigSubtotalTaxColumn.php
+++ b/src/Core/Migration/V6_7/Migration1743064966CartConfigSubtotalTaxColumn.php
@@ -32,7 +32,7 @@ class Migration1743064966CartConfigSubtotalTaxColumn extends MigrationStep
             [$key]
         );
 
-        if (!empty($config)) {
+        if ($config !== []) {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1759390536CartConfigShowTosCheckbox.php
+++ b/src/Core/Migration/V6_7/Migration1759390536CartConfigShowTosCheckbox.php
@@ -31,7 +31,7 @@ class Migration1759390536CartConfigShowTosCheckbox extends MigrationStep
             [$key]
         );
 
-        if (!empty($config)) {
+        if ($config !== []) {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1764064757SetSearchableForExistingCustomFieldsInProductSearch.php
+++ b/src/Core/Migration/V6_7/Migration1764064757SetSearchableForExistingCustomFieldsInProductSearch.php
@@ -27,7 +27,7 @@ class Migration1764064757SetSearchableForExistingCustomFieldsInProductSearch ext
                 AND searchable = 1
         ')->fetchFirstColumn();
 
-        if (\count($customFieldIds) === 0) {
+        if ($customFieldIds === []) {
             return;
         }
 

--- a/src/Core/Profiling/Integration/ServerTiming.php
+++ b/src/Core/Profiling/Integration/ServerTiming.php
@@ -47,7 +47,7 @@ class ServerTiming implements ProfilerInterface
 
     public function onResponseEvent(ResponseEvent $event): void
     {
-        if (!empty($this->elements)) {
+        if ($this->elements !== []) {
             $response = $event->getResponse();
             $response->headers->set('Server-Timing', implode(', ', $this->elements));
         }

--- a/src/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/ActiveRulesDataCollectorSubscriber.php
@@ -81,7 +81,7 @@ class ActiveRulesDataCollectorSubscriber extends AbstractDataCollector implement
 
     private function getMatchingRules(): RuleCollection
     {
-        if (empty($this->ruleIds)) {
+        if ($this->ruleIds === []) {
             return new RuleCollection();
         }
 

--- a/src/Core/Service/AllServiceInstaller.php
+++ b/src/Core/Service/AllServiceInstaller.php
@@ -60,7 +60,7 @@ class AllServiceInstaller
             }
         }
 
-        if (!empty($installedServices)) {
+        if ($installedServices !== []) {
             $this->eventDispatcher->dispatch(new NewServicesInstalledEvent());
         }
 

--- a/src/Core/Service/AppInfo.php
+++ b/src/Core/Service/AppInfo.php
@@ -36,7 +36,7 @@ readonly class AppInfo
             }
         }
 
-        if (!empty($missingKeys)) {
+        if ($missingKeys !== []) {
             throw ServiceException::missingAppVersionInformation(...$missingKeys);
         }
 

--- a/src/Core/Service/Command/Install.php
+++ b/src/Core/Service/Command/Install.php
@@ -40,7 +40,7 @@ class Install extends Command
 
         $installed = $this->manager->install(Context::createCLIContext());
 
-        if (empty($installed)) {
+        if ($installed === []) {
             $io->info('No services were installed');
         } else {
             $io->success(\sprintf('Done. Installed %s', implode(', ', $installed)));

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -148,7 +148,7 @@ class LifecycleManager
     {
         $registryServices = $this->client->getAll();
 
-        if (\count($registryServices) === 0) {
+        if ($registryServices === []) {
             // this is not safe to do if there are zero services.
             // it could be a transient error or a misconfiguration.
             return;

--- a/src/Core/Service/State.php
+++ b/src/Core/Service/State.php
@@ -19,11 +19,11 @@ enum State: string
 
     public static function state(AppEntity $appEntity): State
     {
-        if (\count($appEntity->getRequestedPrivileges()) === 0 && $appEntity->isActive()) {
+        if ($appEntity->getRequestedPrivileges() === [] && $appEntity->isActive()) {
             return State::ACTIVE;
         }
 
-        if (\count($appEntity->getRequestedPrivileges()) > 0 && $appEntity->isActive()) {
+        if ($appEntity->getRequestedPrivileges() !== [] && $appEntity->isActive()) {
             return State::PENDING_PERMISSIONS;
         }
 

--- a/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
+++ b/src/Core/Test/Integration/Builder/Promotion/PromotionFixtureBuilder.php
@@ -114,7 +114,7 @@ class PromotionFixtureBuilder
             $data['useCodes'] = true;
         }
 
-        if (\count($this->dataSetGroups) > 0) {
+        if ($this->dataSetGroups !== []) {
             $data['useSetGroups'] = true;
         }
 
@@ -122,12 +122,12 @@ class PromotionFixtureBuilder
         $this->promotionRepository->create([$data], $this->context->getContext());
 
         // save our defined set groups
-        if (\count($this->dataSetGroups) > 0) {
+        if ($this->dataSetGroups !== []) {
             $this->promotionSetgroupRepository->create($this->dataSetGroups, $this->context->getContext());
         }
 
         // save our added discounts
-        if (\count($this->dataDiscounts) > 0) {
+        if ($this->dataDiscounts !== []) {
             $this->promotionDiscountRepository->create($this->dataDiscounts, $this->context->getContext());
         }
     }

--- a/src/Core/Test/PHPUnit/Extension/DatabaseDiff/Subscriber/TestFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/DatabaseDiff/Subscriber/TestFinishedSubscriber.php
@@ -21,7 +21,7 @@ class TestFinishedSubscriber implements FinishedSubscriber
     {
         $diff = $this->dbState->getDiff();
 
-        if (!empty($diff)) {
+        if ($diff !== []) {
             echo \PHP_EOL . $event->asString() . \PHP_EOL;
 
             print_r($diff);

--- a/src/Core/Test/Stub/SystemConfigService/StaticSystemConfigService.php
+++ b/src/Core/Test/Stub/SystemConfigService/StaticSystemConfigService.php
@@ -10,7 +10,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 class StaticSystemConfigService extends SystemConfigService
 {
     /**
-     * @param array<string, mixed> $config
+     * @param array<string, mixed>|array<string, array<string, mixed>> $config
      */
     public function __construct(private array $config = [])
     {
@@ -74,7 +74,7 @@ class StaticSystemConfigService extends SystemConfigService
             $pointer = $configValue;
         }
 
-        // @phpstan-ignore empty.variable ($foundValues can be empty)
+        // @phpstan-ignore identical.alwaysTrue ($foundValues can be empty)
         if ($foundValues === []) {
             return null;
         }

--- a/src/Core/Test/Stub/SystemConfigService/StaticSystemConfigService.php
+++ b/src/Core/Test/Stub/SystemConfigService/StaticSystemConfigService.php
@@ -75,7 +75,7 @@ class StaticSystemConfigService extends SystemConfigService
         }
 
         // @phpstan-ignore empty.variable ($foundValues can be empty)
-        if (empty($foundValues)) {
+        if ($foundValues === []) {
             return null;
         }
 

--- a/src/Core/Test/TestBuilderTrait.php
+++ b/src/Core/Test/TestBuilderTrait.php
@@ -38,7 +38,7 @@ trait TestBuilderTrait
         $data = \array_merge($data, $this->_dynamic);
 
         return \array_filter($data, function ($value) {
-            if (\is_array($value) && empty($value)) {
+            if ($value === []) {
                 return false;
             }
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -68,7 +68,7 @@ class TestBootstrapper
         if ($this->isForceInstall() || !$this->dbExists()) {
             $this->install();
 
-            if (!empty($this->activePlugins)) {
+            if ($this->activePlugins !== []) {
                 $this->installPlugins();
             }
         } elseif ($this->forceInstallPlugins) {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DefinitionValidatorTest.php
@@ -139,7 +139,7 @@ class DefinitionValidatorTest extends TestCase
     private function createValidatorWithTable(EntityDefinition $definition, array $dbPrimaryKeys): DefinitionValidator
     {
         $pkConstraint = null;
-        if (!empty($dbPrimaryKeys)) {
+        if ($dbPrimaryKeys !== []) {
             $pkColumns = array_map(
                 static function (string $col): UnqualifiedName {
                     static::assertNotEmpty($col);


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
