### PR TITLE
fix: credit note creation for ZUGFeRD invoices (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2025-06-27-fix-invoice-number-selection.md
+++ b/changelog/_unreleased/2025-06-27-fix-invoice-number-selection.md
@@ -1,0 +1,11 @@
+---
+title: Fix invoice number selection for credit notes and storno invoices
+author: Justus Geramb
+author_email: justus@devite.io
+author_github: @jgeramb
+---
+# Administration
+* Changed the filter for documents to allow the selection of invoice numbers from ZUGFeRD and embedded ZUGFeRD invoices when creating credit notes and storno invoices.
+___
+# Core
+* Added the document number as the custom config field 'invoiceNumber' to the document, so that the invoice number can be selected in the frontend.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -303,7 +303,11 @@ export default {
 
         invoiceExists() {
             return this.documents.some((document) => {
-                return document.documentType.technicalName === 'invoice';
+                return (
+                    document.documentType.technicalName === 'invoice' ||
+                    document.documentType.technicalName === 'zugferd_invoice' ||
+                    document.documentType.technicalName === 'zugferd_embedded_invoice'
+                );
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
@@ -41,6 +41,34 @@ export default {
         documentPreconditionsFulfilled() {
             return this.highlightedItems.length !== 0 && this.documentConfig.custom.invoiceNumber;
         },
+
+        documentNumber: {
+            get() {
+                return String(this.documentConfig.documentNumber);
+            },
+            set(value) {
+                this.documentConfig.documentNumber = value;
+            },
+        },
+
+        invoices() {
+            return this.order.documents.filter((document) => {
+                return (
+                    document.documentType.technicalName === 'invoice' ||
+                    document.documentType.technicalName === 'zugferd_invoice' ||
+                    document.documentType.technicalName === 'zugferd_embedded_invoice'
+                );
+            });
+        },
+
+        invoiceNumberOptions() {
+            return this.invoiceNumbers.map((item) => {
+                return {
+                    label: String(item),
+                    value: item,
+                };
+            });
+        },
     },
 
     created() {
@@ -51,23 +79,19 @@ export default {
         createdComponent() {
             this.$super('createdComponent');
 
-            const invoiceNumbers = this.order.documents
-                .filter((document) => {
-                    return (
-                        document.documentType.technicalName === 'invoice' ||
-                        document.documentType.technicalName === 'zugferd_invoice' ||
-                        document.documentType.technicalName === 'zugferd_embedded_invoice'
-                    );
-                })
-                .map((item) => {
-                    return item.config.custom.invoiceNumber;
-                });
+            const invoiceNumbers = this.invoices.map((item) => {
+                return item.config.custom.invoiceNumber;
+            });
 
             this.invoiceNumbers = [...new Set(invoiceNumbers)].sort();
         },
 
         onCreateDocument(additionalAction = false) {
             this.$emit('loading-document');
+
+            const selectedInvoice = this.invoices.find((item) => {
+                return item.config.custom.invoiceNumber === this.documentConfig.custom.invoiceNumber;
+            });
 
             if (this.documentNumberPreview === this.documentConfig.documentNumber) {
                 this.numberRangeService
@@ -80,11 +104,11 @@ export default {
                             });
                         }
                         this.documentConfig.documentNumber = response.number;
-                        this.callDocumentCreate(additionalAction);
+                        this.callDocumentCreate(additionalAction, selectedInvoice?.id);
                     });
             } else {
                 this.documentConfig.custom.creditNoteNumber = this.documentConfig.documentNumber;
-                this.callDocumentCreate(additionalAction);
+                this.callDocumentCreate(additionalAction, selectedInvoice?.id);
             }
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/index.js
@@ -53,7 +53,11 @@ export default {
 
             const invoiceNumbers = this.order.documents
                 .filter((document) => {
-                    return document.documentType.technicalName === 'invoice';
+                    return (
+                        document.documentType.technicalName === 'invoice' ||
+                        document.documentType.technicalName === 'zugferd_invoice' ||
+                        document.documentType.technicalName === 'zugferd_embedded_invoice'
+                    );
                 })
                 .map((item) => {
                     return item.config.custom.invoiceNumber;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
@@ -18,9 +18,9 @@ const orderFixture = {
                 technicalName: 'invoice',
             },
             config: {
-                documentNumber: 1000,
+                documentNumber: '1000',
                 custom: {
-                    invoiceNumber: 1000,
+                    invoiceNumber: '1000',
                 },
             },
         },
@@ -35,9 +35,9 @@ const orderFixture = {
                 technicalName: 'invoice',
             },
             config: {
-                documentNumber: 1001,
+                documentNumber: '1001',
                 custom: {
-                    invoiceNumber: 1001,
+                    invoiceNumber: '1001',
                 },
             },
         },
@@ -390,7 +390,7 @@ describe('sw-order-document-settings-credit-note-modal', () => {
             documentConfig: {
                 documentNumber: 'PREVIEW_NUM_002',
                 custom: {
-                    invoiceNumber: 1000,
+                    invoiceNumber: '1000',
                 },
             },
         });
@@ -407,7 +407,7 @@ describe('sw-order-document-settings-credit-note-modal', () => {
             documentConfig: {
                 documentNumber: 'PREVIEW_NUM_002',
                 custom: {
-                    invoiceNumber: 1001,
+                    invoiceNumber: '1001',
                 },
             },
         });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-credit-note-modal/sw-order-document-settings-credit-note-modal.spec.js
@@ -8,6 +8,7 @@ const orderFixture = {
     id: 'order1',
     documents: [
         {
+            id: 'invoice-doc-1000',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -24,6 +25,7 @@ const orderFixture = {
             },
         },
         {
+            id: 'invoice-doc-1001',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -40,6 +42,7 @@ const orderFixture = {
             },
         },
         {
+            id: 'delivery-note-doc-1001',
             orderId: 'order1',
             sent: true,
             documentMediaFileId: null,
@@ -379,6 +382,40 @@ describe('sw-order-document-settings-credit-note-modal', () => {
 
         expect(wrapper.vm.documentConfig.custom.creditNoteNumber).toBe('PREVIEW_NUM_002');
         expect(wrapper.emitted()['document-create']).toBeTruthy();
+    });
+
+    it('should reference the selected invoice when creating document', async () => {
+        await wrapper.setData({
+            documentNumberPreview: 'PREVIEW_NUM_001',
+            documentConfig: {
+                documentNumber: 'PREVIEW_NUM_002',
+                custom: {
+                    invoiceNumber: 1000,
+                },
+            },
+        });
+
+        await wrapper.vm.onCreateDocument();
+
+        expect(wrapper.emitted()['document-create']).toBeTruthy();
+        expect(wrapper.emitted()['document-create'][0][2]).toBe('invoice-doc-1000');
+    });
+
+    it('should reference the second invoice when it is selected', async () => {
+        await wrapper.setData({
+            documentNumberPreview: 'PREVIEW_NUM_001',
+            documentConfig: {
+                documentNumber: 'PREVIEW_NUM_002',
+                custom: {
+                    invoiceNumber: 1001,
+                },
+            },
+        });
+
+        await wrapper.vm.onCreateDocument();
+
+        expect(wrapper.emitted()['document-create']).toBeTruthy();
+        expect(wrapper.emitted()['document-create'][0][2]).toBe('invoice-doc-1001');
     });
 
     it('should show only invoice numbers in invoice number select field', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-storno-modal/index.js
@@ -49,8 +49,11 @@ export default {
 
         invoices() {
             return this.order.documents.filter((document) => {
-                return document.documentType.technicalName === 'invoice'
-                    || document.documentType.technicalName === 'zugferd_embedded_invoice';
+                return (
+                    document.documentType.technicalName === 'invoice' ||
+                    document.documentType.technicalName === 'zugferd_invoice' ||
+                    document.documentType.technicalName === 'zugferd_embedded_invoice'
+                );
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-select-document-type-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-select-document-type-modal/index.js
@@ -74,7 +74,13 @@ export default {
         documentCriteria() {
             const criteria = new Criteria(1, 100);
             criteria.addFilter(Criteria.equals('order.id', this.order.id));
-            criteria.addFilter(Criteria.equalsAny('documentType.technicalName', ['invoice', 'zugferd_embedded_invoice']));
+            criteria.addFilter(
+                Criteria.equalsAny('documentType.technicalName', [
+                    'invoice',
+                    'zugferd_invoice',
+                    'zugferd_embedded_invoice',
+                ]),
+            );
 
             return criteria;
         },

--- a/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/ZugferdRenderer.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Document\Zugferd\ZugferdBuilder;
 use Shopware\Core\Checkout\Document\Zugferd\ZugferdInvoiceOrdersEvent;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
@@ -94,13 +95,20 @@ class ZugferdRenderer extends AbstractDocumentRenderer
         // So no A11y will be generated
         $config->merge(['fileTypes' => ['xml']]);
 
+        $number = $config->getDocumentNumber() ?: $this->getNumber($context, $order, $operation);
+
+        $now = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        $config->merge([
+            'documentDate' => $operation->getConfig()['documentDate'] ?? $now,
+            'documentNumber' => $number,
+            'custom' => [
+                'invoiceNumber' => $number,
+            ],
+        ]);
+
         // create version of order to ensure the document stays the same even if the order changes
         $operation->setOrderVersionId($this->orderRepository->createVersion($order->getId(), $context, 'document'));
-
-        $documentNumber = $config->getDocumentNumber();
-        if ($documentNumber === null) {
-            $config->setDocumentNumber($documentNumber = $this->getNumber($context, $order, $operation));
-        }
 
         try {
             $content = $this->documentBuilder->buildDocument($order, $config, $context);
@@ -109,7 +117,7 @@ class ZugferdRenderer extends AbstractDocumentRenderer
                 $order->getId(),
                 new RenderedDocument(
                     '',
-                    $documentNumber,
+                    $number,
                     $config->buildName(),
                     FileTypes::XML,
                     $config->jsonSerialize(),

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Document\Service;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeEntity;
 use Shopware\Core\Checkout\Document\DocumentCollection;
@@ -14,6 +15,8 @@ use Shopware\Core\Checkout\Document\Renderer\DocumentRendererRegistry;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Renderer\RendererResult;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaService;
@@ -368,13 +371,19 @@ class DocumentGenerator
             SELECT LOWER(HEX(document.id))
             FROM document INNER JOIN document_type
                 ON document.document_type_id = document_type.id
-            WHERE document_type.technical_name = :technicalName
+            WHERE document_type.technical_name IN (:technicalNames)
             AND document.document_number = :invoiceNumber
             AND document.order_id = :orderId
         ', [
-            'technicalName' => InvoiceRenderer::TYPE,
+            'technicalNames' => [
+                InvoiceRenderer::TYPE,
+                ZugferdRenderer::TYPE,
+                ZugferdEmbeddedRenderer::TYPE,
+            ],
             'invoiceNumber' => $invoiceNumber,
             'orderId' => Uuid::fromHexToBytes($orderId),
+        ], [
+            'technicalNames' => ArrayParameterType::STRING,
         ]);
     }
 

--- a/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
+++ b/src/Core/Checkout/Document/Service/ReferenceInvoiceLoader.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -45,7 +46,7 @@ final class ReferenceInvoiceLoader
         $builder->where('`document_type`.`technical_name` IN (:technicalNames)')
             ->andWhere('`document`.`order_id` = :orderId');
 
-        $builder->setParameter('technicalNames', [InvoiceRenderer::TYPE, ZugferdEmbeddedRenderer::TYPE], ArrayParameterType::STRING);
+        $builder->setParameter('technicalNames', [InvoiceRenderer::TYPE, ZugferdRenderer::TYPE, ZugferdEmbeddedRenderer::TYPE], ArrayParameterType::STRING);
         $builder->setParameter('orderId', Uuid::fromHexToBytes($orderId));
 
         $builder->orderBy('`document`.`sent`', 'DESC');

--- a/tests/integration/Core/Checkout/Document/Service/ReferenceInvoiceLoaderTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/ReferenceInvoiceLoaderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -119,13 +120,35 @@ class ReferenceInvoiceLoaderTest extends TestCase
         static::assertNotEmpty($invoice['documentNumber']);
     }
 
-    public function testLoadWithEmbeddedReferenceDocumentId(): void
+    public function testLoadWithEmbeddedZugferdReferenceDocumentId(): void
     {
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
 
         $invoiceStruct = $this->createDocument(
             ZugferdEmbeddedRenderer::TYPE,
+            $orderId,
+            ['companyName' => 'Test Company'],
+            $this->context
+        )->first();
+
+        static::assertNotNull($invoiceStruct);
+
+        $invoice = $this->referenceInvoiceLoader->load($orderId, $invoiceStruct->getId(), $invoiceStruct->getDeepLinkCode());
+
+        static::assertSame($invoiceStruct->getId(), $invoice['id']);
+        static::assertSame($orderId, $invoice['orderId']);
+        static::assertSame(Defaults::LIVE_VERSION, $invoice['orderVersionId']);
+        static::assertNotEmpty($invoice['documentNumber']);
+    }
+
+    public function testLoadWithZugferdReferenceDocumentId(): void
+    {
+        $cart = $this->generateDemoCart(2);
+        $orderId = $this->persistCart($cart);
+
+        $invoiceStruct = $this->createDocument(
+            ZugferdRenderer::TYPE,
             $orderId,
             ['companyName' => 'Test Company'],
             $this->context

--- a/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Checkout\Document\Service;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeEntity;
 use Shopware\Core\Checkout\Document\DocumentCollection;
@@ -15,8 +16,11 @@ use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\AbstractDocumentRenderer;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererRegistry;
+use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Renderer\RendererResult;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdEmbeddedRenderer;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
 use Shopware\Core\Checkout\Document\Service\AbstractDocumentTypeRenderer;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
@@ -219,6 +223,47 @@ class DocumentGeneratorTest extends TestCase
         static::assertSame($document->getContent(), 'html');
         static::assertSame($document->getFileExtension(), 'html');
         static::assertSame($document->getContentType(), 'text/html');
+    }
+
+    #[TestWith([InvoiceRenderer::TYPE])]
+    #[TestWith([ZugferdRenderer::TYPE])]
+    #[TestWith([ZugferdEmbeddedRenderer::TYPE])]
+    public function testPreviewSetsReferencedDocumentIdFromInvoiceNumber(string $invoiceType): void
+    {
+        $orderId = Uuid::randomHex();
+
+        $renderedDocument = new RenderedDocument(name: 'credit_note', fileExtension: 'html', contentType: 'text/html');
+        $renderedDocument->setContent('html');
+        $rendererResult = new RendererResult();
+        $rendererResult->addSuccess($orderId, $renderedDocument);
+
+        $mockRenderer = $this->createMock(AbstractDocumentRenderer::class);
+        $mockRenderer->method('supports')->willReturn('credit_note');
+        $mockRenderer->method('render')->willReturn($rendererResult);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturnCallback(function (string $sql, array $params) use ($invoiceType): string {
+                static::assertContains($invoiceType, $params['technicalNames'] ?? []);
+
+                return Uuid::randomHex();
+            });
+
+        /** @var StaticEntityRepository<DocumentCollection> $documentRepository */
+        $documentRepository = new StaticEntityRepository([]);
+
+        $generator = new DocumentGenerator(
+            new DocumentRendererRegistry([$mockRenderer]),
+            $this->createMock(DocumentFileRendererRegistry::class),
+            $this->createMock(MediaService::class),
+            $documentRepository,
+            $connection,
+        );
+
+        $operation = new DocumentGenerateOperation($orderId, HtmlRenderer::FILE_EXTENSION, ['custom' => ['invoiceNumber' => 'INV-100']]);
+
+        $generator->preview('credit_note', $operation, 'deepLinkCode', Context::createDefaultContext());
     }
 
     public function testPreviewErrorThrowsDocumentException(): void


### PR DESCRIPTION
resolves #13982

Backports three fixes to make credit note creation work with ZUGFeRD invoices: include ZUGFeRD invoices in the select (#10876), respect the selected invoice when creating the credit note (#14668) and correctly reference it in document previews (#15338).