### PR TITLE
fix: streamline product creation and assignment in Lighthouse tests

### DIFF
--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -22,20 +22,13 @@ test('Category Lighthouse Report', async ({
     StorefrontCategory,
 }) => {
     const productCount = 10;
-    const promises = [];
 
     const category = await TestDataService.createCategory();
 
-    const createProductAndAssign = async() => {
-        const product = await TestDataService.createProductWithImage();
-        return await TestDataService.assignProductCategory(product.id, category.id);
-    }
-
     for (let i = 0; i < productCount; i++) {
-        promises.push(createProductAndAssign());
+        const product = await TestDataService.createProductWithImage();
+        await TestDataService.assignProductCategory(product.id, category.id);
     }
-
-    await Promise.all(promises);
 
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
     await ShopCustomer.attemptsTo(ValidateLighthouseScore(StorefrontCategory.page, 'Storefront-Category'))


### PR DESCRIPTION
### 1. Why is this change necessary?
Reduce the flakiness of Lighthouse Category test 

### 2. What does this change do, exactly?
Currently, we use Promise.all(10 products with images) which creates 10 products with images in parallel. It often leads to a failed test, which is successful with the first or second retry.
(see here: https://github.com/shopware/shopware/actions/runs/22064889163/job/63754046081?pr=14972)

### 3. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/shopware/actions/runs/22064889163/job/63754046081?pr=14972

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
