### PR TITLE
fix: validate RTE code content before closing CMS element settings mo…

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/index.ts
@@ -84,5 +84,15 @@ export default Shopware.Component.wrapComponentConfig({
         onUpdateModelValue(value: string) {
             this.$emit('update:modelValue', value);
         },
+
+        validate(): Promise<boolean> {
+            const original = this.$refs.mtTextEditorOriginal as { validate?: () => Promise<boolean> } | undefined;
+
+            if (!original?.validate) {
+                return Promise.resolve(true);
+            }
+
+            return original.validate();
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/mt-text-editor.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/mt-text-editor.html.twig
@@ -1,5 +1,6 @@
 {% block mt_text_editor_original %}
 <mt-text-editor-original
+    ref="mtTextEditorOriginal"
     v-bind="$attrs"
     v-model="compatValue"
     :custom-buttons="mergedCustomButtons"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -172,9 +172,11 @@ export default Shopware.Component.wrapComponentConfig({
                 return;
             }
 
-            const childComponent = this.$refs.elementComponentRef as {
-                handleUpdateContent: () => boolean | void | Promise<boolean | void>;
-            };
+            const childComponent = this.$refs.elementComponentRef as
+                | {
+                      handleUpdateContent?: () => boolean | void | Promise<boolean | void>;
+                  }
+                | undefined;
 
             if (childComponent?.handleUpdateContent) {
                 const result = await childComponent.handleUpdateContent();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -167,17 +167,21 @@ export default Shopware.Component.wrapComponentConfig({
             this.showElementSettings = true;
         },
 
-        onCloseSettingsModal() {
+        async onCloseSettingsModal() {
             if (!this.showElementSettings) {
                 return;
             }
 
             const childComponent = this.$refs.elementComponentRef as {
-                handleUpdateContent: () => void;
+                handleUpdateContent: () => boolean | void | Promise<boolean | void>;
             };
 
             if (childComponent?.handleUpdateContent) {
-                childComponent.handleUpdateContent();
+                const result = await childComponent.handleUpdateContent();
+
+                if (result === false) {
+                    return;
+                }
             }
 
             this.showElementSettings = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
@@ -479,7 +479,7 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         await flushPromises();
 
         expect(wrapper.vm.showElementSettings).toBe(true);
-        wrapper.vm.onCloseSettingsModal();
+        await wrapper.vm.onCloseSettingsModal();
         expect(wrapper.vm.showElementSettings).toBe(false);
         expect(mockHandleUpdateContent).toHaveBeenCalledTimes(1);
     });
@@ -498,9 +498,47 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         await flushPromises();
 
         expect(wrapper.vm.showElementSettings).toBe(false);
-        wrapper.vm.onCloseSettingsModal();
+        await wrapper.vm.onCloseSettingsModal();
         expect(wrapper.vm.showElementSettings).toBe(false);
         expect(mockHandleUpdateContent).not.toHaveBeenCalled();
+    });
+
+    it('should not close the settings modal if handleUpdateContent returns false', async () => {
+        const mockPreventClose = jest.fn(() => Promise.resolve(false));
+        const wrapper = mount(await wrapTestComponent('sw-cms-slot', { sync: true }), {
+            props: {
+                element: { type: 'with_config_and_unlocked' },
+            },
+            global: {
+                stubs: {
+                    'foo-bar': {
+                        template: '<div class="foo-bar"><slot></slot></div>',
+                        methods: {
+                            handleUpdateContent: mockPreventClose,
+                        },
+                    },
+                    'sw-modal': {
+                        template: '<div class="sw-modal"><slot></slot></div>',
+                    },
+                    'sw-sidebar-collapse': true,
+                    'sw-skeleton-bar': true,
+                },
+                provide: {
+                    cmsService: Shopware.Service('cmsService'),
+                    cmsElementFavorites: Shopware.Service('cmsElementFavorites'),
+                },
+            },
+        });
+
+        await wrapper.setData({
+            showElementSettings: true,
+            isElementSettingsInitialized: true,
+        });
+        await flushPromises();
+
+        await wrapper.vm.onCloseSettingsModal();
+        expect(mockPreventClose).toHaveBeenCalledTimes(1);
+        expect(wrapper.vm.showElementSettings).toBe(true);
     });
 
     it('should keep the settings modal mounted after first close and allow reopening', async () => {
@@ -519,7 +557,7 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         expect(wrapper.find('.sw-modal').exists()).toBe(true);
         expect(wrapper.vm.showElementSettings).toBe(true);
 
-        wrapper.vm.onCloseSettingsModal();
+        await wrapper.vm.onCloseSettingsModal();
         await flushPromises();
 
         expect(wrapper.vm.showElementSettings).toBe(false);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
@@ -111,6 +111,10 @@ describe('src/module/sw-cms/elements/text/config', () => {
     });
 
     describe('handleUpdateContent', () => {
+        afterEach(() => {
+            global.activeFeatureFlags = [];
+        });
+
         it('should return true when textEditor ref is not available', async () => {
             const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/config.spec.js
@@ -5,7 +5,7 @@ import { mount } from '@vue/test-utils';
 import 'src/module/sw-cms/mixin/sw-cms-element.mixin';
 import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 
-async function createWrapper() {
+async function createWrapper(additionalStubs = {}) {
     return mount(await wrapTestComponent('sw-cms-el-config-text', { sync: true }), {
         global: {
             provide: {
@@ -54,6 +54,7 @@ async function createWrapper() {
                         'label',
                     ],
                 },
+                ...additionalStubs,
             },
         },
         props: {
@@ -107,5 +108,51 @@ describe('src/module/sw-cms/elements/text/config', () => {
         expect(wrapper.vm.element.config.content.value).toBe(updatedContent);
         expect(wrapper.emitted('element-update')).toBeTruthy();
         expect(wrapper.emitted()['element-update'][0][0]).toEqual(wrapper.vm.element);
+    });
+
+    describe('handleUpdateContent', () => {
+        it('should return true when textEditor ref is not available', async () => {
+            const wrapper = await createWrapper();
+
+            const result = await wrapper.vm.handleUpdateContent();
+
+            expect(result).toBe(true);
+        });
+
+        it('should delegate to textEditor.validate and return true on success', async () => {
+            const mockValidate = jest.fn(() => Promise.resolve(true));
+            global.activeFeatureFlags = ['METEOR_TEXT_EDITOR'];
+
+            const wrapper = await createWrapper({
+                'mt-text-editor': {
+                    template: '<div></div>',
+                    methods: { validate: mockValidate },
+                },
+            });
+            await flushPromises();
+
+            const result = await wrapper.vm.handleUpdateContent();
+
+            expect(mockValidate).toHaveBeenCalledTimes(1);
+            expect(result).toBe(true);
+        });
+
+        it('should return false when textEditor.validate reports invalid content', async () => {
+            const mockValidate = jest.fn(() => Promise.resolve(false));
+            global.activeFeatureFlags = ['METEOR_TEXT_EDITOR'];
+
+            const wrapper = await createWrapper({
+                'mt-text-editor': {
+                    template: '<div></div>',
+                    methods: { validate: mockValidate },
+                },
+            });
+            await flushPromises();
+
+            const result = await wrapper.vm.handleUpdateContent();
+
+            expect(mockValidate).toHaveBeenCalledTimes(1);
+            expect(result).toBe(false);
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
@@ -77,7 +77,7 @@ export default {
         },
 
         async handleUpdateContent() {
-            const editor = this.$refs.textEditor;
+            const editor = this.$refs.swCmsTextEditor;
 
             if (!editor?.validate) {
                 return true;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/index.js
@@ -76,6 +76,16 @@ export default {
             this.initElementConfig('text');
         },
 
+        async handleUpdateContent() {
+            const editor = this.$refs.textEditor;
+
+            if (!editor?.validate) {
+                return true;
+            }
+
+            return editor.validate();
+        },
+
         onBlur(content) {
             this.emitChanges(content);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -57,6 +57,7 @@
 
                         <mt-text-editor
                             v-else
+                            ref="textEditor"
                             :key="isInherited + '-meteor'"
                             :disabled="isInherited"
                             :model-value="element.config.content.value"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -57,7 +57,7 @@
 
                         <mt-text-editor
                             v-else
-                            ref="textEditor"
+                            ref="swCmsTextEditor"
                             :key="isInherited + '-meteor'"
                             :disabled="isInherited"
                             :model-value="element.config.content.value"


### PR DESCRIPTION
### 1. Why is this change necessary?

When the CMS text element settings modal is closed while the RTE is in code mode with invalid HTML, the modal closes without any validation. The user is not warned about unsupported HTML that would be lost when switching back to WYSIWYG mode.

### 2. What does this change do, exactly?

- Makes `sw-cms-slot.onCloseSettingsModal()` async and checks the return value of `handleUpdateContent()` — if it returns `false`, the modal stays open
- Adds `handleUpdateContent()` to the text element config that calls `validate()` on the mt-text-editor ref
- Forwards `validate()` through the mt-text-editor wrapper to the Meteor component via `defineExpose`
- The Meteor component shows a diff modal if the HTML would change after parsing

### 3. Describe each step to reproduce the issue or behaviour.

- Enable the METEOR_TEXT_EDITOR feature flag -> you need the newest version. probably check it out and link it
- Open CMS designer, add a text element, open its settings
- Switch the text editor to code mode
- Add invalid/unsupported HTML (e.g. `<div style="color: invalid">test</div>`)
- Close the settings modal without switching back to WYSIWYG
- **Before:** Modal closes silently, invalid HTML is accepted
- **After:** Diff modal appears showing the differences, modal stays open

### 4. Please link to the relevant issues (if any).

- closes #15290
- depends on https://github.com/shopware/meteor/pull/1072

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
