### PR TITLE
fix: use new hasLineItemWithType method

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
@@ -39,8 +39,15 @@
 {% endblock %}
 
 {% block page_checkout_confirm_revocation_control %}
-    {% set DOWNLOAD_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_DOWNLOAD') %}
-    {% if page.order.lineItems.hasLineItemWithState(DOWNLOAD_STATE) %}
+    {% if feature('v6.8.0.0') %}
+        {% set DOWNLOAD_STATE = constant('Shopware\\Core\\Content\\Product\\ProductDefinition::TYPE_DIGITAL') %}
+        {% set hasDownladItem = page.order.lineItems.hasLineItemWithType(DOWNLOAD_STATE) %}
+    {% else %}
+        {% set DOWNLOAD_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_DOWNLOAD') %}
+        {% set hasDownladItem = page.order.lineItems.hasLineItemWithState(DOWNLOAD_STATE) %}
+    {% endif %}
+
+    {% if hasDownladItem %}
         <br>{{ 'checkout.confirmRevocationReminder'|trans() }}
     {% endif %}
 {% endblock %}
@@ -58,8 +65,15 @@
 {% endblock %}
 
 {% block page_checkout_confirm_shipping %}
-    {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
-    {% if page.order.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+    {% if feature('v6.8.0.0') %}
+        {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\ProductDefinition::TYPE_PHYSICAL') %}
+        {% set hasPhysicalItem = page.order.lineItems.hasLineItemWithType(PHYSICAL_STATE) %}
+    {% else %}
+        {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
+        {% set hasPhysicalItem = page.order.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+    {% endif %}
+
+    {% if hasPhysicalItem %}
         <div class="col-sm-6 confirm-shipping">
             {% sw_include '@Storefront/storefront/page/account/order/confirm-shipping.html.twig' %}
         </div>

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -141,8 +141,15 @@
                               action="{{ path('frontend.checkout.configure') }}"
                               data-form-auto-submit="true">
                             {% block page_checkout_cart_shipping_costs_trigger %}
-                                {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
-                                {% if page.cart.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+                                {% if feature('v6.8.0.0') %}
+                                    {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\ProductDefinition::TYPE_PHYSICAL') %}
+                                    {% set hasPhysicalItem = page.cart.lineItems.hasLineItemWithProductType(PHYSICAL_STATE) %}
+                                {% else %}
+                                    {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
+                                    {% set hasPhysicalItem = page.cart.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+                                {% endif %}
+
+                                {% if hasPhysicalItem %}
                                     <a class="btn btn-link cart-shipping-costs-btn"
                                        data-bs-toggle="collapse"
                                        href="#collapseShippingCost"

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -128,8 +128,15 @@
                     {% endblock %}
 
                     {% block page_checkout_confirm_shipping %}
-                        {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
-                        {% if page.cart.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+                        {% if feature('v6.8.0.0') %}
+                            {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\ProductDefinition::TYPE_PHYSICAL') %}
+                            {% set hasPhysicalItem = page.cart.lineItems.hasLineItemWithProductType(PHYSICAL_STATE) %}
+                        {% else %}
+                            {% set PHYSICAL_STATE = constant('Shopware\\Core\\Content\\Product\\State::IS_PHYSICAL') %}
+                            {% set hasPhysicalItem = page.cart.lineItems.hasLineItemWithState(PHYSICAL_STATE) %}
+                        {% endif %}
+
+                        {% if hasPhysicalItem %}
                             <div class="col-sm-6 confirm-shipping">
                                 {% sw_include '@Storefront/storefront/page/checkout/confirm/confirm-shipping.html.twig' %}
                             </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
Using the old method with enabled `6.8.0.0` flag will lead into an error

### 2. What does this change do, exactly?
Use new method

### 3. Describe each step to reproduce the issue or behaviour.
Enable `6.8.0.0` and go to checkout confirm page

### 4. Please link to the relevant issues (if any).
- related shopware/shopware/pull/13554

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
