### PR TITLE
fix: restore horizontal scroll in flow builder

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.scss
@@ -1,4 +1,8 @@
 .sw-flow-detail {
+    .sw-card-view .sw-card-view__content {
+        overflow: auto;
+    }
+
     &__warning {
         max-width: 60rem;
     }


### PR DESCRIPTION
resolves #14801

Restores the `overflow: auto` override on `.sw-card-view__content` that was accidentally removed in #14170, re-enabling horizontal scrolling to reach flow builder actions.