### PR TITLE
test: nightly fail over test fixture route loading

### DIFF
--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -14,6 +14,7 @@ $matrix = [
     'fail-fast' => false,
     'matrix' => [
         'test' => [
+            ['path' => 'Core/Framework'], //debug testsuite
             ['path' => 'Core/Checkout'],
             ['path' => 'Core/Content'],
             ['testsuite' => 'core-framework-batch1'],

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -1,6 +1,6 @@
 <?php
 
-$php = ['8.2'];
+$php = ['8.5'];
 $db = ['mysql:8.0'];
 
 $nightly = $_SERVER['argv'][1] ?? false;

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -186,8 +186,12 @@ jobs:
         if: ${{ matrix.test.testsuite != '' }}
         run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "${{ matrix.test.testsuite }}"
 
-      - name: Run PHPUnit path
-        if: ${{ matrix.test.path != '' }}
+      - name: Run PHPUnit path (Core/Framework with determined seed)
+        if: ${{ matrix.test.path == 'Core/Framework' }}
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --random-order-seed 1771552864 -- tests/integration/${{ matrix.test.path }}
+
+      - name: Run PHPUnit path (other paths)
+        if: ${{ matrix.test.path != '' && matrix.test.path != 'Core/Framework' }}
         run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml -- tests/integration/${{ matrix.test.path }}
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
### 1. Why is this change necessary?

One job of the Nightly is failing hard on 6.6.x 

https://github.com/shopware/shopware/actions/runs/22208204308/job/64236698423

This is an old problem due to the way we are using some helpers like Kernel building and specific configuration loading through Symfony & PHPunit. This is happening randomly since it is only a problem when some routes have not been loaded by some tests, it does not occur when tests are more split through different suites (in trunk, in 6.6.x they are gathered).


### 2. What does this change do, exactly?

1. Reproduce the same failing job (first commit, to be wiped) => this extra job will not be kept in our pipelines after that PR

2. Remove usage of lazy loading of:
- platform/config/routes/test/core_framework.xml
-  platform/config/services_test.xml

### 3. Describe each step to reproduce the issue or behaviour.

Locally
```
php -d memory_limit=-1 vendor/bin/phpunit --random-order-seed 1771552864 -- tests/integration/Core/Framework 
```

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
