### PR TITLE
fix: prevent SSO state invalidation caused by race condition during logout redirect

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -400,9 +400,6 @@ The admin menu only supports up to three levels of nesting.`,
             Shopware.Store.get('session').removeCurrentUser();
             Shopware.Store.get('notification').clearGrowlNotificationsForCurrentUser();
             Shopware.Store.get('notification').clearNotificationsForCurrentUser();
-
-            // SSO path redirects via window.location.href — this line only runs for non-SSO
-            this.$router.push({ name: 'sw.login.index' });
         },
 
         addScrollbarOffset() {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.spec.js
@@ -427,17 +427,15 @@ describe('src/app/component/structure/sw-admin-menu', () => {
         expect(wrapper.vm.flyoutStyle.top).toBe('80px');
     });
 
-    it('should call logoutSso on logout and navigate to login', async () => {
+    it('should call logoutSso and clear stores on logout', async () => {
         wrapper = await createWrapper();
         await flushPromises();
 
         wrapper.vm.loginService.logoutSso = jest.fn().mockResolvedValue(undefined);
-        const routerPush = jest.spyOn(wrapper.vm.$router, 'push').mockResolvedValue(undefined);
 
         await wrapper.vm.onLogoutUser();
 
         expect(wrapper.vm.loginService.logoutSso).toHaveBeenCalledTimes(1);
-        expect(routerPush).toHaveBeenCalledWith({ name: 'sw.login.index' });
     });
 
     it('should not show icons in flyout menu items', async () => {

--- a/src/Administration/Resources/app/administration/src/core/service/login.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.spec.js
@@ -880,6 +880,11 @@ describe('core/service/login.service.js', () => {
         });
 
         it('should not redirect to SSO when useDefault is true and session is not SSO', async () => {
+            Shopware.Application.view.router = {
+                currentRoute: { value: { fullPath: '/sw/dashboard/index', name: 'sw.dashboard.index' } },
+                push: jest.fn(),
+            };
+
             const { loginService, clientMock } = loginServiceFactory();
             const navigateToSpy = jest.fn();
             loginService._navigateTo = navigateToSpy;
@@ -935,7 +940,7 @@ describe('core/service/login.service.js', () => {
 
             expect(loginService.getBearerAuthentication()).toBeFalsy();
             expect(navigateToSpy).toHaveBeenCalledWith('https://idp.example.com/authorize?client_id=test&usePromptLogin=1');
-            expect(sessionStorage.getItem('sw-sso-session')).toBeNull();
+            expect(sessionStorage.getItem('sw-sso-session')).toBe('true');
         });
 
         it('should notify logout listeners when switching account', async () => {

--- a/src/Administration/Resources/app/administration/src/core/service/login.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.ts
@@ -603,8 +603,11 @@ export default function createLoginService(
     }
 
     /**
-     * Revokes server-side tokens, clears local auth state, and redirects to
-     * the SSO provider with prompt=login when the session was established via SSO.
+     * Revokes server-side tokens, clears local auth state, and navigates
+     * to the appropriate login surface:
+     * - SSO sessions → full-page redirect to the SSO provider (prompt=login)
+     * - Non-SSO sessions → standard logout via {@link forwardLogout}
+     *
      * Falls back to regular logout if the SSO configuration cannot be loaded.
      */
     async function logoutSso(): Promise<void> {
@@ -636,14 +639,17 @@ export default function createLoginService(
         }
 
         const isSsoSession = !!sessionStorage.getItem('sw-sso-session');
-        sessionStorage.removeItem('sw-sso-session');
-
-        clearAuthState();
-        notifyOnLogoutListener();
 
         if (!loginConfig.useDefault || isSsoSession) {
+            clearAuthState();
+            notifyOnLogoutListener();
+            sessionStorage.setItem('sw-sso-session', 'true');
             navigateToFn(`${loginConfig.url}&usePromptLogin=1`);
+            return;
         }
+
+        sessionStorage.removeItem('sw-sso-session');
+        logout();
     }
 
     /**

--- a/src/Core/Framework/Sso/StateValidator.php
+++ b/src/Core/Framework/Sso/StateValidator.php
@@ -30,12 +30,20 @@ class StateValidator
             $request->getSession()->get(self::SESSION_KEY),
         );
 
+        $request->getSession()->remove(self::SESSION_KEY);
+
         $request->request->set('grant_type', 'shopware_grant');
         $request->request->set('code', $request->query->get('code'));
     }
 
     public function createRandom(Request $request): string
     {
+        $existing = $request->getSession()->get(self::SESSION_KEY);
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
         $random = ByteString::fromRandom(self::RANDOM_LENGTH)->toString();
 
         $request->getSession()->set(self::SESSION_KEY, $random);

--- a/tests/unit/Core/Framework/Sso/StateValidatorTest.php
+++ b/tests/unit/Core/Framework/Sso/StateValidatorTest.php
@@ -50,6 +50,55 @@ class StateValidatorTest extends TestCase
         static::assertSame($code, $request->request->get('code'));
     }
 
+    public function testValidateRemovesSessionKeyAfterSuccess(): void
+    {
+        $validator = new StateValidator();
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with(StateValidator::SESSION_KEY)->willReturn(self::VALID);
+        $session->expects($this->once())->method('remove')->with(StateValidator::SESSION_KEY);
+
+        $request = new Request(['rdm' => self::VALID, 'code' => Uuid::randomHex()]);
+        $request->setSession($session);
+
+        $validator->validateRequest($request);
+    }
+
+    public function testCreateRandomReusesExistingKey(): void
+    {
+        $validator = new StateValidator();
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with(StateValidator::SESSION_KEY)->willReturn(self::VALID);
+        $session->expects($this->never())->method('set');
+
+        $request = new Request();
+        $request->setSession($session);
+
+        $result = $validator->createRandom($request);
+
+        static::assertSame(self::VALID, $result);
+    }
+
+    public function testCreateRandomGeneratesNewKeyWhenNoneExists(): void
+    {
+        $validator = new StateValidator();
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('get')->with(StateValidator::SESSION_KEY)->willReturn(null);
+        $session->expects($this->once())->method('set')->with(
+            StateValidator::SESSION_KEY,
+            static::callback(static fn (string $value): bool => \strlen($value) === 64),
+        );
+
+        $request = new Request();
+        $request->setSession($session);
+
+        $result = $validator->createRandom($request);
+
+        static::assertSame(64, \strlen($result));
+    }
+
     /**
      * @return array<string, array{state: string|null, storedState: string|null, expectException: bool}>
      */


### PR DESCRIPTION
### 1. Why is this change necessary?

After SSO logout, the redirect to the identity provider could be followed by a Vue Router navigation that calls `getLoginTemplateConfig()` again — overwriting the CSRF state token in the PHP session and causing `SSO_LOGIN__INVALID_LOGIN_STATE` on re-authentication. Additionally, repeated logout/login cycles fail because the `sw-sso-session` marker is cleared on first logout and never restored.

### 2. What does this change do, exactly?

- `logoutSso()` returns `Promise<void>` and handles navigation internally (SSO → redirect, non-SSO → `forwardLogout()`), removing the boolean return and eliminating the race condition in `onLogoutUser()`
- The `sw-sso-session` sessionStorage marker is preserved across SSO redirects so repeated cycles work
- `StateValidator::createRandom()` reuses an existing session key instead of generating a new one (idempotent)
- `StateValidator::validateRequest()` removes the session key after successful validation (one-time-use)

### 3. Describe each step to reproduce the issue or behaviour.

1. Log in via SSO
2. Log out → redirected to identity provider ✅
3. Re-authenticate → back in admin ✅
4. Log out again → shows local login page instead of SSO redirect, or `SSO_LOGIN__INVALID_LOGIN_STATE` on callback

### 4. Please link to the relevant issues (if any).

Follow-up to #15569

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them