### PR TITLE
feat: Refactor empty usage in Framework to prepare its prohibition

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1039,12 +1039,6 @@ parameters:
 			path: src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
 
 		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/Plugin/Composer/PackageProvider.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\Plugin\\KernelPluginLoader\\StaticKernelPluginLoader\:\:__construct\(\) has parameter \$plugins with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1181,12 +1175,6 @@ parameters:
 			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Store/Services/FirstRunWizardClient.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/Store/Services/FirstRunWizardService.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'

--- a/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
@@ -8,7 +8,24 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * @phpstan-type TransformedAddressArray array{id: non-empty-string, company?: non-falsy-string, department?: non-falsy-string, salutationId?: non-falsy-string, title?: non-falsy-string, firstName?: non-falsy-string, lastName?: non-falsy-string, street?: non-falsy-string, zipcode?: non-falsy-string, city?: non-falsy-string, phoneNumber?: non-falsy-string, additionalAddressLine1?: non-falsy-string, additionalAddressLine2?: non-falsy-string, countryId?: non-falsy-string, countryStateId?: non-falsy-string, customFields?: array<string, mixed>}
+ * @phpstan-type TransformedAddressArray array{
+ *     id: non-empty-string,
+ *     company?: non-empty-string,
+ *     department?: non-empty-string,
+ *     salutationId?: non-empty-string,
+ *     title?: non-empty-string,
+ *     firstName?: non-empty-string,
+ *     lastName?: non-empty-string,
+ *     street?: non-empty-string,
+ *     zipcode?: non-empty-string,
+ *     city?: non-empty-string,
+ *     phoneNumber?: non-empty-string,
+ *     additionalAddressLine1?: non-empty-string,
+ *     additionalAddressLine2?: non-empty-string,
+ *     countryId?: non-empty-string,
+ *     countryStateId?: non-empty-string,
+ *     customFields?: array<string, mixed>
+ * }
  */
 #[Package('checkout')]
 class AddressTransformer
@@ -53,10 +70,16 @@ class AddressTransformer
             'additionalAddressLine2' => $address->getAdditionalAddressLine2(),
             'countryId' => $address->getCountryId(),
             'countryStateId' => $address->getCountryStateId(),
-            'customFields' => $address->getCustomFields(),
-        ]);
+        ], static function (?string $value): bool {
+            return $value !== null && $value !== '';
+        });
 
         $addressArray['id'] = Uuid::randomHex();
+
+        $customFields = $address->getCustomFields();
+        if ($customFields !== null && $customFields !== []) {
+            $addressArray['customFields'] = $customFields;
+        }
 
         return $addressArray;
     }

--- a/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * @phpstan-type TransformedAddressArray array{id: non-falsy-string, company?: non-falsy-string, department?: non-falsy-string, salutationId?: non-falsy-string, title?: non-falsy-string, firstName?: non-falsy-string, lastName?: non-falsy-string, street?: non-falsy-string, zipcode?: non-falsy-string, city?: non-falsy-string, phoneNumber?: non-falsy-string, additionalAddressLine1?: non-falsy-string, additionalAddressLine2?: non-falsy-string, countryId?: non-falsy-string, countryStateId?: non-falsy-string, customFields?: array<string, mixed>}
+ * @phpstan-type TransformedAddressArray array{id: non-empty-string, company?: non-falsy-string, department?: non-falsy-string, salutationId?: non-falsy-string, title?: non-falsy-string, firstName?: non-falsy-string, lastName?: non-falsy-string, street?: non-falsy-string, zipcode?: non-falsy-string, city?: non-falsy-string, phoneNumber?: non-falsy-string, additionalAddressLine1?: non-falsy-string, additionalAddressLine2?: non-falsy-string, countryId?: non-falsy-string, countryStateId?: non-falsy-string, customFields?: array<string, mixed>}
  */
 #[Package('checkout')]
 class AddressTransformer
@@ -26,7 +26,7 @@ class AddressTransformer
             $output[$address->getId()] = self::transform($address);
         }
 
-        if (!$useIdAsKey) {
+        if ($useIdAsKey === false) {
             return array_values($output);
         }
 
@@ -38,8 +38,7 @@ class AddressTransformer
      */
     public static function transform(CustomerAddressEntity $address): array
     {
-        return array_filter([
-            'id' => Uuid::randomHex(),
+        $addressArray = array_filter([
             'company' => $address->getCompany(),
             'department' => $address->getDepartment(),
             'salutationId' => $address->getSalutationId(),
@@ -56,5 +55,9 @@ class AddressTransformer
             'countryStateId' => $address->getCountryStateId(),
             'customFields' => $address->getCustomFields(),
         ]);
+
+        $addressArray['id'] = Uuid::randomHex();
+
+        return $addressArray;
     }
 }

--- a/src/Core/Framework/Demodata/DemodataService.php
+++ b/src/Core/Framework/Demodata/DemodataService.php
@@ -55,7 +55,7 @@ class DemodataService
 
             $validGenerators = array_filter(iterator_to_array($this->generators), static fn (DemodataGeneratorInterface $generator) => $generator->getDefinition() === $definitionClass);
 
-            if (empty($validGenerators)) {
+            if ($validGenerators === []) {
                 throw DemodataException::noGeneratorFound($definitionClass);
             }
 

--- a/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CategoryGenerator.php
@@ -122,7 +122,7 @@ class CategoryGenerator implements DemodataGeneratorInterface
     {
         $tagAssignments = [];
 
-        if (!empty($tags)) {
+        if ($tags !== []) {
             $chosenTags = $this->faker->randomElements($tags, $this->faker->randomDigit(), false);
 
             if (!empty($chosenTags)) {

--- a/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/CustomerGenerator.php
@@ -212,7 +212,7 @@ class CustomerGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->writer->upsert($this->customerDefinition, $payload, $writeContext);
 
             $context->getConsole()->progressAdvance(\count($payload));
@@ -237,7 +237,7 @@ class CustomerGenerator implements DemodataGeneratorInterface
     {
         $tagAssignments = [];
 
-        if (!empty($tags)) {
+        if ($tags !== []) {
             $chosenTags = $this->faker->randomElements($tags, $this->faker->numberBetween(1, \count($tags)));
 
             if (!empty($chosenTags)) {

--- a/src/Core/Framework/Demodata/Generator/FlowGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/FlowGenerator.php
@@ -196,7 +196,7 @@ class FlowGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->write($payload, $context);
         }
 
@@ -274,7 +274,7 @@ class FlowGenerator implements DemodataGeneratorInterface
      */
     private function getActions(): array
     {
-        if (!empty($this->actions)) {
+        if ($this->actions !== []) {
             return $this->actions;
         }
 
@@ -330,7 +330,7 @@ class FlowGenerator implements DemodataGeneratorInterface
      */
     private function getTags(): array
     {
-        if (!empty($this->tags)) {
+        if ($this->tags !== []) {
             return $this->tags;
         }
 

--- a/src/Core/Framework/Demodata/Generator/MailHeaderFooterGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailHeaderFooterGenerator.php
@@ -57,7 +57,7 @@ class MailHeaderFooterGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->write($payload, $context);
         }
 

--- a/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MailTemplateGenerator.php
@@ -69,7 +69,7 @@ class MailTemplateGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->write($payload, $context);
         }
 

--- a/src/Core/Framework/Demodata/Generator/MediaGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MediaGenerator.php
@@ -118,7 +118,7 @@ class MediaGenerator implements DemodataGeneratorInterface
     {
         $tagAssignments = [];
 
-        if (!empty($tags)) {
+        if ($tags !== []) {
             $chosenTags = $this->faker->randomElements($tags, $this->faker->randomDigit());
 
             if (!empty($chosenTags)) {
@@ -160,7 +160,7 @@ class MediaGenerator implements DemodataGeneratorInterface
             );
         }
 
-        if (\count($images)) {
+        if ($images !== []) {
             return $images[array_rand($images)]->getPathname();
         }
 

--- a/src/Core/Framework/Demodata/Generator/OrderGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/OrderGenerator.php
@@ -128,7 +128,7 @@ class OrderGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($orders)) {
+        if ($orders !== []) {
             $this->writer->upsert($this->orderDefinition, $orders, $writeContext);
         }
 
@@ -144,7 +144,7 @@ class OrderGenerator implements DemodataGeneratorInterface
     {
         $tagAssignments = [];
 
-        if (!empty($tags)) {
+        if ($tags !== []) {
             $chosenTags = $this->faker->randomElements($tags, $this->faker->randomDigit());
 
             if (!empty($chosenTags)) {
@@ -180,7 +180,7 @@ class OrderGenerator implements DemodataGeneratorInterface
             SalesChannelContextService::CUSTOMER_ID => $customerId,
         ];
 
-        if (!empty($paymentMethodIds)) {
+        if ($paymentMethodIds !== []) {
             $options[SalesChannelContextService::PAYMENT_METHOD_ID] = $this->faker->randomElement($paymentMethodIds);
         }
 

--- a/src/Core/Framework/Demodata/Generator/ProductGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductGenerator.php
@@ -130,7 +130,7 @@ class ProductGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->write($payload, $context);
         }
 
@@ -356,7 +356,7 @@ class ProductGenerator implements DemodataGeneratorInterface
     {
         $tagAssignments = [];
 
-        if (!empty($tags)) {
+        if ($tags !== []) {
             $chosenTags = $this->faker->randomElements($tags, $this->faker->randomDigit(), false);
 
             if (!empty($chosenTags)) {

--- a/src/Core/Framework/Demodata/Generator/ProductReviewGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/ProductReviewGenerator.php
@@ -87,7 +87,7 @@ class ProductReviewGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->writer->upsert($this->productReviewDefinition, $payload, $writeContext);
 
             $context->getConsole()->progressAdvance(\count($payload));

--- a/src/Core/Framework/Demodata/Generator/PromotionGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/PromotionGenerator.php
@@ -67,7 +67,7 @@ class PromotionGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->write($payload, $context);
         }
 

--- a/src/Core/Framework/Demodata/Generator/RuleGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/RuleGenerator.php
@@ -79,7 +79,7 @@ class RuleGenerator implements DemodataGeneratorInterface
 
         $ids = $this->ruleRepository->searchIds($criteria, $context->getContext());
 
-        if (!empty($ids->getIds())) {
+        if ($ids->getIds() !== []) {
             return;
         }
 

--- a/src/Core/Framework/Demodata/Generator/UserGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/UserGenerator.php
@@ -75,7 +75,7 @@ class UserGenerator implements DemodataGeneratorInterface
             }
         }
 
-        if (!empty($payload)) {
+        if ($payload !== []) {
             $this->writer->upsert($this->userDefinition, $payload, $writeContext);
 
             $context->getConsole()->progressAdvance(\count($payload));

--- a/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
+++ b/src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
@@ -68,7 +68,7 @@ class CleanPersonalDataCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $types = array_filter(($input->getOption('all')) ? self::VALID_TYPES : [$input->getArgument('type')]);
-        if (\count($types) === 0 || \count(\array_diff($types, self::VALID_TYPES)) > 0) {
+        if ($types === [] || \array_diff($types, self::VALID_TYPES) !== []) {
             throw new \InvalidArgumentException(
                 'Please add the argument "type=guests" to remove guests without orders or the argument "type=carts" to remove canceled carts. Use --all to clean both.'
             );
@@ -89,7 +89,7 @@ class CleanPersonalDataCommand extends Command
             $context = Context::createCLIContext();
             $ids = $this->customerRepository->searchIds($criteria, $context)->getIds();
 
-            if (\count($ids) > 0) {
+            if ($ids !== []) {
                 $this->customerRepository->delete(
                     array_map(fn ($id) => ['id' => $id], $ids),
                     $context

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -972,7 +972,7 @@ class Configuration implements ConfigurationInterface
                             $allowedAreas = ['storefront', 'store_api'];
                             $providedAreas = array_keys($areas);
 
-                            return !empty(array_diff($providedAreas, $allowedAreas));
+                            return array_diff($providedAreas, $allowedAreas) !== [];
                         })
                         ->thenInvalid('Only "storefront" and "store_api" areas are currently supported in default_policies. Config contains unsupported area(s): %s')
                     ->end()

--- a/src/Core/Framework/Event/NestedEvent.php
+++ b/src/Core/Framework/Event/NestedEvent.php
@@ -24,7 +24,7 @@ abstract class NestedEvent extends Event implements ShopwareEvent
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
         $events = [$this];
 

--- a/src/Core/Framework/Event/NestedEventCollection.php
+++ b/src/Core/Framework/Event/NestedEventCollection.php
@@ -21,7 +21,7 @@ class NestedEventCollection extends Collection
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'),
         );
         $events = [];
 

--- a/src/Core/Framework/Feature/Command/FeatureListCommand.php
+++ b/src/Core/Framework/Feature/Command/FeatureListCommand.php
@@ -25,7 +25,7 @@ final class FeatureListCommand extends Command
 
         $formatted = [];
 
-        if (empty($features)) {
+        if ($features === []) {
             $io->info('No features are registered.');
 
             return self::SUCCESS;

--- a/src/Core/Framework/Gateway/Context/Command/Executor/ContextGatewayCommandExecutor.php
+++ b/src/Core/Framework/Gateway/Context/Command/Executor/ContextGatewayCommandExecutor.php
@@ -65,7 +65,7 @@ class ContextGatewayCommandExecutor
 
         $response = new ContextTokenResponse($context->getToken());
 
-        if (!empty($parameters)) {
+        if ($parameters !== []) {
             $response = $this->contextSwitchRoute->switchContext(new RequestDataBag($parameters), $context);
         }
 

--- a/src/Core/Framework/Increment/ArrayIncrementer.php
+++ b/src/Core/Framework/Increment/ArrayIncrementer.php
@@ -81,7 +81,7 @@ class ArrayIncrementer extends AbstractIncrementer
             return;
         }
 
-        if (empty($keys)) {
+        if ($keys === []) {
             unset($this->logs[$cluster]);
 
             return;

--- a/src/Core/Framework/Increment/MySQLIncrementer.php
+++ b/src/Core/Framework/Increment/MySQLIncrementer.php
@@ -86,7 +86,7 @@ class MySQLIncrementer extends AbstractIncrementer
             ->setParameter('pool', $this->poolName)
             ->setParameter('cluster', $cluster);
 
-        if (!empty($keys)) {
+        if ($keys !== []) {
             $query->andWhere('`key` IN (:keys)')
                 ->setParameter('keys', $keys, ArrayParameterType::STRING);
         }

--- a/src/Core/Framework/Increment/RedisIncrementer.php
+++ b/src/Core/Framework/Increment/RedisIncrementer.php
@@ -59,7 +59,7 @@ class RedisIncrementer extends AbstractIncrementer
     {
         $keys = $this->getKeys($cluster);
 
-        if (empty($keys)) {
+        if ($keys === []) {
             return [];
         }
 
@@ -95,11 +95,11 @@ class RedisIncrementer extends AbstractIncrementer
     {
         $keysToDelete = $this->getKeys($cluster);
 
-        if (!empty($keys)) {
+        if ($keys !== []) {
             $keysToDelete = array_map(fn (string $keySuffix) => $this->getKey($cluster, $keySuffix), $keys);
         }
 
-        if (empty($keysToDelete)) {
+        if ($keysToDelete === []) {
             return;
         }
 
@@ -123,7 +123,7 @@ class RedisIncrementer extends AbstractIncrementer
         $keys = $this->redis->keys($this->getKey($cluster));
         \assert(\is_array($keys));
 
-        if (empty($keys) || !\method_exists($this->redis, 'getOption')) {
+        if ($keys === [] || !\method_exists($this->redis, 'getOption')) {
             return [];
         }
 

--- a/src/Core/Framework/Log/Package.php
+++ b/src/Core/Framework/Log/Package.php
@@ -52,7 +52,7 @@ final class Package
 
         $attrs = $reflection->getAttributes(Package::class);
 
-        if (!empty($attrs)) {
+        if ($attrs !== []) {
             return $attrs[0]->getArguments()[0] ?? null;
         }
 

--- a/src/Core/Framework/MessageQueue/MessageHandlerCompilerPass.php
+++ b/src/Core/Framework/MessageQueue/MessageHandlerCompilerPass.php
@@ -27,7 +27,7 @@ class MessageHandlerCompilerPass implements CompilerPassInterface
 
             $attributes = (new \ReflectionClass($class))->getAttributes(AsMessageHandler::class);
 
-            if (empty($attributes)) {
+            if ($attributes === []) {
                 continue;
             }
 

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
@@ -55,7 +55,7 @@ class TaskRegistry
 
         $deletionPayload = $this->getDeletionPayload($alreadyRegisteredTasks);
 
-        if (\count($deletionPayload) > 0) {
+        if ($deletionPayload !== []) {
             $this->scheduledTaskRepository->delete($deletionPayload, $context);
         }
     }
@@ -117,7 +117,7 @@ class TaskRegistry
         }
 
         $updates = array_values(array_filter($updates));
-        if (\count($updates) > 0) {
+        if ($updates !== []) {
             $this->scheduledTaskRepository->update($updates, $context);
         }
     }

--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -111,7 +111,7 @@ class CreateMigrationCommand extends Command
     {
         $pluginBundles = array_filter($this->kernelPluginCollection->all(), static fn (Plugin $value) => mb_strpos($value->getName(), $pluginName) === 0);
 
-        if (\count($pluginBundles) === 0) {
+        if ($pluginBundles === []) {
             throw MigrationException::pluginNotFound($pluginName);
         }
 

--- a/src/Core/Framework/Migration/IndexerQueuer.php
+++ b/src/Core/Framework/Migration/IndexerQueuer.php
@@ -96,7 +96,7 @@ class IndexerQueuer
      */
     private static function upsert(Connection $connection, ?string $id, array $indexerList): void
     {
-        if (empty($indexerList) && $id !== null) {
+        if ($indexerList === [] && $id !== null) {
             $connection->delete('system_config', ['id' => $id]);
 
             return;

--- a/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
+++ b/src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
@@ -180,7 +180,7 @@ EOD;
 
         $referencedColumns = array_map(static fn (UnqualifiedName $column): string => $column->getIdentifier()->getValue(), $constraint->getReferencedColumnNames());
 
-        return \count(array_diff($referencedColumns, $foreignFieldNames)) === 0;
+        return array_diff($referencedColumns, $foreignFieldNames) === [];
     }
 
     /**
@@ -353,7 +353,7 @@ EOD;
         $indexedColumns = $this->getPrimaryKeyColumns($tableName);
         $indexedColumns = array_map(static fn (UnqualifiedName $column): string => $column->getIdentifier()->getValue(), $indexedColumns);
 
-        if (\count(array_intersect($indexedColumns, $keyStructure['COLUMN_NAME']))) {
+        if (array_intersect($indexedColumns, $keyStructure['COLUMN_NAME']) !== []) {
             return \sprintf(
                 self::MODIFY_PRIMARY_KEY_IN_RELATION,
                 $tableName,

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -138,7 +138,7 @@ class PluginCreateCommand extends Command
 
         $question = new Question($questionText);
         $question->setValidator(function (?string $answer) {
-            if ($answer === null || $answer === '' || $answer === '0') {
+            if ($answer === null || $answer === '') {
                 throw PluginException::invalidPluginCreationInputError('Answer cannot be empty');
             }
 

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -138,7 +138,7 @@ class PluginCreateCommand extends Command
 
         $question = new Question($questionText);
         $question->setValidator(function (?string $answer) {
-            if (empty($answer)) {
+            if ($answer === null || $answer === '' || $answer === '0') {
                 throw PluginException::invalidPluginCreationInputError('Answer cannot be empty');
             }
 

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGenerator.php
@@ -48,7 +48,7 @@ class EntityGenerator implements ScaffoldingGenerator
 
         $entities = $this->askForEntities($io);
 
-        if (empty($entities)) {
+        if ($entities === null || $entities === '' || $entities === '0') {
             return;
         }
 
@@ -183,7 +183,7 @@ class EntityGenerator implements ScaffoldingGenerator
     {
         $parsed = $this->parseEntities($entities);
 
-        if (!empty($parsed)) {
+        if ($parsed !== []) {
             $config->addOption(self::OPTION_NAME, $this->parseEntities($entities));
         }
     }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGenerator.php
@@ -48,7 +48,7 @@ class EntityGenerator implements ScaffoldingGenerator
 
         $entities = $this->askForEntities($io);
 
-        if ($entities === null || $entities === '' || $entities === '0') {
+        if ($entities === null || $entities === '') {
             return;
         }
 
@@ -172,7 +172,7 @@ class EntityGenerator implements ScaffoldingGenerator
     {
         $entitiesProvided = $io->confirm('Do you want to create entities?');
 
-        if (!$entitiesProvided) {
+        if ($entitiesProvided === false) {
             return null;
         }
 

--- a/src/Core/Framework/Plugin/Composer/PackageProvider.php
+++ b/src/Core/Framework/Plugin/Composer/PackageProvider.php
@@ -8,6 +8,7 @@ use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Util\ConfigValidator;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
+use Shopware\Core\Framework\Plugin\PluginException;
 
 #[Package('framework')]
 class PackageProvider
@@ -23,7 +24,7 @@ class PackageProvider
         [$errors, $publishErrors, $warnings] = $validator->validate($composerJsonPath, ValidatingArrayLoader::CHECK_ALL, 0);
         $errors = [...$errors, ...$publishErrors];
         if ($errors !== []) {
-            throw new PluginComposerJsonInvalidException($composerJsonPath, $errors);
+            throw PluginException::composerJsonInvalid($composerJsonPath, $errors);
         }
 
         if (\count($warnings) !== 0) {
@@ -34,7 +35,7 @@ class PackageProvider
         try {
             return Factory::createComposer($pluginPath, $composerIO)->getPackage();
         } catch (\InvalidArgumentException $e) {
-            throw new PluginComposerJsonInvalidException($pluginPath . '/composer.json', [$e->getMessage()]);
+            throw PluginException::composerJsonInvalid($pluginPath . '/composer.json', [$e->getMessage()]);
         }
     }
 }

--- a/src/Core/Framework/Plugin/Composer/PackageProvider.php
+++ b/src/Core/Framework/Plugin/Composer/PackageProvider.php
@@ -22,7 +22,7 @@ class PackageProvider
 
         [$errors, $publishErrors, $warnings] = $validator->validate($composerJsonPath, ValidatingArrayLoader::CHECK_ALL, 0);
         $errors = [...$errors, ...$publishErrors];
-        if (\count($errors) !== 0) {
+        if ($errors !== []) {
             throw new PluginComposerJsonInvalidException($composerJsonPath, $errors);
         }
 

--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -112,7 +112,7 @@ abstract class KernelPluginLoader extends Bundle
         }
 
         $this->loadPluginInfos();
-        if (empty($this->pluginInfos)) {
+        if ($this->pluginInfos === []) {
             $this->initialized = true;
 
             return;

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -424,7 +424,7 @@ class PluginLifecycleService
             $dependantPlugins
         );
 
-        if (\count($dependants) > 0) {
+        if ($dependants !== []) {
             throw PluginException::hasActiveDependants($plugin->getName(), $dependants);
         }
 

--- a/src/Core/Framework/Plugin/PluginService.php
+++ b/src/Core/Framework/Plugin/PluginService.php
@@ -129,7 +129,7 @@ class PluginService
 
         // delete plugins, which are in storage but not in filesystem anymore
         $deletePluginIds = $installedPlugins->getIds();
-        if (\count($deletePluginIds) !== 0) {
+        if ($deletePluginIds !== []) {
             $deletePlugins = [];
             foreach ($deletePluginIds as $deletePluginId) {
                 $deletePlugins[] = ['id' => $deletePluginId];
@@ -200,7 +200,7 @@ class PluginService
 
         $manufacturerAuthors = array_filter($composerAuthors, static fn (array $author): bool => ($author['role'] ?? '') === self::COMPOSER_AUTHOR_ROLE_MANUFACTURER);
 
-        if (empty($manufacturerAuthors)) {
+        if ($manufacturerAuthors === []) {
             $manufacturerAuthors = $composerAuthors;
         }
 

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -172,7 +172,7 @@ class AssetService
 
         $targetDirectory = $this->getTargetDirectory($bundleOrAppName);
 
-        if (empty($manifest) || !isset($manifest[$bundleOrAppName])) {
+        if ($manifest === [] || !isset($manifest[$bundleOrAppName])) {
             // if there is no manifest file or no entry for the current bundle, we need to remove all assets and start fresh
             $this->assetFilesystem->deleteDirectory($targetDirectory);
         }

--- a/src/Core/Framework/Routing/AbstractRouteScope.php
+++ b/src/Core/Framework/Routing/AbstractRouteScope.php
@@ -17,7 +17,7 @@ abstract class AbstractRouteScope
     {
         $basePath = explode('/', $path);
 
-        return empty($this->allowedPaths) || \in_array($basePath[1], $this->allowedPaths, true);
+        return $this->allowedPaths === [] || \in_array($basePath[1], $this->allowedPaths, true);
     }
 
     abstract public function isAllowed(Request $request): bool;

--- a/src/Core/Framework/Routing/ApiRequestContextResolver.php
+++ b/src/Core/Framework/Routing/ApiRequestContextResolver.php
@@ -207,7 +207,7 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
             ->executeQuery()
             ->fetchFirstColumn();
 
-        if (empty($data)) {
+        if ($data === []) {
             throw RoutingException::languageNotFound($languageId);
         }
 

--- a/src/Core/Framework/Routing/CanonicalRedirectService.php
+++ b/src/Core/Framework/Routing/CanonicalRedirectService.php
@@ -42,13 +42,13 @@ class CanonicalRedirectService
     {
         // This attribute has been set by the RequestTransformer if the requested URL was superseded.
         $canonical = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK);
-        $shouldRedirect = $this->configService->get('core.seo.redirectToCanonicalUrl');
+        $shouldRedirect = $this->configService->getBool('core.seo.redirectToCanonicalUrl');
 
-        if (!$shouldRedirect) {
+        if ($shouldRedirect === false) {
             return null;
         }
 
-        if (!\is_string($canonical) || ($canonical === '' || $canonical === '0')) {
+        if (!\is_string($canonical) || $canonical === '') {
             return null;
         }
 

--- a/src/Core/Framework/Routing/CanonicalRedirectService.php
+++ b/src/Core/Framework/Routing/CanonicalRedirectService.php
@@ -48,7 +48,7 @@ class CanonicalRedirectService
             return null;
         }
 
-        if (!\is_string($canonical) || empty($canonical)) {
+        if (!\is_string($canonical) || ($canonical === '' || $canonical === '0')) {
             return null;
         }
 

--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -52,7 +52,7 @@ class MatchAllLineItemsRule extends Container
         $flatItems = $this->filterAndFlatten($lineItems);
 
         // When there are no line items of this type, the rule still passes (e.g. "none of promotion" with an empty cart).
-        if (\count($flatItems) === 0) {
+        if ($flatItems === []) {
             return $this->types !== null && $this->types !== [];
         }
 
@@ -99,7 +99,7 @@ class MatchAllLineItemsRule extends Container
     {
         $flat = $collection->getFlat();
 
-        if (empty($this->types)) {
+        if ($this->types === null || $this->types === []) {
             return $flat;
         }
 

--- a/src/Core/Framework/Rule/Container/ZipCodeRule.php
+++ b/src/Core/Framework/Rule/Container/ZipCodeRule.php
@@ -61,13 +61,13 @@ abstract class ZipCodeRule extends Rule
         $compareZipCode = \is_array($this->zipCodes) ? $this->zipCodes[0] : null;
 
         return match ($this->operator) {
-            Rule::OPERATOR_EQ => !empty($this->getMatches($zipCode)),
-            Rule::OPERATOR_NEQ => empty($this->getMatches($zipCode)),
+            Rule::OPERATOR_EQ => $this->getMatches($zipCode) !== [],
+            Rule::OPERATOR_NEQ => $this->getMatches($zipCode) === [],
             self::OPERATOR_GTE => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::greaterThanOrEquals((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_LTE => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::lessThanOrEquals((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_GT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::greaterThan((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_LT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::lessThan((float) $zipCode, (float) $compareZipCode),
-            self::OPERATOR_EMPTY => empty($zipCode),
+            self::OPERATOR_EMPTY => $zipCode === '' || $zipCode === '0',
             default => throw RuleException::unsupportedOperator($this->operator, self::class),
         };
     }

--- a/src/Core/Framework/Rule/Container/ZipCodeRule.php
+++ b/src/Core/Framework/Rule/Container/ZipCodeRule.php
@@ -67,7 +67,7 @@ abstract class ZipCodeRule extends Rule
             self::OPERATOR_LTE => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::lessThanOrEquals((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_GT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::greaterThan((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_LT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::lessThan((float) $zipCode, (float) $compareZipCode),
-            self::OPERATOR_EMPTY => $zipCode === '' || $zipCode === '0',
+            self::OPERATOR_EMPTY => $zipCode === '',
             default => throw RuleException::unsupportedOperator($this->operator, self::class),
         };
     }

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -96,7 +96,7 @@ class CustomFieldRule
      */
     public static function getValue(array $customFields, array $renderedField, ?SalesChannelContext $context = null): array|float|bool|int|string|null
     {
-        if (!empty($customFields) && \is_string($renderedField['name']) && \array_key_exists($renderedField['name'], $customFields)) {
+        if ($customFields !== [] && \is_string($renderedField['name']) && \array_key_exists($renderedField['name'], $customFields)) {
             $value = $customFields[$renderedField['name']];
 
             if (self::isPrice($renderedField) && $value instanceof PriceCollection) {

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -43,7 +43,7 @@ class RuleComparison
         return match ($operator) {
             Rule::OPERATOR_EQ => strcasecmp($ruleValue, $itemValue) === 0,
             Rule::OPERATOR_NEQ => strcasecmp($ruleValue, $itemValue) !== 0,
-            Rule::OPERATOR_EMPTY => empty(trim($itemValue)),
+            Rule::OPERATOR_EMPTY => \in_array(trim($itemValue), ['', '0'], true),
             default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
@@ -81,9 +81,9 @@ class RuleComparison
         $diff = array_intersect($itemValue, $ruleValue);
 
         return match ($operator) {
-            Rule::OPERATOR_EQ => !empty($diff),
-            Rule::OPERATOR_NEQ => empty($diff),
-            Rule::OPERATOR_EMPTY => empty($itemValue),
+            Rule::OPERATOR_EQ => $diff !== [],
+            Rule::OPERATOR_NEQ => $diff === [],
+            Rule::OPERATOR_EMPTY => $itemValue === [],
             default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -43,7 +43,7 @@ class RuleComparison
         return match ($operator) {
             Rule::OPERATOR_EQ => strcasecmp($ruleValue, $itemValue) === 0,
             Rule::OPERATOR_NEQ => strcasecmp($ruleValue, $itemValue) !== 0,
-            Rule::OPERATOR_EMPTY => \in_array(trim($itemValue), ['', '0'], true),
+            Rule::OPERATOR_EMPTY => $itemValue === '',
             default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -43,7 +43,7 @@ class RuleComparison
         return match ($operator) {
             Rule::OPERATOR_EQ => strcasecmp($ruleValue, $itemValue) === 0,
             Rule::OPERATOR_NEQ => strcasecmp($ruleValue, $itemValue) !== 0,
-            Rule::OPERATOR_EMPTY => $itemValue === '',
+            Rule::OPERATOR_EMPTY => trim($itemValue) === '',
             default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }

--- a/src/Core/Framework/Sso/Config/LoginConfigService.php
+++ b/src/Core/Framework/Sso/Config/LoginConfigService.php
@@ -44,7 +44,7 @@ readonly class LoginConfigService
 
     public function getConfig(): ?LoginConfig
     {
-        if (\count($this->rawConfig) === 0) {
+        if ($this->rawConfig === []) {
             return null;
         }
 

--- a/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
+++ b/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
@@ -130,11 +130,11 @@ class SsoUserInvitationMailService
         $lastName = $user?->getLastName();
         $userName = $user?->getUsername();
 
-        if (!empty($firstName) && !empty($lastName)) {
+        if ($firstName !== null && $firstName !== '' && $firstName !== '0' && ($lastName !== null && $lastName !== '' && $lastName !== '0')) {
             return $firstName . ' ' . $lastName;
         }
 
-        if (!empty($userName)) {
+        if ($userName !== null && $userName !== '' && $userName !== '0') {
             return $userName;
         }
 

--- a/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
+++ b/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
@@ -130,11 +130,11 @@ class SsoUserInvitationMailService
         $lastName = $user?->getLastName();
         $userName = $user?->getUsername();
 
-        if ($firstName !== null && $firstName !== '' && $firstName !== '0' && ($lastName !== null && $lastName !== '' && $lastName !== '0')) {
+        if ($firstName !== null && $firstName !== '' && $lastName !== null && $lastName !== '') {
             return $firstName . ' ' . $lastName;
         }
 
-        if ($userName !== null && $userName !== '' && $userName !== '0') {
+        if ($userName !== null && $userName !== '') {
             return $userName;
         }
 

--- a/src/Core/Framework/Sso/TokenService/PublicKeyLoader.php
+++ b/src/Core/Framework/Sso/TokenService/PublicKeyLoader.php
@@ -91,7 +91,7 @@ final class PublicKeyLoader
         }
 
         $publicKeyToString = $publicKey->toString('pkcs8');
-        if (!\is_string($publicKeyToString) || empty($publicKeyToString)) {
+        if (!\is_string($publicKeyToString) || ($publicKeyToString === '' || $publicKeyToString === '0')) {
             return null;
         }
 

--- a/src/Core/Framework/Sso/TokenService/PublicKeyLoader.php
+++ b/src/Core/Framework/Sso/TokenService/PublicKeyLoader.php
@@ -91,7 +91,7 @@ final class PublicKeyLoader
         }
 
         $publicKeyToString = $publicKey->toString('pkcs8');
-        if (!\is_string($publicKeyToString) || ($publicKeyToString === '' || $publicKeyToString === '0')) {
+        if (!\is_string($publicKeyToString) || $publicKeyToString === '') {
             return null;
         }
 

--- a/src/Core/Framework/Store/Exception/LicenseDomainVerificationException.php
+++ b/src/Core/Framework/Store/Exception/LicenseDomainVerificationException.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Framework\Store\Exception;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 
+/**
+ * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed with the next major as it is unused
+ */
 #[Package('checkout')]
 class LicenseDomainVerificationException extends ShopwareHttpException
 {

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -157,7 +157,7 @@ class ExtensionLoader
 
         $id = $this->getLocalesCodesFromLanguageIds([$languageId]);
 
-        if (empty($id)) {
+        if ($id === []) {
             return null;
         }
 

--- a/src/Core/Framework/Store/Services/FirstRunWizardService.php
+++ b/src/Core/Framework/Store/Services/FirstRunWizardService.php
@@ -19,8 +19,8 @@ use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Event\FirstRunWizardFinishedEvent;
 use Shopware\Core\Framework\Store\Event\FirstRunWizardStartedEvent;
 use Shopware\Core\Framework\Store\Event\ShopwareAccountLoginEvent;
-use Shopware\Core\Framework\Store\Exception\LicenseDomainVerificationException;
 use Shopware\Core\Framework\Store\Exception\StoreLicenseDomainMissingException;
+use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\Framework\Store\Struct\AccessTokenStruct;
 use Shopware\Core\Framework\Store\Struct\DomainVerificationRequestStruct;
 use Shopware\Core\Framework\Store\Struct\ExtensionStruct;
@@ -237,7 +237,7 @@ class FirstRunWizardService
         }
 
         if (!$existing || !$existing->isVerified()) {
-            throw new LicenseDomainVerificationException($domain);
+            throw StoreException::licenseDomainVerificationFailure($domain);
         }
         $existing->assign(['active' => true]);
 
@@ -332,7 +332,7 @@ class FirstRunWizardService
         try {
             $this->filesystem->write($validationRequest->getFileName(), $validationRequest->getContent());
         } catch (UnableToWriteFile) {
-            throw new LicenseDomainVerificationException($domain);
+            throw StoreException::licenseDomainVerificationFailure($domain);
         }
     }
 

--- a/src/Core/Framework/Store/Services/FirstRunWizardService.php
+++ b/src/Core/Framework/Store/Services/FirstRunWizardService.php
@@ -172,15 +172,20 @@ class FirstRunWizardService
         foreach ($this->frwClient->getRecommendationRegions($context) as $region) {
             $categories = [];
             foreach ($region['categories'] as $category) {
-                if (empty($category['name']) || empty($category['label'])) {
+                $categoryName = $category['name'] ?? '';
+                $categoryLabel = $category['label'] ?? '';
+
+                if ($categoryName === '' || $categoryLabel === '') {
                     continue;
                 }
-                $categories[] = new PluginCategoryStruct($category['name'], $category['label']);
+                $categories[] = new PluginCategoryStruct($categoryName, $categoryLabel);
             }
-            if (empty($region['name']) || empty($region['label']) || $categories === []) {
+            $regionName = $region['name'] ?? '';
+            $regionLabel = $region['label'] ?? '';
+            if ($regionName === '' || $regionLabel === '' || $categories === []) {
                 continue;
             }
-            $regions->add(new PluginRegionStruct($region['name'], $region['label'], $categories));
+            $regions->add(new PluginRegionStruct($regionName, $regionLabel, $categories));
         }
 
         return $regions;
@@ -278,14 +283,16 @@ class FirstRunWizardService
     ): array {
         $mappedExtensions = [];
         foreach ($extensions as $extension) {
-            if (empty($extension['name']) || empty($extension['localizedInfo']['name'])) {
+            $extensionName = $extension['name'] ?? '';
+            $label = $extension['localizedInfo']['name'] ?? '';
+            if ($extensionName === '' || $label === '') {
                 continue;
             }
 
             $mappedExtensions[] = (new StorePluginStruct())->assign([
-                'name' => $extension['name'],
+                'name' => $extensionName,
                 'type' => $extension['type'] ?? 'plugin',
-                'label' => $extension['localizedInfo']['name'],
+                'label' => $label,
                 'shortDescription' => $extension['localizedInfo']['shortDescription'] ?? '',
 
                 'iconPath' => $extension['iconPath'] ?? null,

--- a/src/Core/Framework/Store/Services/FirstRunWizardService.php
+++ b/src/Core/Framework/Store/Services/FirstRunWizardService.php
@@ -177,7 +177,7 @@ class FirstRunWizardService
                 }
                 $categories[] = new PluginCategoryStruct($category['name'], $category['label']);
             }
-            if (empty($region['name']) || empty($region['label']) || empty($categories)) {
+            if (empty($region['name']) || empty($region['label']) || $categories === []) {
                 continue;
             }
             $regions->add(new PluginRegionStruct($region['name'], $region['label'], $categories));

--- a/src/Core/Framework/Store/StoreException.php
+++ b/src/Core/Framework/Store/StoreException.php
@@ -31,6 +31,7 @@ class StoreException extends HttpException
     public const JWKS_KEY_NOT_FOUND = 'FRAMEWORK__STORE_JWKS_NOT_FOUND';
     public const PLUGIN_NOT_A_ZIP_FILE = 'FRAMEWORK__PLUGIN_NOT_A_ZIP_FILE';
     public const INVALID_CONTEXT_SOURCE_USER = 'FRAMEWORK__INVALID_CONTEXT_SOURCE_USER';
+    public const STORE_LICENSE_DOMAIN_VALIDATION_FAILED = 'FRAMEWORK__STORE_LICENSE_DOMAIN_VALIDATION_FAILED';
 
     public static function cannotDeleteManaged(string $pluginName): self
     {
@@ -207,6 +208,16 @@ class StoreException extends HttpException
             self::INVALID_CONTEXT_SOURCE_USER,
             '{{ contextSource }} does not have a valid user ID',
             ['contextSource' => $contextSource]
+        );
+    }
+
+    public static function licenseDomainVerificationFailure(string $domain): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::STORE_LICENSE_DOMAIN_VALIDATION_FAILED,
+            'License host verification failed for domain "{{ domain }}.',
+            ['domain' => $domain],
         );
     }
 }

--- a/src/Core/Framework/Store/Struct/PermissionCollection.php
+++ b/src/Core/Framework/Store/Struct/PermissionCollection.php
@@ -20,7 +20,7 @@ class PermissionCollection extends StoreCollection
     public function __construct(iterable $elements = [])
     {
         $elements = (array) $elements;
-        if (!empty($elements) && $this->hasNoPermissionStructElements($elements)) {
+        if ($elements !== [] && $this->hasNoPermissionStructElements($elements)) {
             /** @phpstan-ignore-next-line PHPStan does not recognize, that $elements does not contain "PermissionStruct" instances at this point, which is checked by "hasNoPermissionStructElements" method */
             $elements = $this->generatePrivileges($elements);
         }
@@ -105,6 +105,6 @@ class PermissionCollection extends StoreCollection
      */
     private function hasNoPermissionStructElements(array $elements): bool
     {
-        return empty(array_filter($elements, static fn ($element) => $element instanceof PermissionStruct));
+        return array_filter($elements, static fn ($element) => $element instanceof PermissionStruct) === [];
     }
 }

--- a/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
@@ -176,7 +176,7 @@ trait AdminApiTestBehaviour
             'password' => 'shopware',
         ];
 
-        if (!empty($scopes)) {
+        if ($scopes !== []) {
             $authPayload['scope'] = implode(' ', $scopes);
         }
 

--- a/src/Core/Framework/Update/Checkers/WriteableCheck.php
+++ b/src/Core/Framework/Update/Checkers/WriteableCheck.php
@@ -31,7 +31,7 @@ class WriteableCheck
             $this->filesystem->checkSingleDirectoryPermissions($fullPath, true)
         );
 
-        if (empty($directories)) {
+        if ($directories === []) {
             return new ValidationResult(
                 'writeableCheck',
                 true,

--- a/src/Core/Framework/Util/ArrayComparator.php
+++ b/src/Core/Framework/Util/ArrayComparator.php
@@ -26,7 +26,7 @@ class ArrayComparator
      */
     public static function equals(array $a, array $b): bool
     {
-        return \count(array_intersect($a, $b)) > 0;
+        return array_intersect($a, $b) !== [];
     }
 
     /**
@@ -35,6 +35,6 @@ class ArrayComparator
      */
     public static function notEquals(array $a, array $b): bool
     {
-        return \count(array_intersect($a, $b)) === 0;
+        return array_intersect($a, $b) === [];
     }
 }

--- a/src/Core/Framework/Util/Random.php
+++ b/src/Core/Framework/Util/Random.php
@@ -54,12 +54,12 @@ class Random
         }
 
         // charlist is empty or not provided
-        if ($charlist === null || $charlist === '' || $charlist === '0') {
+        if ($charlist === null || $charlist === '') {
             /** @var int<1, max> $numBytes */
             $numBytes = (int) ceil($length * 0.75);
             $bytes = static::getBytes($numBytes);
 
-            /** @var non-empty-string $result phpstan does not understand that some content of $bytes will remain */
+            /** @var non-empty-string $result PHPStan does not understand that some content of $bytes will remain */
             $result = mb_substr(rtrim(base64_encode($bytes), '='), 0, $length, '8bit');
 
             return $result;

--- a/src/Core/Framework/Util/Random.php
+++ b/src/Core/Framework/Util/Random.php
@@ -54,7 +54,7 @@ class Random
         }
 
         // charlist is empty or not provided
-        if (empty($charlist)) {
+        if ($charlist === null || $charlist === '' || $charlist === '0') {
             /** @var int<1, max> $numBytes */
             $numBytes = (int) ceil($length * 0.75);
             $bytes = static::getBytes($numBytes);

--- a/src/Core/Framework/Util/XmlReader.php
+++ b/src/Core/Framework/Util/XmlReader.php
@@ -63,7 +63,7 @@ abstract class XmlReader
     {
         $children = self::getChildByName($list, $name);
 
-        if (\count($children) === 0) {
+        if ($children === []) {
             return null;
         }
 

--- a/src/Core/Framework/Uuid/Uuid.php
+++ b/src/Core/Framework/Uuid/Uuid.php
@@ -21,18 +21,18 @@ class Uuid
     private static ?UnixTimeGenerator $generator = null;
 
     /**
-     * @return non-falsy-string
+     * @return non-empty-string
      */
     public static function randomHex(): string
     {
-        /** @var non-falsy-string */
+        /** @var non-empty-string */
         return bin2hex(self::randomBytes());
     }
 
     /**
      * same as Ramsey\Uuid\UuidFactory->uuidFromBytesAndVersion without using a transfer object
      *
-     * @return non-falsy-string
+     * @return non-empty-string
      */
     public static function randomBytes(): string
     {
@@ -62,7 +62,7 @@ class Uuid
      * @throws InvalidUuidException
      * @throws InvalidUuidLengthException
      *
-     * @return non-falsy-string
+     * @return non-empty-string
      */
     public static function fromBytesToHex(string $bytes): string
     {
@@ -75,7 +75,7 @@ class Uuid
             throw UuidException::invalidUuid($uuid);
         }
 
-        \assert($uuid !== '' && $uuid !== '0');
+        \assert($uuid !== '');
 
         return $uuid;
     }
@@ -85,7 +85,7 @@ class Uuid
      *
      * @param array<TArrayKey, string> $bytesList
      *
-     * @return array<TArrayKey, non-falsy-string>
+     * @return array<TArrayKey, non-empty-string>
      */
     public static function fromBytesToHexList(array $bytesList): array
     {
@@ -99,7 +99,7 @@ class Uuid
      *
      * @param array<TArrayKey, string> $uuids
      *
-     * @return array<TArrayKey, non-falsy-string>
+     * @return array<TArrayKey, non-empty-string>
      */
     public static function fromHexToBytesList(array $uuids): array
     {
@@ -111,7 +111,7 @@ class Uuid
     /**
      * @throws InvalidUuidException
      *
-     * @return non-falsy-string
+     * @return non-empty-string
      */
     public static function fromHexToBytes(string $uuid): string
     {

--- a/src/Core/Framework/Uuid/Uuid.php
+++ b/src/Core/Framework/Uuid/Uuid.php
@@ -75,7 +75,7 @@ class Uuid
             throw UuidException::invalidUuid($uuid);
         }
 
-        \assert(!empty($uuid));
+        \assert($uuid !== '' && $uuid !== '0');
 
         return $uuid;
     }

--- a/src/Core/Framework/Webhook/BusinessEventEncoder.php
+++ b/src/Core/Framework/Webhook/BusinessEventEncoder.php
@@ -72,11 +72,11 @@ class BusinessEventEncoder
 
     /**
      * @param array<string, mixed> $dataTypes
-     * @param object|array<string, mixed> $object
+     * @param FlowEventAware|array<string, mixed> $object
      *
      * @return array<string, mixed>
      */
-    private function encodeType(array $dataTypes, $object): array
+    private function encodeType(array $dataTypes, FlowEventAware|array $object): array
     {
         $data = [];
         foreach ($dataTypes as $name => $dataType) {
@@ -91,7 +91,7 @@ class BusinessEventEncoder
      *
      * @return array<string, mixed>|mixed
      */
-    private function encodeProperty(array $dataType, mixed $property)
+    private function encodeProperty(array $dataType, mixed $property): mixed
     {
         switch ($dataType['type']) {
             case ScalarValueType::TYPE_BOOL:
@@ -103,8 +103,9 @@ class BusinessEventEncoder
             case EntityCollectionType::TYPE:
                 return $this->encodeEntity($dataType, $property);
             case ObjectType::TYPE:
-                if (\is_array($dataType['data']) && (isset($dataType['data']) && $dataType['data'] !== [])) {
-                    return $this->encodeType($dataType['data'], $property);
+                $data = $dataType['data'];
+                if (\is_array($data) && $data !== []) {
+                    return $this->encodeType($data, $property);
                 }
 
                 return $property;
@@ -116,11 +117,9 @@ class BusinessEventEncoder
     }
 
     /**
-     * @param object|array<string, mixed> $object
-     *
-     * @return mixed
+     * @param FlowEventAware|array<string, mixed> $object
      */
-    private function getProperty(string $propertyName, $object)
+    private function getProperty(string $propertyName, FlowEventAware|array $object): mixed
     {
         if (\is_object($object)) {
             $getter = 'get' . $propertyName;

--- a/src/Core/Framework/Webhook/BusinessEventEncoder.php
+++ b/src/Core/Framework/Webhook/BusinessEventEncoder.php
@@ -103,7 +103,7 @@ class BusinessEventEncoder
             case EntityCollectionType::TYPE:
                 return $this->encodeEntity($dataType, $property);
             case ObjectType::TYPE:
-                if (\is_array($dataType['data']) && !empty($dataType['data'])) {
+                if (\is_array($dataType['data']) && (isset($dataType['data']) && $dataType['data'] !== [])) {
                     return $this->encodeType($dataType['data'], $property);
                 }
 

--- a/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
@@ -60,21 +60,21 @@ class HookableBusinessEvent implements Hookable
      */
     private function checkPermissionsForDataType(array $dataType, AclPrivilegeCollection $permissions): bool
     {
-        if ($dataType['type'] === ObjectType::TYPE && \is_array($dataType['data']) && (isset($dataType['data']) && $dataType['data'] !== [])) {
-            foreach ($dataType['data'] as $nested) {
+        $type = $dataType['type'];
+        $data = $dataType['data'];
+        if ($type === ObjectType::TYPE && \is_array($data) && $data !== []) {
+            foreach ($data as $nested) {
                 if (!$this->checkPermissionsForDataType($nested, $permissions)) {
                     return false;
                 }
             }
         }
 
-        if ($dataType['type'] === ArrayType::TYPE && $dataType['of']) {
-            if (!$this->checkPermissionsForDataType($dataType['of'], $permissions)) {
-                return false;
-            }
+        if ($type === ArrayType::TYPE && $dataType['of'] && !$this->checkPermissionsForDataType($dataType['of'], $permissions)) {
+            return false;
         }
 
-        if ($dataType['type'] === EntityType::TYPE || $dataType['type'] === EntityCollectionType::TYPE) {
+        if ($type === EntityType::TYPE || $type === EntityCollectionType::TYPE) {
             /** @var EntityDefinition $definition */
             $definition = new $dataType['entityClass']();
             if (!$permissions->isAllowed($definition->getEntityName(), AclRoleDefinition::PRIVILEGE_READ)) {

--- a/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
@@ -60,7 +60,7 @@ class HookableBusinessEvent implements Hookable
      */
     private function checkPermissionsForDataType(array $dataType, AclPrivilegeCollection $permissions): bool
     {
-        if ($dataType['type'] === ObjectType::TYPE && \is_array($dataType['data']) && !empty($dataType['data'])) {
+        if ($dataType['type'] === ObjectType::TYPE && \is_array($dataType['data']) && (isset($dataType['data']) && $dataType['data'] !== [])) {
             foreach ($dataType['data'] as $nested) {
                 if (!$this->checkPermissionsForDataType($nested, $permissions)) {
                     return false;

--- a/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
@@ -110,7 +110,7 @@ class HookableEventCollector implements ResetInterface
                 $reflection = new \ReflectionClass($definition::class);
                 $collection = $reflection->getAttributes(EntityAttribute::class);
 
-                if (empty($collection)) {
+                if ($collection === []) {
                     continue;
                 }
 

--- a/src/Core/Framework/Webhook/Hookable/WriteResultMerger.php
+++ b/src/Core/Framework/Webhook/Hookable/WriteResultMerger.php
@@ -46,7 +46,7 @@ class WriteResultMerger
 
         $mergedWriteResults = array_values(array_filter($mergedWriteResults));
 
-        if (empty($mergedWriteResults)) {
+        if ($mergedWriteResults === []) {
             return null;
         }
 
@@ -72,7 +72,7 @@ class WriteResultMerger
             $payload = array_merge($payload, $this->getMergeableTranslationPayload($translationResult));
         }
 
-        if (empty($payload)) {
+        if ($payload === []) {
             return null;
         }
 

--- a/src/Core/Framework/Webhook/Service/WebhookManager.php
+++ b/src/Core/Framework/Webhook/Service/WebhookManager.php
@@ -96,7 +96,7 @@ class WebhookManager implements ResetInterface
     {
         $webhooksForEvent = $this->filterWebhooksByLiveVersion($this->getWebhooks($event->getName()), $event);
 
-        if (\count($webhooksForEvent) === 0) {
+        if ($webhooksForEvent === []) {
             return;
         }
 
@@ -244,7 +244,7 @@ class WebhookManager implements ResetInterface
             $requests[] = $request;
         }
 
-        if (\count($requests) > 0) {
+        if ($requests !== []) {
             $pool = new Pool($this->guzzle, $requests);
             $pool->promise()->wait();
         }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
@@ -416,7 +416,7 @@ class EntityHydratorTest extends TestCase
     }
 
     /**
-     * @param list<non-falsy-string> $additionalLanguages
+     * @param list<non-empty-string> $additionalLanguages
      */
     private function createContext(bool $inheritance = true, array $additionalLanguages = []): Context
     {

--- a/tests/unit/Core/Framework/Store/Exception/LicenseDomainVerificationExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/Exception/LicenseDomainVerificationExceptionTest.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\Store\Exception\LicenseDomainVerificationException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
+ * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed with the next major as it is unused
+ *
  * @internal
  */
 #[Package('checkout')]

--- a/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
+++ b/tests/unit/Core/Framework/Store/Services/FirstRunWizardServiceTest.php
@@ -22,11 +22,11 @@ use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\Event\FirstRunWizardFinishedEvent;
 use Shopware\Core\Framework\Store\Event\FirstRunWizardStartedEvent;
 use Shopware\Core\Framework\Store\Event\ShopwareAccountLoginEvent;
-use Shopware\Core\Framework\Store\Exception\LicenseDomainVerificationException;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardClient;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardService;
 use Shopware\Core\Framework\Store\Services\StoreService;
 use Shopware\Core\Framework\Store\Services\TrackingEventClient;
+use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\Framework\Store\Struct\AccessTokenStruct;
 use Shopware\Core\Framework\Store\Struct\DomainVerificationRequestStruct;
 use Shopware\Core\Framework\Store\Struct\FrwState;
@@ -420,7 +420,7 @@ class FirstRunWizardServiceTest extends TestCase
             frwClient: $frwClient,
         );
 
-        $this->expectException(LicenseDomainVerificationException::class);
+        $this->expectExceptionObject(StoreException::licenseDomainVerificationFailure($domain));
 
         $frwService->verifyLicenseDomain($domain, $this->context);
         static::assertEmpty($systemConfigService->all());
@@ -463,8 +463,7 @@ class FirstRunWizardServiceTest extends TestCase
             frwClient: $frwClient,
         );
 
-        $this->expectException(LicenseDomainVerificationException::class);
-        $this->expectExceptionMessage(\sprintf('License host verification failed for domain "%s."', $domain));
+        $this->expectExceptionObject(StoreException::licenseDomainVerificationFailure($domain));
 
         $frwService->verifyLicenseDomain($domain, $this->context);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

At some point in the future we want to disallow the usage of `empty`.
Preparation for https://github.com/shopware/shopware/pull/13986, where you also find some reasoning. 

### 2. What does this change do, exactly?

Refactor the usage of `empty` to use explicit checks instead

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
