### PR TITLE
fix: update feedback ID format for Google reCAPTCHA v2 and v3 components

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -4,7 +4,7 @@
         invisible: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV2.config.invisible')
     } %}
 
-    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+    {% set feedbackId = "#{formId}-grecaptcha-v2-feedback" %}
 
     <div class="captcha-google-re-captcha-v2"
          data-google-re-captcha-v2="true"

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -3,7 +3,7 @@
         siteKey: config('core.basicInformation.activeCaptchasV2.googleReCaptchaV3.config.siteKey')
     } %}
 
-    {% set feedbackId = "#{formId}-grecaptcha-feedback" %}
+    {% set feedbackId = "#{formId}-grecaptcha-v3-feedback" %}
 
     <div class="captcha-google-re-captcha-v3"
          data-google-re-captcha-v3="true"


### PR DESCRIPTION
### 1. Why is this change necessary?
When both reCAPTCHA v2 and v3 are used on the same form, they share the same feedback element ID (`#{formId}-grecaptcha-feedback`), causing a conflict.

### 2. What does this change do, exactly?
Adds a version suffix to the feedback ID — `-grecaptcha-v2-feedback` and `-grecaptcha-v3-feedback` — so both captcha components can coexist on the same form without ID collisions.

### 3. Describe each step to reproduce the issue or behaviour.
1. Enable both Google reCAPTCHA v2 and v3 in the Shopware settings.
2. Open a form that renders both captcha components.
3. Inspect the DOM and observe duplicate element IDs for the feedback elements.

### 4. Please link to the relevant issues (if any).
<!-- relates #N -->

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them