### PR TITLE
ci: fix sync job

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: shopware/octo-sts-action@main
         id: sts-shopware-private
@@ -28,7 +29,6 @@ jobs:
 
       - name: Push to private fork
         run: |
-          git config --unset http."https://github.com/".extraheader
           git config "http.https://github.com/shopware/shopware-private.git/.extraheader" "AUTHORIZATION: basic $(echo -n "x-access-token:${{ steps.sts-shopware-private.outputs.token }}" | base64)"
           git remote add private https://github.com/shopware/shopware-private.git
           git fetch private


### PR DESCRIPTION
### 1. Why is this change necessary?
In `actions/checkout@v6` they changed the authentication behaivour. It is no longer set in `.git/config`.

### 2. What does this change do, exactly?
We don't need to persist the credentials, so we disable it.

### 3. Describe each step to reproduce the issue or behaviour.
Merge a PR and check the triggered Sync Job.
