### PR TITLE
ci: refactor audit scripts to operate on GHSA

### DIFF
--- a/.github/bin/js/README.md
+++ b/.github/bin/js/README.md
@@ -21,6 +21,27 @@ Validates that all dependencies use exact versions (no `^` or `~` prefixes).
 npx esno check-pinned-dependencies.ts
 ```
 
+### `run-npm-audit.ts`
+Shared audit logic used by per-project `scripts/runNpmAudit.ts` wrappers. Exports `runNpmAudit(options)` which runs `npm audit`, filters advisories matching the given GHSA/CVE identifiers, and suggests using `overrides` or adding to the ignore list when vulnerabilities are found.
+
+Each project with known false-positives or unfixable advisories has a thin `scripts/runNpmAudit.ts` wrapper:
+```typescript
+import { runNpmAudit } from '../../../../../../.github/bin/js/run-npm-audit.ts';
+
+runNpmAudit({
+    ignoredGHSAs: [
+        'https://github.com/advisories/GHSA-2g4f-4pwh-qvx6', // ajv ReDoS, moderate severity, devDep only
+    ],
+    ignoredCVEs: [
+        'CVE-2025-58754', // axios DoS, false positive
+    ],
+});
+```
+
+GHSAs are specified as full `https://github.com/advisories/GHSA-xxxx-xxxx-xxxx` URLs so developers can click through directly. The GHSA identifier is extracted from the URL automatically.
+
+When vulnerabilities are detected, the output includes GHSA and CVE identifiers for each advisory, and the suggestions section provides copy-pasteable GHSA URL entries for the ignore list.
+
 ## Adding New Package.json
 
 When adding a new package.json file to the repository:
@@ -30,19 +51,20 @@ When adding a new package.json file to the repository:
    {
        path: './path/to/your/package.json',
        name: 'Your Package Name',
-       hasCustomAuditScript: true  // only if needed
+       hasCustomAuditScript: true  // only if using scripts/runNpmAudit.ts
    }
    ```
 
-2. Set `hasCustomAuditScript: true` only if the package uses a custom audit script instead of `npm audit`
+2. If the package has known advisories to ignore, create `scripts/runNpmAudit.ts` in that package's directory
+   that imports `runNpmAudit` from `.github/bin/js/run-npm-audit.ts` and passes the GHSA/CVE identifiers.
 
 ## CI Checks
 
 The workflow automatically:
 
-- ✅ **Package Completeness**: Ensures all package.json files are tracked
-- ✅ **Dependency Pinning**: Validates all dependencies use exact versions
-- ✅ **Security Audits**: Runs npm audit on all packages in parallel
-- ✅ **Dynamic Scaling**: New packages are automatically included in all checks
+- **Package Completeness**: Ensures all package.json files are tracked
+- **Dependency Pinning**: Validates all dependencies use exact versions
+- **Security Audits**: Runs npm audit on all packages in parallel
+- **Dynamic Scaling**: New packages are automatically included in all checks
 
 No manual workflow updates needed - just update the package list!

--- a/.github/bin/js/check-pinned-dependencies.ts
+++ b/.github/bin/js/check-pinned-dependencies.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, existsSync } from 'node:fs';
-import { getPackageJsonPaths } from './package-discovery.js';
+import { getPackageJsonPaths } from './package-discovery.ts';
 
 interface PackageJsonContent {
     dependencies?: Record<string, string>;

--- a/.github/bin/js/package-discovery.ts
+++ b/.github/bin/js/package-discovery.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
 interface PackageInfo {

--- a/.github/bin/js/package-discovery.ts
+++ b/.github/bin/js/package-discovery.ts
@@ -54,7 +54,7 @@ export const EXPECTED_PACKAGE_JSON_FILES: readonly PackageInfo[] = [
   {
     path: './tests/acceptance/package.json',
     name: 'Tests Acceptance',
-    hasCustomAuditScript: true,
+    hasCustomAuditScript: true
   }
 ] as const;
 

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "dependencies": {
     "@shopware-ag/gh-project-automation": "1.14.1"
   },

--- a/.github/bin/js/run-npm-audit.ts
+++ b/.github/bin/js/run-npm-audit.ts
@@ -1,0 +1,295 @@
+import { execSync } from 'node:child_process';
+
+export interface NpmAuditOptions {
+    ignoredCVEs?: string[];
+    ignoredGHSAs?: string[];
+}
+
+interface AuditVia {
+    source: number;
+    name: string;
+    title: string;
+    url: string;
+    severity: string;
+    range: string;
+    cwe: string[];
+    cvss: { score: number; vectorString: string };
+}
+
+interface AuditVulnerability {
+    name: string;
+    severity: string;
+    range: string;
+    via: Array<AuditVia | string>;
+    isDirect: boolean;
+    effects: string[];
+    fixAvailable:
+        | boolean
+        | {
+              name: string;
+              version: string;
+              isSemVerMajor: boolean;
+          };
+}
+
+interface AuditResult {
+    vulnerabilities: Record<string, AuditVulnerability>;
+}
+
+interface RootAdvisory {
+    ghsa: string | null;
+    title: string;
+    severity: string;
+    url: string;
+    packageName: string;
+    range: string;
+    affectedPackages: string[];
+    fixAvailable:
+        | false
+        | {
+              name: string;
+              version: string;
+              isSemVerMajor: boolean;
+          };
+}
+
+function extractGHSA(url: string): string | null {
+    const match = url.match(/(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})/);
+    return match?.[1] ?? null;
+}
+
+function extractCVEs(via: AuditVia): string[] {
+    const raw = via as unknown as Record<string, unknown>;
+    if (Array.isArray(raw['cve'])) return raw['cve'] as string[];
+    if (typeof raw['cve'] === 'string') return [raw['cve'] as string];
+    return [];
+}
+
+function fetchAuditReport(): AuditResult {
+    let auditRaw = '';
+
+    try {
+        auditRaw = execSync('npm audit --json', { encoding: 'utf8' });
+    } catch (err: unknown) {
+        const execErr = err as { stdout?: Buffer | string; message?: string };
+        if (execErr.stdout) {
+            auditRaw = execErr.stdout.toString();
+        } else {
+            console.error('Error running npm audit:', execErr.message ?? String(err));
+            process.exit(1);
+        }
+    }
+
+    try {
+        return JSON.parse(auditRaw) as AuditResult;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('Failed to parse npm audit JSON:', message);
+        process.exit(1);
+    }
+}
+
+function isIgnored(via: AuditVia, ignoredGHSAs: Set<string>, ignoredCVEs: Set<string>): boolean {
+    const ghsa = via.url ? extractGHSA(via.url) : null;
+    if (ghsa && ignoredGHSAs.has(ghsa)) {
+        return true;
+    }
+
+    if (ignoredCVEs.size > 0) {
+        for (const cve of extractCVEs(via)) {
+            if (ignoredCVEs.has(cve)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+function filterIgnored(audit: AuditResult, ignoredGHSAs: Set<string>, ignoredCVEs: Set<string>): void {
+    for (const pkgName in audit.vulnerabilities) {
+        const pkg = audit.vulnerabilities[pkgName];
+        if (!pkg) continue;
+
+        if (Array.isArray(pkg.via)) {
+            pkg.via = pkg.via.filter((v) => {
+                if (typeof v === 'object') {
+                    return !isIgnored(v, ignoredGHSAs, ignoredCVEs);
+                }
+                return true;
+            });
+        }
+    }
+
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const pkgName in audit.vulnerabilities) {
+            const pkg = audit.vulnerabilities[pkgName];
+            if (!pkg) continue;
+
+            if (Array.isArray(pkg.via) && pkg.via.length > 0) {
+                pkg.via = pkg.via.filter((v) => {
+                    if (typeof v === 'string') {
+                        const refPkg = audit.vulnerabilities[v];
+                        return refPkg && Array.isArray(refPkg.via) && refPkg.via.length > 0;
+                    }
+                    return true;
+                });
+                if (pkg.via.length === 0) {
+                    changed = true;
+                }
+            }
+        }
+    }
+}
+
+function collectAffectedPackages(
+    pkgName: string,
+    audit: AuditResult,
+    visited: Set<string>,
+): void {
+    if (visited.has(pkgName)) return;
+    visited.add(pkgName);
+
+    for (const otherName in audit.vulnerabilities) {
+        const other = audit.vulnerabilities[otherName];
+        if (!other) continue;
+
+        if (Array.isArray(other.via)) {
+            const dependsOnPkg = other.via.some((v) => typeof v === 'string' && v === pkgName);
+            if (dependsOnPkg) {
+                collectAffectedPackages(otherName, audit, visited);
+            }
+        }
+    }
+}
+
+function buildRootAdvisories(audit: AuditResult): RootAdvisory[] {
+    const advisoryMap = new Map<string, RootAdvisory>();
+
+    for (const pkgName in audit.vulnerabilities) {
+        const pkg = audit.vulnerabilities[pkgName];
+        if (!pkg || !Array.isArray(pkg.via)) continue;
+
+        for (const v of pkg.via) {
+            if (typeof v !== 'object') continue;
+
+            const ghsa = v.url ? extractGHSA(v.url) : null;
+            const key = ghsa ?? `source-${v.source}`;
+
+            if (!advisoryMap.has(key)) {
+                const affected = new Set<string>();
+                collectAffectedPackages(pkgName, audit, affected);
+                affected.delete(pkgName);
+
+                const fix = pkg.fixAvailable;
+                advisoryMap.set(key, {
+                    ghsa,
+                    title: v.title || 'Unknown vulnerability',
+                    severity: v.severity || pkg.severity || 'unknown',
+                    url: v.url || '',
+                    packageName: v.name || pkgName,
+                    range: v.range || pkg.range || 'N/A',
+                    affectedPackages: [...affected].sort(),
+                    fixAvailable: fix && typeof fix === 'object' ? fix : false,
+                });
+            }
+        }
+    }
+
+    return [...advisoryMap.values()];
+}
+
+function printAdvisories(advisories: RootAdvisory[], totalPackages: number): void {
+    const plural = advisories.length === 1 ? 'advisory' : 'advisories';
+    console.error(`Found ${advisories.length} ${plural} affecting ${totalPackages} package(s)\n`);
+
+    for (const adv of advisories) {
+        const identifiers: string[] = [];
+        if (adv.ghsa) identifiers.push(adv.ghsa);
+        const idStr = identifiers.length > 0 ? ` (${identifiers.join(', ')})` : '';
+
+        console.error(`${adv.title}${idStr}`);
+        console.error(`  Package: ${adv.packageName} ${adv.range}`);
+        console.error(`  Severity: ${adv.severity}`);
+        if (adv.url) {
+            console.error(`  URL: ${adv.url}`);
+        }
+        if (adv.fixAvailable) {
+            console.error(`  Fix: update ${adv.fixAvailable.name} to ${adv.fixAvailable.version}${adv.fixAvailable.isSemVerMajor ? ' (semver major)' : ''}`);
+        }
+        if (adv.affectedPackages.length > 0) {
+            console.error(`  Affected: ${adv.affectedPackages.join(', ')} (${adv.affectedPackages.length} transitive)`);
+        }
+        console.error('');
+    }
+}
+
+function printSuggestions(advisories: RootAdvisory[]): void {
+    console.error('--- Suggestions ---\n');
+
+    const fixable = advisories.filter((a) => a.fixAvailable);
+    const unfixable = advisories.filter((a) => !a.fixAvailable);
+
+    if (fixable.length > 0) {
+        console.error('Try adding an override in package.json to fix the root dependency:\n');
+        const seen = new Set<string>();
+        for (const adv of fixable) {
+            const key = `${adv.fixAvailable && typeof adv.fixAvailable === 'object' ? adv.fixAvailable.name : ''}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            const fix = adv.fixAvailable as { name: string; version: string; isSemVerMajor: boolean };
+            console.error(`  "overrides": { "${fix.name}": "${fix.version}" }${fix.isSemVerMajor ? '  // semver major — test thoroughly' : ''}`);
+        }
+        console.error('');
+    }
+
+    if (unfixable.length > 0) {
+        console.error('If the vulnerability does not affect your project (e.g. devDep only,');
+        console.error('false positive), add to ignoredGHSAs in scripts/runNpmAudit.ts:\n');
+        for (const adv of unfixable) {
+            if (adv.ghsa) {
+                const url = `https://github.com/advisories/${adv.ghsa}`;
+                console.error(`  '${url}', // ${adv.packageName} ${adv.title}, ${adv.severity} severity`);
+            } else {
+                console.error(`  // ${adv.packageName}: ${adv.title} — no GHSA found, check ${adv.url}`);
+            }
+        }
+        console.error('');
+    }
+
+    if (fixable.length > 0 && unfixable.length === 0) {
+        console.error('All vulnerabilities have fixes available. Prefer overrides over ignoring.\n');
+    }
+}
+
+/**
+ * Run npm audit in the current working directory, filtering out advisories
+ * matching the given GHSA and CVE identifiers.
+ * Exits with code 1 when unignored vulnerabilities remain.
+ */
+export function runNpmAudit(options: NpmAuditOptions = {}): void {
+    const ignoredGHSAs = new Set(
+        (options.ignoredGHSAs ?? []).map((entry) => extractGHSA(entry) ?? entry),
+    );
+    const ignoredCVEs = new Set(options.ignoredCVEs ?? []);
+    const totalIgnored = ignoredGHSAs.size + ignoredCVEs.size;
+
+    const audit = fetchAuditReport();
+    filterIgnored(audit, ignoredGHSAs, ignoredCVEs);
+
+    const remaining = Object.values(audit.vulnerabilities).filter(
+        (pkg) => Array.isArray(pkg.via) && pkg.via.length > 0,
+    );
+
+    if (remaining.length === 0) {
+        console.log(`No vulnerabilities (${totalIgnored} ignored).`);
+        return;
+    }
+
+    const advisories = buildRootAdvisories(audit);
+    printAdvisories(advisories, remaining.length);
+    printSuggestions(advisories);
+    process.exit(1);
+}

--- a/.github/bin/js/tsconfig.json
+++ b/.github/bin/js/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "node",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "lib": ["ES2022"],
     "types": ["node"],
     "esModuleInterop": true,

--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -10,11 +10,15 @@ on:
     paths:
       - "**/package.json"
       - "**/package-lock.json"
+      - "**/scripts/runNpmAudit.ts"
+      - ".github/bin/js/run-npm-audit.ts"
   pull_request:
     types: [opened, synchronize]
     paths:
       - "**/package.json"
       - "**/package-lock.json"
+      - "**/scripts/runNpmAudit.ts"
+      - ".github/bin/js/run-npm-audit.ts"
 
 jobs:
   check-package-completeness:
@@ -30,7 +34,7 @@ jobs:
           node-version: 24
 
       - name: Validate package.json completeness
-        run: npx esno ./.github/bin/js/package-discovery.ts validate
+        run: node ./.github/bin/js/package-discovery.ts validate
 
   check-pinned-dependencies:
     name: Check pinned dependencies
@@ -45,7 +49,7 @@ jobs:
           node-version: 24
 
       - name: Check for unpinned dependencies
-        run: npx esno ./.github/bin/js/check-pinned-dependencies.ts
+        run: node ./.github/bin/js/check-pinned-dependencies.ts
 
   generate-audit-matrix:
     name: Generate audit matrix
@@ -64,7 +68,7 @@ jobs:
       - name: Generate matrix
         id: generate-matrix
         run: |
-          matrix=$(npx esno ./.github/bin/js/package-discovery.ts matrix)
+          matrix=$(node ./.github/bin/js/package-discovery.ts matrix)
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   audit-packages:
@@ -94,5 +98,5 @@ jobs:
 
       - name: Run audit (custom script)
         if: ${{ matrix.hasCustomAuditScript }}
-        run: npx esno ./scripts/runNpmAudit.ts
+        run: node ./scripts/runNpmAudit.ts
         working-directory: ${{ matrix.workingDirectory }}

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -94,6 +94,7 @@
         "@shopware-ag/eslint-config-base": "2.0.0",
         "@shopware-ag/jest-preset-sw6-admin": "6.0.4",
         "@testing-library/jest-dom": "5.17.0",
+        "@types/cli-progress": "3.11.6",
         "@types/convert-units": "2.3.12",
         "@types/debug": "4.1.12",
         "@types/eslint": "9.6.1",
@@ -7510,6 +7511,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -28,7 +28,7 @@
         "app-module-path": "2.2.0",
         "autoprefixer": "10.4.20",
         "axios": "0.30.3",
-        "axios-v1": "npm:axios@1.13.4",
+        "axios-v1": "npm:axios@1.13.5",
         "bottlejs": "2.0.1",
         "cli-progress": "3.12.0",
         "command-line-args": "6.0.1",
@@ -45,8 +45,8 @@
         "fs-extra": "11.3.0",
         "html2canvas": "1.4.1",
         "inter-ui": "3.19.3",
-        "lodash": "4.17.21",
-        "lodash-es": "4.17.21",
+        "lodash": "4.17.23",
+        "lodash-es": "4.17.23",
         "md5-es": "1.8.2",
         "mime-types": "2.1.35",
         "mitt": "3.0.1",
@@ -98,7 +98,7 @@
         "@types/debug": "4.1.12",
         "@types/eslint": "9.6.1",
         "@types/jest": "29.5.14",
-        "@types/lodash": "4.17.20",
+        "@types/lodash": "4.17.24",
         "@types/lodash-es": "4.17.12",
         "@types/mime-types": "2.1.4",
         "@types/node": "20.17.14",
@@ -421,7 +421,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -601,6 +600,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
       "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "regexpu-core": "^6.2.0",
@@ -618,6 +618,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -729,6 +730,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
       "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-wrap-function": "^7.25.9",
@@ -845,6 +847,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
       "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -861,6 +864,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
       "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -876,6 +880,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
       "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -891,6 +896,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
       "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
@@ -908,6 +914,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
       "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -1065,6 +1072,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1205,6 +1213,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
       "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1399,6 +1408,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -1415,6 +1425,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
       "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1430,6 +1441,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
       "integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
@@ -1447,6 +1459,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
       "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1464,6 +1477,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
       "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -1479,6 +1493,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
       "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1494,6 +1509,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
       "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1510,6 +1526,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
       "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1526,6 +1543,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
       "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -1546,6 +1564,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
       "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/template": "^7.25.9"
@@ -1562,6 +1581,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
       "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1577,6 +1597,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
       "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1593,6 +1614,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
       "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1608,6 +1630,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
       "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1624,6 +1647,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
       "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1639,6 +1663,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
       "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1654,6 +1679,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
       "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1685,6 +1711,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
       "integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1701,6 +1728,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
       "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1718,6 +1746,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
       "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1733,6 +1762,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
       "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1748,6 +1778,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
       "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1763,6 +1794,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
       "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1778,6 +1810,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
       "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1810,6 +1843,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
       "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1828,6 +1862,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
       "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1844,6 +1879,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
       "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1860,6 +1896,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
       "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1875,6 +1912,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
       "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -1890,6 +1928,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
       "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1905,6 +1944,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
       "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1922,6 +1962,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
       "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-replace-supers": "^7.25.9"
@@ -1938,6 +1979,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
       "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1953,6 +1995,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
       "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1969,6 +2012,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
       "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1984,6 +2028,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
       "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2000,6 +2045,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
       "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -2017,6 +2063,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
       "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2032,6 +2079,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
       "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
@@ -2048,6 +2096,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
       "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2064,6 +2113,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
       "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2110,6 +2160,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
       "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2125,6 +2176,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
       "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -2141,6 +2193,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
       "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2156,6 +2209,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
       "integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -2171,6 +2225,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz",
       "integrity": "sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.26.5"
       },
@@ -2205,6 +2260,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
       "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -2220,6 +2276,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
       "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2236,6 +2293,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
       "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2252,6 +2310,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
       "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -2268,6 +2327,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
       "integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.26.8",
         "@babel/helper-compilation-targets": "^7.26.5",
@@ -2351,6 +2411,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
       "integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3",
         "core-js-compat": "^3.40.0"
@@ -2364,6 +2425,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2390,6 +2452,7 @@
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -4319,7 +4382,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4343,7 +4405,6 @@
       "integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -4357,7 +4418,6 @@
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4374,7 +4434,6 @@
       "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
         "import-in-the-middle": "^2.0.0",
@@ -4786,7 +4845,6 @@
       "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4804,7 +4862,6 @@
       "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -4823,7 +4880,6 @@
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6049,7 +6105,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -6191,6 +6246,7 @@
       "resolved": "https://registry.npmjs.org/@storybook/core/-/core-8.6.15.tgz",
       "integrity": "sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.15",
         "better-opn": "^3.0.2",
@@ -6222,6 +6278,7 @@
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -6234,6 +6291,7 @@
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -6334,6 +6392,7 @@
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
       "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -6368,7 +6427,6 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.js/-/svg.js-3.2.4.tgz",
       "integrity": "sha512-BjJ/7vWNowlX3Z8O4ywT58DqbNRyYlkk6Yz/D13aB7hGmfQTvGX4Tkgtm/ApYlu9M7lCQi15xUEidqMUmdMYwg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Fuzzyma"
@@ -6392,7 +6450,6 @@
       "resolved": "https://registry.npmjs.org/@svgdotjs/svg.select.js/-/svg.select.js-4.0.2.tgz",
       "integrity": "sha512-5gWdrvoQX3keo03SCmgaBbD+kFftq0F/f2bzCbNnpkkvW6tk4rl4MakORzFuNjvXPWwB4az9GwuvVxQVnjaK2g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14.18"
       },
@@ -6406,7 +6463,6 @@
       "integrity": "sha512-py91kjI1jV5D5W/Q+PurBdGsdU5TFbrzamP7zSCqLdMcHkKi3rQEM5jkQcZr0MXXSJTaayLxS3MWYTBIkzPDrg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -6641,7 +6697,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6762,7 +6817,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.26.1.tgz",
       "integrity": "sha512-fymyd/XZvYiHjBoLt1gxs024xP/LY26d43R1vluYq7AHBL/7DE3ywzy+1GEsGyAv5Je2L0KBhNIR/izbq3Kaqg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7213,7 +7267,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.26.1.tgz",
       "integrity": "sha512-t9Nc/UkrbCfnSHEUi1gvUQ2ZPzvfdYFT5TExoV2DTiUCkhG6+mecT5bTVFGW3QkPmbToL+nFhGn4ZRMDD0SP3Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7240,7 +7293,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
       "integrity": "sha512-8aF+mY/vSHbGFqyG663ds84b+vca5Lge3tHdTMTKazxCnhXR9dn2oQJMnZ78YZvdRbkPkMJJHti9h3K7u2UQvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -7648,9 +7700,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7669,7 +7721,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -7717,7 +7768,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
       "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -7913,7 +7963,6 @@
       "integrity": "sha512-eTH+UOR4I7WbdQnG4Z48ebIA6Bgi7WO8HvFEneeYBxG8qCOYgTOFPSg6ek9ITIDvGjDQzWHcoWHCDO2biByNzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.21.0",
@@ -7944,7 +7993,6 @@
       "integrity": "sha512-Wy+/sdEH9kI3w9civgACwabHbKl+qIOu0uFZ9IMKzX3Jpv9og0ZBJrZExGrPpFAY7rWsXuxs5e7CPPP17A4eYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.21.0",
         "@typescript-eslint/types": "8.21.0",
@@ -8509,7 +8557,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
       "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.4",
         "@vue/compiler-core": "3.5.22",
@@ -8974,7 +9021,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9038,9 +9084,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9135,7 +9181,6 @@
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-4.4.0.tgz",
       "integrity": "sha512-JGsHeQEKDlQh1rob8aBai9/HKvXIpbZ83TnobKZAcdOELf+oQZaxZyAnbbldr6PPBdCgG2zzzLaP1dtEsJxzWw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@svgdotjs/svg.draggable.js": "^3.0.4",
         "@svgdotjs/svg.filter.js": "^3.0.8",
@@ -9348,9 +9393,9 @@
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/assert": {
@@ -9494,7 +9539,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.30.3.tgz",
       "integrity": "sha512-5/tmEb6TmE/ax3mdXBc/Mi6YdPGxQsv+0p5YlciXWt3PHIn0VamqCXhRMtScnwY3lbgSXLneOuXAKUhgmSRpwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.4",
@@ -9517,13 +9561,13 @@
     },
     "node_modules/axios-v1": {
       "name": "axios",
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -9557,7 +9601,6 @@
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -9887,6 +9930,7 @@
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
       "integrity": "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "open": "^8.0.4"
       },
@@ -9899,6 +9943,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9911,6 +9956,7 @@
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -9951,9 +9997,9 @@
       "license": "MIT"
     },
     "node_modules/bn.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-      "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -10071,7 +10117,8 @@
     "node_modules/browser-assert": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
-      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ=="
+      "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
+      "peer": true
     },
     "node_modules/browser-or-node": {
       "version": "3.0.0",
@@ -10230,7 +10277,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -10462,7 +10508,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
       "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -11312,9 +11357,9 @@
       }
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/create-hash": {
@@ -11728,7 +11773,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -12030,8 +12074,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1467305.tgz",
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -12063,9 +12106,9 @@
       }
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/dir-compare": {
@@ -12375,9 +12418,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/emittery": {
@@ -12645,7 +12688,6 @@
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -12686,6 +12728,7 @@
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
       "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -12759,7 +12802,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13139,7 +13181,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -14340,9 +14381,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -14381,9 +14422,9 @@
       "license": "Apache2"
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -14750,6 +14791,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -16477,7 +16519,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16753,7 +16794,6 @@
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
       },
@@ -17340,7 +17380,6 @@
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/console": "^29.7.0",
         "@jest/environment": "^29.7.0",
@@ -17866,6 +17905,7 @@
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.8.0.tgz",
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -18425,15 +18465,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash._basebind": {
@@ -18832,7 +18872,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -19100,9 +19139,9 @@
       }
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/mime": {
@@ -20711,7 +20750,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -20785,7 +20823,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20876,7 +20913,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21088,7 +21124,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -21118,7 +21153,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -21167,7 +21201,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.1.tgz",
       "integrity": "sha512-pbwUjt3G7TlsQQHDiYSupWBhJswpLVB09xXm1YiJPdkjkh9Pe7Y51XdLh5VWIZmROLY8UpUpG03lkdhm9lzIBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -21338,9 +21371,9 @@
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -21826,13 +21859,15 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
       "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -21845,6 +21880,7 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
       "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
@@ -21874,6 +21910,7 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
       "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -21890,13 +21927,15 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
       "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -21909,6 +21948,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -22194,7 +22234,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
       "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -22418,7 +22457,6 @@
       "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -23315,7 +23353,6 @@
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -23600,9 +23637,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23756,8 +23793,7 @@
       "version": "0.163.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
       "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-spritetext": {
       "version": "1.10.0",
@@ -23794,7 +23830,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -23834,7 +23871,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24111,7 +24147,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -24429,7 +24464,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24490,6 +24524,7 @@
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24499,6 +24534,7 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -24512,6 +24548,7 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
       "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24521,6 +24558,7 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24564,7 +24602,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -24785,7 +24822,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -24969,7 +25005,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24988,7 +25023,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -25845,7 +25879,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -4,7 +4,6 @@
   "description": "Shopware administration",
   "main": "./src/core/shopware.js",
   "types": "./types/index.d.ts",
-  "type": "module",
   "scripts": {
     "build": "export VITE_MODE=production && ts-node -T build.ts",
     "code-mods": "node code-mods.js",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -4,6 +4,7 @@
   "description": "Shopware administration",
   "main": "./src/core/shopware.js",
   "types": "./types/index.d.ts",
+  "type": "module",
   "scripts": {
     "build": "export VITE_MODE=production && ts-node -T build.ts",
     "code-mods": "node code-mods.js",
@@ -70,7 +71,7 @@
     "app-module-path": "2.2.0",
     "autoprefixer": "10.4.20",
     "axios": "0.30.3",
-    "axios-v1": "npm:axios@1.13.4",
+    "axios-v1": "npm:axios@1.13.5",
     "bottlejs": "2.0.1",
     "cli-progress": "3.12.0",
     "command-line-args": "6.0.1",
@@ -87,8 +88,8 @@
     "fs-extra": "11.3.0",
     "html2canvas": "1.4.1",
     "inter-ui": "3.19.3",
-    "lodash": "4.17.21",
-    "lodash-es": "4.17.21",
+    "lodash": "4.17.23",
+    "lodash-es": "4.17.23",
     "md5-es": "1.8.2",
     "mime-types": "2.1.35",
     "mitt": "3.0.1",
@@ -140,7 +141,7 @@
     "@types/debug": "4.1.12",
     "@types/eslint": "9.6.1",
     "@types/jest": "29.5.14",
-    "@types/lodash": "4.17.20",
+    "@types/lodash": "4.17.24",
     "@types/lodash-es": "4.17.12",
     "@types/mime-types": "2.1.4",
     "@types/node": "20.17.14",
@@ -222,14 +223,18 @@
     "vuex": "Vuex is deprecated and will be removed with Shopware 6.8.0"
   },
   "overrides": {
+    "@sentry/node": "10.31.0",
+    "@typescript-eslint/eslint-plugin": "8.21.0",
+    "ajv@^6": "6.14.0",
+    "ajv@^8": "8.18.0",
+    "bn.js@^4": "4.12.3",
+    "bn.js@^5": "5.2.3",
+    "braces": "3.0.3",
     "glob": "12.0.0",
     "js-yaml": "4.1.1",
-    "vue": "3.5.22",
-    "@typescript-eslint/eslint-plugin": "8.21.0",
-    "tmp": "0.2.5",
-    "braces": "3.0.3",
     "micromatch": "4.0.8",
+    "vue": "3.5.22",
     "test-exclude": "7.0.1",
-    "@sentry/node": "10.31.0"
+    "tmp": "0.2.5"
   }
 }

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -136,6 +136,7 @@
     "@shopware-ag/eslint-config-base": "2.0.0",
     "@shopware-ag/jest-preset-sw6-admin": "6.0.4",
     "@testing-library/jest-dom": "5.17.0",
+    "@types/cli-progress": "3.11.6",
     "@types/convert-units": "2.3.12",
     "@types/debug": "4.1.12",
     "@types/eslint": "9.6.1",

--- a/src/Administration/Resources/app/administration/scripts/componentImportResolver/generate.ts
+++ b/src/Administration/Resources/app/administration/scripts/componentImportResolver/generate.ts
@@ -3,12 +3,9 @@
  * @package admin
  */
 import { ArrowFunction, CallExpression, Project, SourceFile, ts} from "ts-morph";
-import path from "node:path";
-import fs from "node:fs";
-import { fileURLToPath } from "node:url";
+import * as path from "path";
+import * as fs from "fs";
 import cliProgress from 'cli-progress';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const project = new Project({
     skipAddingFilesFromTsConfig: true,

--- a/src/Administration/Resources/app/administration/scripts/componentImportResolver/generate.ts
+++ b/src/Administration/Resources/app/administration/scripts/componentImportResolver/generate.ts
@@ -3,8 +3,12 @@
  * @package admin
  */
 import { ArrowFunction, CallExpression, Project, SourceFile, ts} from "ts-morph";
-import * as path from "path";
-import * as fs from "fs";
+import path from "node:path";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+import cliProgress from 'cli-progress';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const project = new Project({
     skipAddingFilesFromTsConfig: true,
@@ -194,7 +198,6 @@ const componentImportMap: { [key: string]: componentInfo } = {};
 const sourceFiles = project.getSourceFiles();
 
 // Create progress bar
-const cliProgress = require('cli-progress');
 const pb = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
 pb.start(sourceFiles.length, 0);
 

--- a/src/Administration/Resources/app/administration/scripts/generate-data-set-list/index.ts
+++ b/src/Administration/Resources/app/administration/scripts/generate-data-set-list/index.ts
@@ -5,7 +5,6 @@
 
 import fs from 'fs';
 import path from 'path';
-// @ts-expect-error - There are no types for this package
 import cliProgress from 'cli-progress';
 import colors from 'picocolors';
 

--- a/src/Administration/Resources/app/administration/scripts/generate-position-identifier-list/index.ts
+++ b/src/Administration/Resources/app/administration/scripts/generate-position-identifier-list/index.ts
@@ -5,7 +5,6 @@
 
 import fs from 'fs';
 import path from 'path';
-// @ts-expect-error - There are no types for this package
 import cliProgress from 'cli-progress';
 import colors from 'picocolors';
 

--- a/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
+++ b/src/Administration/Resources/app/administration/scripts/runNpmAudit.ts
@@ -1,103 +1,24 @@
 #!/usr/bin/env node
-import { execSync } from "child_process";
+import { runNpmAudit } from '../../../../../../.github/bin/js/run-npm-audit.ts';
 
-// IDs of advisories to ignore
-const ignored: number[] = [
-  1112030, // elliptic, low severity, devDep only (vite-plugin-node-polyfills/crypto-browserify)
-  1112455, // lodash prototype pollution, moderate severity, devDep only
-  1112453, // lodash-es prototype pollution, moderate severity, devDep only
-  1113371, // minimatch ReDoS, high severity, devDep only, needs ESLint 9 migration to drop eslint-plugin-import
-  1113428, // ajv ReDoS, moderate severity, devDep only (webpack/schema-utils), no fix for ajv 6.x line
-  1113429, // ajv ReDoS, moderate severity, devDep only (webpack/schema-utils), no fix for ajv 6.x line
-  1113402, // bn.js infinite loop, moderate severity, devDep only (vite-plugin-node-polyfills/crypto-browserify)
-  1113275, // axios DoS, high severity, false positive: installed 0.30.3 is not in affected range 1.0.0-1.13.4
-];
-let auditRaw = "";
-
-try {
-  // Capture stdout even if npm audit exits with code 1
-  auditRaw = execSync("npm audit --json", {
-    encoding: "utf8"
-  });
-} catch (err: any) {
-  if (err.stdout) {
-    auditRaw = err.stdout.toString();
-  } else {
-    console.error("Error running npm audit:", err.message);
-    process.exit(1);
-  }
-}
-
-try {
-  const audit = JSON.parse(auditRaw);
-
-  // First pass: filter out ignored advisories
-  for (const pkgName in audit.vulnerabilities) {
-    const pkg = audit.vulnerabilities[pkgName];
-    if (pkg.via && Array.isArray(pkg.via)) {
-      pkg.via = pkg.via.filter((v: any) => !ignored.includes(v.source));
-    }
-  }
-
-  // Second pass: remove packages that only have transitive dependencies on filtered packages
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const pkgName in audit.vulnerabilities) {
-      const pkg = audit.vulnerabilities[pkgName];
-      if (pkg.via && Array.isArray(pkg.via) && pkg.via.length > 0) {
-        // Filter out string references to packages that have no vulnerabilities left
-        pkg.via = pkg.via.filter((v: any) => {
-          if (typeof v === 'string') {
-            // Check if the referenced package has any vulnerabilities left
-            const refPkg = audit.vulnerabilities[v];
-            return refPkg && refPkg.via && refPkg.via.length > 0;
-          }
-          return true; // Keep object entries that weren't filtered in first pass
-        });
-        if (pkg.via.length === 0) {
-          changed = true;
-        }
-      }
-    }
-  }
-
-  const remaining = Object.values(audit.vulnerabilities).reduce(
-    (sum: number, pkg: any) => sum + (pkg.via.length > 0 ? 1 : 0),
-    0
-  );
-
-  if (remaining > 0) {
-    console.error(`❌ Remaining vulnerabilities detected: ${remaining}\n`);
-    Object.values(audit.vulnerabilities)
-      .filter((pkg: any) => pkg.via.length > 0)
-      .forEach((pkg: any) => {
-        console.error(`Package: ${pkg.name || 'unknown'}`);
-        console.error(`Severity: ${pkg.severity || 'unknown'}`);
-        console.error(`Range: ${pkg.range || 'N/A'}`);
-        pkg.via.forEach((v: any) => {
-          // Handle both string and object types in via array
-          if (typeof v === 'string') {
-            console.error(`  - Dependency issue: ${v}`);
-          } else if (v && typeof v === 'object') {
-            const title = v.title || 'Unknown vulnerability';
-            const source = v.source || 'N/A';
-            const url = v.url || (v.source ? `https://github.com/advisories/GHSA-${v.source}` : null);
-
-            console.error(`  - ${title}`);
-            console.error(`    Advisory ID: ${source}`);
-            if (url) {
-              console.error(`    URL: ${url}`);
-            }
-          }
-        });
-        console.error('');
-      });
-    process.exit(1);
-  } else {
-    console.log("✅ No vulnerabilities (ignored IDs excluded).");
-  }
-} catch (err: any) {
-  console.error("Failed to parse npm audit JSON:", err.message);
-  process.exit(1);
-}
+/**
+ * Run from the project directory: node ./scripts/runNpmAudit.ts
+ *
+ * When a new vulnerability is reported, prefer fixing it over ignoring:
+ *
+ * 1. First, try adding an "overrides" entry in package.json to pin the
+ *    vulnerable transitive dependency to a fixed version.
+ * 2. Only add a GHSA here if the vulnerability has no fix available, is a
+ *    false positive, or only affects devDependencies and poses no real risk.
+ *
+ * Each entry should include a comment explaining why it is safe to ignore.
+ *
+ * Example:
+ *   'https://github.com/advisories/GHSA-xxxx-xxxx-xxxx', // pkg-name issue, severity, devDep only, no fix available
+ */
+runNpmAudit({
+    ignoredGHSAs: [
+        'https://github.com/advisories/GHSA-848j-6mx2-7j84', // elliptic ECDSA flaw, low severity, devDep only (vite-plugin-node-polyfills/crypto-browserify), no patch available
+        'https://github.com/advisories/GHSA-3ppc-4f35-3m26', // minimatch ReDoS, high severity, devDep only, needs ESLint 9 migration to drop eslint-plugin-import
+    ],
+});

--- a/src/Administration/Resources/app/administration/scripts/tsconfig.json
+++ b/src/Administration/Resources/app/administration/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["**/*.ts"]
+}

--- a/src/Administration/Resources/app/administration/scripts/tsconfig.json
+++ b/src/Administration/Resources/app/administration/scripts/tsconfig.json
@@ -6,5 +6,11 @@
     "allowImportingTsExtensions": true,
     "types": ["node", "jest"]
   },
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS",
+      "moduleResolution": "Node"
+    }
+  },
   "include": ["**/*.ts"]
 }

--- a/src/Administration/Resources/app/administration/tsconfig.json
+++ b/src/Administration/Resources/app/administration/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2023",
     "lib": ["ES2020", "DOM", "ES2023"],
     "module": "commonjs",
-    "rootDir": "./",
     "baseUrl": "./",
     "paths": {
       "src": ["src"],
@@ -29,7 +28,6 @@
   "include": [
     "build.ts",
     "./src/**/*",
-    "./scripts/**/*",
     "./vite.config.mts",
     "./build/vite-plugins/**/*",
     "./build/plugins.vite.ts",

--- a/src/Storefront/Resources/app/storefront/package-lock.json
+++ b/src/Storefront/Resources/app/storefront/package-lock.json
@@ -143,7 +143,6 @@
       "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -1946,7 +1945,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -1988,7 +1986,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2012,7 +2009,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2150,6 +2146,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
@@ -2174,6 +2201,37 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -3483,7 +3541,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -3546,7 +3603,6 @@
       "integrity": "sha512-WSrnE6JRnH20ZYjOOgSS4aOaPv9gxlkI2KRkN24kagbZnPZMnN8bZZyzw1rrLvwgpuRGv17Uz+hflosbR+SP6w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -4184,7 +4240,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4641,7 +4696,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4709,11 +4763,10 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4743,9 +4796,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -5179,10 +5232,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -5295,13 +5352,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5335,7 +5395,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6638,7 +6697,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6737,6 +6795,24 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -6788,6 +6864,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -7568,6 +7657,34 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
@@ -10231,8 +10348,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -10365,18 +10481,6 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/minimist": {
       "version": "1.2.8",
@@ -11121,7 +11225,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11315,7 +11418,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11346,7 +11448,6 @@
       "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11788,16 +11889,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/read-package-json/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/read-package-json/node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -11830,13 +11921,13 @@
       }
     },
     "node_modules/read-package-json/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -12278,11 +12369,10 @@
       }
     },
     "node_modules/schema-utils/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13021,7 +13111,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
@@ -13341,9 +13430,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13489,6 +13578,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -13500,8 +13620,7 @@
       "version": "0.163.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
       "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-spritetext": {
       "version": "1.10.0",
@@ -13718,7 +13837,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13987,7 +14105,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -14036,7 +14153,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -10,6 +10,7 @@
     "sw"
   ],
   "license": "MIT",
+  "type": "module",
   "scripts": {
     "development": "NODE_ENV=development webpack --config webpack.config.js",
     "hot": "NODE_ENV=development MODE=hot webpack-dev-server --config webpack.config.js",

--- a/src/Storefront/Resources/app/storefront/package.json
+++ b/src/Storefront/Resources/app/storefront/package.json
@@ -10,7 +10,6 @@
     "sw"
   ],
   "license": "MIT",
-  "type": "module",
   "scripts": {
     "development": "NODE_ENV=development webpack --config webpack.config.js",
     "hot": "NODE_ENV=development MODE=hot webpack-dev-server --config webpack.config.js",

--- a/src/Storefront/Resources/app/storefront/scripts/runNpmAudit.ts
+++ b/src/Storefront/Resources/app/storefront/scripts/runNpmAudit.ts
@@ -1,98 +1,23 @@
 #!/usr/bin/env node
-import { execSync } from "child_process";
+import { runNpmAudit } from '../../../../../../.github/bin/js/run-npm-audit.ts';
 
-// IDs of advisories to ignore
-const ignored: number[] = [
-  1113371, // minimatch ReDoS, high severity, devDep only, fix planned in ESLint 9 + Jest 30 update
-  1113428, // ajv ReDoS, moderate severity, devDep only (webpack/schema-utils), no fix for ajv 6.x line
-  1113429, // ajv ReDoS, moderate severity, devDep only (webpack/schema-utils), no fix for ajv 6.x line
-];
-let auditRaw = "";
-
-try {
-  // Capture stdout even if npm audit exits with code 1
-  auditRaw = execSync("npm audit --json", {
-    encoding: "utf8"
-  });
-} catch (err: any) {
-  if (err.stdout) {
-    auditRaw = err.stdout.toString();
-  } else {
-    console.error("Error running npm audit:", err.message);
-    process.exit(1);
-  }
-}
-
-try {
-  const audit = JSON.parse(auditRaw);
-
-  // First pass: filter out ignored advisories
-  for (const pkgName in audit.vulnerabilities) {
-    const pkg = audit.vulnerabilities[pkgName];
-    if (pkg.via && Array.isArray(pkg.via)) {
-      pkg.via = pkg.via.filter((v: any) => !ignored.includes(v.source));
-    }
-  }
-
-  // Second pass: remove packages that only have transitive dependencies on filtered packages
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const pkgName in audit.vulnerabilities) {
-      const pkg = audit.vulnerabilities[pkgName];
-      if (pkg.via && Array.isArray(pkg.via) && pkg.via.length > 0) {
-        // Filter out string references to packages that have no vulnerabilities left
-        pkg.via = pkg.via.filter((v: any) => {
-          if (typeof v === 'string') {
-            // Check if the referenced package has any vulnerabilities left
-            const refPkg = audit.vulnerabilities[v];
-            return refPkg && refPkg.via && refPkg.via.length > 0;
-          }
-          return true; // Keep object entries that weren't filtered in first pass
-        });
-        if (pkg.via.length === 0) {
-          changed = true;
-        }
-      }
-    }
-  }
-
-  const remaining = Object.values(audit.vulnerabilities).reduce(
-    (sum: number, pkg: any) => sum + (pkg.via.length > 0 ? 1 : 0),
-    0
-  );
-
-  if (remaining > 0) {
-    console.error(`❌ Remaining vulnerabilities detected: ${remaining}\n`);
-    Object.values(audit.vulnerabilities)
-      .filter((pkg: any) => pkg.via.length > 0)
-      .forEach((pkg: any) => {
-        console.error(`Package: ${pkg.name || 'unknown'}`);
-        console.error(`Severity: ${pkg.severity || 'unknown'}`);
-        console.error(`Range: ${pkg.range || 'N/A'}`);
-        pkg.via.forEach((v: any) => {
-          // Handle both string and object types in via array
-          if (typeof v === 'string') {
-            console.error(`  - Dependency issue: ${v}`);
-          } else if (v && typeof v === 'object') {
-            const title = v.title || 'Unknown vulnerability';
-            const source = v.source || 'N/A';
-            const url = v.url || (v.source ? `https://github.com/advisories/GHSA-${v.source}` : null);
-
-            console.error(`  - ${title}`);
-            console.error(`    Advisory ID: ${source}`);
-            if (url) {
-              console.error(`    URL: ${url}`);
-            }
-          }
-        });
-        console.error('');
-      });
-    process.exit(1);
-  } else {
-    console.log("✅ No vulnerabilities (ignored IDs excluded).");
-  }
-} catch (err: any) {
-  console.error("Failed to parse npm audit JSON:", err.message);
-  process.exit(1);
-}
+/**
+ * Run from the project directory: node ./scripts/runNpmAudit.ts
+ *
+ * When a new vulnerability is reported, prefer fixing it over ignoring:
+ *
+ * 1. First, try adding an "overrides" entry in package.json to pin the
+ *    vulnerable transitive dependency to a fixed version.
+ * 2. Only add a GHSA here if the vulnerability has no fix available, is a
+ *    false positive, or only affects devDependencies and poses no real risk.
+ *
+ * Each entry should include a comment explaining why it is safe to ignore.
+ *
+ * Example:
+ *   'https://github.com/advisories/GHSA-xxxx-xxxx-xxxx', // pkg-name issue, severity, devDep only, no fix available
+ */
+runNpmAudit({
+    ignoredGHSAs: [
+        'https://github.com/advisories/GHSA-3ppc-4f35-3m26', // minimatch ReDoS, high severity, devDep only, fix planned in ESLint 9 + Jest 30 update
+    ],
+});

--- a/src/Storefront/Resources/app/storefront/tsconfig.json
+++ b/src/Storefront/Resources/app/storefront/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -454,7 +454,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -472,7 +471,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -483,7 +481,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -504,7 +501,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -860,7 +856,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -882,7 +877,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -905,7 +899,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1243,7 +1236,6 @@
       "version": "8.54.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1433,7 +1425,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1476,10 +1467,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1687,7 +1679,6 @@
     "node_modules/axe-core": {
       "version": "4.11.1",
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -1710,7 +1701,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -2065,7 +2055,6 @@
     "node_modules/commander": {
       "version": "12.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2255,8 +2244,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2422,7 +2410,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4602,7 +4589,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4645,7 +4631,6 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
       "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -5956,7 +5941,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/tests/acceptance/scripts/runNpmAudit.ts
+++ b/tests/acceptance/scripts/runNpmAudit.ts
@@ -1,96 +1,22 @@
 #!/usr/bin/env node
-import { execSync } from 'child_process';
+import { runNpmAudit } from '../../../.github/bin/js/run-npm-audit.ts';
 
-// IDs of advisories to ignore
-const ignored: number[] = [
-    1113428, // ajv ReDoS, moderate severity, devDep only, no fix for ajv 6.x line
-];
-let auditRaw = '';
-
-try {
-  // Capture stdout even if npm audit exits with code 1
-  auditRaw = execSync('npm audit --json', {
-    encoding: 'utf8',
-  });
-} catch (err: any) {
-  if (err.stdout) {
-    auditRaw = err.stdout.toString();
-  } else {
-    console.error('Error running npm audit:', err.message);
-    process.exit(1);
-  }
-}
-
-try {
-  const audit = JSON.parse(auditRaw);
-
-  // First pass: filter out ignored advisories
-  for (const pkgName in audit.vulnerabilities) {
-    const pkg = audit.vulnerabilities[pkgName];
-    if (pkg.via && Array.isArray(pkg.via)) {
-      pkg.via = pkg.via.filter((v: any) => !ignored.includes(v.source));
-    }
-  }
-
-  // Second pass: remove packages that only have transitive dependencies on filtered packages
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const pkgName in audit.vulnerabilities) {
-      const pkg = audit.vulnerabilities[pkgName];
-      if (pkg.via && Array.isArray(pkg.via) && pkg.via.length > 0) {
-        // Filter out string references to packages that have no vulnerabilities left
-        pkg.via = pkg.via.filter((v: any) => {
-          if (typeof v === 'string') {
-            // Check if the referenced package has any vulnerabilities left
-            const refPkg = audit.vulnerabilities[v];
-            return refPkg && refPkg.via && refPkg.via.length > 0;
-          }
-          return true; // Keep object entries that weren't filtered in first pass
-        });
-        if (pkg.via.length === 0) {
-          changed = true;
-        }
-      }
-    }
-  }
-
-  const remaining = Object.values(audit.vulnerabilities).reduce<number>(
-    (sum: number, pkg: any) => sum + (pkg.via.length > 0 ? 1 : 0),
-    0
-  );
-
-  if (remaining > 0) {
-    console.error(`❌ Remaining vulnerabilities detected: ${remaining}\n`);
-    Object.values(audit.vulnerabilities)
-      .filter((pkg: any) => pkg.via.length > 0)
-      .forEach((pkg: any) => {
-        console.error(`Package: ${pkg.name || 'unknown'}`);
-        console.error(`Severity: ${pkg.severity || 'unknown'}`);
-        console.error(`Range: ${pkg.range || 'N/A'}`);
-        pkg.via.forEach((v: any) => {
-          // Handle both string and object types in via array
-          if (typeof v === 'string') {
-            console.error(`  - Dependency issue: ${v}`);
-          } else if (v && typeof v === 'object') {
-            const title = v.title || 'Unknown vulnerability';
-            const source = v.source || 'N/A';
-            const url = v.url || (v.source ? `https://github.com/advisories/GHSA-${v.source}` : null);
-
-            console.error(`  - ${title}`);
-            console.error(`    Advisory ID: ${source}`);
-            if (url) {
-              console.error(`    URL: ${url}`);
-            }
-          }
-        });
-        console.error('');
-      });
-    process.exit(1);
-  } else {
-    console.log('✅ No vulnerabilities (ignored IDs excluded).');
-  }
-} catch (err: any) {
-  console.error('Failed to parse npm audit JSON:', err.message);
-  process.exit(1);
-}
+/**
+ * Run from the project directory: node ./scripts/runNpmAudit.ts
+ *
+ * When a new vulnerability is reported, prefer fixing it over ignoring:
+ *
+ * 1. First, try adding an "overrides" entry in package.json to pin the
+ *    vulnerable transitive dependency to a fixed version.
+ * 2. Only add a GHSA here if the vulnerability has no fix available, is a
+ *    false positive, or only affects devDependencies and poses no real risk.
+ *
+ * Each entry should include a comment explaining why it is safe to ignore.
+ *
+ * Example:
+ *   'https://github.com/advisories/GHSA-xxxx-xxxx-xxxx', // pkg-name issue, severity, devDep only, no fix available
+ */
+runNpmAudit({
+    ignoredGHSAs: [
+    ],
+});

--- a/tests/acceptance/scripts/tsconfig.json
+++ b/tests/acceptance/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Based on inconsistencies of using IDs to ignore vulnerabilities I made some changes in process:
- unified script - moved the script code to single place
- left only ignoring logic inside projects, so it's easier to manage
- operating on links to GHSAs (thanks for suggestion @keulinho ) for easier access to vulnerabilities
- improved some overrides and removed some ignored vulnerabilities
- running ts scripts directly through node (perf runtime gain)


Overall the process has not changed, the place to manage overrides and ignores is still the same