### PR TITLE
test: additional a11y check toBeEnabled on locators

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "1.21.1",
-        "@shopware-ag/acceptance-test-suite": "12.5.0",
+        "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@587",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -1145,8 +1145,8 @@
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
       "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.5.0.tgz",
-      "integrity": "sha512-z+CBsv1k960Z6zVfH7SRViAO1nBJF53FO9Z3VLiH1sawBHP4mjF8dYI0PV/2nM850kNi+RNdvQDvQkfwFepXJg==",
+      "resolved": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@587",
+      "integrity": "sha512-ZeIDJFNsJBwN53SrxtfMJwGPiWW+5pKW6FcTbdffnx/t4mMnu6bXWJm7M3TKd1TAhl7f5hnOhEwxyQ8JsdcjFg==",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "1.21.1",
-    "@shopware-ag/acceptance-test-suite": "12.5.0",
+    "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@587",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"


### PR DESCRIPTION
### 1. Why is this change necessary?
It bump the acceptance test suite version to a newer one to test the new a11y check behaviour.

### 2. What does this change do, exactly?
Currently, we have the issue that in mostly cloud CI runs and mostly in dialogues the expect(locator).toBeFocused(); accessibility check fails because the element/locator is inactive.

Playwright do nativly some actionability checks before performing actions like click, scrollIntoView, but sometimes also not. ([ref](https://playwright.dev/docs/actionability))

In our code base with the accessibility check, we imitate the click event with keyboard actions. In conclusion, we have to take care if a locator/element has the state we actually need for testing (in theorie see reference above)

With that change, we make sure our element is:

Stable -> [locator.scrollIntoViewIfNeeded()](https://playwright.dev/docs/api/class-locator#locator-scroll-into-view-if-needed)
Enabled -> [expect(locator).toBeEnabled()](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-enabled)
With that minimal change, we wanna observe if more checks (visi
ble, receivesEvents) are in the future needed and if the issue is solved properly.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/acceptance-test-suite/pull/587

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
