### PR TITLE
fix: Increase total blocking time assertion limit

### DIFF
--- a/src/Administration/Resources/app/administration/lighthouserc.js
+++ b/src/Administration/Resources/app/administration/lighthouserc.js
@@ -56,8 +56,8 @@ module.exports = {
                 // Time to Interactive: Admin must be usable within 4 seconds
                 'interactive': ['error', { maxNumericValue: 4000 }],
 
-                // Total Blocking Time: Prevent excessive JS blocking (60ms threshold)
-                'total-blocking-time': ['error', { maxNumericValue: 60 }],
+                // Total Blocking Time: Prevent excessive JS blocking (150ms threshold)
+                'total-blocking-time': ['error', { maxNumericValue: 150 }],
 
                 // Largest Contentful Paint: Main UI should render within 4 seconds
                 'largest-contentful-paint': ['error', { maxNumericValue: 4000 }],


### PR DESCRIPTION
### 1. Why is this change necessary?

The lighthouse performance pipeline for the administration started failing most of the time. It seems like the assertion limit for the total-blocking-time is a bit strict. If it is raised a bit most of the pipeline runs should succeed again.

### 2. What does this change do, exactly?

The limit for the total-blocking-time assertion is raised from 60ms to 150ms. According to the [Google documentation](https://developer.chrome.com/docs/lighthouse/performance/lighthouse-total-blocking-time) everything below 150ms is considered fast. 

### 3. Describe each step to reproduce the issue or behaviour.

Look into the results for the admin performance checks pipeline at 13th of February 2026.
