### PR TITLE
feat: Single file references in theme.json

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1566,8 +1566,3 @@ parameters:
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigFieldFactory.php
 
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Storefront/Theme/ThemeFileResolver.php

--- a/src/Storefront/Theme/Exception/ThemeCompileException.php
+++ b/src/Storefront/Theme/Exception/ThemeCompileException.php
@@ -33,4 +33,34 @@ class ThemeCompileException extends ShopwareHttpException
     {
         return Response::HTTP_BAD_REQUEST;
     }
+
+    public static function bundleRelativeFileNotFound(
+        string $themeName,
+        string $bundleName,
+        string $filePath
+    ): self {
+        return new self(
+            $themeName,
+            \sprintf(
+                'Unable to load file "@%s/%s". File does not exist.',
+                $bundleName,
+                $filePath
+            )
+        );
+    }
+
+    public static function couldNotCompileTheme(
+        string $themeName,
+        string $filePath,
+        string $reason
+    ): self {
+        return new self(
+            $themeName,
+            \sprintf(
+                'Unable to load file "Resources/%s". %s',
+                $filePath,
+                $reason
+            )
+        );
+    }
 }

--- a/src/Storefront/Theme/Exception/ThemeCompileException.php
+++ b/src/Storefront/Theme/Exception/ThemeCompileException.php
@@ -33,34 +33,4 @@ class ThemeCompileException extends ShopwareHttpException
     {
         return Response::HTTP_BAD_REQUEST;
     }
-
-    public static function bundleRelativeFileNotFound(
-        string $themeName,
-        string $bundleName,
-        string $filePath
-    ): self {
-        return new self(
-            $themeName,
-            \sprintf(
-                'Unable to load file "@%s/%s". File does not exist.',
-                $bundleName,
-                $filePath
-            )
-        );
-    }
-
-    public static function couldNotCompileTheme(
-        string $themeName,
-        string $filePath,
-        string $reason
-    ): self {
-        return new self(
-            $themeName,
-            \sprintf(
-                'Unable to load file "Resources/%s". %s',
-                $filePath,
-                $reason
-            )
-        );
-    }
 }

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -5,7 +5,6 @@ namespace Shopware\Storefront\Theme;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper;
-use Shopware\Storefront\Theme\Exception\ThemeCompileException;
 use Shopware\Storefront\Theme\Exception\ThemeException;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\File;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\FileCollection;
@@ -273,10 +272,13 @@ class ThemeFileResolver
                         $errorReference = $componentBundleNamespace !== null
                             ? '@Components:' . $componentBundleNamespace
                             : '@Components';
-                        throw ThemeCompileException::bundleRelativeFileNotFound(
+                        throw ThemeException::themeCompileException(
                             $themeConfig->getTechnicalName(),
-                            $errorReference,
-                            $bundleRelative['path']
+                            \sprintf(
+                                'Unable to load file "@%s/%s". File does not exist.',
+                                $errorReference,
+                                $bundleRelative['path']
+                            )
                         );
                     }
 
@@ -301,10 +303,13 @@ class ThemeFileResolver
                         $resolvedFiles->add($resolvedFile);
                     }
                 } else {
-                    throw ThemeCompileException::bundleRelativeFileNotFound(
+                    throw ThemeException::themeCompileException(
                         $themeConfig->getTechnicalName(),
-                        $bundleRelative['bundle'],
-                        $bundleRelative['path']
+                        \sprintf(
+                            'Unable to load file "@%s/%s". File does not exist.',
+                            $bundleRelative['bundle'],
+                            $bundleRelative['path']
+                        )
                     );
                 }
                 continue;
@@ -326,10 +331,13 @@ class ThemeFileResolver
                     continue;
                 }
 
-                throw ThemeCompileException::couldNotCompileTheme(
+                throw ThemeException::themeCompileException(
                     $themeConfig->getTechnicalName(),
-                    $filepath,
-                    'Did you forget to build the theme? Try running ./bin/build-storefront.sh'
+                    \sprintf(
+                        'Unable to load file "Resources/%s". %s',
+                        $filepath,
+                        'Did you forget to build the theme? Try running ./bin/build-storefront.sh'
+                    )
                 );
             }
 

--- a/src/Storefront/Theme/ThemeFileResolver.php
+++ b/src/Storefront/Theme/ThemeFileResolver.php
@@ -65,7 +65,10 @@ class ThemeFileResolver
             $themeConfig,
             $configurationCollection,
             $onlySourceFiles,
-            $this->collectConfigurationScriptFiles(...)
+            $this->collectConfigurationScriptFiles(...),
+            [],
+            [],
+            []
         );
     }
 
@@ -79,7 +82,10 @@ class ThemeFileResolver
             $themeConfig,
             $configurationCollection,
             $onlySourceFiles,
-            fn (StorefrontPluginConfiguration $configuration) => $configuration->getStyleFiles()
+            fn (StorefrontPluginConfiguration $configuration) => $configuration->getStyleFiles(),
+            [],
+            [],
+            []
         );
     }
 
@@ -93,7 +99,10 @@ class ThemeFileResolver
             $themeConfig,
             $configurationCollection,
             $onlySourceFiles,
-            fn (StorefrontPluginConfiguration $configuration) => $configuration->getBaseStyleFiles()
+            fn (StorefrontPluginConfiguration $configuration) => $configuration->getBaseStyleFiles(),
+            [],
+            [],
+            []
         );
     }
 
@@ -139,7 +148,9 @@ class ThemeFileResolver
      * @param StorefrontPluginConfigurationCollection $configurationCollection Collection of all available theme configurations
      * @param bool $onlySourceFiles Whether to only include source files (true) or also compiled files (false)
      * @param callable(StorefrontPluginConfiguration, bool): FileCollection $configFileResolver Function to get the initial file collection (either style or script files)
-     * @param array<int, string> $included List of already included files to prevent duplicates
+     * @param array<int, string> $included List of already included namespaces to prevent duplicates
+     * @param array<string, bool> $processedFiles List of already processed absolute file paths to prevent duplicates
+     * @param array<string, bool> $processedConfigs List of already processed configuration names to prevent circular references
      *
      * @return FileCollection Collection of resolved files
      */
@@ -149,8 +160,19 @@ class ThemeFileResolver
         StorefrontPluginConfigurationCollection $configurationCollection,
         bool $onlySourceFiles,
         callable $configFileResolver,
-        array $included = []
+        array $included = [],
+        array $processedFiles = [],
+        array $processedConfigs = []
     ): FileCollection {
+        // Prevent circular configuration references
+        $configName = $themeConfig->getTechnicalName();
+        if (isset($processedConfigs[$configName])) {
+            // Circular reference detected - return empty collection to break the loop
+            return new FileCollection();
+        }
+        $nextProcessedConfigs = $processedConfigs;
+        $nextProcessedConfigs[$configName] = true;
+
         // convertPathsToAbsolute changes the path, this should not affect the passed configuration
         $themeConfig = clone $themeConfig;
 
@@ -169,43 +191,157 @@ class ThemeFileResolver
         $resolvedFiles = new FileCollection();
         $nextIncluded = $included;
 
-        // First pass: collect all namespaced imports (@) to track what needs to be included
+        // Collect namespace includes for tracking
         foreach ($files as $file) {
             $filepath = $file->getFilepath();
-            if ($this->isInclude($filepath)) {
+            if ($this->isInclude($filepath) && !str_contains($filepath, '/')) {
+                // Only track simple @ namespace references (not bundle-relative paths)
                 $nextIncluded[] = $filepath;
             }
         }
 
-        // Second pass: process each file
+        // Process files in order from theme.json
         foreach ($files as $file) {
             $filepath = $file->getFilepath();
 
-            // Handle direct file paths (not starting with @)
-            if (!$this->isInclude($filepath)) {
-                if (\is_file($filepath)) {
-                    $resolvedFiles->add($file);
+            // 1. Handle bundle-relative single file references (@BundleName/path/to/file)
+            // Special case: Check for @Components:BundleName/path syntax first
+            $componentBundleNamespace = null;
+            $processedFilepath = $filepath;
+            if (str_starts_with($filepath, '@Components:')) {
+                // Extract bundle namespace from @Components:BundleName/path
+                $colonPos = strpos($filepath, ':');
+                if ($colonPos !== false) {
+                    $slashPos = strpos($filepath, '/', $colonPos);
+                    if ($slashPos !== false) {
+                        $componentBundleNamespace = substr($filepath, $colonPos + 1, $slashPos - $colonPos - 1);
+                        // Convert to @Components/path format for parseBundleRelativePath
+                        $processedFilepath = '@Components' . substr($filepath, $slashPos);
+                    }
+                }
+            }
+
+            $bundleRelative = $this->parseBundleRelativePath($processedFilepath);
+            if ($bundleRelative !== null) {
+                // Special handling for @Components/ComponentName/file.ext
+                if ($bundleRelative['bundle'] === 'Components') {
+                    if (!Feature::isActive('STOREFRONT_COMPONENTS')) {
+                        continue;
+                    }
+
+                    // Parse component path (e.g., "Sw/Alert/index.scss")
+                    $requestedPath = $bundleRelative['path'];
+
+                    // Find the matching component by checking if any component's style/script path ends with the requested path
+                    $componentFound = false;
+                    foreach ($this->twigComponentHelper->getComponents() as $component) {
+                        // If bundle namespace is specified, filter by it
+                        if ($componentBundleNamespace !== null && $component->getNamespace() !== $componentBundleNamespace) {
+                            continue;
+                        }
+
+                        $componentPath = null;
+
+                        // Get the appropriate path based on file type
+                        if ($fileType === self::SCRIPT_FILES) {
+                            $componentPath = $component->getScriptPath();
+                        } elseif ($fileType === self::STYLE_FILES) {
+                            $componentPath = $component->getStylePath();
+                        }
+
+                        // Check if this component's path matches the requested path
+                        if ($componentPath !== null && str_contains($componentPath, $requestedPath)) {
+                            // Verify the match is at the end of the path (to avoid partial matches)
+                            $normalizedComponentPath = str_replace('\\', '/', $componentPath);
+                            $normalizedRequestedPath = str_replace('\\', '/', $requestedPath);
+
+                            if (str_ends_with($normalizedComponentPath, $normalizedRequestedPath)) {
+                                if (!isset($processedFiles[$componentPath])) {
+                                    $processedFiles[$componentPath] = true;
+                                    $namespaceDir = $component->getRelativeNamespaceDirectory();
+                                    $assetName = $namespaceDir !== '' ? $namespaceDir : null;
+                                    $resolvedFiles->add(new File($componentPath, [], $assetName));
+                                    $componentFound = true;
+
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    if (!$componentFound) {
+                        $errorReference = $componentBundleNamespace !== null
+                            ? '@Components:' . $componentBundleNamespace
+                            : '@Components';
+                        throw ThemeCompileException::bundleRelativeFileNotFound(
+                            $themeConfig->getTechnicalName(),
+                            $errorReference,
+                            $bundleRelative['path']
+                        );
+                    }
 
                     continue;
                 }
+
+                // Handle regular bundle-relative paths
+                $bundleConfig = $configurationCollection->getByTechnicalName($bundleRelative['bundle']);
+                if (!$bundleConfig) {
+                    throw ThemeException::couldNotFindThemeByName($bundleRelative['bundle']);
+                }
+
+                // Resolve the specific file from the bundle
+                $fs = $this->themeFilesystemResolver->getFilesystemForStorefrontConfig($bundleConfig);
+                if ($fs->has('Resources', $bundleRelative['path'])) {
+                    $absolutePath = $fs->realpath('Resources', $bundleRelative['path']);
+
+                    // Skip if already processed
+                    if (!isset($processedFiles[$absolutePath])) {
+                        $processedFiles[$absolutePath] = true;
+                        $resolvedFile = new File($absolutePath, [], $bundleConfig->getAssetName());
+                        $resolvedFiles->add($resolvedFile);
+                    }
+                } else {
+                    throw ThemeCompileException::bundleRelativeFileNotFound(
+                        $themeConfig->getTechnicalName(),
+                        $bundleRelative['bundle'],
+                        $bundleRelative['path']
+                    );
+                }
+                continue;
+            }
+
+            // 2. Handle direct file paths (not starting with @)
+            if (!$this->isInclude($filepath)) {
+                if (\is_file($filepath)) {
+                    // Skip if already processed
+                    if (!isset($processedFiles[$filepath])) {
+                        $processedFiles[$filepath] = true;
+                        $resolvedFiles->add($file);
+                    }
+                    continue;
+                }
+
                 // removes file with old js structure (before async changes) from collection
                 if (!str_ends_with($filepath, $file->assetName . '/' . basename($filepath))) {
                     continue;
                 }
 
-                throw new ThemeCompileException(
+                throw ThemeCompileException::couldNotCompileTheme(
                     $themeConfig->getTechnicalName(),
-                    \sprintf('Unable to load file "Resources/%s". Did you forget to build the theme? Try running ./bin/build-storefront.sh', $filepath)
+                    $filepath,
+                    'Did you forget to build the theme? Try running ./bin/build-storefront.sh'
                 );
             }
 
-            // Skip if this namespace was already included to prevent duplicates
+            // 3. Handle full bundle/namespace references (@BundleName, @Plugins, @Components, etc.)
+
+            // Skip if this namespace was already included (maintain existing behavior)
             if (\in_array($filepath, $included, true)) {
                 continue;
             }
             $included[] = $filepath;
 
-            // Handle @Plugins namespace - include all non-theme plugins
+            // Handle @Plugins
             if ($filepath === '@Plugins') {
                 foreach ($configurationCollection->getNoneThemes() as $plugin) {
                     foreach ($this->resolve(
@@ -214,15 +350,21 @@ class ThemeFileResolver
                         $configurationCollection,
                         $onlySourceFiles,
                         $configFileResolver,
-                        $nextIncluded
+                        $nextIncluded,
+                        $processedFiles,
+                        $nextProcessedConfigs
                     ) as $item) {
-                        $resolvedFiles->add($item);
+                        $itemPath = $item->getFilepath();
+                        if (!isset($processedFiles[$itemPath])) {
+                            $processedFiles[$itemPath] = true;
+                            $resolvedFiles->add($item);
+                        }
                     }
                 }
                 continue;
             }
 
-            // Handle @Components namespace - include all Twig UX components
+            // Handle @Components
             if ($filepath === '@Components') {
                 if (!Feature::isActive('STOREFRONT_COMPONENTS')) {
                     continue;
@@ -233,9 +375,9 @@ class ThemeFileResolver
                         ? $component->getScriptPath()
                         : $component->getStylePath();
 
-                    if ($componentPath !== null) {
+                    if ($componentPath !== null && !isset($processedFiles[$componentPath])) {
+                        $processedFiles[$componentPath] = true;
                         $namespaceDir = $component->getRelativeNamespaceDirectory();
-                        // Use null for assetName if the namespace directory is empty to avoid double slashes
                         $assetName = $namespaceDir !== '' ? $namespaceDir : null;
                         $resolvedFiles->add(new File($componentPath, [], $assetName));
                     }
@@ -244,24 +386,41 @@ class ThemeFileResolver
                 continue;
             }
 
-            // Handle @StorefrontBootstrap namespace - include base SCSS file
+            // Handle @StorefrontBootstrap
             if ($filepath === '@StorefrontBootstrap') {
-                $resolvedFiles->add(new File(
-                    __DIR__ . '/../Resources/app/storefront/src/scss/base.scss',
-                    ['vendor' => __DIR__ . '/../Resources/app/storefront/vendor']
-                ));
-
+                $bootstrapPath = __DIR__ . '/../Resources/app/storefront/src/scss/base.scss';
+                if (!isset($processedFiles[$bootstrapPath])) {
+                    $processedFiles[$bootstrapPath] = true;
+                    $resolvedFiles->add(new File(
+                        $bootstrapPath,
+                        ['vendor' => __DIR__ . '/../Resources/app/storefront/vendor']
+                    ));
+                }
                 continue;
             }
 
-            // Handle other @ namespaces - resolve to specific theme/plugin
+            // Handle other @ThemeName references
             $name = mb_substr($filepath, 1);
             $configuration = $configurationCollection->getByTechnicalName($name);
             if (!$configuration) {
                 throw ThemeException::couldNotFindThemeByName($name);
             }
-            foreach ($this->resolve($fileType, $configuration, $configurationCollection, $onlySourceFiles, $configFileResolver, $nextIncluded) as $item) {
-                $resolvedFiles->add($item);
+
+            foreach ($this->resolve(
+                $fileType,
+                $configuration,
+                $configurationCollection,
+                $onlySourceFiles,
+                $configFileResolver,
+                $nextIncluded,
+                $processedFiles,
+                $nextProcessedConfigs
+            ) as $item) {
+                $itemPath = $item->getFilepath();
+                if (!isset($processedFiles[$itemPath])) {
+                    $processedFiles[$itemPath] = true;
+                    $resolvedFiles->add($item);
+                }
             }
         }
 
@@ -271,6 +430,30 @@ class ThemeFileResolver
     private function isInclude(string $file): bool
     {
         return str_starts_with($file, '@');
+    }
+
+    /**
+     * Check if filepath is a bundle-relative single file reference
+     * Format: @BundleName/relative/path/to/file.ext
+     *
+     * @return array{bundle: string, path: string}|null
+     */
+    private function parseBundleRelativePath(string $filepath): ?array
+    {
+        if (!str_starts_with($filepath, '@')) {
+            return null;
+        }
+
+        // Check if it contains a slash (indicates file path, not just bundle name)
+        $slashPos = strpos($filepath, '/');
+        if ($slashPos === false) {
+            return null;
+        }
+
+        return [
+            'bundle' => substr($filepath, 1, $slashPos - 1),
+            'path' => substr($filepath, $slashPos + 1),
+        ];
     }
 
     private function convertPathsToAbsolute(StorefrontPluginConfiguration $themeConfig, FileCollection $files): void

--- a/tests/unit/Storefront/Framework/Twig/Components/TwigComponentCollectionTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Components/TwigComponentCollectionTest.php
@@ -102,7 +102,7 @@ class TwigComponentCollectionTest extends TestCase
 
     public function testValidateTypeThrowsExceptionForInvalidType(): void
     {
-        $invalidElement = new class() extends Struct {
+        $invalidElement = new class extends Struct {
         };
 
         $this->expectExceptionObject(

--- a/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
+++ b/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
@@ -7,7 +7,10 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Kernel;
 use Shopware\Core\Test\Stub\App\StaticSourceResolver;
+use Shopware\Storefront\Framework\Twig\Components\TwigComponent;
+use Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection;
 use Shopware\Storefront\Framework\Twig\Components\TwigComponentHelper;
+use Shopware\Storefront\Theme\Exception\ThemeException;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\FileCollection;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationFactory;
@@ -493,7 +496,7 @@ class ThemeFileResolverTest extends TestCase
                 ++$overridesCount;
             }
         }
-        static::assertEquals(1, $overridesCount, 'overrides.scss should appear only once (no duplication)');
+        static::assertSame(1, $overridesCount, 'overrides.scss should appear only once (no duplication)');
 
         // Check that overrides.scss appears before base.scss (order preservation)
         $basePosition = -1;
@@ -552,8 +555,9 @@ class ThemeFileResolverTest extends TestCase
         $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
         $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
 
-        $this->expectException(\Shopware\Storefront\Theme\Exception\ThemeException::class);
-        $this->expectExceptionMessage('NonExistentBundle');
+        $this->expectExceptionObject(
+            ThemeException::couldNotFindThemeByName('NonExistentBundle')
+        );
 
         $resolver->resolveStyleFiles($config, $configCollection, false);
     }
@@ -589,7 +593,7 @@ class ThemeFileResolverTest extends TestCase
         );
 
         // Create a test component with anonymous class extending TwigComponent
-        $testComponent = new class('/path/to/components/Sw/Alert/index.html.twig', 'Sw:Alert', 'Storefront') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+        $testComponent = new class('/path/to/components/Sw/Alert/index.html.twig', 'Sw:Alert', 'Storefront') extends TwigComponent {
             public function getStylePath(): string
             {
                 return '/path/to/components/Sw/Alert/index.scss';
@@ -601,7 +605,7 @@ class ThemeFileResolverTest extends TestCase
             }
         };
 
-        $componentCollection = new \Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection([$testComponent]);
+        $componentCollection = new TwigComponentCollection([$testComponent]);
 
         $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
         $twigComponentHelper->expects($this->any())
@@ -649,7 +653,7 @@ class ThemeFileResolverTest extends TestCase
         );
 
         // Create two test components with the same path but different namespaces
-        $componentStorefront = new class('/path/to/components/Custom/Test/index.html.twig', 'Custom:Test', 'Storefront') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+        $componentStorefront = new class('/path/to/components/Custom/Test/index.html.twig', 'Custom:Test', 'Storefront') extends TwigComponent {
             public function getStylePath(): string
             {
                 return '/path/to/components/Custom/Test/index.scss';
@@ -661,7 +665,7 @@ class ThemeFileResolverTest extends TestCase
             }
         };
 
-        $componentPlugin = new class('/path/to/plugin/components/Custom/Test/index.html.twig', 'Custom:Test', 'MyPlugin') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+        $componentPlugin = new class('/path/to/plugin/components/Custom/Test/index.html.twig', 'Custom:Test', 'MyPlugin') extends TwigComponent {
             public function getStylePath(): string
             {
                 return '/path/to/plugin/components/Custom/Test/index.scss';
@@ -678,7 +682,7 @@ class ThemeFileResolverTest extends TestCase
             }
         };
 
-        $componentCollection = new \Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection([
+        $componentCollection = new TwigComponentCollection([
             $componentStorefront,
             $componentPlugin,
         ]);

--- a/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
+++ b/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
@@ -17,7 +17,10 @@ use Shopware\Tests\Unit\Storefront\Theme\fixtures\MockStorefront\MockStorefront;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\SimplePlugin\SimplePlugin;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeNotIncludingPluginJsAndCss\ThemeNotIncludingPluginJsAndCss;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithBundleRelativeFiles\ThemeWithBundleRelativeFiles;
+use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithComponentReference\ThemeWithComponentReference;
+use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithInvalidBundleReference\ThemeWithInvalidBundleReference;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithMultiInheritance\ThemeWithMultiInheritance;
+use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithNamespacedComponentReference\ThemeWithNamespacedComponentReference;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithStorefrontBootstrapScss\ThemeWithStorefrontBootstrapScss;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithStorefrontSkinScss\ThemeWithStorefrontSkinScss;
 use Symfony\Component\Filesystem\Filesystem;
@@ -320,58 +323,6 @@ class ThemeFileResolverTest extends TestCase
         static::assertSame($currentPath, $config->getStyleFiles()->first()?->getFilepath());
     }
 
-    public function testParseBundleRelativePathWithValidPath(): void
-    {
-        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
-        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
-
-        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
-
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('parseBundleRelativePath');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($resolver, '@BundleName/app/storefront/src/scss/custom.scss');
-
-        static::assertIsArray($result);
-        static::assertArrayHasKey('bundle', $result);
-        static::assertArrayHasKey('path', $result);
-        static::assertEquals('BundleName', $result['bundle']);
-        static::assertEquals('app/storefront/src/scss/custom.scss', $result['path']);
-    }
-
-    public function testParseBundleRelativePathWithBundleOnly(): void
-    {
-        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
-        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
-
-        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
-
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('parseBundleRelativePath');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($resolver, '@BundleName');
-
-        static::assertNull($result);
-    }
-
-    public function testParseBundleRelativePathWithNonAtPrefix(): void
-    {
-        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
-        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
-
-        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
-
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('parseBundleRelativePath');
-        $method->setAccessible(true);
-
-        $result = $method->invoke($resolver, 'app/storefront/src/scss/custom.scss');
-
-        static::assertNull($result);
-    }
-
     public function testCircularReferencePreventionReturnsEmptyCollection(): void
     {
         $themePluginBundle = new ThemeWithMultiInheritance(true, __DIR__ . '/fixtures/SimplePlugin');
@@ -410,39 +361,10 @@ class ThemeFileResolverTest extends TestCase
         $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
         $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
 
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('resolve');
-        $method->setAccessible(true);
+        // This should not cause infinite loop - circular references are handled internally
+        $result = $resolver->resolveScriptFiles($config, $configCollection, false);
 
-        // First call - should work
-        /** @var FileCollection $result1 */
-        $result1 = $method->invoke(
-            $resolver,
-            ThemeFileResolver::SCRIPT_FILES,
-            $config,
-            $configCollection,
-            false,
-            fn (\Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration $cfg, bool $onlySourceFiles) => $cfg->getScriptFiles(),
-            [],
-            [],
-            []
-        );
-        static::assertGreaterThan(0, $result1->count());
-
-        // Second call with same config in processedConfigs - should return empty
-        /** @var FileCollection $result2 */
-        $result2 = $method->invoke(
-            $resolver,
-            ThemeFileResolver::SCRIPT_FILES,
-            $config,
-            $configCollection,
-            false,
-            fn (\Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration $cfg, bool $onlySourceFiles) => $cfg->getScriptFiles(),
-            [],
-            [],
-            ['ThemeWithMultiInheritance' => true]
-        );
-        static::assertEquals(0, $result2->count());
+        static::assertGreaterThan(0, $result->count());
     }
 
     public function testFileDeduplicationAcrossNamespaces(): void
@@ -599,7 +521,7 @@ class ThemeFileResolverTest extends TestCase
 
     public function testBundleRelativeFileThrowsExceptionForMissingBundle(): void
     {
-        $themePluginBundle = new ThemeWithStorefrontSkinScss();
+        $themePluginBundle = new ThemeWithInvalidBundleReference();
 
         $sourceResolver = new StaticSourceResolver([]);
         $factory = new StorefrontPluginConfigurationFactory(
@@ -615,11 +537,11 @@ class ThemeFileResolverTest extends TestCase
 
         $kernel = $this->createMock(Kernel::class);
         $kernel->expects($this->any())->method('getBundles')->willReturn([
-            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+            'ThemeWithInvalidBundleReference' => $themePluginBundle,
         ]);
 
         $kernel->expects($this->any())->method('getBundle')->willReturnMap([
-            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+            ['ThemeWithInvalidBundleReference', $themePluginBundle],
         ]);
 
         $themeFilesystemResolver = new ThemeFilesystemResolver(
@@ -630,34 +552,15 @@ class ThemeFileResolverTest extends TestCase
         $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
         $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
 
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('resolve');
-        $method->setAccessible(true);
-
-        // Create a file collection with a bundle-relative reference to a non-existent bundle
-        $fileCollection = new FileCollection();
-        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@NonExistentBundle/app/test.scss'));
-
         $this->expectException(\Shopware\Storefront\Theme\Exception\ThemeException::class);
         $this->expectExceptionMessage('NonExistentBundle');
 
-        $method->invoke(
-            $resolver,
-            ThemeFileResolver::STYLE_FILES,
-            $config,
-            $configCollection,
-            false,
-            fn ($cfg, $onlySourceFiles) => $fileCollection,
-            [],
-            [],
-            []
-        );
+        $resolver->resolveStyleFiles($config, $configCollection, false);
     }
 
     public function testComponentSingleFileReference(): void
     {
-        $themePluginBundle = new ThemeWithStorefrontSkinScss();
-        $storefrontBundle = new MockStorefront();
+        $themePluginBundle = new ThemeWithComponentReference();
 
         $sourceResolver = new StaticSourceResolver([]);
         $factory = new StorefrontPluginConfigurationFactory(
@@ -673,11 +576,11 @@ class ThemeFileResolverTest extends TestCase
 
         $kernel = $this->createMock(Kernel::class);
         $kernel->expects($this->any())->method('getBundles')->willReturn([
-            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+            'ThemeWithComponentReference' => $themePluginBundle,
         ]);
 
         $kernel->expects($this->any())->method('getBundle')->willReturnMap([
-            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+            ['ThemeWithComponentReference', $themePluginBundle],
         ]);
 
         $themeFilesystemResolver = new ThemeFilesystemResolver(
@@ -707,26 +610,7 @@ class ThemeFileResolverTest extends TestCase
 
         $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
 
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('resolve');
-        $method->setAccessible(true);
-
-        // Create a file collection with a component-relative reference
-        $fileCollection = new FileCollection();
-        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@Components/Sw/Alert/index.scss'));
-
-        /** @var FileCollection $result */
-        $result = $method->invoke(
-            $resolver,
-            ThemeFileResolver::STYLE_FILES,
-            $config,
-            $configCollection,
-            false,
-            fn ($cfg, $onlySourceFiles) => $fileCollection,
-            [],
-            [],
-            []
-        );
+        $result = $resolver->resolveStyleFiles($config, $configCollection, false);
 
         // Verify the component file was resolved
         static::assertCount(1, $result);
@@ -736,8 +620,7 @@ class ThemeFileResolverTest extends TestCase
 
     public function testComponentSingleFileReferenceWithBundleNamespace(): void
     {
-        $themePluginBundle = new ThemeWithStorefrontSkinScss();
-        $storefrontBundle = new MockStorefront();
+        $themePluginBundle = new ThemeWithNamespacedComponentReference();
 
         $sourceResolver = new StaticSourceResolver([]);
         $factory = new StorefrontPluginConfigurationFactory(
@@ -753,11 +636,11 @@ class ThemeFileResolverTest extends TestCase
 
         $kernel = $this->createMock(Kernel::class);
         $kernel->expects($this->any())->method('getBundles')->willReturn([
-            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+            'ThemeWithNamespacedComponentReference' => $themePluginBundle,
         ]);
 
         $kernel->expects($this->any())->method('getBundle')->willReturnMap([
-            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+            ['ThemeWithNamespacedComponentReference', $themePluginBundle],
         ]);
 
         $themeFilesystemResolver = new ThemeFilesystemResolver(
@@ -788,6 +671,11 @@ class ThemeFileResolverTest extends TestCase
             {
                 return 'Custom/Test';
             }
+
+            public function getNamespace(): string
+            {
+                return 'MyPlugin';
+            }
         };
 
         $componentCollection = new \Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection([
@@ -802,26 +690,7 @@ class ThemeFileResolverTest extends TestCase
 
         $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
 
-        $reflection = new \ReflectionClass($resolver);
-        $method = $reflection->getMethod('resolve');
-        $method->setAccessible(true);
-
-        // Create a file collection with a namespaced component reference
-        $fileCollection = new FileCollection();
-        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@Components:MyPlugin/Custom/Test/index.scss'));
-
-        /** @var FileCollection $result */
-        $result = $method->invoke(
-            $resolver,
-            ThemeFileResolver::STYLE_FILES,
-            $config,
-            $configCollection,
-            false,
-            fn ($cfg, $onlySourceFiles) => $fileCollection,
-            [],
-            [],
-            []
-        );
+        $result = $resolver->resolveStyleFiles($config, $configCollection, false);
 
         // Verify that only the plugin component was resolved (not the Storefront one)
         static::assertCount(1, $result);

--- a/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
+++ b/tests/unit/Storefront/Theme/ThemeFileResolverTest.php
@@ -16,6 +16,7 @@ use Shopware\Storefront\Theme\ThemeFilesystemResolver;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\MockStorefront\MockStorefront;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\SimplePlugin\SimplePlugin;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeNotIncludingPluginJsAndCss\ThemeNotIncludingPluginJsAndCss;
+use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithBundleRelativeFiles\ThemeWithBundleRelativeFiles;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithMultiInheritance\ThemeWithMultiInheritance;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithStorefrontBootstrapScss\ThemeWithStorefrontBootstrapScss;
 use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithStorefrontSkinScss\ThemeWithStorefrontSkinScss;
@@ -317,5 +318,515 @@ class ThemeFileResolverTest extends TestCase
         );
 
         static::assertSame($currentPath, $config->getStyleFiles()->first()?->getFilepath());
+    }
+
+    public function testParseBundleRelativePathWithValidPath(): void
+    {
+        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('parseBundleRelativePath');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($resolver, '@BundleName/app/storefront/src/scss/custom.scss');
+
+        static::assertIsArray($result);
+        static::assertArrayHasKey('bundle', $result);
+        static::assertArrayHasKey('path', $result);
+        static::assertEquals('BundleName', $result['bundle']);
+        static::assertEquals('app/storefront/src/scss/custom.scss', $result['path']);
+    }
+
+    public function testParseBundleRelativePathWithBundleOnly(): void
+    {
+        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('parseBundleRelativePath');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($resolver, '@BundleName');
+
+        static::assertNull($result);
+    }
+
+    public function testParseBundleRelativePathWithNonAtPrefix(): void
+    {
+        $themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('parseBundleRelativePath');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($resolver, 'app/storefront/src/scss/custom.scss');
+
+        static::assertNull($result);
+    }
+
+    public function testCircularReferencePreventionReturnsEmptyCollection(): void
+    {
+        $themePluginBundle = new ThemeWithMultiInheritance(true, __DIR__ . '/fixtures/SimplePlugin');
+        $storefrontBundle = new MockStorefront();
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+        $storefront = $factory->createFromBundle($storefrontBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+        $configCollection->add($storefront);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
+            'ThemeWithMultiInheritance' => $themePluginBundle,
+            'MockStorefront' => $storefrontBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithMultiInheritance', $themePluginBundle],
+            ['MockStorefront', $storefrontBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('resolve');
+        $method->setAccessible(true);
+
+        // First call - should work
+        /** @var FileCollection $result1 */
+        $result1 = $method->invoke(
+            $resolver,
+            ThemeFileResolver::SCRIPT_FILES,
+            $config,
+            $configCollection,
+            false,
+            fn (\Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration $cfg, bool $onlySourceFiles) => $cfg->getScriptFiles(),
+            [],
+            [],
+            []
+        );
+        static::assertGreaterThan(0, $result1->count());
+
+        // Second call with same config in processedConfigs - should return empty
+        /** @var FileCollection $result2 */
+        $result2 = $method->invoke(
+            $resolver,
+            ThemeFileResolver::SCRIPT_FILES,
+            $config,
+            $configCollection,
+            false,
+            fn (\Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration $cfg, bool $onlySourceFiles) => $cfg->getScriptFiles(),
+            [],
+            [],
+            ['ThemeWithMultiInheritance' => true]
+        );
+        static::assertEquals(0, $result2->count());
+    }
+
+    public function testFileDeduplicationAcrossNamespaces(): void
+    {
+        $themePluginBundle = new ThemeWithMultiInheritance(true, __DIR__ . '/fixtures/SimplePlugin');
+        $storefrontBundle = new MockStorefront();
+        $pluginBundle = new SimplePlugin(true, __DIR__ . '/fixtures/SimplePlugin');
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+        $storefront = $factory->createFromBundle($storefrontBundle);
+        $plugin = $factory->createFromBundle($pluginBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+        $configCollection->add($storefront);
+        $configCollection->add($plugin);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->once())->method('getBundles')->willReturn([
+            'ThemeWithMultiInheritance' => $themePluginBundle,
+            'MockStorefront' => $storefrontBundle,
+            'SimplePlugin' => $pluginBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithMultiInheritance', $themePluginBundle],
+            ['MockStorefront', $storefrontBundle],
+            ['SimplePlugin', $pluginBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+
+        $resolvedFiles = (new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper))->resolveFiles(
+            $config,
+            $configCollection,
+            false
+        );
+
+        $styleFiles = $resolvedFiles['style'];
+        $stylePaths = $styleFiles->getFilepaths();
+
+        // Check that all paths are unique
+        static::assertCount(\count(array_unique($stylePaths)), $stylePaths, 'Style files should not contain duplicates');
+
+        $scriptFiles = $resolvedFiles['script'];
+        $scriptPaths = $scriptFiles->getFilepaths();
+
+        // Check that all paths are unique
+        static::assertCount(\count(array_unique($scriptPaths)), $scriptPaths, 'Script files should not contain duplicates');
+    }
+
+    public function testBundleRelativeFileResolution(): void
+    {
+        $themePluginBundle = new ThemeWithBundleRelativeFiles();
+        $storefrontBundle = new MockStorefront();
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+        $storefront = $factory->createFromBundle($storefrontBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+        $configCollection->add($storefront);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
+            'ThemeWithBundleRelativeFiles' => $themePluginBundle,
+            'MockStorefront' => $storefrontBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithBundleRelativeFiles', $themePluginBundle],
+            ['MockStorefront', $storefrontBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+
+        $resolvedFiles = (new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper))->resolveFiles(
+            $config,
+            $configCollection,
+            false
+        );
+
+        $styleFiles = $resolvedFiles['style'];
+        $paths = $styleFiles->getFilepaths();
+
+        // Check that overrides.scss is resolved
+        $overridesFound = false;
+        $overridesPosition = -1;
+        foreach ($paths as $index => $path) {
+            if (str_contains((string) $path, 'overrides.scss')) {
+                $overridesFound = true;
+                $overridesPosition = $index;
+                break;
+            }
+        }
+        static::assertTrue($overridesFound, 'Bundle-relative file @MockStorefront/app/storefront/src/scss/overrides.scss should be resolved');
+
+        // Check that overrides.scss appears only once (not duplicated when @MockStorefront is expanded)
+        $overridesCount = 0;
+        foreach ($paths as $path) {
+            if (str_contains((string) $path, 'overrides.scss')) {
+                ++$overridesCount;
+            }
+        }
+        static::assertEquals(1, $overridesCount, 'overrides.scss should appear only once (no duplication)');
+
+        // Check that overrides.scss appears before base.scss (order preservation)
+        $basePosition = -1;
+        foreach ($paths as $index => $path) {
+            if (str_contains((string) $path, 'base.scss')) {
+                $basePosition = $index;
+                break;
+            }
+        }
+
+        if ($basePosition !== -1) {
+            static::assertLessThan($basePosition, $overridesPosition, 'Bundle-relative file should appear in order before full bundle expansion');
+        }
+
+        // Check that custom.scss from the theme itself is also included
+        $customFound = false;
+        foreach ($paths as $path) {
+            if (str_contains((string) $path, 'custom.scss')) {
+                $customFound = true;
+                break;
+            }
+        }
+        static::assertTrue($customFound, 'Direct file reference custom.scss should be resolved');
+    }
+
+    public function testBundleRelativeFileThrowsExceptionForMissingBundle(): void
+    {
+        $themePluginBundle = new ThemeWithStorefrontSkinScss();
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
+            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('resolve');
+        $method->setAccessible(true);
+
+        // Create a file collection with a bundle-relative reference to a non-existent bundle
+        $fileCollection = new FileCollection();
+        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@NonExistentBundle/app/test.scss'));
+
+        $this->expectException(\Shopware\Storefront\Theme\Exception\ThemeException::class);
+        $this->expectExceptionMessage('NonExistentBundle');
+
+        $method->invoke(
+            $resolver,
+            ThemeFileResolver::STYLE_FILES,
+            $config,
+            $configCollection,
+            false,
+            fn ($cfg, $onlySourceFiles) => $fileCollection,
+            [],
+            [],
+            []
+        );
+    }
+
+    public function testComponentSingleFileReference(): void
+    {
+        $themePluginBundle = new ThemeWithStorefrontSkinScss();
+        $storefrontBundle = new MockStorefront();
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
+            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        // Create a test component with anonymous class extending TwigComponent
+        $testComponent = new class('/path/to/components/Sw/Alert/index.html.twig', 'Sw:Alert', 'Storefront') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+            public function getStylePath(): string
+            {
+                return '/path/to/components/Sw/Alert/index.scss';
+            }
+
+            public function getRelativeNamespaceDirectory(): string
+            {
+                return 'Sw/Alert';
+            }
+        };
+
+        $componentCollection = new \Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection([$testComponent]);
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+        $twigComponentHelper->expects($this->any())
+            ->method('getComponents')
+            ->willReturn($componentCollection);
+
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('resolve');
+        $method->setAccessible(true);
+
+        // Create a file collection with a component-relative reference
+        $fileCollection = new FileCollection();
+        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@Components/Sw/Alert/index.scss'));
+
+        /** @var FileCollection $result */
+        $result = $method->invoke(
+            $resolver,
+            ThemeFileResolver::STYLE_FILES,
+            $config,
+            $configCollection,
+            false,
+            fn ($cfg, $onlySourceFiles) => $fileCollection,
+            [],
+            [],
+            []
+        );
+
+        // Verify the component file was resolved
+        static::assertCount(1, $result);
+        $resolvedPath = $result->first()?->getFilepath();
+        static::assertStringContainsString('Sw/Alert/index.scss', (string) $resolvedPath);
+    }
+
+    public function testComponentSingleFileReferenceWithBundleNamespace(): void
+    {
+        $themePluginBundle = new ThemeWithStorefrontSkinScss();
+        $storefrontBundle = new MockStorefront();
+
+        $sourceResolver = new StaticSourceResolver([]);
+        $factory = new StorefrontPluginConfigurationFactory(
+            $this->createMock(KernelPluginLoader::class),
+            $sourceResolver,
+            new Filesystem(),
+        );
+
+        $config = $factory->createFromBundle($themePluginBundle);
+
+        $configCollection = new StorefrontPluginConfigurationCollection();
+        $configCollection->add($config);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->expects($this->any())->method('getBundles')->willReturn([
+            'ThemeWithStorefrontSkinScss' => $themePluginBundle,
+        ]);
+
+        $kernel->expects($this->any())->method('getBundle')->willReturnMap([
+            ['ThemeWithStorefrontSkinScss', $themePluginBundle],
+        ]);
+
+        $themeFilesystemResolver = new ThemeFilesystemResolver(
+            $sourceResolver,
+            $kernel
+        );
+
+        // Create two test components with the same path but different namespaces
+        $componentStorefront = new class('/path/to/components/Custom/Test/index.html.twig', 'Custom:Test', 'Storefront') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+            public function getStylePath(): string
+            {
+                return '/path/to/components/Custom/Test/index.scss';
+            }
+
+            public function getRelativeNamespaceDirectory(): string
+            {
+                return 'Custom/Test';
+            }
+        };
+
+        $componentPlugin = new class('/path/to/plugin/components/Custom/Test/index.html.twig', 'Custom:Test', 'MyPlugin') extends \Shopware\Storefront\Framework\Twig\Components\TwigComponent {
+            public function getStylePath(): string
+            {
+                return '/path/to/plugin/components/Custom/Test/index.scss';
+            }
+
+            public function getRelativeNamespaceDirectory(): string
+            {
+                return 'Custom/Test';
+            }
+        };
+
+        $componentCollection = new \Shopware\Storefront\Framework\Twig\Components\TwigComponentCollection([
+            $componentStorefront,
+            $componentPlugin,
+        ]);
+
+        $twigComponentHelper = $this->createMock(TwigComponentHelper::class);
+        $twigComponentHelper->expects($this->any())
+            ->method('getComponents')
+            ->willReturn($componentCollection);
+
+        $resolver = new ThemeFileResolver($themeFilesystemResolver, $twigComponentHelper);
+
+        $reflection = new \ReflectionClass($resolver);
+        $method = $reflection->getMethod('resolve');
+        $method->setAccessible(true);
+
+        // Create a file collection with a namespaced component reference
+        $fileCollection = new FileCollection();
+        $fileCollection->add(new \Shopware\Storefront\Theme\StorefrontPluginConfiguration\File('@Components:MyPlugin/Custom/Test/index.scss'));
+
+        /** @var FileCollection $result */
+        $result = $method->invoke(
+            $resolver,
+            ThemeFileResolver::STYLE_FILES,
+            $config,
+            $configCollection,
+            false,
+            fn ($cfg, $onlySourceFiles) => $fileCollection,
+            [],
+            [],
+            []
+        );
+
+        // Verify that only the plugin component was resolved (not the Storefront one)
+        static::assertCount(1, $result);
+        $resolvedPath = $result->first()?->getFilepath();
+        static::assertStringContainsString('/plugin/components/Custom/Test/index.scss', (string) $resolvedPath);
+        static::assertStringNotContainsString('/path/to/components/Custom/Test/index.scss', (string) $resolvedPath);
     }
 }

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/Resources/app/storefront/src/scss/custom.scss
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/Resources/app/storefront/src/scss/custom.scss
@@ -1,0 +1,4 @@
+// Custom theme styles
+.custom-class {
+    color: red;
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/Resources/theme.json
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/Resources/theme.json
@@ -1,0 +1,12 @@
+{
+  "name": "Theme with bundle relative files",
+  "author": "Shopware AG",
+  "style": [
+    "@MockStorefront/app/storefront/src/scss/overrides.scss",
+    "@MockStorefront",
+    "app/storefront/src/scss/custom.scss"
+  ],
+  "script": [
+    "@MockStorefront"
+  ]
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/ThemeWithBundleRelativeFiles.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithBundleRelativeFiles/ThemeWithBundleRelativeFiles.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithBundleRelativeFiles;
+
+use Shopware\Core\Framework\Bundle;
+use Shopware\Storefront\Framework\ThemeInterface;
+
+/**
+ * @internal
+ */
+class ThemeWithBundleRelativeFiles extends Bundle implements ThemeInterface
+{
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithComponentReference/Resources/theme.json
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithComponentReference/Resources/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Theme with component reference",
+  "author": "Shopware AG",
+  "style": [
+    "@Components/Sw/Alert/index.scss"
+  ]
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithComponentReference/ThemeWithComponentReference.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithComponentReference/ThemeWithComponentReference.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithComponentReference;
+
+use Shopware\Core\Framework\Bundle;
+use Shopware\Storefront\Framework\ThemeInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+class ThemeWithComponentReference extends Bundle implements ThemeInterface
+{
+    public function getThemeName(): string
+    {
+        return 'ThemeWithComponentReference';
+    }
+
+    public function getPath(): string
+    {
+        return __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+    }
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithInvalidBundleReference/Resources/theme.json
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithInvalidBundleReference/Resources/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Theme with invalid bundle reference",
+  "author": "Shopware AG",
+  "style": [
+    "@NonExistentBundle/app/test.scss"
+  ]
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithInvalidBundleReference/ThemeWithInvalidBundleReference.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithInvalidBundleReference/ThemeWithInvalidBundleReference.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithInvalidBundleReference;
+
+use Shopware\Core\Framework\Bundle;
+use Shopware\Storefront\Framework\ThemeInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+class ThemeWithInvalidBundleReference extends Bundle implements ThemeInterface
+{
+    public function getThemeName(): string
+    {
+        return 'ThemeWithInvalidBundleReference';
+    }
+
+    public function getPath(): string
+    {
+        return __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+    }
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithNamespacedComponentReference/Resources/theme.json
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithNamespacedComponentReference/Resources/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Theme with namespaced component reference",
+  "author": "Shopware AG",
+  "style": [
+    "@Components:MyPlugin/Custom/Test/index.scss"
+  ]
+}

--- a/tests/unit/Storefront/Theme/fixtures/ThemeWithNamespacedComponentReference/ThemeWithNamespacedComponentReference.php
+++ b/tests/unit/Storefront/Theme/fixtures/ThemeWithNamespacedComponentReference/ThemeWithNamespacedComponentReference.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeWithNamespacedComponentReference;
+
+use Shopware\Core\Framework\Bundle;
+use Shopware\Storefront\Framework\ThemeInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+class ThemeWithNamespacedComponentReference extends Bundle implements ThemeInterface
+{
+    public function getThemeName(): string
+    {
+        return 'ThemeWithNamespacedComponentReference';
+    }
+
+    public function getPath(): string
+    {
+        return __DIR__;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/shopware/shopware/issues/15146
Fixes: https://github.com/shopware/shopware/pull/10904

### 1. Why is this change necessary?

Currently, you can only specify the whole namespace of a bundle or components for style and script files in the theme.json, but sometimes you want to change the order of specific files compared to other namespaces.

### 2. What does this change do, exactly?

You can now specify single files from other bundles, or component styles, to reference just a single file. The reference is deduplicated when the corresponding bundle namespace is resolved.

**Example:**  

```
  "style": [
    "app/storefront/src/scss/overrides.scss",
    "@CustomTheme/src/scss/custom.scss",            <-- Single file reference from @CustomTheme namespace
    "@Storefront",
    "@Components/Sw/Alert/index.scss",              <-- Single component reference
    "@Components:CustomTheme/Custom/Test.scss",     <-- Single component reference from specific bundle
    "@CustomTheme",
    "@Components",
    "app/storefront/src/scss/base.scss"
  ],
```

