### PR TITLE
feat: Refactor empty usage in checkout, devops and Framework/Adapter to prepare its prohibition

### DIFF
--- a/src/Core/Checkout/Cart/CartSerializationCleaner.php
+++ b/src/Core/Checkout/Cart/CartSerializationCleaner.php
@@ -71,7 +71,7 @@ class CartSerializationCleaner
             return;
         }
 
-        if (\count($customFieldAllowList) === 0) {
+        if ($customFieldAllowList === []) {
             $lineItem->setPayloadValue('customFields', []);
 
             return;

--- a/src/Core/Checkout/Cart/LineItem/Group/LineItemGroup.php
+++ b/src/Core/Checkout/Cart/LineItem/Group/LineItemGroup.php
@@ -42,6 +42,6 @@ class LineItemGroup
      */
     public function hasItems(): bool
     {
-        return \count($this->items) > 0;
+        return $this->items !== [];
     }
 }

--- a/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItemCollection.php
@@ -174,7 +174,7 @@ class LineItemCollection extends Collection
         // Sort all line items by their price definition priority
         krsort($lineItemsByPricePriority);
 
-        if (\count($lineItemsByPricePriority)) {
+        if ($lineItemsByPricePriority !== []) {
             $merged = array_merge(...$lineItemsByPricePriority);
             $this->elements = \array_combine(
                 \array_map($this->getKey(...), $merged),

--- a/src/Core/Checkout/Cart/Order/RecalculationService.php
+++ b/src/Core/Checkout/Cart/Order/RecalculationService.php
@@ -303,7 +303,7 @@ class RecalculationService
         $originalIds = $order->getLineItems()?->getKeys() ?? [];
         $toDeleteIds = \array_values(\array_diff($originalIds, $newIds));
 
-        if (\count($toDeleteIds) > 0) {
+        if ($toDeleteIds !== []) {
             $context->scope(Context::SYSTEM_SCOPE, fn (Context $context) => $this->orderLineItemRepository->delete(
                 \array_map(static fn (string $id) => ['id' => $id], $toDeleteIds),
                 $context
@@ -336,7 +336,7 @@ class RecalculationService
         )->getKeys() ?? [];
         $toDeleteIds = \array_values(\array_diff($originalIds, $newIds));
 
-        if (\count($toDeleteIds) > 0) {
+        if ($toDeleteIds !== []) {
             $context->scope(Context::SYSTEM_SCOPE, fn (Context $context) => $this->orderDeliveryRepository->delete(
                 \array_map(static fn (string $id) => ['id' => $id], $toDeleteIds),
                 $context

--- a/src/Core/Checkout/Customer/SalesChannel/MergeWishlistProductRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/MergeWishlistProductRoute.php
@@ -105,7 +105,7 @@ class MergeWishlistProductRoute extends AbstractMergeWishlistProductRoute
 
         $ids = array_unique(array_filter($productIds->all()));
 
-        if (\count($ids) === 0) {
+        if ($ids === []) {
             return [];
         }
 

--- a/src/Core/Checkout/Order/Api/OrderActionController.php
+++ b/src/Core/Checkout/Order/Api/OrderActionController.php
@@ -49,7 +49,7 @@ class OrderActionController extends AbstractController
         Context $context
     ): JsonResponse {
         $documentTypes = $request->request->all('documentTypes');
-        if (\count($documentTypes) > 0) {
+        if ($documentTypes !== []) {
             $skipSentDocuments = (bool) $request->request->get('skipSentDocuments', false);
             $documentIds = $this->getDocumentIds('order', $orderId, $documentTypes, $skipSentDocuments);
         } else {
@@ -89,7 +89,7 @@ class OrderActionController extends AbstractController
         Context $context
     ): JsonResponse {
         $documentTypes = $request->request->all('documentTypes');
-        if (\count($documentTypes) > 0) {
+        if ($documentTypes !== []) {
             $skipSentDocuments = (bool) $request->request->get('skipSentDocuments', false);
             $documentIds = $this->getDocumentIds('order_transaction', $orderTransactionId, $documentTypes, $skipSentDocuments);
         } else {
@@ -129,7 +129,7 @@ class OrderActionController extends AbstractController
         Context $context
     ): JsonResponse {
         $documentTypes = $request->request->all('documentTypes');
-        if (\count($documentTypes) > 0) {
+        if ($documentTypes !== []) {
             $skipSentDocuments = (bool) $request->request->get('skipSentDocuments', false);
             $documentIds = $this->getDocumentIds('order_delivery', $orderDeliveryId, $documentTypes, $skipSentDocuments);
         } else {

--- a/src/Core/Checkout/Order/Exception/LanguageOfOrderDeleteException.php
+++ b/src/Core/Checkout/Order/Exception/LanguageOfOrderDeleteException.php
@@ -20,7 +20,7 @@ class LanguageOfOrderDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )
@@ -34,7 +34,7 @@ class LanguageOfOrderDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )
@@ -48,7 +48,7 @@ class LanguageOfOrderDeleteException extends ShopwareHttpException
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
             Feature::deprecatedClassMessage(
-                __CLASS__,
+                self::class,
                 'v6.8.0.0',
                 RestrictDeleteViolationException::class
             )

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentDistinguishableNameGenerator.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentDistinguishableNameGenerator.php
@@ -28,7 +28,7 @@ class PaymentDistinguishableNameGenerator
             $payments = $this->getInstalledPayments($context);
 
             $upsertablePayments = $this->generateDistinguishableNamesPayload($payments);
-            if (\count($upsertablePayments) === 0) {
+            if ($upsertablePayments === []) {
                 return;
             }
 
@@ -71,7 +71,7 @@ class PaymentDistinguishableNameGenerator
             }
 
             $distinguishableNames = array_filter($distinguishableNames);
-            if (\count($distinguishableNames) === 0) {
+            if ($distinguishableNames === []) {
                 continue;
             }
 

--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
@@ -70,7 +70,7 @@ class CartScopeDiscountPackager extends DiscountPackager
             }
         }
 
-        if (\count($discountItems) === 0) {
+        if ($discountItems === []) {
             return null;
         }
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
@@ -39,7 +39,7 @@ class PromotionExclusionUpdater
             // create empty array if there are no exclusions
             $promotionExclusions = [];
 
-            if (\count($exclusions) > 0) {
+            if ($exclusions !== []) {
                 $firstResult = array_shift($exclusions);
                 if (\array_key_exists('exclusion_ids', $firstResult)) {
                     // if there are exclusions, set them in array
@@ -109,7 +109,7 @@ class PromotionExclusionUpdater
 
         $types = [];
 
-        if (\count($excludeThisIds) > 0) {
+        if ($excludeThisIds !== []) {
             $sqlStatement .= ' AND id NOT IN (:excludedIds)';
             $params['excludedIds'] = $this->convertHexArrayToByteArray($excludeThisIds);
             $types['excludedIds'] = ArrayParameterType::BINARY;
@@ -117,7 +117,7 @@ class PromotionExclusionUpdater
 
         $results = $this->connection->executeQuery($sqlStatement, $params, $types)->fetchAllAssociative();
 
-        if (\count($results) === 0) {
+        if ($results === []) {
             return [];
         }
 
@@ -176,7 +176,7 @@ class PromotionExclusionUpdater
     private function updateJSON(string $id, array $onlyAddThisExistingIds): void
     {
         $value = '[]';
-        if (\count($onlyAddThisExistingIds) > 0) {
+        if ($onlyAddThisExistingIds !== []) {
             $value = json_encode($onlyAddThisExistingIds, \JSON_THROW_ON_ERROR);
         }
 
@@ -244,13 +244,13 @@ class PromotionExclusionUpdater
      */
     private function convertHexArrayToByteArray(array $hexIds): array
     {
-        if (\count($hexIds) === 0) {
+        if ($hexIds === []) {
             return [];
         }
 
         $validValues = array_values(array_filter($hexIds, fn ($hexId) => Uuid::isValid($hexId)));
 
-        if (\count($validValues) === 0) {
+        if ($validValues === []) {
             return [];
         }
 

--- a/src/Core/Checkout/Promotion/PromotionEntity.php
+++ b/src/Core/Checkout/Promotion/PromotionEntity.php
@@ -503,7 +503,7 @@ class PromotionEntity extends Entity
                 // add the rule to our main rule
                 $requirements->addRule($personaCustomerOR);
             }
-        } elseif ($this->getPersonaRules() !== null && \count($this->getPersonaRules()->getElements()) > 0) {
+        } elseif ($this->getPersonaRules() !== null && $this->getPersonaRules()->getElements() !== []) {
             // we use persona rules.
             // check if we have persona rules and add them
             // to our persona OR as a separate OR rule with all configured rules
@@ -517,7 +517,7 @@ class PromotionEntity extends Entity
             $requirements->addRule($personaRuleOR);
         }
 
-        if ($this->getCartRules() !== null && \count($this->getCartRules()->getElements()) > 0) {
+        if ($this->getCartRules() !== null && $this->getCartRules()->getElements() !== []) {
             $cartOR = new OrRule([]);
 
             foreach ($this->getCartRules()->getElements() as $ruleEntity) {
@@ -555,7 +555,7 @@ class PromotionEntity extends Entity
             $requirements->addRule($groupsRootRule);
         }
 
-        if ($this->getOrderRules() !== null && \count($this->getOrderRules()->getElements()) > 0) {
+        if ($this->getOrderRules() !== null && $this->getOrderRules()->getElements() !== []) {
             $orderOR = new OrRule([]);
 
             foreach ($this->getOrderRules()->getElements() as $ruleEntity) {

--- a/src/Core/Checkout/Promotion/Rule/PromotionCodeOfTypeRule.php
+++ b/src/Core/Checkout/Promotion/Rule/PromotionCodeOfTypeRule.php
@@ -39,7 +39,7 @@ class PromotionCodeOfTypeRule extends Rule
         }
 
         $promotionLineItems = $scope->getCart()->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE);
-        $hasNoPromotionLineItems = \count($promotionLineItems) === 0;
+        $hasNoPromotionLineItems = $promotionLineItems === [];
 
         if ($this->operator === self::OPERATOR_EQ && $hasNoPromotionLineItems) {
             return false;

--- a/src/Core/Checkout/Promotion/Rule/PromotionLineItemRule.php
+++ b/src/Core/Checkout/Promotion/Rule/PromotionLineItemRule.php
@@ -44,7 +44,7 @@ class PromotionLineItemRule extends Rule
         }
 
         $promotionLineItems = $scope->getCart()->getLineItems()->filterFlatByType(LineItem::PROMOTION_LINE_ITEM_TYPE);
-        $hasNoPromotionLineItems = \count($promotionLineItems) === 0;
+        $hasNoPromotionLineItems = $promotionLineItems === [];
 
         if ($hasNoPromotionLineItems) {
             return $this->operator === self::OPERATOR_NEQ;

--- a/src/Core/DevOps/Docs/Script/HooksReferenceGenerator.php
+++ b/src/Core/DevOps/Docs/Script/HooksReferenceGenerator.php
@@ -117,7 +117,7 @@ class HooksReferenceGenerator implements ScriptReferenceGenerator
             }
         }
 
-        if (\count($hookClasses) === 0) {
+        if ($hookClasses === []) {
             throw DocsException::noHookClassesFound();
         }
 

--- a/src/Core/DevOps/Docs/Script/ServiceReferenceGenerator.php
+++ b/src/Core/DevOps/Docs/Script/ServiceReferenceGenerator.php
@@ -176,7 +176,7 @@ class ServiceReferenceGenerator implements ScriptReferenceGenerator
             $scriptServices[] = $class;
         }
 
-        if (\count($scriptServices) === 0) {
+        if ($scriptServices === []) {
             throw DocsException::noScriptServicesFound();
         }
         sort($scriptServices);
@@ -461,7 +461,7 @@ class ServiceReferenceGenerator implements ScriptReferenceGenerator
                 }
             }
 
-            if (\count($files) === 0) {
+            if ($files === []) {
                 throw DocsException::exampleFileNotFound(
                     $method->getName(),
                     $method->getDeclaringClass()->getName(),

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoAfterStatementRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Migration/NoAfterStatementRule.php
@@ -46,7 +46,7 @@ class NoAfterStatementRule implements Rule
             return [];
         }
 
-        if (empty($node->getArgs())) {
+        if ($node->getArgs() === []) {
             return [];
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRouteOverrideInDecoratorsRule.php
@@ -99,7 +99,7 @@ class NoRouteOverrideInDecoratorsRule implements Rule
             return false;
         }
 
-        if (empty($service->getTags())) {
+        if ($service->getTags() === []) {
             return false;
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoUpdatesInExecuteQueryRule.php
@@ -60,7 +60,7 @@ class NoUpdatesInExecuteQueryRule implements Rule
             return $errors;
         }
 
-        if (!empty($node->args)) {
+        if ($node->args !== []) {
             $firstArg = $node->args[0];
 
             if ($firstArg instanceof Node\Arg && $firstArg->value instanceof Node\Scalar\String_) {

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/PublicServiceDecoratorRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/PublicServiceDecoratorRule.php
@@ -47,7 +47,7 @@ class PublicServiceDecoratorRule implements Rule
             return [];
         }
 
-        if (empty($service->getTags())) {
+        if ($service->getTags() === []) {
             return [];
         }
 

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/ShopwareNamespaceStyleRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/ShopwareNamespaceStyleRule.php
@@ -41,7 +41,7 @@ class ShopwareNamespaceStyleRule implements Rule
 
         $namespaceParts = $namespaceNode->name?->getParts() ?: [];
 
-        if (\count($namespaceParts) > 0 && $namespaceParts[0] !== 'Shopware') {
+        if ($namespaceParts !== [] && $namespaceParts[0] !== 'Shopware') {
             return [
                 RuleErrorBuilder::message('Namespace must start with Shopware')
                     ->line($namespaceNode->getStartLine())

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/MockingSimpleObjectsNotAllowedRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/MockingSimpleObjectsNotAllowedRule.php
@@ -98,7 +98,7 @@ class MockingSimpleObjectsNotAllowedRule implements Rule
         }
 
         $parentClassNames = $node->getClassReflection()->getParentClassesNames();
-        if (empty($parentClassNames)) {
+        if ($parentClassNames === []) {
             return false;
         }
 

--- a/src/Core/DevOps/System/Command/OpenApiValidationCommand.php
+++ b/src/Core/DevOps/System/Command/OpenApiValidationCommand.php
@@ -66,7 +66,7 @@ class OpenApiValidationCommand extends Command
             $content['schemaValidationMessages'] ?? []
         );
 
-        if (\count($messages) === 0) {
+        if ($messages === []) {
             return Command::SUCCESS;
         }
 

--- a/src/Core/DevOps/Test/AnnotationTagTester.php
+++ b/src/Core/DevOps/Test/AnnotationTagTester.php
@@ -143,7 +143,7 @@ class AnnotationTagTester
         $match = [];
         preg_match('/([^\s]+):([^\s]*)\s+([^\s]+):([^\s]*)/', $propertiesString, $match, \PREG_UNMATCHED_AS_NULL);
 
-        if (empty($match)) {
+        if ($match === []) {
             throw new \InvalidArgumentException('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared.');
         }
         $properties = [

--- a/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
+++ b/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
@@ -152,13 +152,13 @@ class MakeCoverageTestCommand extends Command
                     continue;
                 }
 
-                if (!\in_array($excludedDir->prefix(), ['', '0'], true) && str_ends_with($fileName, $excludedDir->prefix())) {
+                if ($excludedDir->prefix() !== '' && str_ends_with($fileName, $excludedDir->prefix())) {
                     $failReason = \sprintf('Skip coverage test for excluded directory: %s', $fileName);
 
                     continue;
                 }
 
-                if (!\in_array($excludedDir->suffix(), ['', '0'], true) && str_ends_with($fileName, $excludedDir->suffix())) {
+                if ($excludedDir->suffix() !== '' && str_ends_with($fileName, $excludedDir->suffix())) {
                     $failReason = \sprintf('Skip coverage test for excluded directory: %s', $fileName);
                 }
             }

--- a/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
+++ b/src/Core/DevOps/Test/Command/MakeCoverageTestCommand.php
@@ -47,7 +47,7 @@ class MakeCoverageTestCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $filteredClasses = $this->filterExcludedClasses(array_unique($classes), $input, $io);
 
-        if (empty($filteredClasses)) {
+        if ($filteredClasses === []) {
             $io->note('No coverage tests are created');
 
             return self::SUCCESS;
@@ -101,7 +101,7 @@ class MakeCoverageTestCommand extends Command
             $tests[] = $testFileName;
         }
 
-        if (empty($tests)) {
+        if ($tests === []) {
             $io->note('No coverage tests are created');
 
             return self::SUCCESS;
@@ -152,13 +152,13 @@ class MakeCoverageTestCommand extends Command
                     continue;
                 }
 
-                if (!empty($excludedDir->prefix()) && str_ends_with($fileName, $excludedDir->prefix())) {
+                if (!\in_array($excludedDir->prefix(), ['', '0'], true) && str_ends_with($fileName, $excludedDir->prefix())) {
                     $failReason = \sprintf('Skip coverage test for excluded directory: %s', $fileName);
 
                     continue;
                 }
 
-                if (!empty($excludedDir->suffix()) && str_ends_with($fileName, $excludedDir->suffix())) {
+                if (!\in_array($excludedDir->suffix(), ['', '0'], true) && str_ends_with($fileName, $excludedDir->suffix())) {
                     $failReason = \sprintf('Skip coverage test for excluded directory: %s', $fileName);
                 }
             }

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -211,7 +211,7 @@ class CacheClearer
 
         $files = iterator_to_array($finder->getIterator());
 
-        if (\count($files) > 0) {
+        if ($files !== []) {
             $this->filesystem->remove(array_map(static fn (\SplFileInfo $file): string => $file->getPathname(), $files));
         }
     }

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -119,7 +119,7 @@ class CacheInvalidationSubscriber
 
         $setIds = $this->getSetIds($snippets->getIds());
 
-        if (empty($setIds)) {
+        if ($setIds === []) {
             return;
         }
 
@@ -217,7 +217,7 @@ class CacheInvalidationSubscriber
             $tags[] = CountryStateRoute::ALL_TAG;
         }
 
-        if (empty($tags)) {
+        if ($tags === []) {
             // invalidates the country-state route when a state changed or an assignment between the state and country changed
             $tags = array_map(
                 CountryStateRoute::buildName(...),
@@ -241,7 +241,7 @@ class CacheInvalidationSubscriber
             SalesChannelDefinition::ENTITY_NAME,
             ['navigationCategoryId', 'navigationCategoryDepth', 'serviceCategoryId', 'footerCategoryId']
         );
-        if (!empty($changedSalesChannelSettings)) {
+        if ($changedSalesChannelSettings !== []) {
             // if the sales channel settings changed, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
 
@@ -252,7 +252,7 @@ class CacheInvalidationSubscriber
             CategoryDefinition::ENTITY_NAME,
             ['parentId', 'afterCategoryId', 'visible', 'active']
         );
-        if (!empty($changedCategoryData)) {
+        if ($changedCategoryData !== []) {
             // if category data that has impact on navigation changes, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
 
@@ -260,7 +260,7 @@ class CacheInvalidationSubscriber
         }
 
         $deletedCategories = $event->getDeletedPrimaryKeys(CategoryDefinition::ENTITY_NAME);
-        if (!empty($deletedCategories)) {
+        if ($deletedCategories !== []) {
             // if the category is deleted, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
 
@@ -271,7 +271,7 @@ class CacheInvalidationSubscriber
             CategoryTranslationDefinition::ENTITY_NAME,
             ['name']
         );
-        if (!empty($changedCategoryTranslationData)) {
+        if ($changedCategoryTranslationData !== []) {
             // if translated category data that has impact on navigation changes, we invalidate the complete navigation route
             $this->cacheInvalidator->invalidate([NavigationRoute::ALL_TAG]);
         }
@@ -352,7 +352,7 @@ class CacheInvalidationSubscriber
 
         $keys = array_filter(array_unique($keys));
 
-        if (empty($keys)) {
+        if ($keys === []) {
             return;
         }
 
@@ -365,7 +365,7 @@ class CacheInvalidationSubscriber
         // invalidates the product listing route, each time a manufacturer changed
         $ids = $event->getPrimaryKeys(ProductManufacturerDefinition::ENTITY_NAME);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 
@@ -394,7 +394,7 @@ class CacheInvalidationSubscriber
         // invalidates all stream based pages and routes before the product indexer changes product_stream_mapping
         $ids = $event->getPrimaryKeys(ProductDefinition::ENTITY_NAME);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 
@@ -421,7 +421,7 @@ class CacheInvalidationSubscriber
         // invalidates the product listing route, each time a property changed
         $ids = $event->getDeletedPrimaryKeys(ProductPropertyDefinition::ENTITY_NAME);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -457,7 +457,7 @@ class CacheInvalidationSubscriber
     private function getChangedShippingMethods(EntityWrittenContainerEvent $event): array
     {
         $ids = $event->getPrimaryKeys(ShippingMethodDefinition::ENTITY_NAME);
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -494,7 +494,7 @@ class CacheInvalidationSubscriber
     private function getChangedPaymentMethods(EntityWrittenContainerEvent $event): array
     {
         $ids = $event->getPrimaryKeys(PaymentMethodDefinition::ENTITY_NAME);
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -531,7 +531,7 @@ class CacheInvalidationSubscriber
     private function getChangedCountries(EntityWrittenContainerEvent $event): array
     {
         $ids = $event->getPrimaryKeys(CountryDefinition::ENTITY_NAME);
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -569,7 +569,7 @@ class CacheInvalidationSubscriber
     private function getChangedSalutations(EntityWrittenContainerEvent $event): array
     {
         $ids = $event->getPrimaryKeys(SalutationDefinition::ENTITY_NAME);
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -582,7 +582,7 @@ class CacheInvalidationSubscriber
     private function getChangedLanguages(EntityWrittenContainerEvent $event): array
     {
         $ids = $event->getPrimaryKeys(LanguageDefinition::ENTITY_NAME);
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -621,7 +621,7 @@ class CacheInvalidationSubscriber
     {
         $ids = $event->getPrimaryKeys(CurrencyDefinition::ENTITY_NAME);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
@@ -53,7 +53,7 @@ class CacheInvalidator
     {
         $tags = array_filter(array_unique($tags));
 
-        if (empty($tags)) {
+        if ($tags === []) {
             return;
         }
 
@@ -86,7 +86,7 @@ class CacheInvalidator
     {
         $tags = $this->cache->loadAndDelete();
 
-        if (empty($tags)) {
+        if ($tags === []) {
             return $tags;
         }
 

--- a/src/Core/Framework/Adapter/Cache/CacheTagCollector.php
+++ b/src/Core/Framework/Adapter/Cache/CacheTagCollector.php
@@ -65,7 +65,7 @@ class CacheTagCollector
 
         $tags = array_diff($tags, array_keys($existingTags));
 
-        if (empty($tags)) {
+        if ($tags === []) {
             return;
         }
 

--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -284,7 +284,7 @@ class CacheResponseSubscriber implements EventSubscriberInterface
     {
         $states = $this->getSystemStates($request, $context, $cart);
 
-        if (empty($states)) {
+        if ($states === []) {
             if ($request->cookies->has(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE)) {
                 $response->headers->removeCookie(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);
                 $response->headers->clearCookie(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);

--- a/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
@@ -29,7 +29,7 @@ class MySQLInvalidatorStorage extends AbstractInvalidatorStorage
 
     public function store(array $tags): void
     {
-        if (empty($tags)) {
+        if ($tags === []) {
             return;
         }
 
@@ -76,7 +76,7 @@ class MySQLInvalidatorStorage extends AbstractInvalidatorStorage
 
         ($this->debug)($this, $rows);
 
-        if (empty($rows)) {
+        if ($rows === []) {
             return [];
         }
 

--- a/src/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorage.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorage.php
@@ -78,7 +78,7 @@ class RedisInvalidatorStorage extends AbstractInvalidatorStorage
             $tags = [];
 
             $chunk = $this->redis->sPop(self::KEY, 10000);
-            while (\is_array($chunk) && !empty($chunk)) {
+            while (\is_array($chunk) && $chunk !== []) {
                 foreach ($chunk as $tag) {
                     $tags[] = (string) $tag;
                 }

--- a/src/Core/Framework/Adapter/Cache/Script/Facade/WrittenEventIdCollection.php
+++ b/src/Core/Framework/Adapter/Cache/Script/Facade/WrittenEventIdCollection.php
@@ -45,7 +45,7 @@ class WrittenEventIdCollection implements \IteratorAggregate
     {
         $writeResults = array_values(array_filter(
             $this->writeResults,
-            static fn (EntityWriteResult $result): bool => \count(\array_intersect(array_keys($result->getPayload()), $properties)) > 0
+            static fn (EntityWriteResult $result): bool => \array_intersect(array_keys($result->getPayload()), $properties) !== []
         ));
 
         return new self($writeResults);

--- a/src/Core/Framework/Adapter/Command/CacheInvalidateDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheInvalidateDelayedCommand.php
@@ -29,7 +29,7 @@ class CacheInvalidateDelayedCommand extends Command
 
         $style = new SymfonyStyle($input, $output);
 
-        if (empty($tags)) {
+        if ($tags === []) {
             $style->success('No delayed cache tags found');
 
             return 0;

--- a/src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
+++ b/src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
@@ -21,7 +21,7 @@ class PrefixFilesystem implements FilesystemOperator
         protected FilesystemOperator $filesystem,
         string $prefix
     ) {
-        if ($prefix === '' || $prefix === '0') {
+        if ($prefix === '') {
             if (!Feature::isActive('v6.8.0.0')) {
                 // @phpstan-ignore-next-line
                 throw new \InvalidArgumentException('The prefix must not be empty.');

--- a/src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
+++ b/src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
@@ -21,7 +21,7 @@ class PrefixFilesystem implements FilesystemOperator
         protected FilesystemOperator $filesystem,
         string $prefix
     ) {
-        if (empty($prefix)) {
+        if ($prefix === '' || $prefix === '0') {
             if (!Feature::isActive('v6.8.0.0')) {
                 // @phpstan-ignore-next-line
                 throw new \InvalidArgumentException('The prefix must not be empty.');

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -259,7 +259,7 @@ class Translator extends AbstractTranslator
         // get snippet set by locale but in case there are more than one sets with a same locale, we should prioritize the domain's snippet set
         $snippetSetIds = $this->connection->fetchFirstColumn('SELECT LOWER(HEX(id)) FROM snippet_set WHERE iso = :iso', ['iso' => $locale]);
 
-        if (!empty($snippetSetIds)) {
+        if ($snippetSetIds !== []) {
             $snippetSetId = \in_array($snippetSetId, $snippetSetIds, true) ? $snippetSetId : $snippetSetIds[0];
         }
 
@@ -381,7 +381,7 @@ class Translator extends AbstractTranslator
         do {
             $loadedSnippets = $this->loadSnippets($currentCatalogue, $snippetSetId, $fallbackLocale);
 
-            if (!empty($loadedSnippets)) {
+            if ($loadedSnippets !== []) {
                 $currentCatalogue->add($loadedSnippets);
             }
         } while ($currentCatalogue = $currentCatalogue->getFallbackCatalogue());

--- a/src/Core/Framework/Adapter/Twig/EntityTemplateLoader.php
+++ b/src/Core/Framework/Adapter/Twig/EntityTemplateLoader.php
@@ -104,7 +104,7 @@ class EntityTemplateLoader implements LoaderInterface, EventSubscriberInterface,
         $namespace = $templateName['namespace'];
         $path = $templateName['path'];
 
-        if (empty($this->databaseTemplateCache)) {
+        if ($this->databaseTemplateCache === []) {
             /** @var list<array{path: string, template: string, updatedAt: string|null, namespace: string, hash: string}> $templates */
             $templates = $this->connection->fetchAllAssociative('
                 SELECT

--- a/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
@@ -77,7 +77,7 @@ class BuildBreadcrumbExtension extends AbstractExtension
         }
 
         $categoryIds = array_keys($seoBreadcrumb);
-        if (empty($categoryIds)) {
+        if ($categoryIds === []) {
             return [];
         }
 

--- a/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
@@ -58,8 +58,8 @@ class ComparisonExtension extends AbstractExtension
         $matches = array_intersect($value, $comparable);
 
         return match ($operator) {
-            Rule::OPERATOR_EQ => !empty($matches),
-            Rule::OPERATOR_NEQ => empty($matches),
+            Rule::OPERATOR_EQ => $matches !== [],
+            Rule::OPERATOR_NEQ => $matches === [],
             default => throw throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }

--- a/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
@@ -34,7 +34,7 @@ class MediaExtension extends AbstractExtension
      */
     public function searchMedia(array $ids, Context $context): MediaCollection
     {
-        if (empty($ids)) {
+        if ($ids === []) {
             return new MediaCollection();
         }
 

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -75,7 +75,7 @@ class TwigVariableParser
 
             if ($node instanceof GetAttrExpression) {
                 $path = implode('.', $this->getVariables($node, $aliases));
-                if ($path !== '' && $path !== '0') {
+                if ($path !== '') {
                     $variables[$path] = $path;
                 }
 

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -75,7 +75,7 @@ class TwigVariableParser
 
             if ($node instanceof GetAttrExpression) {
                 $path = implode('.', $this->getVariables($node, $aliases));
-                if (!empty($path)) {
+                if ($path !== '' && $path !== '0') {
                     $variables[$path] = $path;
                 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
