### PR TITLE
fix(admin): hide upload button when runtime extension management is disabled

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.html.twig
@@ -52,7 +52,7 @@
     {% block sw_extension_my_extensions_index_smart_bar_actions %}
     <template #smart-bar-actions>
         {% block sw_extension_my_extensions_index_smart_bar_actions_file_upload %}
-        <sw-extension-file-upload v-if="acl.can('system.plugin_upload') || !extensionManagementDisabled" />
+        <sw-extension-file-upload v-if="acl.can('system.plugin_upload') && !extensionManagementDisabled" />
         {% endblock %}
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -70,14 +70,27 @@ describe('module/sw-extension/page/sw-extension-my-extensions-index', () => {
         });
     });
 
+    afterEach(() => {
+        Shopware.Store.get('context').app.config.settings.disableExtensionManagement = false;
+        global.activeAclRoles = [];
+    });
+
     it('upload button should be there when allowed runtime extension management', async () => {
+        global.activeAclRoles = ['system.plugin_upload'];
         const wrapper = await createWrapper();
 
         expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(true);
     });
 
-    it('upload button should be not there when allowed runtime extension management', async () => {
+    it('upload button should be not there when disabling runtime extension management', async () => {
+        global.activeAclRoles = ['system.plugin_upload'];
         Shopware.Store.get('context').app.config.settings.disableExtensionManagement = true;
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(false);
+    });
+
+    it('upload button should be not there when missing plugin_upload acl', async () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.find('.sw-extension-file-upload').exists()).toBe(false);


### PR DESCRIPTION
### 1. Why is this change necessary?

When setting `runtime_extension_management: false` in the deployment config:
```yaml
shopware:
    deployment:
        runtime_extension_management: false
```
the extension upload button in the admin was still visible to users with the `system.plugin_upload` ACL privilege. The backend correctly rejected the upload with HTTP 403, but the button should not have been shown at all.

### 2. What does this change do, exactly?

The `v-if` condition on the upload button used `||` (OR) instead of `&&` (AND):
```diff
- <sw-extension-file-upload v-if="acl.can('system.plugin_upload') || !extensionManagementDisabled" />
+ <sw-extension-file-upload v-if="acl.can('system.plugin_upload') && !extensionManagementDisabled" />
```
Both conditions must now be true: the user needs the `system.plugin_upload` ACL **and** extension management must not be disabled.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set `shopware.deployment.runtime_extension_management: false` in your config
2. Log in to the admin with a user that has the `system.plugin_upload` ACL privilege
3. Navigate to Extensions > My Extensions
4. **Before fix:** The upload button is visible (but clicking it results in a 403 error)
5. **After fix:** The upload button is hidden

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them