### PR TITLE
refactor(category): replace magic number with navigation depth constant

### DIFF
--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryException;
 use Shopware\Core\Content\Category\Service\DefaultCategoryLevelLoaderInterface;
+use Shopware\Core\Content\Category\Service\NavigationLoaderInterface;
 use Shopware\Core\Content\Category\Tree\CategoryTreePathResolver;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
@@ -77,7 +78,7 @@ class NavigationRoute extends AbstractNavigationRoute
         SalesChannelContext $context,
         Criteria $criteria
     ): NavigationRouteResponse {
-        $depth = $request->query->getInt('depth', $request->request->getInt('depth', 2));
+        $depth = $request->query->getInt('depth', $request->request->getInt('depth', NavigationLoaderInterface::DEFAULT_DEPTH));
 
         $metaInfo = $this->getCategoryMetaInfo($activeId, $rootId);
 

--- a/src/Core/Content/Category/Service/NavigationLoader.php
+++ b/src/Core/Content/Category/Service/NavigationLoader.php
@@ -36,7 +36,7 @@ class NavigationLoader implements NavigationLoaderInterface
      *
      * @throws CategoryNotFoundException
      */
-    public function load(string $activeId, SalesChannelContext $context, string $rootId, int $depth = 2): Tree
+    public function load(string $activeId, SalesChannelContext $context, string $rootId, int $depth = NavigationLoaderInterface::DEFAULT_DEPTH): Tree
     {
         $request = new Request();
         $request->query->set('buildTree', 'false');

--- a/src/Core/Content/Category/Service/NavigationLoaderInterface.php
+++ b/src/Core/Content/Category/Service/NavigationLoaderInterface.php
@@ -9,10 +9,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('discovery')]
 interface NavigationLoaderInterface
 {
+    public const DEFAULT_DEPTH = 2;
+
     /**
      * Returns the first two levels of the category tree, as well as all parents of the active category
      * and the active categories first level of children.
      * The provided active id will be marked as selected
      */
-    public function load(string $activeId, SalesChannelContext $context, string $rootId, int $depth = 2): Tree;
+    public function load(string $activeId, SalesChannelContext $context, string $rootId, int $depth = self::DEFAULT_DEPTH): Tree;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The default navigation depth `2` was hardcoded in 3 separate places (`NavigationLoaderInterface`, `NavigationLoader`, `NavigationRoute`). If someone wanted to change the default, they'd have to find and update all of them. A single `DEFAULT_DEPTH` constant on the interface makes it one place to change.

### 2. What does this change do, exactly?

Introduces a `DEFAULT_DEPTH = 2` constant on `NavigationLoaderInterface` and replaces the hardcoded `2` in the interface signature, its implementation in `NavigationLoader`, and the request fallback in `NavigationRoute`.

### 3. Describe each step to reproduce the issue or behaviour.

Nah.

### 4. Please link to the relevant issues (if any).

Nah.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
