### PR TITLE
refactor: deprecate blocking automatic promotions

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -62,6 +62,11 @@ If the token has already been consumed, the user is redirected to the finish pag
 To support this behavior, a new `consumed` flag has been added to the payment token struct, which indicates if the token has already been processed.
 Since tokens are no longer deleted after use, a new scheduled task runs daily to remove all expired tokens and keep the system clean.
 
+## Automatic promotions are no longer removable
+
+Automatic promotions without a code are no longer removable as it adds more confusion as to how one gets it back than it helps.
+The blocked-promotion handling in `\Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension` has been removed.
+
 ## Removal of `$options` parameter in custom validator's constraints
 
 The `$options` of all Shopware's custom validator constraint are removed, if you use one of them, please use named argument instead

--- a/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
+++ b/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
@@ -126,11 +126,11 @@ class CartExtension extends Struct
             $new->addCode($code);
         }
 
-        if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS')) {
+        Feature::callSilentIfInactive('PERMANENT_AUTOMATIC_PROMOTIONS', static function () use ($extension, $new): void {
             foreach ($extension->getBlockedPromotions() as $id) {
                 $new->blockPromotion($id);
             }
-        }
+        });
 
         return $new;
     }

--- a/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
+++ b/src/Core/Checkout/Promotion/Cart/Extension/CartExtension.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Promotion\Cart\Extension;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
@@ -21,6 +22,8 @@ class CartExtension extends Struct
 
     /**
      * @var array<string>
+     *
+     * @deprecated tag:v6.8.0 - Will be removed without replacement. Automatic promotions can no longer be removed.
      */
     protected array $blockedPromotionIds = [];
 
@@ -65,8 +68,17 @@ class CartExtension extends Struct
         return $this->addedCodes;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement. Automatic promotions can no longer be removed.
+     */
     public function blockPromotion(string $id): void
     {
+        Feature::triggerDeprecationOrThrow('PERMANENT_AUTOMATIC_PROMOTIONS', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+
+        if (Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS')) {
+            return;
+        }
+
         if ($id === '') {
             return;
         }
@@ -76,16 +88,33 @@ class CartExtension extends Struct
         }
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement. Automatic promotions can no longer be removed.
+     */
     public function isPromotionBlocked(string $id): bool
     {
+        Feature::triggerDeprecationOrThrow('PERMANENT_AUTOMATIC_PROMOTIONS', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+
+        if (Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS')) {
+            return false;
+        }
+
         return \in_array($id, $this->blockedPromotionIds, true);
     }
 
     /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement. Automatic promotions can no longer be removed.
+     *
      * @return array<string>
      */
     public function getBlockedPromotions(): array
     {
+        Feature::triggerDeprecationOrThrow('PERMANENT_AUTOMATIC_PROMOTIONS', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+
+        if (Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS')) {
+            return [];
+        }
+
         return $this->blockedPromotionIds;
     }
 
@@ -97,8 +126,10 @@ class CartExtension extends Struct
             $new->addCode($code);
         }
 
-        foreach ($extension->getBlockedPromotions() as $id) {
-            $new->blockPromotion($id);
+        if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS')) {
+            foreach ($extension->getBlockedPromotions() as $id) {
+                $new->blockPromotion($id);
+            }
         }
 
         return $new;

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -149,7 +149,12 @@ class PromotionCollector implements CartDataCollectorInterface
                     continue;
                 }
 
-                if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS') && $cartExtension->isPromotionBlocked($tuple->getPromotion()->getId())) {
+                // @deprecated tag:v6.8.0 - remove complete following block incl. `isPromotionBlocked` variable
+                $isPromotionBlocked = false;
+                Feature::callSilentIfInactive('PERMANENT_AUTOMATIC_PROMOTIONS', static function () use ($tuple, $cartExtension, &$isPromotionBlocked): void {
+                    $isPromotionBlocked = $cartExtension->isPromotionBlocked($tuple->getPromotion()->getId());
+                });
+                if ($isPromotionBlocked) {
                     continue;
                 }
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -149,7 +149,7 @@ class PromotionCollector implements CartDataCollectorInterface
                     continue;
                 }
 
-                if ($cartExtension->isPromotionBlocked($tuple->getPromotion()->getId())) {
+                if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS') && $cartExtension->isPromotionBlocked($tuple->getPromotion()->getId())) {
                     continue;
                 }
 

--- a/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscountPrice\PromotionD
 use Shopware\Core\Checkout\Promotion\PromotionEntity;
 use Shopware\Core\Checkout\Promotion\PromotionException;
 use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Container\OrRule;
 use Shopware\Core\Framework\Rule\Rule;
@@ -132,7 +133,7 @@ class PromotionItemBuilder
         $promotionItem->setLabel($promotion->getTranslation('name'));
         $promotionItem->setDescription($promotion->getTranslation('name'));
         $promotionItem->setGood(false);
-        $promotionItem->setRemovable(true);
+        $promotionItem->setRemovable($code !== '' || !Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS'));
         $promotionItem->setPriceDefinition($promotionDefinition);
 
         // always make sure we have a valid code entry.

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -105,7 +106,7 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
 
         // the user wants to remove an automatic added
         // promotions, so lets do this
-        if ($lineItem->hasPayloadValue('promotionId')) {
+        if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS') && $lineItem->hasPayloadValue('promotionId')) {
             $promotionId = (string) $lineItem->getPayloadValue('promotionId');
             $this->blockPromotion($promotionId, $cart);
         }

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -105,11 +105,14 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
         }
 
         // the user wants to remove an automatic added
-        // promotions, so lets do this
-        if (!Feature::isActive('PERMANENT_AUTOMATIC_PROMOTIONS') && $lineItem->hasPayloadValue('promotionId')) {
-            $promotionId = (string) $lineItem->getPayloadValue('promotionId');
-            $this->blockPromotion($promotionId, $cart);
-        }
+        // promotions, so let's do this
+        Feature::callSilentIfInactive('PERMANENT_AUTOMATIC_PROMOTIONS', function () use ($lineItem, $cart): void {
+            if ($lineItem->hasPayloadValue('promotionId')) {
+                $promotionId = (string) $lineItem->getPayloadValue('promotionId');
+                $extension = $this->getExtension($cart);
+                $extension->blockPromotion($promotionId);
+            }
+        });
     }
 
     /**
@@ -161,12 +164,6 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
     {
         $extension = $this->getExtension($cart);
         $extension->removeCode($code);
-    }
-
-    private function blockPromotion(string $id, Cart $cart): void
-    {
-        $extension = $this->getExtension($cart);
-        $extension->blockPromotion($id);
     }
 
     private function getExtension(Cart $cart): CartExtension

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -71,6 +71,11 @@ shopware:
         major: true
         toggleable: true
         description: "This allows repeated calls to the /payment/finalize-transaction endpoint with the same token without throwing a 'token expired' exception."
+      - name: PERMANENT_AUTOMATIC_PROMOTIONS
+        default: false
+        major: true
+        toggleable: true
+        description: "Automatic promotions cannot be removed anymore and are therefore no longer tracked as blocked after removal."
 
       - name: METEOR_TEXT_EDITOR
         default: false

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/Calculation/PromotionFixedPriceCalculationTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/Calculation/PromotionFixedPriceCalculationTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
@@ -95,6 +96,8 @@ class PromotionFixedPriceCalculationTest extends TestCase
     #[Group('promotions')]
     public function testRemoveOfFixedUnitPromotionsWithoutCode(): void
     {
+        Feature::skipTestIfActive('PERMANENT_AUTOMATIC_PROMOTIONS', $this);
+
         $productId = Uuid::randomHex();
         $promotionId = Uuid::randomHex();
         $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
@@ -128,6 +131,33 @@ class PromotionFixedPriceCalculationTest extends TestCase
         static::assertSame(100.0, $cart->getPrice()->getPositionPrice());
         static::assertSame(100.0, $cart->getPrice()->getTotalPrice());
         static::assertSame(84.03, $cart->getPrice()->getNetPrice(), 'Even after promotion delete try it should be present and product should be discounted');
+    }
+
+    #[Group('promotions')]
+    public function testAutomaticFixedUnitPromotionsWithoutCodeAreNotRemovable(): void
+    {
+        Feature::skipTestIfInActive('PERMANENT_AUTOMATIC_PROMOTIONS', $this);
+
+        $productId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $this->createTestFixtureProduct($productId, 100, 19, static::getContainer(), $context);
+        $this->createTestFixtureFixedDiscountPromotion($promotionId, 40, PromotionDiscountEntity::SCOPE_CART, null, static::getContainer(), $context);
+
+        $cart = $this->cartService->getCart($context->getToken(), $context);
+        $cart = $this->addProduct($productId, 1, $cart, $this->cartService, $context);
+
+        $discountLineItem = $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE)->first();
+        static::assertNotNull($discountLineItem);
+        static::assertFalse($discountLineItem->isRemovable());
+
+        static::assertSame(40.0, $cart->getPrice()->getPositionPrice());
+        static::assertSame(40.0, $cart->getPrice()->getTotalPrice());
+        static::assertSame(33.61, $cart->getPrice()->getNetPrice(), 'Discounted cart does not have expected net price');
+
+        $this->expectExceptionMessage('Line item with identifier');
+        $this->cartService->remove($cart, $discountLineItem->getId(), $context);
     }
 
     /**

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
@@ -148,6 +149,8 @@ class PromotionExtensionCodesTest extends TestCase
     #[Group('promotions')]
     public function testAutoPromotionGetsBlockedWhenDeletingItem(): void
     {
+        Feature::skipTestIfActive('PERMANENT_AUTOMATIC_PROMOTIONS', $this);
+
         $productId = Uuid::randomHex();
         $promotionId = Uuid::randomHex();
 
@@ -171,6 +174,28 @@ class PromotionExtensionCodesTest extends TestCase
         $extension = $cart->getExtension(CartExtension::KEY);
 
         static::assertTrue($extension->isPromotionBlocked($promotionId));
+    }
+
+    #[Group('promotions')]
+    public function testAutoPromotionCannotBeRemoved(): void
+    {
+        Feature::skipTestIfInActive('PERMANENT_AUTOMATIC_PROMOTIONS', $this);
+
+        $productId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+
+        $this->createTestFixtureProduct($productId, 119, 19, static::getContainer(), $this->context);
+        $this->createTestFixturePercentagePromotion($promotionId, null, 100, null, static::getContainer());
+
+        $cart = $this->cartService->getCart($this->context->getToken(), $this->context);
+        $cart = $this->addProduct($productId, 1, $cart, $this->cartService, $this->context);
+
+        $discountLineItem = $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE)->first();
+        static::assertInstanceOf(LineItem::class, $discountLineItem);
+        static::assertFalse($discountLineItem->isRemovable());
+
+        $this->expectExceptionMessage('Line item with identifier');
+        $this->cartService->remove($cart, $discountLineItem->getId(), $this->context);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Extension/CartExtensionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Extension/CartExtensionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -17,10 +18,13 @@ class CartExtensionTest extends TestCase
 {
     /**
      * This test verifies that we can add a promotion
-     * id and it will be found as "blocked" in the extension
+     * id and it will be found as "blocked" in the extension.
+     *
+     * @deprecated tag:v6.8.0 - will be removed
      */
     #[Group('promotions')]
-    public function testPromotionIsBlocked(): void
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testPromotionIsBlockedWhenFeatureDisabled(): void
     {
         $extension = new CartExtension();
         $extension->blockPromotion('abc');
@@ -31,8 +35,11 @@ class CartExtensionTest extends TestCase
     /**
      * This test verifies that a non-existing id
      * is being returned as "not blocked"
+     *
+     * @deprecated tag:v6.8.0 - will be removed
      */
     #[Group('promotions')]
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
     public function testDifferentPromotionIsNotBlocked(): void
     {
         $extension = new CartExtension();
@@ -87,6 +94,53 @@ class CartExtensionTest extends TestCase
     {
         $extension1 = new CartExtension();
         $extension1->addCode('c123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c456');
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertEquals(['c123', 'c456'], $merged->getCodes());
+    }
+
+    #[Group('promotions')]
+    public function testMergeCreatesImmutable(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c456');
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertNotSame($extension1, $merged);
+        static::assertNotSame($extension2, $merged);
+    }
+
+    #[Group('promotions')]
+    public function testMergeKillsDuplicates(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
+
+        $extension2 = new CartExtension();
+        $extension2->addCode('c123'); // Duplicate code
+
+        $merged = $extension1->merge($extension2);
+
+        static::assertEquals(['c123'], $merged->getCodes());
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
+    #[Group('promotions')]
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testMergeMergesBlockedPromotionsWhenFeatureDisabled(): void
+    {
+        $extension1 = new CartExtension();
+        $extension1->addCode('c123');
         $extension1->blockPromotion('p123');
 
         $extension2 = new CartExtension();
@@ -100,32 +154,19 @@ class CartExtensionTest extends TestCase
         static::assertTrue($merged->isPromotionBlocked('p456'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     #[Group('promotions')]
-    public function testMergeCreatesImmutable(): void
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testMergeKillsBlockedPromotionDuplicatesWhenFeatureDisabled(): void
     {
         $extension1 = new CartExtension();
         $extension1->addCode('c123');
         $extension1->blockPromotion('p123');
 
         $extension2 = new CartExtension();
-        $extension2->addCode('c456');
-        $extension2->blockPromotion('p456');
-
-        $merged = $extension1->merge($extension2);
-
-        static::assertNotSame($extension1, $merged);
-        static::assertNotSame($extension2, $merged);
-    }
-
-    #[Group('promotions')]
-    public function testMergeKillsDuplicates(): void
-    {
-        $extension1 = new CartExtension();
-        $extension1->addCode('c123');
-        $extension1->blockPromotion('p123');
-
-        $extension2 = new CartExtension();
-        $extension2->addCode('c123'); // Duplicate code
+        $extension2->addCode('c123');
         $extension2->blockPromotion('p456');
 
         $merged = $extension1->merge($extension2);

--- a/tests/unit/Core/Checkout/Promotion/Cart/CartPromotionsSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/CartPromotionsSubscriberTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Promotion\Cart\CartPromotionsSubscriber;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 
 /**
@@ -31,14 +32,12 @@ class CartPromotionsSubscriberTest extends TestCase
     {
         $guestPromotions = new CartExtension();
         $guestPromotions->addCode('tenpercent');
-        $guestPromotions->blockPromotion('foo');
 
         $guestCart = new Cart('guest');
         $guestCart->addExtension(CartExtension::KEY, $guestPromotions);
 
         $customerPromotions = new CartExtension();
         $customerPromotions->addCode('twentypercent');
-        $customerPromotions->blockPromotion('bar');
 
         $customerCart = new Cart('customer');
         $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
@@ -59,10 +58,6 @@ class CartPromotionsSubscriberTest extends TestCase
         static::assertTrue($customerPromotions->hasCode('tenpercent'));
         static::assertTrue($customerPromotions->hasCode('twentypercent'));
         static::assertFalse($customerPromotions->hasCode('thrirtypercent'));
-
-        static::assertTrue($customerPromotions->isPromotionBlocked('foo'));
-        static::assertTrue($customerPromotions->isPromotionBlocked('bar'));
-        static::assertFalse($customerPromotions->isPromotionBlocked('baz'));
     }
 
     #[Group('promotions')]
@@ -70,14 +65,12 @@ class CartPromotionsSubscriberTest extends TestCase
     {
         $guestPromotions = new CartExtension();
         $guestPromotions->addCode('tenpercent');
-        $guestPromotions->blockPromotion('foo');
 
         $guestCart = new Cart('guest');
         $guestCart->addExtension(CartExtension::KEY, $guestPromotions);
 
         $customerPromotions = new CartExtension();
         $customerPromotions->addCode('tenpercent');
-        $customerPromotions->blockPromotion('foo');
 
         $customerCart = new Cart('customer');
         $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
@@ -97,6 +90,40 @@ class CartPromotionsSubscriberTest extends TestCase
         static::assertCount(1, $customerPromotions->getCodes());
         static::assertTrue($customerPromotions->hasCode('tenpercent'));
         static::assertFalse($customerPromotions->hasCode('tenPercent'));
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
+    #[Group('promotions')]
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testOnBeforeCartMergesBlockedPromotionsWhenFeatureDisabled(): void
+    {
+        $guestPromotions = new CartExtension();
+        $guestPromotions->addCode('tenpercent');
+        $guestPromotions->blockPromotion('foo');
+
+        $guestCart = new Cart('guest');
+        $guestCart->addExtension(CartExtension::KEY, $guestPromotions);
+
+        $customerPromotions = new CartExtension();
+        $customerPromotions->addCode('twentypercent');
+        $customerPromotions->blockPromotion('bar');
+
+        $customerCart = new Cart('customer');
+        $customerCart->addExtension(CartExtension::KEY, $customerPromotions);
+
+        $event = new BeforeCartMergeEvent($customerCart, $guestCart, new LineItemCollection(), Generator::generateSalesChannelContext());
+
+        $subscriber = new CartPromotionsSubscriber();
+        $subscriber->onBeforeCartMerge($event);
+
+        /** @var CartExtension $mergedPromotions */
+        $mergedPromotions = $event->getCustomerCart()->getExtension(CartExtension::KEY);
+
+        static::assertTrue($mergedPromotions->isPromotionBlocked('foo'));
+        static::assertTrue($mergedPromotions->isPromotionBlocked('bar'));
+        static::assertFalse($mergedPromotions->isPromotionBlocked('baz'));
     }
 
     #[Group('promotions')]

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
@@ -25,10 +25,12 @@ use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\Gateway\PromotionGatewayInterface;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Checkout\Promotion\PromotionEntity;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 
 /**
@@ -144,6 +146,51 @@ class PromotionCollectorTest extends TestCase
             new PromotionCollection([$promotion]),
             new PromotionCollection(),
         );
+
+        $cartDataCollection = new CartDataCollection();
+
+        $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
+
+        static::assertNull($cartDataCollection->get(PromotionProcessor::DATA_KEY));
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
+    public function testCollectIgnoresBlockedPromotionsWhenFeatureEnabled(): void
+    {
+        $discountId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+
+        $cart = $this->prepareCart([$discountId], $promotionId);
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        Feature::silent('PERMANENT_AUTOMATIC_PROMOTIONS', fn () => $extension->blockPromotion($promotionId));
+
+        $cartDataCollection = new CartDataCollection();
+
+        $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
+
+        /** @var LineItemCollection $promotions */
+        $promotions = $cartDataCollection->get(PromotionProcessor::DATA_KEY);
+
+        static::assertInstanceOf(LineItemCollection::class, $promotions);
+        static::assertCount(1, $promotions);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testCollectSkipsBlockedPromotionsWhenFeatureDisabled(): void
+    {
+        $discountId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+
+        $cart = $this->prepareCart([$discountId], $promotionId);
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        $extension->blockPromotion($promotionId);
 
         $cartDataCollection = new CartDataCollection();
 

--- a/tests/unit/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriberTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\Subscriber\Storefront\StorefrontCartSubscriber;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -206,6 +207,28 @@ class StorefrontCartSubscriberTest extends TestCase
     }
 
     public function testOnLineItemRemovedPromotionNoCodeButPromotionId(): void
+    {
+        $cart = Generator::createCart();
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setPayloadValue('promotionId', 'PROMOID');
+        $lineItem->setRemovable(true);
+        $cart->add($lineItem);
+        $cart->addExtension(CartExtension::KEY, new CartExtension());
+
+        $subscriber = $this->createSubscriber();
+        $event = new BeforeLineItemRemovedEvent($lineItem, $cart, Generator::generateSalesChannelContext());
+
+        $subscriber->onLineItemRemoved($event);
+        $extension = $cart->getExtensionOfType(CartExtension::KEY, CartExtension::class);
+        static::assertInstanceOf(CartExtension::class, $extension);
+        static::assertFalse($extension->hasCode('PROMOID'));
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
+    #[DisabledFeatures(['PERMANENT_AUTOMATIC_PROMOTIONS'])]
+    public function testOnLineItemRemovedPromotionNoCodeButPromotionIdBlocksPromotionWhenFeatureDisabled(): void
     {
         $cart = Generator::createCart();
         $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);


### PR DESCRIPTION
### 1. Why is this change necessary?
When removing an automatic promotion from the cart, we currently set it to a block list, otherwise it would come back in future calculations. This is confusing to customers as they don't know how to get it back if they clicked it by accident.

### 2. What does this change do, exactly?
Behind a separate feature flag `PERMANENT_AUTOMATIC_PROMOTIONS`, we have removed this blocking feature and made the lineItems non-removable, so that this confusion doesn't happen anymore.

At the same time, we have validated that automatic promotions are still overridden by manual promotions (with a code) if their priority is higher, so that the automatic promotion removal really serves no purpose anymore.

### 3. Describe each step to reproduce the issue or behaviour.
- Create an automatic promotion with a discount
- Have that promotion in a cart
- Try to remove and then get it back: getting back only works if cart is completely empty as it gets deleted then and the saved `blockedPromotionIds` becomes empty as well.

### 4. Please link to the relevant issues (if any).
fixes #13422 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
