### PR TITLE
fix: Optimize CleanupCorruptedMediaHandler

### DIFF
--- a/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
+++ b/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
@@ -55,7 +55,7 @@ final class CleanupCorruptedMediaHandler extends ScheduledTaskHandler
                 return;
             }
 
-            $lastId = $ids[array_key_last($ids)];
+            $lastId = array_last($ids);
 
             $ids = array_map(fn ($id) => ['id' => $id], $ids);
             $this->mediaRepository->delete($ids, $context);

--- a/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
+++ b/src/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandler.php
@@ -4,13 +4,17 @@ namespace Shopware\Core\Content\Media\ScheduledTask;
 
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
@@ -20,6 +24,10 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler(handles: CleanupCorruptedMediaTask::class)]
 final class CleanupCorruptedMediaHandler extends ScheduledTaskHandler
 {
+    private const CORRUPTED_MEDIA_GRACE_PERIOD_DAYS = 30;
+
+    private const CORRUPTED_MEDIA_BATCH_SIZE = 500;
+
     /**
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
      * @param EntityRepository<MediaCollection> $mediaRepository
@@ -35,18 +43,41 @@ final class CleanupCorruptedMediaHandler extends ScheduledTaskHandler
     public function run(): void
     {
         $context = Context::createCLIContext();
+        $lastId = null;
 
+        while (true) {
+            $criteria = $this->buildCleanupCriteria($lastId);
+            $criteria->setLimit(self::CORRUPTED_MEDIA_BATCH_SIZE);
+
+            $ids = $this->mediaRepository->searchIds($criteria, $context)->getIds();
+
+            if ($ids === []) {
+                return;
+            }
+
+            $lastId = $ids[array_key_last($ids)];
+
+            $ids = array_map(fn ($id) => ['id' => $id], $ids);
+            $this->mediaRepository->delete($ids, $context);
+        }
+    }
+
+    private function buildCleanupCriteria(?string $lastId = null): Criteria
+    {
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('fileSize', null));
+        $criteria->addSorting(new FieldSorting('id', FieldSorting::ASCENDING));
+        $criteria->addFilter(new EqualsFilter('uploadedAt', null));
+        $criteria->addFilter(new EqualsFilter('path', null));
+        $criteria->addFilter(new RangeFilter('createdAt', [
+            RangeFilter::LT => (new \DateTimeImmutable())
+                ->sub(new \DateInterval('P' . self::CORRUPTED_MEDIA_GRACE_PERIOD_DAYS . 'D'))
+                ->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]));
 
-        $ids = $this->mediaRepository->searchIds($criteria, $context)->getIds();
-
-        if ($ids === []) {
-            return;
+        if ($lastId !== null) {
+            $criteria->addFilter(new RangeFilter('id', [RangeFilter::GT => Uuid::fromHexToBytes($lastId)]));
         }
 
-        $ids = array_map(fn ($id) => ['id' => $id], $ids);
-
-        $this->mediaRepository->delete($ids, $context);
+        return $criteria;
     }
 }

--- a/src/Core/Migration/V6_7/Migration1771342632AddCorruptedMediaHandlerIndices.php
+++ b/src/Core/Migration/V6_7/Migration1771342632AddCorruptedMediaHandlerIndices.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1771342632AddCorruptedMediaHandlerIndices extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1771342632;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (TableHelper::indexExists($connection, 'media', 'idx.media.uploaded_at_created_at_id')) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'CREATE INDEX `idx.media.uploaded_at_created_at_id` ON `media` (`uploaded_at`, `created_at`, `id`)'
+        );
+    }
+}

--- a/tests/integration/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
+++ b/tests/integration/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
@@ -2,16 +2,20 @@
 
 namespace Shopware\Tests\Integration\Core\Content\Media\ScheduledTask;
 
+use Doctrine\DBAL\ArrayParameterType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\ScheduledTask\CleanupCorruptedMediaHandler;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
@@ -61,7 +65,36 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
                 'fileSize' => null,
                 'mediaType' => 'image/png',
             ],
+            [
+                'id' => $this->ids->create('in-progress'),
+                'fileName' => 'in-progress-file.png',
+                'fileSize' => null,
+                'mediaType' => 'image/png',
+            ],
+            [
+                'id' => $this->ids->create('cdn-media'),
+                'path' => 'https://cdn.example.com/image.jpg',
+                'fileSize' => null,
+            ],
         ], $this->context);
+
+        $corruptedCreatedAt = (new \DateTimeImmutable())
+            ->sub(new \DateInterval('P31D'))
+            ->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        $connection = KernelLifecycleManager::getConnection();
+
+        $connection->executeStatement(
+            'UPDATE media SET created_at = :createdAt WHERE id IN (:ids)',
+            [
+                'createdAt' => $corruptedCreatedAt,
+                'ids' => Uuid::fromHexToBytesList([
+                    $this->ids->get('corrupted-1'),
+                    $this->ids->get('corrupted-2'),
+                ]),
+            ],
+            ['ids' => ArrayParameterType::BINARY]
+        );
     }
 
     public function testCleanupCorruptedMedia(): void
@@ -72,10 +105,14 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
             $this->ids->get('corrupted-1'),
             $this->ids->get('corrupted-2'),
             $this->ids->get('valid'),
+            $this->ids->get('in-progress'),
+            $this->ids->get('cdn-media'),
         ]), $this->context);
 
         $remainingIds = $remainingMedia->getIds();
-        static::assertCount(1, $remainingIds);
-        static::assertSame($this->ids->get('valid'), $remainingIds[0]);
+        static::assertCount(3, $remainingIds);
+        static::assertContains($this->ids->get('valid'), $remainingIds);
+        static::assertContains($this->ids->get('in-progress'), $remainingIds);
+        static::assertContains($this->ids->get('cdn-media'), $remainingIds);
     }
 }

--- a/tests/migration/Core/V6_7/Migration1771342632AddCorruptedMediaHandlerIndicesTest.php
+++ b/tests/migration/Core/V6_7/Migration1771342632AddCorruptedMediaHandlerIndicesTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1771342632AddCorruptedMediaHandlerIndices;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1771342632AddCorruptedMediaHandlerIndices::class)]
+class Migration1771342632AddCorruptedMediaHandlerIndicesTest extends TestCase
+{
+    private const INDEX_NAME = 'idx.media.uploaded_at_created_at_id';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testCreationTimestamp(): void
+    {
+        $migration = new Migration1771342632AddCorruptedMediaHandlerIndices();
+
+        static::assertSame(1771342632, $migration->getCreationTimestamp());
+    }
+
+    public function testMigrationCreatesExpectedIndexAndIsIdempotent(): void
+    {
+        $this->rollback();
+
+        $migration = new Migration1771342632AddCorruptedMediaHandlerIndices();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::indexExists($this->connection, 'media', self::INDEX_NAME));
+        static::assertTrue(TableHelper::indexSpansColumns($this->connection, 'media', self::INDEX_NAME, ['uploaded_at', 'created_at', 'id']));
+    }
+
+    private function rollback(): void
+    {
+        if (!TableHelper::indexExists($this->connection, 'media', self::INDEX_NAME)) {
+            return;
+        }
+
+        $this->connection->executeStatement('DROP INDEX `' . self::INDEX_NAME . '` ON `media`');
+    }
+}

--- a/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
+++ b/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
@@ -10,10 +10,15 @@ use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\ScheduledTask\CleanupCorruptedMediaHandler;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
@@ -34,22 +39,36 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
      */
     private StaticEntityRepository $mediaRepository;
 
+    private IdsCollection $ids;
+
     protected function setUp(): void
     {
         $this->scheduledTaskRepository = new StaticEntityRepository([]);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->ids = new IdsCollection();
     }
 
     public function testRunCleanupCorruptedMediaSuccessfully(): void
     {
         $data = [
-            'id1' => ['primaryKey' => 'id1', 'data' => []],
-            'id2' => ['primaryKey' => 'id2', 'data' => []],
+            $this->ids->get('media-1') => ['primaryKey' => $this->ids->get('media-1'), 'data' => []],
+            $this->ids->get('media-2') => ['primaryKey' => $this->ids->get('media-2'), 'data' => []],
         ];
 
-        $ids = new IdSearchResult(2, $data, new Criteria(), Context::createDefaultContext());
+        $this->mediaRepository = new StaticEntityRepository([
+            function (Criteria $criteria, Context $context) use ($data): IdSearchResult {
+                $this->assertCleanupFilters($criteria);
+                static::assertSame(500, $criteria->getLimit());
 
-        $this->mediaRepository = new StaticEntityRepository([$ids]);
+                return new IdSearchResult(2, $data, $criteria, $context);
+            },
+            function (Criteria $criteria, Context $context): IdSearchResult {
+                $this->assertCleanupFilters($criteria, $this->ids->get('media-2'));
+                static::assertSame(500, $criteria->getLimit());
+
+                return new IdSearchResult(0, [], $criteria, $context);
+            },
+        ]);
 
         $handler = $this->createHandler();
         $handler->run();
@@ -60,15 +79,20 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
         $deletedIds = array_column($deletes, 'id');
         static::assertCount(2, $deletedIds);
 
-        static::assertSame('id1', $deletedIds[0]);
-        static::assertSame('id2', $deletedIds[1]);
+        static::assertSame($this->ids->get('media-1'), $deletedIds[0]);
+        static::assertSame($this->ids->get('media-2'), $deletedIds[1]);
     }
 
     public function testRunCleansNothingUpIfNoCorruptedMediaExists(): void
     {
-        $ids = new IdSearchResult(0, [], new Criteria(), Context::createDefaultContext());
+        $this->mediaRepository = new StaticEntityRepository([
+            function (Criteria $criteria, Context $context): IdSearchResult {
+                $this->assertCleanupFilters($criteria);
+                static::assertSame(500, $criteria->getLimit());
 
-        $this->mediaRepository = new StaticEntityRepository([$ids]);
+                return new IdSearchResult(0, [], $criteria, $context);
+            },
+        ]);
 
         $handler = $this->createHandler();
         $handler->run();
@@ -79,5 +103,57 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
     private function createHandler(): CleanupCorruptedMediaHandler
     {
         return new CleanupCorruptedMediaHandler($this->scheduledTaskRepository, $this->logger, $this->mediaRepository);
+    }
+
+    private function assertCleanupFilters(Criteria $criteria, ?string $lastId = null): void
+    {
+        $sorting = $criteria->getSorting();
+        static::assertCount(1, $sorting);
+        static::assertSame('id', $sorting[0]->getField());
+        static::assertSame(FieldSorting::ASCENDING, $sorting[0]->getDirection());
+
+        $equalsFilters = array_values(array_filter(
+            $criteria->getFilters(),
+            static fn ($filter): bool => $filter instanceof EqualsFilter && $filter->getValue() === null
+        ));
+
+        $fields = array_map(static fn (EqualsFilter $filter): string => $filter->getField(), $equalsFilters);
+        sort($fields);
+
+        static::assertSame(
+            ['path', 'uploadedAt'],
+            $fields
+        );
+
+        $rangeFilters = array_values(array_filter(
+            $criteria->getFilters(),
+            static fn ($filter): bool => $filter instanceof RangeFilter
+        ));
+
+        if ($lastId === null) {
+            static::assertCount(1, $rangeFilters);
+            static::assertSame('createdAt', $rangeFilters[0]->getField());
+            static::assertTrue($rangeFilters[0]->hasParameter(RangeFilter::LT));
+            static::assertIsString($rangeFilters[0]->getParameter(RangeFilter::LT));
+
+            return;
+        }
+
+        static::assertCount(2, $rangeFilters);
+
+        $rangeFields = array_map(static fn (RangeFilter $filter): string => $filter->getField(), $rangeFilters);
+        sort($rangeFields);
+        static::assertSame(['createdAt', 'id'], $rangeFields);
+
+        $idRangeFilters = array_values(array_filter(
+            $rangeFilters,
+            static fn (RangeFilter $filter): bool => $filter->getField() === 'id'
+        ));
+
+        static::assertNotEmpty($idRangeFilters);
+        $idRangeFilter = $idRangeFilters[0];
+
+        static::assertTrue($idRangeFilter->hasParameter(RangeFilter::GT));
+        static::assertSame(Uuid::fromHexToBytes($lastId), $idRangeFilter->getParameter(RangeFilter::GT));
     }
 }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/14634
fixes https://github.com/shopware/shopware/issues/14655

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

  The current corrupted-media cleanup can delete valid media entries in real merchant setups, especially when media is registered from external/CDN sources via Admin API (no Shopware upload step, fileSize may stay
  NULL by design).
  At the same time, the cleanup must still remove genuinely broken placeholders from interrupted two-step uploads.
  This PR fixes that safety gap and improves cleanup scalability for large media tables.

  ### 2. What does this change do, exactly?

  - Refines corrupted-media detection so only stale, unfinished placeholders are targeted.
  - Uses safer conditions centered on upload state and storage path presence, plus a grace period:
      - uploadedAt IS NULL
      - path IS NULL
      - createdAt < now - gracePeriod
  - Keeps cleanup processing in batches with cursor-based iteration to avoid large memory usage and long-running full-table operations.
  - Uses correct ID cursor handling for binary UUID comparison in DAL range filtering.
  - Adds dedicated database indices for the queried fields used by cleanup to improve lookup and batching performance on large media datasets.
  - Adds/validates migration coverage and tests for the cleanup-related DB/index behavior and handler behavior.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Create media entries via Admin API for externally hosted assets (CDN), set path, do not call Shopware upload endpoints, and leave upload-derived fields like fileSize unset.
  2. Let the scheduled corrupted-media cleanup run.
  3. Observe that with old logic, valid CDN media can be removed because it looked “incomplete” by fileSize-based heuristics.
  4. With this PR, those CDN entries are preserved (because path is set), while old unfinished two-step upload placeholders (uploadedAt/path missing and beyond grace period) are cleaned up efficiently using
     indexed, batched processing.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
