### PR TITLE
fix: update linked price field when typing and instant update on model change

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -298,7 +298,7 @@ export default {
             this.$emit('change', this.priceForCurrency);
 
             if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceGrossChangeDebounce();
+                this.onPriceGrossChangeDebounce(value);
             }
         },
 
@@ -309,8 +309,24 @@ export default {
             this.$emit('change', this.priceForCurrency);
 
             if (this.priceForCurrency.linked && value && !value.toString().endsWith('.')) {
-                this.onPriceNetChangeDebounce();
+                this.onPriceNetChangeDebounce(value);
             }
+        },
+
+        onPriceGrossModelChange(value) {
+            if (this.onPriceGrossChangeDebounce.cancel) {
+                this.onPriceGrossChangeDebounce.cancel();
+            }
+
+            this.onPriceGrossChange(value);
+        },
+
+        onPriceNetModelChange(value) {
+            if (this.onPriceNetChangeDebounce.cancel) {
+                this.onPriceNetChangeDebounce.cancel();
+            }
+
+            this.onPriceNetChange(value);
         },
 
         onPriceGrossChange(value) {
@@ -417,12 +433,12 @@ export default {
             this.showModal = false;
         },
 
-        onPriceGrossChangeDebounce: debounce(function onPriceGrossChange() {
-            this.onPriceGrossChange(this.priceForCurrency.gross);
+        onPriceGrossChangeDebounce: debounce(function onPriceGrossChangeDebounce(value) {
+            this.onPriceGrossChange(value);
         }, 300),
 
-        onPriceNetChangeDebounce: debounce(function onPriceNetChange() {
-            this.onPriceNetChange(this.priceForCurrency.net);
+        onPriceNetChangeDebounce: debounce(function onPriceNetChangeDebounce(value) {
+            this.onPriceNetChange(value);
         }, 300),
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -279,18 +279,6 @@ export default {
             this.$emit('change', this.priceForCurrency);
         },
 
-        onEndsWithDecimalSeparator(value) {
-            if (value) {
-                // cancel might not be a function if debounce is not active
-                if (this.onPriceGrossChangeDebounce.cancel) {
-                    this.onPriceGrossChangeDebounce.cancel();
-                }
-                if (this.onPriceNetChangeDebounce.cancel) {
-                    this.onPriceNetChangeDebounce.cancel();
-                }
-            }
-        },
-
         onPriceGrossInputChange(value) {
             this.priceForCurrency.gross = value;
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.html.twig
@@ -27,9 +27,9 @@
             :disabled="isDisabled"
             :name="grossFieldName"
             v-bind="attributesWithoutListeners"
-            @update:model-value="onPriceGrossInputChange"
+            @input-change="onPriceGrossInputChange"
+            @update:model-value="onPriceGrossModelChange"
             @keyup="keymonitor"
-            @ends-with-decimal-separator="onEndsWithDecimalSeparator"
         >
             <template
                 v-if="!disableSuffix && !compact"
@@ -80,9 +80,9 @@
             :disabled="isInherited || disabled"
             :name="netFieldName"
             v-bind="attributesWithoutListeners"
-            @update:model-value="onPriceNetInputChange"
+            @input-change="onPriceNetInputChange"
+            @update:model-value="onPriceNetModelChange"
             @keyup="keymonitor"
-            @ends-with-decimal-separator="onEndsWithDecimalSeparator"
         >
             <template
                 v-if="!disableSuffix && !compact"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
@@ -247,6 +247,61 @@ describe('components/form/sw-price-field', () => {
         expect(convertGrossToNet).toHaveBeenCalled();
     });
 
+    it('should set net value immediately when gross model change is triggered', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const convertGrossToNet = jest.spyOn(wrapper.vm, 'convertGrossToNet');
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceGrossModelChange(euroPrice.gross);
+
+        expect(convertGrossToNet).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set gross value immediately when net model change is triggered', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const convertNetToGross = jest.spyOn(wrapper.vm, 'convertNetToGross');
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceNetModelChange(euroPrice.net);
+
+        expect(convertNetToGross).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call debounced gross handler on input change', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const onPriceGrossChangeDebounce = jest.spyOn(wrapper.vm, 'onPriceGrossChangeDebounce');
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceGrossInputChange(euroPrice.gross);
+
+        expect(onPriceGrossChangeDebounce).toHaveBeenCalledTimes(1);
+        expect(onPriceGrossChangeDebounce).toHaveBeenCalledWith(euroPrice.gross);
+    });
+
+    it('should cancel pending debounce when gross model change is triggered', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const onPriceGrossChangeDebounceCancel = jest.fn();
+        wrapper.vm.onPriceGrossChangeDebounce.cancel = onPriceGrossChangeDebounceCancel;
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceGrossInputChange(euroPrice.gross);
+        wrapper.vm.onPriceGrossModelChange(euroPrice.gross);
+
+        expect(onPriceGrossChangeDebounceCancel).toHaveBeenCalledTimes(1);
+    });
+
     it('should not emit update:value event on price gross change', async () => {
         const wrapper = await setup({ allowEmpty: false });
         await wrapper.setProps({
@@ -299,26 +354,4 @@ describe('components/form/sw-price-field', () => {
         expect(wrapper.vm.priceForCurrency.net).toBe(euroPrice.net);
     });
 
-    it('should cancel the debounce timer when the number field emits "ends-with-decimal-separator" event', async () => {
-        const wrapper = await setup();
-
-        // Type a normal number
-        await wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').setValue('123');
-
-        // Wait for the debounce timer to start
-        await wrapper.vm.$nextTick();
-
-        // Type a number with a decimal separator at the end
-        await wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').setValue('123.');
-
-        // Wait until the debounce timer is finished
-        jest.runAllTimers();
-        await flushPromises();
-
-        // Check if the value is set
-        expect(wrapper.vm.priceForCurrency.gross).toBe(123);
-
-        // Check if the input field value still contains the decimal separator
-        expect(wrapper.findByPlaceholder('sw-product.priceForm.placeholderPriceGross').element.value).toBe('123.');
-    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.spec.js
@@ -287,6 +287,20 @@ describe('components/form/sw-price-field', () => {
         expect(onPriceGrossChangeDebounce).toHaveBeenCalledWith(euroPrice.gross);
     });
 
+    it('should call debounced net handler on input change', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const onPriceNetChangeDebounce = jest.spyOn(wrapper.vm, 'onPriceNetChangeDebounce');
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceNetInputChange(euroPrice.net);
+
+        expect(onPriceNetChangeDebounce).toHaveBeenCalledTimes(1);
+        expect(onPriceNetChangeDebounce).toHaveBeenCalledWith(euroPrice.net);
+    });
+
     it('should cancel pending debounce when gross model change is triggered', async () => {
         const wrapper = await setup({ allowEmpty: false });
         const onPriceGrossChangeDebounceCancel = jest.fn();
@@ -300,6 +314,21 @@ describe('components/form/sw-price-field', () => {
         wrapper.vm.onPriceGrossModelChange(euroPrice.gross);
 
         expect(onPriceGrossChangeDebounceCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cancel pending debounce when net model change is triggered', async () => {
+        const wrapper = await setup({ allowEmpty: false });
+        const onPriceNetChangeDebounceCancel = jest.fn();
+        wrapper.vm.onPriceNetChangeDebounce.cancel = onPriceNetChangeDebounceCancel;
+        await wrapper.setProps({
+            value: [euroPrice],
+            inherited: false,
+        });
+
+        wrapper.vm.onPriceNetInputChange(euroPrice.net);
+        wrapper.vm.onPriceNetModelChange(euroPrice.net);
+
+        expect(onPriceNetChangeDebounceCancel).toHaveBeenCalledTimes(1);
     });
 
     it('should not emit update:value event on price gross change', async () => {
@@ -353,5 +382,4 @@ describe('components/form/sw-price-field', () => {
 
         expect(wrapper.vm.priceForCurrency.net).toBe(euroPrice.net);
     });
-
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the price in linked price fields is updated on blurring the input field with a 300ms debounce time. This leads to two faulty behaviors:
- When pressing save immediately after changing the gross price, the net price is not updated (https://github.com/shopware/shopware/issues/14144)
- The net price is not updated while typing

### 2. What does this change do, exactly?

- The recalculation debounce is triggered when the input-change event on the mt-number-field is fired. Therefore the recalculation happens on every keystroke.
- When the model value changes (blur) the value is updated instantly


### 3. Describe each step to reproduce the issue or behaviour.

- Open a product
- Change gross price
- Click save
=> Net price is not updated


### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/14144
closes https://github.com/shopware/shopware/pull/15261
