### PR TITLE
fix: grecaptcha multi form for 6.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,18 @@ Thumbs.db
 /.vscode/
 !/.vscode/settings.json
 
+# AI/LLM Development Tools
+.claude/
+.cursor/
+.cursorrules
+.tabnine/
+.ai/
+.llm/
+.aider/
+.aiderignore
+.kite/
+.codewhispererignore
+
 # Composer
 /composer.phar
 /auth.json

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -2,6 +2,12 @@ import Plugin from 'src/plugin-system/plugin.class';
 
 export default class GoogleReCaptchaBasePlugin extends Plugin {
     init() {
+        if (window.grecaptcha && typeof window.grecaptcha.ready === 'function') {
+            window.grecaptcha.ready(this._executeGoogleReCaptchaInitialization.bind(this));
+        }
+    }
+
+    _executeGoogleReCaptchaInitialization() {
         this._getForm();
 
         if (!this._form) {

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
@@ -12,15 +12,20 @@ export default class GoogleReCaptchaV2Plugin extends GoogleReCaptchaBasePlugin
     };
 
     init() {
-        super.init();
-
         this.grecaptchaContainer = this.el.querySelector(this.options.checkboxContainer);
         this.grecaptchaContainerIframe = null;
         this.grecaptchaWidgetId = null;
-
         this.currentToken = null;
 
-        this._renderV2Captcha();
+        super.init();
+    }
+
+    _executeGoogleReCaptchaInitialization() {
+        super._executeGoogleReCaptchaInitialization();
+
+        if (this.grecaptcha) {
+            this._renderV2Captcha();
+        }
     }
 
     getGreCaptchaInfo() {

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
@@ -2,17 +2,35 @@ import GoogleReCaptchaBasePlugin from 'src/plugin/captcha/google-re-captcha/goog
 
 describe('GoogleReCaptchaBasePlugin tests', () => {
     let googleReCaptchaBasePlugin = undefined;
+    let mockElement;
+    let originalPluginManager;
+
+    function createMockElement() {
+        const form = document.createElement('form');
+        const inputField = document.createElement('input');
+        inputField.className = 'grecaptcha-input';
+        form.appendChild(inputField);
+
+        form.submit = jest.fn();
+        form.checkValidity = jest.fn(() => true);
+
+        return form;
+    }
 
     beforeEach(() => {
         window.grecaptcha = {
-            ready: () => {},
-            execute: () => {},
+            ready: (cb) => cb(),
+            execute: jest.fn(),
         };
 
-        const mockElement = document.createElement('form');
-        const inputField = document.createElement('input');
-        inputField.className = 'grecaptcha-input';
-        mockElement.appendChild(inputField);
+        mockElement = createMockElement();
+        document.body.appendChild(mockElement);
+
+        originalPluginManager = window.PluginManager;
+        window.PluginManager = {
+            getPluginInstancesFromElement: jest.fn(() => new Map()),
+            getPlugin: jest.fn(() => new Map([['instances', []]])),
+        };
 
         googleReCaptchaBasePlugin = new GoogleReCaptchaBasePlugin(mockElement, {
             grecaptchaInputSelector: '.grecaptcha-input',
@@ -20,7 +38,12 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
     });
 
     afterEach(() => {
+        window.PluginManager = originalPluginManager;
         googleReCaptchaBasePlugin = undefined;
+
+        if (mockElement && mockElement.parentElement) {
+            mockElement.parentElement.removeChild(mockElement);
+        }
     });
 
     test('GoogleReCaptchaBasePlugin exists', () => {
@@ -29,18 +52,71 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
 
     test('Throw error if input field for Google reCAPTCHA is missing', () => {
         const mockForm = document.createElement('form');
+        document.body.appendChild(mockForm);
 
         expect(() => new GoogleReCaptchaBasePlugin(mockForm)).toThrow(Error('Input field for Google reCAPTCHA is missing!'));
 
-        const inputField = document.createElement('input');
-        inputField.className = 'grecaptcha-input';
-        mockForm.appendChild(inputField);
+        if (mockForm.parentElement) {
+            mockForm.parentElement.removeChild(mockForm);
+        }
+    });
 
-        googleReCaptchaBasePlugin = new GoogleReCaptchaBasePlugin(mockForm, {
+    test('init calls grecaptcha.ready for each plugin instance', () => {
+        const mockReady = jest.fn();
+        window.grecaptcha.ready = mockReady;
+
+        new GoogleReCaptchaBasePlugin(mockElement, {
             grecaptchaInputSelector: '.grecaptcha-input',
         });
 
-        expect(typeof googleReCaptchaBasePlugin).toBe('object');
+        const mockElement2 = createMockElement();
+        document.body.appendChild(mockElement2);
+
+        new GoogleReCaptchaBasePlugin(mockElement2, {
+            grecaptchaInputSelector: '.grecaptcha-input',
+        });
+
+        const mockElement3 = createMockElement();
+        document.body.appendChild(mockElement3);
+
+        new GoogleReCaptchaBasePlugin(mockElement3, {
+            grecaptchaInputSelector: '.grecaptcha-input',
+        });
+
+        expect(mockReady).toHaveBeenCalledTimes(3);
+
+        if (mockElement2.parentElement) {
+            mockElement2.parentElement.removeChild(mockElement2);
+        }
+        if (mockElement3.parentElement) {
+            mockElement3.parentElement.removeChild(mockElement3);
+        }
+    });
+
+    test.each([
+        ['grecaptcha is undefined', undefined],
+        ['grecaptcha.ready is not a function', { ready: 'not-a-function' }],
+    ])('init does not call grecaptcha.ready when %s', (_, grecaptchaValue) => {
+        window.grecaptcha = grecaptchaValue;
+
+        expect(() => {
+            new GoogleReCaptchaBasePlugin(mockElement, {
+                grecaptchaInputSelector: '.grecaptcha-input',
+            });
+        }).not.toThrow();
+    });
+
+    test('init does not proceed if no form is found', () => {
+        const divElement = document.createElement('div');
+        const inputField = document.createElement('input');
+        inputField.className = 'grecaptcha-input';
+        divElement.appendChild(inputField);
+
+        const plugin = new GoogleReCaptchaBasePlugin(divElement, {
+            grecaptchaInputSelector: '.grecaptcha-input',
+        });
+
+        expect(plugin._form).toBeFalsy();
     });
 
     test('onFormSubmit is called _onFormSubmitCallback', () => {
@@ -76,5 +152,3 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
         expect(googleReCaptchaBasePlugin._form.submit).toHaveBeenCalled();
     });
 });
-
-

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.test.js
@@ -2,27 +2,47 @@ import GoogleReCaptchaV2Plugin from 'src/plugin/captcha/google-re-captcha/google
 
 describe('GoogleReCaptchaV2Plugin tests', () => {
     let googleReCaptchav2Plugin = undefined;
+    let mockElement;
+    let originalPluginManager;
 
     beforeEach(() => {
         window.grecaptcha = {
-            ready: () => {},
-            execute: () => {}
+            ready: (cb) => cb(),
+            execute: jest.fn(() => Promise.resolve('token')),
+            render: jest.fn(() => 'widgetId'),
         };
 
-        const mockElement = document.createElement('form');
+        mockElement = document.createElement('form');
         const inputField = document.createElement('input');
         const iframe = document.createElement('iframe');
-        inputField.className = 'grecaptcha-input';
+        const container = document.createElement('div');
+        container.className = 'grecaptcha-v2-container';
+        inputField.className = 'grecaptcha-v2-input';
         mockElement.appendChild(inputField);
         mockElement.appendChild(iframe);
+        mockElement.appendChild(container);
 
-        googleReCaptchav2Plugin = new GoogleReCaptchaV2Plugin(mockElement, {
-            grecaptchaInputSelector: '.grecaptcha-input'
-        });
+        mockElement.submit = jest.fn();
+        mockElement.checkValidity = jest.fn(() => true);
+
+        document.body.appendChild(mockElement);
+
+        originalPluginManager = window.PluginManager;
+        window.PluginManager = {
+            getPluginInstancesFromElement: jest.fn(() => new Map()),
+            getPlugin: jest.fn(() => new Map([['instances', []]])),
+        };
+
+        googleReCaptchav2Plugin = new GoogleReCaptchaV2Plugin(mockElement);
     });
 
     afterEach(() => {
+        window.PluginManager = originalPluginManager;
         googleReCaptchav2Plugin = undefined;
+
+        if (mockElement && mockElement.parentElement) {
+            mockElement.parentElement.removeChild(mockElement);
+        }
     });
 
     test('GoogleReCaptchaV2Plugin exists', () => {
@@ -30,11 +50,6 @@ describe('GoogleReCaptchaV2Plugin tests', () => {
     });
 
     test('grecaptcha render is called on initialize', () => {
-        googleReCaptchav2Plugin.grecaptcha.render = jest.fn(() => { return 'widgetId'; });
-        googleReCaptchav2Plugin.grecaptcha.ready = googleReCaptchav2Plugin._onGreCaptchaReady.bind(googleReCaptchav2Plugin);
-
-        googleReCaptchav2Plugin.init();
-
         expect(googleReCaptchav2Plugin.grecaptcha.render).toHaveBeenCalled();
         expect(googleReCaptchav2Plugin.grecaptchaWidgetId).toEqual('widgetId');
         expect(googleReCaptchav2Plugin.grecaptchaContainerIframe.tagName).toEqual('IFRAME');
@@ -101,5 +116,3 @@ describe('GoogleReCaptchaV2Plugin tests', () => {
         expect(googleReCaptchav2Plugin.grecaptchaInput.value).toEqual('token');
     });
 });
-
-

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v3.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-v3.plugin.test.js
@@ -2,26 +2,44 @@ import GoogleReCaptchaV3Plugin from 'src/plugin/captcha/google-re-captcha/google
 
 describe('GoogleReCaptchaV3Plugin tests', () => {
     let googleReCaptchaV3Plugin = undefined;
+    let mockElement;
+    let originalPluginManager;
 
     beforeEach(() => {
         window.grecaptcha = {
-            ready: () => {},
-            execute: () => {}
+            ready: (cb) => cb(),
+            execute: jest.fn(() => Promise.resolve('successToken')),
         };
 
-        const mockElement = document.createElement('form');
+        mockElement = document.createElement('form');
         const inputField = document.createElement('input');
         inputField.className = 'grecaptcha_v3-input';
 
         mockElement.appendChild(inputField);
 
+        mockElement.submit = jest.fn();
+        mockElement.checkValidity = jest.fn(() => true);
+
+        document.body.appendChild(mockElement);
+
+        originalPluginManager = window.PluginManager;
+        window.PluginManager = {
+            getPluginInstancesFromElement: jest.fn(() => new Map()),
+            getPlugin: jest.fn(() => new Map([['instances', []]])),
+        };
+
         googleReCaptchaV3Plugin = new GoogleReCaptchaV3Plugin(mockElement, {
-            grecaptchaInputSelector: '.grecaptcha_v3-input'
+            grecaptchaInputSelector: '.grecaptcha_v3-input',
         });
     });
 
     afterEach(() => {
+        window.PluginManager = originalPluginManager;
         googleReCaptchaV3Plugin = undefined;
+
+        if (mockElement && mockElement.parentElement) {
+            mockElement.parentElement.removeChild(mockElement);
+        }
     });
 
     test('GoogleReCaptchaV3Plugin exists', () => {
@@ -42,8 +60,6 @@ describe('GoogleReCaptchaV3Plugin tests', () => {
             expect(googleReCaptchaV3Plugin._formSubmitting).toEqual(false);
             expect(googleReCaptchaV3Plugin.grecaptchaInput.value).toEqual('successToken');
             expect(googleReCaptchaV3Plugin._submitInvisibleForm).toHaveBeenCalled();
-        })
+        });
     });
 });
-
-

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -4,7 +4,7 @@
         invisible: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV2.config.invisible')
     } %}
 
-    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+    {% set feedbackId = "#{formId}-grecaptcha-v2-feedback" %}
 
     <div class="captcha-google-re-captcha-v2"
          data-google-re-captcha-v2="true"

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -4,6 +4,8 @@
         invisible: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV2.config.invisible')
     } %}
 
+    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+
     <div class="captcha-google-re-captcha-v2"
          data-google-re-captcha-v2="true"
          data-google-re-captcha-v2-options="{{ googleReCaptchaV2Options|json_encode }}">
@@ -11,7 +13,7 @@
             type="text"
             class="d-none grecaptcha-v2-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV2::CAPTCHA_REQUEST_PARAMETER') }}"
-            {% if feature('ACCESSIBILITY_TWEAKS') %}data-validation="required" data-validate-hidden="true"{% endif %}
+            {% if feature('ACCESSIBILITY_TWEAKS') %}data-validation="required" data-validate-hidden="true" aria-describedby="{{ feedbackId }}"{% endif %}
             {% if not feature('ACCESSIBILITY_TWEAKS') %}data-skip-report-validity="true"{% endif %}
             {% if not feature('ACCESSIBILITY_TWEAKS') %}required{% endif %}>
 
@@ -25,6 +27,10 @@
                     {{ 'captcha.googleReCaptcha.dataProtectionInformation'|trans|sw_sanitize }}
                 </div>
             {% endif %}
+        {% endif %}
+
+        {% if feature('ACCESSIBILITY_TWEAKS') %}
+            <div id="{{ feedbackId }}" class="form-field-feedback"></div>
         {% endif %}
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -3,7 +3,7 @@
         siteKey: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV3.config.siteKey')
     } %}
 
-    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+    {% set feedbackId = "#{formId}-grecaptcha-v3-feedback" %}
 
     <div class="captcha-google-re-captcha-v3"
          data-google-re-captcha-v3="true"

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -3,6 +3,8 @@
         siteKey: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV3.config.siteKey')
     } %}
 
+    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+
     <div class="captcha-google-re-captcha-v3"
          data-google-re-captcha-v3="true"
          data-google-re-captcha-v3-options="{{ googleReCaptchaV3Options|json_encode }}">
@@ -10,12 +12,16 @@
             type="text"
             class="d-none grecaptcha_v3-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV3::CAPTCHA_REQUEST_PARAMETER') }}"
-            {% if feature('ACCESSIBILITY_TWEAKS') %}data-validation="required" data-validate-hidden="true"{% endif %}
+            {% if feature('ACCESSIBILITY_TWEAKS') %}data-validation="required" data-validate-hidden="true" aria-describedby="{{ feedbackId }}"{% endif %}
             {% if not feature('ACCESSIBILITY_TWEAKS') %}data-skip-report-validity="true"{% endif %}
             {% if not feature('ACCESSIBILITY_TWEAKS') %}required{% endif %}>
 
         <div class="data-protection-information grecaptcha-protection-information">
             {{ 'captcha.googleReCaptcha.dataProtectionInformation'|trans|sw_sanitize }}
         </div>
+
+        {% if feature('ACCESSIBILITY_TWEAKS') %}
+            <div id="{{ feedbackId }}" class="form-field-feedback"></div>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
When multiple forms with Google reCAPTCHA are on the same page, the plugin initialization can fail because `window.grecaptcha` may not be fully ready when `init()` runs synchronously. Additionally, when the `ACCESSIBILITY_TWEAKS` feature flag is active, validation feedback element IDs are not unique per form, causing conflicts between multiple reCAPTCHA instances.

### 2. What does this change do, exactly?
- Wraps the base plugin initialization in `window.grecaptcha.ready()` to ensure the reCAPTCHA API is fully available before setup (extracted into `_executeGoogleReCaptchaInitialization()` for child plugin extensibility).
- Restructures the V2 plugin to override `_executeGoogleReCaptchaInitialization()` so `_renderV2Captcha()` runs after `this.grecaptcha` is set.
- Makes Twig feedback container IDs unique per form using `formId` (behind `ACCESSIBILITY_TWEAKS` feature flag).
- Updates all three reCAPTCHA test suites with proper mocks for the deferred initialization flow.

### 3. Describe each step to reproduce the issue or behaviour.
1. Enable Google reCAPTCHA V2 (visible) in Admin under Settings > Basic Information > Captcha.
2. Open a page with multiple forms that include reCAPTCHA (e.g. registration + contact form modal).
3. Before this fix: plugin initialization could fail silently or crash if `window.grecaptcha` was not fully ready.
4. After this fix: each plugin instance waits for `grecaptcha.ready()` before initializing, preventing race conditions.

### 4. Please link to the relevant issues (if any).
- relates #15392
- closes #14520 for 6.6.x

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them