### PR TITLE
perf: improve join in PerformanceRedemptionUpdater

### DIFF
--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -124,7 +124,7 @@ class PromotionRedemptionUpdater implements EventSubscriberInterface
             FROM order_line_item
                      LEFT JOIN order_customer
                                ON (order_customer.order_id = order_line_item.order_id
-                                   AND order_customer.version_id = order_line_item.version_id)
+                                   AND order_customer.order_version_id = order_line_item.order_version_id)
             WHERE order_line_item.promotion_id IN (:ids) AND order_line_item.version_id = :versionId AND order_line_item.type = :type
             GROUP BY order_line_item.promotion_id, order_customer.customer_id
         SQL;


### PR DESCRIPTION
### 1. Why is this change necessary?
PromotionRedemptionUpdater did a join on a different column, that then does not have a combined index.

### 2. What does this change do, exactly?
Implementing the join on the correct combined index improves performance, especially with lots of versions in the DB. In a test dataset with 25 versions per order and 2000 line items and 500k order customers, query time on a local system went down from 90.5ms to 60.5ms.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #15269 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
