### PR TITLE
fix: load language on languageId change

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.js
@@ -26,5 +26,5 @@ export default function LanguageAutoFetchingService() {
         Shopware.Store.get('context').api.language = newLanguage;
     }
 
-    watch(Shopware.Store.get('context').api.languageId, loadLanguage);
+    watch(() => Shopware.Store.get('context').api.languageId, loadLanguage);
 }

--- a/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.spec.js
@@ -60,10 +60,7 @@ describe('src/app/service/language-auto-fetching.service.js', () => {
         Shopware.Store.get('context').api.languageId = 'new-language-id';
         await flushPromises();
 
-        expect(repositoryGetMock).toHaveBeenCalledWith(
-            'new-language-id',
-            expect.objectContaining({ inheritance: true }),
-        );
+        expect(repositoryGetMock).toHaveBeenCalledWith('new-language-id', expect.objectContaining({ inheritance: true }));
 
         expect(Shopware.Store.get('context').api.language).toEqual(
             expect.objectContaining({

--- a/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/language-auto-fetching.service.spec.js
@@ -1,0 +1,75 @@
+/**
+ * @sw-package framework
+ */
+
+import { flushPromises } from '@vue/test-utils';
+import LanguageAutoFetchingService from 'src/app/service/language-auto-fetching.service';
+
+describe('src/app/service/language-auto-fetching.service.js', () => {
+    let repositoryGetMock;
+
+    beforeEach(() => {
+        // Reset the isInitialized flag by re-importing the module
+        jest.resetModules();
+
+        repositoryGetMock = jest.fn((id) =>
+            Promise.resolve({
+                id,
+                name: `Language ${id}`,
+                parentId: null,
+            }),
+        );
+
+        jest.spyOn(Shopware.Service('repositoryFactory'), 'create').mockImplementation(() => ({
+            get: repositoryGetMock,
+        }));
+
+        Shopware.Store.get('context').api.languageId = 'initial-language-id';
+        Shopware.Store.get('context').api.language = null;
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should load the language on initialization', async () => {
+        LanguageAutoFetchingService();
+        await flushPromises();
+
+        expect(repositoryGetMock).toHaveBeenCalledWith(
+            'initial-language-id',
+            expect.objectContaining({ inheritance: true }),
+        );
+
+        expect(Shopware.Store.get('context').api.language).toEqual(
+            expect.objectContaining({
+                id: 'initial-language-id',
+                name: 'Language initial-language-id',
+            }),
+        );
+    });
+
+    it('should reload the language when languageId changes', async () => {
+        LanguageAutoFetchingService();
+        await flushPromises();
+
+        // Reset mock to track new calls
+        repositoryGetMock.mockClear();
+
+        // Change the languageId
+        Shopware.Store.get('context').api.languageId = 'new-language-id';
+        await flushPromises();
+
+        expect(repositoryGetMock).toHaveBeenCalledWith(
+            'new-language-id',
+            expect.objectContaining({ inheritance: true }),
+        );
+
+        expect(Shopware.Store.get('context').api.language).toEqual(
+            expect.objectContaining({
+                id: 'new-language-id',
+                name: 'Language new-language-id',
+            }),
+        );
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -117,7 +117,6 @@ const missingTests = [
     'src/app/plugin/sanitize.plugin.js',
     'src/app/route/index.js',
     'src/app/service/feature.service.ts',
-    'src/app/service/language-auto-fetching.service.js',
     'src/app/service/license-violations.service.js',
     'src/app/service/locale-to-language.service.js',
     'src/app/service/search-type.service.js',


### PR DESCRIPTION
### 1. Why is this change necessary?

In some admin views (e.g. Catalog > Categories), the active language entity is not reloaded after changing the language. As a result, sw-language-info can show stale text until a full page reload.

### 2. What does this change do, exactly?

The languageId is now passed to the watcher as a reactive getter in the language-auto-fetching-service.js, so loadLanguage is always called when the language is changed.


### 3. Describe each step to reproduce the issue or behaviour.

1. Add a second language that is not the default language
2. Go to Catalog -> Categories
3. Change the language to a not default language
4. Reload the page
5. Switch to another non-default language
6. The wrong language is displayed in the text below (sw-language-info)


### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/15084
