### PR TITLE
docs: update telemetry docs

### DIFF
--- a/src/Core/Framework/Telemetry/README.md
+++ b/src/Core/Framework/Telemetry/README.md
@@ -3,11 +3,16 @@ This component contains the code for the collection of telemetry in shopware app
 
 Folder structure:
 - `Metrics` - contains the abstractions for the metrics collection and reporting.
+  - `Config` - metric and transport configuration loaded from `telemetry.yaml`.
+  - `Exception` - telemetry-specific exceptions.
+  - `Factory/MetricTransportFactoryInterface` - factory interface for creating transports from configuration.
+  - `Metric` - value objects (`ConfiguredMetric`, `Metric`) and the `Type` enum.
+  - `Transport` - `TransportCollection` that aggregates all registered transport factories.
 
 ## Metrics
 
 ### Supported Metric types
-In the Shopware application, various types of metrics can be collected:
+In the Shopware application, various types of metrics can be collected. These are defined in the `Type` enum:
 
 - **Counter** - Represents a single numerical value that only increases and can be summed, such as the number of requests served, tasks completed, or errors. This metric is reported as a positive increment.
 
@@ -17,8 +22,53 @@ In the Shopware application, various types of metrics can be collected:
 
 - **Histogram** - Samples observations (typically things like request durations or response sizes) and counts them in predefined buckets. Each bucket represents a range of values, and the histogram tracks the number of observations that fall into each bucket. This allows for a detailed distribution analysis of the observed values.
 
-For more details see the [OpenTelemetry Metrics API specification](https://opentelemetry.io/docs/specs/otel/metrics/api/#meter-operations) or 
+For more details see the [OpenTelemetry Metrics API specification](https://opentelemetry.io/docs/specs/otel/metrics/api/#meter-operations) or
 [Prometheus documentation](https://prometheus.io/docs/tutorials/understanding_metric_types/).
+
+### Configuration
+
+All metrics must be pre-configured under the `shopware.telemetry.metrics.definitions` key before they can be emitted. The framework ships default definitions in `src/Core/Framework/Resources/config/packages/telemetry.yaml`. Plugins, apps, and projects add their own definitions in a separate `config/packages/*.yaml` file — Symfony's configuration system deep-merges all files, so existing definitions are preserved.
+
+The `Meter` validates each metric against this merged configuration at emit time. In `dev`/`test` environments, an unconfigured metric throws a `MissingMetricConfigurationException`. In production the exception is logged at error level and the metric is dropped (not emitted to transports).
+
+A PHPStan rule (`NoUnconfiguredMetricAllowed`) additionally enforces at static analysis time that every `ConfiguredMetric` instantiation with a string-literal name has a matching definition in the configuration.
+
+Example of adding metric definitions in a project or plugin:
+
+```yaml
+shopware:
+    telemetry:
+        metrics:
+            namespace: '{example-metrics-namespace}'
+
+            definitions:
+                cache.invalidate.count:
+                    description: 'Number of cache invalidations'
+                    type: 'counter'
+
+                messenger.message.size:
+                    description: 'Size of the message in bytes'
+                    enabled: true
+                    type: 'histogram'
+                    unit: 'byte'
+                    parameters:
+                        buckets: [0, 512, 1024, 2048, 4096, 8192, 16384, 32768]
+
+                dal.associations.count:
+                    description: 'Number of associations loaded'
+                    type: 'histogram'
+                    labels:
+                        entity:
+                            allowed_values: ['product', 'category', 'order']
+```
+
+Each definition supports:
+- `type` (required) - one of `counter`, `updown_counter`, `gauge`, `histogram`.
+- `description` (required) - human-readable description.
+- `enabled` (optional, defaults to `true`) - allows disabling a metric without removing its emitters.
+- `unit` (optional) - unit of measurement (e.g. `byte`).
+- `parameters` (optional) - type-specific parameters (e.g. `buckets` for histograms).
+- `labels` (optional) - map of label names to `allowed_values`. Labels supplied at emit time that are not in this allowlist are silently stripped.
 
 ### Transports
 
@@ -26,7 +76,10 @@ The telemetry component provides a way to emit metrics to different transports. 
 
 #### Creating a Transport
 
-To create a new transport, you need to implement the `Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface` interface.
+To create a new transport, you need to implement two interfaces:
+
+1. `Shopware\Core\Framework\Telemetry\Metrics\Factory\MetricTransportFactoryInterface` - a factory that receives the full `TransportConfig` (containing all metric definitions) and returns a transport instance.
+2. `Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface` - the transport itself, responsible for emitting a `Metric` to the monitoring backend.
 
 Transports should support all basic metric types. If a transport does not support a specific metric type, it should throw a `Shopware\Core\Framework\Telemetry\Metrics\Exception\MetricNotSupportedException` exception.
 If the exception is thrown, it will be logged, but the application will continue to work.
@@ -36,135 +89,158 @@ Here is an example of a custom transport implementation:
 ```php
 <?php
 
-use Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface;use Shopware\Core\Framework\Telemetry\TelemetryException;
+use Shopware\Core\Framework\Telemetry\Metrics\Config\TransportConfig;
+use Shopware\Core\Framework\Telemetry\Metrics\Factory\MetricTransportFactoryInterface;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Metric;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\Type;
+use Shopware\Core\Framework\Telemetry\Metrics\MetricTransportInterface;
+use Shopware\Core\Framework\Telemetry\TelemetryException;
 
-class MetricTransportImplementation implements MetricTransportInterface
+class MyTransportFactory implements MetricTransportFactoryInterface
 {
-    public function emit(MetricInterface $metric): void
+    public function create(TransportConfig $transportConfig): MetricTransportInterface
     {
-        match (true) {
-            $metric instanceof UpDownCounter => $this->handleUpDownCounter($metric),
-            $metric instanceof Counter => $this->handleCounter($metric),
-            $metric instanceof Histogram => $this->handleHistogram($metric),
-            $metric instanceof Gauge => $this->handleGauge($metric),
+        return new MyTransport($transportConfig);
+    }
+}
+
+class MyTransport implements MetricTransportInterface
+{
+    public function __construct(private readonly TransportConfig $config)
+    {
+    }
+
+    public function emit(Metric $metric): void
+    {
+        match ($metric->type) {
+            Type::COUNTER => $this->handleCounter($metric),
+            Type::UPDOWN_COUNTER => $this->handleUpDownCounter($metric),
+            Type::HISTOGRAM => $this->handleHistogram($metric),
+            Type::GAUGE => $this->handleGauge($metric),
             default => throw TelemetryException::metricNotSupported($metric, $this),
         };
     }
 }
 ```
 
-Once that is created, you need to register the transport as service in your application and use the `metric_transport` tag.
+Once that is created, you need to register the transport factory as a service in your application and use the `shopware.metric_transport_factory` tag.
 
 ```xml
-<service id="YourPackage/NameSpace/MetricTransportImplementation">
-    <tag name="shopware.metric_transport"/>
+<service id="YourPackage\NameSpace\MyTransportFactory">
+    <tag name="shopware.metric_transport_factory"/>
 </service>
 ```
 
-Real-world example of transport can be found in the http://github.com/shopware/opentelemetry/ package.
+Real-world example of a transport can be found in the [shopware/opentelemetry](https://github.com/shopware/opentelemetry/) package.
 
 ### Usage
 
-There are two recommended ways to emit metrics in the Shopware application:
+There are two recommended ways to emit metrics in the Shopware application. In both cases, you emit a `ConfiguredMetric` — a lightweight value object that carries only the metric name, value, and optional labels. The `Meter` resolves the full metric definition (type, description, unit) from the YAML configuration at emit time.
 
-#### Using the Events system
+#### Using the Events system with an EventSubscriber
 
+You can create an `EventSubscriberInterface` that injects the `Meter` service and emits metrics in response to domain events. The subscriber should be placed in the relevant package, as it may contain specific domain logic.
 
-##### Attaching to Events
-You can attach metrics to the events using the predefined attributes from the `Shopware\Core\Framework\Telemetry\Metrics\Attribute` namespace.
-This is the preferred way, that would work if the value for the metric is constant or can be directly retrieved from the event property.
+**Simple counter** (constant value):
 
-```php
-
-#[\Shopware\Core\Framework\Telemetry\Metrics\Attribute\Counter(name="my_metric", value: 1, description: "My metric description")]
-class MyEvent
-{
-}
-```
-
-For more dynamic scenarios where the event value is not constant, the `TYPE_DYNAMIC` attribute type can be used to derive the value from the event. In such case value can be either property or a callable that yields one. It is recommended to use this approach when the property or method already exists in the event. If additional data is needed solely for the metric, it is better to use the EventListener approach.
-
-```php
-use Shopware\Core\Framework\Telemetry\Metrics\Attribute\Counter;
-
-#[Counter(name="my_metric", type: Counter::TYPE_DYNAMIC, value: "myMetricValue", description: "My metric description")]
-class MyEvent
-{
-    public AtomicType(int|float)|Closure $myMetricValue;
-
-    # or a method with no arguments
-    public function myMetricValue(): int|float {}
-}
-```
-
-> If both a property and a method with the same name exist, the `attributeValue` will prioritize the property over the method.
-
-
-#### Direct usage of the `Meter` service
-
-##### Dependency Injection
-You can inject the `Meter` service into any service that needs to emit metrics.
-
-For example, if the metric is the result of an event but the metric value cannot be directly obtained from the event property, an event listener can be used. The listener should be placed in the relevant package, as it may contain specific domain logic.
- 
 ```php
 <?php declare(strict_types=1);
 
-namespace Shopware\Package\Subscriber\Statistics;
+namespace Shopware\Core\Framework\Plugin\Telemetry;
 
-final readonly class SomeEventListener {
+use Shopware\Core\Framework\Plugin\Event\PluginPostInstallEvent;
+use Shopware\Core\Framework\Telemetry\Metrics\Meter;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\ConfiguredMetric;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-    public function __construct(private Meter $meter) {}
-
-    public function onEvent(SomeEvent $event): void {
-        $this->meter->emit(new Counter(
-            name: 'some.event',
-            description: 'Number of some events',
-            value: $this->getValueFromEvent($event),
-        ));
+class PluginTelemetrySubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly Meter $meter)
+    {
     }
-    
-    private function getValueFromEvent(MyEvent $event) {
-        // calculate value based on event
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PluginPostInstallEvent::class => 'emitPluginInstallCountMetric',
+        ];
+    }
+
+    public function emitPluginInstallCountMetric(): void
+    {
+        $this->meter->emit(new ConfiguredMetric(name: 'plugin.install.count', value: 1));
     }
 }
 ```
 
-##### Static Context (Not recommended)
+**Dynamic value** derived from the event:
 
-As a last resort, the static context can be used to emit the metric. This approach should only be employed when it is virtually impossible to inject the service (see RetryableTransaction). It is not recommended because it makes the code harder to test and maintain, and it hooks into the global state.
 ```php
-\Shopware\Core\Framework\Telemetry\Metrics\MeterProvider::meter()->emit(new \Shopware\Core\Framework\Telemetry\Metrics\Metric\Counter(name: 'my_metric', value: 1,  description:  'My metric description'));
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Telemetry;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntitySearchedEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Telemetry\Metrics\Meter;
+use Shopware\Core\Framework\Telemetry\Metrics\Metric\ConfiguredMetric;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class EntityTelemetrySubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly Meter $meter)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EntitySearchedEvent::class => ['emitAssociationsCountMetric', 99],
+        ];
+    }
+
+    public function emitAssociationsCountMetric(EntitySearchedEvent $event): void
+    {
+        $criteria = $event->getCriteria();
+        $associationsCount = $this->getAssociationsCountFromCriteria($criteria);
+        $this->meter->emit(new ConfiguredMetric(
+            name: 'dal.associations.count',
+            value: $associationsCount,
+        ));
+    }
+
+    private function getAssociationsCountFromCriteria(Criteria $criteria): int
+    {
+        return array_reduce(
+            $criteria->getAssociations(),
+            fn (int $carry, Criteria $association) => $carry + 1 + $this->getAssociationsCountFromCriteria($association),
+            0
+        );
+    }
+}
 ```
 
-## Customization
+#### Static Context via `MeterProvider` (Not recommended)
 
-> Intentionally left vague, this is largely @todo and is relevant when the feature is no longer @internal
+As a last resort, the static context can be used to emit the metric. This approach should only be employed when it is virtually impossible to inject the `Meter` service (see `RetryableQuery` and `RetryableTransaction`). It is not recommended because it makes the code harder to test and maintain, and it hooks into the global state.
 
-This part is intended for developers who want to customize the telemetry component. It includes:
+```php
+MeterProvider::meter()?->emit(new ConfiguredMetric(name: 'database.locks.count', value: 1));
+```
 
-- Adding the ability to support a new metric type
-- Customizing the type of metrics supported in the Events system (e.g., adding support for new metric types)
+### Default emitted metrics
 
-
-
-## Decisions/Considerations
-
-- The metric attributes are not supported in the current implementation. They have to be added with introducing
-  configuration with a whitelist for metrics, labels and labels values (to be able to manage the cardinality and related
-  costs).
-- The **Histogram** metric does not have explicit support for buckets (like `public ?array $buckets = null`). The reason
-  for this is that possibly this will be added to configuration on the later stage, probably at the transport level, to
-  make it possible to configure the buckets depending on the shopware installation.  
-  Additionally, OpenTelemetry SDK requires this to be configured during meter initialization, so doing this during
-  the emit phase could impact the performance.
+| Metric name | Type | Emitter | Trigger |
+|---|---|---|---|
+| `plugin.install.count` | counter | `PluginTelemetrySubscriber` | `PluginPostInstallEvent` |
+| `app.install.count` | counter | `AppTelemetrySubscriber` | `AppInstalledEvent` |
+| `cache.invalidate.count` | counter | `CacheTelemetrySubscriber` | `InvalidateCacheEvent` |
+| `messenger.message.size` | histogram | `MessageQueueTelemetrySubscriber` | `WorkerMessageReceivedEvent` |
+| `dal.associations.count` | histogram | `EntityTelemetrySubscriber` | `EntitySearchedEvent` |
+| `database.locks.count` | counter | `RetryableQuery` / `RetryableTransaction` | `RetryableException` / deadlock |
 
 ## Future improvements
 - Currently, emit expects the metric value to be precalculated. That means that if some metric will be disabled, the
-  calculation will still be performed. This can be tackled in the next versions of the implementation.
-- Possibility to configure metrics, labels and labels values in the configuration both globally and on the transport
-  level should be added. Unsupported label values should be ignored, with possible replacement to the `other` label
-  value. This will allow to manage the cardinality and related costs.
 
 ## ADRs
 - [ADR-2024-07-30-Add-Telemetry-Abstraction-Layer](../../../../adr/2024-07-30-add-telemetry-abstraction-layer.md)


### PR DESCRIPTION
This pull request significantly updates the telemetry documentation for Shopware, clarifying the metric configuration process, transport implementation, and recommended usage patterns. The README now provides detailed instructions for configuring metrics, creating and registering transports, and emitting metrics in response to domain events. It also introduces stricter validation and enforcement for metric definitions and offers improved examples for both static and dynamic metric emission.

**Metric configuration and validation:**

* Introduced a section describing the requirement for all metrics to be pre-configured in `telemetry.yaml`, with runtime and static analysis validation for metric definitions. Metrics not defined in configuration throw exceptions in development and are silently dropped in production.
* Provided a YAML configuration example and explained supported fields such as `type`, `description`, `enabled`, `unit`, `parameters`, and `labels`, including label allowlists for cardinality control.

**Transport implementation and registration:**

* Updated transport implementation instructions to require a factory interface (`MetricTransportFactoryInterface`) that receives configuration and returns a transport instance, and clarified service registration with the `shopware.metric_transport_factory` tag.
* Enhanced the example code to show how to implement both the factory and the transport, and how to handle metric types with the new `Type` enum.

**Metric emission and usage patterns:**

* Replaced attribute-based emission with recommended event subscriber usage, providing examples for both constant and dynamic metric values, and showing how to inject and use the `Meter` service in domain event subscribers.
* Clarified the static context usage via `MeterProvider`, marking it as not recommended except in rare cases, and updated the example accordingly.

**Documentation improvements:**

* Added a table listing currently emitted metrics, their types, emitters, and triggers for quick reference.
* Removed outdated sections about customization, decisions, and future improvements, replacing them with more actionable guidance and examples.