### PR TITLE
feat: add functionality to schedule tasks in maintenance window

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -105,6 +105,9 @@
                 "messenger": {
                     "$ref": "#/definitions/messenger"
                 },
+                "scheduled_task": {
+                    "$ref": "#/definitions/scheduled_task"
+                },
                 "redis": {
                     "$ref": "#/definitions/redis"
                 },
@@ -373,6 +376,27 @@
                             "default": 12
                         }
                     }
+                }
+            }
+        },
+        "scheduled_task": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "maintenance_window_start": {
+                    "type": "integer",
+                    "default": 1,
+                    "minimum": 0,
+                    "maximum": 23,
+                    "title": "Defines the start of the maintenance window in hours (0-23) at which maintenance scheduled tasks will be scheduled",
+                    "description": "The maintenance window is used to schedule maintenance tasks such as database cleanup or log pruning during off-peak hours."
+                },
+                "maintenance_scheduled_tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "List of maintenance scheduled tasks that are scheduled in the maintenance window"
                 }
             }
         },

--- a/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
+++ b/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
@@ -25,10 +25,12 @@ final class CleanupCartTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly AbstractCartPersister $cartPersister,
         private readonly int $days
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Checkout/Customer/DeleteUnusedGuestCustomerHandler.php
+++ b/src/Core/Checkout/Customer/DeleteUnusedGuestCustomerHandler.php
@@ -25,9 +25,11 @@ final class DeleteUnusedGuestCustomerHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly DeleteUnusedGuestCustomerService $unusedGuestCustomerService
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -38,6 +38,8 @@
         <service id="Shopware\Core\Checkout\Cart\Cleanup\CleanupCartTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
             <argument>%shopware.cart.expire_days%</argument>
             <tag name="messenger.message_handler"/>

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -405,6 +405,8 @@
         <service id="Shopware\Core\Checkout\Customer\DeleteUnusedGuestCustomerHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Checkout\Customer\DeleteUnusedGuestCustomerService" />
 
             <tag name="messenger.message_handler" />

--- a/src/Core/Checkout/DependencyInjection/payment.xml
+++ b/src/Core/Checkout/DependencyInjection/payment.xml
@@ -157,6 +157,8 @@
         <service id="Shopware\Core\Checkout\Payment\Cleanup\CleanupPaymentTokenTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Checkout/Payment/Cleanup/CleanupPaymentTokenTaskHandler.php
+++ b/src/Core/Checkout/Payment/Cleanup/CleanupPaymentTokenTaskHandler.php
@@ -26,9 +26,11 @@ final class CleanupPaymentTokenTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection,
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/DependencyInjection/import_export.xml
+++ b/src/Core/Content/DependencyInjection/import_export.xml
@@ -307,6 +307,8 @@
         <service id="Shopware\Core\Content\ImportExport\ScheduledTask\CleanupImportExportFileTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Content\ImportExport\Service\DeleteExpiredFilesService"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -396,6 +396,8 @@
         <service id="Shopware\Core\Content\Media\ScheduledTask\CleanupCorruptedMediaHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="media.repository"/>
             <tag name="messenger.message_handler" />
         </service>

--- a/src/Core/Content/DependencyInjection/newsletter_recipient.xml
+++ b/src/Core/Content/DependencyInjection/newsletter_recipient.xml
@@ -24,6 +24,8 @@
         <service id="Shopware\Core\Content\Newsletter\ScheduledTask\NewsletterRecipientTaskHandler">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="newsletter_recipient.repository" />
             <tag name="messenger.message_handler" />
         </service>

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -568,6 +568,8 @@
         <service id="Shopware\Core\Content\Product\Cleanup\CleanupProductKeywordDictionaryTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <tag name="messenger.message_handler"/>
         </service>
@@ -579,6 +581,8 @@
         <service id="Shopware\Core\Content\Product\Cleanup\CleanupUnusedDownloadMediaTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Content\Media\UnusedMediaPurger"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -63,6 +63,8 @@
         <service id="Shopware\Core\Content\ProductExport\ScheduledTask\ProductExportGenerateTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="string">%product_export.stale_min_seconds%</argument>

--- a/src/Core/Content/DependencyInjection/product_stream.xml
+++ b/src/Core/Content/DependencyInjection/product_stream.xml
@@ -38,6 +38,8 @@
         <service id="Shopware\Core\Content\ProductStream\ScheduledTask\UpdateProductStreamMappingTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="product_stream.repository"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -106,6 +106,8 @@
         <service id="Shopware\Core\Content\Sitemap\ScheduledTask\SitemapGenerateTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="sales_channel.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="messenger.default_bus"/>

--- a/src/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandler.php
+++ b/src/Core/Content/ImportExport/ScheduledTask/CleanupImportExportFileTaskHandler.php
@@ -26,9 +26,11 @@ final class CleanupImportExportFileTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly DeleteExpiredFilesService $deleteExpiredFilesService
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
+++ b/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
@@ -27,9 +27,11 @@ final class CleanupCorruptedMediaHandler extends ScheduledTaskHandler
     public function __construct(
         protected EntityRepository $scheduledTaskRepository,
         protected readonly LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityRepository $mediaRepository
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandler.php
+++ b/src/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandler.php
@@ -30,9 +30,11 @@ final class NewsletterRecipientTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityRepository $newsletterRecipientRepository
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
+++ b/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
@@ -26,9 +26,11 @@ final class CleanupProductKeywordDictionaryTaskHandler extends ScheduledTaskHand
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandler.php
+++ b/src/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandler.php
@@ -24,9 +24,11 @@ final class CleanupUnusedDownloadMediaTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly UnusedMediaPurger $unusedMediaPurger
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -29,12 +29,14 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection,
         private readonly MessageBusInterface $messageBus,
         private readonly int $staleMinSeconds = 300,
         private readonly float $staleIntervalFactor = 2.0
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/ProductStream/ScheduledTask/UpdateProductStreamMappingTaskHandler.php
+++ b/src/Core/Content/ProductStream/ScheduledTask/UpdateProductStreamMappingTaskHandler.php
@@ -30,9 +30,11 @@ final class UpdateProductStreamMappingTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityRepository $productStreamRepository
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
+++ b/src/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandler.php
@@ -37,12 +37,14 @@ final class SitemapGenerateTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityRepository $salesChannelRepository,
         private readonly SystemConfigService $systemConfigService,
         private readonly MessageBusInterface $messageBus,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandler.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandler.php
@@ -18,9 +18,11 @@ final class InvalidateCacheTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly CacheInvalidator $cacheInvalidator
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
+++ b/src/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandler.php
@@ -36,10 +36,12 @@ final class DeleteCascadeAppsHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityRepository $aclRoleRepository,
         private readonly EntityRepository $integrationRepository
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/App/ScheduledTask/UpdateAppsHandler.php
+++ b/src/Core/Framework/App/ScheduledTask/UpdateAppsHandler.php
@@ -23,9 +23,11 @@ final class UpdateAppsHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly AbstractAppUpdater $appUpdater
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
+++ b/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
@@ -26,10 +26,12 @@ final class CleanupVersionTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection,
         private readonly int $days
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -50,6 +50,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->createStagingNode())
                 ->append($this->createSystemConfigNode())
                 ->append($this->createMessengerSection())
+                ->append($this->createScheduledTaskSection())
                 ->append($this->createSearchSection())
                 ->append($this->createTelemetrySection())
                 ->append($this->createRedisSection())
@@ -1094,6 +1095,20 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('enabled')->defaultTrue()->end()
                         ->integerNode('time_span')->defaultValue(300)->end()
                     ->end()
+            ->end();
+
+        return $rootNode;
+    }
+
+    private function createScheduledTaskSection(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('scheduled_task');
+
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+            ->integerNode('maintenance_window_start')->defaultValue(1)->min(0)->max(23)->end()
+            ->arrayNode('maintenance_scheduled_tasks')->prototype('scalar')->end()->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -307,6 +307,8 @@
         <service id="Shopware\Core\Framework\App\ScheduledTask\UpdateAppsHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Update\AbstractAppUpdater" on-invalid="null"/>
             <tag name="messenger.message_handler"/>
         </service>
@@ -318,6 +320,8 @@
         <service id="Shopware\Core\Framework\App\ScheduledTask\DeleteCascadeAppsHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="acl_role.repository"/>
             <argument type="service" id="integration.repository"/>
             <tag name="messenger.message_handler"/>

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -66,6 +66,8 @@
         <service id="Shopware\Core\Framework\Adapter\Cache\InvalidateCacheTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheInvalidator"/>
 
             <tag name="messenger.message_handler"/>

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -731,6 +731,8 @@
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Version\Cleanup\CleanupVersionTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument>%shopware.dal.versioning.expire_days%</argument>
             <tag name="messenger.message_handler"/>

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -562,6 +562,8 @@ frame-ancestors 'none';
         <service id="Shopware\Core\Framework\Log\ScheduledTask\LogCleanupTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService" />
             <argument type="service" id="Doctrine\DBAL\Connection" />
 

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -266,6 +266,8 @@
         <service id="Shopware\Core\Framework\Store\InAppPurchase\Handler\InAppPurchaseUpdateHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Framework\Store\InAppPurchase\Services\InAppPurchaseUpdater"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider"/>
 

--- a/src/Core/Framework/DependencyInjection/webhook.xml
+++ b/src/Core/Framework/DependencyInjection/webhook.xml
@@ -96,6 +96,8 @@
         <service id="Shopware\Core\Framework\Webhook\ScheduledTask\CleanupWebhookEventLogTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookCleanup"/>
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandler.php
+++ b/src/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandler.php
@@ -25,10 +25,12 @@ final class LogCleanupTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly SystemConfigService $systemConfigService,
         private readonly Connection $connection
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandler.php
@@ -14,10 +14,13 @@ abstract class ScheduledTaskHandler
 {
     /**
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
+     * @param array<string> $maintenanceScheduledTasks
      */
     public function __construct(
         protected EntityRepository $scheduledTaskRepository,
         protected readonly LoggerInterface $exceptionLogger,
+        protected readonly int $maintenanceWindowStart,
+        protected readonly array $maintenanceScheduledTasks
     ) {
     }
 
@@ -100,6 +103,10 @@ abstract class ScheduledTaskHandler
             $newNextExecutionTime = $now;
         }
 
+        if (\in_array($task::class, $this->maintenanceScheduledTasks, true)) {
+            $newNextExecutionTime = $this->getNextMaintenanceWindowStart();
+        }
+
         $this->scheduledTaskRepository->update([
             [
                 'id' => $task->getTaskId(),
@@ -108,5 +115,17 @@ abstract class ScheduledTaskHandler
                 'nextExecutionTime' => $newNextExecutionTime,
             ],
         ], Context::createCLIContext());
+    }
+
+    private function getNextMaintenanceWindowStart(): \DateTimeImmutable
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $nextWindowTime = $now->setTime($this->maintenanceWindowStart, 0);
+
+        if ($nextWindowTime <= $now) {
+            $nextWindowTime = $nextWindowTime->modify('+1 day');
+        }
+
+        return $nextWindowTime;
     }
 }

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -584,6 +584,10 @@ shopware:
     feature_toggle:
         enable: true
 
+    scheduled_task:
+        maintenance_window_start: 1
+        maintenance_scheduled_tasks: []
+
     search:
         term_max_length: 300
         # special chars that will not be removed on tokenizing

--- a/src/Core/Framework/Store/InAppPurchase/Handler/InAppPurchaseUpdateHandler.php
+++ b/src/Core/Framework/Store/InAppPurchase/Handler/InAppPurchaseUpdateHandler.php
@@ -23,9 +23,11 @@ final class InAppPurchaseUpdateHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly InAppPurchaseUpdater $iapUpdater
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
+++ b/src/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandler.php
@@ -25,9 +25,11 @@ final class CleanupWebhookEventLogTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly WebhookCleanup $webhookCleanup
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -71,6 +71,8 @@
         <service id="Shopware\Core\Service\ScheduledTask\InstallServicesTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\Service\LifecycleManager"/>
 
             <tag name="messenger.message_handler"/>

--- a/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
+++ b/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
@@ -24,9 +24,11 @@ final class InstallServicesTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly LifecycleManager $manager,
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -200,6 +200,8 @@
         <service id="Shopware\Core\System\SalesChannel\Context\Cleanup\CleanupSalesChannelContextTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument>%shopware.sales_channel_context.expire_days%</argument>
             <tag name="messenger.message_handler"/>

--- a/src/Core/System/DependencyInjection/usage_data.xml
+++ b/src/Core/System/DependencyInjection/usage_data.xml
@@ -149,6 +149,8 @@
         <service id="Shopware\Core\System\UsageData\ScheduledTask\CollectEntityDataTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Shopware\Core\System\UsageData\Services\EntityDispatchService"/>
 
             <tag name="messenger.message_handler"/>

--- a/src/Core/System/SalesChannel/Context/Cleanup/CleanupSalesChannelContextTaskHandler.php
+++ b/src/Core/System/SalesChannel/Context/Cleanup/CleanupSalesChannelContextTaskHandler.php
@@ -26,10 +26,12 @@ final class CleanupSalesChannelContextTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection,
         private readonly int $days
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandler.php
+++ b/src/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandler.php
@@ -23,9 +23,11 @@ final class CollectEntityDataTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $repository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly EntityDispatchService $entityDispatchService,
     ) {
-        parent::__construct($repository, $logger);
+        parent::__construct($repository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
+++ b/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
@@ -32,13 +32,15 @@ class CreateAliasTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Client $client,
         private readonly Connection $connection,
         private readonly ElasticsearchHelper $elasticsearchHelper,
         private readonly array $config,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -200,6 +200,8 @@
         <service id="Shopware\Elasticsearch\Framework\Indexing\CreateAliasTaskHandler" public="true">
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="OpenSearch\Client"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -171,6 +171,8 @@
         <service id="Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTaskHandler">
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
+            <argument>%shopware.scheduled_task.maintenance_window_start%</argument>
+            <argument>%shopware.scheduled_task.maintenance_scheduled_tasks%</argument>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="shopware.filesystem.theme"/>
             <argument type="service" id="Shopware\Storefront\Theme\AbstractThemePathBuilder"/>

--- a/src/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandler.php
+++ b/src/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandler.php
@@ -25,11 +25,13 @@ final class DeleteThemeFilesTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $exceptionLogger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly Connection $connection,
         private readonly FilesystemOperator $themeFileSystem,
         private readonly AbstractThemePathBuilder $themePathBuilder,
     ) {
-        parent::__construct($scheduledTaskRepository, $exceptionLogger);
+        parent::__construct($scheduledTaskRepository, $exceptionLogger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/tests/integration/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Newsletter/ScheduledTask/NewsletterRecipientTaskHandlerTest.php
@@ -84,6 +84,8 @@ class NewsletterRecipientTaskHandlerTest extends TestCase
         return new NewsletterRecipientTaskHandler(
             static::getContainer()->get('scheduled_task.repository'),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             static::getContainer()->get('newsletter_recipient.repository')
         );
     }

--- a/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -159,6 +159,8 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         return new ProductExportGenerateTaskHandler(
             static::getContainer()->get('scheduled_task.repository'),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             static::getContainer()->get(Connection::class),
             static::getContainer()->get('messenger.default_bus')
         );

--- a/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Sitemap/ScheduledTask/SitemapGenerateTaskHandlerTest.php
@@ -56,6 +56,8 @@ class SitemapGenerateTaskHandlerTest extends TestCase
         $this->sitemapHandler = new SitemapGenerateTaskHandler(
             static::getContainer()->get('scheduled_task.repository'),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $this->salesChannelRepository,
             static::getContainer()->get(SystemConfigService::class),
             $this->messageBusMock,

--- a/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
+++ b/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
@@ -107,6 +107,8 @@ class DeleteCascadeAppsHandlerTest extends TestCase
         $handler = new DeleteCascadeAppsHandler(
             $this->scheduledTaskRepo,
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $this->aclRoleRepo,
             $this->integrationRepo
         );

--- a/tests/integration/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandlerTest.php
@@ -103,6 +103,8 @@ class LogCleanupTaskHandlerTest extends TestCase
         $handler = new LogCleanupTaskHandler(
             $this->scheduledTaskRepository,
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $this->systemConfigService,
             $this->connection
         );

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -70,7 +70,7 @@ class ScheduledTaskHandlerTest extends TestCase
         $task = new TestTask();
         $task->setTaskId($taskId);
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId);
         $handler($task);
 
         static::assertTrue($handler->wasCalled());
@@ -123,7 +123,7 @@ class ScheduledTaskHandlerTest extends TestCase
         $task = new TestTask();
         $task->setTaskId($taskId);
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId);
         $handler($task);
         $nowTime = new \DateTime();
 
@@ -161,7 +161,7 @@ class ScheduledTaskHandlerTest extends TestCase
         $task = new TestTask();
         $task->setTaskId($taskId);
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId, true);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId, true);
 
         $exception = null;
 
@@ -203,7 +203,7 @@ class ScheduledTaskHandlerTest extends TestCase
 
         $this->logger->expects($this->once())->method('error');
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId, true);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId, true);
 
         $exception = null;
 
@@ -227,7 +227,7 @@ class ScheduledTaskHandlerTest extends TestCase
         $task = new TestTask();
         $task->setTaskId($taskId);
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId);
         $handler($task);
 
         static::assertFalse($handler->wasCalled());
@@ -254,7 +254,7 @@ class ScheduledTaskHandlerTest extends TestCase
         $task = new TestTask();
         $task->setTaskId($taskId);
 
-        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId);
+        $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, 1, [], $taskId);
         $handler($task);
 
         static::assertFalse($handler->wasCalled());
@@ -262,6 +262,103 @@ class ScheduledTaskHandlerTest extends TestCase
         /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
         static::assertSame($status, $task->getStatus());
+    }
+
+    public function testHandleReschedulesMaintenanceTaskToNextMaintenanceWindow(): void
+    {
+        $this->connection->executeStatement('DELETE FROM scheduled_task');
+
+        $taskId = Uuid::randomHex();
+        $originalNextExecution = (new \DateTime())->modify('-10 seconds');
+        $interval = 300;
+        $maintenanceWindowStart = 3;
+
+        $this->scheduledTaskRepo->create([
+            [
+                'id' => $taskId,
+                'name' => 'test',
+                'scheduledTaskClass' => TestTask::class,
+                'runInterval' => $interval,
+                'defaultRunInterval' => $interval,
+                'status' => ScheduledTaskDefinition::STATUS_QUEUED,
+                'nextExecutionTime' => $originalNextExecution,
+            ],
+        ], Context::createDefaultContext());
+
+        $task = new TestTask();
+        $task->setTaskId($taskId);
+
+        $handler = new DummyScheduledTaskHandler(
+            $this->scheduledTaskRepo,
+            $this->logger,
+            $maintenanceWindowStart,
+            [TestTask::class],
+            $taskId
+        );
+        $handler($task);
+
+        static::assertTrue($handler->wasCalled());
+
+        /** @var ScheduledTaskEntity $task */
+        $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $expectedNextExecution = $now->setTime($maintenanceWindowStart, 0);
+        if ($expectedNextExecution <= $now) {
+            $expectedNextExecution = $expectedNextExecution->modify('+1 day');
+        }
+
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame(
+            $expectedNextExecution->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $task->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
+    }
+
+    public function testHandleDoesNotUseMaintenanceWindowForNonMaintenanceTasks(): void
+    {
+        $this->connection->executeStatement('DELETE FROM scheduled_task');
+
+        $taskId = Uuid::randomHex();
+        $originalNextExecution = (new \DateTime())->modify('-10 seconds');
+        $interval = 300;
+
+        $this->scheduledTaskRepo->create([
+            [
+                'id' => $taskId,
+                'name' => 'test',
+                'scheduledTaskClass' => TestTask::class,
+                'runInterval' => $interval,
+                'defaultRunInterval' => $interval,
+                'status' => ScheduledTaskDefinition::STATUS_QUEUED,
+                'nextExecutionTime' => $originalNextExecution,
+            ],
+        ], Context::createDefaultContext());
+
+        $task = new TestTask();
+        $task->setTaskId($taskId);
+
+        $handler = new DummyScheduledTaskHandler(
+            $this->scheduledTaskRepo,
+            $this->logger,
+            3,
+            [],
+            $taskId
+        );
+        $handler($task);
+
+        static::assertTrue($handler->wasCalled());
+
+        /** @var ScheduledTaskEntity $task */
+        $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
+
+        $newOriginalNextExecution = clone $originalNextExecution;
+        $newOriginalNextExecution->modify(\sprintf('+%d seconds', $interval));
+        $newOriginalNextExecutionString = $newOriginalNextExecution->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+        $nextExecutionTimeString = $task->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
+        static::assertSame($newOriginalNextExecutionString, $nextExecutionTimeString);
     }
 
     /**

--- a/tests/integration/Core/Framework/MessageQueue/fixtures/DummyScheduledTaskHandler.php
+++ b/tests/integration/Core/Framework/MessageQueue/fixtures/DummyScheduledTaskHandler.php
@@ -22,10 +22,12 @@ final class DummyScheduledTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
+        int $maintenanceWindowStart,
+        array $maintenanceScheduledTasks,
         private readonly string $taskId,
         private readonly bool $shouldThrowException = false
     ) {
-        parent::__construct($scheduledTaskRepository, $logger);
+        parent::__construct($scheduledTaskRepository, $logger, $maintenanceWindowStart, $maintenanceScheduledTasks);
     }
 
     public function run(): void

--- a/tests/unit/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandlerTest.php
+++ b/tests/unit/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandlerTest.php
@@ -27,6 +27,8 @@ class CleanupCartTaskHandlerTest extends TestCase
         $handler = new CleanupCartTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $cartPersister,
             30
         );

--- a/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
+++ b/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
@@ -78,6 +78,6 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
 
     private function createHandler(): CleanupCorruptedMediaHandler
     {
-        return new CleanupCorruptedMediaHandler($this->scheduledTaskRepository, $this->logger, $this->mediaRepository);
+        return new CleanupCorruptedMediaHandler($this->scheduledTaskRepository, $this->logger, 1, [], $this->mediaRepository);
     }
 }

--- a/tests/unit/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandlerTest.php
+++ b/tests/unit/Core/Content/Product/Cleanup/CleanupUnusedDownloadMediaTaskHandlerTest.php
@@ -28,6 +28,8 @@ class CleanupUnusedDownloadMediaTaskHandlerTest extends TestCase
         $this->handler = new CleanupUnusedDownloadMediaTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $this->purger
         );
     }

--- a/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -50,6 +50,8 @@ class ProductExportGenerateTaskHandlerTest extends TestCase
         $productExportGenerateTaskHandler = new ProductExportGenerateTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $connection,
             $messageBusMock
         );

--- a/tests/unit/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandlerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandlerTest.php
@@ -23,6 +23,8 @@ class InvalidateCacheTaskHandlerTest extends TestCase
         $handler = new InvalidateCacheTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $cacheInvalidator
         );
         $handler->run();
@@ -36,6 +38,8 @@ class InvalidateCacheTaskHandlerTest extends TestCase
         $handler = new InvalidateCacheTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $cacheInvalidator
         );
         $handler->run();
@@ -51,6 +55,8 @@ class InvalidateCacheTaskHandlerTest extends TestCase
         $handler = new InvalidateCacheTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $cacheInvalidator
         );
         $handler->run();

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Handler/InAppPurchaseUpdateHandlerTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Handler/InAppPurchaseUpdateHandlerTest.php
@@ -33,6 +33,8 @@ class InAppPurchaseUpdateHandlerTest extends TestCase
         $this->iapUpdateHandler = new InAppPurchaseUpdateHandler(
             $this->createMock(EntityRepository::class),
             $this->logger,
+            1,
+            [],
             $this->iapUpdater,
         );
     }

--- a/tests/unit/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandlerTest.php
+++ b/tests/unit/Core/Framework/Webhook/ScheduledTask/CleanupWebhookEventLogTaskHandlerTest.php
@@ -24,6 +24,8 @@ class CleanupWebhookEventLogTaskHandlerTest extends TestCase
         $handler = new CleanupWebhookEventLogTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $cleaner
         );
 

--- a/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
+++ b/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
@@ -24,6 +24,8 @@ class InstallServicesTaskHandlerTest extends TestCase
         $handler = new InstallServicesTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $manager,
         );
 

--- a/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/ScheduledTask/CollectEntityDataTaskHandlerTest.php
@@ -31,6 +31,8 @@ class CollectEntityDataTaskHandlerTest extends TestCase
         $taskHandler = new CollectEntityDataTaskHandler(
             $repository,
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $entityDispatchService
         );
 

--- a/tests/unit/Elasticsearch/Framework/Indexing/CreateAliasTaskHandlerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/CreateAliasTaskHandlerTest.php
@@ -36,6 +36,8 @@ class CreateAliasTaskHandlerTest extends TestCase
         $handler = new CreateAliasTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $this->createMock(Client::class),
             $connection,
             $elasticsearchHelper,
@@ -60,6 +62,8 @@ class CreateAliasTaskHandlerTest extends TestCase
         $handler = new CreateAliasTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $client,
             $connection,
             $this->createMock(ElasticsearchHelper::class),
@@ -134,6 +138,8 @@ class CreateAliasTaskHandlerTest extends TestCase
         $handler = new CreateAliasTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $client,
             $connection,
             $this->createMock(ElasticsearchHelper::class),
@@ -208,6 +214,8 @@ class CreateAliasTaskHandlerTest extends TestCase
         $handler = new CreateAliasTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $client,
             $connection,
             $this->createMock(ElasticsearchHelper::class),

--- a/tests/unit/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandlerTest.php
+++ b/tests/unit/Storefront/Theme/ScheduledTask/DeleteThemeFilesTaskHandlerTest.php
@@ -101,6 +101,8 @@ class DeleteThemeFilesTaskHandlerTest extends TestCase
         $handler = new DeleteThemeFilesTaskHandler(
             $this->createMock(EntityRepository::class),
             $this->createMock(LoggerInterface::class),
+            1,
+            [],
             $connection,
             $themeFileSystem,
             $themePathBuilder


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/issues/12849

### 2. What does this change do, exactly?

This pull request introduces a new configuration section for scheduled tasks, allowing maintenance windows and specific maintenance tasks to be defined. 

### 3. Describe each step to reproduce the issue or behaviour.

No maintenance window logic exists yet.

### 4. Please link to the relevant issues (if any).

Closes https://github.com/shopware/shopware/issues/12849

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
