### PR TITLE
feat: Add event for the config info API route

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator;
 use Shopware\Core\Framework\Api\ApiException;
+use Shopware\Core\Framework\Api\Event\AdminInfoConfigEvent;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
 use Shopware\Core\Framework\Api\Route\RouteInfo;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
@@ -40,6 +41,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
 #[Package('framework')]
@@ -69,6 +71,7 @@ class InfoController extends AbstractController
         private readonly Filesystem $filesystem,
         private readonly ShopIdProvider $shopIdProvider,
         private readonly StatsService $messageStatsService,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -198,7 +201,7 @@ class InfoController extends AbstractController
             $adminWorker['enableQueueStatsWorker'] = $this->params->get('shopware.admin_worker.enable_queue_stats_worker');
         }
 
-        return new JsonResponse([
+        $config = [
             'version' => $this->getShopwareVersion(),
             'shopId' => $this->getShopId(),
             'appUrl' => (string) EnvironmentHelper::getVariable('APP_URL'),
@@ -216,7 +219,11 @@ class InfoController extends AbstractController
                 'disableExtensionManagement' => !$this->params->get('shopware.deployment.runtime_extension_management'),
             ],
             'inAppPurchases' => $this->inAppPurchase->all(),
-        ]);
+        ];
+
+        $config = $this->eventDispatcher->dispatch(new AdminInfoConfigEvent($config))->getConfig();
+
+        return new JsonResponse($config);
     }
 
     #[Route(path: '/api/_info/version', name: 'api.info.shopware.version', methods: ['GET'])]

--- a/src/Core/Framework/Api/Event/AdminInfoConfigEvent.php
+++ b/src/Core/Framework/Api/Event/AdminInfoConfigEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Api\Event;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class AdminInfoConfigEvent
+{
+    /**
+     * @internal Constructor for internal use only.
+     *
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        private array $config
+    ) {
+    }
+
+    public function addConfig(string $key, mixed $value): void
+    {
+        $this->config[$key] = $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+}

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -179,6 +179,7 @@
             <argument type="service" id="filesystem"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
             <argument type="service" id="Shopware\Core\Framework\MessageQueue\Stats\StatsService"/>
+            <argument type="service" id="event_dispatcher"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -46,6 +46,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -441,6 +442,7 @@ class InfoControllerTest extends TestCase
             new Filesystem(),
             static::getContainer()->get(ShopIdProvider::class),
             $this->createMock(StatsService::class),
+            new EventDispatcher(),
         );
 
         $infoController->setContainer($this->createMock(Container::class));
@@ -516,6 +518,7 @@ class InfoControllerTest extends TestCase
             new Filesystem(),
             static::getContainer()->get(ShopIdProvider::class),
             $this->createMock(StatsService::class),
+            new EventDispatcher(),
         );
 
         $infoController->setContainer($this->createMock(Container::class));

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -33,7 +33,7 @@ use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Asset\UrlPackage;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -52,8 +52,6 @@ class InfoControllerTest extends TestCase
 
     private StatsService&MockObject $statsService;
 
-    private Connection&MockObject $connectionMock;
-
     private MigrationInfo&MockObject $migrationInfo;
 
     private EventDispatcher $eventDispatcher;
@@ -63,6 +61,7 @@ class InfoControllerTest extends TestCase
         parent::setUp();
         $this->shopIdProvider = $this->createMock(ShopIdProvider::class);
         $this->statsService = $this->createMock(StatsService::class);
+        $this->migrationInfo = $this->createMock(MigrationInfo::class);
         $this->eventDispatcher = new EventDispatcher();
     }
 
@@ -74,7 +73,7 @@ class InfoControllerTest extends TestCase
 
         $this->shopIdProvider->expects($this->once())->method('getShopId')->willReturn('shop-id');
 
-        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
+        $content = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
@@ -155,7 +154,7 @@ class InfoControllerTest extends TestCase
             ->method('getShopId')
             ->willThrowException(new ShopIdChangeSuggestedException(ShopId::v2('current-shop-id'), new FingerprintComparisonResult([], [], 75)));
 
-        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
+        $content = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
@@ -169,7 +168,7 @@ class InfoControllerTest extends TestCase
             $event->addConfig('foo', 'bar');
         });
 
-        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
+        $content = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
@@ -186,7 +185,7 @@ class InfoControllerTest extends TestCase
                 new MessageStatsEntity(1, new \DateTime(), 1.00, new MessageTypeStatsCollection())
             )
         );
-        $content = $this->createInstance()->messageStats()->getContent();
+        $content = $this->createController()->messageStats()->getContent();
         static::assertIsString($content);
 
         $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
@@ -200,15 +199,13 @@ class InfoControllerTest extends TestCase
 
     public function testConfigReturnsNullFirstMigrationDateWhenMigrationInfoReturnsNull(): void
     {
-        $this->createInstance();
-
         $this->migrationInfo->method('getFirstMigrationDate')->willReturn(null);
 
-        $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
+        $response = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'));
         $content = $response->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('settings', $data);
         static::assertArrayHasKey('firstMigrationDate', $data['settings']);
@@ -217,15 +214,13 @@ class InfoControllerTest extends TestCase
 
     public function testConfigReturnsNullFirstMigrationDateWhenMigrationInfoReturnsNullAgain(): void
     {
-        $this->createInstance();
-
         $this->migrationInfo->method('getFirstMigrationDate')->willReturn(null);
 
-        $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
+        $response = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'));
         $content = $response->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('settings', $data);
         static::assertArrayHasKey('firstMigrationDate', $data['settings']);
@@ -234,63 +229,60 @@ class InfoControllerTest extends TestCase
 
     public function testConfigReturnsFirstMigrationDateFromMigrationInfo(): void
     {
-        $this->createInstance();
-
         $this->migrationInfo->method('getFirstMigrationDate')->willReturn('2020-01-01T00:00:00.123+00:00');
 
-        $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
+        $response = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'));
         $content = $response->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
 
         static::assertArrayHasKey('settings', $data);
         static::assertArrayHasKey('firstMigrationDate', $data['settings']);
         static::assertSame('2020-01-01T00:00:00.123+00:00', $data['settings']['firstMigrationDate']);
     }
 
-    private function createInstance(): InfoController
+    private function createController(): InfoController
     {
+        $parameterBag = new ParameterBag([
+            'shopware.html_sanitizer.enabled' => true,
+            'shopware.filesystem.private_allowed_extensions' => false,
+            'shopware.admin_worker.transports' => ['slow'],
+            'shopware.admin_worker.enable_notification_worker' => true,
+            'shopware.admin_worker.enable_queue_stats_worker' => true,
+            'shopware.admin_worker.enable_admin_worker' => true,
+            'kernel.shopware_version' => '6.6.9999999-dev',
+            'kernel.shopware_version_revision' => 'PHPUnit',
+            'shopware.media.enable_url_upload_feature' => true,
+            'shopware.staging.administration.show_banner' => false,
+            'shopware.deployment.runtime_extension_management' => true,
+        ]);
+
         $kernel = new StubKernel([
             new AdminExtensionApiPluginWithLocalEntryPoint(true, __DIR__ . '/Fixtures/AdminExtensionApiPluginWithLocalEntryPoint'),
         ]);
 
-        $this->parameterBagMock = $this->createMock(ParameterBagInterface::class);
-        $this->routerMock = $this->createMock(RouterInterface::class);
-        $this->inAppPurchase = StaticInAppPurchaseFactory::createWithFeatures(['SwagApp' => ['SwagApp_premium']]);
-        $this->shopIdProvider = $this->createMock(ShopIdProvider::class);
-        $this->connectionMock = $this->createMock(Connection::class);
-        $this->migrationInfo = $this->createMock(MigrationInfo::class);
-
-        $parameterBagMock->method('get')
-            ->willReturnMap([
-                ['shopware.html_sanitizer.enabled', true],
-                ['shopware.filesystem.private_allowed_extensions', false],
-                ['shopware.admin_worker.transports', ['slow']],
-                ['shopware.admin_worker.enable_notification_worker', true],
-                ['shopware.admin_worker.enable_queue_stats_worker', true],
-                ['shopware.admin_worker.enable_admin_worker', true],
-                ['kernel.shopware_version', '6.6.9999999-dev'],
-                ['kernel.shopware_version_revision', 'PHPUnit'],
-                ['shopware.media.enable_url_upload_feature', true],
-            ]);
-
+        $routerMock = $this->createMock(RouterInterface::class);
         $routerMock->method('generate')
-            ->with(
-                'administration.plugin.index',
-                [
-                    'pluginName' => 'adminextensionapipluginwithlocalentrypoint',
-                ]
-            )
+            ->with('administration.plugin.index', [
+                'pluginName' => 'adminextensionapipluginwithlocalentrypoint',
+            ])
             ->willReturn('/admin/adminextensionapipluginwithlocalentrypoint/index.html');
+
+        $viteAccessor = new ViteFileAccessorDecorator(
+            [],
+            $this->createMock(UrlPackage::class),
+            $kernel,
+            new Filesystem(),
+        );
 
         return new InfoController(
             $this->createMock(DefinitionService::class),
-            $parameterBagMock,
+            $parameterBag,
             $kernel,
             $this->createMock(BusinessEventCollector::class),
             $this->createMock(IncrementGatewayRegistry::class),
-            $this->connectionMock,
+            $this->createMock(Connection::class),
             $this->migrationInfo,
             $this->createMock(AppUrlVerifier::class),
             $routerMock,
@@ -298,12 +290,7 @@ class InfoControllerTest extends TestCase
             new StaticSystemConfigService(),
             $this->createMock(ApiRouteInfoResolver::class),
             StaticInAppPurchaseFactory::createWithFeatures(['SwagApp' => ['SwagApp_premium']]),
-            new ViteFileAccessorDecorator(
-                [],
-                $this->createMock(UrlPackage::class),
-                $kernel,
-                new Filesystem(),
-            ),
+            $viteAccessor,
             new Filesystem(),
             $this->shopIdProvider,
             $this->statsService,

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -10,6 +10,7 @@ use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Content\Flow\Api\FlowActionCollector;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\Controller\InfoController;
+use Shopware\Core\Framework\Api\Event\AdminInfoConfigEvent;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
@@ -26,7 +27,6 @@ use Shopware\Core\Framework\MessageQueue\Stats\Entity\MessageTypeStatsCollection
 use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\Migration\MigrationInfo;
 use Shopware\Core\Framework\Plugin;
-use Shopware\Core\Framework\Store\InAppPurchase;
 use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
@@ -34,6 +34,7 @@ use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -47,14 +48,6 @@ class InfoControllerTest extends TestCase
 {
     use EnvTestBehaviour;
 
-    private InfoController $infoController;
-
-    private ParameterBagInterface&MockObject $parameterBagMock;
-
-    private RouterInterface&MockObject $routerMock;
-
-    private InAppPurchase $inAppPurchase;
-
     private ShopIdProvider&MockObject $shopIdProvider;
 
     private StatsService&MockObject $statsService;
@@ -63,10 +56,14 @@ class InfoControllerTest extends TestCase
 
     private MigrationInfo&MockObject $migrationInfo;
 
+    private EventDispatcher $eventDispatcher;
+
     protected function setUp(): void
     {
         parent::setUp();
+        $this->shopIdProvider = $this->createMock(ShopIdProvider::class);
         $this->statsService = $this->createMock(StatsService::class);
+        $this->eventDispatcher = new EventDispatcher();
     }
 
     public function testConfig(): void
@@ -75,15 +72,12 @@ class InfoControllerTest extends TestCase
             'APP_URL' => 'https://app.url',
         ]);
 
-        $this->createInstance();
-
         $this->shopIdProvider->expects($this->once())->method('getShopId')->willReturn('shop-id');
 
-        $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
-        $content = $response->getContent();
+        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
         static::assertIsArray($data);
         static::assertArrayHasKey('version', $data);
         static::assertSame('6.6.9999999-dev', $data['version']);
@@ -156,21 +150,32 @@ class InfoControllerTest extends TestCase
 
     public function testReturnsCurrentShopIdIfShopIdFingerprintsHaveChanged(): void
     {
-        $this->createInstance();
-
         $this->shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
             ->willThrowException(new ShopIdChangeSuggestedException(ShopId::v2('current-shop-id'), new FingerprintComparisonResult([], [], 75)));
 
-        $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
-
-        $content = $response->getContent();
+        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
         static::assertArrayHasKey('shopId', $data);
         static::assertSame('current-shop-id', $data['shopId']);
+    }
+
+    public function testConfigExtension(): void
+    {
+        $this->eventDispatcher->addListener(AdminInfoConfigEvent::class, function (AdminInfoConfigEvent $event): void {
+            $event->addConfig('foo', 'bar');
+        });
+
+        $content = $this->createInstance()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
+        static::assertIsString($content);
+
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($data);
+        static::assertArrayHasKey('foo', $data);
+        static::assertSame('bar', $data['foo']);
     }
 
     public function testMessageStatsPreservesFloatingPointPrecision(): void
@@ -181,13 +186,10 @@ class InfoControllerTest extends TestCase
                 new MessageStatsEntity(1, new \DateTime(), 1.00, new MessageTypeStatsCollection())
             )
         );
-        $this->createInstance();
-
-        $response = $this->infoController->messageStats();
-        $content = $response->getContent();
+        $content = $this->createInstance()->messageStats()->getContent();
         static::assertIsString($content);
 
-        $data = json_decode($content, true);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
         static::assertIsArray($data);
         static::assertArrayHasKey('stats', $data);
         static::assertArrayHasKey('averageTimeInQueue', $data['stats']);
@@ -247,7 +249,7 @@ class InfoControllerTest extends TestCase
         static::assertSame('2020-01-01T00:00:00.123+00:00', $data['settings']['firstMigrationDate']);
     }
 
-    private function createInstance(): void
+    private function createInstance(): InfoController
     {
         $kernel = new StubKernel([
             new AdminExtensionApiPluginWithLocalEntryPoint(true, __DIR__ . '/Fixtures/AdminExtensionApiPluginWithLocalEntryPoint'),
@@ -260,7 +262,7 @@ class InfoControllerTest extends TestCase
         $this->connectionMock = $this->createMock(Connection::class);
         $this->migrationInfo = $this->createMock(MigrationInfo::class);
 
-        $this->parameterBagMock->method('get')
+        $parameterBagMock->method('get')
             ->willReturnMap([
                 ['shopware.html_sanitizer.enabled', true],
                 ['shopware.filesystem.private_allowed_extensions', false],
@@ -273,7 +275,7 @@ class InfoControllerTest extends TestCase
                 ['shopware.media.enable_url_upload_feature', true],
             ]);
 
-        $this->routerMock->method('generate')
+        $routerMock->method('generate')
             ->with(
                 'administration.plugin.index',
                 [
@@ -282,20 +284,20 @@ class InfoControllerTest extends TestCase
             )
             ->willReturn('/admin/adminextensionapipluginwithlocalentrypoint/index.html');
 
-        $this->infoController = new InfoController(
+        return new InfoController(
             $this->createMock(DefinitionService::class),
-            $this->parameterBagMock,
+            $parameterBagMock,
             $kernel,
             $this->createMock(BusinessEventCollector::class),
             $this->createMock(IncrementGatewayRegistry::class),
             $this->connectionMock,
             $this->migrationInfo,
             $this->createMock(AppUrlVerifier::class),
-            $this->routerMock,
+            $routerMock,
             $this->createMock(FlowActionCollector::class),
             new StaticSystemConfigService(),
             $this->createMock(ApiRouteInfoResolver::class),
-            $this->inAppPurchase,
+            StaticInAppPurchaseFactory::createWithFeatures(['SwagApp' => ['SwagApp_premium']]),
             new ViteFileAccessorDecorator(
                 [],
                 $this->createMock(UrlPackage::class),
@@ -305,6 +307,7 @@ class InfoControllerTest extends TestCase
             new Filesystem(),
             $this->shopIdProvider,
             $this->statsService,
+            $this->eventDispatcher,
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently plugins are subscribing to the Symfony response event, decode the JSON, add another key-value pair and put the JSON back on the reponse in order to add custom information to the `/api/_info/config` API route.

### 2. What does this change do, exactly?

Add an event to make it easier for extensions to add additional information to this API route. 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
