### PR TITLE
fix(cookie): recaptcha form validation issue

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -390,23 +390,27 @@ export default class CookieConfiguration extends Plugin {
     }
 
     /**
-     * Reset cookie configuration when hash has changed
-     * Resets to technically required cookies only
+     * Reset cookie configuration when hash has changed or language consent is missing.
+     * Removes non-required cookies via _applyCookieConfiguration, then also removes
+     * JS-set consent cookies (e.g. _GRECAPTCHA, cookie-preference) to prompt re-consent.
+     * PHP-managed cookies (session, timezone) and cookie-config-hash are preserved.
      * @private
      */
     async _resetCookieConfiguration(data) {
         const cookieGroups = data.elements || [];
         const { activeCookieNames, inactiveCookieNames } = this._applyCookieConfiguration(cookieGroups, 'required', [], data.languageId);
 
-        // Remove all consent cookies that were just set, since we're prompting for re-consent.
-        // Only cookie-config-hash is kept because it tracks per-language consent state.
+        const phpManagedCookies = this._getTechnicallyRequiredCookieNames();
         for (const cookieName of activeCookieNames) {
-            if (cookieName !== this.options.cookieConfigHash) {
+            if (cookieName !== this.options.cookieConfigHash && !phpManagedCookies.includes(cookieName)) {
                 CookieStorage.removeItem(cookieName);
             }
         }
 
-        this._handleUpdateListener([], [...inactiveCookieNames, ...activeCookieNames]);
+        this._handleUpdateListener(
+            activeCookieNames.filter(name => name === this.options.cookieConfigHash || phpManagedCookies.includes(name)),
+            inactiveCookieNames,
+        );
 
         this._checkAndShowCookieBarIfNeeded();
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -398,10 +398,15 @@ export default class CookieConfiguration extends Plugin {
         const cookieGroups = data.elements || [];
         const { activeCookieNames, inactiveCookieNames } = this._applyCookieConfiguration(cookieGroups, 'required', [], data.languageId);
 
-        CookieStorage.removeItem(this.options.cookiePreference);
+        // Remove all consent cookies that were just set, since we're prompting for re-consent.
+        // Only cookie-config-hash is kept because it tracks per-language consent state.
+        for (const cookieName of activeCookieNames) {
+            if (cookieName !== this.options.cookieConfigHash) {
+                CookieStorage.removeItem(cookieName);
+            }
+        }
 
-        const updatedActiveCookieNames = activeCookieNames.filter(name => name !== this.options.cookiePreference);
-        this._handleUpdateListener(updatedActiveCookieNames, inactiveCookieNames);
+        this._handleUpdateListener([], [...inactiveCookieNames, ...activeCookieNames]);
 
         this._checkAndShowCookieBarIfNeeded();
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/cookie-configuration/cookie-configuration.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cookie-configuration/cookie-configuration.plugin.test.js
@@ -596,8 +596,9 @@ describe('CookieConfiguration plugin tests', () => {
                         technicalName: 'required-group',
                         isRequired: true,
                         entries: [
-                            { cookie: 'session-', value: 'abc123', expiration: 30 }, // PHP-managed, should not be set
-                            { cookie: 'csrf-token', value: 'xyz789', expiration: 30 }, // Should be set
+                            { cookie: 'session-', value: 'abc123', expiration: 30 }, // PHP-managed, should not be set or removed
+                            { cookie: 'csrf-token', value: 'xyz789', expiration: 30 }, // Should be set, then removed on reset
+                            { cookie: '_GRECAPTCHA', value: '1', expiration: 30 }, // Consent flag, should be removed on reset
                             { cookie: 'cookie-preference', value: '1', expiration: 30 }, // Will be removed to trigger re-consent
                             { cookie: 'cookie-config-hash', value: newHash, expiration: 30 } // Should be set to prevent re-consent loop
                         ]
@@ -620,6 +621,7 @@ describe('CookieConfiguration plugin tests', () => {
             CookieStorage.setItem(plugin.options.cookiePreference, '1', '30');
             CookieStorage.setItem(plugin.options.cookieConfigHash, JSON.stringify({ [languageId]: oldHash }), '30');
             CookieStorage.setItem('analytics', '1', 365); // User had accepted analytics
+            CookieStorage.setItem('_GRECAPTCHA', '1', 30); // User had accepted reCAPTCHA
 
             const setItemSpy = jest.spyOn(CookieStorage, 'setItem');
             const removeItemSpy = jest.spyOn(CookieStorage, 'removeItem');
@@ -640,6 +642,12 @@ describe('CookieConfiguration plugin tests', () => {
             // Verify hash mismatch detected and non-required cookies are removed
             expect(removeItemSpy).toHaveBeenCalledWith('analytics'); // not required, should be removed
             expect(removeItemSpy).toHaveBeenCalledWith('cookie-preference'); // removed to trigger re-consent
+            expect(removeItemSpy).toHaveBeenCalledWith('_GRECAPTCHA'); // consent flag, removed on reset
+            expect(removeItemSpy).toHaveBeenCalledWith('csrf-token'); // JS-set required cookie, removed on reset
+
+            // PHP-managed cookies must NOT be removed during reset
+            expect(removeItemSpy).not.toHaveBeenCalledWith('session-');
+            expect(removeItemSpy).not.toHaveBeenCalledWith('timezone');
 
             // Verify technically required cookies are set (excluding PHP-managed ones and hash)
             expect(setItemSpy).toHaveBeenCalledWith('csrf-token', 'xyz789', 30); // Required but not PHP-managed

--- a/src/Storefront/Resources/app/storefront/test/plugin/cookie/cookie-permission.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cookie/cookie-permission.plugin.test.js
@@ -314,7 +314,7 @@ describe("Cookie reCAPTCHA Integration tests", () => {
 
                 <div class="form-group">
                     <label for="grecaptcha-v3">reCAPTCHA v3</label>
-                    <input type="hidden" name="_grecaptcha_v3" id="grecaptcha-v3" data-validation="grecaptcha,required" aria-describedby="grecaptcha-v3-feedback">
+                    <input type="hidden" name="_grecaptcha_v3" id="grecaptcha-v3" data-validation="grecaptcha" aria-describedby="grecaptcha-v3-feedback">
                     <div id="grecaptcha-v3-feedback" class="form-field-feedback"></div>
                 </div>
 
@@ -368,11 +368,11 @@ describe("Cookie reCAPTCHA Integration tests", () => {
 		// Get the grecaptcha field
 		const grecaptchaField = document.getElementById("grecaptcha-v3");
 
-		// Validate the field - this should fail and trigger the event
+		// Validate the field - this should fail grecaptcha validation
 		const validationResult = formValidation.validateField(grecaptchaField);
 
-		// Assertions - field should fail both grecaptcha and required validations
-		expect(validationResult).toEqual(["grecaptcha", "required"]);
+		// Assertions - field should fail grecaptcha validation
+		expect(validationResult).toEqual(["grecaptcha"]);
 		expect(showCookieBarSpy).toHaveBeenCalled(); // Cookie bar should be shown
 		expect(setBodyPaddingSpy).toHaveBeenCalled(); // Body padding should be set
 		expect(cookiePermissionPlugin.$emitter.publish).toHaveBeenCalledWith(
@@ -394,9 +394,8 @@ describe("Cookie reCAPTCHA Integration tests", () => {
 			"_showCookieBar",
 		);
 
-		// Get the grecaptcha field and set a value to pass required validation
+		// Get the grecaptcha field
 		const grecaptchaField = document.getElementById("grecaptcha-v3");
-		grecaptchaField.value = "test-token"; // Set a value to pass required validation
 
 		// Validate the field - this should pass
 		const validationResult = formValidation.validateField(grecaptchaField);
@@ -506,17 +505,17 @@ describe("Cookie reCAPTCHA Integration tests", () => {
 		);
 	});
 
-	test("integration: shows cookie bar when cookie-preference is set but _GRECAPTCHA cookie is missing", () => {
-		// This simulates the edge case where cookie-preference was set to 1
-		// but the cookie permission plugin wasn't properly initialized,
-		// so _GRECAPTCHA cookie is missing
+	test("integration: shows cookie bar when _GRECAPTCHA cookie is missing after language switch reset", () => {
+		// After _resetCookieConfiguration, both cookie-preference and _GRECAPTCHA
+		// are removed. The validator checks _GRECAPTCHA and correctly shows the
+		// cookie consent message.
 		CookieStorage.getItem.mockImplementation((cookieName) => {
-			if (cookieName === "cookie-preference") return "1"; // Cookie bar preference is set
-			if (cookieName === "_GRECAPTCHA") return null; // But reCAPTCHA cookies are missing
+			if (cookieName === "cookie-preference") return null;
+			if (cookieName === "_GRECAPTCHA") return null;
 			return null;
 		});
 
-		// Create a new plugin instance that respects the cookie-preference
+		// Create a new plugin instance
 		const testCookieBarElement = document.createElement("div");
 		testCookieBarElement.classList.add("cookie-permission-container");
 		testCookieBarElement.style.display = "none";
@@ -539,9 +538,9 @@ describe("Cookie reCAPTCHA Integration tests", () => {
 		// Validate the field - this should fail and trigger the event to show cookie bar
 		const validationResult = formValidation.validateField(grecaptchaField);
 
-		// Assertions - field should fail both grecaptcha and required validations
-		expect(validationResult).toEqual(["grecaptcha", "required"]);
-		expect(showCookieBarSpy).toHaveBeenCalled(); // Cookie bar should be shown despite cookie-preference being set
+		// Assertions - field should fail grecaptcha validation
+		expect(validationResult).toEqual(["grecaptcha"]);
+		expect(showCookieBarSpy).toHaveBeenCalled();
 		expect(testCookiePlugin.$emitter.publish).toHaveBeenCalledWith("showCookieBar");
 	});
 });

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -13,7 +13,7 @@
             type="hidden"
             class="grecaptcha-v2-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV2::CAPTCHA_REQUEST_PARAMETER') }}"
-            data-validation="grecaptcha,required"
+            data-validation="grecaptcha"
             data-validate-hidden="true"
             aria-describedby="{{ feedbackId }}">
 

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -12,7 +12,7 @@
             type="hidden"
             class="grecaptcha_v3-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV3::CAPTCHA_REQUEST_PARAMETER') }}"
-            data-validation="grecaptcha,required"
+            data-validation="grecaptcha"
             data-validate-hidden="true"
             aria-describedby="{{ feedbackId }}">
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When reCAPTCHA v3 is configured, "Input should not be empty." is incorrectly shown on the registration page in two scenarios: (1) after switching languages in a multi-language storefront without re-accepting cookies, and (2) as a brief flash when submitting the form with all details filled in.

### 2. What does this change do, exactly?

**Fix 1 - Wrong error after language switch:** When cookie configuration resets for a new language, `_resetCookieConfiguration` removed `cookie-preference` but kept `_GRECAPTCHA` (a required cookie). This left them out of sync: the `grecaptcha` validator saw `_GRECAPTCHA=1` and passed, so only the `required` validator failed with "Input should not be empty." The fix extends `_resetCookieConfiguration` to remove all JS-set consent cookies during reset, while preserving PHP-managed cookies (session, timezone) and `cookie-config-hash`. This ensures `_GRECAPTCHA` is cleared and the `grecaptcha` validator correctly shows the cookie consent message.

**Fix 2 - Flashing error on submit:** The captcha hidden input had `data-validation="grecaptcha,required"`. On form submit, the `FormHandler` plugin validates synchronously before the reCAPTCHA plugin obtains the token asynchronously. The `required` validator briefly failed on the empty token field. Removing `required` from the validation rules eliminates the flash. Server-side validation still checks token presence.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a shop with reCAPTCHA v3 configured globally
2. Add a second language to the sales channel

For issue 1 (wrong error message):
3. Accept cookies in the first language
4. Switch to the second language (cookie configuration resets for re-consent)
5. Try to register an account without re-accepting cookies
6. Observe "Input should not be empty." instead of the cookie acceptance prompt

For issue 2 (flashing error):
3. Accept cookies, navigate to registration
4. Fill in all details and click submit
5. Observe "Input should not be empty." flashing briefly before the form submits

### 4. Please link to the relevant issues (if any).

closes #15187

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them