### PR TITLE
fix: Prevent variant score query when ES is active

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -357,7 +357,7 @@ export default {
             }
 
             try {
-                if (this.term) {
+                if (this.term && !this.adminEsEnable) {
                     const variants = await this.productRepository.search(variantCriteria);
                     if (variants.length > 0) {
                         const parentIds = [];


### PR DESCRIPTION
### 1. Why is this change necessary?
We have a "feature" to search in the product listing also if variants match and show the main product, this produces a score query, that can not be resolved by OpenSearch, thus we would bypass OpenSearch if that variants are found

### 2. What does this change do, exactly?
Currently this bypassess the whole feature that we also search for variants when ES is enabled

### Alternative 1

We could still do the variant search and then fetch the matched parent products, however sorting etc are harder when we can't do that in a single query and we would need to merge the results 

### Alternative 2

We could solve that by indexing also variant data into the main products search index, however that means that the index size will increase and most importantly the indexing time increases as we the indexing query will be way more complex as we need to join the product table 🤔 