### PR TITLE
feat: grid spacing system

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -9,9 +9,6 @@
     rowsMd = null,
     rowsLg = null,
     rowsXl = null,
-
-    columnsConfig = null,
-
     gap = 3,
     rowGap = null,
     columnGap = null,
@@ -55,7 +52,7 @@
     <twig:Sw:Grid:Container :padding="{ xs: 0, sm: 2, md: 3, lg: 5, xl: 2, xxl: 1 }" />
     Generates: "p-0 p-sm-2 p-md-3 p-lg-5 p-xl-2 p-xxl-1"
 #}
-{%- macro spacingClasses(prop, classPrefix, specialKeyword = null) %}
+{%- macro gridClasses(prop, classPrefix, specialKeyword = null) %}
     {%- set classes = [] -%}
     {# Prop contains a special keyword, use it to generate a class. #}
     {%- if specialKeyword is not null and specialKeyword is same as prop %}
@@ -80,9 +77,27 @@
     {{- classes|length > 0 ? classes|join(' ') : '' -}}
 {% endmacro -%}
 
-{%- macro spacingInlineStyle(prop, cssProp) %}
+{#
+    Helper macro to generate grid inline CSS for arbitrary values.
+    * prop: Component prop value to generate styles for (padding, margin, gap, etc.)
+    * cssProp: CSS property that will be generated (padding, margin, gap, etc.)
+
+    1. Simple:
+    <twig:Sw:Grid:Container padding="20px" />
+    Generates: "padding: 20px;"
+
+    2. With breakpoints:
+    <twig:Sw:Grid:Container :padding="{ xs: '5px', sm: '10px', md: '15px', lg: '20px', xl: '25px', xxl: '30px' }" />
+    Generates: 
+    @media (min-width: 576px) { padding: 10px; } 
+    @media (min-width: 768px) { padding: 15px; } 
+    @media (min-width: 992px) { padding: 20px; } 
+    @media (min-width: 1200px) { padding: 25px; } 
+    @media (min-width: 1400px) { padding: 30px; }
+#}
+{%- macro gridInlineStyle(prop, cssProp) %}
     {%- set style = '' -%}
-    {%- if prop is not null and prop is string and prop is not iterable %}
+    {%- if prop is not null and prop is not empty and prop is string and prop is not iterable %}
         {%- set style = style ~ "#{cssProp}: #{prop};" -%}
     {% elseif prop is not null and prop is iterable %}
         {%- for breakpoint, value in prop %}
@@ -96,7 +111,7 @@
             {% endif -%}
         {% endfor -%}
     {% endif -%}
-    {# Return value #}
+    {# Output the CSS as string #}
     {{- style -}}
 {% endmacro -%}
 
@@ -298,24 +313,24 @@
     }
 }) %}
 
-{%- set spacingClasses = [
-    _self.spacingClasses(padding, 'p'), 
-    _self.spacingClasses(paddingBottom, 'pb'),
-    _self.spacingClasses(paddingTop, 'pt'),
-    _self.spacingClasses(paddingRight, 'pe'),
-    _self.spacingClasses(paddingLeft, 'ps'),
-    _self.spacingClasses(paddingX, 'px'),
-    _self.spacingClasses(paddingY, 'py'),
-    _self.spacingClasses(marginBottom, 'mb'),
-    _self.spacingClasses(marginTop, 'mt'),
-    _self.spacingClasses(marginRight, 'me'),
-    _self.spacingClasses(marginLeft, 'ms'),
-    _self.spacingClasses(margin, 'm'),
-    _self.spacingClasses(marginX, 'mx'),
-    _self.spacingClasses(marginY, 'my'),
-    _self.spacingClasses(gap, 'gap'),
-    _self.spacingClasses(rowGap, 'row-gap'),
-    _self.spacingClasses(columnGap, 'column-gap'),
+{%- set gridClasses = [
+    _self.gridClasses(padding, 'p'), 
+    _self.gridClasses(paddingBottom, 'pb'),
+    _self.gridClasses(paddingTop, 'pt'),
+    _self.gridClasses(paddingRight, 'pe'),
+    _self.gridClasses(paddingLeft, 'ps'),
+    _self.gridClasses(paddingX, 'px'),
+    _self.gridClasses(paddingY, 'py'),
+    _self.gridClasses(marginBottom, 'mb'),
+    _self.gridClasses(marginTop, 'mt'),
+    _self.gridClasses(marginRight, 'me'),
+    _self.gridClasses(marginLeft, 'ms'),
+    _self.gridClasses(margin, 'm'),
+    _self.gridClasses(marginX, 'mx'),
+    _self.gridClasses(marginY, 'my'),
+    _self.gridClasses(gap, 'gap'),
+    _self.gridClasses(rowGap, 'row-gap'),
+    _self.gridClasses(columnGap, 'column-gap'),
 ]|join(' ')|trim -%}
 
 {% set gridId = 'sw-grid-container-' ~ random() %}
@@ -341,7 +356,7 @@
         border,
         borderVariant,
         borderSubtle,
-    }) ~ ' ' ~ spacingClasses,
+    }) ~ ' ' ~ gridClasses,
 } %}
 
 {% set gridStyle = '' %}
@@ -360,39 +375,44 @@
     {% set rowSetting = rows %}
 {% endif %}
 
-{% set gridStyle = columnSetting ? gridStyle ~ 'grid-template-columns: ' ~ columnSetting|trim ~ '; ' : gridStyle %}
-{% set gridStyle = rowSetting ? gridStyle ~ 'grid-template-rows: ' ~ rowSetting|trim ~ '; ' : gridStyle %}
-
 <div {{ attributes.defaults(attributeDefaults) }}>
 
-     {% block content %}
-        {% for name, slot in slots %}
-            <twig:Slot :name="name"></twig:Slot>
-        {% endfor %}
-     {% endblock %}
+    {% block content %}
+       {% for name, slot in slots %}
+           <twig:Slot :name="name"></twig:Slot>
+       {% endfor %}
+    {% endblock %}
 
-    <style>
-    {{ "##{gridId} {" }}
-        {{- _self.spacingInlineStyle(margin, 'margin') -}}
-        {{- _self.spacingInlineStyle(marginX, 'margin-left') -}}
-        {{- _self.spacingInlineStyle(marginX, 'margin-right') -}}
-        {{- _self.spacingInlineStyle(marginBottom, 'margin-bottom') -}}
-        {{- _self.spacingInlineStyle(marginTop, 'margin-top') -}}
-        {{- _self.spacingInlineStyle(marginLeft, 'margin-left') -}}
-        {{- _self.spacingInlineStyle(marginRight, 'margin-right') -}}
-        {{- _self.spacingInlineStyle(padding, 'padding') -}}
-        {{- _self.spacingInlineStyle(paddingX, 'padding-left') -}}
-        {{- _self.spacingInlineStyle(paddingX, 'padding-right') -}}
-        {{- _self.spacingInlineStyle(paddingY, 'padding-top') -}}
-        {{- _self.spacingInlineStyle(paddingY, 'padding-bottom') -}}
-        {{- _self.spacingInlineStyle(paddingTop, 'padding-top') -}}
-        {{- _self.spacingInlineStyle(paddingBottom, 'padding-bottom') -}}
-        {{- _self.spacingInlineStyle(paddingLeft, 'padding-left') -}}
-        {{- _self.spacingInlineStyle(paddingRight, 'padding-right') -}}
-        {{- _self.spacingInlineStyle(gap, 'gap') -}}
-        {{- _self.spacingInlineStyle(rowGap, 'row-gap') -}}
-        {{- _self.spacingInlineStyle(columnGap, 'column-gap') -}}
-        {% if gridStyle %}{{ gridStyle|trim }}{% endif %}
-    {{ '}' }}
-    </style>
+    {%- set inlineCSS %}
+        {{- _self.gridInlineStyle(margin, 'margin') -}}
+        {{- _self.gridInlineStyle(marginX, 'margin-left') -}}
+        {{- _self.gridInlineStyle(marginX, 'margin-right') -}}
+        {{- _self.gridInlineStyle(marginBottom, 'margin-bottom') -}}
+        {{- _self.gridInlineStyle(marginTop, 'margin-top') -}}
+        {{- _self.gridInlineStyle(marginLeft, 'margin-left') -}}
+        {{- _self.gridInlineStyle(marginRight, 'margin-right') -}}
+        {{- _self.gridInlineStyle(padding, 'padding') -}}
+        {{- _self.gridInlineStyle(paddingX, 'padding-left') -}}
+        {{- _self.gridInlineStyle(paddingX, 'padding-right') -}}
+        {{- _self.gridInlineStyle(paddingY, 'padding-top') -}}
+        {{- _self.gridInlineStyle(paddingY, 'padding-bottom') -}}
+        {{- _self.gridInlineStyle(paddingTop, 'padding-top') -}}
+        {{- _self.gridInlineStyle(paddingBottom, 'padding-bottom') -}}
+        {{- _self.gridInlineStyle(paddingLeft, 'padding-left') -}}
+        {{- _self.gridInlineStyle(paddingRight, 'padding-right') -}}
+        {{- _self.gridInlineStyle(gap, 'gap') -}}
+        {{- _self.gridInlineStyle(rowGap, 'row-gap') -}}
+        {{- _self.gridInlineStyle(columnGap, 'column-gap') -}}
+        {{- _self.gridInlineStyle(columnSetting, 'grid-template-columns') -}}
+        {{- _self.gridInlineStyle(rowSetting, 'grid-template-rows') -}}
+    {% endset -%}
+
+    {# If arbitrary values are passed, generate a style tag with inline CSS. #}
+    {% if inlineCSS is not empty %}
+        <style>
+        {{ "##{gridId} {" }}
+            {{- inlineCSS -}}
+        {{ '}' }}
+        </style>
+    {% endif %}
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -9,7 +9,9 @@
     rowsMd = null,
     rowsLg = null,
     rowsXl = null,
-    gap = 24,
+    gap = 3,
+    rowGap = null,
+    columnGap = null,
     align = 'start',
     alignContent = 'start',
     justify = 'start',
@@ -20,7 +22,73 @@
     border = null,
     borderVariant = null,
     borderSubtle = false,
+    padding = null,
+    paddingX = null,
+    paddingY = null,
+    paddingTop = null,
+    paddingRight = null,
+    paddingBottom = null,
+    paddingLeft = null,
+    margin = null,
+    marginX = null,
+    marginY = null,
+    marginTop = null,
+    marginRight = null,
+    marginBottom = 3,
+    marginLeft = null,
 %}
+
+{#
+    "padding" Usage Example:
+
+    1. Simple: (0-5)
+    <twig:Sw:Grid:Container :padding="3" />
+    Generates simple spacer class p-3
+
+    2. With breakpoints:
+    <twig:Sw:Grid:Container :padding="{ xs: 0, sm: 2, md: 3, lg: 5, xl: 2, xxl: 1 }" />
+    Generates spacing utility classes for the classes for each breakpoint: p-xs-0 p-sm-2 p-md-3 p-lg-5 p-xl-2 p-xxl-1
+
+    3. Inline styling:
+    <twig:Sw:Grid:Container padding="1.6rem" />
+    If the value is a string, it will be used as inline style.
+    Generates inline style style="padding: 10px;"
+#}
+
+{%- macro spacingClasses(prop, classPrefix) %}
+    {%- set classes = [] -%}
+
+    {%- if prop is not null and prop is not string and prop is not iterable %}
+        {%- set classes = classes|merge(["#{classPrefix}-#{prop}"]) -%}
+    {% elseif prop is not null and prop is iterable %}
+        {%- for breakpoint, value in prop %}
+            {%- if value is not string %}
+                {%- set classes = classes|merge(["#{classPrefix}-#{breakpoint}-#{value}"]) -%}
+            {% else -%}
+                {%- set classes = classes|merge(["#{classPrefix}-#{breakpoint}-[#{value}]"]) -%}
+            {% endif -%}
+        {% endfor -%}
+    {% endif -%}
+    {# Return value #}
+    {{- classes|length > 0 ? classes|join(' ') : '' -}}
+{% endmacro -%}
+
+{%- macro spacingInlineStyle(prop, cssProp) %}
+    {%- set style = '' -%}
+
+    {%- if prop is not null and prop is string and prop is not iterable %}
+        {% if cssProp is iterable %}
+            {%- for i in cssProp %}
+                {%- set style = style ~ "#{i}: #{prop};" -%}
+            {% endfor %}
+        {% else %}
+            {%- set style = style ~ "#{cssProp}: #{prop};" -%}
+        {% endif %}
+    {% endif -%}
+
+    {# Return value #}
+    {{- style -}}
+{% endmacro -%}
 
 {% set gridCVA = cva({
     base: 'grid-container',
@@ -220,7 +288,29 @@
     }
 }) %}
 
+{%- set spacingClasses = [
+    _self.spacingClasses(padding, 'p'), 
+    _self.spacingClasses(paddingBottom, 'pb'),
+    _self.spacingClasses(paddingTop, 'pt'),
+    _self.spacingClasses(paddingRight, 'pe'),
+    _self.spacingClasses(paddingLeft, 'ps'),
+    _self.spacingClasses(paddingX, 'px'),
+    _self.spacingClasses(paddingY, 'py'),
+    _self.spacingClasses(marginBottom, 'mb'),
+    _self.spacingClasses(marginTop, 'mt'),
+    _self.spacingClasses(marginRight, 'me'),
+    _self.spacingClasses(marginLeft, 'ms'),
+    _self.spacingClasses(margin, 'm'),
+    _self.spacingClasses(marginX, 'mx'),
+    _self.spacingClasses(marginY, 'my'),
+    _self.spacingClasses(gap, 'gap'),
+    _self.spacingClasses(rowGap, 'row-gap'),
+    _self.spacingClasses(columnGap, 'column-gap'),
+]|join(' ')|trim -%}
+
+{% set gridId = 'sw-grid-container-' ~ random() %}
 {% set attributeDefaults = {
+    'id': gridId,
     'class': gridCVA.apply({
         align,
         alignContent,
@@ -241,7 +331,7 @@
         border,
         borderVariant,
         borderSubtle,
-    }),
+    }) ~ ' ' ~ spacingClasses,
 } %}
 
 {% set gridStyle = '' %}
@@ -262,7 +352,6 @@
 
 {% set gridStyle = columnSetting ? gridStyle ~ 'grid-template-columns: ' ~ columnSetting|trim ~ '; ' : gridStyle %}
 {% set gridStyle = rowSetting ? gridStyle ~ 'grid-template-rows: ' ~ rowSetting|trim ~ '; ' : gridStyle %}
-{% set gridStyle = gap ? gridStyle ~ 'gap: ' ~ gap ~ 'px; margin-bottom: ' ~ gap ~ 'px; ' : gridStyle %}
 
 <div
     {{ attributes.defaults(attributeDefaults) }}
@@ -273,4 +362,24 @@
             <twig:Slot :name="name"></twig:Slot>
         {% endfor %}
      {% endblock %}
+
+    <style>   
+    {{ "##{gridId} {" }} 
+        {{- _self.spacingInlineStyle(margin, 'margin') -}}
+        {{- _self.spacingInlineStyle(marginX, ['margin-left', 'margin-right']) -}}
+        {{- _self.spacingInlineStyle(marginBottom, 'margin-bottom') -}}
+        {{- _self.spacingInlineStyle(marginTop, 'margin-top') -}}
+        {{- _self.spacingInlineStyle(marginLeft, 'margin-left') -}}
+        {{- _self.spacingInlineStyle(marginRight, 'margin-right') -}}
+        {{- _self.spacingInlineStyle(paddingX, ['padding-left', 'padding-right']) -}}
+        {{- _self.spacingInlineStyle(paddingY, ['padding-top', 'padding-bottom']) -}}
+        {{- _self.spacingInlineStyle(paddingTop, 'padding-top') -}}
+        {{- _self.spacingInlineStyle(paddingBottom, 'padding-bottom') -}}
+        {{- _self.spacingInlineStyle(paddingLeft, 'padding-left') -}}
+        {{- _self.spacingInlineStyle(paddingRight, 'padding-right') -}}
+        {{- _self.spacingInlineStyle(gap, 'gap') -}}
+        {{- _self.spacingInlineStyle(rowGap, 'row-gap') -}}
+        {{- _self.spacingInlineStyle(columnGap, 'column-gap') -}}
+    {{ '}' }}
+    </style>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -9,6 +9,9 @@
     rowsMd = null,
     rowsLg = null,
     rowsXl = null,
+
+    columnsConfig = null,
+
     gap = 3,
     rowGap = null,
     columnGap = null,
@@ -39,53 +42,60 @@
 %}
 
 {#
-    "padding" Usage Example:
+    Helper macro to generate grid classes.
+    * prop: property to generate classes for (padding, margin, gap, etc.)
+    * classPrefix: prefix for the classes (p, m, gap, row-gap, columns, etc.)
+    * specialKeyword: special keyword to generate a class for (auto, max-content, etc.)
 
-    1. Simple: (0-5)
+    1. Simple:
     <twig:Sw:Grid:Container :padding="3" />
-    Generates simple spacer class p-3
+    Generates: "p-3"
 
     2. With breakpoints:
     <twig:Sw:Grid:Container :padding="{ xs: 0, sm: 2, md: 3, lg: 5, xl: 2, xxl: 1 }" />
-    Generates spacing utility classes for the classes for each breakpoint: p-xs-0 p-sm-2 p-md-3 p-lg-5 p-xl-2 p-xxl-1
-
-    3. Inline styling:
-    <twig:Sw:Grid:Container padding="1.6rem" />
-    If the value is a string, it will be used as inline style.
-    Generates inline style style="padding: 10px;"
+    Generates: "p-0 p-sm-2 p-md-3 p-lg-5 p-xl-2 p-xxl-1"
 #}
-
-{%- macro spacingClasses(prop, classPrefix) %}
+{%- macro spacingClasses(prop, classPrefix, specialKeyword = null) %}
     {%- set classes = [] -%}
-
+    {# Prop contains a special keyword, use it to generate a class. #}
+    {%- if specialKeyword is not null and specialKeyword is same as prop %}
+        {%- set classes = classes|merge(["#{classPrefix}-#{specialKeyword}"]) -%}
+    {% endif -%}
+    {# Prop contains a simple numeric value for all breakpoints. #}
     {%- if prop is not null and prop is not string and prop is not iterable %}
         {%- set classes = classes|merge(["#{classPrefix}-#{prop}"]) -%}
     {% elseif prop is not null and prop is iterable %}
+        {# Prop contains an object with breakpoint values. #}
         {%- for breakpoint, value in prop %}
             {%- if value is not string %}
-                {%- set classes = classes|merge(["#{classPrefix}-#{breakpoint}-#{value}"]) -%}
-            {% else -%}
-                {%- set classes = classes|merge(["#{classPrefix}-#{breakpoint}-[#{value}]"]) -%}
+                {%- if breakpoint == 'xs' %}
+                    {%- set classes = classes|merge(["#{classPrefix}-#{value}"]) -%}
+                {% else %}
+                    {%- set classes = classes|merge(["#{classPrefix}-#{breakpoint}-#{value}"]) -%}
+                {% endif -%}
             {% endif -%}
         {% endfor -%}
     {% endif -%}
-    {# Return value #}
+    {# Output the classes as string #}
     {{- classes|length > 0 ? classes|join(' ') : '' -}}
 {% endmacro -%}
 
 {%- macro spacingInlineStyle(prop, cssProp) %}
     {%- set style = '' -%}
-
     {%- if prop is not null and prop is string and prop is not iterable %}
-        {% if cssProp is iterable %}
-            {%- for i in cssProp %}
-                {%- set style = style ~ "#{i}: #{prop};" -%}
-            {% endfor %}
-        {% else %}
-            {%- set style = style ~ "#{cssProp}: #{prop};" -%}
-        {% endif %}
+        {%- set style = style ~ "#{cssProp}: #{prop};" -%}
+    {% elseif prop is not null and prop is iterable %}
+        {%- for breakpoint, value in prop %}
+            {%- if value is string %}
+                {% if breakpoint == 'xs' %}
+                    {% set style = style ~ "#{cssProp}: #{value}; " %}
+                {% else %}
+                    {%- set breakpointSize = theme_config('breakpoint.' ~ breakpoint) -%}
+                    {%- set style = style ~ "@media (min-width: #{breakpointSize}px) { #{cssProp}: #{value}; } " -%}
+                {% endif %}
+            {% endif -%}
+        {% endfor -%}
     {% endif -%}
-
     {# Return value #}
     {{- style -}}
 {% endmacro -%}
@@ -353,9 +363,7 @@
 {% set gridStyle = columnSetting ? gridStyle ~ 'grid-template-columns: ' ~ columnSetting|trim ~ '; ' : gridStyle %}
 {% set gridStyle = rowSetting ? gridStyle ~ 'grid-template-rows: ' ~ rowSetting|trim ~ '; ' : gridStyle %}
 
-<div
-    {{ attributes.defaults(attributeDefaults) }}
-    {% if gridStyle %} style="{{ gridStyle|trim }}"{% endif %}>
+<div {{ attributes.defaults(attributeDefaults) }}>
 
      {% block content %}
         {% for name, slot in slots %}
@@ -363,16 +371,20 @@
         {% endfor %}
      {% endblock %}
 
-    <style>   
-    {{ "##{gridId} {" }} 
+    <style>
+    {{ "##{gridId} {" }}
         {{- _self.spacingInlineStyle(margin, 'margin') -}}
-        {{- _self.spacingInlineStyle(marginX, ['margin-left', 'margin-right']) -}}
+        {{- _self.spacingInlineStyle(marginX, 'margin-left') -}}
+        {{- _self.spacingInlineStyle(marginX, 'margin-right') -}}
         {{- _self.spacingInlineStyle(marginBottom, 'margin-bottom') -}}
         {{- _self.spacingInlineStyle(marginTop, 'margin-top') -}}
         {{- _self.spacingInlineStyle(marginLeft, 'margin-left') -}}
         {{- _self.spacingInlineStyle(marginRight, 'margin-right') -}}
-        {{- _self.spacingInlineStyle(paddingX, ['padding-left', 'padding-right']) -}}
-        {{- _self.spacingInlineStyle(paddingY, ['padding-top', 'padding-bottom']) -}}
+        {{- _self.spacingInlineStyle(padding, 'padding') -}}
+        {{- _self.spacingInlineStyle(paddingX, 'padding-left') -}}
+        {{- _self.spacingInlineStyle(paddingX, 'padding-right') -}}
+        {{- _self.spacingInlineStyle(paddingY, 'padding-top') -}}
+        {{- _self.spacingInlineStyle(paddingY, 'padding-bottom') -}}
         {{- _self.spacingInlineStyle(paddingTop, 'padding-top') -}}
         {{- _self.spacingInlineStyle(paddingBottom, 'padding-bottom') -}}
         {{- _self.spacingInlineStyle(paddingLeft, 'padding-left') -}}
@@ -380,6 +392,7 @@
         {{- _self.spacingInlineStyle(gap, 'gap') -}}
         {{- _self.spacingInlineStyle(rowGap, 'row-gap') -}}
         {{- _self.spacingInlineStyle(columnGap, 'column-gap') -}}
+        {% if gridStyle %}{{ gridStyle|trim }}{% endif %}
     {{ '}' }}
     </style>
 </div>

--- a/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Grid/Container.html.twig
@@ -339,12 +339,8 @@
 
 {% set gridId = 'sw-grid-container-' ~ random() %}
 {% set attributeDefaults = {
-<<<<<<< spacing-system
-    'id': gridId,
-    'class': gridCVA.apply({
-=======
+    id: gridId,
     class: gridCVA.apply({
->>>>>>> 8484/storefront-content-system
         align,
         alignContent,
         justify,

--- a/src/Storefront/Resources/views/components/Sw/Header/index.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Header/index.html.twig
@@ -11,7 +11,6 @@
         justifyContent="end"
         align="end"
         autoColumns="max-content"
-        margin="6rem"
     >
         <twig:Sw:Grid:Column :display="{ xs: false, sm: false, md: false, lg: true, xl: true, xxl: true }">
             <twig:Sw:Header:LanguageSelect :languages="header.languages" />
@@ -27,7 +26,6 @@
         justifyContent="stretch"
         alignContent="center"
         align="center"
-
     >
         <twig:Sw:Grid:Column
             justify="stretch"
@@ -51,11 +49,11 @@
         <twig:Sw:Grid:Column justify="end">
             <twig:Sw:Grid:Container
                 columns="auto"
-                gap="0"
                 justifyContent="end"
                 :centered="false"
-                :marginBottom="0"
                 autoColumns="max-content"
+                :marginBottom="0"
+                :gap="0"
             >
 
                 <twig:Sw:Header:WishlistWidget />
@@ -79,7 +77,6 @@
         justify="center"
         border="bottom"
         borderVariant="secondarySubtle"
-        :paddingX="0"
     >
         {# :display="{ xs: false, sm: false, md: false, lg: true, xl: true, xxl: true }" #}
         <twig:Sw:Header:Navbar

--- a/src/Storefront/Resources/views/components/Sw/Header/index.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Header/index.html.twig
@@ -11,7 +11,7 @@
         justifyContent="end"
         align="end"
         autoColumns="max-content"
-        gap="15"
+        margin="6rem"
     >
         <twig:Sw:Grid:Column :display="{ xs: false, sm: false, md: false, lg: true, xl: true, xxl: true }">
             <twig:Sw:Header:LanguageSelect :languages="header.languages" />
@@ -27,7 +27,7 @@
         justifyContent="stretch"
         alignContent="center"
         align="center"
-        gap="16"
+
     >
         <twig:Sw:Grid:Column
             justify="stretch"
@@ -54,6 +54,7 @@
                 gap="0"
                 justifyContent="end"
                 :centered="false"
+                :marginBottom="0"
                 autoColumns="max-content"
             >
 
@@ -78,6 +79,7 @@
         justify="center"
         border="bottom"
         borderVariant="secondarySubtle"
+        :paddingX="0"
     >
         {# :display="{ xs: false, sm: false, md: false, lg: true, xl: true, xxl: true }" #}
         <twig:Sw:Header:Navbar

--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
@@ -36,11 +36,12 @@
             <twig:Slot name="product-grid">
                 <twig:Sw:Grid:Container
                     class="sw-product-listing__grid"
+                    :columnsConfig="{ xs: 1, sm: 1, md: 3, lg: 3, xl: 3, xxl: 3 }"
                     :columns="layout == 'horizontal' ? '1' : '4'"
                     :columnsXl="layout == 'horizontal' ? '1' : '3'"
                     :columnsLg="layout == 'horizontal' ? '1' : '2'"
                     :columnsSm="layout == 'horizontal' ? '1' : '2'"
-                    gap="16">
+                >
                     {% for product in listing.elements %}
                         <twig:Sw:Product:Card
                             :product="product"

--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.html.twig
@@ -36,7 +36,6 @@
             <twig:Slot name="product-grid">
                 <twig:Sw:Grid:Container
                     class="sw-product-listing__grid"
-                    :columnsConfig="{ xs: 1, sm: 1, md: 3, lg: 3, xl: 3, xxl: 3 }"
                     :columns="layout == 'horizontal' ? '1' : '4'"
                     :columnsXl="layout == 'horizontal' ? '1' : '3'"
                     :columnsLg="layout == 'horizontal' ? '1' : '2'"


### PR DESCRIPTION
⚠️  Only relevant for `8484/storefront-content-system`

### 1. Why is this change necessary?

* The grid container element has currently no support for spacers like padding, margin.
* The gap can only be set with a hard-coded value from outside.

### 2. What does this change do, exactly?

* Introduce more props for spacers.
* Use standard spacers (0-5) by default instead of hard-coded spacers.
* Introduce generators (macros) to automatically create classes and CSS inline styles.
  * Macros are quite flexible and could also be imported from another twig file and later also be used in the slot template to generate the classes on element level.
* Add support to control spacers for each breakpoint/viewport.

### 3. Usage

Simple standard spacer:
```twig
<twig:Sw:Grid:Container :padding="3" />
Generates: "p-3"
```

Standard spacer per breakpoint:
```twig
<twig:Sw:Grid:Container :padding="{ xs: 0, sm: 2, md: 3, lg: 5, xl: 2, xxl: 1 }" />
Generates: "p-0 p-sm-2 p-md-3 p-lg-5 p-xl-2 p-xxl-1"
```

Arbitrary spacer:

> [!NOTE]  
> When arbitrary values are passed instead of default spacer, an inline <style> is generated. The CSS is scoped to a unique grid id. The inline <style> tag is needed to also support media-query breakpoints.

```twig
<twig:Sw:Grid:Container padding="20px" />

Generates:
<style>
#sw-grid-container-1839249330 {
    padding: 20px;
}
</style>
```

Arbitrary with breakpoints:

```twig
<twig:Sw:Grid:Container :padding="{ xs: '5px', sm: '10px', md: '15px', lg: '20px', xl: '25px', xxl: '30px' }" />

Generates:
<style>
#sw-grid-container-1839249330 {
    padding: 5px; 
    @media (min-width: 576px) { padding: 10px; } 
    @media (min-width: 768px) { padding: 15px; } 
    @media (min-width: 992px) { padding: 20px; } 
    @media (min-width: 1200px) { padding: 25px; } 
    @media (min-width: 1400px) { padding: 30px; }
}
</style>
```

Mixing arbitrary and standard spacers in breakpoints:

> [!WARNING]  
> It is technically possible to mix standard spacers and custom spacers in a breakpoint config. It is however not recommended because the inline style overrules the default spacers which can lead to unexpected results.

```twig
<twig:Sw:Grid:Container :padding="{ xs: '5px', sm: 3, md: 4, lg: '20px', xl: '25px', xxl: '30px' }" />

Generates:
<div class="grid-container p-sm-3 p-md-4">
<style>
#sw-grid-container-1839249330 {
    padding: 5px; 
    /* @media (min-width: 576px) { padding: 10px; } Not here because standard spacer is used */
    /* @media (min-width: 768px) { padding: 15px; } Not here because standard spacer is used */
    @media (min-width: 992px) { padding: 20px; } 
    @media (min-width: 1200px) { padding: 25px; } 
    @media (min-width: 1400px) { padding: 30px; }
}
</style>
```