### PR TITLE
fix: dynamic product groups

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-filter/index.js
@@ -109,9 +109,12 @@ export default {
                 fields.push(field);
             }
 
+            this.fields = fields;
             this.changeType({ type: null, parameters: null });
 
-            this.fields = fields;
+            if (field === 'cheapestPrice.percentage') {
+                this.actualCondition.value = String(100);
+            }
         },
 
         handleWrapForTypeNull(type, parameters) {
@@ -164,7 +167,27 @@ export default {
             if (this.handleWrapForTypeNull(type, parameters)) {
                 this.actualCondition.parameters = parameters;
                 this.actualCondition.value = null;
+
+                if (type !== null && this.actualCondition.field === 'cheapestPrice.percentage') {
+                    this.applyPercentageDefaultValue(parameters);
+                }
             }
+        },
+
+        applyPercentageDefaultValue(parameters) {
+            const defaultPercentage = 100;
+
+            if (parameters !== null) {
+                Object.keys(parameters).forEach((key) => {
+                    if (parameters[key] === null) {
+                        this.actualCondition.parameters[key] = defaultPercentage;
+                    }
+                });
+
+                return;
+            }
+
+            this.actualCondition.value = String(defaultPercentage);
         },
 
         wrapInNot(condition, newType, parameters) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-filter/sw-product-stream-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-filter/sw-product-stream-filter.spec.js
@@ -36,12 +36,19 @@ async function createWrapper(privileges = []) {
                 conditionDataProviderService: {
                     getPlaceholderData: () => {},
                     getComponentByCondition: () => {},
+                    getOperatorSet: () => [{ identifier: 'empty' }],
                     allowedJsonAccessors: {
                         'json.test': {
                             value: 'json.test',
                             type: 'string',
                         },
+                        'cheapestPrice.percentage': {
+                            value: 'cheapestPrice.percentage',
+                            type: 'float',
+                            trans: 'percentage',
+                        },
                     },
+                    isNegatedType: () => false,
                 },
                 availableTypes: {},
                 availableGroups: [],
@@ -151,5 +158,77 @@ describe('src/module/sw-product-stream/component/sw-product-stream-filter', () =
         await wrapper.vm.$nextTick();
 
         expect(wrapper.vm.fields).toEqual(['json.test']);
+    });
+
+    it('should set default value to 100 when selecting cheapestPrice.percentage field', async () => {
+        const wrapper = await createWrapper(['product_stream.editor']);
+
+        await wrapper.setProps({
+            condition: {
+                field: null,
+                type: null,
+                value: null,
+                parameters: null,
+            },
+        });
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.updateFields({ field: 'cheapestPrice.percentage', index: 0 });
+
+        expect(wrapper.vm.actualCondition.value).toBe('100');
+    });
+
+    it('should set default value to 100 for cheapestPrice.percentage with non-range type', async () => {
+        const wrapper = await createWrapper(['product_stream.editor']);
+
+        await wrapper.setProps({
+            condition: {
+                field: 'cheapestPrice.percentage',
+                type: null,
+                value: null,
+                parameters: null,
+            },
+        });
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.changeType({ type: 'equals', parameters: null });
+
+        expect(wrapper.vm.actualCondition.value).toBe('100');
+    });
+
+    it('should set default parameters to 100 for cheapestPrice.percentage with range type', async () => {
+        const wrapper = await createWrapper(['product_stream.editor']);
+
+        await wrapper.setProps({
+            condition: {
+                field: 'cheapestPrice.percentage',
+                type: null,
+                value: null,
+                parameters: null,
+            },
+        });
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.changeType({ type: 'range', parameters: { gte: null, lte: null } });
+
+        expect(wrapper.vm.actualCondition.parameters).toEqual({ gte: 100, lte: 100 });
+    });
+
+    it('should not set default value for non-percentage fields', async () => {
+        const wrapper = await createWrapper(['product_stream.editor']);
+
+        await wrapper.setProps({
+            condition: {
+                field: null,
+                type: null,
+                value: null,
+                parameters: null,
+            },
+        });
+        await wrapper.vm.$nextTick();
+
+        wrapper.vm.updateFields({ field: 'cheapestPrice', index: 0 });
+
+        expect(wrapper.vm.actualCondition.value).toBeNull();
     });
 });

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilder.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilder.php
@@ -125,12 +125,7 @@ class CheapestPriceAccessorBuilder implements FieldAccessorBuilderInterface
             );
         }
 
-        $coalesceArguments = implode(',', $select);
-        if ($isPercentageAccessor) {
-            $coalesceArguments .= ', 0';
-        }
-
-        return \sprintf('COALESCE(%s)', $coalesceArguments);
+        return \sprintf('COALESCE(%s)', implode(',', $select));
     }
 
     private function useCashRounding(Context $context): bool

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilder.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilder.php
@@ -125,7 +125,16 @@ class CheapestPriceAccessorBuilder implements FieldAccessorBuilderInterface
             );
         }
 
-        return \sprintf('COALESCE(%s)', implode(',', $select));
+        $result = \sprintf('COALESCE(%s)', implode(',', $select));
+
+        // The DB stores the discount percentage (e.g. 25 for "25% off"), but the API
+        // exposes the price-to-list-price ratio (e.g. 75 for "pay 75% of list price").
+        // Invert here so filters/sorts operate on the intuitive ratio scale.
+        if ($isPercentageAccessor) {
+            return \sprintf('(100 - %s)', $result);
+        }
+
+        return $result;
     }
 
     private function useCashRounding(Context $context): bool

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilder.php
@@ -52,7 +52,8 @@ class PriceFieldAccessorBuilder implements FieldAccessorBuilderInterface
             array_pop($parts);
         }
 
-        if (array_last($parts) === 'percentage') {
+        $isPercentageAccessor = array_last($parts) === 'percentage';
+        if ($isPercentageAccessor) {
             $jsonAccessor = 'percentage.' . $jsonAccessor;
             array_pop($parts);
         }
@@ -124,7 +125,16 @@ class PriceFieldAccessorBuilder implements FieldAccessorBuilderInterface
             $template = str_replace(array_keys($variables), array_values($variables), '(ROUND(#accessor# * #multiplier#, 0) / #multiplier#)');
         }
 
-        return \sprintf($template, implode(',', $select));
+        $result = \sprintf($template, implode(',', $select));
+
+        // The DB stores the discount percentage (e.g. 25 for "25% off"), but the API
+        // exposes the price-to-list-price ratio (e.g. 75 for "pay 75% of list price").
+        // Invert here so filters/sorts operate on the intuitive ratio scale.
+        if ($isPercentageAccessor) {
+            return \sprintf('(100 - %s)', $result);
+        }
+
+        return $result;
     }
 
     private function useCashRounding(Context $context): bool

--- a/src/Elasticsearch/Framework/Indexing/Scripts/cheapest_price_percentage.groovy
+++ b/src/Elasticsearch/Framework/Indexing/Scripts/cheapest_price_percentage.groovy
@@ -1,14 +1,14 @@
-double getPercentage(def accessors, def doc) {
+double getRatio(def accessors, def doc) {
     for (accessor in accessors) {
         def key = accessor['key'];
         if (!doc.containsKey(key) || doc[key].empty) {
             continue;
         }
 
-        return (double) doc[key].value;
+        return 100 - (double) doc[key].value;
     }
 
     return 0;
 }
 
-return getPercentage(params['accessors'], doc);
+return getRatio(params['accessors'], doc);

--- a/src/Elasticsearch/Framework/Indexing/Scripts/cheapest_price_percentage_filter.groovy
+++ b/src/Elasticsearch/Framework/Indexing/Scripts/cheapest_price_percentage_filter.groovy
@@ -21,23 +21,23 @@ if (percentageKey == '') {
     return false;
 }
 
-def percentage = (double) doc[percentageKey].value;
+def ratio = 100 - (double) doc[percentageKey].value;
 
 def match = true;
 if (params.containsKey('eq')) {
-    match = match && percentage == params['eq'];
+    match = match && ratio == params['eq'];
 }
 if (params.containsKey('gte')) {
-    match = match && percentage >= params['gte'];
+    match = match && ratio >= params['gte'];
 }
 if (params.containsKey('gt')) {
-    match = match && percentage > params['gt'];
+    match = match && ratio > params['gt'];
 }
 if (params.containsKey('lte')) {
-    match = match && percentage <= params['lte'];
+    match = match && ratio <= params['lte'];
 }
 if (params.containsKey('lt')) {
-    match = match && percentage < params['lt'];
+    match = match && ratio < params['lt'];
 }
 
 return match;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
@@ -666,11 +666,11 @@ class CheapestPriceTest extends TestCase
      */
     public function providerFilterPercentage(): iterable
     {
-        yield 'Test 10% filter without rule' => ['from' => 9, 'to' => 10, 'expected' => ['p.1', 'v.4.2']];
-        yield 'Test 20% filter with rule-a' => ['rules' => ['rule-a'], 'from' => 19, 'to' => 20, 'expected' => ['p.5', 'v.6.1']];
-        yield 'Test 30% filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 29, 'to' => 30, 'expected' => ['v.12.2', 'v.13.2']];
-        yield 'Test 30% filter with rule b+a' => ['rules' => ['rule-b'], 'from' => 29, 'to' => 30, 'expected' => ['v.12.2', 'v.13.2']];
-        yield 'Test 30% filter with rule a and empty result' => ['rules' => ['rule-a'], 'from' => 29, 'to' => 30, 'expected' => []];
+        yield 'Test ~91% ratio without rule' => ['from' => 90, 'to' => 91, 'expected' => ['p.1', 'v.4.2']];
+        yield 'Test ~80% ratio with rule-a' => ['rules' => ['rule-a'], 'from' => 80, 'to' => 81, 'expected' => ['p.5', 'v.6.1']];
+        yield 'Test ~70% ratio with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 70, 'to' => 71, 'expected' => ['v.12.2', 'v.13.2']];
+        yield 'Test ~70% ratio with rule b only' => ['rules' => ['rule-b'], 'from' => 70, 'to' => 71, 'expected' => ['v.12.2', 'v.13.2']];
+        yield 'Test ~70% ratio with rule a and empty result' => ['rules' => ['rule-a'], 'from' => 70, 'to' => 71, 'expected' => []];
     }
 
     /**

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPricePercentageFilterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPricePercentageFilterTest.php
@@ -1,0 +1,216 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Product\DataAbstractionLayer;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class CheapestPricePercentageFilterTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private SalesChannelContext $salesChannelContext;
+
+    protected function setUp(): void
+    {
+        $this->salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)
+            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+    }
+
+    public function testProductWithoutListPriceIsExcludedByPercentageLessThan100(): void
+    {
+        $discountedId = Uuid::randomHex();
+        $noListPriceId = Uuid::randomHex();
+
+        $this->createProduct($discountedId, 90.0, 120.0);
+        $this->createProduct($noListPriceId, 90.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LT => 100]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($discountedId, $result->getIds());
+        static::assertNotContains($noListPriceId, $result->getIds());
+    }
+
+    public function testPercentageLessThan100IncludesAllProductsWithListPrice(): void
+    {
+        $heavilyDiscounted = Uuid::randomHex();
+        $slightlyDiscounted = Uuid::randomHex();
+        $noDiscount = Uuid::randomHex();
+        $noListPrice = Uuid::randomHex();
+
+        $this->createProduct($heavilyDiscounted, 50.0, 200.0);
+        $this->createProduct($slightlyDiscounted, 95.0, 100.0);
+        $this->createProduct($noDiscount, 100.0, 100.0);
+        $this->createProduct($noListPrice, 100.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LT => 100]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($heavilyDiscounted, $result->getIds());
+        static::assertContains($slightlyDiscounted, $result->getIds());
+        static::assertContains($noDiscount, $result->getIds(), 'percentage=0 is < 100, product with listPrice should match');
+        static::assertNotContains($noListPrice, $result->getIds(), 'product without list price must not match');
+    }
+
+    public function testPercentageGreaterThanZeroExcludesNonDiscountedProducts(): void
+    {
+        $discounted = Uuid::randomHex();
+        $noDiscount = Uuid::randomHex();
+        $noListPrice = Uuid::randomHex();
+
+        $this->createProduct($discounted, 90.0, 120.0);
+        $this->createProduct($noDiscount, 100.0, 100.0);
+        $this->createProduct($noListPrice, 100.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::GT => 0]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($discounted, $result->getIds());
+        static::assertNotContains($noDiscount, $result->getIds(), 'percentage=0 should not match GT 0');
+        static::assertNotContains($noListPrice, $result->getIds(), 'product without list price must not match');
+    }
+
+    public function testPercentageRangeFilterWithBothBounds(): void
+    {
+        $discount25 = Uuid::randomHex();
+        $discount50 = Uuid::randomHex();
+        $discount75 = Uuid::randomHex();
+        $noListPrice = Uuid::randomHex();
+
+        $this->createProduct($discount25, 75.0, 100.0);
+        $this->createProduct($discount50, 50.0, 100.0);
+        $this->createProduct($discount75, 25.0, 100.0);
+        $this->createProduct($noListPrice, 50.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [
+            RangeFilter::GTE => 25,
+            RangeFilter::LTE => 50,
+        ]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($discount25, $result->getIds(), 'percentage=25 should match GTE 25');
+        static::assertContains($discount50, $result->getIds(), 'percentage=50 should match LTE 50');
+        static::assertNotContains($discount75, $result->getIds(), 'percentage=75 should exceed upper bound');
+        static::assertNotContains($noListPrice, $result->getIds(), 'product without list price should be excluded');
+    }
+
+    public function testPercentageSortingExcludesNullValues(): void
+    {
+        $discountedId = Uuid::randomHex();
+        $noListPriceId = Uuid::randomHex();
+
+        $this->createProduct($discountedId, 80.0, 100.0);
+        $this->createProduct($noListPriceId, 80.0, null);
+
+        $criteria = new Criteria([$discountedId, $noListPriceId]);
+        $criteria->addSorting(new FieldSorting('product.cheapestPrice.percentage', FieldSorting::ASCENDING));
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LT => 100]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($discountedId, $result->getIds());
+        static::assertNotContains($noListPriceId, $result->getIds());
+    }
+
+    public function testPercentageEqualsZeroMatchesNonDiscountedWithListPrice(): void
+    {
+        $nonDiscounted = Uuid::randomHex();
+        $discounted = Uuid::randomHex();
+        $noListPrice = Uuid::randomHex();
+
+        $this->createProduct($nonDiscounted, 100.0, 100.0);
+        $this->createProduct($discounted, 90.0, 120.0);
+        $this->createProduct($noListPrice, 100.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('product.cheapestPrice.percentage', 0));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($nonDiscounted, $result->getIds(), 'Product with price=listPrice (percentage=0) should match');
+        static::assertNotContains($discounted, $result->getIds(), 'Discounted product should not match percentage=0');
+        static::assertNotContains($noListPrice, $result->getIds(), 'Product without list price should not match percentage=0');
+    }
+
+    public function testPriceFieldPercentageFilterExcludesProductsWithoutListPrice(): void
+    {
+        $discountedId = Uuid::randomHex();
+        $noListPriceId = Uuid::randomHex();
+
+        $this->createProduct($discountedId, 90.0, 120.0);
+        $this->createProduct($noListPriceId, 90.0, null);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new RangeFilter('product.price.percentage', [RangeFilter::LT => 100]));
+
+        $result = $this->searchIds($criteria);
+
+        static::assertContains($discountedId, $result->getIds());
+        static::assertNotContains($noListPriceId, $result->getIds());
+    }
+
+    private function searchIds(Criteria $criteria): IdSearchResult
+    {
+        return static::getContainer()->get('sales_channel.product.repository')
+            ->searchIds($criteria, $this->salesChannelContext);
+    }
+
+    private function createProduct(string $id, float $priceGross, ?float $listGross): void
+    {
+        $price = [
+            'currencyId' => Defaults::CURRENCY,
+            'gross' => $priceGross,
+            'net' => $priceGross,
+            'linked' => false,
+        ];
+
+        if ($listGross !== null) {
+            $price['listPrice'] = [
+                'gross' => $listGross,
+                'net' => $listGross,
+                'linked' => false,
+            ];
+        }
+
+        static::getContainer()->get('product.repository')->create([[
+            'id' => $id,
+            'productNumber' => $id,
+            'name' => 'Percentage test ' . $id,
+            'stock' => 10,
+            'active' => true,
+            'price' => [$price],
+            'tax' => ['name' => 'test', 'taxRate' => 19],
+            'manufacturer' => ['name' => 'test'],
+            'visibilities' => [
+                [
+                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'visibility' => 30,
+                ],
+            ],
+        ]], $this->salesChannelContext->getContext());
+    }
+}

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPricePercentageFilterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPricePercentageFilterTest.php
@@ -49,7 +49,7 @@ class CheapestPricePercentageFilterTest extends TestCase
         static::assertNotContains($noListPriceId, $result->getIds());
     }
 
-    public function testPercentageLessThan100IncludesAllProductsWithListPrice(): void
+    public function testPercentageLessThanOrEqual100IncludesAllProductsWithListPrice(): void
     {
         $heavilyDiscounted = Uuid::randomHex();
         $slightlyDiscounted = Uuid::randomHex();
@@ -62,17 +62,17 @@ class CheapestPricePercentageFilterTest extends TestCase
         $this->createProduct($noListPrice, 100.0, null);
 
         $criteria = new Criteria();
-        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LT => 100]));
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LTE => 100]));
 
         $result = $this->searchIds($criteria);
 
         static::assertContains($heavilyDiscounted, $result->getIds());
         static::assertContains($slightlyDiscounted, $result->getIds());
-        static::assertContains($noDiscount, $result->getIds(), 'percentage=0 is < 100, product with listPrice should match');
+        static::assertContains($noDiscount, $result->getIds(), 'percentage=100 should match LTE 100');
         static::assertNotContains($noListPrice, $result->getIds(), 'product without list price must not match');
     }
 
-    public function testPercentageGreaterThanZeroExcludesNonDiscountedProducts(): void
+    public function testPercentageLessThan100ExcludesNonDiscountedProducts(): void
     {
         $discounted = Uuid::randomHex();
         $noDiscount = Uuid::randomHex();
@@ -83,12 +83,12 @@ class CheapestPricePercentageFilterTest extends TestCase
         $this->createProduct($noListPrice, 100.0, null);
 
         $criteria = new Criteria();
-        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::GT => 0]));
+        $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [RangeFilter::LT => 100]));
 
         $result = $this->searchIds($criteria);
 
         static::assertContains($discounted, $result->getIds());
-        static::assertNotContains($noDiscount, $result->getIds(), 'percentage=0 should not match GT 0');
+        static::assertNotContains($noDiscount, $result->getIds(), 'percentage=100 should not match LT 100');
         static::assertNotContains($noListPrice, $result->getIds(), 'product without list price must not match');
     }
 
@@ -106,15 +106,15 @@ class CheapestPricePercentageFilterTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new RangeFilter('product.cheapestPrice.percentage', [
-            RangeFilter::GTE => 25,
-            RangeFilter::LTE => 50,
+            RangeFilter::GTE => 50,
+            RangeFilter::LTE => 75,
         ]));
 
         $result = $this->searchIds($criteria);
 
-        static::assertContains($discount25, $result->getIds(), 'percentage=25 should match GTE 25');
-        static::assertContains($discount50, $result->getIds(), 'percentage=50 should match LTE 50');
-        static::assertNotContains($discount75, $result->getIds(), 'percentage=75 should exceed upper bound');
+        static::assertContains($discount25, $result->getIds(), 'percentage=75 should match GTE 50');
+        static::assertContains($discount50, $result->getIds(), 'percentage=50 should match LTE 75');
+        static::assertNotContains($discount75, $result->getIds(), 'percentage=25 is below lower bound');
         static::assertNotContains($noListPrice, $result->getIds(), 'product without list price should be excluded');
     }
 
@@ -136,7 +136,7 @@ class CheapestPricePercentageFilterTest extends TestCase
         static::assertNotContains($noListPriceId, $result->getIds());
     }
 
-    public function testPercentageEqualsZeroMatchesNonDiscountedWithListPrice(): void
+    public function testPercentageEquals100MatchesNonDiscountedWithListPrice(): void
     {
         $nonDiscounted = Uuid::randomHex();
         $discounted = Uuid::randomHex();
@@ -147,13 +147,13 @@ class CheapestPricePercentageFilterTest extends TestCase
         $this->createProduct($noListPrice, 100.0, null);
 
         $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('product.cheapestPrice.percentage', 0));
+        $criteria->addFilter(new EqualsFilter('product.cheapestPrice.percentage', 100));
 
         $result = $this->searchIds($criteria);
 
-        static::assertContains($nonDiscounted, $result->getIds(), 'Product with price=listPrice (percentage=0) should match');
-        static::assertNotContains($discounted, $result->getIds(), 'Discounted product should not match percentage=0');
-        static::assertNotContains($noListPrice, $result->getIds(), 'Product without list price should not match percentage=0');
+        static::assertContains($nonDiscounted, $result->getIds(), 'Product with price=listPrice (percentage=100) should match');
+        static::assertNotContains($discounted, $result->getIds(), 'Discounted product should not match percentage=100');
+        static::assertNotContains($noListPrice, $result->getIds(), 'Product without list price should not match percentage=100');
     }
 
     public function testPriceFieldPercentageFilterExcludesProductsWithoutListPrice(): void

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -143,7 +143,7 @@ class ProductStreamUpdaterTest extends TestCase
                 'type' => 'range',
                 'field' => 'cheapestPrice.percentage',
                 'parameters' => [
-                    'lt' => 50,
+                    'gt' => 50,
                 ],
             ]],
         ];

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
@@ -49,6 +49,6 @@ class PriceFieldAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'price.percentage');
 
-        static::assertSame('(ROUND((ROUND(CAST((COALESCE((JSON_UNQUOTE(JSON_EXTRACT(`product`.`price`, "$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) + 0.0))) as DECIMAL(30, 20)), 2)) * 100, 0) / 100)', $sql);
+        static::assertSame('(100 - (ROUND((ROUND(CAST((COALESCE((JSON_UNQUOTE(JSON_EXTRACT(`product`.`price`, "$.cb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) + 0.0))) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
     }
 }

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -2170,7 +2170,7 @@ class ElasticsearchProductTest extends TestCase
 
                 if ($case['operator']) {
                     $operator = (string) $case['operator'];
-                    $percentage = (int) $case['percentage'];
+                    $percentage = (float) $case['percentage'];
 
                     $criteria->addFilter(
                         new RangeFilter('product.cheapestPrice.percentage', [
@@ -2195,47 +2195,47 @@ class ElasticsearchProductTest extends TestCase
     }
 
     /**
-     * @return \Generator<array{ids: array<string>, operator: RangeFilter::*|null, percentage: int|null, direction: FieldSorting::*}>
+     * @return \Generator<array{ids: array<string>, operator: RangeFilter::*|null, percentage: float|null, direction: FieldSorting::*}>
      */
     public function providerCheapestPricePercentageFilterAndSorting(): \Generator
     {
-        yield 'Test filter with greater than 50 percent price to list ratio sorted descending' => [
-            'ids' => ['product-1', 'product-4'],
-            'operator' => RangeFilter::GT,
-            'percentage' => 50,
-            'direction' => FieldSorting::DESCENDING,
-        ];
-
-        yield 'Test filter with greater than 50 percent price to list ratio sorted ascending' => [
-            'ids' => ['product-4', 'product-1'],
-            'operator' => RangeFilter::GT,
-            'percentage' => 50,
-            'direction' => FieldSorting::ASCENDING,
-        ];
-
-        yield 'Test filter with less than 50 percent price to list ratio sorted descending' => [
-            'ids' => ['product-2', 'product-5', 'product-3'],
-            'operator' => RangeFilter::LT,
-            'percentage' => 50,
-            'direction' => FieldSorting::DESCENDING,
-        ];
-
-        yield 'Test filter with less than 50 percent price to list ratio sorted ascending' => [
+        yield 'Test filter with greater than 50 percent ratio sorted descending' => [
             'ids' => ['product-3', 'product-5', 'product-2'],
+            'operator' => RangeFilter::GT,
+            'percentage' => 50,
+            'direction' => FieldSorting::DESCENDING,
+        ];
+
+        yield 'Test filter with greater than 50 percent ratio sorted ascending' => [
+            'ids' => ['product-2', 'product-5', 'product-3'],
+            'operator' => RangeFilter::GT,
+            'percentage' => 50,
+            'direction' => FieldSorting::ASCENDING,
+        ];
+
+        yield 'Test filter with less than 50 percent ratio sorted descending' => [
+            'ids' => ['product-4', 'product-1'],
+            'operator' => RangeFilter::LT,
+            'percentage' => 50,
+            'direction' => FieldSorting::DESCENDING,
+        ];
+
+        yield 'Test filter with less than 50 percent ratio sorted ascending' => [
+            'ids' => ['product-1', 'product-4'],
             'operator' => RangeFilter::LT,
             'percentage' => 50,
             'direction' => FieldSorting::ASCENDING,
         ];
 
-        yield 'Test percent price to list ratio sorted descending' => [
-            'ids' => ['product-1', 'product-4', 'product-2', 'product-5', 'product-7', 'product-6', 'product-3'],
+        yield 'Test percent ratio sorted descending' => [
+            'ids' => ['product-3', 'product-5', 'product-2', 'product-4', 'product-1', 'product-7', 'product-6'],
             'operator' => null,
             'percentage' => null,
             'direction' => FieldSorting::DESCENDING,
         ];
 
-        yield 'Test percent price to list ratio sorted ascending' => [
-            'ids' => ['product-3', 'product-6', 'product-7', 'product-5', 'product-2', 'product-4', 'product-1'],
+        yield 'Test percent ratio sorted ascending' => [
+            'ids' => ['product-6', 'product-7', 'product-1', 'product-4', 'product-2', 'product-5', 'product-3'],
             'operator' => null,
             'percentage' => null,
             'direction' => FieldSorting::ASCENDING,
@@ -2285,7 +2285,7 @@ class ElasticsearchProductTest extends TestCase
 
             static::assertInstanceOf(StatsResult::class, $aggregation);
             static::assertSame(0.0, $aggregation->getMin());
-            static::assertSame(66.67, $aggregation->getMax());
+            static::assertSame(100.0, $aggregation->getMax());
         } catch (\Exception $e) {
             $this->tearDown();
 

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
@@ -5,9 +5,11 @@ namespace Shopware\Tests\Unit\Core\Content\Product\DataAbstractionLayer\Cheapest
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceAccessorBuilder;
 use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceField;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
@@ -53,7 +55,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('(100 - COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100)))', $sql);
     }
 
     public function testWithPercentageAccessorWithRule(): void
@@ -67,7 +69,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('(100 - COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100)))', $sql);
     }
 
     public function testRuleLimit(): void
@@ -82,6 +84,76 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
+        static::assertSame('(100 - COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100)))', $sql);
+    }
+
+    public function testReturnsNullForNonCheapestPriceField(): void
+    {
+        $field = new StringField('name', 'name');
+        $context = Context::createDefaultContext();
+
+        static::assertNull($this->builder->buildAccessor('product', $field, $context, 'name'));
+    }
+
+    public function testPriceAccessorDoesNotInvert(): void
+    {
+        $priceField = new CheapestPriceField('cheapest_price_accessor', 'cheapest_price_accessor');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice');
+
+        static::assertNotNull($sql);
+        static::assertStringNotContainsString('100 -', $sql);
+    }
+
+    public function testListPriceAccessorDoesNotInvert(): void
+    {
+        $priceField = new CheapestPriceField('cheapest_price_accessor', 'cheapest_price_accessor');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.listPrice');
+
+        static::assertNotNull($sql);
+        static::assertStringNotContainsString('100 -', $sql);
+    }
+
+    public function testPercentageAccessorWithNetContext(): void
+    {
+        $priceField = new CheapestPriceField('cheapest_price_accessor', 'cheapest_price_accessor');
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_NET);
+
+        $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 -', $sql);
+        static::assertStringContainsString('percentage.net', $sql);
+        static::assertStringNotContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageAccessorWithExplicitGrossOverride(): void
+    {
+        $priceField = new CheapestPriceField('cheapest_price_accessor', 'cheapest_price_accessor');
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_NET);
+
+        $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage.gross');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 -', $sql);
+        static::assertStringContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageAccessorWithExplicitNetOverride(): void
+    {
+        $priceField = new CheapestPriceField('cheapest_price_accessor', 'cheapest_price_accessor');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage.net');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 -', $sql);
+        static::assertStringContainsString('percentage.net', $sql);
+        static::assertStringNotContainsString('percentage.gross', $sql);
     }
 }

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceAccessorBuilderTest.php
@@ -53,7 +53,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
     }
 
     public function testWithPercentageAccessorWithRule(): void
@@ -67,7 +67,7 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
     }
 
     public function testRuleLimit(): void
@@ -82,6 +82,6 @@ class CheapestPriceAccessorBuilderTest extends TestCase
 
         $sql = $this->builder->buildAccessor('product', $priceField, $context, 'cheapestPrice.percentage');
 
-        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100), 0)', $sql);
+        static::assertSame('COALESCE((ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.rule' . $ruleId . '.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100),(ROUND((ROUND(CAST((JSON_UNQUOTE(JSON_EXTRACT(`product`.`cheapest_price_accessor`, "$.ruledefault.currencyb7d2554b0ce847cd82f3ac9bd1c0dfca.percentage.gross")) * 1) as DECIMAL(30, 20)), 2)) * 100, 0) / 100))', $sql);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\PriceFieldAccessorBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+
+/**
+ * @internal
+ */
+#[CoversClass(PriceFieldAccessorBuilder::class)]
+class PriceFieldAccessorBuilderTest extends TestCase
+{
+    private PriceFieldAccessorBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $this->builder = new PriceFieldAccessorBuilder(
+            $this->createMock(Connection::class)
+        );
+    }
+
+    public function testReturnsNullForNonPriceField(): void
+    {
+        $field = new StringField('name', 'name');
+        $context = Context::createDefaultContext();
+
+        static::assertNull($this->builder->buildAccessor('product', $field, $context, 'name'));
+    }
+
+    public function testPriceAccessorDoesNotInvert(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price');
+
+        static::assertNotNull($sql);
+        static::assertStringNotContainsString('100 -', $sql);
+        static::assertStringContainsString('gross', $sql);
+    }
+
+    public function testListPriceAccessorDoesNotInvert(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.listPrice');
+
+        static::assertNotNull($sql);
+        static::assertStringNotContainsString('100 -', $sql);
+        static::assertStringContainsString('listPrice.gross', $sql);
+    }
+
+    public function testPercentageAccessorInvertsWithGrossContext(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.percentage');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 - ', $sql);
+        static::assertStringContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageAccessorInvertsWithNetContext(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_NET);
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.percentage');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 - ', $sql);
+        static::assertStringContainsString('percentage.net', $sql);
+        static::assertStringNotContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageWithExplicitGrossAccessor(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+        $context->setTaxState(CartPrice::TAX_STATE_NET);
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.percentage.gross');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 - ', $sql);
+        static::assertStringContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageWithExplicitNetAccessor(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.percentage.net');
+
+        static::assertNotNull($sql);
+        static::assertStringStartsWith('(100 - ', $sql);
+        static::assertStringContainsString('percentage.net', $sql);
+        static::assertStringNotContainsString('percentage.gross', $sql);
+    }
+
+    public function testPercentageAccessorUsesDefaultCurrency(): void
+    {
+        $field = new PriceField('price', 'price');
+        $context = Context::createDefaultContext();
+
+        $sql = $this->builder->buildAccessor('product', $field, $context, 'price.percentage');
+
+        static::assertNotNull($sql);
+        static::assertStringContainsString('$.c' . Defaults::CURRENCY . '.percentage.gross', $sql);
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -247,17 +247,17 @@ EOT,
                 'stats' => [
                     'script' => [
                         'source' => <<<EOT
-double getPercentage(def accessors, def doc) {
+double getRatio(def accessors, def doc) {
     for (accessor in accessors) {
         def key = accessor['key'];
         if (!doc.containsKey(key) || doc[key].empty) {
             continue;
         }\n
-        return (double) doc[key].value;
+        return 100 - (double) doc[key].value;
     }\n
     return 0;
 }\n
-return getPercentage(params['accessors'], doc);\n
+return getRatio(params['accessors'], doc);\n
 EOT,
                         'lang' => 'painless',
                         'params' => [
@@ -682,23 +682,23 @@ if (percentageKey == '') {
     return false;
 }
 
-def percentage = (double) doc[percentageKey].value;
+def ratio = 100 - (double) doc[percentageKey].value;
 
 def match = true;
 if (params.containsKey('eq')) {
-    match = match && percentage == params['eq'];
+    match = match && ratio == params['eq'];
 }
 if (params.containsKey('gte')) {
-    match = match && percentage >= params['gte'];
+    match = match && ratio >= params['gte'];
 }
 if (params.containsKey('gt')) {
-    match = match && percentage > params['gt'];
+    match = match && ratio > params['gt'];
 }
 if (params.containsKey('lte')) {
-    match = match && percentage <= params['lte'];
+    match = match && ratio <= params['lte'];
 }
 if (params.containsKey('lt')) {
-    match = match && percentage < params['lt'];
+    match = match && ratio < params['lt'];
 }
 
 return match;


### PR DESCRIPTION
### Actual behaviour

**Shopware version:** v6.7.5.0 (affected), v6.7.4.2 (working as expected)  
**Affected area / extension:** Dynamic Product Groups / Admin / Product Listing

### Description  
In Shopware v6.7.5.0, dynamic product groups no longer respect the condition **“Percentage ratio price/list price is less than 100”**, which is intended to filter and display only discounted products.

Instead of showing only reduced products, the dynamic product group incorrectly returns **all products**.  
In Shopware v6.7.4.2, the same configuration behaves correctly and only displays discounted items.

### Actual behaviour  
- In v6.7.5.0, the dynamic product group ignores the condition and returns **all products**, regardless of whether they are discounted or not.  
- The feature works correctly in v6.7.4.2.


### Expected behaviour

 A dynamic product group with the condition  **“Percentage ratio price/list price is less than 100”**  should return **only products with a reduced price** (i.e., where the actual price is lower than the list price).

### How to reproduce

1. Create a new dynamic product group in the administration.  
2. Add the condition:  
   **Price → Percentage ratio price/list price → is less than → 100**  
3. Save the dynamic product group.  
4. Check the product preview or assign the group to a product listing.  
5. Observe that:  
   - In **v6.7.5.0**, the group shows *all* products instead of only discounted ones.  
   - In **v6.7.4.2**, it works correctly and only shows reduced products.