### PR TITLE
fix: analytics test when admin loads longer then 3s

### DIFF
--- a/tests/acceptance/tests/ProductAnalytics/ValidatePRAEvents.spec.ts
+++ b/tests/acceptance/tests/ProductAnalytics/ValidatePRAEvents.spec.ts
@@ -256,6 +256,10 @@ test('As a merchant, I want to make sure no admin events are sent when I do not 
 
     await test.step('Validate no captured requests for product analytics', async () => {
 
+        // we want to check that something does NOT happen, so we need a hard waitForTimeout, as there is nothing we can actually wait for.
+        // so we wait for 3s to ensure that product analytics events would have been captured
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await AdminDashboard.page.waitForTimeout(3000);
         expect(captured.length).toBe(0);
     });
 });

--- a/tests/acceptance/tests/ProductAnalytics/ValidatePRAEvents.spec.ts
+++ b/tests/acceptance/tests/ProductAnalytics/ValidatePRAEvents.spec.ts
@@ -249,10 +249,8 @@ test('As a merchant, I want to make sure no admin events are sent when I do not 
 
     await test.step('Navigate via link to order page from dashboard', async () => {
 
-        const requestPromise = AdminDashboard.page.waitForRequest(`**/${PRODUCT_ANALYTICS_ENDPOINT}`, { timeout: 3000 });
         await AdminDashboard.adminMenuOrder.click();
         await AdminDashboard.adminMenuOrderOverview.click();
-        await ShopAdmin.expects(requestPromise).rejects.toThrow();
         await ShopAdmin.expects(AdminOrderListing.addOrderButton).toBeVisible();
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This test was flaky, especially on SaaS, see results here: https://github.com/shopware/saas/actions/runs/22359665859?pr=376
Issue was that the admin might initially load longer then 3s, so we can't navigate to the order overview before the timeout was reached, the promise then was rejected before we expected it and the whole test failed

### 2. What does this change do, exactly?
Remove the waiting for that single request, as in this case we don't expect one 
Expecting a timeout is always tricky and is inherently flaky, on the other hand we didn't need the special check as we already have a listener on all analytics requests and expect that that is never called 

