### PR TITLE
feat: experience builder poc

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/index.js
@@ -1,0 +1,41 @@
+/**
+ * @sw-package discovery
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+Shopware.Component.register('sw-content-system-index', () => import('./page/sw-content-system-index'));
+
+/**
+ * @sw-package discovery
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+Shopware.Module.register('sw-content-system', {
+    type: 'core',
+    name: 'content_system',
+    title: 'sw-content-system.general.mainMenuItemGeneral',
+    description: 'sw-content-system.general.descriptionTextModule',
+    color: '#ff68b4',
+    icon: 'regular-content',
+
+    routes: {
+        index: {
+            component: 'sw-content-system-index',
+            path: 'index',
+            meta: {
+                privilege: 'cms.viewer',
+            },
+        },
+    },
+
+    navigation: [
+        {
+            id: 'sw-content-system',
+            label: 'sw-content-system.general.mainMenuItemGeneral',
+            color: '#ff68b4',
+            path: 'sw.content.system.index',
+            icon: 'regular-content',
+            position: 20,
+            parent: 'sw-content',
+            privilege: 'cms.viewer',
+        },
+    ],
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/index.js
@@ -1,0 +1,361 @@
+import template from './sw-content-system-index.html.twig';
+import './sw-content-system-index.scss';
+
+/**
+ * @sw-package discovery
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export default Shopware.Component.wrapComponentConfig({
+    template,
+
+    data() {
+        return {
+            landingPageId: '7c6c8f28f6c549ecb94a6a1760d2f5c1',
+            previewPath: '/content-system/demo/',
+            refreshNonce: Date.now(),
+            isTreeLoading: false,
+            movingElementId: null,
+            previewReady: false,
+            treeError: null,
+            layoutMeta: null,
+            layoutTreeRows: [],
+            selectedElementId: null,
+        };
+    },
+
+    computed: {
+        previewUrl() {
+            const origin = window.location.origin.replace(/\/$/, '');
+            const path = this.previewPath.replace(/\/?$/, '/');
+            const landingPageId = this.landingPageId.trim();
+
+            return `${origin}${path}${landingPageId}?_preview=${this.refreshNonce}`;
+        },
+
+        layoutTreeUrl() {
+            const origin = window.location.origin.replace(/\/$/, '');
+            const landingPageId = this.landingPageId.trim();
+
+            return `${origin}/content-system/demo/layout/${landingPageId}?_preview=${this.refreshNonce}`;
+        },
+
+        layoutTreeMoveUrl() {
+            const origin = window.location.origin.replace(/\/$/, '');
+            const landingPageId = this.landingPageId.trim();
+
+            return `${origin}/content-system/demo/layout/${landingPageId}/move`;
+        },
+    },
+
+    created() {
+        window.addEventListener('message', this.onPreviewMessage);
+        this.loadLayoutTree();
+    },
+
+    beforeUnmount() {
+        window.removeEventListener('message', this.onPreviewMessage);
+    },
+
+    metaInfo() {
+        return {
+            title: this.$createTitle(),
+        };
+    },
+
+    methods: {
+        refreshPreview() {
+            this.previewReady = false;
+            this.refreshNonce = Date.now();
+            this.loadLayoutTree();
+        },
+
+        openPreviewInNewTab() {
+            window.open(this.previewUrl, '_blank', 'noopener');
+        },
+
+        onPreviewMessage(event) {
+            const payload = event?.data;
+
+            if (!payload || typeof payload !== 'object') {
+                return;
+            }
+
+            if (event.origin !== window.location.origin) {
+                return;
+            }
+
+            if (payload.type === 'content-system:refresh-preview') {
+                this.refreshPreview();
+
+                return;
+            }
+
+            if (payload.type === 'content-system:preview-ready') {
+                this.previewReady = true;
+                this.syncSelectionToPreview();
+
+                return;
+            }
+
+            if (payload.type === 'content-system:element-selected' && typeof payload.elementId === 'string') {
+                this.selectedElementId = payload.elementId;
+            }
+        },
+
+        async loadLayoutTree() {
+            const landingPageId = this.landingPageId.trim();
+
+            if (!landingPageId) {
+                this.layoutMeta = null;
+                this.layoutTreeRows = [];
+                this.treeError = null;
+
+                return;
+            }
+
+            this.isTreeLoading = true;
+            this.treeError = null;
+
+            try {
+                const response = await fetch(this.layoutTreeUrl, {
+                    headers: {
+                        Accept: 'application/json',
+                    },
+                });
+
+                const result = await response.json();
+                const payload = result?.payload && typeof result.payload === 'object' ? result.payload : null;
+                const endpoint = typeof result?.endpoint === 'string' ? result.endpoint : this.layoutTreeUrl;
+                const error = typeof result?.error === 'string' ? result.error : null;
+
+                if (!response.ok || error) {
+                    throw new Error(error || `Failed to load layout tree (${response.status})`);
+                }
+
+                this.layoutMeta = {
+                    endpoint,
+                    layoutId: payload?.layoutId ?? null,
+                    layoutName: payload?.layoutName ?? null,
+                };
+                this.layoutTreeRows = this.buildTreeRows(payload);
+                this.ensureSelectedElementStillExists();
+            } catch (error) {
+                this.layoutMeta = null;
+                this.layoutTreeRows = [];
+                this.treeError = error instanceof Error ? error.message : String(error);
+            } finally {
+                this.isTreeLoading = false;
+            }
+        },
+
+        buildTreeRows(payload) {
+            const rows = [];
+
+            if (!payload || typeof payload !== 'object') {
+                return rows;
+            }
+
+            const layoutName = typeof payload.layoutName === 'string' ? payload.layoutName : 'Unnamed layout';
+            const layoutId = typeof payload.layoutId === 'string' ? payload.layoutId : 'n/a';
+
+            rows.push({
+                key: `layout-${layoutId}`,
+                depth: 0,
+                kind: 'layout',
+                label: layoutName,
+                component: 'Layout',
+                elementId: null,
+            });
+
+            if (!Array.isArray(payload.elements)) {
+                return rows;
+            }
+
+            payload.elements.forEach((element, index) => {
+                this.appendElementRows(rows, element, 1, `e-${index}`, [], index, payload.elements.length);
+            });
+
+            return rows;
+        },
+
+        appendElementRows(rows, element, depth, keyPrefix, slotPath, slotIndex, siblingCount) {
+            if (!element || typeof element !== 'object') {
+                return;
+            }
+
+            const elementId = typeof element.id === 'string' ? element.id : `${keyPrefix}-id`;
+            const componentName = typeof element.component === 'string' ? element.component : 'Unknown';
+            const elementPath = [
+                ...slotPath,
+                slotIndex,
+            ];
+
+            rows.push({
+                key: `element-${keyPrefix}-${elementId}`,
+                depth,
+                kind: 'element',
+                label: componentName,
+                component: componentName,
+                elementId,
+                slotPath,
+                slotIndex,
+                canMoveUp: slotIndex > 0,
+                canMoveDown: slotIndex < siblingCount - 1,
+            });
+
+            if (!element.slots || typeof element.slots !== 'object') {
+                return;
+            }
+
+            Object.entries(element.slots).forEach(
+                ([
+                    slotName,
+                    slotEntries,
+                ]) => {
+                    if (!slotEntries || typeof slotEntries !== 'object') {
+                        return;
+                    }
+
+                    rows.push({
+                        key: `slot-${keyPrefix}-${slotName}`,
+                        depth: depth + 1,
+                        kind: 'slot',
+                        label: slotName,
+                        component: 'Slot',
+                        elementId: null,
+                    });
+
+                    const children = this.normalizeSlotEntries(slotEntries);
+                    const childSlotPath = [
+                        ...elementPath,
+                        'slots',
+                        slotName,
+                    ];
+
+                    children.forEach((child, childIndex) => {
+                        this.appendElementRows(
+                            rows,
+                            child,
+                            depth + 2,
+                            `${keyPrefix}-${slotName}-${childIndex}`,
+                            childSlotPath,
+                            childIndex,
+                            children.length,
+                        );
+                    });
+                },
+            );
+        },
+
+        normalizeSlotEntries(slotEntries) {
+            return Object.entries(slotEntries)
+                .filter(
+                    ([
+                        key,
+                        value,
+                    ]) => key !== 'apiAlias' && value && typeof value === 'object',
+                )
+                .map(
+                    ([
+                        ,
+                        value,
+                    ]) => value,
+                );
+        },
+
+        selectTreeRow(row) {
+            if (!row || row.kind !== 'element' || typeof row.elementId !== 'string') {
+                return;
+            }
+
+            this.selectedElementId = row.elementId;
+            this.syncSelectionToPreview();
+        },
+
+        isTreeRowSelected(row) {
+            return row.kind === 'element' && row.elementId === this.selectedElementId;
+        },
+
+        isTreeRowMovePending(row) {
+            return row.kind === 'element' && row.elementId === this.movingElementId;
+        },
+
+        async moveTreeRow(row, direction) {
+            if (!row || row.kind !== 'element' || !Array.isArray(row.slotPath) || typeof row.slotIndex !== 'number') {
+                return;
+            }
+
+            if (this.movingElementId) {
+                return;
+            }
+
+            this.movingElementId = row.elementId;
+            this.treeError = null;
+
+            try {
+                const response = await fetch(this.layoutTreeMoveUrl, {
+                    method: 'POST',
+                    headers: {
+                        Accept: 'application/json',
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        slotPath: row.slotPath,
+                        fromIndex: row.slotIndex,
+                        direction,
+                    }),
+                });
+
+                const result = await response.json();
+                const error = typeof result?.error === 'string' ? result.error : null;
+
+                if (!response.ok || error) {
+                    throw new Error(error || `Failed to move layout element (${response.status})`);
+                }
+
+                if (typeof result?.selectedElementId === 'string') {
+                    this.selectedElementId = result.selectedElementId;
+                }
+
+                this.refreshPreview();
+            } catch (error) {
+                this.treeError = error instanceof Error ? error.message : String(error);
+            } finally {
+                this.movingElementId = null;
+            }
+        },
+
+        syncSelectionToPreview() {
+            if (!this.previewReady || !this.selectedElementId) {
+                return;
+            }
+
+            const iframe = this.$refs.previewFrame;
+            const contentWindow = iframe?.contentWindow;
+
+            if (!contentWindow) {
+                return;
+            }
+
+            contentWindow.postMessage(
+                {
+                    type: 'content-system:select-element',
+                    elementId: this.selectedElementId,
+                },
+                window.location.origin,
+            );
+        },
+
+        ensureSelectedElementStillExists() {
+            if (!this.selectedElementId) {
+                return;
+            }
+
+            const hasSelectedElement = this.layoutTreeRows.some((row) => row.elementId === this.selectedElementId);
+
+            if (!hasSelectedElement) {
+                this.selectedElementId = null;
+            }
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/sw-content-system-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/sw-content-system-index.html.twig
@@ -1,0 +1,147 @@
+{% block sw_content_system_index %}
+<sw-page class="sw-content-system-index">
+    <template #smart-bar-header>
+        <h2>
+            {{ $tc('sw-content-system.general.headline') }}
+        </h2>
+    </template>
+
+    <template #side-content>
+        <aside class="sw-content-system-index__tree">
+            <div class="sw-content-system-index__tree-header">
+                <h3>{{ $tc('sw-content-system.general.treeTitle') }}</h3>
+            </div>
+
+            <div
+                v-if="isTreeLoading"
+                class="sw-content-system-index__tree-state sw-content-system-index__tree-state--muted"
+            >
+                {{ $tc('sw-content-system.general.treeLoading') }}
+            </div>
+
+            <div
+                v-else-if="treeError"
+                class="sw-content-system-index__tree-state sw-content-system-index__tree-state--error"
+            >
+                {{ $tc('sw-content-system.general.treeError') }}: {{ treeError }}
+            </div>
+
+            <div
+                v-else-if="!layoutTreeRows.length"
+                class="sw-content-system-index__tree-state sw-content-system-index__tree-state--muted"
+            >
+                {{ $tc('sw-content-system.general.treeEmpty') }}
+            </div>
+
+            <template v-else>
+                <component
+                    :is="row.kind === 'element' ? 'button' : 'div'"
+                    v-for="row in layoutTreeRows"
+                    :key="row.key"
+                    class="sw-content-system-index__tree-row"
+                    :class="{ 'is-selected': isTreeRowSelected(row), 'is-clickable': row.kind === 'element' }"
+                    :style="{ paddingLeft: `${(row.depth * 14) + 8}px` }"
+                    :type="row.kind === 'element' ? 'button' : null"
+                    @click="row.kind === 'element' ? selectTreeRow(row) : null"
+                >
+                    <span
+                        class="sw-content-system-index__tree-badge"
+                        :class="`is-${row.kind}`"
+                    >
+                        {{ row.kind }}
+                    </span>
+                    <span class="sw-content-system-index__tree-label">{{ row.label }}</span>
+                    <div
+                        v-if="row.kind === 'element'"
+                        class="sw-content-system-index__tree-actions"
+                    >
+                        <button
+                            type="button"
+                            class="sw-content-system-index__tree-action"
+                            :disabled="!row.canMoveUp || isTreeRowMovePending(row)"
+                            :title="$tc('sw-content-system.general.moveUpLabel')"
+                            @click.stop="moveTreeRow(row, 'up')"
+                        >
+                            ↑
+                        </button>
+                        <button
+                            type="button"
+                            class="sw-content-system-index__tree-action"
+                            :disabled="!row.canMoveDown || isTreeRowMovePending(row)"
+                            :title="$tc('sw-content-system.general.moveDownLabel')"
+                            @click.stop="moveTreeRow(row, 'down')"
+                        >
+                            ↓
+                        </button>
+                    </div>
+                </component>
+            </template>
+
+            <div
+                v-if="layoutMeta"
+                class="sw-content-system-index__tree-meta"
+            >
+                <small v-if="layoutMeta.layoutName">{{ $tc('sw-content-system.general.layoutNameLabel') }}: {{ layoutMeta.layoutName }}</small>
+                <small v-if="layoutMeta.layoutId">{{ $tc('sw-content-system.general.layoutIdLabel') }}: {{ layoutMeta.layoutId }}</small>
+                <small v-if="layoutMeta.endpoint">{{ $tc('sw-content-system.general.treeSourceLabel') }}: {{ layoutMeta.endpoint }}</small>
+            </div>
+        </aside>
+    </template>
+
+    <template #content>
+        <div class="sw-content-system-index__builder-shell">
+            <h3 class="sw-content-system-index__title">
+                {{ $tc('sw-content-system.general.previewTitle') }}
+            </h3>
+
+            <p class="sw-content-system-index__intro">
+                {{ $tc('sw-content-system.general.description') }}
+            </p>
+
+            <div class="sw-content-system-index__controls">
+                <mt-text-field
+                    v-model="landingPageId"
+                    :label="$tc('sw-content-system.general.landingPageIdLabel')"
+                />
+
+                <mt-text-field
+                    v-model="previewPath"
+                    :label="$tc('sw-content-system.general.previewPathLabel')"
+                />
+
+                <div class="sw-content-system-index__actions">
+                    <mt-button
+                        variant="primary"
+                        size="small"
+                        @click="refreshPreview"
+                    >
+                        {{ $tc('sw-content-system.general.refreshPreviewButton') }}
+                    </mt-button>
+
+                    <mt-button
+                        variant="secondary"
+                        size="small"
+                        @click="openPreviewInNewTab"
+                    >
+                        {{ $tc('sw-content-system.general.openInNewTabButton') }}
+                    </mt-button>
+                </div>
+            </div>
+
+            <div class="sw-content-system-index__meta">
+                <small>{{ previewUrl }}</small>
+            </div>
+
+            <div class="sw-content-system-index__iframe-wrapper">
+                <iframe
+                    ref="previewFrame"
+                    class="sw-content-system-index__iframe"
+                    :src="previewUrl"
+                    :title="$tc('sw-content-system.general.previewIFrameTitle')"
+                    sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+                ></iframe>
+            </div>
+        </div>
+    </template>
+</sw-page>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/sw-content-system-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/page/sw-content-system-index/sw-content-system-index.scss
@@ -1,0 +1,239 @@
+.sw-content-system-index {
+    .sw-page__content {
+        &.has--side-content {
+            grid-template-columns: 380px minmax(0, 1fr);
+        }
+    }
+
+    .sw-page__main-content-inner,
+    .sw-page__side-content-inner {
+        height: 100%;
+    }
+
+    .sw-page__main-content-inner {
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+    }
+
+    .sw-page__side-content-inner {
+        padding: 0;
+        overflow: hidden;
+    }
+
+    .sw-content-system-index__builder-shell {
+        width: 100%;
+        flex: 1 1 auto;
+        min-height: 0;
+        padding: 20px 20px 16px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .sw-content-system-index__title {
+        margin: 0 0 10px;
+        font-size: 20px;
+        font-weight: 600;
+    }
+
+    .sw-content-system-index__intro {
+        margin-bottom: 20px;
+    }
+
+    .sw-content-system-index__controls {
+        display: grid;
+        grid-template-columns: minmax(320px, 1fr) minmax(260px, 0.8fr) auto;
+        gap: 12px;
+        align-items: end;
+        margin-bottom: 14px;
+    }
+
+    .sw-content-system-index__actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .sw-content-system-index__meta {
+        margin-bottom: 12px;
+        color: var(--color-text-secondary-default);
+        word-break: break-all;
+        flex: 0 0 auto;
+    }
+
+    .sw-content-system-index__tree {
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        padding: 16px 12px 16px 16px;
+        background: linear-gradient(180deg, #f7f9fc 0%, #eef3f8 100%);
+        border-right: 1px solid var(--color-border-primary-default);
+    }
+
+    .sw-content-system-index__tree-header {
+        padding: 0 8px 10px;
+        border-bottom: 1px solid rgba(148, 163, 184, 20%);
+
+        h3 {
+            margin: 0;
+            font-size: 14px;
+            font-weight: 600;
+        }
+    }
+
+    .sw-content-system-index__tree-state {
+        padding: 12px 8px;
+        font-size: 13px;
+    }
+
+    .sw-content-system-index__tree-state--muted {
+        color: var(--color-text-secondary-default);
+    }
+
+    .sw-content-system-index__tree-state--error {
+        color: var(--color-text-danger-default);
+    }
+
+    .sw-content-system-index__tree-row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        width: 100%;
+        min-height: 30px;
+        padding-top: 4px;
+        padding-right: 8px;
+        padding-bottom: 4px;
+        border: 0;
+        border-bottom: 1px dashed rgba(148, 163, 184, 22%);
+        background: transparent;
+        font-size: 12px;
+        text-align: left;
+    }
+
+    .sw-content-system-index__tree-row.is-clickable {
+        cursor: pointer;
+    }
+
+    .sw-content-system-index__tree-row.is-selected {
+        background: rgba(59, 130, 246, 10%);
+        outline: 1px solid rgba(59, 130, 246, 30%);
+    }
+
+    .sw-content-system-index__tree-badge {
+        text-transform: uppercase;
+        border-radius: 4px;
+        padding: 1px 6px;
+        font-size: 10px;
+        line-height: 1.4;
+        background: #eef2f5;
+        color: #475569;
+        flex-shrink: 0;
+    }
+
+    .sw-content-system-index__tree-badge.is-layout {
+        background: #e0f2fe;
+        color: #075985;
+    }
+
+    .sw-content-system-index__tree-badge.is-element {
+        background: #fef3c7;
+        color: #92400e;
+    }
+
+    .sw-content-system-index__tree-badge.is-slot {
+        background: #e2e8f0;
+        color: #334155;
+    }
+
+    .sw-content-system-index__tree-label {
+        word-break: break-word;
+        flex: 1 1 auto;
+    }
+
+    .sw-content-system-index__tree-actions {
+        display: inline-flex;
+        gap: 4px;
+        margin-left: auto;
+        flex-shrink: 0;
+    }
+
+    .sw-content-system-index__tree-action {
+        width: 22px;
+        height: 22px;
+        border: 1px solid rgba(148, 163, 184, 28%);
+        border-radius: 6px;
+        background: rgba(255, 255, 255, 82%);
+        color: #334155;
+        cursor: pointer;
+        font-size: 12px;
+        line-height: 1;
+        padding: 0;
+        transition: background-color 0.15s ease, border-color 0.15s ease;
+    }
+
+    .sw-content-system-index__tree-action:hover:enabled {
+        background: #fff;
+        border-color: rgba(59, 130, 246, 40%);
+    }
+
+    .sw-content-system-index__tree-action:disabled {
+        cursor: default;
+        opacity: 0.35;
+    }
+
+    .sw-content-system-index__tree-meta {
+        margin-top: auto;
+        padding: 10px 8px 0;
+        border-top: 1px solid rgba(148, 163, 184, 20%);
+        display: grid;
+        gap: 4px;
+        color: var(--color-text-secondary-default);
+        word-break: break-all;
+    }
+
+    .sw-content-system-index__iframe-wrapper {
+        flex: 1 1 auto;
+        min-height: 0;
+        border: 1px solid rgba(148, 163, 184, 18%);
+        border-radius: 16px;
+        overflow: hidden;
+        background: #fff;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 8%);
+    }
+
+    .sw-content-system-index__iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+        background: #fff;
+    }
+
+    @media (max-width: 1360px) {
+        .sw-page__content {
+            &.has--side-content {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .sw-content-system-index__builder-shell {
+            padding: 14px 14px 10px;
+        }
+
+        .sw-content-system-index__controls {
+            grid-template-columns: 1fr;
+            align-items: stretch;
+        }
+
+        .sw-content-system-index__tree {
+            min-height: 280px;
+            max-height: 420px;
+            border-right: 0;
+            border-bottom: 1px solid var(--color-border-primary-default);
+        }
+
+        .sw-content-system-index__iframe-wrapper {
+            flex: 1 1 auto;
+            min-height: 500px;
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/snippet/de.json
@@ -1,0 +1,25 @@
+{
+  "sw-content-system": {
+    "general": {
+      "mainMenuItemGeneral": "Content System",
+      "descriptionTextModule": "Benutzerdefiniertes Erlebniswelten-Modul",
+      "headline": "Content System",
+      "description": "Storyblok-ähnliche Live-Vorschau via iFrame für Content-API-basiertes Storefront-Rendering.",
+      "previewTitle": "Live Storefront Vorschau",
+      "landingPageIdLabel": "Landing-Page-ID",
+      "previewPathLabel": "Preview-Pfad",
+      "refreshPreviewButton": "Vorschau aktualisieren",
+      "openInNewTabButton": "In neuem Tab öffnen",
+      "previewIFrameTitle": "Content System Live Storefront Vorschau",
+      "treeTitle": "Persistierter Layout-Baum",
+      "treeLoading": "Layout-Struktur wird geladen...",
+      "treeError": "Layout-Baum konnte nicht geladen werden",
+      "treeEmpty": "Keine Layout-Elemente für diese Entity vorhanden.",
+      "layoutNameLabel": "Layout",
+      "layoutIdLabel": "Layout-ID",
+      "treeSourceLabel": "Quelle",
+      "moveUpLabel": "Nach oben verschieben",
+      "moveDownLabel": "Nach unten verschieben"
+    }
+  }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-content-system/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-content-system/snippet/en.json
@@ -1,0 +1,25 @@
+{
+  "sw-content-system": {
+    "general": {
+      "mainMenuItemGeneral": "Content System",
+      "descriptionTextModule": "Custom Experience Studio module",
+      "headline": "Content System",
+      "description": "Storyblok-like live preview via iframe for Content API driven storefront rendering.",
+      "previewTitle": "Live storefront preview",
+      "landingPageIdLabel": "Landing page ID",
+      "previewPathLabel": "Preview path",
+      "refreshPreviewButton": "Refresh preview",
+      "openInNewTabButton": "Open in new tab",
+      "previewIFrameTitle": "Content System live storefront preview",
+      "treeTitle": "Persisted layout tree",
+      "treeLoading": "Loading layout structure...",
+      "treeError": "Could not load layout tree",
+      "treeEmpty": "No layout elements available for this entity.",
+      "layoutNameLabel": "Layout",
+      "layoutIdLabel": "Layout ID",
+      "treeSourceLabel": "Source",
+      "moveUpLabel": "Move up",
+      "moveDownLabel": "Move down"
+    }
+  }
+}

--- a/src/Core/Content/DependencyInjection/content_system.xml
+++ b/src/Core/Content/DependencyInjection/content_system.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- Entity Definitions -->
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Entity\ContentLayoutDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Entity\ProductContentLayout\ProductContentLayoutDefinition">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\ContentLayoutMetadataDeriver"/>
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Entity\CategoryContentLayout\CategoryContentLayoutDefinition">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\ContentLayoutMetadataDeriver"/>
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Entity\LandingPageContentLayout\LandingPageContentLayoutDefinition">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\ContentLayoutMetadataDeriver"/>
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Entity\HeaderContentLayout\HeaderContentLayoutDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Entity\FooterContentLayout\FooterContentLayoutDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <!-- Scaffolding Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Scaffolding\VirtualRootWrapper"/>
+
+        <!-- Output Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Output\PartialRenderer">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Output\ElementTreeUtil"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Element\Context\ContextDependencyAnalyzer"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Output\SubTreeExtractor"/>
+        </service>
+
+        <!-- Event Listeners (Hydration Pipeline) -->
+        <!-- Pre-Hydration Listeners -->
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PreHydration\VirtualRootPreparationSubscriber">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Scaffolding\VirtualRootWrapper"/>
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PreHydration\PlaceholderResolutionSubscriber">
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PreHydration\RedistributeExpansionSubscriber">
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PreHydration\PartialRenderingPreparationSubscriber">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Output\PartialRenderer"/>
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <!-- Post-Hydration Listeners -->
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PostHydration\VirtualRootCleanupSubscriber">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Scaffolding\VirtualRootWrapper"/>
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Event\Listener\PostHydration\PartialRenderingExtractionSubscriber">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Output\PartialRenderer"/>
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <!-- Field Serializers -->
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\DataRequirementsFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\ContextProvidersFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\ContextConsumersFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\ElementSlotsFieldSerializer" lazy="true">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\ContentElementFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\ContentElementFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\DataRequirementsFieldSerializer"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\ContextProvidersFieldSerializer"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\ContextConsumersFieldSerializer"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\ElementSlotsFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Field\ContentElementListFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Layout\Field\ContentElementFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Field\CriteriaFilterFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Field\CriteriaFilterListFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Field\CriteriaFilterFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Field\ResolutionConfigFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Field\CriteriaFilterFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Field\ParameterBindingFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Field\ResolutionConfigFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\Field\ParameterBindingsFieldSerializer">
+            <argument type="service" id="Symfony\Component\Validator\Validator\ValidatorInterface"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Field\ParameterBindingFieldSerializer"/>
+            <tag name="shopware.field_serializer"/>
+        </service>
+
+        <!-- Content Data Loaders -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoader">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Cache\EntityCacheTagResolver"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\EntityCollectionLoader\EntityCollectionLoader">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Cache\EntityCacheTagResolver"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\ProductListingLoader\ProductListingDataLoader">
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute" />
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <!-- Route Aliases for Decoration Pattern -->
+        <service id="Shopware\Core\Content\Category\Service\NavigationLoaderInterface"
+                 alias="Shopware\Core\Content\Category\Service\NavigationLoader"/>
+        <service id="Shopware\Core\System\Language\SalesChannel\AbstractLanguageRoute"
+                 alias="Shopware\Core\System\Language\SalesChannel\LanguageRoute"/>
+        <service id="Shopware\Core\System\Currency\SalesChannel\AbstractCurrencyRoute"
+                 alias="Shopware\Core\System\Currency\SalesChannel\CurrencyRoute"/>
+        <service id="Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute"
+                 alias="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute"/>
+        <service id="Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute"
+                 alias="Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute"/>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\NavigationLoader\NavigationDataLoader">
+            <argument type="service" id="Shopware\Core\Content\Category\Service\NavigationLoaderInterface"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\NavigationAliasResolver"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\LanguageLoader\LanguageDataLoader">
+            <argument type="service" id="Shopware\Core\System\Language\SalesChannel\AbstractLanguageRoute"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\CurrencyLoader\CurrencyDataLoader">
+            <argument type="service" id="Shopware\Core\System\Currency\SalesChannel\AbstractCurrencyRoute"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\PaymentMethodLoader\PaymentMethodDataLoader">
+            <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\ShippingMethodLoader\ShippingMethodDataLoader">
+            <argument type="service" id="Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute"/>
+            <tag name="content_system.data_loader"/>
+        </service>
+
+        <!-- Data Loader Provider with Tagged Locator -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderProvider">
+            <argument type="tagged_locator" tag="content_system.data_loader" default-index-method="getRequirementType"/>
+        </service>
+
+        <!-- Config Serializers -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\EntityCollectionLoader\EntityCollectionLoaderConfigSerializer">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\EntityLoader\EntityLoaderConfigSerializer"/>
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\ProductListingLoader\ProductListingLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\NavigationLoader\NavigationLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\LanguageLoader\LanguageLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\CurrencyLoader\CurrencyLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\PaymentMethodLoader\PaymentMethodLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\ShippingMethodLoader\ShippingMethodLoaderConfigSerializer">
+            <tag name="content_system.config_serializer"/>
+        </service>
+
+        <!-- Config Serializer Provider with Tagged Locator -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider">
+            <argument type="tagged_locator" tag="content_system.config_serializer" default-index-method="getSource"/>
+        </service>
+
+        <!-- Data Context Resolution -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataContext\DataContextResolver">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataContext\ContextPathResolver"/>
+        </service>
+
+        <!-- Context Path Resolver -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\DataContext\ContextPathResolver"/>
+
+        <!-- Cache Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Cache\EntityCacheTagResolver"/>
+
+        <service id="Shopware\Core\Content\ContentSystem\Cache\CacheFinalizer">
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Cache\CacheInvalidationSubscriber">
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheInvalidator"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Cache\EntityCacheTagResolver"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <!-- Hydration Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Hydration\ContentElementHydrator">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderProvider"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataContext\DataContextResolver"/>
+        </service>
+
+        <!-- Layout Context Utilities -->
+        <service id="Shopware\Core\Content\ContentSystem\Layout\Element\Context\ContextDependencyAnalyzer"/>
+
+        <!-- Output Services (Post-Hydration Processing) -->
+        <service id="Shopware\Core\Content\ContentSystem\Output\ElementTreeUtil"/>
+        <service id="Shopware\Core\Content\ContentSystem\Output\SubTreeExtractor"/>
+
+        <!-- Entity Layout Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutResolver">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\RequestDataExtractor"/>
+        </service>
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutContextFactory">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutResolver"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\RequestDataExtractor"/>
+        </service>
+
+        <!-- Domain-Aware Layout Resolution (Header/Footer) -->
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\DomainAwareLayoutResolver"/>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\NavigationAliasResolver"/>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\HeaderSpecificationSource">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\DomainAwareLayoutResolver"/>
+            <argument type="service" id="header_content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\RequestDataExtractor"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\FooterSpecificationSource">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\DomainAwareLayoutResolver"/>
+            <argument type="service" id="footer_content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Helper\RequestDataExtractor"/>
+        </service>
+
+        <!-- Helper Services -->
+        <service id="Shopware\Core\Content\ContentSystem\Helper\RequestDataExtractor"/>
+        <service id="Shopware\Core\Content\ContentSystem\Helper\ContentLayoutMetadataDeriver"/>
+
+        <!-- Specification Sources -->
+        <!-- Entity Sources - Higher priority -->
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\ProductSpecificationSource">
+            <argument type="service" id="product_content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Entity\ProductContentLayout\ProductContentLayoutDefinition"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutContextFactory"/>
+            <tag name="content_system.context_factory" priority="100"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\CategorySpecificationSource">
+            <argument type="service" id="category_content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Entity\CategoryContentLayout\CategoryContentLayoutDefinition"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutContextFactory"/>
+            <tag name="content_system.context_factory" priority="100"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\LandingPageSpecificationSource">
+            <argument type="service" id="landing_page_content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\Entity\LandingPageContentLayout\LandingPageContentLayoutDefinition"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FactoryHelper\EntityLayoutContextFactory"/>
+            <tag name="content_system.context_factory" priority="100"/>
+        </service>
+
+        <!-- Content Pipeline -->
+        <service id="Shopware\Core\Content\ContentSystem\ContentPipeline" public="true">
+            <argument type="service" id="content_layout.repository"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\ContentElementHydrator"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+
+        <!-- Rendering Specification Factory -->
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationFactory"/>
+
+        <!-- Section Resolvers -->
+        <service id="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationResolver">
+            <argument type="tagged_iterator" tag="content_system.context_factory"/>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationFactory"/>
+            <tag name="content_system.section_resolver" section="main"/>
+        </service>
+
+        <service id="content_system.section_resolver.header" class="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationResolver">
+            <argument type="collection">
+                <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\HeaderSpecificationSource"/>
+            </argument>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationFactory"/>
+            <tag name="content_system.section_resolver" section="header"/>
+        </service>
+
+        <service id="content_system.section_resolver.footer" class="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationResolver">
+            <argument type="collection">
+                <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\FooterSpecificationSource"/>
+            </argument>
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Adapter\RenderingSpecificationFactory"/>
+            <tag name="content_system.section_resolver" section="footer"/>
+        </service>
+
+        <!-- Output Format Handlers -->
+        <service id="Shopware\Core\Content\ContentSystem\Output\Format\FullResponseFactory">
+            <tag name="content_system.output_format" format="full"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Output\Format\SkeletonResponseFactory">
+            <tag name="content_system.output_format" format="skeleton"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Output\Format\DataResponseFactory">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider"/>
+            <tag name="content_system.output_format" format="data"/>
+        </service>
+
+        <service id="Shopware\Core\Content\ContentSystem\Output\Format\DecomposedResponseFactory">
+            <argument type="service" id="Shopware\Core\Content\ContentSystem\Hydration\DataLoader\DataLoaderConfigSerializerProvider"/>
+            <tag name="content_system.output_format" format="decomposed"/>
+        </service>
+
+        <!-- Content Route Loader (arg 0 set by ContentRouteCompilerPass) -->
+        <service id="Shopware\Core\Content\ContentSystem\SalesChannel\Routing\ContentRouteLoader">
+            <argument/>
+            <tag name="routing.loader"/>
+        </service>
+
+        <!-- Demo Command -->
+        <service id="Shopware\Core\Content\ContentSystem\Command\GenerateDemoDataCommand">
+            <argument type="service" id="content_layout.repository"/>
+            <argument type="service" id="product_content_layout.repository"/>
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="sales_channel.repository"/>
+            <argument type="service" id="tax.repository"/>
+            <tag name="console.command"/>
+        </service>
+    </services>
+</container>

--- a/src/Core/Framework/ContentSystem/Command/GenerateDemoDataCommand.php
+++ b/src/Core/Framework/ContentSystem/Command/GenerateDemoDataCommand.php
@@ -1,0 +1,300 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\ContentSystem\Command;
+
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageContentLayout\LandingPageContentLayoutCollection;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\ContentSystem\Layout\Entity\ContentLayoutCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @internal
+ */
+#[AsCommand(
+    name: 'content-system:demo:generate',
+    description: 'Creates a layout-playground demo layout and assigns it to a demo landing page for a storefront sales channel.',
+)]
+#[Package('framework')]
+class GenerateDemoDataCommand extends Command
+{
+    private const LANDING_PAGE_ID = '7c6c8f28f6c549ecb94a6a1760d2f5c1';
+
+    private const LANDING_PAGE_CONTENT_LAYOUT_ID = '91f6a4c7b2664927884d4fdb00b33c4a';
+
+    private const CONTENT_LAYOUT_ID = '22f090beeab811ad59bc5bbe3e087892';
+
+    /**
+     * @param EntityRepository<ContentLayoutCollection> $contentLayoutRepository
+     * @param EntityRepository<LandingPageContentLayoutCollection> $landingPageContentLayoutRepository
+     * @param EntityRepository<LandingPageCollection> $landingPageRepository
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<CmsPageCollection> $cmsPageRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $contentLayoutRepository,
+        private readonly EntityRepository $landingPageContentLayoutRepository,
+        private readonly EntityRepository $landingPageRepository,
+        private readonly EntityRepository $salesChannelRepository,
+        private readonly EntityRepository $cmsPageRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'sales-channel-id',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Optional target storefront sales channel ID. If omitted, the first storefront sales channel is used.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+        $context = Context::createCLIContext();
+
+        $salesChannelId = $input->getOption('sales-channel-id');
+        if (!\is_string($salesChannelId) || $salesChannelId === '') {
+            $salesChannelId = $this->findStorefrontSalesChannelId($context);
+        }
+
+        if ($salesChannelId === null) {
+            $io->error('No storefront sales channel found. Pass one with --sales-channel-id=<id>.');
+
+            return self::FAILURE;
+        }
+
+        $cmsPage = $this->findAnyCmsPage($context);
+        if ($cmsPage === null) {
+            $io->error('No CMS page found. Please create at least one CMS page and run the command again.');
+
+            return self::FAILURE;
+        }
+
+        $this->landingPageRepository->upsert([[
+            'id' => self::LANDING_PAGE_ID,
+            'active' => true,
+            'cmsPageId' => $cmsPage['id'],
+            'cmsPageVersionId' => $cmsPage['versionId'],
+            'translations' => [[
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'name' => 'Content System Layout Playground',
+                'url' => 'content-system-layout-playground',
+                'metaTitle' => 'Content System Layout Playground',
+                'metaDescription' => 'Layout playground created by content-system:demo:generate',
+            ]],
+            'salesChannels' => [[
+                'id' => $salesChannelId,
+            ]],
+        ]], $context);
+
+        $this->contentLayoutRepository->upsert([[
+            'id' => self::CONTENT_LAYOUT_ID,
+            'name' => 'Content System Layout Playground',
+            'version' => 'layout-playground-v1',
+            'layout' => $this->buildLayout(),
+        ]], $context);
+
+        $this->landingPageContentLayoutRepository->upsert([[
+            'id' => self::LANDING_PAGE_CONTENT_LAYOUT_ID,
+            'landingPageId' => self::LANDING_PAGE_ID,
+            'salesChannelId' => $salesChannelId,
+            'contentLayoutId' => self::CONTENT_LAYOUT_ID,
+        ]], $context);
+
+        $io->success('Layout playground demo was generated.');
+        $io->listing([
+            'Sales channel: ' . $salesChannelId,
+            'Landing page ID: ' . self::LANDING_PAGE_ID,
+            'Layout ID: ' . self::CONTENT_LAYOUT_ID,
+            'Store API full route: /store-api/content/landing-page/' . self::LANDING_PAGE_ID,
+            'Store API skeleton route: /store-api/content-skeleton/landing-page/' . self::LANDING_PAGE_ID,
+            'Storefront demo route: /content-system/demo/' . self::LANDING_PAGE_ID,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildLayout(): array
+    {
+        return [[
+            'id' => 'cbb6ae0d94787ca5925a115cb2e12159',
+            'component' => 'Sw:Grid',
+            'properties' => [
+                'columns' => '2',
+            ],
+            'slots' => [
+                'default' => [
+                    [
+                        'id' => 'bae5ad73aadf677e1aaaab638332cb1c',
+                        'component' => 'Sw:Content:Text',
+                        'properties' => [
+                            'text' => 'Content System Layout Playground',
+                            'style' => 'heading',
+                        ],
+                    ],
+                    [
+                        'id' => 'f089adbc9fad44589c913aa0b8ed1417',
+                        'component' => 'Sw:Grid',
+                        'properties' => [
+                            'columns' => '1',
+                        ],
+                        'slots' => [
+                            'default' => [
+                                [
+                                    'id' => '11111111111111111111111111111111',
+                                    'component' => 'Sw:Content:Text',
+                                    'properties' => [
+                                        'text' => 'Left column',
+                                        'style' => 'heading',
+                                    ],
+                                ],
+                                [
+                                    'id' => '22222222222222222222222222222222',
+                                    'component' => 'Sw:Content:Text',
+                                    'properties' => [
+                                        'text' => 'This column demonstrates a nested grid with reusable templates.',
+                                    ],
+                                ],
+                                [
+                                    'id' => '33333333333333333333333333333333',
+                                    'component' => 'Sw:Grid',
+                                    'properties' => [
+                                        'columns' => '2',
+                                    ],
+                                    'slots' => [
+                                        'default' => [
+                                            [
+                                                'id' => '44444444444444444444444444444444',
+                                                'component' => 'Sw:Content:Text',
+                                                'properties' => [
+                                                    'text' => 'Nested A',
+                                                    'style' => 'heading',
+                                                ],
+                                            ],
+                                            [
+                                                'id' => '55555555555555555555555555555555',
+                                                'component' => 'Sw:Content:Text',
+                                                'properties' => [
+                                                    'text' => 'Nested B',
+                                                    'style' => 'heading',
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'id' => 'a5a4a3bffd76609d1b0a36f6fcf68c45',
+                        'component' => 'Sw:Grid',
+                        'properties' => [
+                            'columns' => '1',
+                        ],
+                        'slots' => [
+                            'default' => [
+                                [
+                                    'id' => '66666666666666666666666666666666',
+                                    'component' => 'Sw:Content:Text',
+                                    'properties' => [
+                                        'text' => 'Right column',
+                                        'style' => 'heading',
+                                    ],
+                                ],
+                                [
+                                    'id' => '77777777777777777777777777777777',
+                                    'component' => 'Sw:Content:Text',
+                                    'properties' => [
+                                        'text' => 'The same Sw:Grid template is reused at every depth level.',
+                                    ],
+                                ],
+                                [
+                                    'id' => '88888888888888888888888888888888',
+                                    'component' => 'Sw:Grid',
+                                    'properties' => [
+                                        'columns' => '2',
+                                    ],
+                                    'slots' => [
+                                        'default' => [
+                                            [
+                                                'id' => '99999999999999999999999999999999',
+                                                'component' => 'Sw:Content:Text',
+                                                'properties' => [
+                                                    'text' => 'Card 1',
+                                                    'style' => 'heading',
+                                                ],
+                                            ],
+                                            [
+                                                'id' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                                                'component' => 'Sw:Grid',
+                                                'properties' => [
+                                                    'columns' => '1',
+                                                ],
+                                                'slots' => [
+                                                    'default' => [
+                                                        [
+                                                            'id' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                                                            'component' => 'Sw:Content:Text',
+                                                            'properties' => [
+                                                                'text' => 'Nested inside card 2',
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]];
+    }
+
+    private function findStorefrontSalesChannelId(Context $context): ?string
+    {
+        $criteria = (new Criteria())->setLimit(1);
+        $criteria->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+
+        return $this->salesChannelRepository->searchIds($criteria, $context)->firstId();
+    }
+
+    /**
+     * @return array{id: string, versionId: string}|null
+     */
+    private function findAnyCmsPage(Context $context): ?array
+    {
+        $criteria = (new Criteria())->setLimit(1);
+        $cmsPage = $this->cmsPageRepository->search($criteria, $context)->first();
+
+        if ($cmsPage === null) {
+            return null;
+        }
+
+        return [
+            'id' => $cmsPage->getId(),
+            'versionId' => $cmsPage->getVersionId(),
+        ];
+    }
+}

--- a/src/Core/Framework/DependencyInjection/content-system.xml
+++ b/src/Core/Framework/DependencyInjection/content-system.xml
@@ -237,5 +237,15 @@
             <argument/>
             <tag name="routing.loader"/>
         </service>
+
+        <!-- Demo Command -->
+        <service id="Shopware\Core\Framework\ContentSystem\Command\GenerateDemoDataCommand">
+            <argument type="service" id="content_layout.repository"/>
+            <argument type="service" id="landing_page_content_layout.repository"/>
+            <argument type="service" id="landing_page.repository"/>
+            <argument type="service" id="sales_channel.repository"/>
+            <argument type="service" id="cms_page.repository"/>
+            <tag name="console.command"/>
+        </service>
     </services>
 </container>

--- a/src/Storefront/ContentSystem/Rendering/ContentSystemDemoLayoutManager.php
+++ b/src/Storefront/ContentSystem/Rendering/ContentSystemDemoLayoutManager.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\ContentSystem\Rendering;
+
+use Shopware\Core\Framework\ContentSystem\Adapter\Entity\AbstractContentLayoutAssignmentEntity;
+use Shopware\Core\Framework\ContentSystem\Layout\Element\ContentElement;
+use Shopware\Core\Framework\ContentSystem\Layout\Element\Slot\SlotContent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ContentSystemDemoLayoutManager
+{
+    /**
+     * @param EntityRepository<AbstractContentLayoutAssignmentEntity> $landingPageContentLayoutRepository
+     */
+    public function __construct(
+        private readonly EntityRepository $landingPageContentLayoutRepository,
+        private readonly EntityRepository $contentLayoutRepository,
+    ) {
+    }
+
+    /**
+     * @param list<int|string> $slotPath
+     */
+    public function moveElement(
+        string $landingPageId,
+        SalesChannelContext $salesChannelContext,
+        array $slotPath,
+        int $fromIndex,
+        string $direction,
+    ): string {
+        $assignment = $this->loadAssignment($landingPageId, $salesChannelContext);
+        $contentLayout = $assignment->getContentLayout();
+
+        if ($contentLayout === null) {
+            throw new \RuntimeException('No content layout is assigned to this landing page.');
+        }
+
+        $layout = $this->normalizeLayout($contentLayout->getLayout());
+        $slot = &$this->resolveSlotReference($layout, $slotPath);
+
+        if (!isset($slot[$fromIndex]) || !\is_array($slot[$fromIndex])) {
+            throw new \InvalidArgumentException('The requested source element does not exist.');
+        }
+
+        $targetIndex = match ($direction) {
+            'up' => $fromIndex - 1,
+            'down' => $fromIndex + 1,
+            default => throw new \InvalidArgumentException('The move direction must be "up" or "down".'),
+        };
+
+        if (!isset($slot[$targetIndex]) || !\is_array($slot[$targetIndex])) {
+            throw new \InvalidArgumentException('The requested target position is outside the current slot.');
+        }
+
+        [$slot[$fromIndex], $slot[$targetIndex]] = [$slot[$targetIndex], $slot[$fromIndex]];
+        $slot = \array_values($slot);
+
+        $context = $salesChannelContext->getContext();
+
+        $this->contentLayoutRepository->update([[
+            'id' => $contentLayout->getId(),
+            'layout' => $layout,
+        ]], $context);
+
+        $selectedElement = $slot[$targetIndex] ?? null;
+
+        if (!\is_array($selectedElement) || !isset($selectedElement['id']) || !\is_string($selectedElement['id'])) {
+            throw new \RuntimeException('The moved element no longer has a valid ID.');
+        }
+
+        return $selectedElement['id'];
+    }
+
+    private function loadAssignment(string $landingPageId, SalesChannelContext $salesChannelContext): AbstractContentLayoutAssignmentEntity
+    {
+        $specificAssignment = $this->searchAssignment($landingPageId, $salesChannelContext->getSalesChannelId(), $salesChannelContext->getContext());
+
+        if ($specificAssignment !== null) {
+            return $specificAssignment;
+        }
+
+        $fallbackAssignment = $this->searchAssignment($landingPageId, null, $salesChannelContext->getContext());
+
+        if ($fallbackAssignment !== null) {
+            return $fallbackAssignment;
+        }
+
+        throw new \RuntimeException('No landing-page content layout assignment was found.');
+    }
+
+    private function searchAssignment(string $landingPageId, ?string $salesChannelId, Context $context): ?AbstractContentLayoutAssignmentEntity
+    {
+        $criteria = (new Criteria())->setLimit(1);
+        $criteria->addAssociation('contentLayout');
+        $criteria->addFilter(new EqualsFilter('landingPageId', $landingPageId));
+        $criteria->addFilter(new EqualsFilter('salesChannelId', $salesChannelId));
+
+        $assignment = $this->landingPageContentLayoutRepository->search($criteria, $context)->first();
+
+        if (!$assignment instanceof AbstractContentLayoutAssignmentEntity) {
+            return null;
+        }
+
+        return $assignment;
+    }
+
+    /**
+     * @param list<mixed> $layout
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeLayout(array $layout): array
+    {
+        return array_map(function (mixed $element): array {
+            if (\is_array($element)) {
+                return $element;
+            }
+
+            if ($element instanceof ContentElement) {
+                return $this->serializeElement($element);
+            }
+
+            throw new \InvalidArgumentException('The content layout contains an unsupported element structure.');
+        }, $layout);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeElement(ContentElement $element): array
+    {
+        $serialized = [
+            'id' => $element->getId(),
+            'component' => $element->getComponent(),
+            'properties' => $element->getProperties(),
+        ];
+
+        if ($element->getDataRequirements() !== []) {
+            throw new \InvalidArgumentException('Demo layout reordering currently supports layout-only elements without data requirements.');
+        }
+
+        if (!$element->hasSlots()) {
+            return $serialized;
+        }
+
+        $slots = [];
+
+        foreach ($element->getSlots() as $slotName => $slotContent) {
+            if (!$slotContent instanceof SlotContent) {
+                throw new \InvalidArgumentException('The content layout contains an unsupported slot structure.');
+            }
+
+            $slots[$slotName] = [];
+
+            foreach ($slotContent as $childElement) {
+                if (!$childElement instanceof ContentElement) {
+                    throw new \InvalidArgumentException('The content layout contains an unsupported child element structure.');
+                }
+
+                $slots[$slotName][] = $this->serializeElement($childElement);
+            }
+        }
+
+        $serialized['slots'] = $slots;
+
+        return $serialized;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $layout
+     * @param list<int|string> $slotPath
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function &resolveSlotReference(array &$layout, array $slotPath): array
+    {
+        $slot = &$layout;
+
+        foreach ($slotPath as $segment) {
+            if (\is_int($segment)) {
+                if (!isset($slot[$segment]) || !\is_array($slot[$segment])) {
+                    throw new \InvalidArgumentException('The layout path points to a missing element index.');
+                }
+
+                $slot = &$slot[$segment];
+
+                continue;
+            }
+
+            if (!isset($slot[$segment]) || !\is_array($slot[$segment])) {
+                throw new \InvalidArgumentException('The layout path points to a missing container segment.');
+            }
+
+            $slot = &$slot[$segment];
+        }
+
+        if (!\array_is_list($slot)) {
+            throw new \InvalidArgumentException('The resolved layout path is not a movable slot.');
+        }
+
+        return $slot;
+    }
+}

--- a/src/Storefront/ContentSystem/Rendering/ContentSystemDemoPageLoader.php
+++ b/src/Storefront/ContentSystem/Rendering/ContentSystemDemoPageLoader.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\ContentSystem\Rendering;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[Package('framework')]
+class ContentSystemDemoPageLoader
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly StorefrontContentRenderer $contentRenderer
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function load(string $landingPageId, Request $request, SalesChannelContext $context): array
+    {
+        $fullResponse = $this->requestStoreApiPayload('/store-api/content/landing-page/' . $landingPageId, $request, $context);
+
+        return [
+            'landingPageId' => $landingPageId,
+            'salesChannelId' => $context->getSalesChannelId(),
+            'fullEndpoint' => $fullResponse['endpoint'],
+            'renderedLayoutHtml' => $this->contentRenderer->renderLayout($fullResponse['payload']),
+            'fullError' => $fullResponse['error'],
+        ];
+    }
+
+    /**
+     * @return array{endpoint: string, payload: array<string, mixed>|null, error: string|null}
+     */
+    public function loadSkeleton(string $landingPageId, Request $request, SalesChannelContext $context): array
+    {
+        return $this->requestStoreApiPayload('/store-api/content-skeleton/landing-page/' . $landingPageId, $request, $context);
+    }
+
+    /**
+     * @return array{endpoint: string, payload: array<string, mixed>|null, error: string|null}
+     */
+    private function requestStoreApiPayload(string $path, Request $request, SalesChannelContext $context): array
+    {
+        $endpoint = $request->getSchemeAndHttpHost() . $path;
+        $accessKey = $context->getSalesChannel()->getAccessKey();
+        $payload = null;
+        $error = null;
+
+        try {
+            $response = $this->httpClient->request('GET', $endpoint, [
+                'headers' => ['sw-access-key' => $accessKey],
+            ]);
+
+            $payload = $response->toArray(false);
+        } catch (ExceptionInterface $e) {
+            $error = $e->getMessage();
+        }
+
+        return [
+            'endpoint' => $endpoint,
+            'payload' => $payload,
+            'error' => $error,
+        ];
+    }
+}

--- a/src/Storefront/ContentSystem/Rendering/StorefrontContentRenderer.php
+++ b/src/Storefront/ContentSystem/Rendering/StorefrontContentRenderer.php
@@ -1,0 +1,116 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\ContentSystem\Rendering;
+
+use Shopware\Core\Framework\Log\Package;
+use Twig\Environment;
+
+#[Package('framework')]
+class StorefrontContentRenderer
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly Environment $twig)
+    {
+    }
+
+    /**
+     * @param array<string, mixed>|null $fullPayload
+     */
+    public function renderLayout(?array $fullPayload): string
+    {
+        if ($fullPayload === null || !isset($fullPayload['elements']) || !\is_array($fullPayload['elements'])) {
+            return '';
+        }
+
+        $html = '';
+
+        foreach ($fullPayload['elements'] as $element) {
+            if (!\is_array($element)) {
+                continue;
+            }
+
+            $html .= $this->renderElement($element);
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param array<string, mixed> $element
+     */
+    private function renderElement(array $element): string
+    {
+        $component = $element['component'] ?? null;
+        if (!\is_string($component) || $component === '') {
+            return '';
+        }
+
+        $slotHtml = [];
+        if (isset($element['slots']) && \is_array($element['slots'])) {
+            foreach ($element['slots'] as $slotName => $slotEntries) {
+                if (!\is_string($slotName) || !\is_array($slotEntries)) {
+                    continue;
+                }
+
+                $renderedChildren = [];
+                foreach ($this->normalizeSlotEntries($slotEntries) as $childElement) {
+                    if (!\is_array($childElement)) {
+                        continue;
+                    }
+
+                    $renderedChildren[] = $this->renderElement($childElement);
+                }
+
+                $slotHtml[$slotName] = $renderedChildren;
+            }
+        }
+
+        $template = $this->resolveTemplate($component);
+
+        return $this->twig->render($template, [
+            'element' => $element,
+            'slotHtml' => $slotHtml,
+            'componentName' => $component,
+        ]);
+    }
+
+    /**
+     * @param array<mixed> $slotEntries
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeSlotEntries(array $slotEntries): array
+    {
+        $normalized = [];
+
+        foreach ($slotEntries as $slotKey => $slotEntry) {
+            if ($slotKey === 'apiAlias') {
+                continue;
+            }
+
+            if (\is_array($slotEntry)) {
+                $normalized[] = $slotEntry;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function resolveTemplate(string $component): string
+    {
+        $slug = mb_strtolower($component);
+        $slug = str_replace(':', '-', $slug);
+        $slug = preg_replace('/[^a-z0-9\-]+/', '-', $slug) ?? 'sw-unknown';
+        $slug = trim($slug, '-');
+
+        $template = '@Storefront/storefront/content-system/component/' . $slug . '.html.twig';
+
+        if ($this->twig->getLoader()->exists($template)) {
+            return $template;
+        }
+
+        return '@Storefront/storefront/content-system/component/sw-unknown.html.twig';
+    }
+}

--- a/src/Storefront/Controller/ContentSystemDemoController.php
+++ b/src/Storefront/Controller/ContentSystemDemoController.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoLayoutManager;
+use Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoPageLoader;
+use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID]])]
+#[Package('discovery')]
+class ContentSystemDemoController extends StorefrontController
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly ContentSystemDemoPageLoader $pageLoader,
+        private readonly ContentSystemDemoLayoutManager $layoutManager,
+    ) {
+    }
+
+    #[Route(
+        path: '/content-system/demo/{landingPageId}',
+        name: 'frontend.content-system.demo.page',
+        defaults: [PlatformRequest::ATTRIBUTE_HTTP_CACHE => false],
+        methods: [Request::METHOD_GET]
+    )]
+    public function index(string $landingPageId, Request $request, SalesChannelContext $context): Response
+    {
+        $response = $this->renderStorefront(
+            '@Storefront/storefront/page/content-system/demo.html.twig',
+            $this->pageLoader->load($landingPageId, $request, $context)
+        );
+
+        // Allow embedding the demo preview inside the administration (same origin).
+        $response->headers->set(PlatformRequest::HEADER_FRAME_OPTIONS, 'SAMEORIGIN');
+
+        return $response;
+    }
+
+    #[Route(
+        path: '/content-system/demo/layout/{landingPageId}',
+        name: 'frontend.content-system.demo.layout',
+        defaults: [PlatformRequest::ATTRIBUTE_HTTP_CACHE => false],
+        methods: [Request::METHOD_GET]
+    )]
+    public function layout(string $landingPageId, Request $request, SalesChannelContext $context): JsonResponse
+    {
+        $skeletonResponse = $this->pageLoader->loadSkeleton($landingPageId, $request, $context);
+
+        return new JsonResponse([
+            'landingPageId' => $landingPageId,
+            'salesChannelId' => $context->getSalesChannelId(),
+            'endpoint' => $skeletonResponse['endpoint'],
+            'payload' => $skeletonResponse['payload'],
+            'error' => $skeletonResponse['error'],
+        ]);
+    }
+
+    #[Route(
+        path: '/content-system/demo/layout/{landingPageId}/move',
+        name: 'frontend.content-system.demo.layout.move',
+        defaults: [PlatformRequest::ATTRIBUTE_HTTP_CACHE => false],
+        methods: [Request::METHOD_POST]
+    )]
+    public function moveLayoutElement(string $landingPageId, Request $request, SalesChannelContext $context): JsonResponse
+    {
+        try {
+            $payload = $request->toArray();
+            $slotPath = $payload['slotPath'] ?? [];
+            $fromIndex = $payload['fromIndex'] ?? null;
+            $direction = $payload['direction'] ?? null;
+
+            if (!\is_array($slotPath) || !\array_is_list($slotPath)) {
+                throw new \InvalidArgumentException('slotPath must be a JSON array.');
+            }
+
+            if (!\is_int($fromIndex)) {
+                throw new \InvalidArgumentException('fromIndex must be an integer.');
+            }
+
+            if (!\is_string($direction)) {
+                throw new \InvalidArgumentException('direction must be a string.');
+            }
+
+            $elementId = $this->layoutManager->moveElement($landingPageId, $context, $slotPath, $fromIndex, $direction);
+
+            return new JsonResponse([
+                'success' => true,
+                'landingPageId' => $landingPageId,
+                'selectedElementId' => $elementId,
+            ]);
+        } catch (\Throwable $exception) {
+            return new JsonResponse([
+                'success' => false,
+                'error' => $exception->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+    }
+}

--- a/src/Storefront/DependencyInjection/content-system.xml
+++ b/src/Storefront/DependencyInjection/content-system.xml
@@ -53,5 +53,10 @@
             <argument type="service" id="Shopware\Core\Framework\ContentSystem\Adapter\FactoryHelper\DomainAwareLayoutResolver"/>
             <argument type="service" id="footer_content_layout.repository"/>
         </service>
+
+        <service id="Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoLayoutManager">
+            <argument type="service" id="landing_page_content_layout.repository"/>
+            <argument type="service" id="content_layout.repository"/>
+        </service>
     </services>
 </container>

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -163,6 +163,15 @@
             </call>
         </service>
 
+        <service id="Shopware\Storefront\Controller\ContentSystemDemoController">
+            <argument type="service" id="Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoPageLoader"/>
+            <argument type="service" id="Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoLayoutManager"/>
+
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
         <service id="Shopware\Storefront\Controller\MaintenanceController" public="true">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Storefront\Page\Maintenance\MaintenancePageLoader"/>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -145,6 +145,15 @@
             <argument type="service" id="twig"/>
         </service>
 
+        <service id="Shopware\Storefront\ContentSystem\Rendering\StorefrontContentRenderer">
+            <argument type="service" id="twig"/>
+        </service>
+
+        <service id="Shopware\Storefront\ContentSystem\Rendering\ContentSystemDemoPageLoader">
+            <argument type="service" id="http_client"/>
+            <argument type="service" id="Shopware\Storefront\ContentSystem\Rendering\StorefrontContentRenderer"/>
+        </service>
+
         <service id="Shopware\Storefront\Framework\Twig\Extension\UrlEncodingTwigFilter" public="false">
             <tag name="twig.extension"/>
         </service>

--- a/src/Storefront/Resources/views/storefront/content-system/component/sw-content-text.html.twig
+++ b/src/Storefront/Resources/views/storefront/content-system/component/sw-content-text.html.twig
@@ -1,0 +1,14 @@
+{% set style = element.properties.style|default('body') %}
+{% set text = element.properties.text|default('') %}
+
+<div
+    class="content-system-text"
+    data-component="Sw:Content:Text"
+    data-content-element-id="{{ element.id|default('')|e('html_attr') }}"
+>
+    {% if style == 'heading' %}
+        <h2 class="h4">{{ text }}</h2>
+    {% else %}
+        <p class="mb-0">{{ text }}</p>
+    {% endif %}
+</div>

--- a/src/Storefront/Resources/views/storefront/content-system/component/sw-grid.html.twig
+++ b/src/Storefront/Resources/views/storefront/content-system/component/sw-grid.html.twig
@@ -1,0 +1,26 @@
+{% set columns = element.properties.columns|default('1') %}
+{% set slot = slotHtml.default|default([]) %}
+{% set columnClass = 'col-12' %}
+
+{% if columns == '2' %}
+    {% set columnClass = 'col-12 col-lg-6' %}
+{% elseif columns == '3' %}
+    {% set columnClass = 'col-12 col-lg-4' %}
+{% elseif columns == '4' %}
+    {% set columnClass = 'col-12 col-lg-3' %}
+{% endif %}
+
+<section
+    class="content-system-grid mb-4"
+    data-component="Sw:Grid"
+    data-columns="{{ columns|e('html_attr') }}"
+    data-content-element-id="{{ element.id|default('')|e('html_attr') }}"
+>
+    <div class="row g-3">
+        {% for childHtml in slot %}
+            <div class="{{ columnClass }}">
+                {{ childHtml|raw }}
+            </div>
+        {% endfor %}
+    </div>
+</section>

--- a/src/Storefront/Resources/views/storefront/content-system/component/sw-unknown.html.twig
+++ b/src/Storefront/Resources/views/storefront/content-system/component/sw-unknown.html.twig
@@ -1,0 +1,7 @@
+<div
+    class="alert alert-secondary mb-3"
+    data-component="{{ componentName|e('html_attr') }}"
+    data-content-element-id="{{ element.id|default('')|e('html_attr') }}"
+>
+    Unsupported Content System component: <code>{{ componentName }}</code>
+</div>

--- a/src/Storefront/Resources/views/storefront/page/content-system/demo.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content-system/demo.html.twig
@@ -1,0 +1,116 @@
+{% sw_extends '@Storefront/storefront/base.html.twig' %}
+
+{% block base_content %}
+    <div class="container-main content-main">
+        <div class="container py-4">
+            {% if fullError %}
+                <div class="alert alert-danger mb-3">
+                    Could not load Content API payload: {{ fullError }}
+                </div>
+            {% endif %}
+
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h2 class="h4 mb-0">Rendered layout playground preview</h2>
+                <small class="text-muted">
+                    Landing page: <code>{{ landingPageId }}</code>
+                </small>
+            </div>
+
+            <div class="border rounded p-3">
+                {{ renderedLayoutHtml|raw }}
+            </div>
+
+            <div class="mt-3 text-muted">
+                <small>Source: <code>{{ fullEndpoint }}</code></small>
+            </div>
+        </div>
+    </div>
+
+    <style>
+        [data-content-element-id] {
+            transition: outline-color 0.12s ease, box-shadow 0.12s ease;
+        }
+
+        .content-system-preview-is-selected {
+            outline: 2px solid #3b82f6;
+            outline-offset: 4px;
+            box-shadow: 0 0 0 4px rgb(59 130 246 / 15%);
+        }
+    </style>
+
+    <script>
+        (() => {
+            const isEmbeddedPreview = window.parent && window.parent !== window;
+
+            if (!isEmbeddedPreview) {
+                return;
+            }
+
+            const parentOrigin = window.location.origin;
+            let selectedElement = null;
+
+            const selectElement = (elementId) => {
+                if (selectedElement) {
+                    selectedElement.classList.remove('content-system-preview-is-selected');
+                }
+
+                if (!elementId) {
+                    selectedElement = null;
+                    return;
+                }
+
+                selectedElement = document.querySelector(`[data-content-element-id="${CSS.escape(elementId)}"]`);
+
+                if (!selectedElement) {
+                    return;
+                }
+
+                selectedElement.classList.add('content-system-preview-is-selected');
+                selectedElement.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'center',
+                });
+            };
+
+            window.addEventListener('message', (event) => {
+                if (event.origin !== parentOrigin || !event.data || typeof event.data !== 'object') {
+                    return;
+                }
+
+                if (event.data.type === 'content-system:select-element' && typeof event.data.elementId === 'string') {
+                    selectElement(event.data.elementId);
+                }
+            });
+
+            document.addEventListener('click', (event) => {
+                const target = event.target instanceof Element ? event.target.closest('[data-content-element-id]') : null;
+
+                if (!target) {
+                    return;
+                }
+
+                const elementId = target.getAttribute('data-content-element-id');
+
+                if (!elementId) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+
+                selectElement(elementId);
+
+                window.parent.postMessage({
+                    type: 'content-system:element-selected',
+                    elementId,
+                }, parentOrigin);
+            });
+
+            window.addEventListener('load', () => {
+                window.parent.postMessage({
+                    type: 'content-system:preview-ready',
+                }, parentOrigin);
+            });
+        })();
+    </script>
+{% endblock %}


### PR DESCRIPTION
fixes [#15365](https://github.com/shopware/shopware/issues/15365)

Further details: https://shopware.atlassian.net/wiki/spaces/SHB/pages/21524873217/Experience+Studio+POC

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We want to validate the architectural direction for an Experience Studio page builder on top of the new Content System. This PR creates a focused POC that proves we can use the persisted content layout as the source of truth, render it in a real storefront preview, and inspect/edit the structure from the administration without building a second renderer inside the admin.

### 2. What does this change do, exactly?
This PR introduces a layout-playground POC for the Content System.
It adds:
- a demo data generator for a dedicated landing page and persisted content layout
- a storefront demo route that renders the Content API result
- an administration page builder view with:
    - a persisted layout tree
    - a live storefront iframe preview
    - element selection sync between tree and preview
    - persisted element reordering inside the tree

The POC is intentionally layout-focused and uses nested grid/text elements to validate recursive rendering, preview architecture, and editor interaction without mixing in more complex entity hydration concerns.

<img width="2949" height="1166" alt="Bildschirmfoto 2026-03-10 um 14 08 00" src="https://github.com/user-attachments/assets/a2a2190f-b547-49b4-81e3-a91c103760b0" />

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup the project on this branch.
2. Generate the demo data:
  - docker compose exec -T web bin/console content-system:demo:generate
3. Open the storefront preview:
  - http://localhost:8000/content-system/demo/7c6c8f28f6c549ecb94a6a1760d2f5c1
4. Open the Content API routes for inspection:
  - full payload:
      - http://localhost:8000/store-api/content/landing-page/7c6c8f28f6c549ecb94a6a1760d2f5c1
  - skeleton payload:
      - http://localhost:8000/store-api/content-skeleton/landing-page/7c6c8f28f6c549ecb94a6a1760d2f5c1 
5. Open the administration and navigate to:
  - Content > Content System
6. Verify the current behavior:
  - the persisted layout is visible as a tree
    - the real storefront is rendered in the iframe
    - selecting an element in the tree highlights it in the preview
    - selecting an element in the preview selects it in the tree
    - moving elements up/down in the tree persists the layout change and updates the preview


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
