### PR TITLE
fix(admin): Clean up usage data consent modal checklist and icon layout

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/subcomponents/sw-settings-usage-data-consent-check-list/sw-settings-usage-data-consent-check-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/subcomponents/sw-settings-usage-data-consent-check-list/sw-settings-usage-data-consent-check-list.scss
@@ -2,8 +2,16 @@
     display: flex;
     flex-direction: column;
     row-gap: var(--scale-size-16);
+    list-style: none;
+    margin: 0;
     padding: var(--scale-size-24) var(--scale-size-16);
     background-color: var(--color-elevation-surface-sunken);
     border-radius: var(--border-radius-m);
     font-size: var(--font-size-xs);
+
+    li {
+        display: flex;
+        align-items: center;
+        column-gap: var(--scale-size-8);
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/sw-settings-usage-data-consent-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/sw-settings-usage-data-consent-modal.scss
@@ -1,5 +1,6 @@
 .sw-settings-usage-data-consent-modal__content {
     .sw-setting-usage-data-consent-modal__icon-union {
+        display: block;
         margin: 0 auto var(--scale-size-16);
         max-width: var(--scale-size-72);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

  The usage data consent modal in Administration showed duplicate visual markers in its promise list (default list bullet plus
  check icon), which is inconsistent and looks broken.
  Additionally, the union icon positioning/styling in the modal was not centralized, making layout behavior less consistent.

  ### 2. What does this change do, exactly?

  - Removes default ul/li list bullets in the consent checklist.
  - Aligns checklist items consistently (icon + label spacing/alignment).
  - Centralizes sw-settings-usage-data-consent-modal__icon-union styling in the modal SCSS for consistent icon layout.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Start Shopware locally (Docker dev setup).
  2. Enable PRODUCT_ANALYTICS feature flag
  3. Open the Administration (/admin) with usage data consent not yet decided.
  4. Open/view the “Help us improve” consent modal.
  5. Check the promise list items:
      - GDPR compliant
      - Securely stored data
      - No data is shared with third parties
  6. Observe each item shows an extra default bullet in addition to the check icon.

  ### 4. Please link to the relevant issues (if any).

  No linked issue.

  ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is relevant for external developers:
      - Add a short entry to RELEASE_INFO-6.<major>.md under “Upcoming” for informational changes, including the consequences of
        the change and how it affects external developers.
      - Add an UPGRADE section in UPGRADE-6.<next-major>.md for breaking changes (what/why/impact/how to adapt).
      - See the Documenting a Release Process
        (https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them