### PR TITLE
test: remove hidden assertions in QueueTestBehaviour trait

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
@@ -22,7 +22,7 @@ trait QueueTestBehaviour
     {
         static::getContainer()->get(Connection::class)->executeStatement('DELETE FROM messenger_messages');
         $bus = static::getContainer()->get('messenger.bus.test_shopware');
-        static::assertInstanceOf(TraceableMessageBus::class, $bus);
+        \assert($bus instanceof TraceableMessageBus);
         $bus->reset();
     }
 
@@ -33,12 +33,12 @@ trait QueueTestBehaviour
         $eventDispatcher->addSubscriber(static::getContainer()->get(MessageQueueStatsSubscriber::class));
 
         $locator = static::getContainer()->get('messenger.test_receiver_locator');
-        static::assertInstanceOf(ServiceLocator::class, $locator);
+        \assert($locator instanceof ServiceLocator);
 
         $receiver = $locator->get('async');
 
         $bus = static::getContainer()->get('messenger.bus.test_shopware');
-        static::assertInstanceOf(MessageBusInterface::class, $bus);
+        \assert($bus instanceof MessageBusInterface);
 
         $worker = new Worker([$receiver], $bus, $eventDispatcher);
 
@@ -53,7 +53,7 @@ trait QueueTestBehaviour
     protected function getDispatchedMessageCount(string $messageClass): int
     {
         $bus = static::getContainer()->get('messenger.bus.test_shopware');
-        static::assertInstanceOf(TraceableMessageBus::class, $bus);
+        \assert($bus instanceof TraceableMessageBus);
 
         $count = 0;
         foreach ($bus->getDispatchedMessages() as $message) {

--- a/tests/integration/Core/Framework/TestCaseBase/QueueTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/QueueTestBehaviourTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
+
+/**
+ * @internal
+ */
+class QueueTestBehaviourTest extends TestCase
+{
+    use KernelTestBehaviour;
+    use QueueTestBehaviour;
+
+    public function testNoAssertionIsPerformedInTheTrait(): void
+    {
+        // Ensures runWorker() and getDispatchedMessageCount() do not perform any PHPUnit assertions,
+        // and clearQueue() is implicitly verified via its #[Before]/#[After] hooks around this test.
+        static::expectNotToPerformAssertions();
+
+        $this->runWorker();
+        $this->getDispatchedMessageCount(\stdClass::class);
+    }
+}

--- a/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
@@ -93,6 +95,8 @@ class ProductSearchQueryBuilderTest extends TestCase
         $connection->rollBack();
     }
 
+    #[DoesNotPerformAssertions]
+    #[TestDox('Warmup Elasticsearch index and test data for dependent tests')]
     public function testIndexing(): IdsCollection
     {
         $this->connection->executeStatement('DELETE FROM product');


### PR DESCRIPTION
### 1. Why is this change necessary?
This is the last step of https://github.com/shopware/shopware/issues/11998 all traits evaluated, this is the last to be fixed.

Assertions should be:

- direct in the tests, not hidden in methods of traits and unrelated to what is tested (like checking we get an object of a certain type from the container) 
- clearly identified as assert helper in the trait (like in MailTemplateTestBehaviour, AdminApiTestBehaviour)

### 2. What does this change do, exactly?

- Replace hidden PHPUnit assertions with \assert, since those were implemented as safeguard or PHPstan indication
- Make a test to enforce no PHPUnit assertion can come back 

### 3. Describe each step to reproduce the issue or behaviour.

- Run locally the different suites integration, migration, devops (no risky test)
- Run the pipeline (no risky test)

### 4. Please link to the relevant issues (if any).
- closes  https://github.com/shopware/shopware/issues/11998

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
