### PR TITLE
chore: rename PermissionPersister

### DIFF
--- a/src/Core/Framework/App/Lifecycle/AppLifecycle.php
+++ b/src/Core/Framework/App/Lifecycle/AppLifecycle.php
@@ -23,7 +23,6 @@ use Shopware\Core\Framework\App\Event\PostAppDeletedEvent;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
 use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -66,7 +65,7 @@ class AppLifecycle extends AbstractAppLifecycle
     public function __construct(
         private readonly iterable $persisters,
         private readonly EntityRepository $appRepository,
-        private readonly PermissionPersister $permissionPersister,
+        private readonly PermissionLifecycleService $permissionLifecycle,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly AppRegistrationService $registrationService,
         private readonly AppStateService $appStateService,
@@ -216,7 +215,7 @@ class AppLifecycle extends AbstractAppLifecycle
 
         $this->updateCustomEntities($app, $manifest);
 
-        $this->permissionPersister->updatePrivileges(
+        $this->permissionLifecycle->updatePrivileges(
             $manifest->getPermissions(),
             $id,
             $manifest->validatesPermissions() === false && $parameters->acceptPermissions,
@@ -308,10 +307,10 @@ class AppLifecycle extends AbstractAppLifecycle
                     'id' => $app->getIntegrationId(),
                     'deletedAt' => new \DateTimeImmutable(),
                 ]], $context);
-                $this->permissionPersister->softDeleteRole($app->getAclRoleId());
+                $this->permissionLifecycle->softDeleteRole($app->getAclRoleId());
             } else {
                 $this->integrationRepository->delete([['id' => $app->getIntegrationId()]], $context);
-                $this->permissionPersister->removeRole($app->getAclRoleId());
+                $this->permissionLifecycle->removeRole($app->getAclRoleId());
             }
 
             $this->deleteAclRole($app->getName(), $context);

--- a/src/Core/Framework/App/Lifecycle/PermissionLifecycleService.php
+++ b/src/Core/Framework/App/Lifecycle/PermissionLifecycleService.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Framework\App\Lifecycle\Persister;
+namespace Shopware\Core\Framework\App\Lifecycle;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Defaults;
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal only for use by the app-system
  */
 #[Package('framework')]
-class PermissionPersister
+class PermissionLifecycleService
 {
     public function __construct(
         private readonly Connection $connection,

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -65,7 +65,7 @@
             <tag name="shopware.app_manifest.validator"/>
         </service>
 
-        <service id="Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister">
+        <service id="Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\App\Privileges\Privileges"/>
         </service>
@@ -290,7 +290,7 @@
         <service id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle">
             <argument type="tagged_iterator" tag="shopware.app_lifecycle.persister"/>
             <argument type="service" id="app.repository"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister"/>
+            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>

--- a/src/Core/Framework/DependencyInjection/app_test.xml
+++ b/src/Core/Framework/DependencyInjection/app_test.xml
@@ -8,7 +8,7 @@
         <service id="app-life-cycle-dev" public="true" class="Shopware\Core\Framework\App\Lifecycle\AppLifecycle">
             <argument type="tagged_iterator" tag="shopware.app_lifecycle.persister"/>
             <argument type="service" id="app.repository"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister"/>
+            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -33,8 +33,8 @@ use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Lifecycle\Persister\FlowEventPersister;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\Xml\Permission\Permissions;
 use Shopware\Core\Framework\App\Template\TemplateCollection;
@@ -500,14 +500,14 @@ class AppLifecycleTest extends TestCase
             ],
         ]], $context);
 
-        $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+        $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
         $permissions = Permissions::fromArray([
             'permissions' => [
                 'product' => ['update'],
             ],
         ]);
 
-        $permissionPersister->updatePrivileges($permissions, $id, true, $context);
+        $permissionLifecycle->updatePrivileges($permissions, $id, true, $context);
 
         $app = [
             'id' => $id,
@@ -677,14 +677,14 @@ class AppLifecycleTest extends TestCase
             ],
         ]], $context);
 
-        $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+        $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
         $permissions = Permissions::fromArray([
             'permissions' => [
                 'product' => ['update'],
             ],
         ]);
 
-        $permissionPersister->updatePrivileges($permissions, $id, true, $context);
+        $permissionLifecycle->updatePrivileges($permissions, $id, true, $context);
 
         $app = [
             'id' => $id,
@@ -780,14 +780,14 @@ class AppLifecycleTest extends TestCase
             ],
         ]], $context);
 
-        $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+        $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
         $permissions = Permissions::fromArray([
             'permissions' => [
                 'product' => ['update'],
             ],
         ]);
 
-        $permissionPersister->updatePrivileges($permissions, $id, true, $context);
+        $permissionLifecycle->updatePrivileges($permissions, $id, true, $context);
 
         $app = [
             'id' => $id,

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -324,14 +324,14 @@ class AppRegistrationServiceTest extends TestCase
             ],
         ]], $context);
 
-        $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+        $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
         $permissions = Permissions::fromArray([
             'permissions' => [
                 'product' => ['update'],
             ],
         ]);
 
-        $permissionPersister->updatePrivileges($permissions, $id, true, $context);
+        $permissionLifecycle->updatePrivileges($permissions, $id, true, $context);
     }
 
     private function buildAppResponse(Manifest $manifest, string $appSecret, ?ShopId $shopId = null): string

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppLocaleProvider;
 use Shopware\Core\Framework\App\Event\AppDeletedEvent;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Manifest\Xml\Permission\Permissions;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
@@ -713,14 +713,14 @@ class WebhookManagerTest extends TestCase
             ],
         ]);
 
-        $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+        $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
         $permissions = Permissions::fromArray([
             'permissions' => [
                 'product' => ['read'],
             ],
         ]);
 
-        $permissionPersister->updatePrivileges($permissions, $appId, true, Context::createDefaultContext());
+        $permissionLifecycle->updatePrivileges($permissions, $appId, true, Context::createDefaultContext());
 
         $this->appendNewResponse(new Response(200));
 
@@ -1012,12 +1012,12 @@ class WebhookManagerTest extends TestCase
         }
 
         if ($permissions !== null && $appId !== null) {
-            $permissionPersister = static::getContainer()->get(PermissionPersister::class);
+            $permissionLifecycle = static::getContainer()->get(PermissionLifecycleService::class);
             $permissions = Permissions::fromArray([
                 'permissions' => $permissions,
             ]);
 
-            $permissionPersister->updatePrivileges($permissions, $appId, true, $context);
+            $permissionLifecycle->updatePrivileges($permissions, $appId, true, $context);
         }
     }
 

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -18,7 +18,7 @@ use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Validation\ConfigValidator;
@@ -370,7 +370,7 @@ class AppLifecycleTest extends TestCase
         return new AppLifecycle(
             [],
             $appRepository,
-            $this->createMock(PermissionPersister::class),
+            $this->createMock(PermissionLifecycleService::class),
             $this->eventDispatcher,
             $this->createMock(AppRegistrationService::class),
             $this->createMock(AppStateService::class),

--- a/tests/unit/Core/Framework/App/Lifecycle/PermissionLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/PermissionLifecycleServiceTest.php
@@ -1,12 +1,12 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PermissionPersister;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
 use Shopware\Core\Framework\App\Manifest\Xml\Permission\Permissions;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
@@ -15,20 +15,20 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
-#[CoversClass(PermissionPersister::class)]
-class PermissionPersisterTest extends TestCase
+#[CoversClass(PermissionLifecycleService::class)]
+class PermissionLifecycleServiceTest extends TestCase
 {
     private Connection&MockObject $connection;
 
     private Privileges&MockObject $permissions;
 
-    private PermissionPersister $persister;
+    private PermissionLifecycleService $service;
 
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->permissions = $this->createMock(Privileges::class);
-        $this->persister = new PermissionPersister($this->connection, $this->permissions);
+        $this->service = new PermissionLifecycleService($this->connection, $this->permissions);
     }
 
     public function testUpdatePrivilegesAutoAcceptsIfFlagIsSpecified(): void
@@ -42,7 +42,7 @@ class PermissionPersisterTest extends TestCase
             ->method('setPrivileges')
             ->with($appId, ['customer:read', 'customer:update'], $context);
 
-        $this->persister->updatePrivileges($permissions, $appId, true, $context);
+        $this->service->updatePrivileges($permissions, $appId, true, $context);
     }
 
     public function testUpdatePrivilegesDoesNotAutoAcceptIfFlagIsNotSpecified(): void
@@ -56,6 +56,6 @@ class PermissionPersisterTest extends TestCase
             ->method('requestPrivileges')
             ->with($appId, ['customer:read', 'customer:update'], $context);
 
-        $this->persister->updatePrivileges($permissions, $appId, false, Context::createDefaultContext());
+        $this->service->updatePrivileges($permissions, $appId, false, Context::createDefaultContext());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

In https://github.com/shopware/shopware/pull/15226 we introduced a new interface for all the persisters. `PermissionPersister` did not fit the interface and therefore we rename so it's clear it's not quite the same.

### 2. What does this change do, exactly?

Rename to `PermissionLifecycleService` and move namespace up one