### PR TITLE
ci: fix openapi-lint on shopware-private

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -121,6 +121,7 @@ jobs:
   openapi-lint:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       id-token: write
     env:
       APP_ENV: prod


### PR DESCRIPTION
### 1. Why is this change necessary?
The `openapi-lint` job fails on `shopware-private` (And any other fork), because it can't clone `shopware-private`.

### 2. What does this change do, exactly?
Add `contents: read` permissions to the `GITHUB_TOKEN`.

### 3. Describe each step to reproduce the issue or behaviour.
Run the `PHP Checks` workflow on a Fork.