### PR TITLE
fix: administration have no robots information + set robots meta to no-index, no-follow

### DIFF
--- a/src/Administration/Resources/views/administration/layout/base.html.twig
+++ b/src/Administration/Resources/views/administration/layout/base.html.twig
@@ -10,6 +10,10 @@
         </title>
     {% endblock %}
 
+    {% block administration_meta %}
+        <meta name="robots" content="noindex, nofollow" />
+    {% endblock %}
+
     {% block administration_favicons %}
         <link rel="apple-touch-icon" href="{{ asset('administration/static/img/favicon/apple-touch-icon.png', '@Administration') }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('administration/static/img/favicon/favicon-16x16.png', '@Administration') }}">


### PR DESCRIPTION
### 1. Why is this change necessary?
The administration currenly provide no robots information. The default is `index, follow`.
This can lead to administration pages being indexed by search engines.
Normaly this should not happen but i have found some cases where the administration ends up in the google index. This might be an easy way of identifying shopware installations with unrestricted administrations. 

### 2. What does this change do, exactly?
I added a block to the administration base.html.twig called `administration_meta` for potential overwrites of other meta information and set the robots meta.tag values to `no-index, no-follow`. 

### 3. Describe each step to reproduce the issue or behaviour.

Visit the administration with a robots analyser, for example (mine was SeeRobots). 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
