### PR TITLE
test: adjust CriteriaParserTest expectations 

### DIFF
--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -658,7 +658,7 @@ EOT,
             [
                 'script' => [
                     'script' => [
-                        'inline' => <<<EOT
+                        'source' => <<<EOT
 String getPercentageKey(def accessors, def doc) {
     for (accessor in accessors) {
         def key = accessor['key'];
@@ -1115,7 +1115,7 @@ EOT,
         $sortedFilterArray = $sortedFilter->toArray();
 
         // Unset the 'source' key before comparison.
-        unset($sortedFilterArray['script']['script']['inline']);
+        unset($sortedFilterArray['script']['script']['source']);
 
         static::assertEquals($expectedFilter, $sortedFilterArray);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Since https://github.com/shyim/opensearch-php-dsl/pull/19  CriteriaParserTest is now failing, on every branch derived from trunk

Which is logical as 

```
     public function toArray(): array
     {
-        $query = ['inline' => $this->script];
+        $query = ['source' => $this->script];
         $output = $this->processArray($query);
```

This is why we get the following failures:

```
There were 3 failures:

1) Shopware\Tests\Unit\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParserTest::testParseFilter with data set "EqualsFilter cheapestPrice.percentage field" (Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter Object (...), [[['String getPercentageKey(def a...tch;\n', [10.0, [['cheapest_price_ruledefault_cu...entage', 1]]]]]])
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 [
     'script' => Array &1 [
         'script' => Array &2 [
-            'inline' => 'String getPercentageKey(def accessors, def doc) {\n
+            'source' => 'String getPercentageKey(def accessors, def doc) {\n
     for (accessor in accessors) {\n
         def key = accessor['key'];\n
         if (!doc.containsKey(key) || doc[key].empty) {\n

/home/runner/work/shopware/shopware/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php:171

2) Shopware\Tests\Unit\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParserTest::testFilterParsing with data set "range filter: cheapestPrice" (Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter Object (...), [[[[10, [['cheapest_price_ruledefault_cu..._gross', 1]], 100, true, 100.0]]]])
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'script' => Array (
         'script' => Array (
             'params' => [...]
+            'source' => 'double getPrice(def accessors...tch;\n'
         )
     )
 )

/home/runner/work/shopware/shopware/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php:1120

3) Shopware\Tests\Unit\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParserTest::testFilterParsing with data set "range filter: cheapestPrice price/list price percentage" (Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter Object (...), [[[[10, [['cheapest_price_ruledefault_cu...entage', 1]]]]]])
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
     'script' => Array (
         'script' => Array (
             'params' => [...]
+            'source' => 'String getPercentageKey(def a...tch;\n'
         )
     )
 )

/home/runner/work/shopware/shopware/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php:1120
```

### 2. What does this change do, exactly?

Adjust expectations to use `source` rather than `inline`

### 3. Describe each step to reproduce the issue or behaviour.

Run `php -d memory_limit=-1 vendor/bin/phpunit --testsuite "unit" --filter CriteriaParserTest`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
