### PR TITLE
fix: rating average for products with variants

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
@@ -206,8 +206,8 @@ class ProductIndexer extends EntityIndexer
         }
 
         if ($message->allow(self::RATING_AVERAGE_UPDATER)) {
-            Profiler::trace('product:indexer:rating', function () use ($parentIds, $context): void {
-                $this->ratingAverageUpdater->update($parentIds, $context);
+            Profiler::trace('product:indexer:rating', function () use ($ids, $parentIds, $context): void {
+                $this->ratingAverageUpdater->update(array_unique([...$parentIds, ...$this->getParentIds($ids)]), $context);
             });
         }
 

--- a/src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
@@ -44,7 +44,7 @@ class RatingAverageUpdater
             'AVG(product_review.points) as average',
         );
         $query->from('product_review');
-        $query->leftJoin('product_review', 'product', 'product', 'product.id = product_review.product_id OR product.parent_id = product_review.product_id');
+        $query->innerJoin('product_review', 'product', 'product', 'product.id = product_review.product_id');
         $query->andWhere('product_review.status = 1');
         $query->andWhere('product.id IN (:ids) OR product.parent_id IN (:ids)');
         $query->andWhere('product.version_id = :version');

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
@@ -255,6 +255,39 @@ class ProductRatingAverageIndexerTest extends TestCase
     }
 
     /**
+     * tests that reviews on both parent and variant product are averaged correctly
+     */
+    #[Group('reviews')]
+    public function testRatingAverageIsCorrectWhenReviewsExistOnParentAndVariant(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $this->createProduct($parentId);
+
+        $this->productRepository->create(
+            [
+                [
+                    'id' => $variantId,
+                    'productNumber' => $variantId,
+                    'stock' => 1,
+                    'active' => true,
+                    'parentId' => $parentId,
+                ],
+            ],
+            $this->salesChannel->getContext()
+        );
+
+        $this->createReview(Uuid::randomHex(), 5.0, $parentId, true);
+        $this->createReview(Uuid::randomHex(), 4.0, $variantId, true);
+
+        $products = $this->productRepository->search(new Criteria([$parentId]), $this->salesChannel->getContext());
+
+        static::assertInstanceOf(ProductEntity::class, $product = $products->get($parentId));
+        static::assertSame(4.5, $product->getRatingAverage());
+    }
+
+    /**
      * tests that the full index works
      */
     #[Group('reviews')]


### PR DESCRIPTION
resolves #15221

Fixes an incorrect `rating_average` on parent products when reviews exist on both the parent and its variants.