### PR TITLE
fix: broken transaction level on cache storage deadlock

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -48,6 +48,13 @@ The Store API newsletter routes now return `200 OK` with a response body instead
 
 Product main categories are now inherited from parent product if not explicitly defined on the variant itself.
 
+### CategoryIndexer doesn't dispatch IndexingMetaEvent when only index irrelevant data changes
+
+The CategoryIndexer did already check for changed payload and only triggered the tree/child-count updaters when the `parentId` changed and the breadcrumb updater when the `name` changed. 
+But it still dispatched the `CategoryIndexingMessage`, even though all relevant Updaters would be skipped. For performance and efficiency reasons that event is not thrown anymore in the case of an update when only irrelevant data has changed.
+This saves resources, as we don't need to fetch any child categories, dispatch unneeded messages and create DB transactions when it's not needed, especially as this whole handling was also triggered when you only assign products to a category, which is a quite common action.
+Note that this only affects the update case, in the case of newly inserted or deleted categories the event is still dispatched, as all updaters are relevant in that case.
+
 ### Deprecation of unused `TemplateGroup` class
 
 The class `\Shopware\Core\Content\Seo\SeoUrlTemplate\TemplateGroup` has been deprecated as it is unused and will be removed in the next major version v6.8.0.

--- a/src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
+++ b/src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
@@ -130,6 +130,11 @@ class CategoryIndexer extends EntityIndexer
             );
         }
 
+        if (!$runAllUpdaters && !$parentIdChanged && !$nameChanged) {
+            // we would skip all updaters, so we can return early without dispatching messages for children
+            return null;
+        }
+
         $children = $this->fetchChildren($ids, $event->getContext()->getVersionId());
         $ids = array_unique(array_merge($ids, $children));
 

--- a/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
@@ -110,9 +110,7 @@ class MySQLInvalidatorStorage extends AbstractInvalidatorStorage
         $this->connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
 
         try {
-            // try to retry deadlock related exceptions
-            // additionally our implementation fixes a dbal issue with wrong transaction nesting level after deadlock exceptions (see https://github.com/doctrine/dbal/issues/6651)
-            return RetryableTransaction::retryable($this->connection, $callback);
+            return RetryableTransaction::transactional($this->connection, $callback);
         } finally {
             // restore original isolation mode
             $this->connection->setTransactionIsolation($transactionIsolation);

--- a/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\TransactionIsolationLevel;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -109,7 +110,9 @@ class MySQLInvalidatorStorage extends AbstractInvalidatorStorage
         $this->connection->setTransactionIsolation(TransactionIsolationLevel::READ_COMMITTED);
 
         try {
-            return $this->connection->transactional($callback);
+            // try to retry deadlock related exceptions
+            // additionally our implementation fixes a dbal issue with wrong transaction nesting level after deadlock exceptions (see https://github.com/doctrine/dbal/issues/6651)
+            return RetryableTransaction::retryable($this->connection, $callback);
         } finally {
             // restore original isolation mode
             $this->connection->setTransactionIsolation($transactionIsolation);

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
@@ -32,6 +32,43 @@ class RetryableTransaction
     }
 
     /**
+     * Executes the given closure inside a DBAL transaction. In case of a deadlock (RetryableException) the transaction
+     * is rolled back. There are no retries, and the original exception is re-thrown.
+     *
+     * @template TReturn of mixed
+     *
+     * @param \Closure(Connection): TReturn $closure
+     *
+     * @return TReturn
+     */
+    public static function transactional(Connection $connection, \Closure $closure)
+    {
+        $originalNestingLevel = $connection->getTransactionNestingLevel();
+        try {
+            return $connection->transactional($closure);
+        } catch (\Throwable $e) {
+            if ($originalNestingLevel > 0) {
+                // If this RetryableTransaction was executed inside another transaction, do not retry this nested
+                // transaction. Remember that the whole (outermost) transaction was already rolled back by the database
+                // when any RetryableException is thrown.
+                // Rethrow the exception here so only the outermost transaction is retried which in turn includes this
+                // nested transaction.
+                throw $e;
+            }
+
+            // after failure and rollback in transactional we need to make sure the nesting level
+            // is correct (see https://github.com/doctrine/dbal/issues/6651) and transaction is rolled back
+            // it's safe to assume that correct nesting level is 0, as we check for transaction nesting level
+            // in condition above
+            self::fixConnection($connection);
+
+            // we still throw the exception, so it can be handled gracefully by the caller
+            // however the transactionNestingLevel is fixed, so this won't cause follow up issues
+            throw $e;
+        }
+    }
+
+    /**
      * @template TReturn of mixed
      *
      * @param \Closure(Connection): TReturn $closure The function to execute transactionally.

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerTest.php
@@ -135,36 +135,41 @@ class CategoryIndexerTest extends TestCase
      *
      * @param array<string, mixed> $categoryPayload Fields written to category table
      * @param array<string, mixed>|null $translationPayload Fields written to category_translation table
-     * @param list<string> $expectedSkips
+     * @param list<string>|null $expectedSkips
      */
     #[DataProvider('selectiveIndexingCases')]
     public function testSelectiveIndexing(
         array $categoryPayload,
         ?array $translationPayload,
         string $categoryOperation,
-        array $expectedSkips,
+        ?array $expectedSkips,
     ): void {
         $this->prepareFetchChildrenMethod([]);
 
         $containerEvent = $this->createCategoryWrittenEvent($categoryPayload, $categoryOperation, $translationPayload);
         $message = $this->indexer->update($containerEvent);
 
+        if ($expectedSkips === null) {
+            static::assertNull($message);
+
+            return;
+        }
+
         static::assertNotNull($message);
         static::assertEqualsCanonicalizing($expectedSkips, $message->getSkip());
     }
 
     /**
-     * @return \Generator<string, array{categoryPayload: array<string, mixed>, translationPayload: array<string, mixed>|null, categoryOperation: string, expectedSkips: list<string>}>
+     * @return \Generator<string, array{categoryPayload: array<string, mixed>, translationPayload: array<string, mixed>|null, categoryOperation: string, expectedSkips: list<string>|null}>
      */
     public static function selectiveIndexingCases(): \Generator
     {
         // Translation-only updates (category gets updatedAt, translation gets the actual field)
-        // Message is dispatched for BC (external systems may listen), but all built-in updaters skipped
         yield 'translation: metaDescription only - all updaters skipped' => [
             'categoryPayload' => ['updatedAt' => new \DateTimeImmutable()],
             'translationPayload' => ['metaDescription' => 'new desc'],
             'categoryOperation' => EntityWriteResult::OPERATION_UPDATE,
-            'expectedSkips' => [CategoryIndexer::CHILD_COUNT_UPDATER, CategoryIndexer::TREE_UPDATER, CategoryIndexer::BREADCRUMB_UPDATER],
+            'expectedSkips' => null,
         ];
 
         yield 'translation: name change - breadcrumb only' => [
@@ -235,7 +240,7 @@ class CategoryIndexerTest extends TestCase
                 $uuid,
                 [],
                 CategoryDefinition::ENTITY_NAME,
-                EntityWriteResult::OPERATION_UPDATE
+                EntityWriteResult::OPERATION_INSERT
             );
         }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransactionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransactionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Doctrine\Doctrine;
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDO\Exception;


### PR DESCRIPTION
### 1. Why is this change necessary?
The cache invalidator mysql storage might run into deadlocks, which is somewhat expected in rare race conditions, and we handle that gracefully, however if that happens the dbal transaction level is messed up, so when afterwards another transaction is started it will always fail

### 2. What does this change do, exactly?
Use our retryable transaction, which already has a workaround implemented for underlying DBAL issue

### 3. Describe each step to reproduce the issue or behaviour.

discovered the following case whily debugging race conditions in the ATS:
* we create a product and assign it a category (we only assign the category-id), we run that request in parallel to create two products
* as part of the product.written we invalidate the caches and call the store function of the invalidator storage
* in some race conditions between the two parallel requests, one of those calls runs in a deadlock
* the deadlock is handled gracefully and we switch to immediate invalidate
* however transaction nesting level in dbal connection is not reduced
* because we assigned a category, category.written event is dispatched as well and category indexer kicks in
* because no field was changed we add skips for all updaters in the `update` call, but still dispatch the indexing message
* in `handle` method we begin a new transaction, however all updater are skipped so we don't execute any SQL in the transaction
* we try to commit the empty transaction, which fails because of doctrine savepoint errors, because DBAL has transaction nesting level of 2, because it did not reset the nesting level on deadlock for the invalidator storage 💣 

