### PR TITLE
fix: Check plugin requirements during activation

### DIFF
--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -61,6 +61,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 class PluginLifecycleService
 {
     final public const STATE_SKIP_ASSET_BUILDING = 'skip-asset-building';
+    final public const PLUGIN_LIFECYCLE_METHOD_ACTIVATE = 'activate';
 
     /**
      * @var array{plugin: PluginEntity, context: Context}|null
@@ -358,7 +359,7 @@ class PluginLifecycleService
             return $activateContext;
         }
 
-        $this->requirementValidator->validateRequirements($plugin, $shopwareContext, 'activate');
+        $this->requirementValidator->validateRequirements($plugin, $shopwareContext, self::PLUGIN_LIFECYCLE_METHOD_ACTIVATE);
 
         $this->eventDispatcher->dispatch(new PluginPreActivateEvent($plugin, $activateContext));
 

--- a/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
+++ b/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Composer\Factory;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\Requirement\Exception\ComposerNameMissingException;
 use Shopware\Core\Framework\Plugin\Requirement\Exception\ConflictingPackageException;
 use Shopware\Core\Framework\Plugin\Requirement\Exception\MissingRequirementException;
@@ -48,7 +49,7 @@ class RequirementsValidator
      */
     public function validateRequirements(PluginEntity $plugin, Context $context, string $method): void
     {
-        if ($plugin->getManagedByComposer()) {
+        if ($plugin->getManagedByComposer() && $method !== PluginLifecycleService::PLUGIN_LIFECYCLE_METHOD_ACTIVATE) {
             // Composer does the requirements checking if the plugin is managed by composer
             // no need to do it manually
 
@@ -108,7 +109,7 @@ class RequirementsValidator
     }
 
     /**
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function getPluginDependencies(PluginEntity $plugin): array
     {
@@ -122,9 +123,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param array{'require': Link[], 'conflict': Link[]} $pluginDependencies
+     * @param array{require: array<string, Link>, conflict: array<string, Link>} $pluginDependencies
      *
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function validateComposerPackages(
         array $pluginDependencies,
@@ -143,9 +144,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param array{'require': Link[], 'conflict': Link[]} $pluginDependencies
+     * @param array{require: array<string, Link>, conflict: array<string, Link>} $pluginDependencies
      *
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function checkComposerDependencies(
         array $pluginDependencies,
@@ -191,9 +192,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param array{'require': Link[], 'conflict': Link[]} $pluginDependencies
+     * @param array{require: array<string, Link>, conflict: array<string, Link>} $pluginDependencies
      *
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function validateInstalledPlugins(
         Context $context,
@@ -256,7 +257,7 @@ class RequirementsValidator
     }
 
     /**
-     * @return PackageInterface[]
+     * @return array<string, PackageInterface>
      */
     private function getComposerPackagesFromPlugins(): array
     {
@@ -272,9 +273,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param array{'require': Link[], 'conflict': Link[]} $pluginDependencies
+     * @param array{require: array<string, Link>, conflict: array<string, Link>} $pluginDependencies
      *
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function validateReplaces(
         PackageInterface $package,
@@ -308,9 +309,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param Link[] $pluginRequirements
+     * @param array<string, Link> $pluginRequirements
      *
-     * @return Link[]
+     * @return array<string, Link>
      */
     private function checkRequirement(
         array $pluginRequirements,
@@ -336,9 +337,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param Link[] $pluginConflicts
+     * @param array<string, Link> $pluginConflicts
      *
-     * @return Link[]
+     * @return array<string, Link>
      */
     private function checkConflict(
         array $pluginConflicts,
@@ -365,7 +366,7 @@ class RequirementsValidator
     }
 
     /**
-     * @param Link[] $pluginRequirements
+     * @param array<string, Link> $pluginRequirements
      */
     private function addRemainingRequirementsAsException(
         array $pluginRequirements,
@@ -379,9 +380,9 @@ class RequirementsValidator
     }
 
     /**
-     * @param array{'require': Link[], 'conflict': Link[]} $pluginDependencies
+     * @param array{require: array<string, Link>, conflict: array<string, Link>} $pluginDependencies
      *
-     * @return array{'require': Link[], 'conflict': Link[]}
+     * @return array{require: array<string, Link>, conflict: array<string, Link>}
      */
     private function validateShippedDependencies(
         PluginEntity $plugin,

--- a/tests/unit/Core/Framework/Plugin/Requirement/RequirementsValidatorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Requirement/RequirementsValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\Requirement\Exception\RequirementStackException;
 use Shopware\Core\Framework\Plugin\Requirement\RequirementsValidator;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -137,6 +138,30 @@ class RequirementsValidatorTest extends TestCase
         }
 
         static::assertNull($exception);
+    }
+
+    public function testValidatesWithPluginIsManagedByComposerWhileActivating(): void
+    {
+        $path = str_replace($this->projectDir, '', $this->fixturePath . 'SwagRequirementInvalidTest');
+
+        $plugin = $this->createPlugin($path);
+        $plugin->setManagedByComposer(true);
+
+        $exception = null;
+
+        try {
+            $this->createValidator()->validateRequirements($plugin, Context::createDefaultContext(), PluginLifecycleService::PLUGIN_LIFECYCLE_METHOD_ACTIVATE);
+        } catch (RequirementStackException $exception) {
+        }
+
+        $packages = [];
+        static::assertInstanceOf(RequirementStackException::class, $exception);
+        foreach ($exception->getRequirements() as $requirement) {
+            $packages[] = $requirement->getParameters()['requirement'];
+        }
+
+        static::assertContains('shopware/platform', $packages);
+        static::assertContains('test/not-installed', $packages);
     }
 
     public function testResolveActiveDependants(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

If a plugin is managed by composer, and it is deactivated during a Shopware update, it could be possible, that the plugin is no longer compatible with SW after this update. 
If now the plugin is tried to be activated again, it could lead to errors as incompatible code is used. See linked issue. 
This happens, because the requirements are not checked for composer managed plugins. But composer is not executed during activation, so requirements are not checked again. 

### 2. What does this change do, exactly?

Introduce an exception for the case, when the requirement validator is called during activation of the plugin, so SW will re-check the requirements manually in this case.

### 3. Describe each step to reproduce the issue or behaviour.

see linked issue

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/12229

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
