### PR TITLE
fix: double clicking checkout confirm form (6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -238,8 +238,12 @@
         <form id="confirmOrderForm"
               action="{{ confirmOrderFormAction }}"
               data-form-preserver="true"
-              data-form-handler="true"
-              data-form-handler-options="{{ { formFieldSelector: null }|json_encode }}"
+              {% if feature('ACCESSIBILITY_TWEAKS') %}
+                  data-form-handler="true"
+                  data-form-handler-options="{{ { formFieldSelector: null }|json_encode }}"
+              {% else %}
+                  data-form-submit-loader="true"
+              {% endif %}
               data-form-add-history="true"
               data-form-add-history-options="{{ formAddHistoryOptions|json_encode }}"
               method="post">


### PR DESCRIPTION
### 1. Why is this change necessary?
As a regression from a backport of #13999 , the `form-submit-loader` plugin was removed from the checkout confirm page and replace by the form-handler. This form-handler does not exist if `ACCESSIBILITY_TWEAKS` is disabled.

### 2. What does this change do, exactly?
Bringing back the `form-submit-loader` if `ACCESSIBILITY_TWEAKS` is disabled.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #15268

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
