### PR TITLE
fix: invalidate closeout products PDPs on stock change

### DIFF
--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -184,6 +184,12 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Core\Content\Product\Stock\ProductStockChangedCacheInvalidationListener">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheInvalidator"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Content\Product\Stock\AvailableStockMirrorSubscriber">
             <tag name="kernel.event_listener"/>
         </service>

--- a/src/Core/Content/Product/Stock/ProductStockChangedCacheInvalidationListener.php
+++ b/src/Core/Content/Product/Stock/ProductStockChangedCacheInvalidationListener.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Stock;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Product\Events\ProductStockAlteredEvent;
+use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+final readonly class ProductStockChangedCacheInvalidationListener implements EventSubscriberInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private Connection $connection,
+        private CacheInvalidator $cacheInvalidator,
+    ) {
+    }
+
+    /**
+     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ProductStockAlteredEvent::class => 'onStockAltered',
+        ];
+    }
+
+    public function onStockAltered(ProductStockAlteredEvent $event): void
+    {
+        $ids = $event->getIds();
+
+        if ($ids === []) {
+            return;
+        }
+
+        $parentIds = $this->resolveParentIdsToInvalidate($ids);
+
+        if ($parentIds === []) {
+            return;
+        }
+
+        $this->cacheInvalidator->invalidate(
+            array_map(ProductDetailRoute::buildName(...), $parentIds),
+            false
+        );
+    }
+
+    /**
+     * Returns distinct parent IDs for closeout products that require PDP cache invalidation.
+     *
+     * Non-closeout products never affect calculatedMaxPurchase in core, so they are always skipped.
+     * All closeout products are invalidated unconditionally — no stock-vs-maxPurchase comparison is
+     * attempted here because:
+     *   - StockStorage is decoratable, so the DB stock value may not reflect the effective stock;
+     *   - the maxPurchase fallback (core.cart.maxQuantity) is sales-channel-aware, but this listener
+     *     only receives a plain Context (no SalesChannelContext), making cross-channel comparison
+     *     unreliable;
+     *   - replicating ProductMaxPurchaseCalculator logic would couple invalidation to business rules
+     *     that may be decorated independently.
+     *
+     * Extensions that make stock affect non-closeout products must handle their own invalidation.
+     *
+     * @param list<string> $ids
+     *
+     * @return list<string>
+     */
+    private function resolveParentIdsToInvalidate(array $ids): array
+    {
+        return $this->connection->fetchFirstColumn(
+            'SELECT DISTINCT LOWER(HEX(COALESCE(p.parent_id, p.id)))
+            FROM product p
+            LEFT JOIN product parent ON parent.id = p.parent_id AND parent.version_id = p.version_id
+            WHERE p.id IN (:ids)
+            AND p.version_id = :version
+            AND COALESCE(p.is_closeout, parent.is_closeout, 0) = 1',
+            [
+                'ids' => Uuid::fromHexToBytesList($ids),
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+            ],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Simple fix alternative to https://github.com/shopware/shopware/pull/15376

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/14816

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
