### PR TITLE
fix: allow searching while suggest is still loading

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -2,7 +2,7 @@ import Plugin from 'src/plugin-system/plugin.class';
 import DomAccess from 'src/helper/dom-access.helper';
 import Debouncer from 'src/helper/debouncer.helper';
 import HttpClient from 'src/service/http-client.service';
-import ButtonLoadingIndicator from 'src/utility/loading-indicator/button-loading-indicator.util';
+import LoadingIndicatorUtil from 'src/utility/loading-indicator/loading-indicator.util';
 import Iterator from 'src/helper/iterator.helper';
 
 export default class SearchWidgetPlugin extends Plugin {
@@ -185,7 +185,7 @@ export default class SearchWidgetPlugin extends Plugin {
         this._client.abort();
 
         // init loading indicator
-        const indicator = new ButtonLoadingIndicator(this._submitButton);
+        const indicator = new LoadingIndicatorUtil(this._submitButton);
         indicator.create();
 
         this.$emitter.publish('beforeSearch');


### PR DESCRIPTION
### Shopware Version

6.6+

### Affected area / extension

Platform(Default)

### Actual behaviour

When using the default search in StoreFront, if you hit Enter at the incorrect time (generally the instant the suggestion box is loading) the search will not take you to the search results page.

You may have to try this several times to get the timing right. We've experienced this in several projects.

### Expected behaviour

Search should always go to the results page when you press enter.

### How to reproduce

Try searching, varying the time when you press enter. Personally I can time it approximately every 1 in 10 searches. It will vary based on the users typing speed.

### Cherry-pick from https://github.com/shopware/shopware/pull/13727