### PR TITLE
fix: align flow names with event names

### DIFF
--- a/src/Core/Migration/V6_7/Migration1773647849AlignFlowNameWithEventName.php
+++ b/src/Core/Migration/V6_7/Migration1773647849AlignFlowNameWithEventName.php
@@ -36,36 +36,13 @@ class Migration1773647849AlignFlowNameWithEventName extends MigrationStep
     public function update(Connection $connection): void
     {
         foreach (self::FLOW_TRANSLATION_MAPPING as $eventName => $data) {
-            $this->updateFlowName($connection, $eventName, $data);
+            $connection->update(
+                'flow',
+                ['name' => $data['new']],
+                ['event_name' => $eventName, 'name' => $data['old']]
+            );
         }
 
         $this->registerIndexer($connection, 'flow.indexer');
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    private function updateFlowName(Connection $connection, string $eventName, array $data): void
-    {
-        $flowId = $connection->createQueryBuilder()->select('id')
-            ->from('flow')
-            ->where('name = :name')
-            ->andWhere('event_name = :eventName')
-            ->setParameters([
-                'name' => $data['old'],
-                'eventName' => $eventName,
-            ])
-            ->executeQuery()
-            ->fetchOne();
-
-        if (!$flowId) {
-            return;
-        }
-
-        $connection->update(
-            'flow',
-            ['name' => $data['new']],
-            ['id' => $flowId]
-        );
     }
 }

--- a/src/Core/Migration/V6_7/Migration1773647849AlignFlowNameWithEventName.php
+++ b/src/Core/Migration/V6_7/Migration1773647849AlignFlowNameWithEventName.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\V6_5\Migration1689257577AddMissingTransactionMailFlow;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class Migration1773647849AlignFlowNameWithEventName extends MigrationStep
+{
+    final public const FLOW_TRANSLATION_MAPPING = [
+        'state_enter.order_transaction.state.authorized' => [
+            'old' => Migration1689257577AddMissingTransactionMailFlow::AUTHORIZED_FLOW,
+            'new' => 'Payment enters status authorized',
+        ],
+        'state_enter.order_transaction.state.chargeback' => [
+            'old' => Migration1689257577AddMissingTransactionMailFlow::CHARGEBACK_FLOW,
+            'new' => 'Payment enters status chargeback',
+        ],
+        'state_enter.order_transaction.state.unconfirmed' => [
+            'old' => Migration1689257577AddMissingTransactionMailFlow::UNCONFIRMED_FLOW,
+            'new' => 'Payment enters status unconfirmed',
+        ],
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1773647849;
+    }
+
+    public function update(Connection $connection): void
+    {
+        foreach (self::FLOW_TRANSLATION_MAPPING as $eventName => $data) {
+            $this->updateFlowName($connection, $eventName, $data);
+        }
+
+        $this->registerIndexer($connection, 'flow.indexer');
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function updateFlowName(Connection $connection, string $eventName, array $data): void
+    {
+        $flowId = $connection->createQueryBuilder()->select('id')
+            ->from('flow')
+            ->where('name = :name')
+            ->andWhere('event_name = :eventName')
+            ->setParameters([
+                'name' => $data['old'],
+                'eventName' => $eventName,
+            ])
+            ->executeQuery()
+            ->fetchOne();
+
+        if (!$flowId) {
+            return;
+        }
+
+        $connection->update(
+            'flow',
+            ['name' => $data['new']],
+            ['id' => $flowId]
+        );
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1773647849AlignFlowNameWithEventNameTest.php
+++ b/tests/migration/Core/V6_7/Migration1773647849AlignFlowNameWithEventNameTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1773647849AlignFlowNameWithEventName;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1773647849AlignFlowNameWithEventName::class)]
+class Migration1773647849AlignFlowNameWithEventNameTest extends TestCase
+{
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+    public function testAlignFlowNameWithEventName(): void
+    {
+        $flowIds = [];
+
+        foreach (Migration1773647849AlignFlowNameWithEventName::FLOW_TRANSLATION_MAPPING as $eventName => $data) {
+            $flowId = $this->connection->fetchOne(
+                'SELECT id FROM flow WHERE event_name = :eventName',
+                ['eventName' => $eventName]
+            );
+
+            if (!$flowId) {
+                continue;
+            }
+
+            $this->connection->update(
+                'flow',
+                ['name' => $data['old']],
+                ['id' => $flowId]
+            );
+
+            $flowIds[$eventName] = $flowId;
+        }
+
+        static::assertCount(
+            \count(Migration1773647849AlignFlowNameWithEventName::FLOW_TRANSLATION_MAPPING),
+            $flowIds
+        );
+
+        $migration = new Migration1773647849AlignFlowNameWithEventName();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        foreach (Migration1773647849AlignFlowNameWithEventName::FLOW_TRANSLATION_MAPPING as $eventName => $data) {
+            static::assertArrayHasKey($eventName, $flowIds);
+
+            $name = $this->connection->fetchOne(
+                'SELECT name FROM flow WHERE id = :id',
+                ['id' => $flowIds[$eventName]]
+            );
+
+            static::assertSame($data['new'], $name);
+        }
+    }
+}


### PR DESCRIPTION
resolves https://github.com/shopware/shopware/issues/13150

### Changes

- "Order enters status authorized" => "Payment enters status authorized"
- "Order enters status chargeback" => "Payment enters status chargeback"
- "Order enters status unconfirmed" => "Payment enters status unconfirmed"