### PR TITLE
test: fail fast in product filter test

### DIFF
--- a/tests/acceptance/tests/Product/ProductFilter.spec.ts
+++ b/tests/acceptance/tests/Product/ProductFilter.spec.ts
@@ -9,9 +9,7 @@ test('Customer should see unavailable filter disabled based on selected filter',
     StorefrontHome,
     SelectProductFilterOption,
     CheckVisibilityInHome,
-    InstanceMeta,
 }) => {
-    test.slow(InstanceMeta.isSaaS);
     await TestDataService.setSystemConfig({ 'core.listing.disableEmptyFilterOptions': true });
     const color = await TestDataService.createColorPropertyGroup(
         {
@@ -212,9 +210,7 @@ test('Customer should see unavailable filter options disabled when filtering by 
     TestDataService,
     StorefrontHome,
     CheckVisibilityInHome,
-    InstanceMeta,
 }) => {
-    test.slow(InstanceMeta.isSaaS);
     await TestDataService.setSystemConfig({ 'core.listing.disableEmptyFilterOptions': true });
     const color = await TestDataService.createColorPropertyGroup();
     const propertyGroupsColor: PropertyGroup[] = [color];


### PR DESCRIPTION
### 1. Why is this change necessary?
The product filter test in SaaS needs in the worst case 7min because we marked the test as "slow" which triples the timeout time. Because we are using polling to assert the locators it could happen it tooks 3min run time per test try.

### 2. What does this change do, exactly?
remove the slow tag so that the test fail in 1 minute


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
