### PR TITLE
ci(backport): use lts node versions

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: build shopware
         run: |

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
       - name: install packages
         working-directory: src/Storefront/Resources/app/storefront
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: Refresh Package List
         shell: bash
@@ -354,7 +354,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
 
       - name: Install dependencies
         working-directory: new-shopware/tests/acceptance

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: lts/*
       - name: install packages
         working-directory: src/Storefront/Resources/app/storefront
         run: |


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Backport for CI to use LTS node version