### PR TITLE
fix: required fields from static files should override php definitions

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -225,10 +225,12 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
      *
      * @return array<string, array<string, mixed>>
      */
-    private function mergeComponentsSchemaRequiredFieldsRecursive(array $specsFromDefinition, array $specsFromStaticJsonDefinition): array
+    private function mergeComponentsSchemaRequiredFieldsRecursive(array &$specsFromDefinition, array $specsFromStaticJsonDefinition): array
     {
         foreach ($specsFromDefinition['components']['schemas'] as $key => $value) {
             if (isset($specsFromStaticJsonDefinition['components']['schemas'][$key]['required'])) {
+                unset($specsFromDefinition['components']['schemas'][$key]['required']);
+
                 continue;
             }
 

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -228,12 +228,13 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
     private function mergeComponentsSchemaRequiredFieldsRecursive(array $specsFromDefinition, array $specsFromStaticJsonDefinition): array
     {
         foreach ($specsFromDefinition['components']['schemas'] as $key => $value) {
-            if (isset($specsFromStaticJsonDefinition['components']['schemas'][$key]['required']) && isset($specsFromDefinition['components']['schemas'][$key]['required'])) {
+            if (isset($specsFromStaticJsonDefinition['components']['schemas'][$key]['required'])) {
+                continue;
+            }
+
+            if (isset($specsFromDefinition['components']['schemas'][$key]['required'])) {
                 $specsFromStaticJsonDefinition['components']['schemas'][$key]['required']
-                    = array_values(array_unique(array_merge(
-                        $specsFromStaticJsonDefinition['components']['schemas'][$key]['required'],
-                        $specsFromDefinition['components']['schemas'][$key]['required']
-                    )));
+                    = $specsFromDefinition['components']['schemas'][$key]['required'];
             }
         }
 

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -230,10 +230,10 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
         foreach ($specsFromDefinition['components']['schemas'] as $key => $value) {
             if (isset($specsFromStaticJsonDefinition['components']['schemas'][$key]['required']) && isset($specsFromDefinition['components']['schemas'][$key]['required'])) {
                 $specsFromStaticJsonDefinition['components']['schemas'][$key]['required']
-                    = array_merge_recursive(
+                    = array_values(array_unique(array_merge(
                         $specsFromStaticJsonDefinition['components']['schemas'][$key]['required'],
                         $specsFromDefinition['components']['schemas'][$key]['required']
-                    );
+                    )));
             }
         }
 

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -139,7 +139,7 @@ class StoreApiGeneratorTest extends TestCase
         static::assertContains('apiAlias', $entities['Simple']['required']);
     }
 
-    public function testMergeComponentsSchemaRequiredFieldsDeduplication(): void
+    public function testStaticJsonRequiredFieldsTakePrecedenceOverDefinition(): void
     {
         $reflection = new \ReflectionClass($this->generator);
         $method = $reflection->getMethod('mergeComponentsSchemaRequiredFieldsRecursive');
@@ -150,6 +150,12 @@ class StoreApiGeneratorTest extends TestCase
                     'Country' => [
                         'required' => ['id', 'name', 'addressFormat'],
                     ],
+                    'OnlyInPhp' => [
+                        'required' => ['id'],
+                    ],
+                    'ExplicitlyEmpty' => [
+                        'required' => ['id', 'name'],
+                    ],
                 ],
             ],
         ];
@@ -158,7 +164,11 @@ class StoreApiGeneratorTest extends TestCase
             'components' => [
                 'schemas' => [
                     'Country' => [
-                        'required' => ['id', 'name', 'addressFormat'],
+                        'required' => ['id', 'name'],
+                    ],
+                    'OnlyInPhp' => [],
+                    'ExplicitlyEmpty' => [
+                        'required' => [],
                     ],
                 ],
             ],
@@ -166,11 +176,17 @@ class StoreApiGeneratorTest extends TestCase
 
         $result = $method->invoke($this->generator, $specsFromDefinition, $specsFromJson);
 
+        // Static JSON defines required for Country — use it as-is, no merge with PHP
         $required = $result['components']['schemas']['Country']['required'];
-        static::assertCount(3, $required, 'Required fields should not contain duplicates after merge');
-        static::assertContains('id', $required);
-        static::assertContains('name', $required);
-        static::assertContains('addressFormat', $required);
+        static::assertSame(['id', 'name'], $required);
+
+        // Static JSON has no required for OnlyInPhp — fall back to PHP definition
+        $required = $result['components']['schemas']['OnlyInPhp']['required'];
+        static::assertSame(['id'], $required);
+
+        // Static JSON explicitly sets required to empty — PHP required is ignored
+        $required = $result['components']['schemas']['ExplicitlyEmpty']['required'];
+        static::assertSame([], $required);
     }
 
     public function testGroupsParametersParsing(): void

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -139,6 +139,40 @@ class StoreApiGeneratorTest extends TestCase
         static::assertContains('apiAlias', $entities['Simple']['required']);
     }
 
+    public function testMergeComponentsSchemaRequiredFieldsDeduplication(): void
+    {
+        $reflection = new \ReflectionClass($this->generator);
+        $method = $reflection->getMethod('mergeComponentsSchemaRequiredFieldsRecursive');
+
+        $specsFromDefinition = [
+            'components' => [
+                'schemas' => [
+                    'Country' => [
+                        'required' => ['id', 'name', 'addressFormat'],
+                    ],
+                ],
+            ],
+        ];
+
+        $specsFromJson = [
+            'components' => [
+                'schemas' => [
+                    'Country' => [
+                        'required' => ['id', 'name', 'addressFormat'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $method->invoke($this->generator, $specsFromDefinition, $specsFromJson);
+
+        $required = $result['components']['schemas']['Country']['required'];
+        static::assertCount(3, $required, 'Required fields should not contain duplicates after merge');
+        static::assertContains('id', $required);
+        static::assertContains('name', $required);
+        static::assertContains('addressFormat', $required);
+    }
+
     public function testGroupsParametersParsing(): void
     {
         $schema = $this->generator->generate(

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -121,7 +121,7 @@ class StoreApiGeneratorTest extends TestCase
         static::assertArrayNotHasKey('/_action/order_delivery/{orderDeliveryId}/state/{transition}', $paths);
     }
 
-    public function testMergeComponentsSchemaRequiredFieldsRecursive(): void
+    public function testStaticJsonRequiredFieldsTakePrecedenceOverDefinition(): void
     {
         $schema = $this->customApiGenerator->generate(
             $this->definitionRegistry->getDefinitions(),
@@ -132,61 +132,35 @@ class StoreApiGeneratorTest extends TestCase
 
         $entities = $schema['components']['schemas'];
 
+        // Case 1: Simple.json defines required: ["apiAlias"], PHP defines required: ["requiredField"]
+        // Static JSON takes precedence — only "apiAlias" should be present
         static::assertArrayHasKey('Simple', $entities);
         static::assertArrayHasKey('required', $entities['Simple']);
-        static::assertCount(2, $entities['Simple']['required']);
-        static::assertContains('requiredField', $entities['Simple']['required']);
-        static::assertContains('apiAlias', $entities['Simple']['required']);
+        static::assertSame(['apiAlias'], $entities['Simple']['required']);
+
+        // Case 2: TestEntityWithAssociations.json defines required: [], PHP defines required: ["name"]
+        // Static JSON explicitly sets empty — PHP required is ignored
+        static::assertArrayHasKey('TestEntityWithAssociations', $entities);
+        static::assertArrayHasKey('required', $entities['TestEntityWithAssociations']);
+        static::assertSame([], $entities['TestEntityWithAssociations']['required']);
     }
 
-    public function testStaticJsonRequiredFieldsTakePrecedenceOverDefinition(): void
+    public function testPhpRequiredFieldsUsedWhenNoStaticJsonRequired(): void
     {
-        $reflection = new \ReflectionClass($this->generator);
-        $method = $reflection->getMethod('mergeComponentsSchemaRequiredFieldsRecursive');
+        // $this->generator has no custom bundle schemas, so Simple has no JSON override
+        $schema = $this->generator->generate(
+            $this->definitionRegistry->getDefinitions(),
+            DefinitionService::STORE_API,
+            DefinitionService::TYPE_JSON_API,
+            null
+        );
 
-        $specsFromDefinition = [
-            'components' => [
-                'schemas' => [
-                    'Country' => [
-                        'required' => ['id', 'name', 'addressFormat'],
-                    ],
-                    'OnlyInPhp' => [
-                        'required' => ['id'],
-                    ],
-                    'ExplicitlyEmpty' => [
-                        'required' => ['id', 'name'],
-                    ],
-                ],
-            ],
-        ];
+        $entities = $schema['components']['schemas'];
 
-        $specsFromJson = [
-            'components' => [
-                'schemas' => [
-                    'Country' => [
-                        'required' => ['id', 'name'],
-                    ],
-                    'OnlyInPhp' => [],
-                    'ExplicitlyEmpty' => [
-                        'required' => [],
-                    ],
-                ],
-            ],
-        ];
-
-        $result = $method->invoke($this->generator, $specsFromDefinition, $specsFromJson);
-
-        // Static JSON defines required for Country — use it as-is, no merge with PHP
-        $required = $result['components']['schemas']['Country']['required'];
-        static::assertSame(['id', 'name'], $required);
-
-        // Static JSON has no required for OnlyInPhp — fall back to PHP definition
-        $required = $result['components']['schemas']['OnlyInPhp']['required'];
-        static::assertSame(['id'], $required);
-
-        // Static JSON explicitly sets required to empty — PHP required is ignored
-        $required = $result['components']['schemas']['ExplicitlyEmpty']['required'];
-        static::assertSame([], $required);
+        // Case 3: No static JSON for Simple — PHP required fields should be used as fallback
+        static::assertArrayHasKey('Simple', $entities);
+        static::assertArrayHasKey('required', $entities['Simple']);
+        static::assertContains('requiredField', $entities['Simple']['required']);
     }
 
     public function testGroupsParametersParsing(): void

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/TestEntityWithAssociations.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/TestEntityWithAssociations.json
@@ -1,0 +1,13 @@
+{
+  "openapi": "3.1.0",
+  "info": [],
+  "paths": [],
+  "components": {
+    "schemas": {
+      "TestEntityWithAssociations": {
+        "type": "object",
+        "required": []
+      }
+    }
+  }
+}

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/DefinitionWithAssociations.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/DefinitionWithAssociations.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\IgnoreInOpenapiSchema;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
@@ -37,7 +38,7 @@ class DefinitionWithAssociations extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware()),
-            (new StringField('name', 'name'))->addFlags(new ApiAware()),
+            (new StringField('name', 'name'))->addFlags(new ApiAware(), new Required()),
 
             // Association with description and ApiAware for Store API
             (new ManyToOneAssociationField(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When generator takes definition from PHP class and from JSON static definition it merges it. Static files should take priority and override this field. 