### PR TITLE
fix: endless redirect loop when product SEO URL contains query parameters

### DIFF
--- a/src/Core/Content/Seo/AbstractSeoResolver.php
+++ b/src/Core/Content/Seo/AbstractSeoResolver.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Content\Seo;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-type ResolvedSeoUrl = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string}
+ * @phpstan-type ResolvedSeoUrlArray = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string, seoPathInfo?: string}
  */
 #[Package('inventory')]
 abstract class AbstractSeoResolver
@@ -13,7 +13,29 @@ abstract class AbstractSeoResolver
     abstract public function getDecorated(): AbstractSeoResolver;
 
     /**
-     * @return ResolvedSeoUrl
+     * @deprecated tag:v6.8.0 - will be removed in v6.8.0, use {@see resolveUrl()} instead
+     *
+     * @return ResolvedSeoUrlArray
      */
     abstract public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array;
+
+    /**
+     * Default implementation delegates to {@see resolve()} for backward compatibility with existing
+     * decorators that only override resolve(). Subclasses should override this method directly to
+     * benefit from query-string-aware resolution.
+     *
+     * In v6.8.0 this method becomes abstract and {@see resolve()} will be removed.
+     */
+    public function resolveUrl(SeoUrlRequestContext $context): ResolvedSeoUrl
+    {
+        $data = $this->resolve($context->languageId, $context->salesChannelId, $context->pathInfo);
+
+        return new ResolvedSeoUrl(
+            pathInfo: $data['pathInfo'],
+            isCanonical: (bool) $data['isCanonical'],
+            id: $data['id'] ?? null,
+            canonicalPathInfo: $data['canonicalPathInfo'] ?? null,
+            seoPathInfo: $data['seoPathInfo'] ?? null,
+        );
+    }
 }

--- a/src/Core/Content/Seo/AbstractSeoResolver.php
+++ b/src/Core/Content/Seo/AbstractSeoResolver.php
@@ -2,10 +2,11 @@
 
 namespace Shopware\Core\Content\Seo;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-type ResolvedSeoUrl = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string}
+ * @phpstan-type ResolvedSeoUrl = array{id?: string, pathInfo: string, isCanonical: bool|string, canonicalPathInfo?: string, seoPathInfo?: string}
  */
 #[Package('inventory')]
 abstract class AbstractSeoResolver
@@ -16,4 +17,19 @@ abstract class AbstractSeoResolver
      * @return ResolvedSeoUrl
      */
     abstract public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array;
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:becomes-abstract - will become abstract in v6.8.0
+     *
+     * @return ResolvedSeoUrl
+     */
+    public function resolveWithQueryString(string $languageId, string $salesChannelId, string $pathInfo, ?string $queryString): array
+    {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
+        );
+
+        return $this->resolve($languageId, $salesChannelId, $pathInfo);
+    }
 }

--- a/src/Core/Content/Seo/EmptyPathInfoResolver.php
+++ b/src/Core/Content/Seo/EmptyPathInfoResolver.php
@@ -2,10 +2,11 @@
 
 namespace Shopware\Core\Content\Seo;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @phpstan-import-type ResolvedSeoUrl from AbstractSeoResolver
+ * @phpstan-import-type ResolvedSeoUrlArray from AbstractSeoResolver
  */
 #[Package('inventory')]
 class EmptyPathInfoResolver extends AbstractSeoResolver
@@ -23,15 +24,50 @@ class EmptyPathInfoResolver extends AbstractSeoResolver
     }
 
     /**
-     * @return ResolvedSeoUrl
+     * @deprecated tag:v6.8.0 - will be removed in v6.8.0, use {@see resolveUrl()} instead
+     *
+     * @return ResolvedSeoUrlArray
      */
     public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
     {
-        $seoPathInfo = ltrim($pathInfo, '/');
-        if ($seoPathInfo === '') {
-            return ['pathInfo' => '/', 'isCanonical' => false];
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', self::class . '::resolveUrl()')
+        );
+
+        $resolved = $this->resolveUrl(new SeoUrlRequestContext(
+            languageId: $languageId,
+            salesChannelId: $salesChannelId,
+            pathInfo: $pathInfo,
+        ));
+
+        $data = [
+            'pathInfo' => $resolved->pathInfo,
+            'isCanonical' => $resolved->isCanonical,
+        ];
+
+        if ($resolved->id !== null) {
+            $data['id'] = $resolved->id;
         }
 
-        return $this->getDecorated()->resolve($languageId, $salesChannelId, $pathInfo);
+        if ($resolved->canonicalPathInfo !== null) {
+            $data['canonicalPathInfo'] = $resolved->canonicalPathInfo;
+        }
+
+        if ($resolved->seoPathInfo !== null) {
+            $data['seoPathInfo'] = $resolved->seoPathInfo;
+        }
+
+        return $data;
+    }
+
+    public function resolveUrl(SeoUrlRequestContext $context): ResolvedSeoUrl
+    {
+        $seoPathInfo = ltrim($context->pathInfo, '/');
+        if ($seoPathInfo === '') {
+            return new ResolvedSeoUrl(pathInfo: '/', isCanonical: false);
+        }
+
+        return $this->getDecorated()->resolveUrl($context);
     }
 }

--- a/src/Core/Content/Seo/EmptyPathInfoResolver.php
+++ b/src/Core/Content/Seo/EmptyPathInfoResolver.php
@@ -27,11 +27,19 @@ class EmptyPathInfoResolver extends AbstractSeoResolver
      */
     public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
     {
+        return $this->resolveWithQueryString($languageId, $salesChannelId, $pathInfo, null);
+    }
+
+    /**
+     * @return ResolvedSeoUrl
+     */
+    public function resolveWithQueryString(string $languageId, string $salesChannelId, string $pathInfo, ?string $queryString): array
+    {
         $seoPathInfo = ltrim($pathInfo, '/');
         if ($seoPathInfo === '') {
             return ['pathInfo' => '/', 'isCanonical' => false];
         }
 
-        return $this->getDecorated()->resolve($languageId, $salesChannelId, $pathInfo);
+        return $this->getDecorated()->resolveWithQueryString($languageId, $salesChannelId, $pathInfo, $queryString);
     }
 }

--- a/src/Core/Content/Seo/ResolvedSeoUrl.php
+++ b/src/Core/Content/Seo/ResolvedSeoUrl.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('inventory')]
+final readonly class ResolvedSeoUrl
+{
+    public function __construct(
+        public string $pathInfo,
+        public bool $isCanonical,
+        public ?string $id = null,
+        public ?string $canonicalPathInfo = null,
+        public ?string $seoPathInfo = null,
+    ) {
+    }
+}

--- a/src/Core/Content/Seo/SeoResolver.php
+++ b/src/Core/Content/Seo/SeoResolver.php
@@ -4,12 +4,14 @@ namespace Shopware\Core\Content\Seo;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @phpstan-import-type ResolvedSeoUrl from AbstractSeoResolver
+ * @phpstan-import-type ResolvedSeoUrlArray from AbstractSeoResolver
  */
 #[Package('inventory')]
 class SeoResolver extends AbstractSeoResolver
@@ -27,33 +29,83 @@ class SeoResolver extends AbstractSeoResolver
     }
 
     /**
-     * @return ResolvedSeoUrl
+     * @deprecated tag:v6.8.0 - will be removed in v6.8.0, use {@see resolveUrl()} instead
+     *
+     * @return ResolvedSeoUrlArray
      */
     public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
     {
-        $seoPathInfo = trim($pathInfo, '/');
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', self::class . '::resolveUrl()')
+        );
+
+        $resolved = $this->resolveUrl(new SeoUrlRequestContext($languageId, $salesChannelId, $pathInfo));
+
+        $data = [
+            'pathInfo' => $resolved->pathInfo,
+            'isCanonical' => $resolved->isCanonical,
+        ];
+
+        if ($resolved->id !== null) {
+            $data['id'] = $resolved->id;
+        }
+
+        if ($resolved->canonicalPathInfo !== null) {
+            $data['canonicalPathInfo'] = $resolved->canonicalPathInfo;
+        }
+
+        if ($resolved->seoPathInfo !== null) {
+            $data['seoPathInfo'] = $resolved->seoPathInfo;
+        }
+
+        return $data;
+    }
+
+    public function resolveUrl(SeoUrlRequestContext $context): ResolvedSeoUrl
+    {
+        $seoPathInfo = trim($context->pathInfo, '/');
+        $normalizedQueryString = $this->normalizeQueryString($context->queryString);
 
         $query = (new QueryBuilder($this->connection))
-            ->select('id', 'path_info pathInfo', 'is_canonical isCanonical', 'sales_channel_id salesChannelId')
+            ->select('id', 'path_info pathInfo', 'seo_path_info seoPathInfo', 'is_canonical isCanonical', 'sales_channel_id salesChannelId')
             ->from('seo_url')
             ->where('language_id = :language_id')
             ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)')
-            ->andWhere('(seo_path_info = :seoPath OR seo_path_info = :seoPathWithSlash)')
-            ->andWhere('seo_url.is_deleted = 0')
-            ->setParameter('language_id', Uuid::fromHexToBytes($languageId))
-            ->setParameter('sales_channel_id', Uuid::fromHexToBytes($salesChannelId))
+            ->andWhere('seo_url.is_deleted = 0');
+
+        $seoPathConditions = [
+            'seo_path_info = :seoPath',
+            'seo_path_info = :seoPathWithSlash',
+        ];
+
+        $query->setParameter('language_id', Uuid::fromHexToBytes($context->languageId))
+            ->setParameter('sales_channel_id', Uuid::fromHexToBytes($context->salesChannelId))
             ->setParameter('seoPath', $seoPathInfo)
             ->setParameter('seoPathWithSlash', $seoPathInfo . '/');
 
+        $queryCandidates = array_values(array_unique(array_filter(
+            [$normalizedQueryString, $context->queryString],
+            static fn (?string $query): bool => $query !== null && $query !== ''
+        )));
+
+        foreach ($queryCandidates as $index => $candidate) {
+            $seoPathConditions[] = "seo_path_info = :seoPathWithQuery{$index}";
+            $seoPathConditions[] = "seo_path_info = :seoPathWithSlashAndQuery{$index}";
+            $query->setParameter("seoPathWithQuery{$index}", $seoPathInfo . '?' . $candidate)
+                ->setParameter("seoPathWithSlashAndQuery{$index}", $seoPathInfo . '/?' . $candidate);
+        }
+
+        $query->andWhere('(' . implode(' OR ', $seoPathConditions) . ')');
         $query->setTitle('seo-url::resolve');
 
         $seoPaths = $query->executeQuery()->fetchAllAssociative();
 
-        // sort seoPaths by filled salesChannelId and isCanonical, save file sort on SQL server
-        usort($seoPaths, static function ($a, $b) {
+        usort($seoPaths, function ($a, $b) use ($normalizedQueryString) {
             if ($a['isCanonical'] === null) {
                 return 1;
             }
+
             if ($b['isCanonical'] === null) {
                 return -1;
             }
@@ -61,14 +113,30 @@ class SeoResolver extends AbstractSeoResolver
             if ($a['salesChannelId'] === null) {
                 return 1;
             }
+
             if ($b['salesChannelId'] === null) {
                 return -1;
+            }
+
+            if ($normalizedQueryString !== null) {
+                $aMatches = $this->storedQueryMatches($a['seoPathInfo'] ?? null, $normalizedQueryString);
+                $bMatches = $this->storedQueryMatches($b['seoPathInfo'] ?? null, $normalizedQueryString);
+                if ($aMatches !== $bMatches) {
+                    return $aMatches ? -1 : 1;
+                }
             }
 
             return 0;
         });
 
-        $seoPath = $seoPaths[0] ?? ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+        $seoPath = ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+
+        foreach ($seoPaths as $path) {
+            $seoPath = $path;
+            if ($path['isCanonical']) {
+                break;
+            }
+        }
 
         if (!$seoPath['isCanonical']) {
             $query = (new QueryBuilder($this->connection))
@@ -80,8 +148,8 @@ class SeoResolver extends AbstractSeoResolver
                 ->andWhere('is_canonical = 1')
                 ->andWhere('is_deleted = 0')
                 ->setMaxResults(1)
-                ->setParameter('language_id', Uuid::fromHexToBytes($languageId))
-                ->setParameter('sales_channel_id', Uuid::fromHexToBytes($salesChannelId))
+                ->setParameter('language_id', Uuid::fromHexToBytes($context->languageId))
+                ->setParameter('sales_channel_id', Uuid::fromHexToBytes($context->salesChannelId))
                 ->setParameter('pathInfo', '/' . ltrim((string) $seoPath['pathInfo'], '/'));
 
             $query->setTitle('seo-url::resolve-fallback');
@@ -100,6 +168,33 @@ class SeoResolver extends AbstractSeoResolver
 
         $seoPath['pathInfo'] = '/' . ltrim((string) $seoPath['pathInfo'], '/');
 
-        return $seoPath;
+        return new ResolvedSeoUrl(
+            pathInfo: $seoPath['pathInfo'],
+            isCanonical: (bool) $seoPath['isCanonical'],
+            id: $seoPath['id'] ?? null,
+            canonicalPathInfo: $seoPath['canonicalPathInfo'] ?? null,
+            seoPathInfo: $seoPath['seoPathInfo'] ?? null,
+        );
+    }
+
+    private function normalizeQueryString(?string $queryString): ?string
+    {
+        $normalizedQueryString = Request::normalizeQueryString($queryString);
+
+        return $normalizedQueryString === '' ? null : $normalizedQueryString;
+    }
+
+    private function storedQueryMatches(mixed $storedSeoPathInfo, string $normalizedQueryString): bool
+    {
+        if (!\is_string($storedSeoPathInfo)) {
+            return false;
+        }
+
+        $storedQuery = parse_url($storedSeoPathInfo, \PHP_URL_QUERY);
+        if (!\is_string($storedQuery)) {
+            return false;
+        }
+
+        return $this->normalizeQueryString($storedQuery) === $normalizedQueryString;
     }
 }

--- a/src/Core/Content/Seo/SeoResolver.php
+++ b/src/Core/Content/Seo/SeoResolver.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @phpstan-import-type ResolvedSeoUrl from AbstractSeoResolver
@@ -31,28 +32,80 @@ class SeoResolver extends AbstractSeoResolver
      */
     public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
     {
+        return $this->resolveWithQueryString($languageId, $salesChannelId, $pathInfo, null);
+    }
+
+    /**
+     * @return ResolvedSeoUrl
+     */
+    public function resolveWithQueryString(string $languageId, string $salesChannelId, string $pathInfo, ?string $queryString): array
+    {
         $seoPathInfo = trim($pathInfo, '/');
+        $normalizedQueryString = self::normalizeQueryString($queryString);
 
         $query = (new QueryBuilder($this->connection))
-            ->select('id', 'path_info pathInfo', 'is_canonical isCanonical', 'sales_channel_id salesChannelId')
+            ->select('id', 'path_info pathInfo', 'seo_path_info seoPathInfo', 'is_canonical isCanonical', 'sales_channel_id salesChannelId')
             ->from('seo_url')
             ->where('language_id = :language_id')
-            ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)')
-            ->andWhere('(seo_path_info = :seoPath OR seo_path_info = :seoPathWithSlash)')
-            ->setParameter('language_id', Uuid::fromHexToBytes($languageId))
+            ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)');
+
+        $seoPathConditions = [
+            'seo_path_info = :seoPath',
+            'seo_path_info = :seoPathWithSlash',
+        ];
+
+        $query->setParameter('language_id', Uuid::fromHexToBytes($languageId))
             ->setParameter('sales_channel_id', Uuid::fromHexToBytes($salesChannelId))
             ->setParameter('seoPath', $seoPathInfo)
             ->setParameter('seoPathWithSlash', $seoPathInfo . '/');
 
+        if ($normalizedQueryString !== null) {
+            $seoPathConditions[] = 'seo_path_info = :seoPathWithQuery';
+            $seoPathConditions[] = 'seo_path_info = :seoPathWithSlashAndQuery';
+            $seoPathConditions[] = 'seo_path_info LIKE :seoPathLikeQuery';
+            $seoPathConditions[] = 'seo_path_info LIKE :seoPathWithSlashLikeQuery';
+            $query->setParameter('seoPathWithQuery', $seoPathInfo . '?' . $normalizedQueryString)
+                ->setParameter('seoPathWithSlashAndQuery', $seoPathInfo . '/?' . $normalizedQueryString)
+                ->setParameter('seoPathLikeQuery', $seoPathInfo . '?%')
+                ->setParameter('seoPathWithSlashLikeQuery', $seoPathInfo . '/?%');
+        }
+
+        $query->andWhere('(' . implode(' OR ', $seoPathConditions) . ')');
+
         $query->setTitle('seo-url::resolve');
 
         $seoPaths = $query->executeQuery()->fetchAllAssociative();
+        $requestQueryParams = null;
+        if ($normalizedQueryString !== null) {
+            $requestQueryParams = self::parseQueryParameters($normalizedQueryString);
 
-        // sort seoPaths by filled salesChannelId and isCanonical, save file sort on SQL server
-        usort($seoPaths, static function ($a, $b) {
+            $seoPaths = array_values(array_filter($seoPaths, static function (array $seoPath) use ($seoPathInfo, $normalizedQueryString, $requestQueryParams): bool {
+                [$priority] = self::calculateQueryMatch($seoPathInfo, $normalizedQueryString, $requestQueryParams, (string) ($seoPath['seoPathInfo'] ?? ''));
+
+                return $priority > 0;
+            }));
+        }
+
+        // Prefer exact query-string matches first, then controlled query fallback matches,
+        // then plain path matches. Afterwards sort by canonical and sales-channel specificity.
+        usort($seoPaths, static function ($a, $b) use ($seoPathInfo, $normalizedQueryString, $requestQueryParams) {
+            if ($normalizedQueryString !== null && $requestQueryParams !== null) {
+                [$aPriority, $aSpecificity] = self::calculateQueryMatch($seoPathInfo, $normalizedQueryString, $requestQueryParams, (string) ($a['seoPathInfo'] ?? ''));
+                [$bPriority, $bSpecificity] = self::calculateQueryMatch($seoPathInfo, $normalizedQueryString, $requestQueryParams, (string) ($b['seoPathInfo'] ?? ''));
+
+                if ($aPriority !== $bPriority) {
+                    return $bPriority <=> $aPriority;
+                }
+
+                if ($aSpecificity !== $bSpecificity) {
+                    return $bSpecificity <=> $aSpecificity;
+                }
+            }
+
             if ($a['isCanonical'] === null) {
                 return 1;
             }
+
             if ($b['isCanonical'] === null) {
                 return -1;
             }
@@ -60,6 +113,7 @@ class SeoResolver extends AbstractSeoResolver
             if ($a['salesChannelId'] === null) {
                 return 1;
             }
+
             if ($b['salesChannelId'] === null) {
                 return -1;
             }
@@ -67,7 +121,23 @@ class SeoResolver extends AbstractSeoResolver
             return 0;
         });
 
-        $seoPath = $seoPaths[0] ?? ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+        $seoPath = ['pathInfo' => $seoPathInfo, 'isCanonical' => false];
+
+        foreach ($seoPaths as $path) {
+            $seoPath = $path;
+            if ($path['isCanonical']) {
+                break;
+            }
+        }
+
+        if ($normalizedQueryString !== null && $seoPath['isCanonical'] && isset($seoPath['seoPathInfo']) && \is_string($seoPath['seoPathInfo'])) {
+            $storedQueryString = parse_url($seoPath['seoPathInfo'], \PHP_URL_QUERY);
+            $normalizedStoredQueryString = self::normalizeQueryString(\is_string($storedQueryString) ? $storedQueryString : null);
+
+            if ($normalizedStoredQueryString !== null && $normalizedStoredQueryString !== $normalizedQueryString) {
+                $seoPath['canonicalPathInfo'] = '/' . ltrim($seoPath['seoPathInfo'], '/');
+            }
+        }
 
         if (!$seoPath['isCanonical']) {
             $query = (new QueryBuilder($this->connection))
@@ -99,5 +169,73 @@ class SeoResolver extends AbstractSeoResolver
         $seoPath['pathInfo'] = '/' . ltrim((string) $seoPath['pathInfo'], '/');
 
         return $seoPath;
+    }
+
+    /**
+     * @param array<string, mixed> $requestQueryParams
+     *
+     * @return array{int, int}
+     */
+    private static function calculateQueryMatch(string $seoPathInfo, string $queryString, array $requestQueryParams, string $storedSeoPathInfo): array
+    {
+        $storedQueryString = parse_url($storedSeoPathInfo, \PHP_URL_QUERY);
+        if (!\is_string($storedQueryString) || $storedQueryString === '') {
+            return [1, 0];
+        }
+
+        $normalizedStoredQueryString = self::normalizeQueryString($storedQueryString);
+        $storedPathInfo = trim((string) parse_url($storedSeoPathInfo, \PHP_URL_PATH), '/');
+
+        if ($normalizedStoredQueryString === $queryString && rtrim($storedPathInfo, '/') === rtrim($seoPathInfo, '/')) {
+            return [3, \strlen($normalizedStoredQueryString)];
+        }
+
+        $storedQueryParams = self::parseQueryParameters($storedQueryString);
+
+        $specificity = 0;
+        foreach ($storedQueryParams as $key => $storedValue) {
+            if (!\array_key_exists($key, $requestQueryParams)) {
+                return [0, 0];
+            }
+
+            $requestValue = $requestQueryParams[$key];
+            if (!\is_string($storedValue) || !\is_string($requestValue)) {
+                return [0, 0];
+            }
+
+            if ($storedValue !== $requestValue) {
+                return [0, 0];
+            }
+
+            $specificity += \strlen($storedValue);
+        }
+
+        return [2, $specificity];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function parseQueryParameters(string $queryString): array
+    {
+        parse_str($queryString, $rawQueryParams);
+
+        $queryParams = [];
+        foreach ($rawQueryParams as $key => $value) {
+            if (!\is_string($key)) {
+                continue;
+            }
+
+            $queryParams[$key] = $value;
+        }
+
+        return $queryParams;
+    }
+
+    private static function normalizeQueryString(?string $queryString): ?string
+    {
+        $normalizedQueryString = Request::normalizeQueryString($queryString);
+
+        return $normalizedQueryString === '' ? null : $normalizedQueryString;
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRequestContext.php
+++ b/src/Core/Content/Seo/SeoUrlRequestContext.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('inventory')]
+final readonly class SeoUrlRequestContext
+{
+    public function __construct(
+        public string $languageId,
+        public string $salesChannelId,
+        public string $pathInfo,
+        public ?string $queryString = null,
+    ) {
+    }
+}

--- a/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
+++ b/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
@@ -82,11 +82,18 @@ class ValidSeoPathInfo extends Constraint
      * rejection would abort the whole indexing batch. Each run of disallowed
      * sequences is collapsed into a single separator.
      *
+     * Raw spaces are percent-encoded to `%20` first: a stored literal space
+     * could never be matched by the resolver because the frontend always
+     * sends the space percent-encoded, so a query-bearing SEO path such as
+     * `product?colo=red blue` is normalised to `product?colo=red%20blue`.
+     *
      * Valid percent-escapes survive untouched, so `rawurlencode(slugify(...))`
      * output for non-ASCII slug configs (e.g. `caf%C3%A9`) is preserved.
      */
     public static function sanitize(string $path): string
     {
+        $path = \str_replace(' ', '%20', $path);
+
         return (string) \preg_replace(
             '/(?:' . self::DISALLOWED_SEQUENCES . ')+/',
             self::SANITIZE_SEPARATOR,

--- a/src/Core/Framework/Routing/CanonicalRedirectService.php
+++ b/src/Core/Framework/Routing/CanonicalRedirectService.php
@@ -55,7 +55,11 @@ class CanonicalRedirectService
         $queryString = $request->getQueryString();
 
         if ($queryString) {
-            $canonical = \sprintf('%s?%s', $canonical, $queryString);
+            $canonicalQueryString = parse_url($canonical, \PHP_URL_QUERY);
+
+            if (!\is_string($canonicalQueryString) || $canonicalQueryString === '') {
+                $canonical = \sprintf('%s?%s', $canonical, $queryString);
+            }
         }
 
         return new RedirectResponse($canonical, Response::HTTP_MOVED_PERMANENTLY);

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -3,6 +3,8 @@
 namespace Shopware\Storefront\Framework\Routing;
 
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
+use Shopware\Core\Content\Seo\ResolvedSeoUrl;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
 use Shopware\Core\PlatformRequest;
@@ -11,9 +13,6 @@ use Shopware\Storefront\Framework\Routing\Struct\DomainStruct;
 use Shopware\Storefront\Framework\StorefrontFrameworkException;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @phpstan-import-type ResolvedSeoUrl from AbstractSeoResolver
- */
 #[Package('framework')]
 class RequestTransformer implements RequestTransformerInterface
 {
@@ -174,7 +173,7 @@ class RequestTransformer implements RequestTransformerInterface
          */
         $transformedServerVars = array_merge(
             $request->server->all(),
-            ['REQUEST_URI' => rtrim($request->getBasePath(), '/') . $resolved['pathInfo']]
+            ['REQUEST_URI' => rtrim($request->getBasePath(), '/') . $resolved->pathInfo]
         );
 
         $transformedRequest = $request->duplicate(null, null, null, null, null, $transformedServerVars);
@@ -185,7 +184,7 @@ class RequestTransformer implements RequestTransformerInterface
             $transformedRequest->attributes->get(self::SALES_CHANNEL_ABSOLUTE_BASE_URL)
             . $transformedRequest->attributes->get(self::SALES_CHANNEL_BASE_URL)
         );
-        $transformedRequest->attributes->set(self::SALES_CHANNEL_RESOLVED_URI, $resolved['pathInfo']);
+        $transformedRequest->attributes->set(self::SALES_CHANNEL_RESOLVED_URI, $resolved->pathInfo);
 
         $transformedRequest->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $salesChannel->salesChannelId);
         $transformedRequest->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
@@ -213,7 +212,7 @@ class RequestTransformer implements RequestTransformerInterface
             $salesChannel->maintenanceIpAllowlist
         );
 
-        if (isset($resolved['canonicalPathInfo'])) {
+        if ($resolved->canonicalPathInfo !== null) {
             $urlPath = parse_url($salesChannel->url, \PHP_URL_PATH);
             if ($urlPath === false || $urlPath === null) {
                 $urlPath = '';
@@ -226,7 +225,7 @@ class RequestTransformer implements RequestTransformerInterface
 
             $transformedRequest->attributes->set(
                 SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK,
-                $this->getSchemeAndHttpHost($request) . $baseUrlPath . $resolved['canonicalPathInfo']
+                $this->getSchemeAndHttpHost($request) . $baseUrlPath . $resolved->canonicalPathInfo
             );
         }
 
@@ -323,10 +322,7 @@ class RequestTransformer implements RequestTransformerInterface
         return $bestMatch;
     }
 
-    /**
-     * @return ResolvedSeoUrl
-     */
-    private function resolveSeoUrl(Request $request, string $baseUrl, string $languageId, string $salesChannelId): array
+    private function resolveSeoUrl(Request $request, string $baseUrl, string $languageId, string $salesChannelId): ResolvedSeoUrl
     {
         $seoPathInfo = $request->getPathInfo();
 
@@ -335,6 +331,15 @@ class RequestTransformer implements RequestTransformerInterface
         // incoming request:  'shop-dev.de/detail'
         // without leading slash, detail would be stripped
         $baseUrl = rtrim($baseUrl, '/') . '/';
+
+        // Include query string in resolving so SEO URLs stored with query parameters
+        // (e.g., "awesome-product?test=123") are matched exactly when present.
+        // Use the raw QUERY_STRING server var rather than $request->getQueryString(),
+        // which already normalizes (e.g. value-less keys gain a trailing `=`).
+        // SeoResolver tries both the raw and normalized forms against stored seo_path_info,
+        // so a stored "?test123" can still match a request like "?test123".
+        $rawQueryString = (string) $request->server->get('QUERY_STRING', '');
+        $queryString = $rawQueryString === '' ? null : $rawQueryString;
 
         if ($this->equalsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = '';
@@ -360,11 +365,14 @@ class RequestTransformer implements RequestTransformerInterface
             $seoPathInfo = mb_substr($seoPathInfo, mb_strlen($scriptName));
         }
 
-        $resolved = $this->resolver->resolve($languageId, $salesChannelId, $seoPathInfo);
-
-        $resolved['pathInfo'] = '/' . ltrim($resolved['pathInfo'], '/');
-
-        return $resolved;
+        // pathInfo is already normalized with a leading slash by the resolver
+        // (see SeoResolver::resolveUrl() / EmptyPathInfoResolver::resolveUrl()).
+        return $this->resolver->resolveUrl(new SeoUrlRequestContext(
+            languageId: $languageId,
+            salesChannelId: $salesChannelId,
+            pathInfo: $seoPathInfo,
+            queryString: $queryString,
+        ));
     }
 
     private function getSchemeAndHttpHost(Request $request): string

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -319,13 +319,20 @@ class RequestTransformer implements RequestTransformerInterface
         // without leading slash, detail would be stripped
         $baseUrl = rtrim($baseUrl, '/') . '/';
 
+        // Include query string in resolving so SEO URLs stored with query parameters
+        // (e.g., "awesome-product?test=123") are matched exactly when present.
+        $queryString = $request->getQueryString();
+        if ($queryString === null || $queryString === '') {
+            $queryString = null;
+        }
+
         if ($this->equalsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = '';
         } elseif ($this->containsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = mb_substr($seoPathInfo, mb_strlen($baseUrl));
         }
 
-        $resolved = $this->resolver->resolve($languageId, $salesChannelId, $seoPathInfo);
+        $resolved = $this->resolver->resolveWithQueryString($languageId, $salesChannelId, $seoPathInfo, $queryString);
 
         $resolved['pathInfo'] = '/' . ltrim($resolved['pathInfo'], '/');
 

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -318,13 +318,20 @@ class RequestTransformer implements RequestTransformerInterface
         // without leading slash, detail would be stripped
         $baseUrl = rtrim($baseUrl, '/') . '/';
 
+        // Include query string in resolving so SEO URLs stored with query parameters
+        // (e.g., "awesome-product?test=123") are matched exactly when present.
+        $queryString = $request->getQueryString();
+        if ($queryString === null || $queryString === '') {
+            $queryString = null;
+        }
+
         if ($this->equalsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = '';
         } elseif ($this->containsBaseUrl($seoPathInfo, $baseUrl)) {
             $seoPathInfo = mb_substr($seoPathInfo, mb_strlen($baseUrl));
         }
 
-        $resolved = $this->resolver->resolve($languageId, $salesChannelId, $seoPathInfo);
+        $resolved = $this->resolver->resolveWithQueryString($languageId, $salesChannelId, $seoPathInfo, $queryString);
 
         $resolved['pathInfo'] = '/' . ltrim($resolved['pathInfo'], '/');
 

--- a/tests/integration/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoResolverTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
 use Shopware\Core\Content\Seo\SeoResolver;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -50,14 +51,17 @@ class SeoResolverTest extends TestCase
         $salesChannelId = Uuid::randomHex();
         $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '');
-        static::assertSame(['pathInfo' => '/', 'isCanonical' => false], $resolved);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, ''));
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/');
-        static::assertSame(['pathInfo' => '/', 'isCanonical' => false], $resolved);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, '/'));
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '//');
-        static::assertSame(['pathInfo' => '/', 'isCanonical' => false], $resolved);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, '//'));
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
     }
 
     public function testResolveSeoPathPassthrough(): void
@@ -66,11 +70,13 @@ class SeoResolverTest extends TestCase
         $salesChannelId = Uuid::randomHex();
         $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/foo/bar');
-        static::assertSame(['pathInfo' => '/foo/bar', 'isCanonical' => false], $resolved);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, '/foo/bar'));
+        static::assertSame('/foo/bar', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'foo/bar');
-        static::assertSame(['pathInfo' => '/foo/bar', 'isCanonical' => false], $resolved);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, 'foo/bar'));
+        static::assertSame('/foo/bar', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
     }
 
     public function testResolveSeoPath(): void
@@ -98,63 +104,30 @@ class SeoResolverTest extends TestCase
             ],
         ], Context::createDefaultContext());
 
+        $languageId = $context->getLanguageId();
+
         // pathInfo
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'detail/1234');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertFalse($resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/detail/1234');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertFalse($resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'detail/1234/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertFalse($resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/detail/1234/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertFalse($resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        foreach (['detail/1234', '/detail/1234', 'detail/1234/', '/detail/1234/'] as $path) {
+            $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($languageId, $salesChannelId, $path));
+            static::assertSame('/detail/1234', $resolved->pathInfo);
+            static::assertFalse($resolved->isCanonical);
+            static::assertSame('/awesome-product-v2', $resolved->canonicalPathInfo);
+        }
 
         // old canonical
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('0', $resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('0', $resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('0', $resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('0', $resolved['isCanonical']);
-        static::assertArrayHasKey('canonicalPathInfo', $resolved);
-        static::assertSame('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        foreach (['awesome-product', '/awesome-product', 'awesome-product/', '/awesome-product/'] as $path) {
+            $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($languageId, $salesChannelId, $path));
+            static::assertSame('/detail/1234', $resolved->pathInfo);
+            static::assertFalse($resolved->isCanonical);
+            static::assertSame('/awesome-product-v2', $resolved->canonicalPathInfo);
+        }
 
         // canonical
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product-v2');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('1', $resolved['isCanonical']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product-v2');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('1', $resolved['isCanonical']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product-v2/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('1', $resolved['isCanonical']);
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product-v2/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('1', $resolved['isCanonical']);
+        foreach (['awesome-product-v2', '/awesome-product-v2', 'awesome-product-v2/', '/awesome-product-v2/'] as $path) {
+            $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($languageId, $salesChannelId, $path));
+            static::assertSame('/detail/1234', $resolved->pathInfo);
+            static::assertTrue($resolved->isCanonical);
+        }
     }
 
     public function testResolveSeoPathWithCanonicalIsNull(): void
@@ -182,9 +155,9 @@ class SeoResolverTest extends TestCase
             ],
         ], Context::createDefaultContext());
 
-        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product/');
-        static::assertSame('/detail/1234', $resolved['pathInfo']);
-        static::assertSame('1', $resolved['isCanonical']);
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, '/awesome-product/'));
+        static::assertSame('/detail/1234', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
     }
 
     public function testResolveCanonMultiLang(): void
@@ -221,13 +194,13 @@ class SeoResolverTest extends TestCase
             ],
         ], Context::createDefaultContext());
 
-        $actual = $this->seoResolver->resolve($this->deLanguageId, $salesChannelDeId, 'awesome-product-de');
-        static::assertArrayHasKey('id', $actual);
-        static::assertSame($deId, Uuid::fromBytesToHex($actual['id']));
+        $actual = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($this->deLanguageId, $salesChannelDeId, 'awesome-product-de'));
+        static::assertNotNull($actual->id);
+        static::assertSame($deId, Uuid::fromBytesToHex($actual->id));
 
-        $actual = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, $salesChannelDeId, 'awesome-product-en');
-        static::assertArrayHasKey('id', $actual);
-        static::assertSame($enId, Uuid::fromBytesToHex($actual['id']));
+        $actual = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(Defaults::LANGUAGE_SYSTEM, $salesChannelDeId, 'awesome-product-en'));
+        static::assertNotNull($actual->id);
+        static::assertSame($enId, Uuid::fromBytesToHex($actual->id));
     }
 
     public function testResolveSamePathForDifferentSalesChannels(): void
@@ -266,13 +239,13 @@ class SeoResolverTest extends TestCase
 
         $unknownSalesChannelId = Uuid::randomHex();
         // returns default for unknown sales channels
-        $actual = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, $unknownSalesChannelId, 'awesome-product');
-        static::assertSame('/detail/default', $actual['pathInfo']);
-        static::assertTrue((bool) $actual['isCanonical']);
+        $actual = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(Defaults::LANGUAGE_SYSTEM, $unknownSalesChannelId, 'awesome-product'));
+        static::assertSame('/detail/default', $actual->pathInfo);
+        static::assertTrue($actual->isCanonical);
 
-        $actual = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, $otherSalesChannelId, 'awesome-product');
-        static::assertSame('/detail/other', $actual['pathInfo']);
-        static::assertTrue((bool) $actual['isCanonical']);
+        $actual = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(Defaults::LANGUAGE_SYSTEM, $otherSalesChannelId, 'awesome-product'));
+        static::assertSame('/detail/other', $actual->pathInfo);
+        static::assertTrue($actual->isCanonical);
     }
 
     public function testSalesChannelSpecificSeoulWillBePrioritized(): void
@@ -299,10 +272,240 @@ class SeoResolverTest extends TestCase
             ],
         ], Context::createDefaultContext());
 
-        $salesChannelResponse = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, $salesChannelId, 'awesome-product');
-        static::assertSame('/sales-channel', $salesChannelResponse['pathInfo']);
+        $salesChannelResponse = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(Defaults::LANGUAGE_SYSTEM, $salesChannelId, 'awesome-product'));
+        static::assertSame('/sales-channel', $salesChannelResponse->pathInfo);
 
-        $salesChannelResponse = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, Uuid::randomHex(), 'awesome-product');
-        static::assertSame('/default', $salesChannelResponse['pathInfo']);
+        $salesChannelResponse = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(Defaults::LANGUAGE_SYSTEM, Uuid::randomHex(), 'awesome-product'));
+        static::assertSame('/default', $salesChannelResponse->pathInfo);
+    }
+
+    public function testResolveSeoPathWithCanonicalContainingQueryString(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'test=123',
+        ));
+
+        static::assertSame('/detail/12345', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveSeoPathWithPercentEncodedCharacter(): void
+    {
+        // Valid percent-escapes (e.g. "café" slugified to "caf%C3%A9") are kept storable by the
+        // SEO path validation (see fix/seo-url-percent-400-13796); the resolver must therefore be
+        // able to look them up verbatim. getPathInfo() keeps the path percent-encoded, so the
+        // stored seo_path_info is compared as-is.
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/cafe',
+                'seoPathInfo' => 'caf%C3%A9',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'caf%C3%A9',
+        ));
+
+        static::assertSame('/detail/cafe', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveSeoPathWithPercentEncodedQueryValue(): void
+    {
+        // A query-bearing SEO URL whose value contains a valid percent-escape ("ref=a%20b") must
+        // resolve without triggering a canonical redirect. The raw request query is matched verbatim
+        // against the stored seo_path_info, so the escape round-trips correctly.
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?ref=a%20b',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'ref=a%20b',
+        ));
+
+        static::assertSame('/detail/12345', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveSeoPathWithDifferentQueryStringDoesNotMatchCanonicalQuery(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'test=12334',
+        ));
+
+        static::assertSame('/Main-product/SWDEMO10001', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveSeoPathWithQueryStringPrefersExactVariantMatch(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/base',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/variant-b',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.2',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+            'test=5.2',
+        ));
+
+        static::assertSame('/detail/variant-b', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveSeoPathWithDifferentQueryValueFallsBackToPlainCanonical(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/base',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/variant-54',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.4',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+            'test=5.42',
+        ));
+
+        static::assertSame('/detail/base', $resolved->pathInfo);
+        static::assertSame('Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65', $resolved->seoPathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveWithoutQueryPrefersPlainCanonicalOverQueryVariant(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/query',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveUrl(new SeoUrlRequestContext($context->getLanguageId(), $salesChannelId, 'Main-product/SWDEMO10001'));
+
+        static::assertSame('/detail/plain', $resolved->pathInfo);
+        static::assertSame('Main-product/SWDEMO10001', $resolved->seoPathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
     }
 }

--- a/tests/integration/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoResolverTest.php
@@ -305,4 +305,197 @@ class SeoResolverTest extends TestCase
         $salesChannelResponse = $this->seoResolver->resolve(Defaults::LANGUAGE_SYSTEM, Uuid::randomHex(), 'awesome-product');
         static::assertSame('/default', $salesChannelResponse['pathInfo']);
     }
+
+    public function testResolveSeoPathWithCanonicalContainingQueryString(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveWithQueryString($context->getLanguageId(), $salesChannelId, 'Main-product/SWDEMO10001', 'test=123');
+
+        static::assertSame('/detail/12345', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveSeoPathWithDifferentQueryStringDoesNotMatchCanonicalQuery(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/12345',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveWithQueryString(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'test=12334'
+        );
+
+        static::assertSame('/Main-product/SWDEMO10001', $resolved['pathInfo']);
+        static::assertFalse((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveSeoPathWithQueryStringPrefersExactVariantMatch(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/base',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/variant-b',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.2',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveWithQueryString(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+            'test=5.2'
+        );
+
+        static::assertSame('/detail/variant-b', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveSeoPathWithDifferentQueryValueFallsBackToPlainCanonical(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/base',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/variant-54',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.4',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveWithQueryString(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+            'test=5.42'
+        );
+
+        static::assertSame('/detail/base', $resolved['pathInfo']);
+        static::assertArrayHasKey('seoPathInfo', $resolved);
+        static::assertSame('Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65', $resolved['seoPathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveSeoPathWithExtraRequestQueryUsesVariantFallback(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/variant-54',
+                'seoPathInfo' => 'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.4',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolveWithQueryString(
+            $context->getLanguageId(),
+            $salesChannelId,
+            'Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65',
+            'test=5.4&acv=1'
+        );
+
+        static::assertSame('/detail/variant-54', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayHasKey('canonicalPathInfo', $resolved);
+        static::assertSame('/Aerodynamic-Aluminum-Chin-Up/SW-019d22fd316872bb96162ee6016a6c65?test=5.4', $resolved['canonicalPathInfo']);
+    }
+
+    public function testResolveWithoutQueryPrefersPlainCanonicalOverQueryVariant(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $this->seoUrlRepository->create([
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/query',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+                'isCanonical' => true,
+            ],
+            [
+                'salesChannelId' => $salesChannelId,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'routeName' => 'r',
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+                'isCanonical' => true,
+            ],
+        ], $context);
+
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'Main-product/SWDEMO10001');
+
+        static::assertSame('/detail/plain', $resolved['pathInfo']);
+        static::assertArrayHasKey('seoPathInfo', $resolved);
+        static::assertSame('Main-product/SWDEMO10001', $resolved['seoPathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
 }

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -299,6 +299,80 @@ class RequestTransformerTest extends TestCase
         static::assertSame('http://base.test' . $resolvedUrl, $resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
     }
 
+    public function testCanonicalSeoUrlWithQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Main-product/SWDEMO10001?test=123',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Main-product/SWDEMO10001?test=123');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+
+        // Matching canonical SEO URL should not set a canonical link (no redirect loop)
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
+    public function testPlainCanonicalSeoUrlWithRequestQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Main-product/SWDEMO10001',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Main-product/SWDEMO10001?utm=123');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
     /**
      * @return iterable<string, string[]>
      */

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -299,6 +299,116 @@ class RequestTransformerTest extends TestCase
         static::assertSame('http://base.test' . $resolvedUrl, $resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
     }
 
+    public function testCanonicalSeoUrlWithQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Main-product/SWDEMO10001?test=123',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Main-product/SWDEMO10001?test=123');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+
+        // Matching canonical SEO URL should not set a canonical link (no redirect loop)
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
+    public function testCanonicalSeoUrlWithFlagQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Latest-Product/SW10005?test12345',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Latest-Product/SW10005?test12345');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
+    public function testPlainCanonicalSeoUrlWithRequestQueryParameterDoesNotSetCanonicalLink(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $domainId = Uuid::randomHex();
+
+        $this->createSalesChannels([
+            self::getGermanSalesChannel($salesChannelId, $domainId, 'http://base.test'),
+        ]);
+
+        $con = static::getContainer()->get(Connection::class);
+        $con->insert(
+            'seo_url',
+            [
+                'id' => Uuid::randomBytes(),
+                'language_id' => Uuid::fromHexToBytes($this->deLanguageId),
+                'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                'foreign_key' => Uuid::randomBytes(),
+                'route_name' => 'frontend.detail.page',
+                'path_info' => '/detail/87a78cf58f114d5587ae23c140825694',
+                'seo_path_info' => 'Main-product/SWDEMO10001',
+                'is_canonical' => 1,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]
+        );
+
+        $request = Request::create('http://base.test/Main-product/SWDEMO10001?utm=123');
+
+        $resolved = $this->requestTransformer->transform($request);
+
+        static::assertSame(
+            '/detail/87a78cf58f114d5587ae23c140825694',
+            $resolved->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI)
+        );
+        static::assertNull($resolved->attributes->get(SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK));
+    }
+
     /**
      * @return iterable<string, string[]>
      */

--- a/tests/unit/Core/Content/Seo/AbstractSeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/AbstractSeoResolverTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\AbstractSeoResolver;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[CoversClass(AbstractSeoResolver::class)]
+class AbstractSeoResolverTest extends TestCase
+{
+    public function testDefaultResolveUrlImplConstructsDtoFromLegacyResolveArray(): void
+    {
+        $resolver = new class extends AbstractSeoResolver {
+            public function getDecorated(): AbstractSeoResolver
+            {
+                throw new DecorationPatternException(self::class);
+            }
+
+            public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
+            {
+                return [
+                    'id' => 'binaryId',
+                    'pathInfo' => '/detail/1234',
+                    'isCanonical' => '1',
+                    'canonicalPathInfo' => '/awesome-product',
+                    'seoPathInfo' => 'awesome-product',
+                ];
+            }
+        };
+
+        $resolved = $resolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), Uuid::randomHex(), '/awesome-product'));
+
+        static::assertSame('/detail/1234', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical, 'isCanonical coerced from string "1"');
+        static::assertSame('binaryId', $resolved->id);
+        static::assertSame('/awesome-product', $resolved->canonicalPathInfo);
+        static::assertSame('awesome-product', $resolved->seoPathInfo);
+    }
+
+    public function testDefaultResolveUrlImplDefaultsOptionalFieldsToNull(): void
+    {
+        $resolver = new class extends AbstractSeoResolver {
+            public function getDecorated(): AbstractSeoResolver
+            {
+                throw new DecorationPatternException(self::class);
+            }
+
+            public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
+            {
+                return ['pathInfo' => '/foo/bar', 'isCanonical' => false];
+            }
+        };
+
+        $resolved = $resolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), Uuid::randomHex(), 'foo/bar'));
+
+        static::assertSame('/foo/bar', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+        static::assertNull($resolved->id);
+        static::assertNull($resolved->canonicalPathInfo);
+        static::assertNull($resolved->seoPathInfo);
+    }
+}

--- a/tests/unit/Core/Content/Seo/EmptyPathInfoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/EmptyPathInfoResolverTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\AbstractSeoResolver;
+use Shopware\Core\Content\Seo\EmptyPathInfoResolver;
+use Shopware\Core\Content\Seo\ResolvedSeoUrl;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+
+/**
+ * @internal
+ */
+#[CoversClass(EmptyPathInfoResolver::class)]
+class EmptyPathInfoResolverTest extends TestCase
+{
+    public function testResolveUrlReturnsRootForEmptyPath(): void
+    {
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $decorated->expects($this->never())->method('resolveUrl');
+
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        $resolved = $resolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), Uuid::randomHex(), ''));
+
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+    }
+
+    public function testResolveUrlReturnsRootForSlashOnlyPath(): void
+    {
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $decorated->expects($this->never())->method('resolveUrl');
+
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        $resolved = $resolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), Uuid::randomHex(), '/'));
+
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+    }
+
+    public function testResolveUrlDelegatesNonEmptyPathToDecorated(): void
+    {
+        $expected = new ResolvedSeoUrl(pathInfo: '/detail/1234', isCanonical: true);
+
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $decorated
+            ->expects($this->once())
+            ->method('resolveUrl')
+            ->with(static::callback(static fn (SeoUrlRequestContext $context): bool => $context->pathInfo === '/awesome-product'))
+            ->willReturn($expected);
+
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        $resolved = $resolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), Uuid::randomHex(), '/awesome-product'));
+
+        static::assertSame($expected, $resolved);
+    }
+
+    public function testGetDecoratedReturnsInjectedResolver(): void
+    {
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        static::assertSame($decorated, $resolver->getDecorated());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedResolveReturnsRootArrayForEmptyPath(): void
+    {
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $decorated->expects($this->never())->method('resolveUrl');
+
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        $data = $resolver->resolve(Uuid::randomHex(), Uuid::randomHex(), '');
+
+        static::assertSame(['pathInfo' => '/', 'isCanonical' => false], $data);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedResolveProjectsAllPopulatedFieldsToArray(): void
+    {
+        $decorated = $this->createMock(AbstractSeoResolver::class);
+        $decorated
+            ->expects($this->once())
+            ->method('resolveUrl')
+            ->willReturn(new ResolvedSeoUrl(
+                pathInfo: '/detail/1234',
+                isCanonical: true,
+                id: 'binaryId',
+                canonicalPathInfo: '/awesome-product',
+                seoPathInfo: 'awesome-product',
+            ));
+
+        $resolver = new EmptyPathInfoResolver($decorated);
+
+        $data = $resolver->resolve(Uuid::randomHex(), Uuid::randomHex(), '/awesome-product');
+
+        static::assertSame([
+            'pathInfo' => '/detail/1234',
+            'isCanonical' => true,
+            'id' => 'binaryId',
+            'canonicalPathInfo' => '/awesome-product',
+            'seoPathInfo' => 'awesome-product',
+        ], $data);
+    }
+
+    public function testDeprecatedResolveThrowsWhenFeatureActive(): void
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            static::markTestSkipped('Feature v6.8.0.0 must be active to assert the throw behaviour.');
+        }
+
+        $resolver = new EmptyPathInfoResolver($this->createMock(AbstractSeoResolver::class));
+
+        $this->expectException(\Throwable::class);
+        $resolver->resolve(Uuid::randomHex(), Uuid::randomHex(), '/awesome-product');
+    }
+}

--- a/tests/unit/Core/Content/Seo/ResolvedSeoUrlTest.php
+++ b/tests/unit/Core/Content/Seo/ResolvedSeoUrlTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\ResolvedSeoUrl;
+
+/**
+ * @internal
+ */
+#[CoversClass(ResolvedSeoUrl::class)]
+class ResolvedSeoUrlTest extends TestCase
+{
+    public function testAllFieldsAreExposed(): void
+    {
+        $resolved = new ResolvedSeoUrl(
+            pathInfo: '/detail/1234',
+            isCanonical: true,
+            id: 'binaryId',
+            canonicalPathInfo: '/awesome-product',
+            seoPathInfo: 'awesome-product',
+        );
+
+        static::assertSame('/detail/1234', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertSame('binaryId', $resolved->id);
+        static::assertSame('/awesome-product', $resolved->canonicalPathInfo);
+        static::assertSame('awesome-product', $resolved->seoPathInfo);
+    }
+
+    public function testOptionalFieldsDefaultToNull(): void
+    {
+        $resolved = new ResolvedSeoUrl(pathInfo: '/', isCanonical: false);
+
+        static::assertSame('/', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+        static::assertNull($resolved->id);
+        static::assertNull($resolved->canonicalPathInfo);
+        static::assertNull($resolved->seoPathInfo);
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoResolverTest.php
@@ -5,13 +5,17 @@ namespace Shopware\Tests\Unit\Core\Content\Seo;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoResolver;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Stub\Doctrine\FakeResultFactory;
 
 /**
@@ -100,26 +104,25 @@ class SeoResolverTest extends TestCase
     }
 
     #[DataProvider('resolveDataProvider')]
-    public function testResolveWithIsCanonical(string $pathInfo, string $expected): void
+    public function testResolveUrlWithIsCanonical(string $pathInfo, string $expected): void
     {
         $salesChannelId = Uuid::randomHex();
         $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, true, $pathInfo));
 
-        $resolvedSeoUrl = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, $pathInfo);
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), $salesChannelId, $pathInfo));
 
-        static::assertSame($expected, $resolvedSeoUrl['pathInfo']);
+        static::assertSame($expected, $resolved->pathInfo);
     }
 
     #[DataProvider('resolveCanonicalDataProvider')]
-    public function testResolveWithNotCanonical(string $pathInfo, string $expected): void
+    public function testResolveUrlWithNotCanonical(string $pathInfo, string $expected): void
     {
         $salesChannelId = Uuid::randomHex();
         $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, false, $pathInfo));
 
-        /** @var array{canonicalPathInfo: string, pathInfo: string, isCanonical: bool} $resolvedSeoUrl */
-        $resolvedSeoUrl = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, $pathInfo);
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), $salesChannelId, $pathInfo));
 
-        static::assertSame($expected, $resolvedSeoUrl['canonicalPathInfo']);
+        static::assertSame($expected, $resolved->canonicalPathInfo);
     }
 
     public function testResolveIgnoresDeletedSeoUrls(): void
@@ -128,11 +131,321 @@ class SeoResolverTest extends TestCase
         $salesChannelId = Uuid::randomHex();
         $seoResolver = new SeoResolver($this->createSqliteConnectionWithDeletedSeoUrl($languageId, $salesChannelId));
 
-        /** @var array{pathInfo: string, isCanonical: bool|string} $resolvedSeoUrl */
-        $resolvedSeoUrl = $seoResolver->resolve($languageId, $salesChannelId, 'awesome-product');
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext($languageId, $salesChannelId, 'awesome-product'));
 
-        static::assertSame('/default', $resolvedSeoUrl['pathInfo']);
-        static::assertTrue((bool) $resolvedSeoUrl['isCanonical']);
+        static::assertSame('/default', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+    }
+
+    public function testResolveUrlWithQueryStringReturnsCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $expectedPathInfo = '/detail/12345';
+
+        $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, true, $expectedPathInfo));
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'test=123',
+        ));
+
+        static::assertSame($expectedPathInfo, $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+    }
+
+    public function testResolveUrlWithoutQueryStringPrefersPlainCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/query',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001'));
+
+        static::assertSame('/detail/plain', $resolved->pathInfo);
+        static::assertSame('Main-product/SWDEMO10001', $resolved->seoPathInfo);
+        static::assertTrue($resolved->isCanonical);
+    }
+
+    public function testResolveUrlWithPlainCanonicalAndQueryStringDoesNotSetCanonicalPathInfo(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'utm=123',
+        ));
+
+        static::assertSame('/detail/plain', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveUrlWithFlagQueryStringDoesNotSetCanonicalPathInfo(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/flag',
+                'seoPathInfo' => 'Latest-Product/SW10005?test12345',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'Latest-Product/SW10005',
+            'test12345=',
+        ));
+
+        static::assertSame('/detail/flag', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+        static::assertNull($resolved->canonicalPathInfo);
+    }
+
+    public function testResolveUrlMatchesStoredFlagQueryVerbatim(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $storedSeoPath = 'Latest-Product/SW10005?test12345';
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $matchResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/flag',
+                'seoPathInfo' => $storedSeoPath,
+            ],
+        ], $connection);
+        $emptyResult = FakeResultFactory::createResult([], $connection);
+
+        // Return the stored row only when the verbatim flag candidate is among the bound params.
+        // Symfony normalizes the request query `test12345` to `test12345=`, so without the raw
+        // candidate the stored `?test12345` would never be matched by the exact-match SQL.
+        $connection->method('executeQuery')->willReturnCallback(
+            static fn (string $sql, array $params = []): Result => \in_array($storedSeoPath, $params, true)
+                ? $matchResult
+                : $emptyResult
+        );
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'Latest-Product/SW10005',
+            'test12345',
+        ));
+
+        static::assertSame('/detail/flag', $resolved->pathInfo);
+        static::assertTrue($resolved->isCanonical);
+    }
+
+    public function testResolveUrlFallsBackToPlainPathWhenNoRowMatches(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        // When no seo_url row matches (exact-match SQL returns nothing), the resolver
+        // returns the requested path verbatim as a non-canonical result. The exact-match
+        // (LIKE-removal) behaviour itself is covered by the integration test
+        // testResolveSeoPathWithDifferentQueryStringDoesNotMatchCanonicalQuery against a real DB.
+        $connection = $this->createMock(Connection::class);
+        $emptyResult = FakeResultFactory::createResult([], $connection);
+        $connection->method('executeQuery')->willReturn($emptyResult, $emptyResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'product-a',
+            'promo=summer&utm=fb',
+        ));
+
+        static::assertSame('/product-a', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+    }
+
+    public function testResolveThrowsWhenFeatureActive(): void
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            static::markTestSkipped('Feature v6.8.0.0 must be active to assert the throw behaviour.');
+        }
+
+        $salesChannelId = Uuid::randomHex();
+        $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, true, '/seo-url'));
+
+        $this->expectException(\Throwable::class);
+        $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, '/seo-url');
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedResolveProjectsAllFieldsToArray(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $foreignId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => $foreignId,
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/1234',
+                'seoPathInfo' => 'awesome-product',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+        $data = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, 'awesome-product');
+
+        static::assertSame('/detail/1234', $data['pathInfo']);
+        static::assertTrue($data['isCanonical']);
+        static::assertArrayHasKey('id', $data);
+        static::assertSame($foreignId, $data['id']);
+        static::assertArrayHasKey('seoPathInfo', $data);
+        static::assertSame('awesome-product', $data['seoPathInfo']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $data);
+    }
+
+    public function testResolveUrlPrefersCanonicalRowWhoseQueryMatchesRequest(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        // Two canonical rows for the same sales channel match the request: a plain row and a
+        // query-bearing variant. The query-matching variant is returned SECOND, so only the
+        // usort query tie-break (not insertion order) can make it win. This guards the core of
+        // the fix: a request carrying `?test=123` must resolve to the row stored with that query.
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/variant',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(
+            Uuid::randomHex(),
+            $salesChannelId,
+            'Main-product/SWDEMO10001',
+            'test=123',
+        ));
+
+        static::assertSame('/detail/variant', $resolved->pathInfo);
+        static::assertSame('Main-product/SWDEMO10001?test=123', $resolved->seoPathInfo);
+        static::assertTrue($resolved->isCanonical);
+    }
+
+    public function testResolveUrlFallbackFindsCanonicalSiblingWhenFirstHitIsNotCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        // First query: returns a non-canonical row pointing at /detail/1234.
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => false,
+                'pathInfo' => '/detail/1234',
+                'seoPathInfo' => 'old-slug',
+            ],
+        ], $connection);
+        // Second query: fallback canonical lookup finds the canonical sibling for /detail/1234.
+        $secondResult = FakeResultFactory::createResult([
+            [
+                'pathInfo' => '/detail/1234',
+                'seoPathInfo' => 'awesome-product-v2',
+            ],
+        ], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveUrl(new SeoUrlRequestContext(Uuid::randomHex(), $salesChannelId, 'old-slug'));
+
+        static::assertSame('/detail/1234', $resolved->pathInfo);
+        static::assertFalse($resolved->isCanonical);
+        static::assertSame('/awesome-product-v2', $resolved->canonicalPathInfo);
     }
 
     private function getMockConnection(string $salesChannelId, bool $isCanonical, string $pathInfo): Connection&MockObject

--- a/tests/unit/Core/Content/Seo/SeoResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoResolverTest.php
@@ -125,6 +125,113 @@ class SeoResolverTest extends TestCase
         static::assertSame($expected, $resolvedSeoUrl['canonicalPathInfo']);
     }
 
+    public function testResolveWithQueryStringReturnsCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $expectedPathInfo = '/detail/12345';
+
+        $seoResolver = new SeoResolver($this->getMockConnection($salesChannelId, true, $expectedPathInfo));
+
+        $resolvedSeoUrl = $seoResolver->resolveWithQueryString(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001', 'test=123');
+
+        static::assertSame($expectedPathInfo, $resolvedSeoUrl['pathInfo']);
+        static::assertTrue((bool) $resolvedSeoUrl['isCanonical']);
+    }
+
+    public function testResolveWithoutQueryStringPrefersPlainCanonical(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/query',
+                'seoPathInfo' => 'Main-product/SWDEMO10001?test=123',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolve(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001');
+
+        static::assertNotEmpty($resolved);
+
+        static::assertSame('/detail/plain', $resolved['pathInfo']);
+        static::assertArrayHasKey('seoPathInfo', $resolved);
+        static::assertSame('Main-product/SWDEMO10001', $resolved['seoPathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+    }
+
+    public function testResolveWithPlainCanonicalAndQueryStringDoesNotSetCanonicalPathInfo(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/plain',
+                'seoPathInfo' => 'Main-product/SWDEMO10001',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveWithQueryString(Uuid::randomHex(), $salesChannelId, 'Main-product/SWDEMO10001', 'utm=123');
+
+        static::assertSame('/detail/plain', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
+    public function testResolveWithFlagQueryStringDoesNotSetCanonicalPathInfo(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+
+        $connection = $this->createMock(Connection::class);
+        $firstResult = FakeResultFactory::createResult([
+            [
+                'id' => Uuid::randomHex(),
+                'salesChannelId' => $salesChannelId,
+                'isCanonical' => true,
+                'pathInfo' => '/detail/flag',
+                'seoPathInfo' => 'Latest-Product/SW10005?test12345',
+            ],
+        ], $connection);
+        $secondResult = FakeResultFactory::createResult([], $connection);
+
+        $connection->method('executeQuery')->willReturn($firstResult, $secondResult);
+        $connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $seoResolver = new SeoResolver($connection);
+
+        $resolved = $seoResolver->resolveWithQueryString(Uuid::randomHex(), $salesChannelId, 'Latest-Product/SW10005', 'test12345=');
+
+        static::assertSame('/detail/flag', $resolved['pathInfo']);
+        static::assertTrue((bool) $resolved['isCanonical']);
+        static::assertArrayNotHasKey('canonicalPathInfo', $resolved);
+    }
+
     private function getMockConnection(string $salesChannelId, bool $isCanonical, string $pathInfo): Connection&MockObject
     {
         $mock = $this->createMock(Connection::class);

--- a/tests/unit/Core/Content/Seo/SeoUrlRequestContextTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRequestContextTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[CoversClass(SeoUrlRequestContext::class)]
+class SeoUrlRequestContextTest extends TestCase
+{
+    public function testReadonlyConstruction(): void
+    {
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $context = new SeoUrlRequestContext(
+            languageId: $languageId,
+            salesChannelId: $salesChannelId,
+            pathInfo: 'awesome-product',
+            queryString: 'test=123',
+        );
+
+        static::assertSame($languageId, $context->languageId);
+        static::assertSame($salesChannelId, $context->salesChannelId);
+        static::assertSame('awesome-product', $context->pathInfo);
+        static::assertSame('test=123', $context->queryString);
+    }
+
+    public function testQueryStringIsOptional(): void
+    {
+        $context = new SeoUrlRequestContext(
+            languageId: Uuid::randomHex(),
+            salesChannelId: Uuid::randomHex(),
+            pathInfo: 'awesome-product',
+        );
+
+        static::assertNull($context->queryString);
+    }
+}

--- a/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
@@ -54,6 +54,10 @@ class ValidSeoPathInfoTest extends TestCase
         yield 'valid percent-escapes untouched' => ['caf%C3%A9', 'caf%C3%A9'];
         // A consecutive run of disallowed characters collapses to one separator.
         yield 'control characters collapsed' => ["foo\0\nbar", 'foo-bar'];
+        // Raw spaces are percent-encoded so query-bearing SEO paths stay matchable
+        // by the resolver, which only ever sees the space as %20 from the frontend.
+        yield 'space in query value encoded' => ['product?colo=red blue', 'product?colo=red%20blue'];
+        yield 'multiple spaces encoded' => ['product?a=b c d', 'product?a=b%20c%20d'];
     }
 
     #[DataProvider('sanitizeProvider')]

--- a/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
+++ b/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
@@ -72,6 +72,70 @@ class CanonicalRedirectServiceTest extends TestCase
         static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
     }
 
+    public function testGetRedirectWithQueryParametersAlreadyInCanonicalUrl(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet?foo=bar']);
+        $request->server->set('QUERY_STRING', 'foo=bar');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
+    }
+
+    public function testGetRedirectWithDifferentQueryParametersInCanonicalUrl(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet?foo=bar']);
+        $request->server->set('QUERY_STRING', 'baz=qux');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
+    }
+
+    public function testCanonicalWithExistingQueryStringPreservesStoredQuery(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/awesome-product?lang=en']);
+        $request->server->set('QUERY_STRING', 'test=123');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/awesome-product?lang=en', $response->getTargetUrl());
+    }
+
+    public function testCanonicalWithoutQueryStringAppendsRequestQuery(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/awesome-product']);
+        $request->server->set('QUERY_STRING', 'test=123');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/awesome-product?test=123', $response->getTargetUrl());
+    }
+
     public function testExtensionIsDispatched(): void
     {
         $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet']);

--- a/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
+++ b/tests/unit/Core/Framework/Routing/CanonicalRedirectServiceTest.php
@@ -72,6 +72,38 @@ class CanonicalRedirectServiceTest extends TestCase
         static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
     }
 
+    public function testGetRedirectWithQueryParametersAlreadyInCanonicalUrl(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet?foo=bar']);
+        $request->server->set('QUERY_STRING', 'foo=bar');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
+    }
+
+    public function testGetRedirectWithDifferentQueryParametersInCanonicalUrl(): void
+    {
+        $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet?foo=bar']);
+        $request->server->set('QUERY_STRING', 'baz=qux');
+
+        $canonicalRedirectService = new CanonicalRedirectService(
+            $this->getSystemConfigService(true),
+            new ExtensionDispatcher(new EventDispatcher()),
+        );
+
+        $response = $canonicalRedirectService->getRedirect($request);
+
+        static::assertInstanceOf(RedirectResponse::class, $response);
+        static::assertSame('/lorem/ipsum/dolor-sit/amet?foo=bar', $response->getTargetUrl());
+    }
+
     public function testExtensionIsDispatched(): void
     {
         $request = self::getRequest([SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK => '/lorem/ipsum/dolor-sit/amet']);

--- a/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\AbstractSeoResolver;
+use Shopware\Core\Content\Seo\ResolvedSeoUrl;
+use Shopware\Core\Content\Seo\SeoUrlRequestContext;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -66,6 +68,165 @@ class RequestTransformerTest extends TestCase
         $requestTransformer->transform($originalRequest);
     }
 
+    public function testResolverReceivesQueryStringForExactMatching(): void
+    {
+        $decorated = $this->createMock(RequestTransformerInterface::class);
+        $decorated->method('transform')->willReturnCallback(fn ($request) => $request);
+
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $resolver = $this->createMock(AbstractSeoResolver::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolveUrl')
+            ->with(static::callback(static function (SeoUrlRequestContext $context) use ($languageId, $salesChannelId): bool {
+                return $context->languageId === $languageId
+                    && $context->salesChannelId === $salesChannelId
+                    && $context->pathInfo === 'Main-product/SWDEMO10001'
+                    && $context->queryString === 'test=123';
+            }))
+            ->willReturn(new ResolvedSeoUrl(pathInfo: '/detail/123', isCanonical: true));
+
+        $domains = new DomainCollection();
+        $domains->set('http://shopware.com/', DomainStruct::fromArray([
+            'url' => 'http://shopware.com',
+            'id' => Uuid::randomHex(),
+            'salesChannelId' => $salesChannelId,
+            'typeId' => Uuid::randomHex(),
+            'snippetSetId' => Uuid::randomHex(),
+            'currencyId' => Uuid::randomHex(),
+            'languageId' => $languageId,
+            'themeId' => Uuid::randomHex(),
+            'maintenance' => '0',
+            'maintenanceIpAllowlist' => '',
+            'locale' => 'en-GB',
+            'themeName' => 'Storefront',
+            'parentThemeName' => '',
+        ]));
+
+        $domainLoader = $this->createMock(AbstractDomainLoader::class);
+        $domainLoader
+            ->expects($this->once())
+            ->method('loadDomains')
+            ->willReturn($domains);
+
+        $requestTransformer = new RequestTransformer($decorated, $resolver, [], $domainLoader);
+
+        $originalRequest = Request::create('http://shopware.com/Main-product/SWDEMO10001?test=123');
+        $transformedRequest = $requestTransformer->transform($originalRequest);
+
+        static::assertSame('/detail/123', $transformedRequest->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI));
+    }
+
+    public function testResolverReceivesRawFlagQueryString(): void
+    {
+        // Symfony's Request::getQueryString() normalizes value-less keys: `?test123` becomes
+        // `test123=`. The SEO URL resolver compares the request query against stored
+        // seo_path_info verbatim, so it needs the raw form to match a stored `path?test123`.
+        // The RequestTransformer reads QUERY_STRING from server vars rather than
+        // getQueryString() to preserve that raw shape.
+        $decorated = $this->createMock(RequestTransformerInterface::class);
+        $decorated->method('transform')->willReturnCallback(fn ($request) => $request);
+
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $capturedContext = null;
+        $resolver = $this->createMock(AbstractSeoResolver::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolveUrl')
+            ->willReturnCallback(static function (SeoUrlRequestContext $context) use (&$capturedContext): ResolvedSeoUrl {
+                $capturedContext = $context;
+
+                return new ResolvedSeoUrl(pathInfo: '/detail/123', isCanonical: true);
+            });
+
+        $domains = new DomainCollection();
+        $domains->set('http://shopware.com/', DomainStruct::fromArray([
+            'url' => 'http://shopware.com',
+            'id' => Uuid::randomHex(),
+            'salesChannelId' => $salesChannelId,
+            'typeId' => Uuid::randomHex(),
+            'snippetSetId' => Uuid::randomHex(),
+            'currencyId' => Uuid::randomHex(),
+            'languageId' => $languageId,
+            'themeId' => Uuid::randomHex(),
+            'maintenance' => '0',
+            'maintenanceIpAllowlist' => '',
+            'locale' => 'en-GB',
+            'themeName' => 'Storefront',
+            'parentThemeName' => '',
+        ]));
+
+        $domainLoader = $this->createMock(AbstractDomainLoader::class);
+        $domainLoader
+            ->expects($this->once())
+            ->method('loadDomains')
+            ->willReturn($domains);
+
+        $requestTransformer = new RequestTransformer($decorated, $resolver, [], $domainLoader);
+
+        $originalRequest = Request::create('http://shopware.com/Latest-Product/SW10005?test12345');
+        $requestTransformer->transform($originalRequest);
+
+        static::assertNotNull($capturedContext);
+        static::assertSame('test12345', $capturedContext->queryString, 'raw QUERY_STRING preserved (not normalized to "test12345=")');
+        static::assertSame('Latest-Product/SW10005', $capturedContext->pathInfo);
+    }
+
+    public function testResolverReceivesNullForEmptyQueryString(): void
+    {
+        $decorated = $this->createMock(RequestTransformerInterface::class);
+        $decorated->method('transform')->willReturnCallback(fn ($request) => $request);
+
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $capturedContext = null;
+        $resolver = $this->createMock(AbstractSeoResolver::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolveUrl')
+            ->willReturnCallback(static function (SeoUrlRequestContext $context) use (&$capturedContext): ResolvedSeoUrl {
+                $capturedContext = $context;
+
+                return new ResolvedSeoUrl(pathInfo: '/foo', isCanonical: false);
+            });
+
+        $domains = new DomainCollection();
+        $domains->set('http://shopware.com/', DomainStruct::fromArray([
+            'url' => 'http://shopware.com',
+            'id' => Uuid::randomHex(),
+            'salesChannelId' => $salesChannelId,
+            'typeId' => Uuid::randomHex(),
+            'snippetSetId' => Uuid::randomHex(),
+            'currencyId' => Uuid::randomHex(),
+            'languageId' => $languageId,
+            'themeId' => Uuid::randomHex(),
+            'maintenance' => '0',
+            'maintenanceIpAllowlist' => '',
+            'locale' => 'en-GB',
+            'themeName' => 'Storefront',
+            'parentThemeName' => '',
+        ]));
+
+        $domainLoader = $this->createMock(AbstractDomainLoader::class);
+        $domainLoader
+            ->expects($this->once())
+            ->method('loadDomains')
+            ->willReturn($domains);
+
+        $requestTransformer = new RequestTransformer($decorated, $resolver, [], $domainLoader);
+
+        $originalRequest = Request::create('http://shopware.com/foo');
+        $requestTransformer->transform($originalRequest);
+
+        static::assertNotNull($capturedContext);
+        static::assertNull($capturedContext->queryString);
+    }
+
     /**
      * @param array<string, string> $serverVars
      */
@@ -92,10 +253,10 @@ class RequestTransformerTest extends TestCase
         $decorated->method('transform')->willReturnCallback(static fn ($request) => $request);
 
         $resolver = $this->createMock(AbstractSeoResolver::class);
-        $resolver->method('resolve')->willReturnCallback(static fn ($langId, $scId, $seoPathInfo) => [
-            'pathInfo' => '/' . ltrim($seoPathInfo, '/'),
-            'isCanonical' => false,
-        ]);
+        $resolver->method('resolveUrl')->willReturnCallback(static fn (SeoUrlRequestContext $context) => new ResolvedSeoUrl(
+            pathInfo: '/' . ltrim($context->pathInfo, '/'),
+            isCanonical: false,
+        ));
 
         $domains = new DomainCollection();
         $domains->set($domainKey, DomainStruct::fromArray([

--- a/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -64,6 +64,59 @@ class RequestTransformerTest extends TestCase
         $requestTransformer->transform($originalRequest);
     }
 
+    public function testResolverReceivesQueryStringForExactMatching(): void
+    {
+        $decorated = $this->createMock(RequestTransformerInterface::class);
+        $decorated->method('transform')->willReturnCallback(fn ($request) => $request);
+
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $resolver = $this->createMock(AbstractSeoResolver::class);
+        $resolver
+            ->expects($this->once())
+            ->method('resolveWithQueryString')
+            ->with(
+                $languageId,
+                $salesChannelId,
+                'Main-product/SWDEMO10001',
+                'test=123'
+            )
+            ->willReturn([
+                'pathInfo' => '/detail/123',
+                'isCanonical' => true,
+            ]);
+
+        $domainLoader = $this->createMock(AbstractDomainLoader::class);
+        $domainLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn([
+                'http://shopware.com/' => [
+                    'url' => 'http://shopware.com',
+                    'id' => Uuid::randomHex(),
+                    'salesChannelId' => $salesChannelId,
+                    'typeId' => Uuid::randomHex(),
+                    'snippetSetId' => Uuid::randomHex(),
+                    'currencyId' => Uuid::randomHex(),
+                    'languageId' => $languageId,
+                    'themeId' => Uuid::randomHex(),
+                    'maintenance' => '0',
+                    'maintenanceIpWhitelist' => '',
+                    'locale' => 'en-GB',
+                    'themeName' => 'Storefront',
+                    'parentThemeName' => '',
+                ],
+            ]);
+
+        $requestTransformer = new RequestTransformer($decorated, $resolver, [], $domainLoader);
+
+        $originalRequest = Request::create('http://shopware.com/Main-product/SWDEMO10001?test=123');
+        $transformedRequest = $requestTransformer->transform($originalRequest);
+
+        static::assertSame('/detail/123', $transformedRequest->attributes->get(RequestTransformer::SALES_CHANNEL_RESOLVED_URI));
+    }
+
     /**
      * @param array<string, string> $serverVars
      */
@@ -90,7 +143,7 @@ class RequestTransformerTest extends TestCase
         $decorated->method('transform')->willReturnCallback(static fn ($request) => $request);
 
         $resolver = $this->createMock(AbstractSeoResolver::class);
-        $resolver->method('resolve')->willReturnCallback(static fn ($langId, $scId, $seoPathInfo) => [
+        $resolver->method('resolveWithQueryString')->willReturnCallback(static fn ($langId, $scId, $seoPathInfo) => [
             'pathInfo' => '/' . ltrim($seoPathInfo, '/'),
             'isCanonical' => false,
         ]);


### PR DESCRIPTION
### Actual behaviour

If a product is assigned a custom SEO URL in the admin that includes a query parameter (e.g. Main-product/SWDEMO10001?test=123), accessing this URL results in an endless redirect loop.
The query parameter is continuously appended, e.g.:
?test=123?test=123?test=123 etc.

### Expected behaviour

Custom SEO URLs with query parameters should either:

Load correctly without triggering a redirect loop, or

Be validated and disallowed if unsupported.

### How to reproduce

1. Go to Shopware Administration → Catalogues → Products.
2. Edit any product (e.g., Main Product).
3. Scroll to the SEO URLs section.
4. Add a custom SEO path like: Main-product/SWDEMO10001?test=123
5. Save and clear the cache.
6. Open the generated URL in the browser.
7. Observe the infinite redirect loop.