### PR TITLE
feat: allow custom HTTP client injection for S3 client creation

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -90,6 +90,18 @@ Two new events are dispatched when the product slider CMS element resolves its p
 - `Shopware\Core\Content\Product\Events\ProductSliderStaticCriteriaEvent` is fired by the `StaticProductProcessor` when resolving a static product list.
 - `Shopware\Core\Content\Product\Events\ProductSliderStreamCriteriaEvent` is fired by the `ProductStreamProcessor` when resolving a product stream.
 
+### Allow custom HTTP client injection for S3 client creation
+
+The S3 client creation flow (`S3ClientFactory`, `AwsS3v3Factory`, `PresignedUploadUrlGenerator`)
+now accepts an optional `HttpClientInterface` parameter. When provided, this HTTP client is
+forwarded to the underlying AsyncAws `S3Client` instead of letting it create its own default.
+
+Both `AwsS3v3Factory` and `PresignedUploadUrlGenerator` are wired via DI to the new
+`shopware.filesystem.s3.client` service ID. This service is not registered by default, so
+`null` is injected and AsyncAws uses its own internal HTTP client. Integrators can register
+the `shopware.filesystem.s3.client` service to provide a custom Symfony HTTP client with
+custom timeouts, retry strategies, or HTTP protocol version for S3 operations.
+
 ## Administration
 
 ## Storefront

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -273,6 +273,7 @@
             <argument type="service" id="Shopware\Core\Content\Media\Core\Application\AbstractMediaPathStrategy"/>
             <argument>%shopware.filesystem.public%</argument>
             <argument type="service" id="logger"/>
+            <argument type="service" id="shopware.filesystem.s3.client" on-invalid="null"/>
         </service>
 
         <service id="Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface" class="Shopware\Core\Content\Media\MediaUrlPlaceholderHandler" public="true">

--- a/src/Core/Content/Media/Upload/PresignedUploadUrlGenerator.php
+++ b/src/Core/Content/Media/Upload/PresignedUploadUrlGenerator.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\S3ClientFactory;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @internal
@@ -36,6 +37,7 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
         AbstractMediaPathStrategy $mediaPathStrategy,
         array $filesystemConfig,
         LoggerInterface $logger,
+        ?HttpClientInterface $httpClient = null,
         int $expirationMinutes = 5,
         bool $enabled = true,
     ): self {
@@ -49,7 +51,7 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
         }
 
         try {
-            $result = S3ClientFactory::create($s3Config);
+            $result = S3ClientFactory::create($s3Config, $httpClient);
         } catch (\Throwable $e) {
             throw MediaException::presignedUploadInvalidConfiguration($e->getMessage(), $e);
         }

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -7,6 +7,7 @@ use League\Flysystem\AsyncAwsS3\PortableVisibilityConverter;
 use League\Flysystem\FilesystemAdapter;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[Package('framework')]
 class AwsS3v3Factory implements AdapterFactoryInterface
@@ -17,7 +18,8 @@ class AwsS3v3Factory implements AdapterFactoryInterface
      * @param int<1, max> $batchWriteSize
      */
     public function __construct(
-        private readonly int $batchWriteSize = 250
+        private readonly int $batchWriteSize = 250,
+        private readonly ?HttpClientInterface $httpClient = null,
     ) {
     }
 
@@ -28,7 +30,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
     {
         $this->validateDependencies();
 
-        $result = S3ClientFactory::create($config);
+        $result = S3ClientFactory::create($config, $this->httpClient);
 
         $adapter = new AsyncAwsS3WriteBatchAdapter($result['client'], $result['bucket'], $result['root'], new PortableVisibilityConverter());
         $adapter->batchSize = $this->batchWriteSize;

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/S3ClientFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/S3ClientFactory.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Adapter\Filesystem\Adapter;
 use AsyncAws\S3\S3Client;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @phpstan-type S3Config array{bucket: string, region: string, root: string, credentials?: array{key: string, secret: string}, endpoint?: string, options?: array<mixed>, use_path_style_endpoint?: bool, visibility?: string, url?: string}
@@ -19,7 +20,7 @@ class S3ClientFactory
      *
      * @return array{client: S3Client, bucket: string, root: string}
      */
-    public static function create(array $config): array
+    public static function create(array $config, ?HttpClientInterface $httpClient = null): array
     {
         $options = self::resolveS3Options($config);
 
@@ -41,7 +42,7 @@ class S3ClientFactory
         }
 
         return [
-            'client' => new S3Client($clientConfig),
+            'client' => new S3Client($clientConfig, null, $httpClient),
             'bucket' => $options['bucket'],
             'root' => $options['root'],
         ];

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -46,6 +46,7 @@
 
         <service class="Shopware\Core\Framework\Adapter\Filesystem\Adapter\AwsS3v3Factory" id="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory.amazon_s3">
             <argument>%shopware.filesystem.batch_write_size%</argument>
+            <argument type="service" id="shopware.filesystem.s3.client" on-invalid="null"/>
             <tag name="shopware.filesystem.factory"/>
         </service>
 

--- a/tests/unit/Core/Content/Media/Upload/PresignedUploadUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/Upload/PresignedUploadUrlGeneratorTest.php
@@ -12,6 +12,9 @@ use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\Upload\PresignedUploadUrlGenerator;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @internal
@@ -368,5 +371,33 @@ class PresignedUploadUrlGeneratorTest extends TestCase
         );
 
         static::assertNull($generator->getFileMetadata('media/ab/cd/test.jpg'));
+    }
+
+    public function testCreateWithCustomHttpClient(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->willReturnCallback(function (string $method, string $url, array $options = []): ResponseInterface {
+                static::assertSame('HEAD', $method);
+                static::assertNotSame('', $url);
+
+                return new MockResponse('', ['http_code' => 200]);
+            });
+
+        $generator = PresignedUploadUrlGenerator::create(
+            $this->mediaPathStrategy,
+            [
+                'type' => 'amazon-s3',
+                'config' => [
+                    'bucket' => 'test-bucket',
+                    'region' => 'eu-west-1',
+                ],
+            ],
+            new NullLogger(),
+            httpClient: $httpClient,
+        );
+
+        $generator->verifyUpload('media/test.jpg');
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -2,12 +2,15 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Adapter;
 
+use AsyncAws\Core\AbstractApi;
 use AsyncAws\S3\S3Client;
+use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
 use League\Flysystem\AsyncAwsS3\PortableVisibilityConverter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AwsS3v3Factory;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @internal
@@ -103,5 +106,26 @@ class AwsS3v3FactoryTest extends TestCase
             $adapter,
             $factory->create($config)
         );
+    }
+
+    public function testCreateWithCustomHttpClient(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $config = [
+            'bucket' => 'private',
+            'region' => 'local',
+            'root' => 'foobar',
+        ];
+
+        $factory = new AwsS3v3Factory(250, $httpClient);
+        $adapter = $factory->create($config);
+
+        static::assertInstanceOf(AsyncAwsS3WriteBatchAdapter::class, $adapter);
+
+        // Verify the custom HTTP client was forwarded to the underlying S3Client
+        $s3Client = (new \ReflectionProperty(AsyncAwsS3Adapter::class, 'client'))->getValue($adapter);
+        $actualHttpClient = (new \ReflectionProperty(AbstractApi::class, 'httpClient'))->getValue($s3Client);
+        static::assertSame($httpClient, $actualHttpClient);
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/S3ClientFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/S3ClientFactoryTest.php
@@ -2,12 +2,14 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Adapter;
 
+use AsyncAws\Core\AbstractApi;
 use AsyncAws\S3\S3Client;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\S3ClientFactory;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @internal
@@ -109,5 +111,21 @@ class S3ClientFactoryTest extends TestCase
                 // missing secret
             ],
         ]);
+    }
+
+    public function testCreateWithCustomHttpClient(): void
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $result = S3ClientFactory::create([
+            'bucket' => 'test-bucket',
+            'region' => 'eu-west-1',
+        ], $httpClient);
+
+        static::assertInstanceOf(S3Client::class, $result['client']);
+
+        // Verify the custom HTTP client was injected via reflection
+        $property = new \ReflectionProperty(AbstractApi::class, 'httpClient');
+        static::assertSame($httpClient, $property->getValue($result['client']));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, `S3ClientFactory::create()` never passes a Symfony `HttpClientInterface` to the underlying AsyncAws `S3Client`. This means S3 operations always use an internally created default HTTP client, ignoring any application-level HTTP configuration (timeouts, retry strategies, HTTP protocol version).

Integrators cannot control HTTP behavior for S3 operations without decorating or replacing core services. This is problematic in environments where HTTP/2 causes compatibility issues with certain S3-compatible storage providers, or where custom timeouts and retry strategies are needed.

### 2. What does this change do, exactly?

Adds an optional `?HttpClientInterface $httpClient = null` parameter to:
- `S3ClientFactory::create()`: forwarded to the AsyncAws `S3Client` constructor
- `AwsS3v3Factory` constructor: forwarded to `S3ClientFactory::create()`
- `PresignedUploadUrlGenerator::create()`: forwarded to `S3ClientFactory::create()`

Both DI service definitions (`filesystem.xml`, `media.xml`) wire the new `shopware.filesystem.s3.client` service ID with `on-invalid="null"`. This service is **not registered by default**, so `null` is injected and AsyncAws uses its own internal
`RetryableHttpClient` with `AwsRetryStrategy`. Integrators can register the `shopware.filesystem.s3.client` service to provide a custom HTTP client:

```yaml
# config/packages/s3.yaml
framework:
    http_client:
        scoped_clients:
            s3.client:
                base_uri: 'https://s3.eu-west-1.amazonaws.com'
                timeout: 30
```

```xml
<!-- services.xml -->
<service id="shopware.filesystem.s3.client" alias="s3.client"/>
```

When `null` (the default), behavior is identical to today, so fully backward compatible.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure an S3 filesystem adapter in `shopware.yaml`
2. Observe that the S3 client uses its own internally created HTTP client
3. There is no way to configure timeouts, retries, or HTTP version for S3 operations
4. With this change, integrators register `shopware.filesystem.s3.client` with a Symfony scoped HTTP client and it will be used for all S3 operations

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Added entry to `RELEASE_INFO-6.7.md` under "Upcoming" / `## Core`
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Added [docs](https://github.com/shopware/docs/pull/2187)