### PR TITLE
feat: add warning message to the error that catches unexpected warnings in admins testing environment

### DIFF
--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -536,7 +536,7 @@ global.console.warn = (...args) => {
 
     if (!silenceWarning) {
         // Create an error to preserve the original console.warn stack
-        const e = new Error(`Unexpected console.warn: ${  args.join(' ')}`);
+        const e = new Error(`Unexpected console.warn: ${args.join(' ')}`);
         warnTrace = e.stack;
 
         // Set console.warn arguments for global after each

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -536,7 +536,7 @@ global.console.warn = (...args) => {
 
     if (!silenceWarning) {
         // Create an error to preserve the original console.warn stack
-        const e = new Error();
+        const e = new Error("Unexpected console.warn: " + args.join(' '));
         warnTrace = e.stack;
 
         // Set console.warn arguments for global after each

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -536,7 +536,7 @@ global.console.warn = (...args) => {
 
     if (!silenceWarning) {
         // Create an error to preserve the original console.warn stack
-        const e = new Error("Unexpected console.warn: " + args.join(' '));
+        const e = new Error(`Unexpected console.warn: ${  args.join(' ')}`);
         warnTrace = e.stack;
 
         // Set console.warn arguments for global after each


### PR DESCRIPTION
When a test case uses `console.warn`, the test throws an error if it is not allowed.
Unfortunately, the real warning is printed right at the top of the test run, not close to the actual error message. On top of that, because the console output is usually very large, the warnings just get cut off because the console buffer can't hold as much text.

With this change, the warning message will be injected into the error message, making it much easier to understand the context and where the warning originates.
