### PR TITLE
fix(admin): delete amplitude user data when consent is revoked during deferred init

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.spec.js
@@ -621,5 +621,53 @@ describe('src/app/post-init/amplitude.init.ts', () => {
 
             jest.useRealTimers();
         });
+
+        it('deletes user data when consent is revoked before deferred runtime activation finishes', async () => {
+            const { init, createInstance } = await import('@amplitude/analytics-browser');
+            const consentStore = useConsentStore();
+
+            jest.useFakeTimers();
+            consentStore.consents.product_analytics.status = 'revoked';
+
+            await initAmplitude();
+
+            init.mockClear();
+            createInstance.mockClear();
+
+            consentStore.$patch({
+                consents: {
+                    ...consentStore.consents,
+                    product_analytics: {
+                        ...consentStore.consents.product_analytics,
+                        status: 'accepted',
+                    },
+                },
+            });
+
+            await flushPromises();
+
+            consentStore.$patch({
+                consents: {
+                    ...consentStore.consents,
+                    product_analytics: {
+                        ...consentStore.consents.product_analytics,
+                        status: 'revoked',
+                    },
+                },
+            });
+
+            await flushPromises();
+
+            expect(init).not.toHaveBeenCalled();
+            expect(createInstance).toHaveBeenCalledTimes(1);
+            expect(mockDeleteUserAmplitudeClient.track).toHaveBeenCalledWith('delete_user', {
+                shop_id: testShopId,
+                user_id: testUserId,
+                amplitude_user_id: `${testShopId}:${testUserId}`,
+            });
+            expect(mockDeleteUserAmplitudeClient.flush).toHaveBeenCalled();
+
+            jest.useRealTimers();
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init-post/amplitude.init.ts
@@ -22,6 +22,8 @@ type AmplitudeModule = typeof AmplitudeClient;
 
 let stopTelemetryConsentWatch: (() => void) | null = null;
 let pendingTelemetryActivationTimeout: number | null = null;
+let amplitudeModulePromise: Promise<AmplitudeModule> | null = null;
+let telemetryStateChangeToken = 0;
 
 /**
  * @private
@@ -45,6 +47,8 @@ export default async function (): Promise<void> {
     const pushConsentEventToAmplitude = createConsentEventHandler(anonymousGatewayClient);
     let isTelemetryInitialized = false;
     let isTelemetryListenerRegistered = false;
+    let isTelemetryLogoutListenerRegistered = false;
+    let isDefaultShopwarePropertiesPluginRegistered = false;
     let amplitude: AmplitudeModule | null = null;
     let pushTelemetryEventToAmplitude: ReturnType<typeof createTelemetryEventHandler> | null = null;
 
@@ -60,14 +64,33 @@ export default async function (): Promise<void> {
     // eslint-disable-next-line listeners/no-missing-remove-event-listener
     Shopware.Utils.EventBus.on('consent', pushConsentEventToAmplitude);
 
-    const ensureTelemetryInitialized = async (): Promise<void> => {
+    const ensureAmplitudeModuleLoaded = async (): Promise<AmplitudeModule> => {
+        if (amplitude !== null) {
+            return amplitude;
+        }
+
+        amplitudeModulePromise ??= import('@amplitude/analytics-browser').catch((error: unknown) => {
+            amplitudeModulePromise = null;
+
+            throw error;
+        });
+        amplitude = await amplitudeModulePromise;
+        pushTelemetryEventToAmplitude ??= createTelemetryEventHandler(amplitude);
+
+        if (!isTelemetryLogoutListenerRegistered) {
+            registerTelemetryLogoutListener(amplitude);
+            isTelemetryLogoutListenerRegistered = true;
+        }
+
+        return amplitude;
+    };
+
+    const ensureTelemetryInitialized = async (stateChangeToken: number): Promise<void> => {
         if (isTelemetryInitialized) {
             return;
         }
 
-        amplitude = await import('@amplitude/analytics-browser');
-        pushTelemetryEventToAmplitude = createTelemetryEventHandler(amplitude);
-        registerTelemetryLogoutListener(amplitude);
+        const loadedAmplitude = await ensureAmplitudeModuleLoaded();
 
         let defaultLanguageName = '';
 
@@ -77,22 +100,32 @@ export default async function (): Promise<void> {
             defaultLanguageName = 'N/A';
         }
 
-        addDefaultShopwarePropertiesPlugin(amplitude, defaultLanguageName);
-        initTelemetryAmplitude(amplitude, analyticsGatewayUrl);
+        if (stateChangeToken !== telemetryStateChangeToken || !isTelemetryConsentAccepted.value) {
+            return;
+        }
+
+        if (!isDefaultShopwarePropertiesPluginRegistered) {
+            addDefaultShopwarePropertiesPlugin(loadedAmplitude, defaultLanguageName);
+            isDefaultShopwarePropertiesPluginRegistered = true;
+        }
+
+        initTelemetryAmplitude(loadedAmplitude, analyticsGatewayUrl);
 
         isTelemetryInitialized = true;
     };
 
-    const enableTelemetryTracking = async (): Promise<void> => {
+    const enableTelemetryTracking = async (stateChangeToken: number): Promise<void> => {
         if (isTelemetryListenerRegistered) {
             return;
         }
 
-        await ensureTelemetryInitialized();
+        await ensureTelemetryInitialized(stateChangeToken);
 
         if (
+            stateChangeToken !== telemetryStateChangeToken ||
             isTelemetryListenerRegistered ||
             !isTelemetryConsentAccepted.value ||
+            !isTelemetryInitialized ||
             amplitude === null ||
             pushTelemetryEventToAmplitude === null
         ) {
@@ -104,11 +137,7 @@ export default async function (): Promise<void> {
         isTelemetryListenerRegistered = true;
     };
 
-    const disableTelemetryTracking = (): void => {
-        if (!isTelemetryInitialized || amplitude === null) {
-            return;
-        }
-
+    const disableTelemetryTracking = async (shouldDeleteUserData: boolean): Promise<void> => {
         if (isTelemetryListenerRegistered && pushTelemetryEventToAmplitude !== null) {
             Shopware.Utils.EventBus.off('telemetry', pushTelemetryEventToAmplitude);
             isTelemetryListenerRegistered = false;
@@ -116,9 +145,11 @@ export default async function (): Promise<void> {
 
         const shopId = Shopware.Store.get('context').app.config.shopId;
         const userId = Shopware.Store.get('session').currentUser?.id;
+        let loadedAmplitude = amplitude;
 
-        if (typeof userId === 'string') {
-            const privacyAmplitude = createPrivacyAmplitudeClient(amplitude, analyticsGatewayUrl);
+        if (shouldDeleteUserData && typeof userId === 'string') {
+            loadedAmplitude = await ensureAmplitudeModuleLoaded();
+            const privacyAmplitude = createPrivacyAmplitudeClient(loadedAmplitude, analyticsGatewayUrl);
 
             privacyAmplitude.track('delete_user', {
                 shop_id: shopId,
@@ -127,32 +158,38 @@ export default async function (): Promise<void> {
             });
             privacyAmplitude.flush();
         }
-        amplitude.setOptOut(true);
-        amplitude.flush();
-        amplitude.reset();
+
+        if (isTelemetryInitialized && loadedAmplitude !== null) {
+            loadedAmplitude.setOptOut(true);
+            loadedAmplitude.flush();
+            loadedAmplitude.reset();
+        }
+
         clearAmplitudeCookies();
     };
 
-    const syncTelemetryTracking = async (consentAccepted: boolean): Promise<void> => {
+    const syncTelemetryTracking = async (consentAccepted: boolean, shouldDeleteUserData = false): Promise<void> => {
         clearPendingTelemetryActivation();
+        telemetryStateChangeToken += 1;
+        const stateChangeToken = telemetryStateChangeToken;
 
         if (consentAccepted) {
-            await enableTelemetryTracking();
+            await enableTelemetryTracking(stateChangeToken);
 
             return;
         }
 
-        disableTelemetryTracking();
+        await disableTelemetryTracking(shouldDeleteUserData);
     };
 
     await syncTelemetryTracking(isTelemetryConsentAccepted.value);
     clearPendingTelemetryActivation();
     stopTelemetryConsentWatch?.();
-    stopTelemetryConsentWatch = watch(isTelemetryConsentAccepted, (consentAccepted) => {
+    stopTelemetryConsentWatch = watch(isTelemetryConsentAccepted, (consentAccepted, previousConsentAccepted) => {
         clearPendingTelemetryActivation();
 
         if (!consentAccepted) {
-            void syncTelemetryTracking(false);
+            void syncTelemetryTracking(false, previousConsentAccepted);
 
             return;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

  Revoking the administration `product_analytics` consent did not always trigger the Amplitude `delete_user` request.

  This could happen when consent was accepted and then revoked again before the deferred telemetry activation finished.
  In that case, the revoke path returned early because the telemetry client had not completed initialization yet.

  ### 2. What does this change do, exactly?

  It decouples the privacy deletion request from full telemetry initialization.

  The change:
  - keeps the deferred activation for accepted consent
  - cancels outdated activation work when consent changes again
  - sends the Amplitude `delete_user` request on a real `accepted -> revoked` transition even if telemetry
  initialization has not finished yet
  - adds a regression test for the accept-then-immediately-revoke race

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Open the administration with `product_analytics` consent initially revoked.
  2. Accept the user data / product analytics consent.
  3. Revoke it again immediately before the deferred activation finishes.
  4. Check the network requests.
  5. Before this change, no Amplitude `/delete-user` request was sent in that race condition.
  6. After this change, the `/delete-user` request is sent reliably.

  ### 4. Please link to the relevant issues (if any).

  closes: https://github.com/shopware/SwagProductAnalytics/issues/49

  ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the
  consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/
  documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them