### PR TITLE
fix: dispatch AppActivatedEvent for active apps on reinstall

### DIFF
--- a/src/Core/Framework/App/AppException.php
+++ b/src/Core/Framework/App/AppException.php
@@ -67,6 +67,7 @@ class AppException extends HttpException
     final public const INVALID_SHOP_ID_CONFIGURATION = 'FRAMEWORK__APP_INVALID_SHOP_ID_CONFIGURATION';
     final public const SHOP_ID_CHANGE_STRATEGY_NOT_FOUND = 'FRAMEWORK__APP_SHOP_ID_CHANGE_STRATEGY_NOT_FOUND';
     final public const MANIFEST_NOT_FOUND = 'FRAMEWORK__APP_MANIFEST_NOT_FOUND';
+    final public const RE_REGISTRATION_FAILED = 'FRAMEWORK__APP_RE_REGISTRATION_FAILED';
 
     /**
      * @internal will be removed once store extensions are installed over composer
@@ -555,6 +556,20 @@ class AppException extends HttpException
             self::MANIFEST_NOT_FOUND,
             'No "manifest.xml" file in path "{{ path }}" found. (The file must be placed in the app root folder.)',
             ['path' => $path],
+        );
+    }
+
+    /**
+     * @param array<string> $failedAppNames
+     */
+    public static function reRegistrationFailed(array $failedAppNames, ?\Throwable $previous = null): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::RE_REGISTRATION_FAILED,
+            'Failed to re-register {{ count }} app(s): {{ apps }}',
+            ['count' => (string) \count($failedAppNames), 'apps' => implode(', ', $failedAppNames)],
+            $previous
         );
     }
 }

--- a/src/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategy.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -64,8 +65,18 @@ class MoveShopPermanentlyStrategy extends AbstractShopIdChangeStrategy
             $this->shopIdProvider->regenerateAndSetShopId($e->shopId->id);
         }
 
-        $this->forEachInstalledApp($context, function (Manifest $manifest, AppEntity $app, Context $context): void {
-            $this->reRegisterApp($manifest, $app, $context);
+        $failedApps = [];
+
+        $this->forEachInstalledApp($context, function (Manifest $manifest, AppEntity $app, Context $context) use (&$failedApps): void {
+            try {
+                $this->reRegisterApp($manifest, $app, $context);
+            } catch (\Throwable $e) {
+                $failedApps[$app->getName()] = $e;
+            }
         });
+
+        if ($failedApps !== []) {
+            throw AppException::reRegistrationFailed(array_keys($failedApps), current($failedApps) ?: null);
+        }
     }
 }

--- a/src/Core/Framework/App/ShopIdChangeResolver/ReinstallAppsStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/ReinstallAppsStrategy.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Event\AppActivatedEvent;
 use Shopware\Core\Framework\App\Event\AppInstalledEvent;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -58,11 +60,27 @@ class ReinstallAppsStrategy extends AbstractShopIdChangeStrategy
     {
         $this->shopIdProvider->deleteShopId();
 
-        $this->forEachInstalledApp($context, function (Manifest $manifest, AppEntity $app, Context $context): void {
-            $this->reRegisterApp($manifest, $app, $context);
-            $this->eventDispatcher->dispatch(
-                new AppInstalledEvent($app, $manifest, $context)
-            );
+        $failedApps = [];
+
+        $this->forEachInstalledApp($context, function (Manifest $manifest, AppEntity $app, Context $context) use (&$failedApps): void {
+            try {
+                $this->reRegisterApp($manifest, $app, $context);
+                $this->eventDispatcher->dispatch(
+                    new AppInstalledEvent($app, $manifest, $context)
+                );
+
+                if ($app->isActive()) {
+                    $this->eventDispatcher->dispatch(
+                        new AppActivatedEvent($app, $context)
+                    );
+                }
+            } catch (\Throwable $e) {
+                $failedApps[$app->getName()] = $e;
+            }
         });
+
+        if ($failedApps !== []) {
+            throw AppException::reRegistrationFailed(array_keys($failedApps), current($failedApps) ?: null);
+        }
     }
 }

--- a/src/Core/Framework/Webhook/WebhookCacheClearer.php
+++ b/src/Core/Framework/Webhook/WebhookCacheClearer.php
@@ -23,6 +23,7 @@ class WebhookCacheClearer implements EventSubscriberInterface, ResetInterface
     public static function getSubscribedEvents(): array
     {
         return [
+            'app.written' => 'clearWebhookCache',
             'acl_role.written' => 'clearPrivilegesCache',
         ];
     }

--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -28,7 +28,10 @@ trait AppSystemTestBehaviour
         );
     }
 
-    protected function loadAppsFromDir(string $appDir, bool $activateApps = true): void
+    /**
+     * @param array<string> $installAppNames if provided, only these apps will be installed and existing apps won't be deleted
+     */
+    protected function loadAppsFromDir(string $appDir, bool $activateApps = true, array $installAppNames = []): void
     {
         $appService = new AppService(
             new AppLifecycleIterator(
@@ -38,7 +41,7 @@ trait AppSystemTestBehaviour
             static::getContainer()->get(AppLifecycle::class)
         );
 
-        $fails = $appService->doRefreshApps(new AppInstallParameters(activate: $activateApps), Context::createDefaultContext());
+        $fails = $appService->doRefreshApps(new AppInstallParameters(activate: $activateApps), Context::createDefaultContext(), $installAppNames);
 
         if ($fails !== []) {
             $errors = \array_map(function (array $fail): string {

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\AppUrlChangeResolver;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -111,6 +112,44 @@ class MoveShopPermanentlyStrategyTest extends TestCase
         $moveShopPermanentlyResolver->resolve($this->context);
 
         static::assertSame($shopId, $this->shopIdProvider->getShopId());
+    }
+
+    public function testItContinuesWithOtherAppsWhenOneRegistrationFails(): void
+    {
+        $testAppDir = (string) realpath(__DIR__ . '/../Manifest/_fixtures/test');
+        $withConfigAppDir = (string) realpath(__DIR__ . '/../Manifest/_fixtures/withConfig');
+
+        $this->loadAppsFromDir($testAppDir);
+        $this->loadAppsFromDir($withConfigAppDir, true, ['withConfig']);
+
+        $this->changeAppUrl();
+
+        $registrationsService = $this->createMock(AppRegistrationService::class);
+        $calls = 0;
+        $registrationsService->expects($this->exactly(2))
+            ->method('registerApp')
+            ->willReturnCallback(static function () use (&$calls): void {
+                ++$calls;
+
+                if ($calls === 1) {
+                    throw new \RuntimeException('Could not reach app server');
+                }
+            });
+
+        $moveShopPermanentlyResolver = new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver([
+                'test' => new Filesystem($testAppDir),
+                'withConfig' => new Filesystem($withConfigAppDir),
+            ]),
+            static::getContainer()->get('app.repository'),
+            $registrationsService,
+            $this->shopIdProvider
+        );
+
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessage('Failed to re-register 1 app(s):');
+
+        $moveShopPermanentlyResolver->resolve($this->context);
     }
 
     private function changeAppUrl(bool $expectsToThrow = true): string

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Integration\Core\Framework\App\AppUrlChangeResolver;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Event\AppActivatedEvent;
 use Shopware\Core\Framework\App\Event\AppInstalledEvent;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
@@ -71,9 +73,20 @@ class ReinstallAppsStrategyTest extends TestCase
             );
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher->expects($this->once())
+        $eventDispatcher->expects($this->exactly(2))
             ->method('dispatch')
-            ->with(static::isInstanceOf(AppInstalledEvent::class));
+            ->willReturnCallback(function (object $event): object {
+                static $calls = 0;
+                ++$calls;
+
+                if ($calls === 1) {
+                    static::assertInstanceOf(AppInstalledEvent::class, $event);
+                } else {
+                    static::assertInstanceOf(AppActivatedEvent::class, $event);
+                }
+
+                return $event;
+            });
 
         $reinstallAppsResolver = new ReinstallAppsStrategy(
             new StaticSourceResolver(['test' => new Filesystem($appDir)]),
@@ -124,6 +137,61 @@ class ReinstallAppsStrategyTest extends TestCase
         $reinstallAppsResolver->resolve($this->context);
 
         static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
+    }
+
+    public function testItContinuesWithOtherAppsWhenOneRegistrationFails(): void
+    {
+        $testAppDir = (string) realpath(__DIR__ . '/../Manifest/_fixtures/test');
+        $withConfigAppDir = (string) realpath(__DIR__ . '/../Manifest/_fixtures/withConfig');
+
+        $this->loadAppsFromDir($testAppDir);
+        $this->loadAppsFromDir($withConfigAppDir, true, ['withConfig']);
+
+        $this->changeAppUrl();
+
+        $registrationsService = $this->createMock(AppRegistrationService::class);
+        $calls = 0;
+        $registrationsService->expects($this->exactly(2))
+            ->method('registerApp')
+            ->willReturnCallback(static function () use (&$calls): void {
+                ++$calls;
+
+                if ($calls === 1) {
+                    throw new \RuntimeException('Could not reach app server');
+                }
+            });
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $event): object {
+                static $calls = 0;
+                ++$calls;
+
+                if ($calls === 1) {
+                    static::assertInstanceOf(AppInstalledEvent::class, $event);
+                } else {
+                    static::assertInstanceOf(AppActivatedEvent::class, $event);
+                }
+
+                return $event;
+            });
+
+        $reinstallAppsResolver = new ReinstallAppsStrategy(
+            new StaticSourceResolver([
+                'test' => new Filesystem($testAppDir),
+                'withConfig' => new Filesystem($withConfigAppDir),
+            ]),
+            static::getContainer()->get('app.repository'),
+            $registrationsService,
+            $this->shopIdProvider,
+            $eventDispatcher
+        );
+
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessage('Failed to re-register 1 app(s):');
+
+        $reinstallAppsResolver->resolve($this->context);
     }
 
     private function changeAppUrl(bool $expectToThrow = true): string

--- a/tests/unit/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/unit/Core/Framework/App/ShopIdChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -1,0 +1,221 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopIdChangeResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
+use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\ShopId\FingerprintComparisonResult;
+use Shopware\Core\Framework\App\ShopId\ShopId;
+use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\MoveShopPermanentlyStrategy;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Filesystem;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\App\StaticSourceResolver;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[CoversClass(MoveShopPermanentlyStrategy::class)]
+class MoveShopPermanentlyStrategyTest extends TestCase
+{
+    private const MANIFEST_WITH_SETUP = __DIR__ . '/../Manifest/_fixtures/test';
+    private const MANIFEST_WITHOUT_SETUP = __DIR__ . '/../Manifest/_fixtures/compatibility';
+
+    public function testGetName(): void
+    {
+        $strategy = $this->createStrategy();
+
+        static::assertSame(MoveShopPermanentlyStrategy::STRATEGY_NAME, $strategy->getName());
+    }
+
+    public function testGetDescription(): void
+    {
+        $strategy = $this->createStrategy();
+
+        static::assertIsString($strategy->getDescription());
+        static::assertNotEmpty($strategy->getDescription());
+    }
+
+    public function testGetDecoratedThrowsException(): void
+    {
+        $strategy = $this->createStrategy();
+
+        $this->expectException(DecorationPatternException::class);
+        $strategy->getDecorated();
+    }
+
+    public function testResolveReturnsEarlyWhenNoShopIdChange(): void
+    {
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('reset');
+        $shopIdProvider->expects($this->once())->method('getShopId');
+        $shopIdProvider->expects($this->never())->method('regenerateAndSetShopId');
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->never())->method('registerApp');
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([]);
+
+        $strategy = new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver(),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+    }
+
+    public function testResolveReRegistersAppsOnShopIdChange(): void
+    {
+        $app = $this->createAppEntity('test');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('reset');
+        $shopIdProvider->expects($this->once())
+            ->method('getShopId')
+            ->willThrowException($this->createShopIdChangedException('test-shop-id'));
+        $shopIdProvider->expects($this->once())
+            ->method('regenerateAndSetShopId')
+            ->with('test-shop-id');
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->once())
+            ->method('registerApp')
+            ->with(
+                static::callback(static fn (Manifest $manifest): bool => $manifest->getMetadata()->getName() === 'test'),
+                $app->getId(),
+                static::callback(static fn (string $secret): bool => $secret !== ''),
+                static::isInstanceOf(Context::class)
+            );
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $strategy = new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver(['test' => new Filesystem(self::MANIFEST_WITH_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+
+        static::assertCount(1, $appRepo->updates);
+    }
+
+    public function testResolveSkipsAppsWithoutSetup(): void
+    {
+        $app = $this->createAppEntity('minimal');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->method('getShopId')
+            ->willThrowException($this->createShopIdChangedException('test-shop-id'));
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->never())->method('registerApp');
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $strategy = new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver(['minimal' => new Filesystem(self::MANIFEST_WITHOUT_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+
+        static::assertEmpty($appRepo->updates);
+    }
+
+    public function testResolveCollectsFailuresAndThrowsException(): void
+    {
+        $app1 = $this->createAppEntity('test', 'app-1');
+        $app2 = $this->createAppEntity('test', 'app-2');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->method('getShopId')
+            ->willThrowException($this->createShopIdChangedException('test-shop-id'));
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $calls = 0;
+        $registrationService->expects($this->exactly(2))
+            ->method('registerApp')
+            ->willReturnCallback(static function () use (&$calls): void {
+                ++$calls;
+
+                if ($calls === 1) {
+                    throw new \RuntimeException('Could not reach app server');
+                }
+            });
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app1, $app2]),
+        ]);
+
+        $strategy = new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver(['test' => new Filesystem(self::MANIFEST_WITH_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider
+        );
+
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessage('Failed to re-register 1 app(s):');
+
+        $strategy->resolve(Context::createDefaultContext());
+    }
+
+    private function createStrategy(): MoveShopPermanentlyStrategy
+    {
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([]);
+
+        return new MoveShopPermanentlyStrategy(
+            new StaticSourceResolver(),
+            $appRepo,
+            $this->createMock(AppRegistrationService::class),
+            $this->createMock(ShopIdProvider::class)
+        );
+    }
+
+    private function createAppEntity(string $name, ?string $id = null): AppEntity
+    {
+        $id ??= Uuid::randomHex();
+        $integrationId = Uuid::randomHex();
+
+        $app = new AppEntity();
+        $app->setId($id);
+        $app->setUniqueIdentifier($id);
+        $app->setName($name);
+        $app->setIntegrationId($integrationId);
+        $app->setActive(true);
+
+        return $app;
+    }
+
+    private function createShopIdChangedException(string $shopId): ShopIdChangeSuggestedException
+    {
+        return new ShopIdChangeSuggestedException(
+            ShopId::v2($shopId),
+            new FingerprintComparisonResult([], [], 100)
+        );
+    }
+}

--- a/tests/unit/Core/Framework/App/ShopIdChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/unit/Core/Framework/App/ShopIdChangeResolver/ReinstallAppsStrategyTest.php
@@ -1,0 +1,240 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopIdChangeResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Event\AppActivatedEvent;
+use Shopware\Core\Framework\App\Event\AppInstalledEvent;
+use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\ReinstallAppsStrategy;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Filesystem;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\App\StaticSourceResolver;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ReinstallAppsStrategy::class)]
+class ReinstallAppsStrategyTest extends TestCase
+{
+    private const MANIFEST_WITH_SETUP = __DIR__ . '/../Manifest/_fixtures/test';
+    private const MANIFEST_WITHOUT_SETUP = __DIR__ . '/../Manifest/_fixtures/compatibility';
+
+    public function testGetName(): void
+    {
+        $strategy = $this->createStrategy();
+
+        static::assertSame(ReinstallAppsStrategy::STRATEGY_NAME, $strategy->getName());
+    }
+
+    public function testGetDescription(): void
+    {
+        $strategy = $this->createStrategy();
+
+        static::assertIsString($strategy->getDescription());
+        static::assertNotEmpty($strategy->getDescription());
+    }
+
+    public function testGetDecoratedThrowsException(): void
+    {
+        $strategy = $this->createStrategy();
+
+        $this->expectException(DecorationPatternException::class);
+        $strategy->getDecorated();
+    }
+
+    public function testResolveDeletesShopIdAndReRegistersApps(): void
+    {
+        $app = $this->createAppEntity('test', active: true);
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('deleteShopId');
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->once())
+            ->method('registerApp')
+            ->with(
+                static::callback(static fn (Manifest $manifest): bool => $manifest->getMetadata()->getName() === 'test'),
+                $app->getId(),
+                static::callback(static fn (string $secret): bool => $secret !== ''),
+                static::isInstanceOf(Context::class)
+            );
+
+        $dispatchedEvents = [];
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $event) use (&$dispatchedEvents): object {
+                $dispatchedEvents[] = $event;
+
+                return $event;
+            });
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $strategy = new ReinstallAppsStrategy(
+            new StaticSourceResolver(['test' => new Filesystem(self::MANIFEST_WITH_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider,
+            $eventDispatcher
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+
+        static::assertCount(1, $appRepo->updates);
+        static::assertCount(2, $dispatchedEvents);
+        static::assertInstanceOf(AppInstalledEvent::class, $dispatchedEvents[0]);
+        static::assertInstanceOf(AppActivatedEvent::class, $dispatchedEvents[1]);
+    }
+
+    public function testResolveDoesNotDispatchActivatedEventForInactiveApps(): void
+    {
+        $app = $this->createAppEntity('test', active: false);
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->once())->method('registerApp');
+
+        $dispatchedEvents = [];
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())
+            ->method('dispatch')
+            ->willReturnCallback(function (object $event) use (&$dispatchedEvents): object {
+                $dispatchedEvents[] = $event;
+
+                return $event;
+            });
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $strategy = new ReinstallAppsStrategy(
+            new StaticSourceResolver(['test' => new Filesystem(self::MANIFEST_WITH_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider,
+            $eventDispatcher
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+
+        static::assertCount(1, $dispatchedEvents);
+        static::assertInstanceOf(AppInstalledEvent::class, $dispatchedEvents[0]);
+    }
+
+    public function testResolveSkipsAppsWithoutSetup(): void
+    {
+        $app = $this->createAppEntity('minimal');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $registrationService->expects($this->never())->method('registerApp');
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app]),
+        ]);
+
+        $strategy = new ReinstallAppsStrategy(
+            new StaticSourceResolver(['minimal' => new Filesystem(self::MANIFEST_WITHOUT_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider,
+            $eventDispatcher
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+
+        static::assertEmpty($appRepo->updates);
+    }
+
+    public function testResolveCollectsFailuresAndThrowsException(): void
+    {
+        $app1 = $this->createAppEntity('test', 'app-1');
+        $app2 = $this->createAppEntity('test', 'app-2');
+
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+
+        $registrationService = $this->createMock(AppRegistrationService::class);
+        $calls = 0;
+        $registrationService->expects($this->exactly(2))
+            ->method('registerApp')
+            ->willReturnCallback(static function () use (&$calls): void {
+                ++$calls;
+
+                if ($calls === 1) {
+                    throw new \RuntimeException('Could not reach app server');
+                }
+            });
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([
+            new AppCollection([$app1, $app2]),
+        ]);
+
+        $strategy = new ReinstallAppsStrategy(
+            new StaticSourceResolver(['test' => new Filesystem(self::MANIFEST_WITH_SETUP)]),
+            $appRepo,
+            $registrationService,
+            $shopIdProvider,
+            $eventDispatcher
+        );
+
+        $this->expectException(AppException::class);
+        $this->expectExceptionMessage('Failed to re-register 1 app(s):');
+
+        $strategy->resolve(Context::createDefaultContext());
+    }
+
+    private function createStrategy(): ReinstallAppsStrategy
+    {
+        /** @var StaticEntityRepository<AppCollection> $appRepo */
+        $appRepo = new StaticEntityRepository([]);
+
+        return new ReinstallAppsStrategy(
+            new StaticSourceResolver(),
+            $appRepo,
+            $this->createMock(AppRegistrationService::class),
+            $this->createMock(ShopIdProvider::class),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+    }
+
+    private function createAppEntity(string $name, ?string $id = null, bool $active = true): AppEntity
+    {
+        $id ??= Uuid::randomHex();
+        $integrationId = Uuid::randomHex();
+
+        $app = new AppEntity();
+        $app->setId($id);
+        $app->setUniqueIdentifier($id);
+        $app->setName($name);
+        $app->setIntegrationId($integrationId);
+        $app->setActive($active);
+
+        return $app;
+    }
+}

--- a/tests/unit/Core/Framework/Webhook/WebhookCacheClearerTest.php
+++ b/tests/unit/Core/Framework/Webhook/WebhookCacheClearerTest.php
@@ -16,6 +16,7 @@ class WebhookCacheClearerTest extends TestCase
     public function testGetSubscribedEvents(): void
     {
         static::assertSame([
+            'app.written' => 'clearWebhookCache',
             'acl_role.written' => 'clearPrivilegesCache',
         ], WebhookCacheClearer::getSubscribedEvents());
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
During app reinstallation (as part of shop ID/url change handling), only AppInstalledEvent is emitted.
For apps that are already active, listeners/extensions that rely on AppActivatedEvent never run, which creates an inconsistent app lifecycle and can skip activation-dependent follow-up logic.

### 2. What does this change do, exactly?
* Both `MoveShopPermanentlyStrategy` and `ReinstallAppsStrategy` now attempt to re-register all installed apps, collecting any failures and throwing a single `RuntimeException` at the end listing all failed apps instead of stopping at the first error. This ensures that issues with one app do not prevent others from being processed. 

* In `ReinstallAppsStrategy`, after re-registration, `AppInstalledEvent` is always dispatched, and if the app is active, an additional `AppActivatedEvent` is dispatched. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Install an app and ensure it is active.
2. Trigger the reinstall flow via shop ID/url change handling (the path that uses ReinstallAppsStrategy).
3. Observe dispatched lifecycle events
4. Before this change: only AppInstalledEvent is dispatched.
5. After this change: AppInstalledEvent is dispatched first, followed by AppActivatedEvent for active apps

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them