### PR TITLE
chore: expose ShopId DTO from ShopIdProvider

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -406,7 +406,7 @@ WHERE app.active = 1 AND app.base_app_url is not null');
     private function getShopId(): string
     {
         try {
-            return $this->shopIdProvider->getShopId();
+            return $this->shopIdProvider->getShopId()->id;
         } catch (ShopIdChangeSuggestedException $e) {
             return $e->shopId->id;
         }

--- a/src/Core/Framework/App/Api/AppJWTGenerateRoute.php
+++ b/src/Core/Framework/App/Api/AppJWTGenerateRoute.php
@@ -49,7 +49,7 @@ class AppJWTGenerateRoute
         $expiration = new \DateTimeImmutable('+10 minutes');
 
         /** @var non-empty-string $shopId */
-        $shopId = $this->shopIdProvider->getShopId();
+        $shopId = $this->shopIdProvider->getShopId()->id;
         $builder = $configuration
             ->builder()
             ->issuedBy($shopId)

--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -37,7 +37,7 @@ class QuerySigner
         }
 
         $unsignedUri = Uri::withQueryValues(new Uri($uri), [
-            'shop-id' => $this->shopIdProvider->getShopId(),
+            'shop-id' => $this->shopIdProvider->getShopId()->id,
             'shop-url' => $this->shopUrl,
             'timestamp' => (string) (new \DateTime())->getTimestamp(),
             'sw-version' => $this->shopwareVersion,

--- a/src/Core/Framework/App/Lifecycle/Registration/AppRegistrationService.php
+++ b/src/Core/Framework/App/Lifecycle/Registration/AppRegistrationService.php
@@ -198,7 +198,7 @@ class AppRegistrationService
             'secretKey' => $secretAccessKey,
             'timestamp' => (string) (new \DateTime())->getTimestamp(),
             'shopUrl' => $this->shopUrl,
-            'shopId' => $shopId,
+            'shopId' => $shopId->id,
         ];
     }
 

--- a/src/Core/Framework/App/Lifecycle/Registration/HandshakeFactory.php
+++ b/src/Core/Framework/App/Lifecycle/Registration/HandshakeFactory.php
@@ -42,7 +42,7 @@ readonly class HandshakeFactory
         $privateSecret = $setup->getSecret();
 
         try {
-            $shopId = $this->shopIdProvider->getShopId();
+            $shopId = $this->shopIdProvider->getShopId()->id;
         } catch (ShopIdChangeSuggestedException $e) {
             throw AppException::registrationFailed(
                 $appName,

--- a/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
+++ b/src/Core/Framework/App/Payload/AppPayloadServiceHelper.php
@@ -42,7 +42,7 @@ class AppPayloadServiceHelper
     {
         return new Source(
             $this->shopUrl,
-            $this->shopIdProvider->getShopId(),
+            $this->shopIdProvider->getShopId()->id,
             $appVersion,
             $this->inAppPurchase->getJWTByExtension($appName),
         );

--- a/src/Core/Framework/App/ShopId/ShopId.php
+++ b/src/Core/Framework/App/ShopId/ShopId.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
  * @phpstan-type ShopIdV2Config array{id: string, version: 2, fingerprints: array<string, string>}
  */
 #[Package('framework')]
-readonly class ShopId
+readonly class ShopId implements \Stringable
 {
     /**
      * @param array<string, string> $fingerprints
@@ -23,6 +23,11 @@ readonly class ShopId
         public array $fingerprints = [],
         public int $version = 2,
     ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->id;
     }
 
     public function getFingerprint(string $identifier): ?string
@@ -57,6 +62,22 @@ readonly class ShopId
         }
 
         throw AppException::invalidShopIdConfiguration();
+    }
+
+    /**
+     * @return array{
+     *    id: string,
+     *    fingerprints: array<string, string>,
+     *    version: int
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'fingerprints' => $this->fingerprints,
+            'version' => $this->version,
+        ];
     }
 
     /**

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -36,10 +36,10 @@ class ShopIdProvider implements ResetInterface
     /**
      * @throws ShopIdChangeSuggestedException
      */
-    public function getShopId(): string
+    public function getShopId(): ShopId
     {
         if ($this->shopId) {
-            return $this->shopId->id;
+            return $this->shopId;
         }
 
         $this->shopId = $this->fetchShopIdFromSystemConfig() ?? $this->regenerateAndSetShopId();
@@ -55,7 +55,7 @@ class ShopIdProvider implements ResetInterface
             $this->regenerateAndSetShopId($this->shopId->id);
         }
 
-        return $this->shopId->id;
+        return $this->shopId;
     }
 
     public function regenerateAndSetShopId(?string $existingShopId = null): ShopId
@@ -95,8 +95,10 @@ class ShopIdProvider implements ResetInterface
             $oldShopId = null;
         }
 
-        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2, (array) $shopId, null, false);
+        $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $shopId->toArray(), null, false);
         $this->eventDispatcher->dispatch(new ShopIdChangedEvent($shopId, $oldShopId));
+
+        $this->shopId = $shopId;
     }
 
     private function hasAppsRegisteredAtAppServers(): bool

--- a/src/Core/Service/ServiceRegistry/PermissionLogger.php
+++ b/src/Core/Service/ServiceRegistry/PermissionLogger.php
@@ -39,7 +39,7 @@ class PermissionLogger implements RemoteLogger
                 new SaveConsentRequest(
                     identifier: $consent->identifier,
                     consentingUserId: $consent->consentingUserId,
-                    shopIdentifier: $this->shopIdProvider->getShopId(),
+                    shopIdentifier: $this->shopIdProvider->getShopId()->id,
                     consentDate: $consent->grantedAt->format(\DateTime::ATOM),
                     consentRevision: $consent->revision,
                     licenseHost: $this->systemConfigService->getString(self::CONFIG_STORE_LICENSE_HOST),

--- a/src/Core/System/UsageData/Services/ShopIdProvider.php
+++ b/src/Core/System/UsageData/Services/ShopIdProvider.php
@@ -28,6 +28,6 @@ readonly class ShopIdProvider
             return ShopId::fromSystemConfig($shopId)->id;
         }
 
-        return $this->shopIdProvider->getShopId();
+        return $this->shopIdProvider->getShopId()->id;
     }
 }

--- a/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
+++ b/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
@@ -61,7 +61,7 @@ class TemplateDataSubscriber implements EventSubscriberInterface
         }
 
         try {
-            $shopId = $this->shopIdProvider->getShopId();
+            $shopId = $this->shopIdProvider->getShopId()->id;
         } catch (ShopIdChangeSuggestedException) {
             return;
         }

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -80,7 +80,7 @@ class InfoControllerTest extends TestCase
 
         $expected = [
             'version' => '6.7.9999999.9999999-dev',
-            'shopId' => $shopId,
+            'shopId' => $shopId->id,
             'appUrl' => 'https://test-app.url',
             'versionRevision' => str_repeat('0', 32),
             'adminWorker' => [

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -75,7 +75,7 @@ class MoveShopPermanentlyStrategyTest extends TestCase
 
         $moveShopPermanentlyResolver->resolve($this->context);
 
-        static::assertSame($shopId, $this->shopIdProvider->getShopId());
+        static::assertSame($shopId, $this->shopIdProvider->getShopId()->id);
     }
 
     public function testItIgnoresAppsWithoutSetup(): void
@@ -98,7 +98,7 @@ class MoveShopPermanentlyStrategyTest extends TestCase
 
         $moveShopPermanentlyResolver->resolve($this->context);
 
-        static::assertSame($shopId, $this->shopIdProvider->getShopId());
+        static::assertSame($shopId, $this->shopIdProvider->getShopId()->id);
     }
 
     private function changeAppUrl(bool $expectsToThrow = true): string
@@ -117,7 +117,7 @@ class MoveShopPermanentlyStrategyTest extends TestCase
         }
         static::assertSame($expectsToThrow, $wasThrown);
 
-        return $shopId;
+        return $shopId->id;
     }
 
     private function getInstalledApp(Context $context): AppEntity

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
@@ -83,7 +83,7 @@ class ReinstallAppsStrategyTest extends TestCase
 
         $reinstallAppsResolver->resolve($this->context);
 
-        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId()->id);
     }
 
     public function testItIgnoresAppsWithoutSetup(): void
@@ -111,7 +111,7 @@ class ReinstallAppsStrategyTest extends TestCase
 
         $reinstallAppsResolver->resolve($this->context);
 
-        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId()->id);
     }
 
     private function changeAppUrl(bool $expectToThrow = true): string
@@ -130,7 +130,7 @@ class ReinstallAppsStrategyTest extends TestCase
         }
         static::assertSame($expectToThrow, $wasThrown);
 
-        return $shopId;
+        return $shopId->id;
     }
 
     private function getInstalledApp(Context $context): AppEntity

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -75,7 +75,7 @@ class UninstallAppsStrategyTest extends TestCase
 
         $uninstallAppsResolver->resolve($this->context);
 
-        static::assertNotSame($shopId, $this->shopIdProvider->getShopId());
+        static::assertNotSame($shopId, $this->shopIdProvider->getShopId()->id);
 
         static::assertNull($this->getInstalledApp($this->context));
     }
@@ -96,7 +96,7 @@ class UninstallAppsStrategyTest extends TestCase
         }
         static::assertTrue($wasThrown);
 
-        return $shopId;
+        return $shopId->id;
     }
 
     private function getInstalledApp(Context $context): ?AppEntity

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
@@ -105,7 +105,7 @@ class AppRegistrationServiceTest extends TestCase
         static::assertSame($integration->getAccessKey(), $postBody['apiKey']);
 
         static::assertSame($_SERVER['APP_URL'], $postBody['shopUrl']);
-        static::assertSame($this->shopIdProvider->getShopId(), $postBody['shopId']);
+        static::assertSame($this->shopIdProvider->getShopId()->id, $postBody['shopId']);
 
         $json = \json_encode($postBody, \JSON_THROW_ON_ERROR);
         static::assertNotFalse($json);
@@ -197,7 +197,7 @@ class AppRegistrationServiceTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/minimal/manifest.xml');
 
         $appSecret = 'dont_tell';
-        $shopId = Uuid::randomHex();
+        $shopId = ShopId::v2(Uuid::randomHex());
         $appResponseBody = $this->buildAppResponse($manifest, $appSecret, $shopId);
 
         $this->appendNewResponse(new Response(200, [], $appResponseBody));
@@ -223,7 +223,7 @@ class AppRegistrationServiceTest extends TestCase
         $shopIdMock = $this->createMock(ShopIdProvider::class);
         $shopIdMock->expects($this->once())
             ->method('getShopId')
-            ->willThrowException(new ShopIdChangeSuggestedException(ShopId::v2($shopId), new FingerprintComparisonResult([], [], 75)));
+            ->willThrowException(new ShopIdChangeSuggestedException($shopId, new FingerprintComparisonResult([], [], 75)));
 
         $registrator = new AppRegistrationService(
             $handshakeFactory,
@@ -334,7 +334,7 @@ class AppRegistrationServiceTest extends TestCase
         $permissionPersister->updatePrivileges($permissions, $id, true, $context);
     }
 
-    private function buildAppResponse(Manifest $manifest, string $appSecret, ?string $shopId = null): string
+    private function buildAppResponse(Manifest $manifest, string $appSecret, ?ShopId $shopId = null): string
     {
         if (!$shopId) {
             $shopId = $this->shopIdProvider->getShopId();
@@ -347,7 +347,7 @@ class AppRegistrationServiceTest extends TestCase
 
         $proof = \hash_hmac(
             'sha256',
-            $shopId . $this->shopUrl . $manifest->getMetadata()->getName(),
+            $shopId->id . $this->shopUrl . $manifest->getMetadata()->getName(),
             $secret
         );
 

--- a/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
@@ -349,7 +349,7 @@ class AppAsyncPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
         static::assertArrayHasKey('source', $content);
         static::assertSame([
             'url' => $this->shopUrl,
-            'shopId' => $this->shopIdProvider->getShopId(),
+            'shopId' => $this->shopIdProvider->getShopId()->id,
             'appVersion' => '1.0.0',
             'inAppPurchases' => null,
         ], $content['source']);
@@ -532,7 +532,7 @@ class AppAsyncPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
         static::assertArrayHasKey('source', $content);
         static::assertSame([
             'url' => $this->shopUrl,
-            'shopId' => $this->shopIdProvider->getShopId(),
+            'shopId' => $this->shopIdProvider->getShopId()->id,
             'appVersion' => '1.0.0',
             'inAppPurchases' => null,
         ], $content['source']);

--- a/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
@@ -49,7 +49,7 @@ class AppPreparedPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
         static::assertArrayHasKey('source', $content);
         static::assertSame([
             'url' => $this->shopUrl,
-            'shopId' => $this->shopIdProvider->getShopId(),
+            'shopId' => $this->shopIdProvider->getShopId()->id,
             'appVersion' => '1.0.0',
             'inAppPurchases' => null,
         ], $content['source']);

--- a/tests/integration/Core/Framework/App/Payment/AppRecurringHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppRecurringHandlerTest.php
@@ -54,7 +54,7 @@ class AppRecurringHandlerTest extends AbstractAppPaymentHandlerTestCase
         static::assertArrayHasKey('source', $content);
         static::assertSame([
             'url' => $this->shopUrl,
-            'shopId' => $this->shopIdProvider->getShopId(),
+            'shopId' => $this->shopIdProvider->getShopId()->id,
             'appVersion' => '1.0.0',
             'inAppPurchases' => null,
         ], $content['source']);

--- a/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
@@ -53,7 +53,7 @@ class AppRefundHandlerTest extends AbstractAppPaymentHandlerTestCase
         static::assertArrayHasKey('source', $content);
         static::assertSame([
             'url' => $this->shopUrl,
-            'shopId' => $this->shopIdProvider->getShopId(),
+            'shopId' => $this->shopIdProvider->getShopId()->id,
             'appVersion' => '1.0.0',
             'inAppPurchases' => null,
         ], $content['source']);

--- a/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -48,7 +48,7 @@ class ShopIdProviderTest extends TestCase
         static::assertIsArray($shopIdConfig);
 
         static::assertArrayHasKey('id', $shopIdConfig);
-        static::assertSame($shopId, $shopIdConfig['id']);
+        static::assertSame($shopId->id, $shopIdConfig['id']);
 
         static::assertArrayHasKey('version', $shopIdConfig);
         static::assertSame(2, $shopIdConfig['version']);
@@ -70,7 +70,7 @@ class ShopIdProviderTest extends TestCase
 
         $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
 
-        $shopId = $this->shopIdProvider->getShopId();
+        $shopId = $this->shopIdProvider->getShopId()->id;
         $shopIdV2Config = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
 
         static::assertIsArray($shopIdV2Config);
@@ -109,14 +109,14 @@ class ShopIdProviderTest extends TestCase
     {
         /** @var string $appUrlBeforeUpdate */
         $appUrlBeforeUpdate = EnvironmentHelper::getVariable('APP_URL');
-        $shopIdBeforeUpdate = $this->shopIdProvider->getShopId();
+        $shopIdBeforeUpdate = $this->shopIdProvider->getShopId()->id;
         $shopIdConfigBeforeUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertSame($appUrlBeforeUpdate, $shopIdConfigBeforeUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);
 
         $this->shopIdProvider->reset();
 
         $this->setEnvVars(['APP_URL' => $newAppUrl = 'https://new.url']);
-        $shopIdAfterUpdate = $this->shopIdProvider->getShopId();
+        $shopIdAfterUpdate = $this->shopIdProvider->getShopId()->id;
         static::assertSame($shopIdBeforeUpdate, $shopIdAfterUpdate);
         $shopIdConfigAfterUpdate = $this->systemConfigService->get(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2);
         static::assertSame($newAppUrl, $shopIdConfigAfterUpdate['fingerprints'][AppUrl::IDENTIFIER] ?? null);

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -182,7 +182,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -481,7 +481,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -534,7 +534,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -684,7 +684,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -755,7 +755,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -805,7 +805,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],
@@ -861,7 +861,7 @@ class WebhookManagerTest extends TestCase
             ],
             'source' => [
                 'url' => $this->shopUrl,
-                'shopId' => $this->shopIdProvider->getShopId(),
+                'shopId' => $this->shopIdProvider->getShopId()->id,
                 'appVersion' => '0.0.1',
                 'inAppPurchases' => null,
             ],

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -63,6 +63,9 @@ class InfoControllerTest extends TestCase
         $this->statsService = $this->createMock(StatsService::class);
         $this->migrationInfo = $this->createMock(MigrationInfo::class);
         $this->eventDispatcher = new EventDispatcher();
+
+        $shopId = ShopId::v2('shop-id');
+        $this->shopIdProvider->expects($this->any())->method('getShopId')->willReturn($shopId);
     }
 
     public function testConfig(): void
@@ -70,8 +73,6 @@ class InfoControllerTest extends TestCase
         $this->setEnvVars([
             'APP_URL' => 'https://app.url',
         ]);
-
-        $this->shopIdProvider->expects($this->once())->method('getShopId')->willReturn('shop-id');
 
         $content = $this->createController()->config(Context::createDefaultContext(), Request::create('http://localhost'))->getContent();
         static::assertIsString($content);

--- a/tests/unit/Core/Framework/App/Api/AppJWTGenerateRouteTest.php
+++ b/tests/unit/Core/Framework/App/Api/AppJWTGenerateRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Api\AppJWTGenerateRoute;
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
 use Shopware\Core\Test\Generator;
@@ -50,6 +51,12 @@ class AppJWTGenerateRouteTest extends TestCase
 
     public function testGenerate(): void
     {
+        $shopId = ShopId::v2('shop-id');
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider
+            ->method('getShopId')
+            ->willReturn($shopId);
+
         $inAppPurchase = StaticInAppPurchaseFactory::createWithFeatures(['extension-1' => ['purchase-1', 'purchase-2'], 'extension-2' => ['purchase-3']]);
 
         $privileges = [
@@ -68,7 +75,7 @@ class AppJWTGenerateRouteTest extends TestCase
 
         $appJWTGenerateRoute = new AppJWTGenerateRoute(
             $connection,
-            $this->createMock(ShopIdProvider::class),
+            $shopIdProvider,
             $inAppPurchase,
         );
 

--- a/tests/unit/Core/Framework/App/Api/ShopIdControllerTest.php
+++ b/tests/unit/Core/Framework/App/Api/ShopIdControllerTest.php
@@ -155,7 +155,7 @@ class ShopIdControllerTest extends TestCase
 
         $this->shopIdProvider->expects($this->once())
             ->method('getShopId')
-            ->willReturn($shopId->id);
+            ->willReturn($shopId);
 
         $response = $this->controller->checkShopId($this->context);
 

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\QuerySigner;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -43,7 +44,7 @@ class QuerySignerTest extends TestCase
         $shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
-            ->willReturn('shopId');
+            ->willReturn(ShopId::v2('shopId'));
 
         $app = new AppEntity();
         $app->setName('extension-1');
@@ -92,7 +93,7 @@ class QuerySignerTest extends TestCase
         $shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
-            ->willReturn('shopId');
+            ->willReturn(ShopId::v2('shopId'));
 
         $app = new AppEntity();
         $app->setName('extension-1');

--- a/tests/unit/Core/Framework/App/InAppPurchases/Payload/InAppPurchasesPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/InAppPurchases/Payload/InAppPurchasesPayloadServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\App\InAppPurchases\Payload\InAppPurchasesPayload;
 use Shopware\Core\Framework\App\InAppPurchases\Payload\InAppPurchasesPayloadService;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\App\Payload\AppPayloadStruct;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -37,10 +38,11 @@ class InAppPurchasesPayloadServiceTest extends TestCase
 
     public function testRequest(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = $this->createMock(AppPayloadServiceHelper::class);
         $appPayloadServiceHelper->expects($this->once())
@@ -98,10 +100,11 @@ class InAppPurchasesPayloadServiceTest extends TestCase
 
     public function testRequestReceiveFilteredResponse(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = $this->createMock(AppPayloadServiceHelper::class);
         $appPayloadServiceHelper->expects($this->once())
@@ -157,12 +160,13 @@ class InAppPurchasesPayloadServiceTest extends TestCase
 
     public function testAppSecretMissing(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
 
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = new AppPayloadServiceHelper(
             $definitionInstanceRegistry,

--- a/tests/unit/Core/Framework/App/Lifecycle/AppRegistrationServiceTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppRegistrationServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory;
 use Shopware\Core\Framework\App\Lifecycle\Registration\PrivateHandshake;
 use Shopware\Core\Framework\App\Lifecycle\Registration\StoreHandshake;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -66,12 +67,15 @@ class AppRegistrationServiceTest extends TestCase
             )
         );
 
+        $shopIdProviderMock = $this->createMock(ShopIdProvider::class);
+        $shopIdProviderMock->method('getShopId')->willReturn(ShopId::v2('shop-id'));
+
         $this->appRegistrationService = new AppRegistrationService(
             $this->handshakeFactoryMock,
             new Client(['handler' => $this->mockHandler]),
             $this->appRepositoryMock,
             'https://shopware.swag',
-            $this->createMock(ShopIdProvider::class),
+            $shopIdProviderMock,
             '6.5.2.0'
         );
     }

--- a/tests/unit/Core/Framework/App/Payload/AppPayloadServiceHelperTest.php
+++ b/tests/unit/Core/Framework/App/Payload/AppPayloadServiceHelperTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\App\Payload\Source;
 use Shopware\Core\Framework\App\Payload\SourcedPayloadInterface;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\App\TaxProvider\Payload\TaxProviderPayload;
 use Shopware\Core\Framework\Context;
@@ -40,6 +41,7 @@ class AppPayloadServiceHelperTest extends TestCase
 
     public function testBuildSource(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $inAppPurchase = StaticInAppPurchaseFactory::createWithFeatures([
             'TestApp' => ['purchase-1', 'purchase-2'],
             'AnotherApp' => ['purchase-3'],
@@ -48,7 +50,7 @@ class AppPayloadServiceHelperTest extends TestCase
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = new AppPayloadServiceHelper(
             $this->createMock(DefinitionInstanceRegistry::class),
@@ -103,13 +105,14 @@ class AppPayloadServiceHelperTest extends TestCase
 
     public function testCreateRequestOptionsWithNoParams(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $context = Context::createDefaultContext();
         $definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
         $entityEncoder = $this->createMock(JsonEntityEncoder::class);
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = new AppPayloadServiceHelper(
             $definitionInstanceRegistry,
@@ -144,13 +147,14 @@ class AppPayloadServiceHelperTest extends TestCase
 
     public function testCreateRequestOptionsWithAdditionalParams(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $context = Context::createDefaultContext();
         $definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
         $entityEncoder = $this->createMock(JsonEntityEncoder::class);
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $appPayloadServiceHelper = new AppPayloadServiceHelper(
             $definitionInstanceRegistry,

--- a/tests/unit/Core/Framework/App/Payment/Payload/PaymentPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/Payment/Payload/PaymentPayloadServiceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\App\Payment\Payload\PaymentPayloadService;
 use Shopware\Core\Framework\App\Payment\Payload\Struct\PaymentPayload;
 use Shopware\Core\Framework\App\Payment\Payload\Struct\PaymentPayloadInterface;
 use Shopware\Core\Framework\App\Payment\Response\PaymentResponse;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -64,10 +65,11 @@ class PaymentPayloadServiceTest extends TestCase
             ->method('getByEntityName')
             ->willReturn($definition);
 
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $entityEncoder = new JsonEntityEncoder(
             new Serializer([new StructNormalizer()], [new JsonEncoder()])

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -74,7 +74,7 @@ class ShopIdProviderTest extends TestCase
         static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
         static::assertSame($shopIdV1Config['value'] ?? null, $shopIdChangedEvent->oldShopId?->id);
         static::assertSame($shopIdV1Config['app_url'] ?? null, $shopIdChangedEvent->oldShopId?->getFingerprint(AppUrl::IDENTIFIER) ?? null);
-        static::assertSame($shopId, $shopIdChangedEvent->newShopId->id);
+        static::assertSame($shopId->id, $shopIdChangedEvent->newShopId->id);
     }
 
     public function testUpgradesShopIdToV2IfShopIdInSystemConfigIsV1(): void
@@ -110,11 +110,7 @@ class ShopIdProviderTest extends TestCase
             });
         $systemConfigService->expects($this->exactly(2))
             ->method('set')
-            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, static::callback(static function (array $config) use ($shopIdV2Config): bool {
-                static::assertSame($shopIdV2Config, $config);
-
-                return true;
-            }));
+            ->with(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $shopIdV2Config);
 
         $provider = new ShopIdProvider(
             $systemConfigService,
@@ -131,7 +127,7 @@ class ShopIdProviderTest extends TestCase
         static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
         static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->oldShopId?->id);
         static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->newShopId->id);
-        static::assertSame($shopIdV1Config['value'], $upgradedShopId);
+        static::assertSame($shopIdV1Config['value'], $upgradedShopId->id);
     }
 
     public function testThrowsIfFingerprintsHaveChangedAndHasAppsRegisteredAtAppServers(): void
@@ -220,7 +216,7 @@ class ShopIdProviderTest extends TestCase
             $fingerprintGenerator,
         );
 
-        static::assertSame($shopId->id, $provider->getShopId());
+        static::assertSame($shopId->id, $provider->getShopId()->id);
     }
 
     public function testDeletesShopId(): void

--- a/tests/unit/Core/Framework/App/TaxProvider/Payload/TaxProviderPayloadServiceTest.php
+++ b/tests/unit/Core/Framework/App/TaxProvider/Payload/TaxProviderPayloadServiceTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Api\Serializer\JsonEntityEncoder;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\App\TaxProvider\Payload\TaxProviderPayload;
 use Shopware\Core\Framework\App\TaxProvider\Payload\TaxProviderPayloadService;
@@ -46,6 +47,7 @@ class TaxProviderPayloadServiceTest extends TestCase
 
     public function testRequest(): void
     {
+        $shopId = ShopId::v2($this->ids->get('shop-id'));
         $definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
         $definitionInstanceRegistry
             ->method('getByEntityClass')
@@ -54,7 +56,7 @@ class TaxProviderPayloadServiceTest extends TestCase
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $entityEncoder = new JsonEntityEncoder(
             new Serializer([new StructNormalizer()], [new JsonEncoder()])
@@ -188,6 +190,7 @@ class TaxProviderPayloadServiceTest extends TestCase
 
     public function testAppSecretMissing(): void
     {
+        $shopId = ShopId::v2('123');
         $definitionInstanceRegistry = $this->createMock(DefinitionInstanceRegistry::class);
         $definitionInstanceRegistry
             ->method('getByEntityClass')
@@ -196,7 +199,7 @@ class TaxProviderPayloadServiceTest extends TestCase
         $shopIdProvider = $this->createMock(ShopIdProvider::class);
         $shopIdProvider
             ->method('getShopId')
-            ->willReturn($this->ids->get('shop-id'));
+            ->willReturn($shopId);
 
         $entityEncoder = new JsonEntityEncoder(
             new Serializer([new StructNormalizer()], [new JsonEncoder()])

--- a/tests/unit/Core/Service/ServiceRegistry/PermissionLoggerTest.php
+++ b/tests/unit/Core/Service/ServiceRegistry/PermissionLoggerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Service\ServiceRegistry;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Service\Message\LogPermissionToRegistryMessage;
 use Shopware\Core\Service\Permission\ConsentState;
@@ -76,7 +77,7 @@ class PermissionLoggerTest extends TestCase
             grantedAt: new \DateTime('2025-06-13 12:00:00')
         );
 
-        $shopId = 'test-shop-id';
+        $shopId = ShopId::v2('test-shop-id');
         $licenseHost = 'https://example.com';
 
         $this->shopIdProvider
@@ -96,7 +97,7 @@ class PermissionLoggerTest extends TestCase
             ->with(static::callback(static function (SaveConsentRequest $request) use ($consent, $shopId, $licenseHost) {
                 return $request->identifier === $consent->identifier
                     && $request->consentingUserId === $consent->consentingUserId
-                    && $request->shopIdentifier === $shopId
+                    && $request->shopIdentifier === $shopId->id
                     && $request->consentDate === $consent->grantedAt->format(\DateTime::ATOM)
                     && $request->consentRevision === $consent->revision
                     && $request->licenseHost === $licenseHost;
@@ -139,7 +140,7 @@ class PermissionLoggerTest extends TestCase
             grantedAt: new \DateTime('2025-06-13 12:00:00')
         );
 
-        $shopId = 'test-shop-id';
+        $shopId = ShopId::v2('test-shop-id');
 
         $this->shopIdProvider
             ->expects($this->once())
@@ -158,7 +159,7 @@ class PermissionLoggerTest extends TestCase
             ->with(static::callback(static function (SaveConsentRequest $request) use ($consent, $shopId) {
                 return $request->identifier === $consent->identifier
                     && $request->consentingUserId === $consent->consentingUserId
-                    && $request->shopIdentifier === $shopId
+                    && $request->shopIdentifier === $shopId->id
                     && $request->consentDate === $consent->grantedAt->format(\DateTime::ATOM)
                     && $request->consentRevision === $consent->revision
                     && $request->licenseHost === '';

--- a/tests/unit/Core/System/UsageData/Services/ShopIdProviderTest.php
+++ b/tests/unit/Core/System/UsageData/Services/ShopIdProviderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\UsageData\Services;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\System\UsageData\Services\ShopIdProvider;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 
@@ -34,10 +35,12 @@ class ShopIdProviderTest extends TestCase
 
     public function testReturnsShopIdFromInner(): void
     {
+        $shopId = ShopId::v2('shopId');
+
         $appShopIdProvider = $this->createMock(\Shopware\Core\Framework\App\ShopId\ShopIdProvider::class);
         $appShopIdProvider->expects($this->once())
             ->method('getShopId')
-            ->willReturn('shopId');
+            ->willReturn($shopId);
 
         $providerToTest = new ShopIdProvider(
             $appShopIdProvider,

--- a/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
@@ -168,10 +168,11 @@ class TemplateDataSubscriberTest extends TestCase
             ->method('getActiveApps')
             ->willReturn(['someApp']);
 
+        $shopId = ShopId::v2('123');
         $this->shopIdProvider
             ->expects($this->once())
             ->method('getShopId')
-            ->willReturn('123');
+            ->willReturn($shopId);
 
         $this->subscriber->addShopIdParameter($event);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

To support work for the APP_URL verification topic

### 2. What does this change do, exactly?

Small refactor to expose the entire ShopId DTO instead of just the ID so that the fingerprint data is also available.