### PR TITLE
fix: prevent maintenance mode heading style inconsistency (#15090)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -662,8 +662,10 @@
         {% endblock %}
 
         {% block sw_sales_channel_detail_base_options_maintenance_header %}
-        <h4 class="sw-sales-channel-detail-base__headline-text">
-            {{ $tc('sw-sales-channel.detail.maintenanceModeTitle') }}
+        <h4 class="sw-sales-channel-detail-base__headline">
+            <span class="sw-sales-channel-detail-base__headline-text">
+                {{ $tc('sw-sales-channel.detail.maintenanceModeTitle') }}
+            </span>
         </h4>
 
         <div class="sw-sales-channel-detail-base__description-text">

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.scss
@@ -39,7 +39,8 @@ $sw-sales-channel-detail-color-text-access-key: $color-darkgray-200;
     }
 
     .sw-sales-channel-detail-base__headline-text {
-        font-weight: bold;
+        font-weight: $font-weight-semi-bold;
+        font-size: $font-size-s;
     }
 
     .sw-sales-channel-detail-base__description-text {

--- a/tests/acceptance/tests/Visual/Administration/SalesChannels.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/SalesChannels.spec.ts
@@ -1,11 +1,7 @@
 import { test, assertScreenshot, setViewport, hideElements } from '@fixtures/AcceptanceTest';
 
-test.skip('Visual: Administration sales channels page', { 
-    tag: '@Visual', 
-    annotation: {
-        type: 'issue',
-        description: 'https://github.com/shopware/shopware/issues/15090',
-    }, 
+test('Visual: Administration sales channels page', {
+    tag: '@Visual',
 }, async ({
     ShopAdmin,
     AdminSalesChannelDetail,


### PR DESCRIPTION
### 1. Why is this change necessary?

The "Maintenance mode" heading in the Sales Channel detail page uses an `<h4>` element with a direct CSS class that applies `font-weight: bold`. Browser default heading styles interfere with this, causing the text styling to change inconsistently after a browser refresh. This also causes the visual acceptance test to fail.

### 2. What does this change do, exactly?

- Wraps the heading text in a `<span>` with the `__headline-text` class inside the `<h4>`, matching the existing pattern used by the Domains and Hreflang components in the same module
- Replaces `font-weight: bold` with the Shopware design token `$font-weight-semi-bold` and adds `font-size: $font-size-s` for explicit styling
- Unskips the visual acceptance test `SalesChannels.spec.ts`

### 3. Describe each step to reproduce the issue or behaviour.

1. Open any Sales Channel detail page in the Administration
2. Observe the "Maintenance mode" heading in the Status section
3. Refresh the browser
4. The heading text styling changes (font weight/size inconsistency)

### 4. Please link to the relevant issues (if any).

- closes #15090

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
