### PR TITLE
fix: remove unknown tags field

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/newsletter.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/newsletter.json
@@ -112,10 +112,6 @@
                                         "description": "Zip code",
                                         "type": "string"
                                     },
-                                    "tags": {
-                                        "description": "Zip code",
-                                        "type": "string"
-                                    },
                                     "languageId": {
                                         "description": "Identifier of the language.",
                                         "type": "string",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

As reported on [Discord](https://discord.com/channels/1308047705309708348/1367208211635114035/1482060380141387970), the `tags` field is not usedin `NewsletterSubscribeRoute`.

### 2. What does this change do, exactly?

It removes incorrectly defined field.

### 3. Describe each step to reproduce the issue or behaviour.

See StoreAPI schema.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
