### PR TITLE
fix: Dynamic Product Group preview not showing correct results when Advanced Search is enabled

### DIFF
--- a/src/Elasticsearch/Product/ProductCriteriaParser.php
+++ b/src/Elasticsearch/Product/ProductCriteriaParser.php
@@ -52,9 +52,17 @@ class ProductCriteriaParser extends CriteriaParser
 
             $query = new BoolQuery();
 
-            $query->add(
-                new TermQuery('active', true),
-            );
+            // Shopware\Administration\Controller\AdminProductStreamController::productStreamPreview() add ProductAvailableFilter
+            // but remove active filter, so we need to check if active filter is added to the query
+            foreach ($filter->getQueries() as $subFilter) {
+                if ($subFilter instanceof EqualsFilter && \in_array($subFilter->getField(), ['product.active', 'active'], true)) {
+                    $query->add(
+                        new TermQuery('active', true),
+                    );
+
+                    break;
+                }
+            }
 
             $query->add(
                 new RangeQuery('visibility_' . $filter->getSalesChannelId(), [RangeFilter::GTE => $filter->getVisibility()]),

--- a/tests/unit/Elasticsearch/Product/ProductCriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductCriteriaParserTest.php
@@ -177,6 +177,39 @@ class ProductCriteriaParserTest extends TestCase
         static::assertSame($visibility, $visibilityQuery['range']['visibility_' . $salesChannelId]['gte']);
     }
 
+    public function testParseProductAvailableFilterWithoutActiveFilter(): void
+    {
+        $storage = new ArrayKeyValueStorage([
+            ElasticsearchOptimizeSwitch::FLAG => true,
+        ]);
+        $parser = new ProductCriteriaParser(
+            $this->helper,
+            $this->customFieldService,
+            $storage,
+            $this->decoratedParser
+        );
+
+        $salesChannelId = Uuid::randomHex();
+        $visibility = 30;
+        $filter = new ProductAvailableFilter($salesChannelId, $visibility);
+
+        $queries = $filter->getQueries();
+        array_pop($queries);
+        $filter->assign(['queries' => $queries]);
+
+        $result = $parser->parseFilter($filter, $this->productDefinition, 'root', $this->context);
+
+        static::assertInstanceOf(BoolQuery::class, $result);
+
+        $queryArray = $result->toArray();
+
+        static::assertSame([
+            'range' => [
+                'visibility_' . $salesChannelId => ['gte' => $visibility],
+            ],
+        ], $queryArray);
+    }
+
     public function testParseCategoriesRoIdEqualsFilter(): void
     {
         $storage = new ArrayKeyValueStorage();


### PR DESCRIPTION
This pull request enhances the logic for parsing product filters in Elasticsearch by ensuring that the `active` field is only included in the query when an explicit filter on `product.active` is present.

**Product Filter Parsing Logic:**

* Updated `ProductCriteriaParser::parseFilter` to check if an `EqualsFilter` on `product.active` exists before adding a `TermQuery` for the `active` field. This prevents unnecessary filtering on the `active` field when not explicitly requested.
