### PR TITLE
fix(magnifier): prevent event registration when zoom container is missing

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -102,6 +102,10 @@ export default class MagnifierPlugin extends Plugin {
             this._zoomImageContainer = document.querySelector(this.options.zoomImageContainerSelector);
         }
 
+        if (!this._zoomImageContainer) {
+            return;
+        }
+
         this._registerEvents();
     }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
@@ -43,6 +43,28 @@ describe('MagnifierPlugin tests', () => {
         document.body.innerHTML = '';
     });
 
+    describe('init', () => {
+        test('should not register events when zoom image container is missing (e.g. CMS pages without product context)', () => {
+            document.body.innerHTML = `
+                <div data-magnifier>
+                    <div class="js-magnifier-container">
+                        <img class="js-magnifier-image" src="#" />
+                    </div>
+                </div>
+            `;
+
+            const el = document.querySelector('[data-magnifier]');
+            const plugin = new MagnifierPlugin(el);
+
+            expect(plugin._zoomImageContainer).toBeNull();
+
+            const image = el.querySelector('.js-magnifier-image');
+            expect(() => {
+                image.dispatchEvent(new MouseEvent('mousemove'));
+            }).not.toThrow();
+        });
+    });
+
     describe('_setZoomImageSize', () => {
         test('should clamp height to window.innerHeight / 2 when computed height exceeds maxHeight', () => {
             // keepAspectRatioOnZoom: true (default), scaleZoomImage: false (default)


### PR DESCRIPTION
### 1. Why is this change necessary?
JS Error on CMS Pages when using the image-gallery CMS element.

```
Uncaught TypeError: can't access property "querySelector", this._zoomImageContainer is null
    _createZoomImage http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _onMouseMove http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _registerEvents http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _registerEvents http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _registerEvents http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    init http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _init http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:1
    a http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:1
    n http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.magnifier.plugin.4ed312.js:1
    _initializePluginOnElement http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:5
    _initializePlugin http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:5
    _initializePlugin http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:5
    initializePlugins http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:5
    initializePlugins http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:5
    <anonymous> http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:12
    EventListener.handleEvent* http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:12
    <anonymous> http://e2e-test-kids-store-1771408760.localhost:8000/theme/e8bf4d484c797e0e4c39e3392184394d/js/storefront/storefront.js?1771408863:12
```

### 2. What does this change do, exactly?
Prevent the JS error by not registering unnecessary events (needed only on the product detail page).

### 3. Describe each step to reproduce the issue or behaviour.
Create an image gallery CMS element for a landing page. And check the browser console.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
