### PR TITLE
feat: Use higher batch size for simpler admin es indexers

### DIFF
--- a/src/Elasticsearch/DependencyInjection/Configuration.php
+++ b/src/Elasticsearch/DependencyInjection/Configuration.php
@@ -69,6 +69,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('hosts')->end()
                         ->booleanNode('enabled')->end()
                         ->booleanNode('refresh_indices')->end()
+                        ->integerNode('indexing_batch_size')->defaultValue(1000)->end()
                         ->scalarNode('index_prefix')->end()
                         ->scalarNode('throw_exception')->end()
                         ->arrayNode('index_settings')->variablePrototype()->end()->end()

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -12,6 +12,7 @@ elasticsearch:
     administration:
         hosts: "%env(string:ADMIN_OPENSEARCH_URL)%"
         enabled: "%env(bool:SHOPWARE_ADMIN_ES_ENABLED)%"
+        indexing_batch_size: "%env(int:SHOPWARE_ADMIN_ES_INDEXING_BATCH_SIZE)%"
         refresh_indices: "%env(bool:SHOPWARE_ADMIN_ES_REFRESH_INDICES)%"
         index_prefix: "%env(string:SHOPWARE_ADMIN_ES_INDEX_PREFIX)%"
         throw_exception: "%env(string:SHOPWARE_ADMIN_ES_THROW_EXCEPTION)%"
@@ -129,6 +130,7 @@ parameters:
     env(SHOPWARE_ADMIN_ES_REFRESH_INDICES): ""
     env(SHOPWARE_ADMIN_ES_THROW_EXCEPTION): "1"
     env(SHOPWARE_ES_INDEXING_BATCH_SIZE): "100"
+    env(SHOPWARE_ADMIN_ES_INDEXING_BATCH_SIZE): "1000"
     env(SHOPWARE_ES_EXCLUDE_SOURCE): "0"
     env(SHOPWARE_ES_NGRAM_MIN_GRAM): "4"
     env(SHOPWARE_ES_NGRAM_MAX_GRAM): "5"

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -427,7 +427,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="cms_page.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="cms_page"/>
         </service>
@@ -436,7 +436,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="customer.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="customer"/>
         </service>
@@ -445,7 +445,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="customer_group.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="customer_group"/>
         </service>
@@ -455,7 +455,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="landing_page.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="landing_page"/>
         </service>
@@ -465,7 +465,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="product_manufacturer.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="product_manufacturer"/>
         </service>
@@ -475,7 +475,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="media.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="media"/>
         </service>
@@ -484,7 +484,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="order.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="order"/>
         </service>
@@ -493,7 +493,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="payment_method.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="payment_method"/>
         </service>
@@ -503,6 +503,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="product.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
+            <!-- use general (storefront) batch size, as the query is more complex and therefore slower -->
             <argument>%elasticsearch.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="product"/>
@@ -513,7 +514,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="promotion.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="promotion"/>
         </service>
@@ -523,7 +524,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="property_group.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="property_group"/>
         </service>
@@ -532,7 +533,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="sales_channel.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="sales_channel"/>
         </service>
@@ -541,7 +542,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="shipping_method.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="shipping_method"/>
         </service>
@@ -551,7 +552,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="category.repository"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder" />
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="category"/>
         </service>
@@ -560,7 +561,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="newsletter_recipient.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="newsletter_recipient"/>
         </service>
@@ -569,7 +570,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory" />
             <argument type="service" id="product_stream.repository"/>
-            <argument>%elasticsearch.indexing_batch_size%</argument>
+            <argument>%elasticsearch.administration.indexing_batch_size%</argument>
 
             <tag name="shopware.elastic.admin-searcher-index" key="product_stream"/>
         </service>


### PR DESCRIPTION
Batches of 100 are pretty small, esp when you have millions of e.g. media elements only creating the batches and dispatching the messages to the queue take ~15min on a SaaS shop with ~900.000 medias