### PR TITLE
feat: Add danger rule so the baseline for routes without Schema doesn't get bigger

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -42,7 +42,7 @@ return (new Config())
         $files = $context->platform->pullRequest->getFiles();
 
         if ($files->matches('changelog/_unreleased/*.md')->count() > 0) {
-            $context->failure('The Pull Request makes use of the old changelog format. Please document your changes in the `RELEASE_INFO-6.7.md` and `UPGRADE-6.8.md` file respectively. For detailed infos please refer to the [release documentation guide](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md).');;
+            $context->failure('The Pull Request makes use of the old changelog format. Please document your changes in the `RELEASE_INFO-6.7.md` and `UPGRADE-6.8.md` file respectively. For detailed infos please refer to the [release documentation guide](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md).');
         }
     })
 
@@ -287,7 +287,6 @@ return (new Config())
             ? $dom->loadXML($phpUnitConfigFromPullRequest->getContent())
             : $dom->load($phpUnitConfig);
 
-
         if ($domLoad) {
             $xpath = new DOMXPath($dom);
             foreach ($xpath->query('//source/exclude/directory') as $dirDomElement) {
@@ -523,6 +522,17 @@ return (new Config())
                 'Please add the integration test(s) within one of the core-batch testsuite of phpunit.xml.dist: <br/><br/>'
                 . implode('<br/>', array_unique($missing))
             );
+        }
+    })
+    ->useRule(function (Context $context): void {
+        $routesSnapshot = $context->platform->pullRequest->getFiles()->get('tests/integration/Core/Framework/_snapshots/routes_without_schema/snapshot.json');
+        if (!$routesSnapshot instanceof File) {
+            return;
+        }
+
+        $additions = $routesSnapshot->additions ?? 0;
+        if ($additions !== 0) {
+            $context->failure('Do not extend the `snapshot.json` file. Please create an open API schema for the new endpoint instead.');
         }
     })
 ;


### PR DESCRIPTION
### 1. Why is this change necessary?

People are lazy and do not write API schemas. Instead they are extending the baseline of routes which do not have a schema. This needs to be prevented.

### 2. What does this change do, exactly?

Add a danger.php rule, that emits a failure, if new things are added to the snapshot file

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
