### PR TITLE
chore: add saas-infrastructure as allowed package

### DIFF
--- a/src/Core/Framework/Log/Package.php
+++ b/src/Core/Framework/Log/Package.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Log;
 /**
  * @internal
  *
- * @phpstan-type PackageString 'inventory'|'checkout'|'after-sales'|'framework'|'data-services'|'innovation'|'discovery'|'b2b'|'fundamentals@framework'|'fundamentals@discovery'|'fundamentals@checkout'|'fundamentals@after-sales'
+ * @phpstan-type PackageString 'inventory'|'checkout'|'after-sales'|'framework'|'data-services'|'innovation'|'discovery'|'b2b'|'fundamentals@framework'|'fundamentals@discovery'|'fundamentals@checkout'|'fundamentals@after-sales'|'saas-infrastructure'
  *
  * # Important
  * if the above valid types / domains are changed, please also update them here:


### PR DESCRIPTION
Add `'saas-infrastructure'` to the list of allowed package strings.