### PR TITLE
fix: hide TOS setting

### DIFF
--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -65,6 +65,7 @@
 
         <input-field type="bool">
             <name>showTosCheckbox</name>
+            <flag>v6.8.0.0</flag>
             <label>Customers are required to agree to the terms and conditions</label>
             <label lang="de-DE">Eine Zustimmung der AGB durch den Kunden ist erforderlich</label>
         </input-field>


### PR DESCRIPTION
### 1. Why is this change necessary?
The setting is not respected without 6.8 feature flag and should therefore be hidden to not confuse anyone.

### 2. What does this change do, exactly?
Hide it without `6.8.0.0` enabled.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #14964 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
