### PR TITLE
ci: only use currents on scheduled nightly

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -68,7 +68,7 @@ jobs:
           poll_interval: 1m
           token: ${{ steps.sts.outputs.token }}
           env:
-            NIGHTLY=${{ inputs.nightly }}
+            NIGHTLY=${{ inputs.nightly }}\nUPSTREAM_EVENT_NAME=${{ github.event_name }}
 
   mergeability-check:
     name: Downstream Mergeability Check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -380,11 +380,11 @@ jobs:
         working-directory: new-shopware/tests/acceptance
         run: npx playwright install --with-deps chromium
       - name: Run update tests with reporting
-        if: inputs.nightly == 'true'
+        if: ${{ (inputs.nightly == 'true' && github.event_name == 'schedule') && 'true' || '' }}
         working-directory: new-shopware/tests/acceptance
         run: npx pwc --project-id ${{ secrets.CURRENTS_PROJECT_ID }} --key ${{ secrets.CURRENTS_RECORD_KEY }} -- --project=Update --trace=on
       - name: Run update tests
-        if: inputs.nightly != 'true'
+        if: ${{ (inputs.nightly != 'true' || github.event_name != 'schedule') && 'true' || '' }}
         working-directory: new-shopware/tests/acceptance
         run: npx playwright test --project=Update --trace=on
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently manual nightly runs run playwright with reporting enabled,  but we only want this to happen on scheduled runs.

### 2. What does this change do, exactly?
Check if this run got triggered by an schedule.

### 3. Describe each step to reproduce the issue or behaviour.
Run the nightly