### PR TITLE
fix: use correct expiry for symfony cache

### DIFF
--- a/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheStore.php
@@ -186,7 +186,7 @@ class CacheStore implements StoreInterface
             $item->tag($tags);
         }
 
-        $item->expiresAt($cacheResponse->getExpires());
+        $item->expiresAfter($cacheResponse->getMaxAge());
 
         $this->eventDispatcher->dispatch(
             new HttpCacheStoreEvent($item, $tags, $request, $response)

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
@@ -16,8 +16,6 @@ use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\CacheItem;
-use Symfony\Component\Clock\Clock;
-use Symfony\Component\Clock\MockClock;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
@@ -256,6 +256,7 @@ class CacheStoreTest extends TestCase
         $request = new Request();
         $response = new Response();
         $response->headers->set('date', date('Y-m-d H:i:s'));
+        $response->setSharedMaxAge(7200);
 
         $cache = new TagAwareAdapter(new ArrayAdapter());
 

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStoreTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -258,7 +260,8 @@ class CacheStoreTest extends TestCase
         $response->headers->set('date', date('Y-m-d H:i:s'));
         $response->setSharedMaxAge(7200);
 
-        $cache = new TagAwareAdapter(new ArrayAdapter());
+        $arrayAdapter = new ArrayAdapter();
+        $cache = new TagAwareAdapter($arrayAdapter);
 
         $stateValidator = $this->createMock(CacheStateValidator::class);
         $stateValidator->expects($this->never())->method('isValid');
@@ -288,6 +291,11 @@ class CacheStoreTest extends TestCase
         // Verify the cache item was stored correctly
         $cacheItem = $cache->getItem($key);
         static::assertTrue($cacheItem->isHit());
+
+        $expiry = \Closure::bind(function (string $key): float {
+            return $this->expiries[$key];
+        }, $arrayAdapter, $arrayAdapter)($key);
+        static::assertEqualsWithDelta(microtime(true) + 7200, $expiry, 1);
 
         $cacheData = CacheCompressor::uncompress($cacheItem);
         static::assertInstanceOf(Response::class, $cacheData);


### PR DESCRIPTION
fixes: https://github.com/shopware/shopware/issues/15135

### 1. Why is this change necessary?
We don't set the response `expiry` anymore, so the expiry on the cache item was expected to be null in most cases (which means does not expire). This shouldn't have led to immediate problems because symfony **should** check s-maxAge header when the cache item was hit anyway and delete the cache entry when necessary, however this might lead to a lot of old responses in the cache that never expires automatically if it is not hit anymore

### 2. What does this change do, exactly?

Instead of expiry directly use symfonies built-in `$response->getMaxAge()`, which checks first for `s-maxAge` and then `maxAge` header, and only if those are not set it falls back to checking the `expiry`.

This is more inline with how reverse proxies handle expiries.

