### PR TITLE
fix: race condition between cart persist and load (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-03-13-fix-race-condition-cart-persist-and-load.md
+++ b/changelog/_unreleased/2026-03-13-fix-race-condition-cart-persist-and-load.md
@@ -4,4 +4,4 @@ author: Max Stegmeyer
 author_email: m.stegmeyer@shopware.com
 ---
 # Core
-* Fixed a race condition where concurrent cart load and persist could overwrite or lose cart data. Cart load now sets the cart as persisted and the error hash; Redis cart persister uses `SET NX` semantics when creating and only updates existing keys when the cart was already persisted, and dispatches `CartSavedEvent` only after a successful persist.
+* Changed `CartPersister` and `RedisCartPersister` to only insert a cart if it is new, otherwise only update it to avoid a race condition where concurrent cart load and persist could overwrite or lose cart data.

--- a/changelog/_unreleased/2026-03-13-fix-race-condition-cart-persist-and-load.md
+++ b/changelog/_unreleased/2026-03-13-fix-race-condition-cart-persist-and-load.md
@@ -1,0 +1,7 @@
+---
+title: Fix race condition between cart persist and load
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+---
+# Core
+* Fixed a race condition where concurrent cart load and persist could overwrite or lose cart data. Cart load now sets the cart as persisted and the error hash; Redis cart persister uses `SET NX` semantics when creating and only updates existing keys when the cart was already persisted, and dispatches `CartSavedEvent` only after a successful persist.

--- a/src/Core/Checkout/Cart/Cart.php
+++ b/src/Core/Checkout/Cart/Cart.php
@@ -34,6 +34,8 @@ class Cart extends Struct
 
     protected bool $modified = false;
 
+    protected bool $persisted = false;
+
     protected ?string $customerComment = null;
 
     protected ?string $affiliateCode = null;
@@ -232,6 +234,16 @@ class Cart extends Struct
     public function markUnmodified(): void
     {
         $this->modified = false;
+    }
+
+    public function isPersisted(): bool
+    {
+        return $this->persisted;
+    }
+
+    public function setPersisted(bool $persisted): void
+    {
+        $this->persisted = $persisted;
     }
 
     public function getCustomerComment(): ?string

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -48,7 +48,7 @@ class CartPersister extends AbstractCartPersister
 
         try {
             $cart = $this->compressor->unserialize($content['payload'], (int) $content['compressed']);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             // When we can't decode it, we have to delete it
             throw CartException::tokenNotFound($token);
         }
@@ -59,6 +59,7 @@ class CartPersister extends AbstractCartPersister
 
         $cart->setToken($token);
         $cart->setRuleIds(json_decode((string) $content['rule_ids'], true, 512, \JSON_THROW_ON_ERROR) ?? []);
+        $cart->setPersisted(true);
 
         $this->eventDispatcher->dispatch(new CartLoadedEvent($cart, $context));
 
@@ -85,11 +86,19 @@ class CartPersister extends AbstractCartPersister
             return;
         }
 
-        $sql = <<<'SQL'
-            INSERT INTO `cart` (`token`, `payload`, `rule_ids`, `compressed`, `created_at`)
-            VALUES (:token, :payload, :rule_ids, :compressed, :now)
-            ON DUPLICATE KEY UPDATE `payload` = :payload, `compressed` = :compressed, `rule_ids` = :rule_ids, `created_at` = :now;
-        SQL;
+        if (!$cart->isPersisted()) {
+            $sql = <<<'SQL'
+                INSERT INTO `cart` (`token`, `payload`, `rule_ids`, `compressed`, `created_at`)
+                VALUES (:token, :payload, :rule_ids, :compressed, :now)
+                ON DUPLICATE KEY UPDATE `payload` = :payload, `compressed` = :compressed, `rule_ids` = :rule_ids, `created_at` = :now;
+            SQL;
+        } else {
+            $sql = <<<'SQL'
+                UPDATE `cart`
+                SET `payload` = :payload, `rule_ids` = :rule_ids, `compressed` = :compressed, `created_at` = :now
+                WHERE `token` = :token;
+            SQL;
+        }
 
         [$compressed, $serializeCart] = $this->serializeCart($cart);
 
@@ -102,8 +111,13 @@ class CartPersister extends AbstractCartPersister
         ];
 
         $query = new RetryableQuery($this->connection, $this->connection->prepare($sql));
-        $query->execute($data);
+        $result = $query->execute($data);
 
+        if ($cart->isPersisted() && (int) $result === 0) {
+            return;
+        }
+
+        $cart->setPersisted(true);
         $this->eventDispatcher->dispatch(new CartSavedEvent($context, $cart));
     }
 

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -21,6 +21,9 @@ class RedisCartPersister extends AbstractCartPersister
 {
     final public const PREFIX = 'cart-persister-';
 
+    private const SET_ONLY_IF_EXISTS = 'XX';
+    private const EXPIRES_IN_SECONDS = 'EX';
+
     /**
      * @param RedisTypeHint $redis
      *
@@ -54,7 +57,7 @@ class RedisCartPersister extends AbstractCartPersister
 
         try {
             $value = \unserialize($value);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             throw CartException::tokenNotFound($token);
         }
 
@@ -64,7 +67,7 @@ class RedisCartPersister extends AbstractCartPersister
 
         try {
             $content = $this->compressor->unserialize($value['content'], (int) $value['compressed']);
-        } catch (\Exception) {
+        } catch (\Throwable) {
             // When we can't decode it, we have to delete it
             throw CartException::tokenNotFound($token);
         }
@@ -81,6 +84,7 @@ class RedisCartPersister extends AbstractCartPersister
 
         $cart->setToken($token);
         $cart->setRuleIds($content['rule_ids']);
+        $cart->setPersisted(true);
 
         $this->eventDispatcher->dispatch(new CartLoadedEvent($cart, $context));
 
@@ -90,8 +94,6 @@ class RedisCartPersister extends AbstractCartPersister
     public function save(Cart $cart, SalesChannelContext $context): void
     {
         $shouldPersist = $this->shouldPersist($cart);
-
-        $this->eventDispatcher->dispatch(new CartSavedEvent($context, $cart));
 
         $event = new CartVerifyPersistEvent($context, $cart, $shouldPersist);
 
@@ -103,8 +105,18 @@ class RedisCartPersister extends AbstractCartPersister
         }
 
         $content = $this->serializeCart($cart, $context);
+        $options = [self::EXPIRES_IN_SECONDS => $this->expireDays * 86400];
 
-        $this->redis->set(self::PREFIX . $cart->getToken(), $content, ['EX' => $this->expireDays * 86400]);
+        if ($cart->isPersisted()) {
+            $options[] = self::SET_ONLY_IF_EXISTS;
+        }
+
+        if ($this->redis->set(self::PREFIX . $cart->getToken(), $content, $options) === false) {
+            return;
+        }
+
+        $cart->setPersisted(true);
+        $this->eventDispatcher->dispatch(new CartSavedEvent($context, $cart));
     }
 
     public function delete(string $token, SalesChannelContext $context): void
@@ -124,8 +136,10 @@ class RedisCartPersister extends AbstractCartPersister
         $copyContext->setRuleIds($cart->getRuleIds());
 
         $cart->setToken($newToken);
+        $cart->setPersisted(false);
         $this->save($cart, $copyContext);
         $cart->setToken($oldToken);
+        $cart->setPersisted(true);
 
         $this->delete($oldToken, $context);
     }

--- a/src/Core/Test/Stub/Redis/RedisStub.php
+++ b/src/Core/Test/Stub/Redis/RedisStub.php
@@ -35,6 +35,8 @@ class RedisStub extends \Redis
     private function doSet(string $key, mixed $value, mixed $options = null): bool
     {
         $expire = 0;
+        $mustExist = false;
+        $mustNotExist = false;
 
         if (\is_array($options)) {
             if (isset($options['ex'])) {
@@ -44,8 +46,32 @@ class RedisStub extends \Redis
             if (isset($options['EX'])) {
                 $expire = time() + $options['EX'];
             }
+
+            foreach ($options as $option) {
+                if (!\is_string($option)) {
+                    continue;
+                }
+
+                $option = strtolower($option);
+
+                if ($option === 'xx') {
+                    $mustExist = true;
+                }
+
+                if ($option === 'nx') {
+                    $mustNotExist = true;
+                }
+            }
         } elseif (\is_int($options)) {
             $expire = time() + $options;
+        }
+
+        if ($mustExist && !\array_key_exists($key, $this->data)) {
+            return false;
+        }
+
+        if ($mustNotExist && \array_key_exists($key, $this->data)) {
+            return false;
         }
 
         $this->data[$key] = ['value' => $value, 'expire' => $expire];

--- a/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
+++ b/tests/integration/Core/Checkout/Cart/CartPersisterTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
@@ -77,7 +78,10 @@ class CartPersisterTest extends TestCase
         $persister = new CartPersister($connection, $eventDispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
         $cart = $persister->load('existing', Generator::generateSalesChannelContext());
 
-        static::assertEquals(new Cart('existing'), $cart);
+        $expected = new Cart('existing');
+        $expected->setPersisted(true);
+
+        static::assertEquals($expected, $cart);
     }
 
     public function testEmptyCartShouldNotBeSaved(): void
@@ -152,6 +156,32 @@ class CartPersisterTest extends TestCase
         static::assertNotEmpty($token);
     }
 
+    public function testSavingExistingCartDoesNotRecreateDeletedCart(): void
+    {
+        $cart = new Cart('existing');
+        $cart->add(
+            (new LineItem('A', 'test'))
+                ->setPrice(new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()))
+                ->setLabel('test')
+        );
+
+        $persister = static::getContainer()->get(CartPersister::class);
+        $context = $this->getSalesChannelContext($cart->getToken());
+
+        $persister->save($cart, $context);
+        $persister->delete($cart->getToken(), $context);
+        $persister->save($cart, $context);
+
+        $token = static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT token FROM cart WHERE token = :token', ['token' => $cart->getToken()]);
+
+        static::assertFalse($token);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRecalculationCartShouldNotBeSaved(): void
     {
         $cartBehavior = new CartBehavior([], true, true);

--- a/tests/integration/Core/Checkout/Cart/RedisCartPersisterTest.php
+++ b/tests/integration/Core/Checkout/Cart/RedisCartPersisterTest.php
@@ -94,6 +94,21 @@ class RedisCartPersisterTest extends TestCase
         $this->persister->load($token, $context);
     }
 
+    public function testSavingExistingCartDoesNotRecreateDeletedCart(): void
+    {
+        $token = Uuid::randomHex();
+        $cart = new Cart($token);
+        $cart->add(new LineItem('test', 'test'));
+
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->persister->save($cart, $context);
+        $this->persister->delete($token, $context);
+        $this->persister->save($cart, $context);
+
+        static::assertSame(0, $this->redis->exists(RedisCartPersister::PREFIX . $token));
+    }
+
     public function testLoadGzipCompressedCart(): void
     {
         $token = Uuid::randomHex();
@@ -104,6 +119,8 @@ class RedisCartPersisterTest extends TestCase
         $this->redis->set(RedisCartPersister::PREFIX . $token, serialize($compressed));
 
         $loaded = $this->persister->load($token, $this->createMock(SalesChannelContext::class));
+
+        $cart->setPersisted(true);
 
         static::assertEquals($cart, $loaded);
     }
@@ -122,6 +139,8 @@ class RedisCartPersisterTest extends TestCase
         $this->redis->set(RedisCartPersister::PREFIX . $token, serialize($compressed));
 
         $loaded = $this->persister->load($token, $this->createMock(SalesChannelContext::class));
+
+        $cart->setPersisted(true);
 
         static::assertEquals($cart, $loaded);
     }

--- a/tests/unit/Core/Checkout/Cart/CartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartPersisterTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCompressor;
+use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\CartSerializationCleaner;
+use Shopware\Core\Checkout\Cart\Event\CartSavedEvent;
+use Shopware\Core\Checkout\Cart\Event\CartVerifyPersistEvent;
+use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartPersister::class)]
+#[Package('checkout')]
+class CartPersisterTest extends TestCase
+{
+    public function testDecorated(): void
+    {
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $connection = $this->createMock(Connection::class);
+        $persister = new CartPersister($connection, new CollectingEventDispatcher(), $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
+        $this->expectException(DecorationPatternException::class);
+        $persister->getDecorated();
+    }
+
+    public function testLoadWithUnserializationTypeError(): void
+    {
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn(['payload' => 'invalid serialized data', 'rule_ids' => null, 'compressed' => 0]);
+
+        $cartCompressor = $this->createMock(CartCompressor::class);
+        $cartCompressor->expects($this->once())
+            ->method('unserialize')
+            ->with('invalid serialized data', 0)
+            ->willThrowException(new \TypeError('Unserialization failed'));
+
+        $persister = new CartPersister($connection, new CollectingEventDispatcher(), $cartSerializationCleaner, $cartCompressor);
+
+        $this->expectException(CartTokenNotFoundException::class);
+        $persister->load('token', Generator::generateSalesChannelContext());
+    }
+
+    public function testSavePersistsNewCartAndDispatchesSavedEvent(): void
+    {
+        $cart = new Cart('token');
+        $cart->add(new LineItem('line-item', 'test'));
+
+        $statement = $this->createMock(Statement::class);
+        $statement->expects($this->once())
+            ->method('executeStatement')
+            ->willReturn(1);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('prepare')
+            ->with(static::stringContains('INSERT INTO `cart`'))
+            ->willReturn($statement);
+
+        $eventDispatcher = new CollectingEventDispatcher();
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $persister = new CartPersister($connection, $eventDispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
+
+        $persister->save($cart, Generator::generateSalesChannelContext());
+
+        static::assertTrue($cart->isPersisted());
+        static::assertCount(2, $eventDispatcher->getEvents());
+        static::assertInstanceOf(CartVerifyPersistEvent::class, $eventDispatcher->getEvents()[0]);
+        static::assertInstanceOf(CartSavedEvent::class, $eventDispatcher->getEvents()[1]);
+    }
+
+    public function testSaveDoesNotDispatchSavedEventWhenPersistedCartUpdateAffectsZeroRows(): void
+    {
+        $cart = new Cart('token');
+        $cart->add(new LineItem('line-item', 'test'));
+        $cart->setPersisted(true);
+
+        $statement = $this->createMock(Statement::class);
+        $statement->expects($this->once())
+            ->method('executeStatement')
+            ->willReturn(0);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('prepare')
+            ->with(static::stringContains('UPDATE `cart`'))
+            ->willReturn($statement);
+
+        $eventDispatcher = new CollectingEventDispatcher();
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $persister = new CartPersister($connection, $eventDispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'));
+
+        $persister->save($cart, Generator::generateSalesChannelContext());
+
+        static::assertTrue($cart->isPersisted());
+        static::assertCount(1, $eventDispatcher->getEvents());
+        static::assertContainsOnlyInstancesOf(CartVerifyPersistEvent::class, $eventDispatcher->getEvents());
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/CartTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order;
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
@@ -1333,6 +1333,7 @@ class OrderConverterTest extends TestCase
             'source' => null,
             'hash' => null,
             'states' => [],
+            'persisted' => false,
         ];
     }
 

--- a/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
+++ b/tests/unit/Core/Checkout/Cart/RedisCartPersisterTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order;
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -72,6 +72,25 @@ class RedisCartPersisterTest extends TestCase
         static::assertFalse($redis->exists(RedisCartPersister::PREFIX . $token));
     }
 
+    public function testSavingExistingCartDoesNotCreateMissingCart(): void
+    {
+        $token = Uuid::randomHex();
+        $cart = new Cart($token);
+        $cart->add(new LineItem('test', 'test'));
+
+        $dispatcher = $this->createMock(EventDispatcher::class);
+        $redis = new RedisStub();
+        $cartSerializationCleaner = $this->createMock(CartSerializationCleaner::class);
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $persister = new RedisCartPersister($redis, $dispatcher, $cartSerializationCleaner, new CartCompressor(false, 'gzip'), 90);
+        $persister->save($cart, $context);
+        $persister->delete($token, $context);
+        $persister->save($cart, $context);
+
+        static::assertFalse($redis->exists(RedisCartPersister::PREFIX . $token));
+    }
+
     public function testLoad(): void
     {
         $token = Uuid::randomHex();
@@ -93,6 +112,7 @@ class RedisCartPersisterTest extends TestCase
         $loadedCart = $persister->load($token, $context);
 
         $cart->setData(null);
+        $cart->setPersisted(true);
 
         static::assertEquals($cart, $loadedCart);
     }
@@ -177,6 +197,8 @@ class RedisCartPersisterTest extends TestCase
         $context = $this->createMock(SalesChannelContext::class);
 
         $loadedCart = (new RedisCartPersister($uncompressedRedis, $dispatcher, $cartSerializationCleaner, $compressor, 90))->load($token, $context);
+
+        $cart->setPersisted(true);
 
         static::assertEquals($cart, $loadedCart);
     }

--- a/tests/unit/Core/Checkout/Cart/ValidatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/ValidatorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Unit\Core\Checkout\Cart\Order;
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
### 1. Why is this change necessary?
backport of #15501 
includes backport of #11556 due to test backport issues
fixes https://github.com/shopware/shopware/issues/11928

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
