### PR TITLE
fix: preserve customer context on order creation in the Administration area

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -20,6 +20,10 @@ interface GridColumn {
     primary?: boolean;
 }
 
+interface CustomerFilterRef {
+    term: string;
+}
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default Component.wrapComponentConfig({
     template,
@@ -187,8 +191,11 @@ export default Component.wrapComponentConfig({
                 return;
             }
 
-            // @ts-expect-error
-            this.$refs.customerFilter.term = this.customerData?.customerNumber;
+            const customerFilter = this.$refs.customerFilter as CustomerFilterRef | undefined;
+            if (customerFilter) {
+                customerFilter.term = this.customerData?.customerNumber ?? '';
+            }
+
             void this.onSearch(this.customerData?.customerNumber);
             void this.onCheckCustomer(this.customerData);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -191,12 +191,14 @@ export default Component.wrapComponentConfig({
                 return;
             }
 
+            const customerNumber = this.customerData.customerNumber ?? '';
+
             const customerFilter = this.$refs.customerFilter as CustomerFilterRef | undefined;
             if (customerFilter) {
-                customerFilter.term = this.customerData?.customerNumber ?? '';
+                customerFilter.term = customerNumber;
             }
 
-            void this.onSearch(this.customerData?.customerNumber);
+            void this.onSearch(customerNumber);
             void this.onCheckCustomer(this.customerData);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
@@ -49,6 +49,10 @@ export default {
     methods: {
         async createdComponent() {
             const customerId = this.$route.query?.customerId;
+            const orderStore = Store.get('swOrder');
+
+            // Reset so grid never sees a stale customer (with or without customerId)
+            orderStore.$reset();
 
             if (!customerId) {
                 this.routeCustomerReady = true;
@@ -57,23 +61,13 @@ export default {
 
             try {
                 const customer = await this.customerRepository.get(customerId, Shopware.Context.api, this.customerCriteria);
-
-                if (!customer) {
-                    return;
-                }
-
-                const orderStore = Store.get('swOrder');
-
-                // Reset store so the customer grid never sees a stale customer from a previous session
-                orderStore.$reset();
-
-                orderStore.setCustomer(customer);
+                if (customer) orderStore.setCustomer(customer);
             } finally {
                 this.routeCustomerReady = true;
             }
         },
 
-        async onCloseCreateModal() {
+        onCloseCreateModal() {
             this.$nextTick(() => {
                 this.$router.push({ name: 'sw.order.index' });
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
@@ -11,6 +11,12 @@ const { Criteria } = Data;
 export default {
     template,
 
+    data() {
+        return {
+            routeCustomerReady: false,
+        };
+    },
+
     computed: {
         customerRepository() {
             return Service('repositoryFactory').create('customer');
@@ -45,16 +51,29 @@ export default {
             const customerId = this.$route.query?.customerId;
 
             if (!customerId) {
+                this.routeCustomerReady = true;
                 return;
             }
 
-            const customer = await this.customerRepository.get(customerId, Shopware.Context.api, this.customerCriteria);
-            if (customer) {
-                Store.get('swOrder').setCustomer(customer);
+            try {
+                const customer = await this.customerRepository.get(customerId, Shopware.Context.api, this.customerCriteria);
+
+                if (!customer) {
+                    return;
+                }
+
+                const orderStore = Store.get('swOrder');
+
+                // Reset store so the customer grid never sees a stale customer from a previous session
+                orderStore.$reset();
+
+                orderStore.setCustomer(customer);
+            } finally {
+                this.routeCustomerReady = true;
             }
         },
 
-        onCloseCreateModal() {
+        async onCloseCreateModal() {
             this.$nextTick(() => {
                 this.$router.push({ name: 'sw.order.index' });
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/sw-order-create-initial.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/sw-order-create-initial.html.twig
@@ -1,8 +1,10 @@
 {% block sw_order_create_create_initial %}
 <div class="sw-order-create-initial">
     <sw-order-create-initial-modal
+        v-if="routeCustomerReady"
         @modal-close="onCloseCreateModal"
         @order-preview="onPreviewOrder"
     />
+    <sw-loader v-else />
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/sw-order-create-initial.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/sw-order-create-initial.spec.js
@@ -35,6 +35,7 @@ async function createWrapper(customerId = null) {
             },
             stubs: {
                 'sw-order-create-initial-modal': true,
+                'sw-loader': true,
             },
         },
     });


### PR DESCRIPTION
### 1. Why is this change necessary?
Because the Administration loses the selected customer context after aborting order creation or refreshing the customer page, which can lead to creating orders for the wrong customer.

### 2. What does this change do, exactly?
It ensures the currently selected customer is always preserved when starting a new order from the customer’s orders tab or after refreshing the customer page.

### 3. Describe each step to reproduce the issue or behaviour
Scenario 1:
1. Open Customer A → Orders -> Add order
2. Abort and return to Dashboard
3. Open Customer B -> Orders -> Add order
4. The customer context is lost instead of preselecting Customer B

Scenario 2:
1. Open Customer A -> Orders -> Add order
2. Refresh the page multiple times
3. After several attempts, the customer context is lost

### 4. Please link to the relevant issues
- Fixes https://github.com/shopware/shopware/issues/14213

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
