### PR TITLE
fix: avoid double event tracking on first consent

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -383,6 +383,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             const consentStore = useConsentStore();
             const eventBusOnSpy = jest.spyOn(Shopware.Utils.EventBus, 'on');
 
+            jest.useFakeTimers();
             consentStore.consents.product_analytics.status = 'revoked';
 
             await initAmplitude();
@@ -403,6 +404,12 @@ describe('src/app/post-init/amplitude.init.ts', () => {
 
             await flushPromises();
 
+            expect(init).not.toHaveBeenCalled();
+            expect(eventBusOnSpy).not.toHaveBeenCalledWith('telemetry', expect.any(Function));
+
+            jest.runOnlyPendingTimers();
+            await flushPromises();
+
             expect(init).toHaveBeenCalledTimes(1);
             expect(eventBusOnSpy).toHaveBeenCalledWith('telemetry', expect.any(Function));
             expect(setOptOut).toHaveBeenCalledWith(false);
@@ -420,6 +427,64 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             );
 
             expect(track.mock.calls).toHaveLength(1);
+
+            jest.useRealTimers();
+        });
+
+        it('does not start telemetry before the deferred runtime activation finishes', async () => {
+            const { track } = await import('@amplitude/analytics-browser');
+            const consentStore = useConsentStore();
+
+            jest.useFakeTimers();
+            consentStore.consents.product_analytics.status = 'revoked';
+
+            await initAmplitude();
+            track.mockClear();
+
+            consentStore.$patch({
+                consents: {
+                    ...consentStore.consents,
+                    product_analytics: {
+                        ...consentStore.consents.product_analytics,
+                        status: 'accepted',
+                    },
+                },
+            });
+
+            await flushPromises();
+
+            Shopware.Utils.EventBus.emit(
+                'telemetry',
+                new TelemetryEvent('page_change', {
+                    from: { name: 'sw.dashboard.index', path: '/sw/dashboard/index' },
+                    to: {
+                        name: 'sw.product.index',
+                        path: '/sw/product/index',
+                        fullPath: '/sw-product/index?order=asc&page=1&limit=50',
+                    },
+                }),
+            );
+
+            expect(track).not.toHaveBeenCalled();
+
+            jest.runOnlyPendingTimers();
+            await flushPromises();
+
+            Shopware.Utils.EventBus.emit(
+                'telemetry',
+                new TelemetryEvent('page_change', {
+                    from: { name: 'sw.dashboard.index', path: '/sw/dashboard/index' },
+                    to: {
+                        name: 'sw.product.index',
+                        path: '/sw/product/index',
+                        fullPath: '/sw-product/index?order=asc&page=1&limit=50',
+                    },
+                }),
+            );
+
+            expect(track.mock.calls).toHaveLength(1);
+
+            jest.useRealTimers();
         });
 
         it('does not send consent events when gateway base url is missing', async () => {

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -12,6 +12,7 @@ type AnonymousAmplitudeClient = ReturnType<AmplitudeModule['createInstance']>;
 type PrivacyAmplitudeClient = ReturnType<AmplitudeModule['createInstance']>;
 
 let stopTelemetryConsentWatch: (() => void) | null = null;
+let pendingTelemetryActivationTimeout: number | null = null;
 
 /**
  * @private
@@ -43,6 +44,15 @@ export default async function (): Promise<void> {
     initPrivacyAmplitude(privacyAmplitude, analyticsGatewayUrl);
 
     const pushConsentEventToAmplitude = createConsentEventHandler(anonymousAmplitude);
+
+    const clearPendingTelemetryActivation = (): void => {
+        if (pendingTelemetryActivationTimeout === null) {
+            return;
+        }
+
+        window.clearTimeout(pendingTelemetryActivationTimeout);
+        pendingTelemetryActivationTimeout = null;
+    };
 
     // eslint-disable-next-line listeners/no-missing-remove-event-listener
     Shopware.Utils.EventBus.on('consent', pushConsentEventToAmplitude);
@@ -111,6 +121,8 @@ export default async function (): Promise<void> {
     };
 
     const syncTelemetryTracking = async (consentAccepted: boolean): Promise<void> => {
+        clearPendingTelemetryActivation();
+
         if (consentAccepted) {
             await enableTelemetryTracking();
 
@@ -121,9 +133,22 @@ export default async function (): Promise<void> {
     };
 
     await syncTelemetryTracking(isTelemetryConsentAccepted.value);
+    clearPendingTelemetryActivation();
     stopTelemetryConsentWatch?.();
     stopTelemetryConsentWatch = watch(isTelemetryConsentAccepted, (consentAccepted) => {
-        void syncTelemetryTracking(consentAccepted);
+        clearPendingTelemetryActivation();
+
+        if (!consentAccepted) {
+            void syncTelemetryTracking(false);
+
+            return;
+        }
+
+        // delay runtime activation so the consent interaction itself is only tracked anonymously
+        pendingTelemetryActivationTimeout = window.setTimeout(() => {
+            pendingTelemetryActivationTimeout = null;
+            void syncTelemetryTracking(true);
+        }, 0);
     });
 }
 


### PR DESCRIPTION
resolves: https://github.com/shopware/SwagProductAnalytics/issues/46