### PR TITLE
feat: make model editor scale lockable

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/index.ts
@@ -263,6 +263,16 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         /**
+         * Changes whether the scale is linked or not. Will be called when the user changes the linked state in the UI.
+         * @param value - boolean value indicating whether the scale should be linked or not
+         */
+        changeModelScaleLinked(value: boolean): void {
+            if (!this.toolbox) return;
+
+            this.toolbox.getTool('transform').setGizmoScaleLinked(value);
+        },
+
+        /**
          * Saves the model to the media library.
          */
         async save(): Promise<void> {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.html.twig
@@ -82,6 +82,8 @@
                     <sw-vector-field
                         :value="currentProperties.scale"
                         :label="$t('sw-model-editor.properties.transformation.scale.label')"
+                        linkable
+                        @link-change="changeModelScaleLinked"
                         @input-change="changeModelScale"
                         @update:value="changeModelScale"
                     />


### PR DESCRIPTION
### 1. Why is this change necessary?

The scale filed in the model editor should be lockable, so you can ensure uniform scaling if wanted.

### 2. What does this change do, exactly?

Add the possibility to lock all 3 axis of scaling in the model editor.

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload 3d model
2. Open 3d model editor
3. Select model
4. Lock/Unlock the scale filed

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
