### PR TITLE
fix: linked price fields not updating on save

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -2,7 +2,6 @@ import template from './sw-price-field.html.twig';
 import './sw-price-field.scss';
 
 const { Application } = Shopware;
-const { debounce } = Shopware.Utils;
 
 /**
  * @sw-package framework
@@ -279,18 +278,6 @@ export default {
             this.$emit('change', this.priceForCurrency);
         },
 
-        onEndsWithDecimalSeparator(value) {
-            if (value) {
-                // cancel might not be a function if debounce is not active
-                if (this.onPriceGrossChangeDebounce.cancel) {
-                    this.onPriceGrossChangeDebounce.cancel();
-                }
-                if (this.onPriceNetChangeDebounce.cancel) {
-                    this.onPriceNetChangeDebounce.cancel();
-                }
-            }
-        },
-
         onPriceGrossInputChange(value) {
             this.priceForCurrency.gross = value;
 
@@ -298,7 +285,7 @@ export default {
             this.$emit('change', this.priceForCurrency);
 
             if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceGrossChangeDebounce();
+                this.onPriceGrossChange(value);
             }
         },
 
@@ -309,7 +296,7 @@ export default {
             this.$emit('change', this.priceForCurrency);
 
             if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceNetChangeDebounce();
+                this.onPriceNetChange(value);
             }
         },
 
@@ -416,13 +403,5 @@ export default {
         onCloseModal() {
             this.showModal = false;
         },
-
-        onPriceGrossChangeDebounce: debounce(function onPriceGrossChange() {
-            this.onPriceGrossChange(this.priceForCurrency.gross);
-        }, 300),
-
-        onPriceNetChangeDebounce: debounce(function onPriceNetChange() {
-            this.onPriceNetChange(this.priceForCurrency.net);
-        }, 300),
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -284,9 +284,7 @@ export default {
             this.$emit('price-gross-change', value);
             this.$emit('change', this.priceForCurrency);
 
-            if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceGrossChange(value);
-            }
+            this.onPriceGrossChange(value);
         },
 
         onPriceNetInputChange(value) {
@@ -295,21 +293,31 @@ export default {
             this.$emit('price-net-change', value);
             this.$emit('change', this.priceForCurrency);
 
-            if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceNetChange(value);
-            }
+            this.onPriceNetChange(value);
         },
 
         onPriceGrossChange(value) {
-            if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.convertGrossToNet(value);
+            if (!this.priceForCurrency.linked) {
+                return;
             }
+
+            if (value === null || value === undefined || value === '' || value.toString().endsWith('.')) {
+                return;
+            }
+
+            this.convertGrossToNet(value);
         },
 
         onPriceNetChange(value) {
-            if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.convertNetToGross(value);
+            if (!this.priceForCurrency.linked) {
+                return;
             }
+
+            if (value === null || value === undefined || value === '' || value.toString().endsWith('.')) {
+                return;
+            }
+
+            this.convertNetToGross(value);
         },
 
         convertNetToGross(value) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
@@ -29,7 +29,6 @@
             v-bind="attributesWithoutListeners"
             @update:model-value="onPriceGrossInputChange"
             @keyup="keymonitor"
-            @ends-with-decimal-separator="onEndsWithDecimalSeparator"
         >
             <template
                 v-if="!disableSuffix && !compact"
@@ -82,7 +81,6 @@
             v-bind="attributesWithoutListeners"
             @update:model-value="onPriceNetInputChange"
             @keyup="keymonitor"
-            @ends-with-decimal-separator="onEndsWithDecimalSeparator"
         >
             <template
                 v-if="!disableSuffix && !compact"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
@@ -99,12 +99,6 @@ describe('components/form/sw-price-field', () => {
                 },
             };
         };
-
-        jest.useFakeTimers();
-    });
-
-    afterEach(() => {
-        jest.useRealTimers();
     });
 
     it('should contain the dollar price', async () => {
@@ -228,7 +222,6 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceNetInputChange(euroPrice.net);
-        jest.runAllTimers();
 
         expect(convertNetToGross).toHaveBeenCalled();
     });
@@ -242,7 +235,6 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceGrossInputChange(euroPrice.gross);
-        jest.runAllTimers();
 
         expect(convertGrossToNet).toHaveBeenCalled();
     });
@@ -255,7 +247,6 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceGrossInputChange(euroPrice.gross);
-        jest.runAllTimers();
 
         expect(wrapper.emitted('update:value')).toBeFalsy();
     });
@@ -268,12 +259,11 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceNetInputChange(euroPrice.net);
-        jest.runAllTimers();
 
         expect(wrapper.emitted('update:value')).toBeFalsy();
     });
 
-    it('should have the typed gross value after input change and after debounce time', async () => {
+    it('should have the typed gross value after input change', async () => {
         const wrapper = await setup({ allowEmpty: true });
         await wrapper.setProps({
             value: [euroPrice],
@@ -281,12 +271,11 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceGrossInputChange(euroPrice.gross);
-        jest.runAllTimers();
 
         expect(wrapper.vm.priceForCurrency.gross).toBe(euroPrice.gross);
     });
 
-    it('should have the typed net value after input change and after debounce time', async () => {
+    it('should have the typed net value after input change', async () => {
         const wrapper = await setup({ allowEmpty: true });
         await wrapper.setProps({
             value: [euroPrice],
@@ -294,31 +283,7 @@ describe('components/form/sw-price-field', () => {
         });
 
         wrapper.vm.onPriceNetInputChange(euroPrice.net);
-        jest.runAllTimers();
 
         expect(wrapper.vm.priceForCurrency.net).toBe(euroPrice.net);
-    });
-
-    it('should cancel the debounce timer when the number field emits "ends-with-decimal-separator" event', async () => {
-        const wrapper = await setup();
-
-        // Type a normal number
-        await wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').setValue('123');
-
-        // Wait for the debounce timer to start
-        await wrapper.vm.$nextTick();
-
-        // Type a number with a decimal separator at the end
-        await wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').setValue('123.');
-
-        // Wait until the debounce timer is finished
-        jest.runAllTimers();
-        await flushPromises();
-
-        // Check if the value is set
-        expect(wrapper.vm.priceForCurrency.gross).toBe(123);
-
-        // Check if the input field value still contains the decimal separator
-        expect(wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').element.value).toBe('123.');
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

There was a 300ms debounce for input changes in the gross price in sw-price-field before the net price was recacalculated. The mt-number-field emits model value changes only on blur, so there is no debounce necessary anymore. 
When pressing the save button without clicking anywhere else before, the debounce triggered the updated after saving, which prevented the net price from updating.

### 2. What does this change do, exactly?

The debounce behavior has been removed to immidiatly update the price calculation on blur of the input field. The debounce is no longer needed, because the mt-number-input only updates its value on change (e.g. blur), not on every keypress.

### 3. Describe each step to reproduce the issue or behaviour.

See  https://github.com/shopware/shopware/issues/14144


### 4. Please link to the relevant issues (if any).

Closes  https://github.com/shopware/shopware/issues/14144
