### PR TITLE
fix(language-widget): update language display in offcanvas

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
@@ -24,10 +24,12 @@
                                     aria-expanded="false"
                                     aria-label="{{ 'header.languageTrigger'|trans({ '%lang%': context.languageInfo.name })|striptags }}">
                                 {% block layout_header_actions_language_widget_content_inner %}
-                                    {% if not feature('v6.8.0.0') %}
+                                    {% if feature('v6.8.0.0') %}
+                                        <span class="top-bar-nav-text">{{ context.languageInfo.name }}</span>
+                                    {% else %}
                                         <span aria-hidden="true" class="top-bar-list-icon language-flag country-{{ country }} language-{{ language }}"></span>
+                                        <span class="top-bar-nav-text d-none d-md-inline">{{ context.languageInfo.name }}</span>
                                     {% endif %}
-                                    <span class="top-bar-nav-text d-none d-md-inline">{{ context.languageInfo.name }}</span>
                                 {% endblock %}
                             </button>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
With the v6.8.0.0 feature flag active, the language flag icon is removed but the language name remains hidden on mobile via `d-none d-md-inline`, resulting in an empty button in the offcanvas navigation.

### 2. What does this change do, exactly?
When v6.8.0.0 is active, the language name in the trigger button is rendered without responsive hiding classes, ensuring it is always visible. This aligns with the currency widget behavior.

### 3. Describe each step to reproduce the issue or behaviour.
1. Activate feature flag `V6_8_0_0=1`
2. Open the storefront on a smartphone viewport
3. Open the offcanvas navigation menu
4. Observe the language switcher button is now showing the language name

### 4. Please link to the relevant issues (if any).
closes #15112

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them