### PR TITLE
feat: Ensure proper types on connection driver options

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -42,6 +42,11 @@ When creating external media via `POST /api/_action/media/external-link`, you ca
 
 The same `thumbnails` payload shape is accepted by `POST /api/_action/media/{id}/external-thumbnails`.
 
+### Support of long-running MySQL connections
+
+It is now possible to use libraries like [`doctrine-mysql-come-back`](https://github.com/facile-it/doctrine-mysql-come-back), which wrap the default DBAL connection.
+More information on how to set up, can be found here: https://developer.shopware.com/docs/guides/hosting/infrastructure/database.html#setup-for-long-running-environments
+
 ## API
 
 ### Deprecation of newsletter route methods
@@ -98,7 +103,7 @@ Product main categories are now inherited from parent product if not explicitly 
 
 ### CategoryIndexer doesn't dispatch IndexingMetaEvent when only index irrelevant data changes
 
-The CategoryIndexer did already check for changed payload and only triggered the tree/child-count updaters when the `parentId` changed and the breadcrumb updater when the `name` changed. 
+The CategoryIndexer did already check for changed payload and only triggered the tree/child-count updaters when the `parentId` changed and the breadcrumb updater when the `name` changed.
 But it still dispatched the `CategoryIndexingMessage`, even though all relevant Updaters would be skipped. For performance and efficiency reasons that event is not thrown anymore in the case of an update when only irrelevant data has changed.
 This saves resources, as we don't need to fetch any child categories, dispatch unneeded messages and create DB transactions when it's not needed, especially as this whole handling was also triggered when you only assign products to a category, which is a quite common action.
 Note that this only affects the update case, in the case of newly inserted or deleted categories the event is still dispatched, as all updaters are relevant in that case.

--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -11,8 +11,11 @@ use Doctrine\DBAL\Tools\DsnParser;
 use Pdo\Mysql;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Config\Util\XmlUtils;
 
 /**
+ * @phpstan-import-type Params from DriverManager
+ *
  * @internal
  */
 #[Package('framework')]
@@ -41,10 +44,8 @@ class MySQLFactory
             $url = 'mysql://root:shopware@127.0.0.1:3306/shopware';
         }
 
-        $replicaUrl = (string) EnvironmentHelper::getVariable('DATABASE_REPLICA_0_URL');
-
         $dsnParser = new DsnParser(['mysql' => 'pdo_mysql']);
-        $dsnParameters = $dsnParser->parse($url);
+        $dsnParameters = self::parseDsn($dsnParser, $url);
 
         $parameters = array_merge([
             'charset' => 'utf8mb4',
@@ -55,7 +56,7 @@ class MySQLFactory
         $parameters['driverOptions'] = [
             \PDO::ATTR_STRINGIFY_FETCHES => true,
             \PDO::ATTR_TIMEOUT => 5,
-        ] + ($dsnParameters['driverOptions'] ?? []);
+        ] + $dsnParameters['driverOptions'];
 
         $initCommands = [
             'SET @@session.time_zone = \'+00:00\'',
@@ -89,7 +90,8 @@ class MySQLFactory
             $parameters['driverOptions'][Mysql::ATTR_COMPRESS] = true;
         }
 
-        if ($replicaUrl) {
+        $replicaUrl = (string) EnvironmentHelper::getVariable('DATABASE_REPLICA_0_URL');
+        if ($replicaUrl !== '') {
             if (!isset($parameters['wrapperClass'])) {
                 $parameters['wrapperClass'] = PrimaryReadReplicaConnection::class;
             }
@@ -98,12 +100,12 @@ class MySQLFactory
             $parameters['primary'] = array_merge([
                 'charset' => $parameters['charset'],
             ], $dsnParameters);
-            $parameters['primary']['driverOptions'] = $parameters['driverOptions'] + ($dsnParameters['driverOptions'] ?? []);
+            $parameters['primary']['driverOptions'] = $parameters['driverOptions'] + $dsnParameters['driverOptions'];
 
             $parameters['replica'] = [];
 
             for ($i = 0; $replicaUrl = (string) EnvironmentHelper::getVariable('DATABASE_REPLICA_' . $i . '_URL'); ++$i) {
-                $replicaParams = $dsnParser->parse($replicaUrl);
+                $replicaParams = self::parseDsn($dsnParser, $replicaUrl);
 
                 $parameters['replica'][$i] = array_merge([
                     'charset' => $parameters['charset'],
@@ -113,5 +115,36 @@ class MySQLFactory
         }
 
         return DriverManager::getConnection($parameters, $config);
+    }
+
+    /**
+     * @return Params&array{driverOptions: array<mixed>}
+     */
+    private static function parseDsn(DsnParser $dsnParser, string $url): array
+    {
+        $dsnParameters = $dsnParser->parse($url);
+
+        $dsnParameters['driverOptions'] = array_map(static function (mixed $value): mixed {
+            return self::castValue($value);
+        }, $dsnParameters['driverOptions'] ?? []);
+
+        return $dsnParameters;
+    }
+
+    private static function castValue(mixed $value): mixed
+    {
+        if (is_iterable($value)) {
+            foreach ($value as &$item) {
+                $item = self::castValue($item);
+            }
+
+            return $value;
+        }
+
+        if (!\is_string($value)) {
+            return $value;
+        }
+
+        return XmlUtils::phpize($value);
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Database/MySQLFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Database;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\Middleware;
@@ -101,8 +102,7 @@ class MySQLFactoryTest extends TestCase
             ),
         ]);
 
-        $connection = MySQLFactory::create();
-        $params = $connection->getParams();
+        $params = MySQLFactory::create()->getParams();
 
         static::assertArrayHasKey('driverOptions', $params);
 
@@ -114,7 +114,7 @@ class MySQLFactoryTest extends TestCase
 
         // Verify custom option from DSN is preserved
         static::assertArrayHasKey($customOption, $params['driverOptions']);
-        static::assertSame('1', $params['driverOptions'][$customOption]);
+        static::assertSame($customValue, $params['driverOptions'][$customOption]);
     }
 
     public function testDriverOptionsFromDsnArePreservedInReplicaConfiguration(): void
@@ -138,15 +138,14 @@ class MySQLFactoryTest extends TestCase
             ),
         ]);
 
-        $connection = MySQLFactory::create();
-        $params = $connection->getParams();
+        $params = MySQLFactory::create()->getParams();
 
         // Verify primary connection has both default and custom options
         static::assertArrayHasKey('primary', $params);
         static::assertArrayHasKey('driverOptions', $params['primary']);
         static::assertArrayHasKey(\PDO::ATTR_STRINGIFY_FETCHES, $params['primary']['driverOptions']);
         static::assertArrayHasKey($customOption, $params['primary']['driverOptions']);
-        static::assertSame('1', $params['primary']['driverOptions'][$customOption]);
+        static::assertSame($customValue, $params['primary']['driverOptions'][$customOption]);
 
         // Verify replica connection has both default and custom options
         static::assertArrayHasKey('replica', $params);
@@ -154,7 +153,30 @@ class MySQLFactoryTest extends TestCase
         static::assertArrayHasKey('driverOptions', $params['replica'][0]);
         static::assertArrayHasKey(\PDO::ATTR_STRINGIFY_FETCHES, $params['replica'][0]['driverOptions']);
         static::assertArrayHasKey($replicaCustomOption, $params['replica'][0]['driverOptions']);
-        static::assertSame('1', $params['replica'][0]['driverOptions'][$replicaCustomOption]);
+        static::assertSame($replicaCustomValue, $params['replica'][0]['driverOptions'][$replicaCustomOption]);
+    }
+
+    public function testWrapperClassWithDriverOptions(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://user:pass@localhost:3306/shopware?wrapperClass=Shopware\Tests\Unit\Core\Framework\Adapter\Database\MyWrapper&driverOptions[x_foo_bar]=3&driverOptions[foo][bar]=true',
+        ]);
+
+        $connection = MySQLFactory::create();
+
+        // Assert connection is not created - we don't want to connect to a real database in unit tests
+        static::assertFalse($connection->isConnected());
+
+        $params = $connection->getParams();
+        static::assertArrayHasKey('wrapperClass', $params);
+        static::assertSame(MyWrapper::class, $params['wrapperClass']);
+        static::assertArrayHasKey('driverOptions', $params);
+        $driverOptions = $params['driverOptions'];
+        static::assertArrayHasKey('x_foo_bar', $driverOptions);
+        static::assertSame(3, $driverOptions['x_foo_bar']);
+        static::assertArrayHasKey('foo', $driverOptions);
+        static::assertArrayHasKey('bar', $driverOptions['foo']);
+        static::assertTrue($driverOptions['foo']['bar']);
     }
 
     /**
@@ -198,4 +220,11 @@ class MyMiddleware implements Middleware
     {
         return new MyDriver($driver);
     }
+}
+
+/**
+ * @internal
+ */
+class MyWrapper extends Connection
+{
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently all additional driver options parsed from the `DATABASE_URL` are strings. If you want to make use of something like this `DATABASE_URL="mysql://username:password@localhost:3306/dbname?wrapperClass=?wrapperClass=Facile\DoctrineMySQLComeBack\Doctrine\DBAL\Connection&driverOptions[x_reconnect_attempts]=3` you need to cast the `x_reconnect_attempts` parameter properly to integer type, otherwise using this wrapper will fail. See https://github.com/facile-it/doctrine-mysql-come-back/blob/3.0.3/src/ConnectionTrait.php#L67

Documentation for the usage is here https://github.com/shopware/docs/pull/2189

### 2. What does this change do, exactly?

Iterate over the driver options and use `\Symfony\Component\Config\Util\XmlUtils::phpize` to cast the string value to an according PHP type. 

### 3. Describe each step to reproduce the issue or behaviour.

Try to use the connection wrapper like described above.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/14313

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
