### PR TITLE
ci(deps): revert codeowners plus upgrade

### DIFF
--- a/.github/workflows/codeowner.yml
+++ b/.github/workflows/codeowner.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Codeowners Plus'
-        uses: multimediallc/codeowners-plus@v1.8.0
+        uses: multimediallc/codeowners-plus@v1.7.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'


### PR DESCRIPTION
### 1. Why is this change necessary?
This version (1.8.0) does not exist anymore

### 2. What does this change do, exactly?
Go back to 1.7.0

### 3. Describe each step to reproduce the issue or behaviour.
see broken pipeline here: https://github.com/shopware/shopware/pull/15001
got broken here: https://github.com/shopware/shopware/pull/14151

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
