### PR TITLE
fix(snippet-command): Add translation command confirmation prompt

### DIFF
--- a/src/Core/System/Snippet/Command/InstallTranslationCommand.php
+++ b/src/Core/System/Snippet/Command/InstallTranslationCommand.php
@@ -11,9 +11,11 @@ use Shopware\Core\System\Snippet\SnippetException;
 use Shopware\Core\System\Snippet\Struct\TranslationConfig;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * @internal
@@ -38,11 +40,18 @@ class InstallTranslationCommand extends Command
         $this->addOption('all', null, InputOption::VALUE_NONE, 'Fetch all available translations');
         $this->addOption('locales', null, InputOption::VALUE_OPTIONAL, 'Fetch translations for specific locale codes comma separated, e.g. "de-DE,en-US"');
         $this->addOption('skip-activation', null, InputOption::VALUE_NONE, 'Skip activation of created languages');
+        $this->addOption('confirm', null, InputOption::VALUE_NONE, 'Confirms TOS bla bla');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $locales = $this->getLocales($input);
+
+        if (!$this->isConfirmed($input, $output) ) {
+            $output->writeln('<error>Command aborted.</error>');
+
+            return self::FAILURE;
+        }
 
         try {
             $metadata = $this->metadataLoader->getUpdatedLocalMetadata($locales);
@@ -78,6 +87,22 @@ class InstallTranslationCommand extends Command
         TranslationCommandHelper::handleSavingMetadataCLIOutput(fn () => $this->metadataLoader->save($metadata), $output);
 
         return self::SUCCESS;
+    }
+
+    private function isConfirmed(InputInterface $input, OutputInterface $output): bool
+    {
+        if ($input->getOption('confirm')) {
+            return true;
+        }
+
+        $questionHelper = $this->getHelper('question');
+        \assert($questionHelper instanceof QuestionHelper);
+
+        return $questionHelper->ask(
+            $input,
+            $output,
+            new ConfirmationQuestion('<question>Are you sure, you want to ...</question> ', false)
+        );
     }
 
     /**

--- a/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -98,6 +98,7 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'en-GB,es-ES']);
         $tester->assertCommandIsSuccessful();
@@ -137,6 +138,7 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'en-GB,es-ES,de-DE']);
         $tester->assertCommandIsSuccessful();
@@ -166,6 +168,7 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'es-ES']);
         $output = $tester->getDisplay();
@@ -188,6 +191,7 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'es-ES']);
         $output = $tester->getDisplay();
@@ -218,6 +222,7 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'en-GB', '--skip-activation' => true]);
         $tester->assertCommandIsSuccessful();
@@ -231,12 +236,91 @@ class InstallTranslationCommandTest extends TestCase
 
         $command = $this->getCommand();
         $tester = new CommandTester($command);
+        $tester->setInputs(['y']);
 
         $tester->execute(['--locales' => 'en-GB']);
         $output = $tester->getDisplay();
 
         static::assertStringContainsString('An error occurred while fetching metadata: "Unable to fetch metadata"', $output);
         static::assertSame(InstallTranslationCommand::FAILURE, $tester->getStatusCode());
+    }
+
+    public function testCommandAbortsWhenConfirmationIsDeclined(): void
+    {
+        $this->metadataLoader->expects($this->never())
+            ->method('getUpdatedLocalMetadata');
+
+        $command = $this->getCommand();
+        $tester = new CommandTester($command);
+        $tester->setInputs(['n']);
+
+        $tester->execute(['--locales' => 'en-GB']);
+        $output = $tester->getDisplay();
+
+        static::assertStringContainsString('Command aborted.', $output);
+        static::assertSame(InstallTranslationCommand::FAILURE, $tester->getStatusCode());
+    }
+
+    public function testCommandSkipsInteractiveConfirmationWithConfirmOption(): void
+    {
+        $collection = new MetadataCollection([
+            MetadataEntry::create([
+                'locale' => 'en-GB',
+                'updatedAt' => '2024-01-01T00:00:00+00:00',
+                'progress' => 100,
+            ]),
+        ]);
+        $collection->get('en-GB')?->markForUpdate();
+
+        $this->initMetadataLoader($collection);
+
+        $this->translationLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(function (string $locale): void {
+                static::assertSame('en-GB', $locale);
+            });
+
+        $command = $this->getCommand();
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--locales' => 'en-GB', '--confirm' => true]);
+        $output = $tester->getDisplay();
+
+        static::assertSame(InstallTranslationCommand::SUCCESS, $tester->getStatusCode());
+        static::assertStringNotContainsString('Are you sure, you want to ...', $output);
+    }
+
+    public function testCommandDoesNotAskForConfirmationWithConfirmOptionEvenWhenNegativeInputIsProvided(): void
+    {
+        $collection = new MetadataCollection([
+            MetadataEntry::create([
+                'locale' => 'en-GB',
+                'updatedAt' => '2024-01-01T00:00:00+00:00',
+                'progress' => 100,
+            ]),
+        ]);
+        $collection->get('en-GB')?->markForUpdate();
+
+        $this->initMetadataLoader($collection);
+
+        $this->translationLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(function (string $locale): void {
+                static::assertSame('en-GB', $locale);
+            });
+
+        $command = $this->getCommand();
+        $tester = new CommandTester($command);
+        $tester->setInputs(['n']);
+
+        $tester->execute(['--locales' => 'en-GB', '--confirm' => true]);
+        $output = $tester->getDisplay();
+
+        static::assertSame(InstallTranslationCommand::SUCCESS, $tester->getStatusCode());
+        static::assertStringNotContainsString('Command aborted.', $output);
+        static::assertStringNotContainsString('Are you sure, you want to ...', $output);
     }
 
     private function getCommand(): InstallTranslationCommand


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
*To be edited*

### 2. What does this change do, exactly?
Adds a confirmation prompt and a command parameter to surpass this question

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
