### PR TITLE
refactor: implement sw-vector-field varaints colored - neutral

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.scss
@@ -28,27 +28,6 @@ $sw-button-transition: all 0.15s ease-out;
     flex: 0 0 400px;
     border-left: 1px solid var(--color-border-primary-default);
 
-    .sw-vector-field__input__x {
-        .mt-field__addition.is--prefix {
-            color: #c20017;
-            background: #fff2f0;
-        }
-    }
-
-    .sw-vector-field__input__y {
-        .mt-field__addition.is--prefix {
-            color: #00ab26;
-            background: #e1ffe0;
-        }
-    }
-
-    .sw-vector-field__input__z {
-        .mt-field__addition.is--prefix {
-            color: #0081d4;
-            background: #eef6ff;
-        }
-    }
-
     .sw-model-editor-sidebar-content-item {
         border-bottom: 1px solid #d1d9e0;
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/index.ts
@@ -58,6 +58,31 @@ export default Shopware.Component.wrapComponentConfig({
             required: false,
             default: null,
         },
+
+        variant: {
+            type: String,
+            required: false,
+            default: 'colored',
+            validValues: [
+                'neutral',
+                'colored',
+            ],
+            validator(value: string) {
+                return [
+                    'neutral',
+                    'colored',
+                ].includes(value);
+            },
+        },
+    },
+
+    computed: {
+        classes(): Record<string, boolean> {
+            return {
+                'sw-vector-field': true,
+                [`sw-vector-field--${this.variant}`]: true,
+            };
+        },
     },
 
     data() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.html.twig
@@ -2,7 +2,7 @@
     :label="label"
     :description="description"
     :disabled="disabled"
-    class="sw-vector-field"
+    :class="classes"
 >
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_vector_field_label %}

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.scss
@@ -35,3 +35,26 @@
         display: none;
     }
 }
+
+.sw-vector-field--colored {
+    .sw-vector-field__input__x {
+        .mt-field__addition.is--prefix {
+            color: #c20017;
+            background: #fff2f0;
+        }
+    }
+
+    .sw-vector-field__input__y {
+        .mt-field__addition.is--prefix {
+            color: #00ab26;
+            background: #e1ffe0;
+        }
+    }
+
+    .sw-vector-field__input__z {
+        .mt-field__addition.is--prefix {
+            color: #0081d4;
+            background: #eef6ff;
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -1722,6 +1722,10 @@
   "sw-context-button": {
     "ariaLabel": "Kontextmenü öffnen"
   },
+  "sw-vector-field": {
+    "lock-uniform-scale": "Gleichmäßige Skalierung sperren",
+    "unlock-uniform-scale": "Gleichmäßige Skalierung entsperren"
+  },
   "sw-model-editor": {
       "titleModal": "Model Editor",
       "open-model-editor-tooltip": "Model Editor öffnen",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -1722,6 +1722,10 @@
   "sw-context-button": {
     "ariaLabel": "Open context menu"
   },
+  "sw-vector-field": {
+    "lock-uniform-scale": "Lock uniform scale",
+    "unlock-uniform-scale": "Unlock uniform scale"
+  },
   "sw-model-editor": {
     "titleModal": "Model Editor",
     "open-model-editor-tooltip": "Open Model Editor",


### PR DESCRIPTION
### 1. Why is this change necessary?

The sw-vector-field may need to have a colored or neutral color style.

### 2. What does this change do, exactly?

Implement the two color styles in a central way.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- relates #15284

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
