### PR TITLE
feat(administration): send identified consent_revoked event with deletion identifiers

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -11,8 +11,17 @@ const mockAnonymousAmplitudeClient = {
     reset: jest.fn(),
 };
 
+const mockDeleteUserAmplitudeClient = {
+    init: jest.fn(),
+    track: jest.fn(),
+    flush: jest.fn(),
+};
+
 jest.mock('@amplitude/analytics-browser', () => ({
-    createInstance: jest.fn(() => mockAnonymousAmplitudeClient),
+    createInstance: jest
+        .fn()
+        .mockImplementationOnce(() => mockAnonymousAmplitudeClient)
+        .mockImplementationOnce(() => mockDeleteUserAmplitudeClient),
     add: jest.fn(),
     init: jest.fn(),
     track: jest.fn(),
@@ -26,16 +35,26 @@ jest.mock('@amplitude/analytics-browser', () => ({
 
 describe('src/app/post-init/amplitude.init.ts', () => {
     let mockLoginService;
+    const testShopId = 'knneBsx7LiKySnUq';
+    const testUserId = '8b8ebef4-7fa3-4844-ab7e-120463ea558b';
 
     beforeEach(() => {
         jest.clearAllMocks();
         Shopware.Utils.EventBus.all?.clear();
+        const { createInstance } = jest.requireMock('@amplitude/analytics-browser');
+        createInstance.mockReset();
+        createInstance
+            .mockImplementationOnce(() => mockAnonymousAmplitudeClient)
+            .mockImplementationOnce(() => mockDeleteUserAmplitudeClient);
 
         mockAnonymousAmplitudeClient.init.mockClear();
         mockAnonymousAmplitudeClient.track.mockClear();
         mockAnonymousAmplitudeClient.setTransport.mockClear();
         mockAnonymousAmplitudeClient.flush.mockClear();
         mockAnonymousAmplitudeClient.reset.mockClear();
+        mockDeleteUserAmplitudeClient.init.mockClear();
+        mockDeleteUserAmplitudeClient.track.mockClear();
+        mockDeleteUserAmplitudeClient.flush.mockClear();
 
         mockLoginService = {
             addOnLogoutListener: jest.fn(),
@@ -54,6 +73,10 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         };
 
         Shopware.Store.get('context').app.analyticsGatewayUrl = 'https://gateway.example';
+        Shopware.Store.get('context').app.config.shopId = testShopId;
+        Shopware.Store.get('session').currentUser = {
+            id: testUserId,
+        };
         useConsentStore().consents = {
             product_analytics: {
                 name: 'product_analytics',
@@ -82,6 +105,10 @@ describe('src/app/post-init/amplitude.init.ts', () => {
     describe('initialization', () => {
         it('add enrichment plugin and calls initialization routine', async () => {
             const { init, add, createInstance } = await import('@amplitude/analytics-browser');
+            createInstance.mockReset();
+            createInstance
+                .mockImplementationOnce(() => mockAnonymousAmplitudeClient)
+                .mockImplementationOnce(() => mockDeleteUserAmplitudeClient);
 
             await initAmplitude();
 
@@ -110,7 +137,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                 }),
             );
 
-            expect(createInstance).toHaveBeenCalledTimes(1);
+            expect(createInstance).toHaveBeenCalledTimes(2);
             expect(mockAnonymousAmplitudeClient.init).toHaveBeenCalledWith(
                 expect.any(String),
                 undefined,
@@ -118,18 +145,32 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     serverUrl: 'https://gateway.example/event/anonymous',
                 }),
             );
+            expect(mockDeleteUserAmplitudeClient.init).toHaveBeenCalledWith(
+                expect.any(String),
+                undefined,
+                expect.objectContaining({
+                    serverUrl: 'https://gateway.example/delete-user',
+                }),
+            );
         });
 
         it('does not initialize anonymous amplitude when gateway base url is missing', async () => {
+            const { createInstance } = await import('@amplitude/analytics-browser');
+            createInstance.mockReset();
             Shopware.Store.get('context').app.analyticsGatewayUrl = null;
 
             await initAmplitude();
 
             expect(mockAnonymousAmplitudeClient.init).not.toHaveBeenCalled();
+            expect(mockDeleteUserAmplitudeClient.init).not.toHaveBeenCalled();
         });
 
         it('initializes only anonymous amplitude without product analytics consent', async () => {
-            const { init } = await import('@amplitude/analytics-browser');
+            const { init, createInstance } = await import('@amplitude/analytics-browser');
+            createInstance.mockReset();
+            createInstance
+                .mockImplementationOnce(() => mockAnonymousAmplitudeClient)
+                .mockImplementationOnce(() => mockDeleteUserAmplitudeClient);
             useConsentStore().consents.product_analytics.status = 'revoked';
 
             await initAmplitude();
@@ -140,6 +181,13 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                 undefined,
                 expect.objectContaining({
                     serverUrl: 'https://gateway.example/event/anonymous',
+                }),
+            );
+            expect(mockDeleteUserAmplitudeClient.init).toHaveBeenCalledWith(
+                expect.any(String),
+                undefined,
+                expect.objectContaining({
+                    serverUrl: 'https://gateway.example/delete-user',
                 }),
             );
         });
@@ -230,6 +278,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             useConsentStore().consents.product_analytics.status = 'revoked';
 
             await initAmplitude();
+            track.mockClear();
 
             Shopware.Utils.EventBus.emit(
                 'telemetry',
@@ -294,7 +343,11 @@ describe('src/app/post-init/amplitude.init.ts', () => {
         });
 
         it('stops telemetry after consent is revoked during runtime', async () => {
-            const { reset, setOptOut } = await import('@amplitude/analytics-browser');
+            const { reset, setOptOut, createInstance } = await import('@amplitude/analytics-browser');
+            createInstance.mockReset();
+            createInstance
+                .mockImplementationOnce(() => mockAnonymousAmplitudeClient)
+                .mockImplementationOnce(() => mockDeleteUserAmplitudeClient);
             const consentStore = useConsentStore();
             const eventBusOffSpy = jest.spyOn(Shopware.Utils.EventBus, 'off');
 
@@ -315,6 +368,12 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             await flushPromises();
 
             expect(eventBusOffSpy).toHaveBeenCalledWith('telemetry', expect.any(Function));
+            expect(mockDeleteUserAmplitudeClient.track).toHaveBeenCalledWith('delete_user', {
+                shop_id: testShopId,
+                user_id: testUserId,
+                amplitude_user_id: `${testShopId}:${testUserId}`,
+            });
+            expect(mockDeleteUserAmplitudeClient.flush).toHaveBeenCalledTimes(1);
             expect(setOptOut).toHaveBeenCalledWith(true);
             expect(reset).toHaveBeenCalled();
         });
@@ -383,13 +442,8 @@ describe('src/app/post-init/amplitude.init.ts', () => {
     });
 
     describe('user identification', () => {
-        const testShopId = 'knneBsx7LiKySnUq';
-        const testUserId = '8b8ebef4-7fa3-4844-ab7e-120463ea558b';
-
         beforeEach(() => {
             jest.clearAllMocks();
-
-            Shopware.Store.get('context').app.config.shopId = testShopId;
         });
 
         it('should set user ID in format "shopId:userId"', async () => {
@@ -433,12 +487,8 @@ describe('src/app/post-init/amplitude.init.ts', () => {
     });
 
     describe('login and logout tracking', () => {
-        const testShopId = 'knneBsx7LiKySnUq';
-
         beforeEach(() => {
             jest.clearAllMocks();
-
-            Shopware.Store.get('context').app.config.shopId = testShopId;
         });
 
         it('should track Login event when a identify telemetry event with a different userId arrives', async () => {

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -9,6 +9,7 @@ import createTelemetryEventHandler from './amplitude.telemetry-handlers';
 
 type AmplitudeModule = typeof AmplitudeClient;
 type AnonymousAmplitudeClient = ReturnType<AmplitudeModule['createInstance']>;
+type PrivacyAmplitudeClient = ReturnType<AmplitudeModule['createInstance']>;
 
 let stopTelemetryConsentWatch: (() => void) | null = null;
 
@@ -32,12 +33,14 @@ export default async function (): Promise<void> {
     });
     const amplitude = await import('@amplitude/analytics-browser');
     const anonymousAmplitude = amplitude.createInstance();
+    const privacyAmplitude = amplitude.createInstance();
     const pushTelemetryEventToAmplitude = createTelemetryEventHandler(amplitude);
     let isTelemetryInitialized = false;
     let isTelemetryListenerRegistered = false;
 
     registerAnonymousLogoutListener(anonymousAmplitude);
     initAnonymousAmplitude(anonymousAmplitude, analyticsGatewayUrl);
+    initPrivacyAmplitude(privacyAmplitude, analyticsGatewayUrl);
 
     const pushConsentEventToAmplitude = createConsentEventHandler(anonymousAmplitude);
 
@@ -91,6 +94,17 @@ export default async function (): Promise<void> {
             isTelemetryListenerRegistered = false;
         }
 
+        const shopId = Shopware.Store.get('context').app.config.shopId;
+        const userId = Shopware.Store.get('session').currentUser?.id;
+
+        if (typeof userId === 'string') {
+            privacyAmplitude.track('delete_user', {
+                shop_id: shopId,
+                user_id: userId,
+                amplitude_user_id: `${shopId}:${userId}`,
+            });
+            privacyAmplitude.flush();
+        }
         amplitude.setOptOut(true);
         amplitude.flush();
         amplitude.reset();
@@ -143,6 +157,11 @@ function initAnonymousAmplitude(anonymousAmplitude: AnonymousAmplitudeClient, an
 function initTelemetryAmplitude(amplitude: AmplitudeModule, analyticsGatewayUrl: string): void {
     // The real key will be added by the gateway
     amplitude.init('placeholder-apikey', undefined, createAmplitudeInitOptions(`${analyticsGatewayUrl}/event`));
+}
+
+function initPrivacyAmplitude(privacyAmplitude: PrivacyAmplitudeClient, analyticsGatewayUrl: string): void {
+    // The real key will be added by the gateway
+    privacyAmplitude.init('placeholder-apikey', undefined, createAmplitudeInitOptions(`${analyticsGatewayUrl}/delete-user`));
 }
 
 function createAmplitudeInitOptions(serverUrl: string) {


### PR DESCRIPTION
### 1. Why is this change necessary?

  When product_analytics consent is revoked, we need to trigger user deletion handling via gateway without overloading the
  regular telemetry ingestion route.

  Using /event for this requires payload branching and special-case handling in gateway. A dedicated path is cleaner and
  keeps concerns separated:

  - telemetry events stay on /event
  - delete-user trigger is sent to a dedicated endpoint

  ### 2. What does this change do, exactly?

  This change updates Administration amplitude initialization to use a dedicated identified Amplitude client instance for
  user deletion triggers.

  On runtime revoke of product_analytics consent:

  - telemetry tracking is still disabled as before
  - a dedicated event is sent via gateway path /delete-user (not /event)
  - payload includes deterministic identifiers:
      - shop_id
      - user_id
      - amplitude_user_id (${shopId}:${userId})

  Implementation details:

  - existing telemetry Amplitude instance remains unchanged (/event)
  - anonymous consent-event instance remains unchanged (/event/anonymous)
  - new dedicated instance initialized with serverUrl: ${analyticsGatewayUrl}/delete-user
  - revoke flow sends delete_user event through this dedicated client and flushes it

  Unit tests in amplitude.init.spec.js were updated accordingly:

  - assert dedicated client initialization for /delete-user
  - assert revoke flow sends delete_user payload via dedicated client
  - keep existing telemetry/anonymous behavior checks intact

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Open Administration with PRODUCT_ANALYTICS enabled and analyticsGatewayUrl configured.
  2. Ensure product_analytics consent is initially accepted.
  3. Revoke product_analytics consent at runtime.
  4. Observe behavior:

  - Before this change:
      - revoke handling relied on telemetry channel semantics and no dedicated route separation.
  - After this change:
      - a dedicated delete_user event is sent to ${analyticsGatewayUrl}/delete-user with shop_id, user_id, amplitude_user_id
      - telemetry is then opted out and reset as before.

  ### 4. Please link to the relevant issues (if any).

  - Jira issue: please insert

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is relevant for external developers:
      - Add a short entry to RELEASE_INFO-6.<major>.md under “Upcoming” for informational changes, including the
        consequences of the change and how it affects external developers.
      - Add an UPGRADE section in UPGRADE-6.<next-major>.md for breaking changes (what/why/impact/how to adapt).
      - See the Documenting a Release Process
        (https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them