### PR TITLE
revert: fix: order address validation

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
@@ -152,9 +152,7 @@ export default {
 
         onEditAddress(id) {
             if (id === this.address.id) {
-                // clone, to prevent side effects when closing the modal
-                this.currentAddress = cloneDeep(this.address);
-
+                this.currentAddress = this.address;
                 return;
             }
 
@@ -189,7 +187,6 @@ export default {
 
             // edit order address
             if (this.currentAddress.id === this.address.id) {
-                this.address = cloneDeep(this.address);
                 return this.orderRepository
                     .save(this.order, this.versionContext)
                     .then(() => {


### PR DESCRIPTION
- Revert https://github.com/shopware/shopware/pull/14923
- fixes https://github.com/shopware/shopware/issues/15459

Reverted:
Prevent order address to be updated, when closing the modal without "apply" (close button or click next to the modal), and save the order afterward