### PR TITLE
fix: use correct delimiter in refresh migration command

### DIFF
--- a/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
@@ -58,7 +58,7 @@ class RefreshMigrationCommand extends Command
 
     private function getCurrentTimestamp(string $filename): string
     {
-        if (!preg_match('/#Migration(\d+).*?\.php#i/', $filename, $matches)) {
+        if (!preg_match('/Migration(\d+).*?\.php/i', $filename, $matches)) {
             throw MigrationException::couldNotDetermineTimestamp();
         }
 

--- a/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
@@ -4,11 +4,9 @@ namespace Shopware\Tests\Unit\Core\Framework\Migration\Command;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Migration\Command\CreateMigrationCommand;
 use Shopware\Core\Framework\Migration\Command\RefreshMigrationCommand;
 use Shopware\Core\Framework\Migration\MigrationException;
 use Shopware\Core\Framework\Migration\MigrationStep;
-use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -33,7 +31,7 @@ class RefreshMigrationCommandTest extends TestCase
         $command = new RefreshMigrationCommand();
         $commandTester = new CommandTester($command);
 
-        $this->expectExceptionObject(MigrationException::migrationFileDoesNotExist( __DIR__ . '/_fixtures/DoesNotExist.php'));
+        $this->expectExceptionObject(MigrationException::migrationFileDoesNotExist(__DIR__ . '/_fixtures/DoesNotExist.php'));
         $commandTester->execute(['path' => __DIR__ . '/_fixtures/DoesNotExist.php']);
     }
 
@@ -54,7 +52,7 @@ class RefreshMigrationCommandTest extends TestCase
             ->in(__DIR__ . '/_fixtures')
             ->name('Migration*.php');
 
-        $this->assertCount(1, $finder);
+        static::assertCount(1, $finder);
 
         foreach ($finder as $file => $fileInfo) {
             static::assertFileExists($file);

--- a/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Migration\Command\CreateMigrationCommand;
+use Shopware\Core\Framework\Migration\Command\RefreshMigrationCommand;
+use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @internal
+ */
+#[CoversClass(RefreshMigrationCommand::class)]
+class RefreshMigrationCommandTest extends TestCase
+{
+    public function testExecuteThrowsWhenClassNameDoesNotContainMigrationTimestamp(): void
+    {
+        $command = new RefreshMigrationCommand();
+        $commandTester = new CommandTester($command);
+
+        $this->expectExceptionObject(MigrationException::couldNotDetermineTimestamp());
+        $commandTester->execute(['path' => __DIR__ . '/_fixtures/InvalidMigration.php']);
+    }
+
+    public function testExecuteThrowsClassAtPathDoesNotExist(): void
+    {
+        $command = new RefreshMigrationCommand();
+        $commandTester = new CommandTester($command);
+
+        $this->expectExceptionObject(MigrationException::migrationFileDoesNotExist( __DIR__ . '/_fixtures/DoesNotExist.php'));
+        $commandTester->execute(['path' => __DIR__ . '/_fixtures/DoesNotExist.php']);
+    }
+
+    public function testExecute(): void
+    {
+        $command = new RefreshMigrationCommand();
+        $commandTester = new CommandTester($command);
+
+        $fs = new Filesystem();
+
+        $filePath = __DIR__ . '/_fixtures/Migration1772030791Test.php';
+        // create temp file for test
+        $fs->copy(__DIR__ . '/_fixtures/Migration1772030791Test.php.bak', $filePath);
+
+        $commandTester->execute(['path' => $filePath]);
+
+        $finder = (new Finder())
+            ->in(__DIR__ . '/_fixtures')
+            ->name('Migration*.php');
+
+        $this->assertCount(1, $finder);
+
+        foreach ($finder as $file => $fileInfo) {
+            static::assertFileExists($file);
+
+            require_once $file;
+
+            $class = $fileInfo->getBasename('.php');
+            $migration = new $class();
+
+            static::assertInstanceOf(MigrationStep::class, $migration);
+            $newTimestamp = $migration->getCreationTimestamp();
+            // assert that the new timestamp is within 1 second of the current time, to account for any slight delays in execution
+            static::assertEqualsWithDelta(time(), $newTimestamp, 1);
+            // assert that the new timestamp is in the file name as well
+            static::assertStringContainsString((string) $newTimestamp, $file);
+
+            $fs->remove($file);
+        }
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
+++ b/tests/unit/Core/Framework/Migration/Command/RefreshMigrationCommandTest.php
@@ -64,8 +64,8 @@ class RefreshMigrationCommandTest extends TestCase
 
             static::assertInstanceOf(MigrationStep::class, $migration);
             $newTimestamp = $migration->getCreationTimestamp();
-            // assert that the new timestamp is within 1 second of the current time, to account for any slight delays in execution
-            static::assertEqualsWithDelta(time(), $newTimestamp, 1);
+            // assert that the new timestamp is within 3 second of the current time, to account for any slight delays in execution
+            static::assertEqualsWithDelta(time(), $newTimestamp, 3);
             // assert that the new timestamp is in the file name as well
             static::assertStringContainsString((string) $newTimestamp, $file);
 

--- a/tests/unit/Core/Framework/Migration/Command/_fixtures/InvalidMigration.php
+++ b/tests/unit/Core/Framework/Migration/Command/_fixtures/InvalidMigration.php
@@ -5,6 +5,9 @@ namespace Shopware\Tests\Unit\Core\Framework\Migration\Command\_fixtures;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
+/**
+ * @internal
+ */
 class InvalidMigration extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/tests/unit/Core/Framework/Migration/Command/_fixtures/InvalidMigration.php
+++ b/tests/unit/Core/Framework/Migration/Command/_fixtures/InvalidMigration.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Migration\Command\_fixtures;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class InvalidMigration extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1772030791;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+}

--- a/tests/unit/Core/Framework/Migration/Command/_fixtures/Migration1772030791Test.php.bak
+++ b/tests/unit/Core/Framework/Migration/Command/_fixtures/Migration1772030791Test.php.bak
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1772030791Test extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1772030791;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
fixes: https://github.com/shopware/shopware/issues/14904

### 1. Why is this change necessary?
Regex was wrong because suddenly we have two delimiters

### 2. What does this change do, exactly?
Fix the regex and add tests

### 3. Describe each step to reproduce the issue or behaviour.
see issue

### 4. Please link to the relevant issues (if any).
 https://github.com/shopware/shopware/issues/14904
