### PR TITLE
fix: Correct description of the `customer.hash` field

### DIFF
--- a/src/Core/Checkout/Customer/CustomerDefinition.php
+++ b/src/Core/Checkout/Customer/CustomerDefinition.php
@@ -122,7 +122,7 @@ class CustomerDefinition extends EntityDefinition
             (new BoolField('double_opt_in_registration', 'doubleOptInRegistration'))->addFlags(new ApiAware())->setDescription('Set to `true` to allow user subscriptions to an email marketing list.'),
             (new DateTimeField('double_opt_in_email_sent_date', 'doubleOptInEmailSentDate'))->addFlags(new ApiAware())->setDescription('Date and time when the double opt-in email was sent.'),
             (new DateTimeField('double_opt_in_confirm_date', 'doubleOptInConfirmDate'))->addFlags(new ApiAware())->setDescription('Date and time when the double opt-in email was confirmed.'),
-            (new StringField('hash', 'hash'))->addFlags(new ApiAware())->setDescription('Password hash for customer recovery.'),
+            (new StringField('hash', 'hash'))->addFlags(new ApiAware())->setDescription('Customer registration double opt-in hash for confirming the customer account.'),
             (new BoolField('guest', 'guest'))->addFlags(new ApiAware())->setDescription('Boolean value is `true` if it is to be a guest account.'),
             (new DateTimeField('first_login', 'firstLogin'))->addFlags(new ApiAware())->setDescription('To capture date and time of customer\'s first login.'),
             (new DateTimeField('last_login', 'lastLogin'))->addFlags(new ApiAware())->setDescription('To capture date and time of customer\'s last login.'),


### PR DESCRIPTION
### 1. Why is this change necessary?
The `customer.hash` field has nothing to do with the password hash, stored in `customer.password`.

### 2. What does this change do, exactly?
Correct the description.

### 3. Describe each step to reproduce the issue or behaviour.
:eyes: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
