### PR TITLE
fix: prevent image upscaling in standard display mode (#14468)

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
@@ -53,9 +53,16 @@
                                         {% set attributes = attributes|merge({ 'loading': 'lazy' }) %}
                                     {% endif %}
 
-                                    {% sw_thumbnails 'cms-image-thumbnails' with {
-                                        media: element.data.media
-                                    } %}
+                                    {% if displayMode == 'standard' and element.data.media.metaData.width is defined %}
+                                        {% sw_thumbnails 'cms-image-thumbnails' with {
+                                            media: element.data.media,
+                                            sizes: { default: element.data.media.metaData.width ~ 'px' }
+                                        } %}
+                                    {% else %}
+                                        {% sw_thumbnails 'cms-image-thumbnails' with {
+                                            media: element.data.media
+                                        } %}
+                                    {% endif %}
                                 {% endblock %}
                             </div>
                         {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?

The CMS image element in "standard" (original) display mode upscales images to fill the block width, even when the image is smaller than the block. A 50x50 image gets stretched to ~1145px wide, resulting in a blurry, pixelated display.

The root cause is the `sizes` attribute on the `<img>` tag. It is calculated from container/layout breakpoints (e.g. `1360px`) instead of the actual image dimensions. When the browser sees `sizes="1360px"` with `srcset="...50w"`, it computes the image's CSS intrinsic width as 1360px (per HTML spec for `w` descriptors), causing `max-width: 100%` to stretch the image to the full container width.

### 2. What does this change do, exactly?

For the `standard` display mode, when `metaData.width` is available on the media entity, the `sw_thumbnails` call now passes `sizes: { default: '<originalWidth>px' }` instead of relying on the auto-calculated container-based sizes.

This tells the browser the image will be at most its natural width, so it computes the correct intrinsic dimensions and does not upscale. The existing CSS `max-width: 100%` still ensures the image scales down responsively on smaller viewports.

Other display modes (`cover`, `stretch`, `contain`) are not affected. If `metaData` is not available, the existing behavior is preserved as a fallback.

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload a small image (e.g. 50x50 pixels) in the admin media manager
2. Create a CMS page with an image element
3. Assign the small image and set the display mode to "Standard" (Original)
4. View the page in the storefront
5. **Before fix:** The 50x50 image is stretched to fill the full block width (~1145px), appearing blurry
6. **After fix:** The image displays at its natural 50x50 size

### 4. Please link to the relevant issues (if any).

- closes #14468

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
