### PR TITLE
chore: update bootstrap version to 5.3.8

### DIFF
--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -14,7 +14,7 @@
         "@shopware-ag/dive": "2.2.29",
         "@swc/core": "1.10.14",
         "autoprefixer": "10.4.13",
-        "bootstrap": "5.3.3",
+        "bootstrap": "5.3.8",
         "copy-webpack-plugin": "12.0.2",
         "core-js": "3.40.0",
         "css-loader": "7.1.2",
@@ -5267,9 +5267,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -30,7 +30,7 @@
     "@shopware-ag/dive": "2.2.29",
     "@swc/core": "1.10.14",
     "autoprefixer": "10.4.13",
-    "bootstrap": "5.3.3",
+    "bootstrap": "5.3.8",
     "copy-webpack-plugin": "12.0.2",
     "core-js": "3.40.0",
     "css-loader": "7.1.2",


### PR DESCRIPTION
### 1. Why is this change necessary?
Bootstrap 5.3.3 is outdated. Version 5.3.8 includes bug fixes for spinners in flex containers, the color-contrast() function (WCAG 2.1 compliance), modal/offcanvas header spacing, popover/tooltip behavior, and Sass compatibility improvements for newer Dart Sass versions.

### 2. What does this change do, exactly?
Updates the Bootstrap dependency in the Storefront from 5.3.3 to 5.3.8. This is a patch-level update with no breaking changes. All existing JS unit tests (996/996), JS lint, and SCSS lint pass without modifications.

### 3. Describe each step to reproduce the issue or behaviour.
1. Update bootstrap version in src/Storefront/Resources/app/storefront/package.json from 5.3.3 to 5.3.8
2. Run npm install in the storefront directory
3. Run node copy-to-vendor.js to update the vendor copy
4. Run bin/console theme:compile to verify theme compilation
5. Run npm run unit to verify all JS tests pass
6. Run npm run lint:js and npm run lint:scss to verify linting

### 4. Please link to the relevant issues (if any).
relates https://github.com/twbs/bootstrap/releases/tag/v5.3.8

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them