### PR TITLE
feat: Refactor empty usage in Framework DAL to prepare its prohibition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -535,12 +535,6 @@ parameters:
 			path: src/Core/Framework/Api/Exception/IncompletePrimaryKeyException.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\Api\\Exception\\MissingPrivilegeException\:\:__construct\(\) has parameter \$privilege with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Api/Exception/MissingPrivilegeException.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\Api\\Exception\\ResourceNotFoundException\:\:__construct\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -603,12 +597,6 @@ parameters:
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
-			count: 6
-			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/DefaultFieldAccessorBuilder.php
 
@@ -653,18 +641,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedContainerEvent.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Exception\\SearchRequestException\:\:__construct\(\) has parameter \$exceptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
 
 		-
 			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\CreatedByField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
@@ -803,18 +779,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldVisibility.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
 
 		-
 			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Indexing\\TreeUpdaterBag\:\:addEntity\(\) has parameter \$entity with no value type specified in iterable type array\.$#'
@@ -965,18 +929,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/WriteCommandExceptionEvent.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\WriteException\:\:getExceptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'

--- a/src/Core/Framework/Api/Acl/AclCriteriaValidator.php
+++ b/src/Core/Framework/Api/Acl/AclCriteriaValidator.php
@@ -26,7 +26,7 @@ class AclCriteriaValidator
     /**
      * @throws AccessDeniedHttpException
      *
-     * @return array<string>
+     * @return list<string>
      */
     public function validate(string $entity, Criteria $criteria, Context $context): array
     {
@@ -76,6 +76,6 @@ class AclCriteriaValidator
             }
         }
 
-        return array_unique(array_filter($missing));
+        return array_values(array_unique(array_filter($missing)));
     }
 }

--- a/src/Core/Framework/Api/ApiException.php
+++ b/src/Core/Framework/Api/ApiException.php
@@ -125,7 +125,7 @@ class ApiException extends HttpException
     }
 
     /**
-     * @param string[] $permissions
+     * @param list<string> $permissions
      */
     public static function missingPrivileges(array $permissions): ShopwareHttpException
     {

--- a/src/Core/Framework/Api/Controller/ApiController.php
+++ b/src/Core/Framework/Api/Controller/ApiController.php
@@ -248,7 +248,7 @@ class ApiController extends AbstractController
 
         // trigger acl validation
         $missing = $this->criteriaValidator->validate($definition->getEntityName(), $criteria, $context);
-        $permissions = array_unique(array_filter(array_merge($permissions, $missing)));
+        $permissions = array_values(array_unique(array_filter(array_merge($permissions, $missing))));
 
         if (!empty($permissions)) {
             throw ApiException::missingPrivileges($permissions);
@@ -459,7 +459,7 @@ class ApiController extends AbstractController
 
             // trigger acl validation
             $nested = $this->criteriaValidator->validate($definition->getEntityName(), $criteria, $context);
-            $permissions = array_unique(array_filter(array_merge($permissions, $nested)));
+            $permissions = array_values(array_unique(array_filter(array_merge($permissions, $nested))));
 
             if (!empty($permissions)) {
                 throw ApiException::missingPrivileges($permissions);
@@ -594,7 +594,7 @@ class ApiController extends AbstractController
         $repository = $this->definitionRegistry->getRepository($definition->getEntityName());
 
         $nested = $this->criteriaValidator->validate($definition->getEntityName(), $criteria, $context);
-        $permissions = array_unique(array_filter(array_merge($permissions, $nested)));
+        $permissions = array_values(array_unique(array_filter(array_merge($permissions, $nested))));
 
         if (!empty($permissions)) {
             throw ApiException::missingPrivileges($permissions);

--- a/src/Core/Framework/Api/Exception/MissingPrivilegeException.php
+++ b/src/Core/Framework/Api/Exception/MissingPrivilegeException.php
@@ -11,6 +11,9 @@ class MissingPrivilegeException extends ShopwareHttpException
 {
     final public const MISSING_PRIVILEGE_ERROR = 'FRAMEWORK__MISSING_PRIVILEGE_ERROR';
 
+    /**
+     * @param list<string> $privilege
+     */
     public function __construct(array $privilege = [])
     {
         $errorMessage = json_encode([

--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -57,7 +57,7 @@ class Context extends Struct
 
         // Should be already a valid language chain, but we will ensure it anyway
         $languageIdChain = array_values(array_filter($languageIdChain));
-        if (empty($languageIdChain)) {
+        if ($languageIdChain === []) {
             throw FrameworkException::invalidArgumentException('Argument "languageIdChain" must not be empty');
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -116,7 +116,7 @@ class AttributeEntityCompiler
 
         $collection = $reflection->getAttributes(Entity::class);
 
-        if (empty($collection)) {
+        if ($collection === []) {
             return [];
         }
 
@@ -166,7 +166,7 @@ class AttributeEntityCompiler
     {
         foreach ($list as $attribute) {
             $attribute = $property->getAttributes($attribute);
-            if (!empty($attribute)) {
+            if ($attribute !== []) {
                 return $attribute[0];
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateEntitiesCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateEntitiesCommand.php
@@ -54,7 +54,7 @@ class CreateEntitiesCommand extends Command
 
         foreach ($classes as $domain => $domainClasses) {
             foreach ($domainClasses as $entityClasses) {
-                if (empty($entityClasses)) {
+                if ($entityClasses === null || $entityClasses === []) {
                     continue;
                 }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
@@ -345,7 +345,7 @@ EOF;
         $entity = array_pop($entity);
 
         $callTemplate = '';
-        if (!empty($calls)) {
+        if ($calls !== []) {
             $callTemplate = "\n        " . implode("\n        ", $calls);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateMigrationCommand.php
@@ -134,7 +134,7 @@ class CreateMigrationCommand extends Command
 
         $queries = $this->queryGenerator->generateQueries($entityDefinition);
 
-        if (!empty($queries)) {
+        if ($queries !== []) {
             $path = Path::join($directory, MigrationFileRenderer::createMigrationClassName($timestamp, $entity) . '.php');
 
             $className = MigrationFileRenderer::createMigrationClassName($timestamp, $entity);

--- a/src/Core/Framework/DataAbstractionLayer/Command/DataAbstractionLayerValidateCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/DataAbstractionLayerValidateCommand.php
@@ -74,7 +74,7 @@ class DataAbstractionLayerValidateCommand extends Command
             );
         }
 
-        $hasErrors = \count($errors) > 0;
+        $hasErrors = $errors !== [];
         if ($asJson) {
             if ($hasErrors) {
                 $io->write(json_encode($errors, \JSON_THROW_ON_ERROR));

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidSortQueryExcep
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingSystemTranslationException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingTranslationLanguageException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\PropertyNotFoundException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnableToLoadPathException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnsupportedCommandTypeException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\DateHistogramAggregation;
@@ -145,6 +146,7 @@ class DataAbstractionLayerException extends HttpException
     public const TREE_UPDATER_ERROR = 'FRAMEWORK__DAL_TREE_UPDATER_ERROR';
     public const ASSOCIATION_NOT_INHERITED = 'FRAMEWORK__DAL_ASSOCIATION_NOT_INHERITED';
     public const ENTITY_HYDRATOR_ERROR = 'FRAMEWORK__DAL_ENTITY_HYDRATOR_ERROR';
+    public const UNABLE_TO_LOAD_PATH = 'FRAMEWORK__DAL_UNABLE_TO_LOAD_PATH';
 
     public static function invalidSerializerField(string $expectedClass, Field $field): self
     {
@@ -1261,5 +1263,13 @@ class DataAbstractionLayerException extends HttpException
             self::ENTITY_HYDRATOR_ERROR,
             $message,
         );
+    }
+
+    /**
+     * @param array<string, string> $paths
+     */
+    public static function unableToLoadPath(string $path, array $paths): UnableToLoadPathException
+    {
+        return new UnableToLoadPathException($path, $paths);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -342,7 +342,7 @@ class DataAbstractionLayerException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return new self(
@@ -370,7 +370,7 @@ class DataAbstractionLayerException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return new self(
@@ -390,7 +390,7 @@ class DataAbstractionLayerException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return new self(
@@ -526,7 +526,7 @@ class DataAbstractionLayerException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return new self(
@@ -999,7 +999,7 @@ class DataAbstractionLayerException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return new self(

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Shopware\Core\Framework\Api\Exception\InvalidSyncOperationException;
+use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\FieldAccessorBuilderNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\InvalidSortingDirectionException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\ParentAssociationCanNotBeFetched;
@@ -30,6 +31,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\Hook;
+use Shopware\Core\Framework\ShopwareHttpException;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Elasticsearch\Product\ElasticsearchProductException;
 use Symfony\Component\HttpFoundation\Response;
@@ -139,6 +141,10 @@ class DataAbstractionLayerException extends HttpException
     public const FOREIGN_KEY_HAS_NO_ASSOCIATION_FIELD = 'FRAMEWORK__FOREIGN_KEY_HAS_NO_ASSOCIATION_FIELD';
     public const WRONG_FIELD_TYPE_FOR_EXTENSION = 'FRAMEWORK__WRONG_FIELD_TYPE_FOR_EXTENSION';
     public const DBAL_SERIALIZED_FIELD_REQUIRES_INDEXER = 'FRAMEWORK__DBAL_SERIALIZED_FIELD_REQUIRES_INDEXER';
+    public const INVALID_WRITE_CONTEXT = 'FRAMEWORK__DAL_INVALID_WRITE_CONTEXT';
+    public const TREE_UPDATER_ERROR = 'FRAMEWORK__DAL_TREE_UPDATER_ERROR';
+    public const ASSOCIATION_NOT_INHERITED = 'FRAMEWORK__DAL_ASSOCIATION_NOT_INHERITED';
+    public const ENTITY_HYDRATOR_ERROR = 'FRAMEWORK__DAL_ENTITY_HYDRATOR_ERROR';
 
     public static function invalidSerializerField(string $expectedClass, Field $field): self
     {
@@ -1209,6 +1215,51 @@ class DataAbstractionLayerException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::DBAL_SERIALIZED_FIELD_REQUIRES_INDEXER,
             'Serialized fields can only be written by an indexer.',
+        );
+    }
+
+    public static function invalidWriteContext(string $message): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::INVALID_WRITE_CONTEXT,
+            $message,
+        );
+    }
+
+    public static function treeUpdateError(string $message): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::TREE_UPDATER_ERROR,
+            $message,
+        );
+    }
+
+    public static function associationNotInherited(string $association): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::ASSOCIATION_NOT_INHERITED,
+            'Association "{{ association }}" is not marked as inherited',
+            ['association' => $association],
+        );
+    }
+
+    /**
+     * @param list<string> $permissions
+     */
+    public static function missingPrivileges(array $permissions): ShopwareHttpException
+    {
+        return new MissingPrivilegeException($permissions);
+    }
+
+    public static function entityHydratorError(string $message): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::ENTITY_HYDRATOR_ERROR,
+            $message,
         );
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -78,7 +78,7 @@ class RepositoryIterator
 
         $values = $ids->getIds();
 
-        if (empty($values)) {
+        if ($values === []) {
             return null;
         }
 
@@ -111,7 +111,7 @@ class RepositoryIterator
         // increase offset for next iteration
         $this->criteria->setOffset((int) $this->criteria->getOffset() + (int) $this->criteria->getLimit());
 
-        if (empty($result->getIds())) {
+        if ($result->getIds() === []) {
             return null;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/SalesChannelRepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/SalesChannelRepositoryIterator.php
@@ -61,7 +61,7 @@ class SalesChannelRepositoryIterator
         $ids = $this->repository->searchIds($this->criteria, $this->context);
         $this->criteria->setOffset((int) $this->criteria->getOffset() + (int) $this->criteria->getLimit());
 
-        if (!empty($ids->getIds())) {
+        if ($ids->getIds() !== []) {
             return $ids->getIds();
         }
 
@@ -79,7 +79,7 @@ class SalesChannelRepositoryIterator
         // increase offset for next iteration
         $this->criteria->setOffset((int) $this->criteria->getOffset() + (int) $this->criteria->getLimit());
 
-        if (empty($result->getIds())) {
+        if ($result->getIds() === []) {
             return null;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolver.php
@@ -19,7 +19,7 @@ class CriteriaFieldsResolver
      */
     public function resolve(Criteria $criteria, EntityDefinition $definition): array
     {
-        if (empty($criteria->getFields())) {
+        if ($criteria->getFields() === []) {
             return [];
         }
 
@@ -58,7 +58,7 @@ class CriteriaFieldsResolver
         foreach ($criteria->getFields() as $field) {
             $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $field);
 
-            if (empty($fields)) {
+            if ($fields === []) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
@@ -90,7 +90,7 @@ class CriteriaQueryBuilder
 
         $parsed = $this->parser->parse($filter, $definition, $context);
 
-        if (empty($parsed->getWheres())) {
+        if ($parsed->getWheres() === []) {
             return;
         }
 
@@ -162,7 +162,7 @@ class CriteriaQueryBuilder
             $context
         );
 
-        if (empty($queries->getWheres())) {
+        if ($queries->getWheres() === []) {
             return;
         }
 
@@ -202,7 +202,7 @@ class CriteriaQueryBuilder
 
         $select = 'SUM(' . implode(' + ', $queries->getWheres()) . ') / ' . \sprintf('COUNT(%s.%s)', $definition->getEntityName(), $primary->getStorageName());
 
-        if (!empty($distincts)) {
+        if ($distincts !== []) {
             $select .= ' * (' . implode(' + ', $distincts) . ')';
         }
 
@@ -215,7 +215,7 @@ class CriteriaQueryBuilder
         }
 
         $minScore = array_map(fn (ScoreQuery $query) => $query->getScore(), $criteria->getQueries());
-        \assert(!empty($minScore));
+        \assert($minScore !== []);
 
         $minScore = min($minScore);
 
@@ -237,7 +237,7 @@ class CriteriaQueryBuilder
         foreach ($queries as $scoreQuery) {
             $parsed = $this->parser->parse($scoreQuery->getQuery(), $definition, $context);
 
-            if (empty($parsed->getWheres())) {
+            if ($parsed->getWheres() === []) {
                 continue;
             }
 
@@ -248,7 +248,7 @@ class CriteriaQueryBuilder
             }
         }
 
-        if (empty($conditions)) {
+        if ($conditions === []) {
             return;
         }
 
@@ -262,7 +262,7 @@ class CriteriaQueryBuilder
             return false;
         }
 
-        return $query->hasState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN) || !empty($criteria->getGroupFields());
+        return $query->hasState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN) || $criteria->getGroupFields() !== [];
     }
 
     /**
@@ -300,7 +300,7 @@ class CriteriaQueryBuilder
 
     private function hasQueriesOrTerm(Criteria $criteria): bool
     {
-        return !empty($criteria->getQueries()) || $criteria->getTerm();
+        return $criteria->getQueries() !== [] || $criteria->getTerm();
     }
 
     private function validateSortingDirection(string $direction): void

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
@@ -176,7 +176,7 @@ class EntityAggregator implements EntityAggregatorInterface
 
         $table = $definition->getEntityName();
 
-        if (\count($scoreCriteria->getQueries()) > 0) {
+        if ($scoreCriteria->getQueries() !== []) {
             $escapedTable = EntityDefinitionQueryHelper::escape($table);
             $scoreQuery = new QueryBuilder($this->connection);
 
@@ -226,7 +226,7 @@ class EntityAggregator implements EntityAggregatorInterface
     {
         $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $aggregation->getField(), false);
 
-        if (\count($fields) === 0) {
+        if ($fields === []) {
             return null;
         }
 
@@ -283,7 +283,7 @@ class EntityAggregator implements EntityAggregatorInterface
         EntityDefinition $definition,
         Context $context
     ): void {
-        if (!empty($aggregation->getFilter())) {
+        if ($aggregation->getFilter() !== []) {
             $this->criteriaQueryBuilder->addFilter($definition, new MultiFilter(MultiFilter::CONNECTION_AND, $aggregation->getFilter()), $query, $context);
         }
 
@@ -541,7 +541,7 @@ class EntityAggregator implements EntityAggregatorInterface
                 return new CountResult($aggregation->getName(), (int) $value);
 
             case $aggregation instanceof StatsAggregation:
-                if (empty($rows)) {
+                if ($rows === []) {
                     return new StatsResult($aggregation->getName(), 0, 0, 0.0, 0.0);
                 }
 
@@ -571,7 +571,7 @@ class EntityAggregator implements EntityAggregatorInterface
     ): EntityResult {
         $ids = array_filter(array_column($rows, $aggregation->getName()));
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return new EntityResult($aggregation->getName(), new EntityCollection());
         }
 
@@ -594,7 +594,7 @@ class EntityAggregator implements EntityAggregatorInterface
         array $rows,
         Context $context
     ): DateHistogramResult {
-        if (empty($rows)) {
+        if ($rows === []) {
             return new DateHistogramResult($aggregation->getName(), []);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -336,7 +336,7 @@ class EntityDefinitionQueryHelper
             $path[] = $field->getPropertyName();
         }
 
-        if (empty($path)) {
+        if ($path === []) {
             return null;
         }
 
@@ -482,7 +482,7 @@ class EntityDefinitionQueryHelper
             fn (Field $field) => $field instanceof StorageAware
                 && $definition->getFields()->get($field->getPropertyName()) instanceof TranslatedField,
         );
-        if (!empty($partial)) {
+        if ($partial !== []) {
             $fields = $fields->filter(fn (Field $field) => isset($partial[$field->getPropertyName()]));
         }
 
@@ -596,7 +596,7 @@ class EntityDefinitionQueryHelper
         $primaryKeys = $criteria->getIds();
         $primaryKeys = array_values($primaryKeys);
 
-        if (empty($primaryKeys)) {
+        if ($primaryKeys === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -208,7 +208,7 @@ class EntityForeignKeyResolver
         Context $context,
         bool $restrictDeleteOnlyFirstLevel = false
     ): array {
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -267,7 +267,7 @@ class EntityForeignKeyResolver
 
         $affected = $query->executeQuery()->fetchAllAssociative();
 
-        if (empty($affected)) {
+        if ($affected === []) {
             return [];
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -286,7 +287,7 @@ class EntityHydrator
     protected function manyToMany(array $row, string $root, Entity $entity, ?Field $field): void
     {
         if ($field === null) {
-            throw new \RuntimeException('No field provided');
+            throw DataAbstractionLayerException::entityHydratorError('No association field for "manyToMany" provided');
         }
 
         $accessor = $root . '.' . $field->getPropertyName() . '.id_mapping';
@@ -360,11 +361,11 @@ class EntityHydrator
     protected function manyToOne(array $row, string $root, ?Field $field, Context $context): ?Entity
     {
         if ($field === null) {
-            throw new \RuntimeException('No field provided');
+            throw DataAbstractionLayerException::entityHydratorError('No association field for "manyToOne" provided');
         }
 
         if (!$field instanceof AssociationField) {
-            throw new \RuntimeException(\sprintf('Provided field %s is no association field', $field->getPropertyName()));
+            throw DataAbstractionLayerException::entityHydratorError(\sprintf('Provided field %s is no association field', $field->getPropertyName()));
         }
         $pk = $this->getManyToOneProperty($field);
 
@@ -497,11 +498,10 @@ class EntityHydrator
         );
 
         if ($reference === null) {
-            throw new \RuntimeException(\sprintf(
-                'Can not find field by storage name %s in definition %s',
-                $field->getReferenceField(),
-                $field->getReferenceDefinition()->getEntityName()
-            ));
+            throw DataAbstractionLayerException::fieldByStorageNameNotFound(
+                $field->getReferenceDefinition()->getEntityName(),
+                $field->getReferenceField()
+            );
         }
 
         return self::$manyToOne[$key] = $reference->getPropertyName();
@@ -564,7 +564,7 @@ class EntityHydrator
         $hydrator = $this->container->get($hydratorClass);
 
         if (!$hydrator instanceof self) {
-            throw new \RuntimeException(\sprintf('Hydrator for entity %s not registered', $definition->getEntityName()));
+            throw DataAbstractionLayerException::entityHydratorError(\sprintf('Hydrator for entity %s not registered', $definition->getEntityName()));
         }
 
         $identifier = implode('-', self::buildUniqueIdentifier($definition, $row, $root));
@@ -578,7 +578,7 @@ class EntityHydrator
         $entity = new $entityClass();
 
         if (!$entity instanceof Entity) {
-            throw new \RuntimeException(\sprintf('Expected instance of Entity.php, got %s', $entity::class));
+            throw DataAbstractionLayerException::entityHydratorError(\sprintf('Expected instance of Entity.php, got %s', $entity::class));
         }
 
         $entity->addExtension(EntityReader::FOREIGN_KEYS, new ArrayStruct([], $definition->getEntityName() . '_foreign_keys_extension'));

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -84,7 +84,7 @@ class EntityHydrator
 
         self::$partialFullPaths = [];
 
-        if (!empty(self::$partial)) {
+        if (self::$partial !== []) {
             /** @var TEntityCollection $collection */
             $collection = new EntityCollection();
 
@@ -412,7 +412,7 @@ class EntityHydrator
                 $values[] = self::value($row, $accessor, $propertyName);
             }
 
-            if (empty($values)) {
+            if ($values === []) {
                 return;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -713,7 +713,8 @@ class EntityReader implements EntityReaderInterface
             }
         }
 
-        if ($filteredIds = \array_filter($ids) !== []) {
+        $filteredIds = \array_filter($ids);
+        if ($filteredIds !== []) {
             $fieldCriteria->setIds($filteredIds);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -108,8 +108,8 @@ class EntityReader implements EntityReaderInterface
         array $fieldsForPartialLoading,
         bool $isPartialLoading,
     ): EntityCollection {
-        $hasFilters = !empty($criteria->getFilters()) || !empty($criteria->getPostFilters());
-        $hasIds = !empty($criteria->getIds());
+        $hasFilters = $criteria->getFilters() !== [] || $criteria->getPostFilters() !== [];
+        $hasIds = $criteria->getIds() !== [];
 
         if (!$performEmptySearch && !$hasFilters && !$hasIds) {
             return $collection;
@@ -158,8 +158,8 @@ class EntityReader implements EntityReaderInterface
             $isPartialLoading,
         );
 
-        $hasIds = !empty($criteria->getIds());
-        if ($hasIds && empty($criteria->getSorting())) {
+        $hasIds = $criteria->getIds() !== [];
+        if ($hasIds && $criteria->getSorting() === []) {
             $collection->sortByIdArray($criteria->getIds());
         }
 
@@ -368,7 +368,7 @@ class EntityReader implements EntityReaderInterface
             $fieldsForPartialLoading,
         );
 
-        if (!empty($criteria->getIds())) {
+        if ($criteria->getIds() !== []) {
             $this->queryHelper->addIdCondition($criteria, $definition, $query);
         }
 
@@ -713,7 +713,7 @@ class EntityReader implements EntityReaderInterface
             }
         }
 
-        if (\count($filteredIds = \array_filter($ids)) !== 0) {
+        if ($filteredIds = \array_filter($ids) !== []) {
             $fieldCriteria->setIds($filteredIds);
         }
 
@@ -797,7 +797,7 @@ class EntityReader implements EntityReaderInterface
         // collect all ids of many-to-many association which already stored inside the struct instances
         $ids = $this->collectManyToManyIds($collection, $association);
 
-        if (\count($ids) !== 0) {
+        if ($ids !== []) {
             $criteria->setIds($ids);
         }
 
@@ -944,7 +944,7 @@ class EntityReader implements EntityReaderInterface
 
         $orderBy = '';
         $parts = $query->getOrderByParts();
-        if (!empty($parts)) {
+        if ($parts !== []) {
             $orderBy = ' ORDER BY ' . implode(', ', $parts);
             $query->resetOrderBy();
         }
@@ -999,7 +999,7 @@ class EntityReader implements EntityReaderInterface
         /** @var EntityCollection<Entity> $collectionClass */
         $collectionClass = $referenceClass->getCollectionClass();
 
-        if (\count($ids) !== 0) {
+        if ($ids !== []) {
             // only read data when we have found mapped IDs
             // otherwise we would load the whole reference table
             $fieldCriteria->setIds($ids);
@@ -1251,9 +1251,9 @@ class EntityReader implements EntityReaderInterface
 
         return $fieldCriteria->getOffset() !== null
             || $fieldCriteria->getLimit() !== null
-            || !empty($fieldCriteria->getSorting())
-            || !empty($fieldCriteria->getFilters())
-            || !empty($fieldCriteria->getPostFilters())
+            || $fieldCriteria->getSorting() !== []
+            || $fieldCriteria->getFilters() !== []
+            || $fieldCriteria->getPostFilters() !== []
         ;
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcher.php
@@ -71,7 +71,7 @@ class EntitySearcher implements EntitySearcherInterface
 
         $query = $this->criteriaQueryBuilder->build($query, $definition, $criteria, $context);
 
-        if (!empty($criteria->getIds())) {
+        if ($criteria->getIds() !== []) {
             $this->queryHelper->addIdCondition($criteria, $definition, $query);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
@@ -87,7 +87,7 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
     {
         $state = $this->getCurrentState($definition, $primaryKey, $commandQueue);
 
-        $exists = !empty($state);
+        $exists = $state !== [];
 
         $isChild = $this->isChild($definition, $data, $state, $primaryKey, $commandQueue);
 
@@ -502,7 +502,7 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             $primaryKeys[$entity][] = $command->getPrimaryKey();
         }
 
-        if (empty($primaryKeys)) {
+        if ($primaryKeys === []) {
             return;
         }
 
@@ -567,7 +567,7 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             // check if current loop matches the command primary key
             $primaryKey = array_intersect($command->getPrimaryKey(), $state);
 
-            if (\count(array_diff_assoc($command->getPrimaryKey(), $primaryKey)) === 0) {
+            if (array_diff_assoc($command->getPrimaryKey(), $primaryKey) === []) {
                 return new ChangeSet($state, $command->getPayload(), $command instanceof DeleteCommand);
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/JsonFieldAccessorBuilder.php
@@ -94,7 +94,7 @@ class JsonFieldAccessorBuilder implements FieldAccessorBuilderInterface
                 continue;
             }
 
-            if ($field instanceof JsonField && !empty($field->getPropertyMapping())) {
+            if ($field instanceof JsonField && $field->getPropertyMapping() !== []) {
                 return $this->getField($subPath, $field->getPropertyMapping());
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -94,7 +94,7 @@ class CriteriaPartResolver
         }
 
         $parsed = $this->parser->parse($filter, $definition, $context);
-        if (empty($parsed->getWheres())) {
+        if ($parsed->getWheres() === []) {
             return;
         }
 
@@ -105,7 +105,7 @@ class CriteriaPartResolver
         $subQuery->andWhere(implode(' AND ', $parsed->getWheres()));
 
         $singleFieldFilters = array_filter($filter->getQueries(), fn (Filter $filter): bool => $filter instanceof SingleFieldFilter);
-        if (empty($singleFieldFilters)) {
+        if ($singleFieldFilters === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
@@ -139,7 +139,7 @@ class JoinGroupBuilder
     {
         $fields = EntityDefinitionQueryHelper::getFieldsOfAccessor($definition, $filter->getField(), false);
 
-        if (\count($fields) === 0) {
+        if ($fields === []) {
             return null;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -593,7 +593,7 @@ class DefinitionValidator
 
         $parentDefinitionClass = $parentDefinition->getClass();
         $translationDefinitionClass = $translationDefinition->getClass();
-        if (empty($translationsAssociationFields)) {
+        if ($translationsAssociationFields === []) {
             $violations[$parentDefinitionClass] = \sprintf(
                 'The parentDefinition `%s` for `%s` should define a `TranslationsAssociationField for `%s`. The parentDefinition could be wrong too.',
                 $parentDefinitionClass,

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -66,7 +66,7 @@ class MultiInsertQueryQueue
 
     public function execute(): void
     {
-        if (empty($this->inserts)) {
+        if ($this->inserts === []) {
             return;
         }
 
@@ -134,7 +134,7 @@ class MultiInsertQueryQueue
      */
     private function prepareOnDuplicateKeyUpdatePart(array $fieldsToUpdate): string
     {
-        if (\count($fieldsToUpdate) === 0) {
+        if ($fieldsToUpdate === []) {
             return '';
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
@@ -170,7 +170,7 @@ class EntityCollection extends Collection
 
         $values = [];
         foreach ($this->elements as $element) {
-            if (empty($fields)) {
+            if ($fields === []) {
                 $values[$element->getUniqueIdentifier()] = $element->getCustomFields();
 
                 continue;

--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -247,7 +247,7 @@ class EntityRepository
 
         $ids = $this->searchIds($criteria, $context);
 
-        if (empty($ids->getIds())) {
+        if ($ids->getIds() === []) {
             /** @var TEntityCollection $collection */
             $collection = $this->definition->getCollectionClass();
 
@@ -269,7 +269,7 @@ class EntityRepository
                 $data = $search[$element->getUniqueIdentifier()];
                 unset($data['id']);
 
-                if (empty($data)) {
+                if ($data === []) {
                     continue;
                 }
 

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityDeleteEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityDeleteEvent.php
@@ -103,7 +103,7 @@ class EntityDeleteEvent extends Event implements ShopwareEvent
 
     public function filled(): bool
     {
-        return \count($this->commands) > 0;
+        return $this->commands !== [];
     }
 
     public function addSuccess(\Closure $callback): void

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
@@ -144,7 +144,7 @@ class EntityWrittenContainerEvent extends NestedEvent
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
         return $this->findPrimaryKeys($entity, function (EntityWriteResult $result) {
@@ -152,7 +152,7 @@ class EntityWrittenContainerEvent extends NestedEvent
                 return true;
             }
 
-            return !empty($result->getPayload());
+            return $result->getPayload() !== [];
         });
     }
 
@@ -168,7 +168,7 @@ class EntityWrittenContainerEvent extends NestedEvent
                 return true;
             }
 
-            return !empty(array_diff(array_keys($result->getPayload()), $ignoredFields));
+            return array_diff(array_keys($result->getPayload()), $ignoredFields) !== [];
         });
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
@@ -100,10 +100,10 @@ class EntityWrittenEvent extends NestedEvent implements GenericEvent
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
 
-        return \count($this->errors) > 0;
+        return $this->errors !== [];
     }
 
     /**
@@ -113,7 +113,7 @@ class EntityWrittenEvent extends NestedEvent implements GenericEvent
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
         $this->events->add($event);
     }
@@ -142,7 +142,7 @@ class EntityWrittenEvent extends NestedEvent implements GenericEvent
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
         if ($this->existences === null) {
             $this->existences = [];

--- a/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
@@ -10,6 +10,9 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('framework')]
 class SearchRequestException extends ShopwareHttpException
 {
+    /**
+     * @param array<string, list<\Throwable>> $exceptions
+     */
     public function __construct(private array $exceptions = [])
     {
         parent::__construct('Mapping failed, got {{ numberOfFailures }} failure(s).', ['numberOfFailures' => \count($exceptions)]);

--- a/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
@@ -27,7 +27,7 @@ class SearchRequestException extends ShopwareHttpException
 
     public function tryToThrow(): void
     {
-        if (empty($this->exceptions)) {
+        if ($this->exceptions === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/UnableToLoadPathException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/UnableToLoadPathException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Exception;
+
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class UnableToLoadPathException extends DataAbstractionLayerException
+{
+    /**
+     * @param array<string, string> $paths
+     */
+    public function __construct(string $path, array $paths)
+    {
+        parent::__construct(
+            Response::HTTP_BAD_REQUEST,
+            self::UNABLE_TO_LOAD_PATH,
+            'Unable to load %s: %s',
+            ['path' => $path, 'paths' => print_r($paths, true)],
+        );
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
+++ b/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
@@ -3,8 +3,8 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Facade;
 
 use Shopware\Core\Framework\Api\Acl\AclCriteriaValidator;
-use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
@@ -101,7 +101,7 @@ class RepositoryFacade
         $missingPermissions = $this->criteriaValidator->validate($entityName, $criteriaObject, $this->context);
 
         if ($missingPermissions !== []) {
-            throw new MissingPrivilegeException($missingPermissions);
+            throw DataAbstractionLayerException::missingPrivileges($missingPermissions);
         }
 
         return $criteriaObject;

--- a/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
+++ b/src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
@@ -100,7 +100,7 @@ class RepositoryFacade
 
         $missingPermissions = $this->criteriaValidator->validate($entityName, $criteriaObject, $this->context);
 
-        if (!empty($missingPermissions)) {
+        if ($missingPermissions !== []) {
             throw new MissingPrivilegeException($missingPermissions);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAware.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAware.php
@@ -26,7 +26,7 @@ class ApiAware extends Flag
             $this->allowList[$source] = self::BASE_URLS[$source];
         }
 
-        if (empty($protectedSources)) {
+        if ($protectedSources === []) {
             $this->allowList = self::BASE_URLS;
         }
     }

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
@@ -56,7 +56,7 @@ class CustomFieldsSerializer extends JsonFieldSerializer
         $field->setPropertyMapping($this->getFields(array_keys($attributes)));
         $encoded = $this->validateMapping($field, $attributes, $parameters);
 
-        if (empty($encoded)) {
+        if ($encoded === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/FkFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/FkFieldSerializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnableToLoadPathException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\DoNotUseContext;
@@ -54,7 +55,8 @@ class FkFieldSerializer extends AbstractFieldSerializer
         if ($this->shouldUseContext($field, $data->isRaw(), $value)) {
             try {
                 $value = $parameters->getContext()->get($field->getReferenceDefinition()->getEntityName(), $field->getReferenceField());
-            } catch (\InvalidArgumentException) {
+            } catch (\InvalidArgumentException|UnableToLoadPathException) {
+                /** @deprecated tag:v6.8.0 - Remove InvalidArgumentException from catch as it is not thrown anymore */
                 if ($this->requiresValidation($field, $existence, $value, $parameters)) {
                     $this->validate($this->getConstraints($field), $data, $parameters->getPath());
                 }

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
@@ -40,7 +40,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
 
         $value = $data->getValue() ?? $field->getDefault();
 
-        if ($value !== null && !empty($field->getPropertyMapping())) {
+        if ($value !== null && $field->getPropertyMapping() !== []) {
             $value = $this->validateMapping($field, $value, $parameters);
         }
 
@@ -63,7 +63,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
 
         $raw = json_decode((string) $value, true);
         $decoded = $raw;
-        if (empty($field->getPropertyMapping())) {
+        if ($field->getPropertyMapping() === []) {
             return $raw;
         }
 
@@ -120,7 +120,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
         // If a mapping is defined, you should not send properties that are undefined.
         // Sending undefined fields will throw an UnexpectedFieldException
         $keyDiff = array_diff(array_keys($data), $propertyKeys);
-        if (\count($keyDiff)) {
+        if ($keyDiff !== []) {
             foreach ($keyDiff as $fieldName) {
                 $parameters->getContext()->getExceptions()->add(
                     new UnexpectedFieldException($fieldPath . '/' . $fieldName, (string) $fieldName)
@@ -155,7 +155,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
              * This also allows directly storing non-array values like strings.
              * But all fields extending JsonField be properly validated.
              */
-            if ($nestedField::class === JsonField::class && empty($nestedField->getPropertyMapping())) {
+            if ($nestedField::class === JsonField::class && $nestedField->getPropertyMapping() === []) {
                 // Validate required flag manually
                 if ($nestedField->is(Required::class)) {
                     $this->validate([new NotNull()], $kvPair, $nestedParams->getPath());

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
@@ -31,7 +31,7 @@ class ChildCountUpdater
     {
         $definition = $this->registry->getByEntityName($entity);
 
-        if (empty($parentIds)) {
+        if ($parentIds === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -89,7 +89,7 @@ class EntityIndexerRegistry
                 continue;
             }
 
-            if (\count($only) > 0 && !\in_array($indexer->getName(), $only, true)) {
+            if ($only !== [] && !\in_array($indexer->getName(), $only, true)) {
                 continue;
             }
 
@@ -198,14 +198,14 @@ class EntityIndexerRegistry
      */
     public function sendIndexingMessage(array $indexer = [], array $skip = [], bool $postUpdate = false): void
     {
-        if (empty($indexer)) {
+        if ($indexer === []) {
             $indexer = [];
             foreach ($this->indexer as $loop) {
                 $indexer[] = $loop->getName();
             }
         }
 
-        if (empty($indexer)) {
+        if ($indexer === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
@@ -38,7 +38,7 @@ class InheritanceUpdater
     public function update(string $entity, array $ids, Context $context): void
     {
         $ids = array_unique(array_filter($ids));
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Indexing;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
@@ -73,7 +74,7 @@ class InheritanceUpdater
             $flag = $association->getFlag(Inherited::class);
 
             if (!$flag instanceof Inherited) {
-                throw new \RuntimeException(\sprintf('Association %s is not marked as inherited', $definition->getEntityName() . '.' . $association->getPropertyName()));
+                throw DataAbstractionLayerException::associationNotInherited($definition->getEntityName() . '.' . $association->getPropertyName());
             }
 
             $foreignKey = $flag->getForeignKey() ?: ($definition->getEntityName() . '_id');

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldUpdater.php
@@ -37,7 +37,7 @@ class ManyToManyIdFieldUpdater
     {
         $definition = $this->registry->getByEntityName($entity);
 
-        if (empty($ids)) {
+        if ($ids === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/Subscriber/RegisteredIndexerSubscriber.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/Subscriber/RegisteredIndexerSubscriber.php
@@ -49,7 +49,7 @@ class RegisteredIndexerSubscriber implements EventSubscriberInterface
     {
         $queuedIndexers = $this->indexerQueuer->getIndexers();
 
-        if (empty($queuedIndexers)) {
+        if ($queuedIndexers === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
@@ -290,7 +291,7 @@ class TreeUpdater
         } while ($parentIds !== [] && $levels >= 0);
 
         if ($levels <= 0) {
-            throw new \RuntimeException('Reached max depth, aborting');
+            throw DataAbstractionLayerException::treeUpdateError('Reached max depth, aborting');
         }
     }
 
@@ -357,7 +358,7 @@ class TreeUpdater
     private function updateEntity(array $entity, EntityDefinition $definition, ?TreePathField $pathField, ?TreeLevelField $levelField, Context $context, TreeUpdaterBag $bag): void
     {
         if ($pathField === null && $levelField) {
-            throw new \RuntimeException('`TreePathField` or `TreeLevelField` required.');
+            throw DataAbstractionLayerException::treeUpdateError('`TreePathField` or `TreeLevelField` required.');
         }
 
         if ($bag->alreadyUpdated($entity['id'])) {

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
@@ -37,7 +37,7 @@ class TreeUpdater
     public function batchUpdate(array $updateIds, string $entity, Context $context, bool $recursive = false): void
     {
         $updateIds = Uuid::fromHexToBytesList(array_unique($updateIds));
-        if (empty($updateIds)) {
+        if ($updateIds === []) {
             return;
         }
 
@@ -301,7 +301,7 @@ class TreeUpdater
      */
     private function fetchByColumn(array $ids, EntityDefinition $definition, string $column, Context $context, TreeUpdaterBag $bag): array
     {
-        if (empty($ids)) {
+        if ($ids === []) {
             return [];
         }
 
@@ -328,7 +328,7 @@ class TreeUpdater
      */
     private function updateLevelRecursively(array $updateIds, EntityDefinition $definition, Context $context, TreeUpdaterBag $bag, bool $recursive): void
     {
-        if (empty($updateIds)) {
+        if ($updateIds === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/RepositorySearchDetector.php
+++ b/src/Core/Framework/DataAbstractionLayer/RepositorySearchDetector.php
@@ -31,17 +31,17 @@ class RepositorySearchDetector
         }
 
         // group by is only supported by entity searcher
-        if (\count($criteria->getGroupFields())) {
+        if ($criteria->getGroupFields() !== []) {
             return true;
         }
 
         // sortings are only supported by entity searcher
-        if (\count($criteria->getSorting())) {
+        if ($criteria->getSorting() !== []) {
             return true;
         }
 
         // queries can only be handled in entity searcher
-        if (\count($criteria->getQueries())) {
+        if ($criteria->getQueries() !== []) {
             return true;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -584,7 +584,7 @@ class Criteria extends Struct implements \Stringable
         }
 
         // result will be sorted by interpreted search term and the calculated ranking
-        if (!\in_array($this->getTerm(), [null, '', '0'], true)) {
+        if (($this->getTerm() ?? '') !== '') {
             return false;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -194,7 +194,7 @@ class Criteria extends Struct implements \Stringable
      */
     public function hasEqualsFilter($field): bool
     {
-        return \count(array_filter($this->filters, static fn (Filter $filter) /* EqualsFilter $filter */ => $filter instanceof EqualsFilter && $filter->getField() === $field)) > 0;
+        return array_filter($this->filters, static fn (Filter $filter) /* EqualsFilter $filter */ => $filter instanceof EqualsFilter && $filter->getField() === $field) !== [];
     }
 
     /**
@@ -574,22 +574,22 @@ class Criteria extends Struct implements \Stringable
 
     public function useIdSorting(): bool
     {
-        if (empty($this->getIds())) {
+        if ($this->getIds() === []) {
             return false;
         }
 
         // manual sorting provided
-        if (!empty($this->getSorting())) {
+        if ($this->getSorting() !== []) {
             return false;
         }
 
         // result will be sorted by interpreted search term and the calculated ranking
-        if (!empty($this->getTerm())) {
+        if (!\in_array($this->getTerm(), [null, '', '0'], true)) {
             return false;
         }
 
         // result will be sorted by calculated ranking
-        if (!empty($this->getQueries())) {
+        if ($this->getQueries() !== []) {
             return false;
         }
 
@@ -664,7 +664,7 @@ class Criteria extends Struct implements \Stringable
      */
     private function validateIds(array $ids): void
     {
-        if (\count($ids) === 0) {
+        if ($ids === []) {
             throw DataAbstractionLayerException::invalidCriteriaIds($ids, 'Ids should not be empty');
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/CriteriaArrayConverter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/CriteriaArrayConverter.php
@@ -57,29 +57,29 @@ class CriteriaArrayConverter
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getIds())) {
+        if ($criteria->getIds() !== []) {
             $array['ids'] = $criteria->getIds();
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getFilters())) {
+        if ($criteria->getFilters() !== []) {
             $array['filter'] = array_map(static fn (Filter $filter) => QueryStringParser::toArray($filter), $criteria->getFilters());
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getPostFilters())) {
+        if ($criteria->getPostFilters() !== []) {
             $array['post-filter'] = array_map(static fn (Filter $filter) => QueryStringParser::toArray($filter), $criteria->getPostFilters());
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getAssociations())) {
+        if ($criteria->getAssociations() !== []) {
             foreach ($criteria->getAssociations() as $assocName => $association) {
                 $array['associations'][$assocName] = $this->convert($association);
             }
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getSorting())) {
+        if ($criteria->getSorting() !== []) {
             $array['sort'] = json_decode(json_encode($criteria->getSorting(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
 
             foreach ($array['sort'] as &$sort) {
@@ -90,7 +90,7 @@ class CriteriaArrayConverter
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getQueries())) {
+        if ($criteria->getQueries() !== []) {
             $array['query'] = [];
 
             foreach ($criteria->getQueries() as $query) {
@@ -105,7 +105,7 @@ class CriteriaArrayConverter
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getGroupFields())) {
+        if ($criteria->getGroupFields() !== []) {
             $array['grouping'] = [];
 
             foreach ($criteria->getGroupFields() as $groupField) {
@@ -114,7 +114,7 @@ class CriteriaArrayConverter
         }
 
         /** @var array<string, mixed> $array */
-        if (\count($criteria->getAggregations())) {
+        if ($criteria->getAggregations() !== []) {
             $array['aggregations'] = $this->aggregationParser->toArray($criteria->getAggregations());
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
@@ -67,7 +67,7 @@ class IdSearchResult extends Struct
 
     public function firstId(): ?string
     {
-        if (empty($this->ids)) {
+        if ($this->ids === []) {
             return null;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
@@ -193,7 +193,7 @@ class AggregationParser
     {
         $name = \array_key_exists('name', $aggregation) ? (string) $aggregation['name'] : null;
 
-        if (empty($name) || is_numeric($name)) {
+        if ($name === null || $name === '' || $name === '0' || is_numeric($name)) {
             $exceptions->add(DataAbstractionLayerException::invalidAggregationQuery('The aggregation name should be a non-empty string.'), '/aggregations/' . $index);
 
             return null;
@@ -207,7 +207,7 @@ class AggregationParser
 
         $type = $aggregation['type'] ?? null;
 
-        if (!\is_string($type) || empty($type) || is_numeric($type)) {
+        if (!\is_string($type) || ($type === '' || $type === '0') || is_numeric($type)) {
             $exceptions->add(DataAbstractionLayerException::invalidAggregationQuery('The aggregations of "%s" should be a non-empty string.'), '/aggregations/' . $index);
 
             return null;

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParser.php
@@ -193,7 +193,7 @@ class AggregationParser
     {
         $name = \array_key_exists('name', $aggregation) ? (string) $aggregation['name'] : null;
 
-        if ($name === null || $name === '' || $name === '0' || is_numeric($name)) {
+        if ($name === null || $name === '' || is_numeric($name)) {
             $exceptions->add(DataAbstractionLayerException::invalidAggregationQuery('The aggregation name should be a non-empty string.'), '/aggregations/' . $index);
 
             return null;
@@ -207,7 +207,7 @@ class AggregationParser
 
         $type = $aggregation['type'] ?? null;
 
-        if (!\is_string($type) || ($type === '' || $type === '0') || is_numeric($type)) {
+        if (!\is_string($type) || $type === '' || is_numeric($type)) {
             $exceptions->add(DataAbstractionLayerException::invalidAggregationQuery('The aggregations of "%s" should be a non-empty string.'), '/aggregations/' . $index);
 
             return null;

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
@@ -159,7 +159,7 @@ class QueryStringParser
                     $values = [$values];
                 }
 
-                if (empty($values)) {
+                if ($values === []) {
                     throw DataAbstractionLayerException::invalidFilterQuery('Parameter "value" for equalsAll filter does not contain any value.', $path . '/value');
                 }
 
@@ -187,7 +187,7 @@ class QueryStringParser
                     $values = [$values];
                 }
 
-                if (empty($values)) {
+                if ($values === []) {
                     throw DataAbstractionLayerException::invalidFilterQuery('Parameter "value" for equalsAny filter does not contain any value.', $path . '/value');
                 }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -293,7 +293,7 @@ class SqlQueryParser
         $result->resetWheres();
 
         $glue = ' ' . $query->getOperator() . ' ';
-        if (!empty($wheres)) {
+        if ($wheres !== []) {
             $result->addWhere('(' . implode($glue, $wheres) . ')');
         }
 
@@ -310,7 +310,7 @@ class SqlQueryParser
 
         $glue = ' ' . $query->getOperator() . ' ';
 
-        if (!empty($wheres)) {
+        if ($wheres !== []) {
             $result->addWhere('NOT (' . implode($glue, $wheres) . ')');
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -306,7 +306,7 @@ class RequestCriteriaBuilder
     {
         $parts = array_filter(explode(',', $query));
 
-        if (empty($parts)) {
+        if ($parts === []) {
             throw DataAbstractionLayerException::invalidSortQuery('The "sort" parameter needs to be a sorting array or a comma separated list of fields', '/sort');
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoader.php
@@ -54,7 +54,7 @@ WHERE product_search_config.language_id = :languageId AND product_search_config_
                 ]
             );
 
-            if (!empty($config)) {
+            if ($config !== []) {
                 return array_map(function (array $item): array {
                     return [
                         'and_logic' => $item['and_logic'],

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
@@ -82,7 +82,7 @@ class TokenFilter extends AbstractTokenFilter
         foreach ($tokens as $tag) {
             $tag = trim((string) $tag);
 
-            if ($tag === '' || $tag === '0' || mb_strlen($tag) < $minSearchTermLength) {
+            if ($tag === '' || mb_strlen($tag) < $minSearchTermLength) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
@@ -28,7 +28,7 @@ class TokenFilter extends AbstractTokenFilter
      */
     public function filter(array $tokens, Context $context): array
     {
-        if (empty($tokens)) {
+        if ($tokens === []) {
             return $tokens;
         }
 
@@ -57,7 +57,7 @@ class TokenFilter extends AbstractTokenFilter
      */
     private function excludedTermsFilter(array $tokens, array $excludedTerms): array
     {
-        if (empty($excludedTerms) || empty($tokens)) {
+        if ($excludedTerms === [] || $tokens === []) {
             return $tokens;
         }
 
@@ -82,7 +82,7 @@ class TokenFilter extends AbstractTokenFilter
         foreach ($tokens as $tag) {
             $tag = trim((string) $tag);
 
-            if (empty($tag) || mb_strlen($tag) < $minSearchTermLength) {
+            if ($tag === '' || $tag === '0' || mb_strlen($tag) < $minSearchTermLength) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
@@ -51,7 +51,7 @@ class Tokenizer implements TokenizerInterface
         foreach ($tags as $tag) {
             $tag = trim($tag);
 
-            if ($tag === '' || $tag === '0' || mb_strlen($tag) < $tokenMinimumLength) {
+            if ($tag === '' || mb_strlen($tag) < $tokenMinimumLength) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
@@ -51,14 +51,14 @@ class Tokenizer implements TokenizerInterface
         foreach ($tags as $tag) {
             $tag = trim($tag);
 
-            if (empty($tag) || mb_strlen($tag) < $tokenMinimumLength) {
+            if ($tag === '' || $tag === '0' || mb_strlen($tag) < $tokenMinimumLength) {
                 continue;
             }
 
             $filtered[] = $tag;
         }
 
-        if (empty($filtered)) {
+        if ($filtered === []) {
             return $tags;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
+++ b/src/Core/Framework/DataAbstractionLayer/Util/AfterSort.php
@@ -55,7 +55,7 @@ class AfterSort
 
         $lastId = $first->getId();
 
-        while (\count($elements) > 0) {
+        while ($elements !== []) {
             foreach ($elements as $index => $element) {
                 // @phpstan-ignore property.dynamicName
                 if ($lastId !== $element->$propertyName) {
@@ -81,7 +81,7 @@ class AfterSort
                 $lastId = $nextItem->getId();
             }
 
-            if (!\count($elements)) {
+            if ($elements === []) {
                 break;
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -416,7 +416,7 @@ class VersionManager
             }
         }
 
-        /** @phpstan-ignore empty.variable (might be overridden by reference) */
+        /** @phpstan-ignore notIdentical.alwaysFalse (might be overridden by reference) */
         if ($extensions !== []) {
             $payload['extensions'] = $extensions;
         }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -378,7 +378,7 @@ class VersionManager
                 }
 
                 $nested = array_filter($nested);
-                if (empty($nested)) {
+                if ($nested === []) {
                     continue;
                 }
 
@@ -394,7 +394,7 @@ class VersionManager
                     $nested[] = ['id' => $item['id']];
                 }
 
-                if (empty($nested)) {
+                if ($nested === []) {
                     continue;
                 }
 
@@ -417,7 +417,7 @@ class VersionManager
         }
 
         /** @phpstan-ignore empty.variable (might be overridden by reference) */
-        if (!empty($extensions)) {
+        if ($extensions !== []) {
             $payload['extensions'] = $extensions;
         }
 
@@ -760,7 +760,7 @@ class VersionManager
                         }
 
                         $payload = $data->getPayload();
-                        if (empty($payload)) {
+                        if ($payload === null || $payload === []) {
                             break;
                         }
                         $payload = $this->addVersionToPayload($payload, $definition, Defaults::LIVE_VERSION);
@@ -801,7 +801,7 @@ class VersionManager
             $operations[] = new SyncOperation('delete-' . $entity, $entity, 'delete', $payload);
         }
 
-        if (empty($operations)) {
+        if ($operations === []) {
             return new WriteResult([], [], []);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
@@ -83,7 +83,7 @@ class WriteCommandQueue
         $commands = array_filter($this->commands);
         $counter = 0;
 
-        while (!empty($commands)) {
+        while ($commands !== []) {
             ++$counter;
 
             if ($counter === 50) {

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
@@ -92,7 +92,7 @@ class EntityWriteResultFactory
 
             $ids = array_map(fn (EntityWriteResult $result) => $result->getPrimaryKey(), $result);
 
-            if (empty($ids)) {
+            if ($ids === []) {
                 continue;
             }
 
@@ -236,7 +236,7 @@ class EntityWriteResultFactory
                 $writeResults,
                 static fn (EntityWriteResult $result): bool => $result->getOperation() === EntityWriteResult::OPERATION_DELETE
             ));
-            if (!empty($deletedEntities)) {
+            if ($deletedEntities !== []) {
                 $deleted[$entityName] = $deletedEntities;
             }
 
@@ -245,7 +245,7 @@ class EntityWriteResultFactory
                 static fn (EntityWriteResult $result): bool => \in_array($result->getOperation(), [EntityWriteResult::OPERATION_INSERT, EntityWriteResult::OPERATION_UPDATE], true)
             ));
 
-            if (!empty($updatedEntities)) {
+            if ($updatedEntities !== []) {
                 $updated[$entityName] = $updatedEntities;
             }
         }
@@ -306,7 +306,7 @@ class EntityWriteResultFactory
 
         $ids = array_unique(array_filter(array_column($parentIds, 'id')));
 
-        if (\count($ids) === 0) {
+        if ($ids === []) {
             return [];
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
@@ -211,7 +211,7 @@ class EntityWriter implements EntityWriterInterface
     private function validateSyncOperationInput(SyncOperation $operation): void
     {
         $errors = $operation->validate();
-        if (\count($errors)) {
+        if ($errors !== []) {
             throw DataAbstractionLayerException::invalidSyncOperationException(\sprintf('Invalid sync operation. %s', implode(' ', $errors)));
         }
     }
@@ -400,7 +400,7 @@ class EntityWriter implements EntityWriterInterface
         if (!$definition instanceof MappingEntityDefinition) {
             $restrictions = $this->foreignKeyResolver->getAffectedDeleteRestrictions($definition, $resolved, $writeContext->getContext(), true);
 
-            if (!empty($restrictions)) {
+            if ($restrictions !== []) {
                 throw DataAbstractionLayerException::restrictDeleteViolations($definition, $restrictions);
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidator.php
@@ -47,7 +47,7 @@ class LockValidator implements EventSubscriberInterface
         $writeCommands = $event->getCommands();
         $lockedEntities = $this->containsLockedEntities($writeCommands);
 
-        if (empty($lockedEntities)) {
+        if ($lockedEntities === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/ParentRelationValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/ParentRelationValidator.php
@@ -43,7 +43,7 @@ class ParentRelationValidator implements EventSubscriberInterface
         $writeCommands = $event->getCommands();
         $selfReferences = $this->containsSelfReferencingParent($writeCommands);
 
-        if (empty($selfReferences)) {
+        if ($selfReferences === []) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -228,7 +228,7 @@ class WriteCommandExtractor
         // call map with child associations only
         $children = array_filter($fields, static fn (Field $field) => $field instanceof ChildrenAssociationField);
 
-        if (\count($children) > 0) {
+        if ($children !== []) {
             $this->map($children, $stack, $existence, $parameters);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Write;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,7 +31,7 @@ class WriteContext
     /**
      * @var LanguageData
      */
-    private array $languages;
+    private array $languages = [];
 
     /**
      * @var array<string, string>|null
@@ -57,8 +59,8 @@ class WriteContext
      */
     public function getLanguages(): array
     {
-        if (!isset($this->languages) || $this->languages === []) {
-            throw new \RuntimeException('languages not initialized');
+        if ($this->languages === []) {
+            throw DataAbstractionLayerException::invalidWriteContext('Languages are not initialized.');
         }
 
         return $this->languages;
@@ -92,7 +94,11 @@ class WriteContext
         $path = $this->buildPathName($entity, $propertyName);
 
         if (!$this->has($entity, $propertyName)) {
-            throw new \InvalidArgumentException(\sprintf('Unable to load %s: %s', $path, print_r($this->paths, true)));
+            if (Feature::isActive('v6.8.0.0')) {
+                /** @phpstan-ignore shopware.domainException (Will be fixed with next major) */
+                throw new \InvalidArgumentException(\sprintf('Unable to load %s: %s', $path, print_r($this->paths, true)));
+            }
+            throw DataAbstractionLayerException::invalidWriteContext(\sprintf('Unable to load %s: %s', $path, print_r($this->paths, true)));
         }
 
         return $this->paths[$path];

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
@@ -57,7 +57,7 @@ class WriteContext
      */
     public function getLanguages(): array
     {
-        if (empty($this->languages)) {
+        if (!isset($this->languages) || $this->languages === []) {
             throw new \RuntimeException('languages not initialized');
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Write;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\UnableToLoadPathException;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
@@ -89,6 +90,9 @@ class WriteContext
         $this->paths[$this->buildPathName($entity, $propertyName)] = $value;
     }
 
+    /**
+     * @throws \InvalidArgumentException|UnableToLoadPathException
+     */
     public function get(string $entity, string $propertyName): string
     {
         $path = $this->buildPathName($entity, $propertyName);
@@ -98,7 +102,7 @@ class WriteContext
                 /** @phpstan-ignore shopware.domainException (Will be fixed with next major) */
                 throw new \InvalidArgumentException(\sprintf('Unable to load %s: %s', $path, print_r($this->paths, true)));
             }
-            throw DataAbstractionLayerException::invalidWriteContext(\sprintf('Unable to load %s: %s', $path, print_r($this->paths, true)));
+            throw DataAbstractionLayerException::unableToLoadPath($path, $this->paths);
         }
 
         return $this->paths[$path];

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
@@ -40,7 +40,7 @@ class WriteException extends ShopwareHttpException
      */
     public function tryToThrow(): void
     {
-        if (\count($this->exceptions)) {
+        if ($this->exceptions !== []) {
             throw $this;
         }
     }

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
@@ -13,7 +13,7 @@ class WriteException extends ShopwareHttpException
     private const MESSAGE = "There are {{ errorCount }} error(s) while writing data.\n\n{{ messagesString }}";
 
     /**
-     * @var \Throwable[]
+     * @var list<\Throwable>
      */
     private array $exceptions = [];
 
@@ -30,6 +30,9 @@ class WriteException extends ShopwareHttpException
         return $this;
     }
 
+    /**
+     * @return list<\Throwable>
+     */
     public function getExceptions(): array
     {
         return $this->exceptions;

--- a/src/Core/System/StateMachine/StateMachineException.php
+++ b/src/Core/System/StateMachine/StateMachineException.php
@@ -93,7 +93,7 @@ class StateMachineException extends HttpException
     }
 
     /**
-     * @param string[] $permissions
+     * @param list<string> $permissions
      */
     public static function missingPrivileges(array $permissions): ShopwareHttpException
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
