### PR TITLE
feat: add action response possibility to newsletter subscribe route

### DIFF
--- a/src/Core/System/Resources/config/newsletter.xml
+++ b/src/Core/System/Resources/config/newsletter.xml
@@ -10,8 +10,8 @@
             <label>Subscription URL</label>
             <label lang="de-DE">Anmelde-URL</label>
             <placeholder><![CDATA[/newsletter-subscribe?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%]]></placeholder>
-            <helpText><![CDATA[URL to confirm the subscription to the newsletter.<br/>Available placeholders: <br/>%%HASHEDEMAIL%%<br/>%%SUBSCRIBEHASH%%]]></helpText>
-            <helpText lang="de-DE"><![CDATA[URL um die Newsletter-Anmeldung zu bestätigen.<br/>Verfügbare Platzhalter: <br/>%%HASHEDEMAIL%%<br/>%%SUBSCRIBEHASH%%]]></helpText>
+            <helpText><![CDATA[URL to confirm the subscription to the newsletter.<br/>Available placeholders: <br/>%%HASHEDEMAIL%%<br/>%%SUBSCRIBEHASH%%<br/><br/>Use "redirectTo" or "forwardTo" parameters to send customers to a specific page after newsletter confirmation. Make sure to use the technical route name and URL-encode the "redirectParameters" parameter if needed.<br/>Example:<br/><em>/newsletter-subscribe?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%<b>&redirectTo=frontend.landing.page&redirectParameters=%7B%22landingPageId%22%3A%20%22019c0477f11d709b838b7108f2260cb9%22%7D</b></em>]]></helpText>
+            <helpText lang="de-DE"><![CDATA[URL um die Newsletter-Anmeldung zu bestätigen.<br/>Verfügbare Platzhalter: <br/>%%HASHEDEMAIL%%<br/>%%SUBSCRIBEHASH%%<br/><br/>Verwende die Parameter "redirectTo" oder "forwardTo", um Kunden nach der Bestätigung des Newsletters auf eine bestimmte Seite weiterzuleiten. Stelle sicher, dass der technische Routenname verwendet wird und der Parameter "redirectParameters" bei Bedarf URL-codiert ist.<br/>Beispiel:<br/><em>/newsletter-subscribe?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%<b>&redirectTo=frontend.landing.page&redirectParameters=%7B%22landingPageId%22%3A%20%22019c0477f11d709b838b7108f2260cb9%22%7D</b></em>]]></helpText>
         </input-field>
 
         <input-field type="bool">

--- a/src/Storefront/Controller/NewsletterController.php
+++ b/src/Storefront/Controller/NewsletterController.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Controller;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Newsletter\NewsletterException;
 use Shopware\Core\Content\Newsletter\SalesChannel\AbstractNewsletterConfirmRoute;
+use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\QueryDataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -62,6 +63,10 @@ class NewsletterController extends StorefrontController
             $this->addFlash(self::DANGER, $this->trans('newsletter.subscriptionConfirmationFailed'));
 
             throw $throwable;
+        }
+
+        if (RequestParamHelper::get($request, 'redirectTo') || RequestParamHelper::get($request, 'forwardTo')) {
+            return $this->createActionResponse($request);
         }
 
         $page = $this->newsletterConfirmRegisterPageLoader->load($request, $context);

--- a/src/Storefront/Controller/NewsletterController.php
+++ b/src/Storefront/Controller/NewsletterController.php
@@ -66,6 +66,8 @@ class NewsletterController extends StorefrontController
         }
 
         if (RequestParamHelper::get($request, 'redirectTo') || RequestParamHelper::get($request, 'forwardTo')) {
+            $this->addFlash(self::SUCCESS, $this->trans('newsletter.subscriptionCompleted'));
+
             return $this->createActionResponse($request);
         }
 

--- a/tests/integration/Storefront/Controller/NewsletterControllerTest.php
+++ b/tests/integration/Storefront/Controller/NewsletterControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
+use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -19,7 +20,9 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * @internal
@@ -67,7 +70,9 @@ class NewsletterControllerTest extends TestCase
 
     public function testRegisterNewsletterForCustomerDoi(): void
     {
-        $systemConfigService = static::getContainer()->get(SystemConfigService::class);
+        $container = static::getContainer();
+
+        $systemConfigService = $container->get(SystemConfigService::class);
         static::assertNotNull($systemConfigService);
         $systemConfigService->set('core.newsletter.doubleOptInRegistered', true);
 
@@ -88,16 +93,22 @@ class NewsletterControllerTest extends TestCase
 
         static::assertSame(200, $response->getStatusCode());
 
-        $repo = static::getContainer()->get('newsletter_recipient.repository');
+        $repo = $container->get('newsletter_recipient.repository');
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', 'nltest@example.com'));
+        $context = Context::createDefaultContext();
         /** @var NewsletterRecipientEntity $recipientEntry */
-        $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->first();
+        $recipientEntry = $repo->search($criteria, $context)->first();
+
+        $params = [
+            'em' => Hasher::hash('nltest@example.com', 'sha1'),
+            'hash' => $recipientEntry->getHash(),
+        ];
 
         $browser->request(
             'GET',
-            '/newsletter-subscribe?em=' . Hasher::hash('nltest@example.com', 'sha1') . '&hash=' . $recipientEntry->getHash()
+            '/newsletter-subscribe?' . http_build_query($params)
         );
 
         $response = $browser->getResponse();
@@ -109,10 +120,38 @@ class NewsletterControllerTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', 'nltest@example.com'));
         /** @var NewsletterRecipientEntity $recipientEntry */
-        $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->first();
+        $recipientEntry = $repo->search($criteria, $context)->first();
 
-        static::assertSame('optIn', (string) $recipientEntry->getStatus());
+        static::assertSame(NewsletterSubscribeRoute::STATUS_OPT_IN, (string) $recipientEntry->getStatus());
         $this->validateRecipientData($recipientEntry);
+
+        // Reset status and test again with redirect
+        $repo->update([
+            [
+                'id' => $recipientEntry->getId(),
+                'status' => NewsletterSubscribeRoute::STATUS_NOT_SET,
+            ],
+        ], $context);
+
+        $params['redirectTo'] = 'frontend.home.page';
+
+        $browser->request(
+            'GET',
+            '/newsletter-subscribe?' . http_build_query($params)
+        );
+
+        $response = $browser->getResponse();
+
+        static::assertSame(302, $response->getStatusCode());
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/', $response->getTargetUrl());
+
+        $session = $this->getSession();
+        static::assertInstanceOf(Session::class, $session);
+        $success = $session->getFlashBag()->get('success');
+
+        static::assertNotEmpty($success);
+        static::assertSame($container->get('translator')->trans('newsletter.subscriptionCompleted'), $success[0]);
     }
 
     private function login(): KernelBrowser


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Sometimes you may want to redirect to a custom category or landing page instead of showing the default alert after the newsletter subscription is confirmed.

### 2. What does this change do, exactly?
Add the possibility to use redirectTo/forwardTo parameters on the `frontend.newsletter.subscribe` route.

<img width="969" height="665" alt="Screenshot 2026-02-17 094646" src="https://github.com/user-attachments/assets/f57eaa3e-18fe-4bc7-a00b-e7648138360c" />

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
