### PR TITLE
fix: Do not hide important info from mobile users

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/register/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/register/index.html.twig
@@ -16,7 +16,7 @@
                             } %}
 
                             {% block page_account_register_advantages %}
-                                <div class="login-advantages d-none d-lg-block">
+                                <div class="login-advantages">
                                     {% block page_account_register_advantages_title %}
                                         <div class="h5 login-advantages-header">
                                             {{ 'account.registerAdvantagesHeader'|trans|sw_sanitize }}


### PR DESCRIPTION
### 1. Why is this change necessary?

Mobile users should be encouraged to register, too.


### 2. What does this change do, exactly?

Unhide the page_account_register_advantages block on mobile.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use mobile device
2. Open the register page
3. Register advantages are not visible

But they should be visible for mobile users, too.

### 4. Please link to the relevant issues (if any).

none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
