### PR TITLE
fix: ATTRIBUTE_NO_STORE is not processed when CACHE_REWORK feature is disabled

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Adapter\Cache\Http;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Framework\Adapter\Cache\CacheStateSubscriber;
+use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
@@ -85,7 +86,7 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
         if (!$this->httpCacheEnabled) {
             // no-store attribute still has to be processed even in early return case
-            if ($request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE)) {
+            if ($this->isNoStoreRoute($request)) {
                 $this->applyPolicy($request, $response, $area, false, null);
             }
 
@@ -200,6 +201,12 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
         // old behavior
         if (!Feature::isActive('CACHE_REWORK') && !Feature::isActive('v6.8.0.0')) {
+            if ($this->isNoStoreRoute($request)) {
+                $this->addNoStoreHeader($request, $response);
+
+                return;
+            }
+
             $sMaxAge = $cacheAttribute->sMaxAge ?? $this->defaultTtl;
             $response->setSharedMaxAge($sMaxAge);
 
@@ -239,7 +246,10 @@ class CacheResponseSubscriber implements EventSubscriberInterface
     private function noCache(Request $request, Response $response, string $area): void
     {
         if (!Feature::isActive('CACHE_REWORK') && !Feature::isActive('v6.8.0.0')) {
-            // do nothing for backwards compatibility
+            if ($this->isNoStoreRoute($request)) {
+                $this->addNoStoreHeader($request, $response);
+            }
+
             return;
         }
         $this->applyPolicy($request, $response, $area, false, null);
@@ -346,7 +356,7 @@ class CacheResponseSubscriber implements EventSubscriberInterface
      */
     private function setCurrencyCookie(Request $request, Response $response): void
     {
-        $currencyId = $request->get(SalesChannelContextService::CURRENCY_ID);
+        $currencyId = RequestParamHelper::get($request, SalesChannelContextService::CURRENCY_ID);
 
         if (!$currencyId) {
             return;
@@ -365,5 +375,23 @@ class CacheResponseSubscriber implements EventSubscriberInterface
             (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
             true
         );
+    }
+
+    private function isNoStoreRoute(Request $request): bool
+    {
+        return $request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE);
+    }
+
+    private function addNoStoreHeader(Request $request, Response $response): void
+    {
+        if (!$this->isNoStoreRoute($request)) {
+            return;
+        }
+
+        $response->setMaxAge(0);
+        $response->headers->addCacheControlDirective('no-cache');
+        $response->headers->addCacheControlDirective('no-store');
+        $response->headers->addCacheControlDirective('must-revalidate');
+        $response->setExpires(new \DateTime('@0'));
     }
 }

--- a/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 
@@ -50,9 +49,7 @@ class CacheResponseSubscriberTest extends TestCase
         $response = $browser->getResponse();
 
         // see noCache() in CacheResponseSubscriber, no-store is only enforced when CACHE_REWORK and v6.8.0.0 are active
-        if (Feature::isActive('CACHE_REWORK') || Feature::isActive('v6.8.0.0')) {
-            static::assertTrue($response->headers->hasCacheControlDirective('no-store'), 'Failed asserting route: ' . $routeName . ' with status code: ' . $response->getStatusCode());
-        }
+        static::assertTrue($response->headers->hasCacheControlDirective('no-store'), 'Failed asserting route: ' . $routeName . ' with status code: ' . $response->getStatusCode());
         static::assertTrue($response->headers->hasCacheControlDirective('private'), 'Failed asserting route: ' . $routeName . ' with status code: ' . $response->getStatusCode());
         static::assertFalse($response->isCacheable());
     }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -406,6 +406,41 @@ class CacheResponseSubscriberTest extends TestCase
     }
 
     /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
+    #[DataProvider('noStoreWithoutCacheReworkProvider')]
+    #[DisabledFeatures(['CACHE_REWORK', 'v6.8.0.0'])]
+    public function testNoStoreAppliedWithoutCacheRework(string $method, bool $withHttpCache): void
+    {
+        $request = new Request();
+        $request->setMethod($method);
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $this->createMock(SalesChannelContext::class));
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_NO_STORE, true);
+
+        if ($withHttpCache) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
+        }
+
+        $response = new Response();
+        $this->subscriber->setResponseCache($this->createResponseEvent($request, $response));
+
+        static::assertTrue($response->headers->hasCacheControlDirective('no-store'));
+        static::assertTrue($response->headers->hasCacheControlDirective('no-cache'));
+        static::assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        static::assertFalse($response->isCacheable());
+    }
+
+    /**
+     * @return iterable<string, array{method: string, withHttpCache: bool}>
+     */
+    public static function noStoreWithoutCacheReworkProvider(): iterable
+    {
+        yield 'GET route with cache attribute' => ['method' => Request::METHOD_GET, 'withHttpCache' => true];
+        yield 'GET route without cache attribute' => ['method' => Request::METHOD_GET, 'withHttpCache' => false];
+        yield 'POST route' => ['method' => Request::METHOD_POST, 'withHttpCache' => false];
+    }
+
+    /**
      * @param array<string, mixed> $requestResponseOptions
      * @param array{
      *     policies?: array<string, CachePolicyConfig>,


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/pull/14243 introduced a bug: ATTRIBUTE_NO_STORE is not processed when CACHE_REWORK feature is disabled. Some routes stopped having no_store directive for cache-control.

### 2. What does this change do, exactly?

Recovered old behavior.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/15061

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
