### PR TITLE
fix: Fix issue ES working wrong with NotEquals filter in nested fields

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -567,11 +567,21 @@ class CriteriaParser
                 foreach ($context->getLanguageIdChain() as $languageId) {
                     $query->add(new ExistsQuery($this->getTranslatedFieldName($fieldName, $languageId)), BoolQuery::MUST_NOT);
                 }
-            } else {
-                $query->add(new ExistsQuery($fieldName), BoolQuery::MUST_NOT);
+
+                return $this->createNestedQuery($query, $definition, $filter->getField());
             }
 
-            return $this->createNestedQuery($query, $definition, $filter->getField());
+            $path = $this->getNestedPath($definition, $filter->getField());
+
+            if ($path) {
+                $query->add(new NestedQuery($path, new ExistsQuery($fieldName)), BoolQuery::MUST_NOT);
+
+                return $query;
+            }
+
+            $query->add(new ExistsQuery($fieldName), BoolQuery::MUST_NOT);
+
+            return $query;
         }
 
         $value = $this->parseValue($definition, $filter, $filter->getValue());

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -1295,6 +1295,24 @@ EOT,
                 ],
             ],
         ];
+
+        yield 'EqualsFilter null on nested association field' => [
+            new EqualsFilter('unit.id', null),
+            [
+                'bool' => [
+                    'must_not' => [
+                        [
+                            'nested' => [
+                                'path' => 'unit',
+                                'query' => [
+                                    'exists' => ['field' => 'unit.id'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function getDefinition(string $entityName = 'product'): EntityDefinition


### PR DESCRIPTION
This pull request updates the handling of `EqualsFilter` queries for `null` values on nested association fields in the Elasticsearch criteria parser. It ensures that when filtering for `null` on a nested field, the generated query properly uses a nested query structure, and adds a corresponding unit test to validate this behavior.

**Improvements to Elasticsearch query generation:**
* Updated `CriteriaParser.php` to generate a `NestedQuery` with an `ExistsQuery` for `EqualsFilter` with `null` on nested association fields, ensuring correct Elasticsearch query semantics.

Root Cause: When filtering field.id = null on a nested field, the old code wraps must_not inside the nested query:

  { "nested": { "path": "media", "query": { "bool": { "must_not": [{ "exists": { "field": "media.id" } }] } } } }

  This only evaluates against existing nested objects. If the media array is [], there's nothing to evaluate against, so no documents match. This same bug affects ALL nested fields (tags, categories, etc.).
  Fix: Move must_not outside the nested query, which is the correct ES semantics:

  { "bool": { "must_not": [{ "nested": { "path": "media", "query": { "exists": { "field": "media.id" } } } }] } }

  This correctly means "find documents where NO nested media object exists with an id" — which matches both empty arrays and arrays of objects without id.