### PR TITLE
fix: bulk edit list price or cheapest price not possible without also checking base price checkbox

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -29,7 +29,13 @@ export default {
             isLoadedData: false,
             isSaveSuccessful: false,
             displayAdvancePricesModal: false,
+            /**
+             * @deprecated tag:v6.8.0 - will be removed without replacement
+             */
             isDisabledListPrice: true,
+            /**
+             * @deprecated tag:v6.8.0 - will be removed without replacement
+             */
             isDisabledRegulationPrice: true,
             bulkEditProduct: {},
             bulkEditSelected: [],
@@ -280,9 +286,7 @@ export default {
                             ? this.$t('sw-bulk-edit.product.prices.listPrice.label')
                             : this.$t('sw-bulk-edit.product.prices.listPrice.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.listPrice.placeholderListPrice'),
-                        disabled: this.isChild
-                            ? this.bulkEditProduct?.isPriceInherited?.isInherited
-                            : this.isDisabledListPrice,
+                        disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
                     },
                 },
                 {
@@ -296,9 +300,7 @@ export default {
                             ? this.$t('sw-bulk-edit.product.prices.regulationPrice.label')
                             : this.$t('sw-bulk-edit.product.prices.regulationPrice.changeLabel'),
                         placeholder: this.$t('sw-bulk-edit.product.prices.regulationPrice.placeholderRegulationPrice'),
-                        disabled: this.isChild
-                            ? this.bulkEditProduct?.isPriceInherited?.isInherited
-                            : this.isDisabledRegulationPrice,
+                        disabled: this.isChild ? this.bulkEditProduct?.isPriceInherited?.isInherited : false,
                     },
                 },
             ];
@@ -1110,11 +1112,6 @@ export default {
                 return;
             }
 
-            if (item === 'price') {
-                this.isDisabledListPrice = !this.bulkEditProduct.price.isChanged;
-                this.isDisabledRegulationPrice = !this.bulkEditProduct.price.isChanged;
-            }
-
             if (value && typeof value !== 'boolean') {
                 this.product[item] = Array.isArray(value) ? value : [value];
             }
@@ -1212,21 +1209,61 @@ export default {
 
         processListPrice() {
             const priceField = this.bulkEditSelected.find((dataField) => {
-                return dataField.field === 'price' && !types.isEmpty(dataField.value);
+                return dataField.field === 'price';
             });
+
+            if (priceField?.value === null) {
+                return;
+            }
 
             if (priceField) {
                 priceField.value[0].listPrice = this.product?.listPrice[0];
+            } else {
+                // Add price change when only listPrice is changed - price payload is required for API
+                this.bulkEditSelected.push({
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        {
+                            currencyId: this.currency.id,
+                            gross: null,
+                            net: null,
+                            linked: true,
+                            listPrice: this.product?.listPrice[0],
+                            regulationPrice: null,
+                        },
+                    ],
+                });
             }
         },
 
         processRegulationPrice() {
             const priceField = this.bulkEditSelected.find((dataField) => {
-                return dataField.field === 'price' && !types.isEmpty(dataField.value);
+                return dataField.field === 'price';
             });
+
+            if (priceField?.value === null) {
+                return;
+            }
 
             if (priceField) {
                 priceField.value[0].regulationPrice = this.product?.regulationPrice[0];
+            } else {
+                // Add price change when only regulationPrice is changed - price payload is required for API
+                this.bulkEditSelected.push({
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        {
+                            currencyId: this.currency.id,
+                            gross: null,
+                            net: null,
+                            linked: true,
+                            listPrice: null,
+                            regulationPrice: this.product?.regulationPrice[0],
+                        },
+                    ],
+                });
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -719,6 +719,128 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
         expect(changeField.value[0]).toHaveProperty('listPrice');
     });
 
+    it('should send listPrice in request when only listPrice is changed without price', async () => {
+        const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
+
+        await flushPromises();
+
+        wrapper.vm.product.listPrice = [
+            {
+                currencyId: wrapper.vm.currency.id,
+                gross: 100,
+                net: 84.03,
+                linked: true,
+            },
+        ];
+        wrapper.vm.bulkEditProduct.listPrice.isChanged = true;
+
+        wrapper.vm.onProcessData();
+
+        const changeField = wrapper.vm.bulkEditSelected.find((field) => field.field === 'price');
+        expect(changeField).toBeDefined();
+        expect(changeField.value[0]).toHaveProperty('listPrice');
+        expect(changeField.value[0].listPrice.gross).toBe(100);
+
+        expect(changeField.value[0].gross).toBeNull();
+        expect(changeField.value[0].net).toBeNull();
+    });
+
+    it('should send regulationPrice in request when only regulationPrice is changed without price', async () => {
+        const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
+
+        await flushPromises();
+
+        wrapper.vm.product.regulationPrice = [
+            {
+                currencyId: wrapper.vm.currency.id,
+                gross: 150,
+                net: 126.05,
+                linked: true,
+            },
+        ];
+        wrapper.vm.bulkEditProduct.regulationPrice.isChanged = true;
+
+        wrapper.vm.onProcessData();
+
+        const changeField = wrapper.vm.bulkEditSelected.find((field) => field.field === 'price');
+        expect(changeField).toBeDefined();
+        expect(changeField.value[0]).toHaveProperty('regulationPrice');
+        expect(changeField.value[0].regulationPrice.gross).toBe(150);
+
+        expect(changeField.value[0].gross).toBeNull();
+        expect(changeField.value[0].net).toBeNull();
+    });
+
+    it('should preserve child price inheritance when restoring inherited prices', async () => {
+        const wrapper = await createWrapper(
+            undefined,
+            {
+                name: 'sw.bulk.edit.product',
+                params: { parentId: 'productId' },
+            },
+            {
+                productRepositoryMock: {
+                    create: jest.fn(() => ({
+                        isNew: () => true,
+                    })),
+                    get: jest.fn(() => {
+                        return Promise.resolve({
+                            id: 'productId',
+                            name: 'parentProduct',
+                            tax: {
+                                id: 'rate1',
+                                taxRate: 19,
+                            },
+                            price: [
+                                {
+                                    currencyId: 'currencyId1',
+                                    gross: 10,
+                                    net: 8.4,
+                                    linked: true,
+                                    listPrice: {
+                                        currencyId: 'currencyId1',
+                                        gross: 12,
+                                        net: 10.08,
+                                        linked: true,
+                                    },
+                                    regulationPrice: {
+                                        currencyId: 'currencyId1',
+                                        gross: 11,
+                                        net: 9.24,
+                                        linked: true,
+                                    },
+                                },
+                            ],
+                            purchasePrices: [
+                                {
+                                    currencyId: 'currencyId1',
+                                    gross: 8,
+                                    net: 6.72,
+                                    linked: true,
+                                },
+                            ],
+                        });
+                    }),
+                },
+            },
+        );
+
+        await flushPromises();
+
+        wrapper.vm.onInheritanceRemove({ name: 'isPriceInherited' });
+        wrapper.vm.bulkEditProduct.isPriceInherited.isChanged = true;
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.onInheritanceRestore({ name: 'isPriceInherited' });
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.onProcessData();
+
+        const priceChanges = wrapper.vm.bulkEditSelected.filter((field) => field.field === 'price');
+        expect(priceChanges).toHaveLength(1);
+        expect(priceChanges[0].value).toBeNull();
+    });
+
     it('should be correct data when select categories', async () => {
         const productEntity = {
             categories: [
@@ -961,6 +1083,17 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
             },
         ],
         [
+            false,
+            'price',
+            [
+                {
+                    currencyId: 'currencyId',
+                    gross: '1',
+                    net: '2',
+                },
+            ],
+        ],
+        [
             true,
             'price',
             true,
@@ -998,7 +1131,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
 
         let expected;
         if (value && typeof value !== 'boolean') {
-            expected = [value];
+            expected = Array.isArray(value) ? value : [value];
         }
 
         expect(wrapper.vm.product[item]).toEqual(expected);

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
@@ -317,6 +317,8 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
     }
 
     formatPrice(price, dbPrice) {
+        const preserveFromDb = price.gross === null && price.net === null;
+
         if (price.gross === null) {
             price.linked = false;
             price.gross = dbPrice?.gross ?? 0;
@@ -325,6 +327,12 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
         if (price.net === null) {
             price.linked = false;
             price.net = dbPrice?.net ?? 0;
+        }
+
+        // When both gross and net were null (e.g. listPrice/regulationPrice-only bulk edit),
+        // preserve base price semantics (linked) from DB to avoid unintended changes
+        if (preserveFromDb && dbPrice?.linked !== undefined) {
+            price.linked = dbPrice.linked;
         }
 
         return price;

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
@@ -101,6 +101,106 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
         expect(result).toBe(true);
     });
 
+    it('should preserve base price fields (gross/net/linked) when only listPrice is changed', async () => {
+        const currencyId = 'b7d2554b0ce847cd82f3ac9bd1c0dfca';
+        const handler = getBulkEditProductHandler();
+        const originalBasePrice = {
+            currencyId,
+            gross: 50,
+            net: 42.02,
+            linked: true,
+            listPrice: { currencyId, gross: 80, net: 67.23, linked: true },
+        };
+
+        handler.getProducts = jest.fn().mockResolvedValue(undefined);
+        handler.products = [
+            {
+                id: 'product_1',
+                price: [originalBasePrice],
+            },
+        ];
+
+        const syncSpy = jest.spyOn(handler.syncService, 'sync').mockResolvedValue({ data: [] });
+
+        await handler.bulkEdit(
+            ['product_1'],
+            [
+                {
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        {
+                            currencyId,
+                            gross: null,
+                            net: null,
+                            linked: true,
+                            listPrice: { currencyId, gross: 100, net: 84.03, linked: true },
+                            regulationPrice: null,
+                        },
+                    ],
+                },
+            ],
+        );
+
+        const syncPayload = syncSpy.mock.calls[0][0];
+        const productPayload = syncPayload['upsert-product'].payload[0];
+
+        expect(productPayload.price[0].gross).toBe(50);
+        expect(productPayload.price[0].net).toBe(42.02);
+        expect(productPayload.price[0].linked).toBe(true);
+        expect(productPayload.price[0].listPrice.gross).toBe(100);
+    });
+
+    it('should preserve base price fields (gross/net/linked) when only regulationPrice is changed', async () => {
+        const currencyId = 'b7d2554b0ce847cd82f3ac9bd1c0dfca';
+        const handler = getBulkEditProductHandler();
+        const originalBasePrice = {
+            currencyId,
+            gross: 75,
+            net: 63.03,
+            linked: true,
+            regulationPrice: { currencyId, gross: 90, net: 75.63, linked: true },
+        };
+
+        handler.getProducts = jest.fn().mockResolvedValue(undefined);
+        handler.products = [
+            {
+                id: 'product_1',
+                price: [originalBasePrice],
+            },
+        ];
+
+        const syncSpy = jest.spyOn(handler.syncService, 'sync').mockResolvedValue({ data: [] });
+
+        await handler.bulkEdit(
+            ['product_1'],
+            [
+                {
+                    field: 'price',
+                    type: 'overwrite',
+                    value: [
+                        {
+                            currencyId,
+                            gross: null,
+                            net: null,
+                            linked: true,
+                            listPrice: null,
+                            regulationPrice: { currencyId, gross: 150, net: 126.05, linked: true },
+                        },
+                    ],
+                },
+            ],
+        );
+
+        const syncPayload = syncSpy.mock.calls[0][0];
+        const productPayload = syncPayload['upsert-product'].payload[0];
+
+        expect(productPayload.price[0].gross).toBe(75);
+        expect(productPayload.price[0].net).toBe(63.03);
+        expect(productPayload.price[0].linked).toBe(true);
+        expect(productPayload.price[0].regulationPrice.gross).toBe(150);
+    });
+
     describe('test buildBulkSyncPayload', () => {
         let handler = null;
 


### PR DESCRIPTION
This pull request refactors the handling of `listPrice` and `regulationPrice` fields in the bulk edit product page, ensuring that changes to these fields are properly sent in the API request even when the main price field is not changed. It also removes legacy logic for disabling these fields and adds tests to verify the new behavior.

Bulk edit price field logic improvements:

* Removed legacy disabling logic for `listPrice` and `regulationPrice` fields, allowing them to be edited independently of the main price field. (`sw-bulk-edit-product/index.js`) [[1]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L285-R291) [[2]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L301-R307) [[3]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L1113-L1117)
* Updated the data processing logic so that when only `listPrice` or `regulationPrice` is changed, a price payload is constructed and included in the API request, ensuring proper backend handling. (`sw-bulk-edit-product/index.js`) [[1]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R1221-R1236) [[2]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R1247-R1262)

Deprecation and cleanup:

* Marked `isDisabledListPrice` and `isDisabledRegulationPrice` as deprecated and scheduled for removal in v6.8.0, reflecting their obsolescence in the new logic. (`sw-bulk-edit-product/index.js`)

Testing enhancements:

* Added new unit tests to verify that requests include `listPrice` or `regulationPrice` when only those fields are changed, improving coverage and reliability. (`sw-bulk-edit-product.spec.js`)