### PR TITLE
test: update lighthouse category report to make it cache compatible

### DIFF
--- a/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
+++ b/tests/acceptance/tests/Pagespeed/Lighthouse.spec.ts
@@ -21,6 +21,9 @@ test('Category Lighthouse Report', async ({
     ValidateLighthouseScore,
     StorefrontCategory,
 }) => {
+
+    test.setTimeout(150_000);
+
     const productCount = 10;
 
     const category = await TestDataService.createCategory();
@@ -31,6 +34,15 @@ test('Category Lighthouse Report', async ({
     }
 
     await ShopCustomer.goesTo(StorefrontCategory.url(category.name));
+
+    await ShopCustomer.expects(async () => {
+        await TestDataService.clearCaches();
+        await ShopCustomer.goesTo(`${StorefrontCategory.url(category.name)}?a=${Date.now()}`);
+        await ShopCustomer.expects(StorefrontCategory.page.locator('.cms-listing-row').locator('.product-name')).toHaveCount(productCount);
+    }).toPass({
+        intervals: [1_000, 2_500], // retry after 1 seconds, then every 2.5 seconds
+    });
+
     await ShopCustomer.attemptsTo(ValidateLighthouseScore(StorefrontCategory.page, 'Storefront-Category'))
 });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In Cloud the caching in enabled therefore we have to check if all products are fist visible on category page and after we have to make the speed test.

### 2. What does this change do, exactly?
It deletes the caches until timeout and check each defined seconds if all products are available on category page.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
