### PR TITLE
fix: Use correct array annotation for country address format property

### DIFF
--- a/src/Core/System/Country/CountryEntity.php
+++ b/src/Core/System/Country/CountryEntity.php
@@ -76,7 +76,7 @@ class CountryEntity extends Entity
     protected ?string $defaultPostalCodePattern = null;
 
     /**
-     * @var array<array<string, array<string, string>>>
+     * @var list<list<string>>
      */
     protected array $addressFormat;
 
@@ -331,7 +331,7 @@ class CountryEntity extends Entity
     }
 
     /**
-     * @return array<array<string, array<string, string>>>
+     * @return list<list<string>>
      */
     public function getAddressFormat(): array
     {
@@ -339,7 +339,7 @@ class CountryEntity extends Entity
     }
 
     /**
-     * @param array<array<string, array<string, string>>> $addressFormat
+     * @param list<list<string>> $addressFormat
      */
     public function setAddressFormat(array $addressFormat): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

type of `addressFormat` is wrong in API response.
Now:
```
"addressFormat": {
  "type": "object"
},
```
Actual needed:
```
"addressFormat": {
  "type": "array",
  "items": {
    "type": "array",
    "items": {
      "type": "string"
    }
  }
},
```

Ref: https://github.com/shopware/shopware/blob/v6.7.7.1/src/Core/System/Country/CountryDefinition.php `DEFAULT_ADDRESS_FORMAT`

### 2. What does this change do, exactly?

Only fixing the array annotation. The rest should be fixed with https://github.com/shopware/shopware/pull/15257

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
