### PR TITLE
fix: Missing undefined array key checks in HookableBusinessEvent

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -919,12 +919,6 @@ parameters:
 			path: src/Core/Framework/Event/BusinessEventCollector.php
 
 		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/Event/EventData/ScalarValueType.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\Parameter\\AdditionalBundleParameters\:\:__construct\(\) has parameter \$kernelParameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -913,12 +913,6 @@ parameters:
 			path: src/Core/Framework/DependencyInjection/FrameworkExtension.php
 
 		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 1
-			path: src/Core/Framework/Event/BusinessEventCollector.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\Parameter\\AdditionalBundleParameters\:\:__construct\(\) has parameter \$kernelParameters with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Core/Framework/Event/A11yRenderedDocumentAware.php
+++ b/src/Core/Framework/Event/A11yRenderedDocumentAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface A11yRenderedDocumentAware
 {

--- a/src/Core/Framework/Event/BusinessEventCollector.php
+++ b/src/Core/Framework/Event/BusinessEventCollector.php
@@ -5,10 +5,11 @@ namespace Shopware\Core\Framework\Event;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\App\Event\CustomAppEvent;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class BusinessEventCollector
 {
     /**
@@ -49,7 +50,7 @@ class BusinessEventCollector
     }
 
     /**
-     * @param class-string $class
+     * @param class-string<FlowEventAware> $class
      */
     public function define(string $class, ?string $name = null): ?BusinessEventDefinition
     {
@@ -57,11 +58,11 @@ class BusinessEventCollector
             ->newInstanceWithoutConstructor();
 
         if (!$instance instanceof FlowEventAware) {
-            throw new \RuntimeException(\sprintf('Event %s is not a business event', $class));
+            FrameworkException::invalidEventData(\sprintf('Event %s is not a business event', $class));
         }
 
         $name ??= $instance->getName();
-        if (!$name) {
+        if ($name === '') {
             return null;
         }
 
@@ -86,14 +87,18 @@ class BusinessEventCollector
 
     private function fetchAppEvents(BusinessEventCollectorResponse $result): BusinessEventCollectorResponse
     {
-        $appEvents = $this->connection->fetchAllAssociative('SELECT `app_flow_event`.`name`, `app_flow_event`.`aware` FROM `app_flow_event` JOIN `app` ON `app_flow_event`.`app_id` = `app`.`id` WHERE `app`.`active` = 1');
+        $appEvents = $this->connection->fetchAllAssociative(
+            'SELECT `app_flow_event`.`name`, `app_flow_event`.`aware`
+             FROM `app_flow_event` JOIN `app` ON `app_flow_event`.`app_id` = `app`.`id`
+             WHERE `app`.`active` = 1'
+        );
 
-        array_map(function ($event) use ($result): void {
+        array_map(static function (array $event) use ($result): void {
             $definition = new BusinessEventDefinition(
                 $event['name'],
                 CustomAppEvent::class,
                 [],
-                json_decode($event['aware'], true) ?? []
+                json_decode($event['aware'], true, 512, \JSON_THROW_ON_ERROR) ?? []
             );
 
             if (!$result->get($definition->getName())) {

--- a/src/Core/Framework/Event/BusinessEventCollectorEvent.php
+++ b/src/Core/Framework/Event/BusinessEventCollectorEvent.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class BusinessEventCollectorEvent extends NestedEvent
 {
     final public const NAME = 'collect.business-events';

--- a/src/Core/Framework/Event/BusinessEventCollectorResponse.php
+++ b/src/Core/Framework/Event/BusinessEventCollectorResponse.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Struct\Collection;
 /**
  * @extends Collection<BusinessEventDefinition>
  */
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class BusinessEventCollectorResponse extends Collection
 {
     protected function getExpectedClass(): ?string

--- a/src/Core/Framework/Event/BusinessEventDefinition.php
+++ b/src/Core/Framework/Event/BusinessEventDefinition.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class BusinessEventDefinition extends Struct
 {
     /**

--- a/src/Core/Framework/Event/BusinessEventRegistry.php
+++ b/src/Core/Framework/Event/BusinessEventRegistry.php
@@ -29,11 +29,11 @@ use Shopware\Core\Content\RevocationRequest\Event\RevocationRequestEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\Recovery\UserRecoveryRequestEvent;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class BusinessEventRegistry
 {
     /**
-     * @var list<class-string>
+     * @var list<class-string<FlowEventAware>>
      */
     private array $classes = [
         CustomerBeforeLoginEvent::class,
@@ -64,18 +64,17 @@ class BusinessEventRegistry
     ];
 
     /**
-     * @param list<class-string> $classes
+     * @param list<class-string<FlowEventAware>> $classes
      */
     public function addClasses(array $classes): void
     {
-        /** @var list<class-string> */
-        $classes = array_unique(array_merge($this->classes, $classes));
+        $classes = array_values(array_unique(array_merge($this->classes, $classes)));
 
         $this->classes = $classes;
     }
 
     /**
-     * @return list<class-string>
+     * @return list<class-string<FlowEventAware>>
      */
     public function getClasses(): array
     {

--- a/src/Core/Framework/Event/BusinessEvents.php
+++ b/src/Core/Framework/Event/BusinessEvents.php
@@ -27,7 +27,7 @@ use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\Recovery\UserRecoveryRequestEvent;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 final class BusinessEvents
 {
     public const CHECKOUT_CUSTOMER_BEFORE_LOGIN = CustomerBeforeLoginEvent::EVENT_NAME;

--- a/src/Core/Framework/Event/Command/DebugDumpBusinessEventsCommand.php
+++ b/src/Core/Framework/Event/Command/DebugDumpBusinessEventsCommand.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\OutputInterface;
     name: 'debug:business-events',
     description: 'Dumps all business events',
 )]
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class DebugDumpBusinessEventsCommand extends Command
 {
     /**

--- a/src/Core/Framework/Event/CustomerAware.php
+++ b/src/Core/Framework/Event/CustomerAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface CustomerAware
 {

--- a/src/Core/Framework/Event/CustomerGroupAware.php
+++ b/src/Core/Framework/Event/CustomerGroupAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface CustomerGroupAware
 {

--- a/src/Core/Framework/Event/DataMappingEvent.php
+++ b/src/Core/Framework/Event/DataMappingEvent.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Symfony\Contracts\EventDispatcher\Event;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class DataMappingEvent extends Event implements ShopwareEvent
 {
     /**

--- a/src/Core/Framework/Event/EventData/ArrayType.php
+++ b/src/Core/Framework/Event/EventData/ArrayType.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class ArrayType implements EventDataType
 {
     final public const TYPE = 'array';

--- a/src/Core/Framework/Event/EventData/EntityCollectionType.php
+++ b/src/Core/Framework/Event/EventData/EntityCollectionType.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class EntityCollectionType implements EventDataType
 {
     final public const TYPE = 'collection';

--- a/src/Core/Framework/Event/EventData/EntityCollectionType.php
+++ b/src/Core/Framework/Event/EventData/EntityCollectionType.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Event\EventData;
 
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
@@ -9,10 +10,16 @@ class EntityCollectionType implements EventDataType
 {
     final public const TYPE = 'collection';
 
+    /**
+     * @param class-string<EntityDefinition> $definitionClass
+     */
     public function __construct(private readonly string $definitionClass)
     {
     }
 
+    /**
+     * @return array{type: string, entityClass: class-string<EntityDefinition>}
+     */
     public function toArray(): array
     {
         return [

--- a/src/Core/Framework/Event/EventData/EntityType.php
+++ b/src/Core/Framework/Event/EventData/EntityType.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class EntityType implements EventDataType
 {
     final public const TYPE = 'entity';

--- a/src/Core/Framework/Event/EventData/EntityType.php
+++ b/src/Core/Framework/Event/EventData/EntityType.php
@@ -35,6 +35,9 @@ class EntityType implements EventDataType
         $this->entityName = $entityDefinition->getEntityName();
     }
 
+    /**
+     * @return array{type: string, entityClass: class-string<EntityDefinition>, entityName: string}
+     */
     public function toArray(): array
     {
         return [

--- a/src/Core/Framework/Event/EventData/EventDataCollection.php
+++ b/src/Core/Framework/Event/EventData/EventDataCollection.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class EventDataCollection
 {
     /**

--- a/src/Core/Framework/Event/EventData/EventDataType.php
+++ b/src/Core/Framework/Event/EventData/EventDataType.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 interface EventDataType
 {
     /**

--- a/src/Core/Framework/Event/EventData/MailRecipientStruct.php
+++ b/src/Core/Framework/Event/EventData/MailRecipientStruct.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class MailRecipientStruct
 {
     private ?string $bcc = null;

--- a/src/Core/Framework/Event/EventData/ObjectType.php
+++ b/src/Core/Framework/Event/EventData/ObjectType.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event\EventData;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class ObjectType implements EventDataType
 {
     final public const TYPE = 'object';

--- a/src/Core/Framework/Event/EventData/ScalarValueType.php
+++ b/src/Core/Framework/Event/EventData/ScalarValueType.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\Event\EventData;
 
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('fundamentals@after-sales')]
@@ -24,12 +26,19 @@ class ScalarValueType implements EventDataType
     public function __construct(string $type)
     {
         if (!\in_array($type, self::VALID_TYPES, true)) {
-            throw new \InvalidArgumentException(\sprintf('Invalid type "%s" provided, valid ones are: %s', $type, implode(', ', self::VALID_TYPES)));
+            $message = \sprintf('Invalid type "%s" provided, valid ones are: %s', $type, implode(', ', self::VALID_TYPES));
+            if (!Feature::isActive('v6.8.0.0')) {
+                throw new \InvalidArgumentException($message); /** @phpstan-ignore shopware.domainException (Will be fixed with next major) */
+            }
+            throw FrameworkException::invalidArgumentException($message);
         }
 
         $this->type = $type;
     }
 
+    /**
+     * @return array{type: self::TYPE_*}
+     */
     public function toArray(): array
     {
         return [

--- a/src/Core/Framework/Event/EventData/ScalarValueType.php
+++ b/src/Core/Framework/Event/EventData/ScalarValueType.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 class ScalarValueType implements EventDataType
 {
     final public const TYPE_STRING = 'string';

--- a/src/Core/Framework/Event/FlowEventAware.php
+++ b/src/Core/Framework/Event/FlowEventAware.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('after-sales')]
+#[Package('framework')]
 interface FlowEventAware extends ShopwareEvent
 {
     public static function getAvailableData(): EventDataCollection;

--- a/src/Core/Framework/Event/FlowLogEvent.php
+++ b/src/Core/Framework/Event/FlowLogEvent.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-#[Package('after-sales')]
+#[Package('framework')]
 class FlowLogEvent extends Event implements FlowEventAware
 {
     final public const NAME = 'flow.log';

--- a/src/Core/Framework/Event/GenericEvent.php
+++ b/src/Core/Framework/Event/GenericEvent.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 interface GenericEvent
 {
     public function getName(): string;

--- a/src/Core/Framework/Event/IsFlowEventAware.php
+++ b/src/Core/Framework/Event/IsFlowEventAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('after-sales')]
+#[Package('framework')]
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final class IsFlowEventAware
 {

--- a/src/Core/Framework/Event/LanguageAware.php
+++ b/src/Core/Framework/Event/LanguageAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface LanguageAware
 {

--- a/src/Core/Framework/Event/MailAware.php
+++ b/src/Core/Framework/Event/MailAware.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Event;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface MailAware
 {

--- a/src/Core/Framework/Event/OrderAware.php
+++ b/src/Core/Framework/Event/OrderAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface OrderAware
 {

--- a/src/Core/Framework/Event/ProductAware.php
+++ b/src/Core/Framework/Event/ProductAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface ProductAware
 {

--- a/src/Core/Framework/Event/SalesChannelAware.php
+++ b/src/Core/Framework/Event/SalesChannelAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface SalesChannelAware
 {

--- a/src/Core/Framework/Event/UserAware.php
+++ b/src/Core/Framework/Event/UserAware.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Event;
 
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('fundamentals@after-sales')]
+#[Package('framework')]
 #[IsFlowEventAware]
 interface UserAware
 {

--- a/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Event\EventData\EntityCollectionType;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\ObjectType;
 use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\BusinessEventEncoder;
@@ -77,11 +78,17 @@ class HookableBusinessEvent implements Hookable
 
         if ($type === EntityType::TYPE || $type === EntityCollectionType::TYPE) {
             $entityDefinitionClass = $dataType['entityClass'] ?? null;
-            if (\is_string($entityDefinitionClass) && is_a($entityDefinitionClass, EntityDefinition::class, true)) {
-                $definition = new $entityDefinitionClass();
-                if (!$permissions->isAllowed($definition->getEntityName(), AclRoleDefinition::PRIVILEGE_READ)) {
-                    return false;
-                }
+            if (!\is_string($entityDefinitionClass) || !is_a($entityDefinitionClass, EntityDefinition::class, true)) {
+                throw FrameworkException::invalidEventData(\sprintf(
+                    '"entityClass" value of flow event data type "%s" must be a class string of type "%s"',
+                    EntityType::TYPE,
+                    EntityDefinition::class
+                ));
+            }
+
+            $definition = new $entityDefinitionClass();
+            if (!$permissions->isAllowed($definition->getEntityName(), AclRoleDefinition::PRIVILEGE_READ)) {
+                return false;
             }
         }
 

--- a/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableBusinessEvent.php
@@ -56,12 +56,12 @@ class HookableBusinessEvent implements Hookable
     }
 
     /**
-     * @param array<mixed> $dataType
+     * @param array<string, mixed> $dataType
      */
     private function checkPermissionsForDataType(array $dataType, AclPrivilegeCollection $permissions): bool
     {
-        $type = $dataType['type'];
-        $data = $dataType['data'];
+        $type = $dataType['type'] ?? null;
+        $data = $dataType['data'] ?? null;
         if ($type === ObjectType::TYPE && \is_array($data) && $data !== []) {
             foreach ($data as $nested) {
                 if (!$this->checkPermissionsForDataType($nested, $permissions)) {
@@ -70,15 +70,18 @@ class HookableBusinessEvent implements Hookable
             }
         }
 
-        if ($type === ArrayType::TYPE && $dataType['of'] && !$this->checkPermissionsForDataType($dataType['of'], $permissions)) {
+        $of = $dataType['of'] ?? null;
+        if ($type === ArrayType::TYPE && \is_array($of) && $of !== [] && !$this->checkPermissionsForDataType($of, $permissions)) {
             return false;
         }
 
         if ($type === EntityType::TYPE || $type === EntityCollectionType::TYPE) {
-            /** @var EntityDefinition $definition */
-            $definition = new $dataType['entityClass']();
-            if (!$permissions->isAllowed($definition->getEntityName(), AclRoleDefinition::PRIVILEGE_READ)) {
-                return false;
+            $entityDefinitionClass = $dataType['entityClass'] ?? null;
+            if (\is_string($entityDefinitionClass) && is_a($entityDefinitionClass, EntityDefinition::class, true)) {
+                $definition = new $entityDefinitionClass();
+                if (!$permissions->isAllowed($definition->getEntityName(), AclRoleDefinition::PRIVILEGE_READ)) {
+                    return false;
+                }
             }
         }
 

--- a/tests/unit/Core/Framework/Event/EventData/ScalarValueTypeTest.php
+++ b/tests/unit/Core/Framework/Event/EventData/ScalarValueTypeTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Unit\Core\Framework\Event\EventData;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\FrameworkException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -23,7 +25,15 @@ class ScalarValueTypeTest extends TestCase
 
     public function testThrowExceptionOnInvalidType(): void
     {
-        static::expectException(\InvalidArgumentException::class);
+        $this->expectExceptionObject(FrameworkException::invalidArgumentException('Invalid type "test" provided, valid ones are: string, int, float, bool'));
+
+        new ScalarValueType('test');
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testThrowExceptionOnInvalidTypeDeprecated(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
 
         new ScalarValueType('test');
     }

--- a/tests/unit/Core/Framework/Webhook/Hookable/HookableBusinessEventTest.php
+++ b/tests/unit/Core/Framework/Webhook/Hookable/HookableBusinessEventTest.php
@@ -1,13 +1,15 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Core\Framework\Webhook\Hookable;
+namespace Shopware\Tests\Unit\Core\Framework\Webhook\Hookable;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
+use Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Event\FlowEventAware;
-use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\Webhook\_fixtures\BusinessEvents\ArrayBusinessEvent;
 use Shopware\Core\Framework\Test\Webhook\_fixtures\BusinessEvents\CollectionBusinessEvent;
 use Shopware\Core\Framework\Test\Webhook\_fixtures\BusinessEvents\EntityBusinessEvent;
@@ -27,21 +29,22 @@ use Shopware\Core\System\Tax\TaxEntity;
 /**
  * @internal
  */
+#[CoversClass(HookableBusinessEvent::class)]
 class HookableBusinessEventTest extends TestCase
 {
-    use IntegrationTestBehaviour;
-
     public function testGetter(): void
     {
         $scalarEvent = new ScalarBusinessEvent();
         $event = HookableBusinessEvent::fromBusinessEvent(
             $scalarEvent,
-            static::getContainer()->get(BusinessEventEncoder::class)
+            new BusinessEventEncoder(
+                $this->createMock(JsonEntityEncoder::class),
+                $this->createMock(DefinitionInstanceRegistry::class)
+            )
         );
 
         static::assertSame($scalarEvent->getName(), $event->getName());
-        $shopwareVersion = static::getContainer()->getParameter('kernel.shopware_version');
-        static::assertSame($scalarEvent->getEncodeValues($shopwareVersion), $event->getWebhookPayload());
+        static::assertSame($scalarEvent->getEncodeValues(''), $event->getWebhookPayload());
     }
 
     #[DataProvider('getEventsWithoutPermissions')]
@@ -49,29 +52,10 @@ class HookableBusinessEventTest extends TestCase
     {
         $event = HookableBusinessEvent::fromBusinessEvent(
             $rootEvent,
-            static::getContainer()->get(BusinessEventEncoder::class)
+            $this->createMock(BusinessEventEncoder::class)
         );
 
         static::assertTrue($event->isAllowed(Uuid::randomHex(), new AclPrivilegeCollection([])));
-    }
-
-    #[DataProvider('getEventsWithPermissions')]
-    public function testIsAllowedForEntityBasedEvents(FlowEventAware $rootEvent): void
-    {
-        $event = HookableBusinessEvent::fromBusinessEvent(
-            $rootEvent,
-            static::getContainer()->get(BusinessEventEncoder::class)
-        );
-
-        $allowedPermissions = new AclPrivilegeCollection([
-            TaxDefinition::ENTITY_NAME . ':' . AclRoleDefinition::PRIVILEGE_READ,
-        ]);
-        static::assertTrue($event->isAllowed(Uuid::randomHex(), $allowedPermissions));
-
-        $notAllowedPermissions = new AclPrivilegeCollection([
-            ProductDefinition::ENTITY_NAME . ':' . AclRoleDefinition::PRIVILEGE_READ,
-        ]);
-        static::assertFalse($event->isAllowed(Uuid::randomHex(), $notAllowedPermissions));
     }
 
     /**
@@ -85,6 +69,25 @@ class HookableBusinessEventTest extends TestCase
             [new StructuredArrayObjectBusinessEvent()],
             [new UnstructuredObjectBusinessEvent()],
         ];
+    }
+
+    #[DataProvider('getEventsWithPermissions')]
+    public function testIsAllowedForEntityBasedEvents(FlowEventAware $rootEvent): void
+    {
+        $event = HookableBusinessEvent::fromBusinessEvent(
+            $rootEvent,
+            $this->createMock(BusinessEventEncoder::class)
+        );
+
+        $allowedPermissions = new AclPrivilegeCollection([
+            TaxDefinition::ENTITY_NAME . ':' . AclRoleDefinition::PRIVILEGE_READ,
+        ]);
+        static::assertTrue($event->isAllowed(Uuid::randomHex(), $allowedPermissions));
+
+        $notAllowedPermissions = new AclPrivilegeCollection([
+            ProductDefinition::ENTITY_NAME . ':' . AclRoleDefinition::PRIVILEGE_READ,
+        ]);
+        static::assertFalse($event->isAllowed(Uuid::randomHex(), $notAllowedPermissions));
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Due to the refactoring of removing the usage of `empty` it can now happen, that an undefined array key access is happening in the `HookableBusinessEvent`. (see PR https://github.com/shopware/shopware/pull/15042/changes#diff-805d7e1aa3994187a04e7a6b72cc75ab40ef9f46e90d344909a5e961f269728dR64-R65 )

### 2. What does this change do, exactly?

Use `??` operator to initialise the variables correctly.

### 3. Describe each step to reproduce the issue or behaviour.

Execute the `HookableBusinessEventTest` with the `restrictWarnings` setting in the `phpunit.xml.dist` set to `false`. Warnings about undefined array key will appear, like described in the linked issue. 

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/15395

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
