### PR TITLE
fix(cms-sliders): Revert - Adjust image slider/galery styling (#14913)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -173,7 +173,9 @@
                         {% endblock %}
 
                         {% block sw_cms_element_image_gallery_config_settings_vertical_align %}
+                        {# ToDo NEXT-38801 - Re-enable and fix broken vertical align #}
                         <mt-select
+                            v-if="false"
                             v-model="element.config.verticalAlign.value"
                             :label="$tc('sw-cms.elements.general.config.label.verticalAlign')"
                             :placeholder="$tc('sw-cms.elements.general.config.label.verticalAlign')"
@@ -247,7 +249,7 @@
 
                     <div class="sw-cms-el-config-image-gallery__settings-options-toggles">
                         {% block sw_cms_element_image_gallery_config_settings_zoom_toggles %}
-                        {% block sw_cms_element_image_gallery_config_settings_toggle_zoom %}
+                            {% block sw_cms_element_image_gallery_config_settings_toggle_zoom %}
                         <sw-cms-inherit-wrapper
                             field="zoom"
                             :element="element"
@@ -260,9 +262,9 @@
                                 />
                             </template>
                         </sw-cms-inherit-wrapper>
-                        {% endblock %}
+                            {% endblock %}
 
-                        {% block sw_cms_element_image_gallery_config_settings_toggle_fullscreen %}
+                            {% block sw_cms_element_image_gallery_config_settings_toggle_fullscreen %}
                         <sw-cms-inherit-wrapper
                             field="fullScreen"
                             :element="element"
@@ -275,11 +277,11 @@
                                 />
                             </template>
                         </sw-cms-inherit-wrapper>
-                        {% endblock %}
+                            {% endblock %}
                         {% endblock %}
 
                         {% block sw_cms_element_image_gallery_config_settings_aspect_ratio_magnifier_over_gallery_toggles %}
-                        {% block sw_cms_element_image_gallery_config_settings_toggle_keep_aspect_ratio_on_zoom %}
+                            {% block sw_cms_element_image_gallery_config_settings_toggle_keep_aspect_ratio_on_zoom %}
                         <sw-cms-inherit-wrapper
                             field="keepAspectRatioOnZoom"
                             :element="element"
@@ -292,9 +294,9 @@
                                 />
                             </template>
                         </sw-cms-inherit-wrapper>
-                        {% endblock %}
+                            {% endblock %}
 
-                        {% block sw_cms_element_image_gallery_config_settings_toggle_magnifier_over_gallery %}
+                            {% block sw_cms_element_image_gallery_config_settings_toggle_magnifier_over_gallery %}
                         <sw-cms-inherit-wrapper
                             field="magnifierOverGallery"
                             :element="element"
@@ -308,9 +310,9 @@
                                 />
                             </template>
                         </sw-cms-inherit-wrapper>
-                        {% endblock %}
+                            {% endblock %}
 
-                        {% block sw_cms_element_image_gallery_config_settings_use_fetch_priority_on_first_item %}
+                            {% block sw_cms_element_image_gallery_config_settings_use_fetch_priority_on_first_item %}
                         <sw-cms-inherit-wrapper
                             field="useFetchPriorityOnFirstItem"
                             :element="element"
@@ -326,7 +328,7 @@
                                 />
                             </template>
                         </sw-cms-inherit-wrapper>
-                        {% endblock %}
+                            {% endblock %}
                         {% endblock %}
                     </div>
                 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/sw-cms-el-image-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/sw-cms-el-image-slider.scss
@@ -15,22 +15,6 @@
         display: grid;
         position: relative;
 
-        &.has-vertical-align {
-            display: flex;
-
-            &.is-align-top {
-                align-items: flex-start;
-            }
-
-            &.is-align-center {
-                align-items: center;
-            }
-
-            &.is-align-bottom {
-                align-items: flex-end;
-            }
-        }
-
         .sw-cms-el-image-slider__image,
         .sw-cms-el-image-slider__video {
             margin: 0 auto;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -133,28 +133,27 @@
                         </sw-cms-inherit-wrapper>
                         {% endblock %}
                         {% endblock %}
-                    </div>
-                    {% endblock %}
-                    {% endblock %}
 
-                    {% block sw_cms_element_image_slider_config_settings_vertical_align %}
-                    {# @deprecated tag:v6.8.0 - Block will be removed. Use `sw_cms_element_image_slider_config_settings_vertical_align` instead. #}
-                    {% block sw_cms_element_image_gallery_config_settings_vertical_align %}
-                    <sw-cms-inherit-wrapper
-                        v-if="element.config.displayMode.value !== 'cover'"
-                        field="verticalAlign"
-                        :element="element"
-                        :label="$t('sw-cms.elements.general.config.label.verticalAlign')"
-                    >
-                        <template #default="{ isInherited }">
-                            <mt-select
-                                v-model="element.config.verticalAlign.value"
-                                :disabled="isInherited"
-                                :placeholder="$t('sw-cms.elements.general.config.label.verticalAlign')"
-                                :options="verticalAlignValueOptions"
-                            />
-                        </template>
-                    </sw-cms-inherit-wrapper>
+                        {% block sw_cms_element_image_slider_config_settings_vertical_align %}
+                        {# @deprecated tag:v6.8.0 - Block will be removed. Use `sw_cms_element_image_slider_config_settings_vertical_align` instead. #}
+                        {% block sw_cms_element_image_gallery_config_settings_vertical_align %}
+                        <sw-cms-inherit-wrapper
+                            field="verticalAlign"
+                            :element="element"
+                            :label="$t('sw-cms.elements.general.config.label.verticalAlign')"
+                        >
+                            <template #default="{ isInherited }">
+                                <mt-select
+                                    v-model="element.config.verticalAlign.value"
+                                    :placeholder="$t('sw-cms.elements.general.config.label.verticalAlign')"
+                                    :disabled="isInherited || element.config.displayMode.value === 'cover'"
+                                    :options="verticalAlignValueOptions"
+                                />
+                            </template>
+                        </sw-cms-inherit-wrapper>
+                        {% endblock %}
+                        {% endblock %}
+                    </div>
                     {% endblock %}
                     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
@@ -47,10 +47,6 @@
     }
 
     &__setting-auto-slide {
-        &.mt-banner {
-            padding-bottom: 0;
-        }
-
         &.sw-field--switch .sw-field__label label {
             margin-right: 0;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -309,7 +309,6 @@
                                 class="sw-cms-el-config-product-slider__tab-settings-layout-border"
                                 :label="$t('sw-cms.elements.productSlider.config.label.border')"
                                 :disabled="isInherited"
-                                bordered
                             />
                         </template>
                     </sw-cms-inherit-wrapper>

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -51,33 +51,6 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     .gallery-slider-image {
         display: block;
     }
-
-    &.has-vertical-align {
-        display: flex;
-
-        &.is-align-top {
-            align-items: flex-start;
-        }
-
-        &.is-align-center {
-            align-items: center;
-        }
-
-        &.is-align-bottom {
-            align-items: flex-end;
-        }
-    }
-}
-
-.gallery-slider-item-container {
-    &.tns-item {
-        margin: 0 2px;
-    }
-
-    &.tns-item.tns-slide-active {
-        display: flex;
-        justify-content: center;
-    }
 }
 
 .gallery-slider-item,

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
@@ -15,22 +15,6 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     position: relative;
     height: 100%;
 
-    &.has-vertical-align {
-        display: flex;
-
-        &.is-align-top {
-            align-items: flex-start;
-        }
-
-        &.is-align-center {
-            align-items: center;
-        }
-
-        &.is-align-bottom {
-            align-items: flex-end;
-        }
-    }
-
     .image-slider-image {
         display: block;
         width: 100%;

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -19,19 +19,6 @@
         {% set navigationDots = sliderConfig.navigationDots.value %}
         {% set galleryPosition = sliderConfig.galleryPosition.value %}
         {% set verticalAlign = sliderConfig.verticalAlign.value %}
-
-        {% set containerClass = '' %}
-        {% if minHeight and verticalAlign %}
-            {% set containerClass = ' has-vertical-align is-align-' %}
-            {% if verticalAlign == "center" %}
-                {% set containerClass = containerClass ~ 'center' %}
-            {% elseif verticalAlign == "flex-end" %}
-                {% set containerClass = containerClass ~ 'bottom' %}
-            {% else %}
-                {% set containerClass = containerClass ~ 'top' %}
-            {% endif %}
-        {% endif %}
-
         {% set zoomImageContainerSelector = sliderConfig.zoomImageContainerSelector.value %}
         {% set arViewerBaseOptions = {
             snippets: {
@@ -207,7 +194,7 @@
                                     {% if imageCount > 1 %}
                                         {% block element_image_gallery_inner_multiple_slides %}
                                             {% block element_image_gallery_inner_container %}
-                                                <div class="gallery-slider-container{{ containerClass }}"
+                                                <div class="gallery-slider-container"
                                                      data-gallery-slider-container="true">
                                                     {% block element_image_gallery_inner_items %}
                                                         {% for image in mediaItems %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -2,54 +2,12 @@
     {% set sliderConfig = element.fieldConfig.elements %}
     {% set visibleValues = ['inside', 'outside'] %}
     {% set blockId = block.id %}
-    {% set displayMode = sliderConfig.displayMode.value %}
-    {% set navigationArrows = sliderConfig.navigationArrows.value %}
-    {% set navigationDots = sliderConfig.navigationDots.value %}
-    {% set verticalAlign = sliderConfig.verticalAlign.value %}
-    {% set minHeight = sliderConfig.minHeight.value|trim|replace({' ':''}) %}
 
-    {% set containerClass = '' %}
-    {% set alignmentClass = ' align-self-start' %}
-    {% set arrowsClass = '' %}
-    {% set dotsClass = '' %}
-    {% set prevClass = '' %}
-    {% set nextClass = '' %}
-
-    {% if displayMode == 'contain' and verticalAlign %}
-        {% set containerClass = ' has-vertical-align is-align-' %}
-        {% if verticalAlign == 'center' %}
-            {% set containerClass = containerClass ~ 'center' %}
-        {% elseif verticalAlign == 'flex-end' %}
-            {% set containerClass = containerClass ~ 'bottom' %}
-        {% else %}
-            {% set containerClass = containerClass ~ 'top' %}
-        {% endif %}
-    {% endif %}
-
-    {% if verticalAlign == "center" %}
-        {% set alignmentClass = ' align-self-center' %}
-    {% elseif verticalAlign == "flex-end" %}
-        {% set alignmentClass = ' align-self-end' %}
-    {% endif %}
-
-    {% if navigationArrows == "outside" %}
-        {% set arrowsClass = ' has-nav-outside' %}
-        {% set prevClass = ' is-nav-prev-outside' %}
-        {% set nextClass = ' is-nav-next-outside' %}
-    {% elseif navigationArrows == "inside" %}
-        {% set prevClass = ' is-nav-prev-inside' %}
-        {% set nextClass = ' is-nav-next-inside' %}
-    {% endif %}
-
-    {% if navigationDots == "outside" %}
-        {% set dotsClass = ' has-dots-outside' %}
-    {% endif %}
-
-    <div class="cms-element-{{ element.type }}{% if displayMode == "standard" and verticalAlign %} has-vertical-alignment{% endif %}">
+    <div class="cms-element-{{ element.type }}{% if sliderConfig.displayMode.value == "standard" and sliderConfig.verticalAlign.value %} has-vertical-alignment{% endif %}">
         {% set baseSliderOptions = {
             slider: {
-                controls: navigationArrows in visibleValues,
-                nav: navigationDots in visibleValues,
+                controls: sliderConfig.navigationArrows.value in visibleValues,
+                nav: sliderConfig.navigationDots.value in visibleValues,
                 navPosition: 'bottom',
                 mouseDrag: true,
                 autoplay: sliderConfig.autoSlide.value,
@@ -57,16 +15,16 @@
                 autoplayTimeout: sliderConfig.autoplayTimeout.value,
                 speed: sliderConfig.speed.value,
                 ariaLive: sliderConfig.autoSlide.value ? false : true,
-                autoHeight: (displayMode == "standard") ? true : false
+                autoHeight: (sliderConfig.displayMode.value == "standard") ? true : false
             }
         } %}
 
         {% block element_image_slider_alignment %}
             {% if config.verticalAlign.value %}
-                <div class="cms-element-alignment{{ alignmentClass }}">
+                <div class="cms-element-alignment{% if sliderConfig.verticalAlign.value == "center" %} align-self-center{% elseif sliderConfig.verticalAlign.value == "flex-end" %} align-self-end{% else %} align-self-start{% endif %}">
             {% endif %}
                 <div
-                    class="base-slider image-slider{{ arrowsClass }}{{ dotsClass }}"
+                    class="base-slider image-slider{% if sliderConfig.navigationArrows.value == "outside" %} has-nav-outside{% endif %}{% if sliderConfig.navigationDots.value == "outside" %} has-dots-outside{% endif %}"
                     data-base-slider="true"
                     data-base-slider-options='{{ baseSliderOptions|json_encode }}'
                     role="region"
@@ -82,12 +40,12 @@
                             } %}
                         {% endblock %}
 
-                        <div class="image-slider-container{{ containerClass }}"
+                        <div class="image-slider-container"
                              data-base-slider-container="true">
                             {% for image in element.data.sliderItems %}
 
                                 {% set imageElement %}
-                                    <div class="image-slider-item{% if loop.first != true %} is-not-first{% endif %} is-{{ displayMode }}"{% if minHeight and displayMode == "cover" %} style="min-height: {{ minHeight }}"{% endif %}>
+                                    <div class="image-slider-item{% if loop.first != true %} is-not-first{% endif %} is-{{ sliderConfig.displayMode.value }}"{% if sliderConfig.minHeight.value and sliderConfig.displayMode.value == "cover" %} style="min-height: {{ sliderConfig.minHeight.value|trim|replace({' ':''}) }}"{% endif %}>
                                         {% set attributes = {
                                             'class': 'img-fluid image-slider-image',
                                             'alt': element.config.isDecorative.value ? '' : (image.media.translated.alt ?: ''),
@@ -128,14 +86,14 @@
                         </div>
 
                         {% block element_image_slider_controls %}
-                            {% if navigationArrows !== 'none' %}
+                            {% if sliderConfig.navigationArrows.value !== 'none' %}
                                 <div class="image-slider-controls-container">
                                     <div class="base-slider-controls"
                                         data-base-slider-controls="true">
                                         {% block element_image_slider_controls_items %}
                                             {% block element_image_slider_controls_items_arrows %}
                                                 <button
-                                                    class="base-slider-controls-prev image-slider-controls-prev{{ prevClass }}"
+                                                    class="base-slider-controls-prev image-slider-controls-prev{% if sliderConfig.navigationArrows.value == "outside" %} is-nav-prev-outside{% elseif sliderConfig.navigationArrows.value == "inside" %} is-nav-prev-inside{% endif %}"
                                                     aria-label="{{ 'general.previous'|trans|striptags }}"
                                                 >
                                                     {% block element_image_slider_controls_items_prev_icon %}
@@ -143,7 +101,7 @@
                                                     {% endblock %}
                                                 </button>
                                                 <button
-                                                    class="base-slider-controls-next image-slider-controls-next{{ nextClass }}"
+                                                    class="base-slider-controls-next image-slider-controls-next{% if sliderConfig.navigationArrows.value == "outside" %} is-nav-next-outside{% elseif sliderConfig.navigationArrows.value == "inside" %} is-nav-next-inside{% endif %}"
                                                     aria-label="{{ 'general.next'|trans|striptags }}"
                                                 >
                                                     {% block element_image_slider_controls_items_next_icon %}


### PR DESCRIPTION
This reverts commit 53055f4cda3a56b33c5b6bc344ee816b2393354a.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Changes broke the galery & buybox components.

### 2. What does this change do, exactly?
Revert the commit, so we can re-evaluate the issues

### 3. Describe each step to reproduce the issue or behaviour.
- Create a landing page
- Try galery & buy box
- Everything was totally borken

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
