### PR TITLE
fix: normalize telemetry event names to snake_case

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -162,7 +162,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     },
                 }),
                 {
-                    eventName: 'Page Viewed',
+                    eventName: 'page_viewed',
                     properties: {
                         sw_route_from_name: 'sw.dashboard.index',
                         sw_route_from_href: '/sw/dashboard/index',
@@ -189,7 +189,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     }),
                 }),
                 {
-                    eventName: 'Button Click',
+                    eventName: 'button_click',
                     properties: {
                         sw_element_id: 'administration.sw-product.save',
                         sw_element_product_name: 'nice product',
@@ -212,7 +212,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     originalEvent: new Event('click'),
                 }),
                 {
-                    eventName: 'Link Visited',
+                    eventName: 'link_visited',
                     properties: {
                         sw_link_href: 'https://example.com',
                         sw_link_type: 'external',
@@ -549,7 +549,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             jest.clearAllMocks();
         });
 
-        it('should track Login event when a identify telemetry event with a different userId arrives', async () => {
+        it('should track login event when a identify telemetry event with a different userId arrives', async () => {
             const amplitude = await import('@amplitude/analytics-browser');
 
             let amplitudeUserId = null;
@@ -567,7 +567,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     userId: newUserId,
                 }),
             );
-            expect(amplitude.track).toHaveBeenCalledWith('Login');
+            expect(amplitude.track).toHaveBeenCalledWith('login');
 
             newUserId = 'newUserId-2';
             Shopware.Utils.EventBus.emit(
@@ -576,7 +576,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
                     userId: newUserId,
                 }),
             );
-            expect(amplitude.track).toHaveBeenCalledWith('Login');
+            expect(amplitude.track).toHaveBeenCalledWith('login');
 
             const sameUserId = newUserId;
             Shopware.Utils.EventBus.emit(
@@ -589,7 +589,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
             expect(amplitude.track).toHaveBeenCalledTimes(2);
         });
 
-        it('should track Logout event when a reset telemetry event arrives', async () => {
+        it('should track logout event when a reset telemetry event arrives', async () => {
             const amplitude = await import('@amplitude/analytics-browser');
 
             await initAmplitude();
@@ -598,7 +598,7 @@ describe('src/app/post-init/amplitude.init.ts', () => {
 
             Shopware.Utils.EventBus.emit('telemetry', resetEvent);
 
-            expect(amplitude.track).toHaveBeenCalledWith('Logout');
+            expect(amplitude.track).toHaveBeenCalledWith('logout');
         });
 
         it('should flush telemetry amplitude on logout listener execution', async () => {

--- a/src/Administration/Resources/app/administration/src/core/telemetry/amplitude/amplitude.telemetry-handlers.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/amplitude/amplitude.telemetry-handlers.spec.js
@@ -31,7 +31,7 @@ describe('src/core/telemetry/amplitude/amplitude.telemetry-handlers.ts', () => {
         );
 
         expect(amplitude.setUserId).toHaveBeenCalledWith('shop-id-1:user-id-1');
-        expect(amplitude.track).toHaveBeenCalledWith('Login');
+        expect(amplitude.track).toHaveBeenCalledWith('login');
 
         amplitude.track.mockClear();
         amplitude.getUserId.mockReturnValue('shop-id-1:user-id-1');
@@ -50,7 +50,7 @@ describe('src/core/telemetry/amplitude/amplitude.telemetry-handlers.ts', () => {
     it('tracks logout and flushes/resets immediately', () => {
         pushTelemetryEventToAmplitude(new TelemetryEvent('reset', {}));
 
-        expect(amplitude.track).toHaveBeenCalledWith('Logout');
+        expect(amplitude.track).toHaveBeenCalledWith('logout');
         expect(amplitude.flush).toHaveBeenCalledTimes(1);
         expect(amplitude.reset).toHaveBeenCalledTimes(1);
     });
@@ -70,12 +70,24 @@ describe('src/core/telemetry/amplitude/amplitude.telemetry-handlers.ts', () => {
             }),
         );
 
-        expect(amplitude.track).toHaveBeenCalledWith('Page Viewed', {
+        expect(amplitude.track).toHaveBeenCalledWith('page_viewed', {
             sw_route_from_name: 'Symbol(from-route)',
             sw_route_from_href: '/from',
             sw_route_to_name: null,
             sw_route_to_href: '/to',
             sw_route_to_query: 'limit=10',
+        });
+    });
+
+    it('passes through programmatic telemetry event names unchanged', () => {
+        pushTelemetryEventToAmplitude(
+            new TelemetryEvent('programmatic', {
+                eventName: 'page_viewed',
+            }),
+        );
+
+        expect(amplitude.track).toHaveBeenCalledWith('page_viewed', {
+            eventName: 'page_viewed',
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/core/telemetry/amplitude/amplitude.telemetry-handlers.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/amplitude/amplitude.telemetry-handlers.ts
@@ -17,7 +17,7 @@ export default function createTelemetryEventHandler(
 ): (telemetryEvent: TelemetryEvent<EventTypes>) => void {
     const telemetryEventHandlers: TelemetryEventHandlers = {
         page_change: (event) => {
-            amplitude.track('Page Viewed', {
+            amplitude.track('page_viewed', {
                 sw_route_from_name: normalizeRouteName(event.eventData.from.name),
                 sw_route_from_href: event.eventData.from.path,
                 sw_route_to_name: normalizeRouteName(event.eventData.to.name),
@@ -34,11 +34,11 @@ export default function createTelemetryEventHandler(
             // add more user properties via amplitude.identify(); ?
 
             if (newUserId && previousUserId !== newUserId) {
-                amplitude.track('Login');
+                amplitude.track('login');
             }
         },
         reset: () => {
-            amplitude.track('Logout');
+            amplitude.track('logout');
             amplitude.flush();
             amplitude.reset();
         },
@@ -47,15 +47,10 @@ export default function createTelemetryEventHandler(
 
             const eventProperties: Record<string, TrackableType> = {};
 
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
-            const capitalizedTagName = string.capitalizeString(target.tagName);
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
-            const capitalizedEventName = string.capitalizeString(originalEvent.type);
+            let eventName = string.snakeCase(`${target.tagName} ${originalEvent.type}`);
 
-            let eventName = `${capitalizedTagName} ${capitalizedEventName}`;
-
-            if (capitalizedTagName === 'A') {
-                eventName = 'Link Visited';
+            if (target.tagName === 'A') {
+                eventName = 'link_visited';
 
                 eventProperties.sw_link_href = target.getAttribute('href') ?? '';
                 eventProperties.sw_link_type = target.getAttribute('target') === '_blank' ? 'external' : 'internal';


### PR DESCRIPTION
### 1. Why is this change necessary?

 Anonymous telemetry events already use snake_case names like `consent_modal_viewed`, while identified admin telemetry events were still emitted with title-cased names like `Page Viewed`, `Login`, and `Logout`. That inconsistency makes downstream telemetry processing and querying harder and creates two naming conventions for the same telemetry surface.

  ### 2. What does this change do, exactly?

  This change normalizes identified administration telemetry event names to snake_case at the Amplitude handler level.

  It changes:
  - `Page Viewed` to `page_viewed`
  - `Login` to `login`
  - `Logout` to `logout`
  - generated interaction events such as `Button Click` to `button_click`
  - generated link events to `link_visited`

  It also keeps programmatic telemetry event names as a strict pass-through contract, so callers must provide snake_case names themselves.

  The affected admin telemetry tests were updated accordingly.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Enable product analytics in the administration.
  2. Open the administration and allow telemetry tracking.
  3. Trigger identified telemetry events, for example by:
     - navigating between admin pages
     - clicking tracked UI elements
     - logging in or out
  4. Inspect the emitted telemetry event names in the Amplitude client or related tests.
  5. Before this change, identified events are emitted as values like `Page Viewed`, `Button Click`, `Login`, and `Logout`.
  6. Anonymous consent events already use snake_case, for example `consent_modal_viewed`.
  7. After this change, identified telemetry events also use snake_case consistently.

  ### 4. Please link to the relevant issues (if any).

  N/A

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the
  change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md)
  for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them