### PR TITLE
fix: add missing inheritance switch for switch and  checkbox field in theme configuration

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.html.twig
@@ -4,7 +4,6 @@
     :class="{ 'is--inherited': isInherited, 'is--required': required, 'has--parent' : hasParent }"
 >
     {% block sw_inherit_wrapper_toggle %}
-    <template v-if="label">
         {% block sw_inherit_wrapper_toggle_wrapper %}
         <div class="sw-inherit-wrapper__toggle-wrapper">
             {% block sw_inherit_wrapper_toggle_wrapper_field %}
@@ -21,6 +20,7 @@
             {% block sw_inherit_wrapper_toggle_wrapper_label %}
             <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
             <label
+                v-if="label"
                 class="sw-inherit-wrapper__inheritance-label"
                 :class="labelClasses"
             >
@@ -37,7 +37,6 @@
             {% endblock %}
         </div>
         {% endblock %}
-    </template>
     {% endblock %}
 
     {% block sw_inherit_wrapper_content %}

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.scss
@@ -59,4 +59,9 @@
         border-left-color: $color-module-purple-900;
         border-right-color: $color-module-purple-900;
     }
+
+    .mt-switch {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.spec.js
@@ -77,4 +77,19 @@ describe('src/app/component/utils/sw-inherit-wrapper', () => {
         expect(wrapper.vm).toBeTruthy();
         expect(wrapper.vm.isInherited).toBe(true);
     });
+
+    it('should render inheritance switch without label', async () => {
+        const wrapper = await createWrapper({
+            propsData: {
+                value: null,
+                inheritedValue: 1,
+                hasParent: true,
+                label: null,
+            },
+            global: createWrapperGlobalValue,
+        });
+
+        expect(wrapper.find('sw-inheritance-switch-stub').exists()).toBe(true);
+        expect(wrapper.find('.sw-inherit-wrapper__inheritance-label').exists()).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.spec.js
@@ -636,14 +636,14 @@ describe('src/module/sw-product/component/sw-product-properties', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        expect(wrapper.find('.sw-inheritance-switch').exists()).toBeTruthy();
+        expect(wrapper.find('.sw-card__title .sw-inheritance-switch').exists()).toBeTruthy();
 
         await wrapper.setProps({
             showInheritanceSwitcher: false,
         });
         expect(wrapper.vm.showInheritanceSwitcher).toBe(false);
 
-        expect(wrapper.find('.sw-inheritance-switch').exists()).toBeFalsy();
+        expect(wrapper.find('.sw-card__title .sw-inheritance-switch').exists()).toBeFalsy();
     });
 
     it('should close properties modal and call a callback', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
@@ -696,7 +696,9 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
 
         const allPricesMatrix = wrapper.findAllComponents('.sw-settings-shipping-price-matrix');
         const numberFields = wrapper.findAll('input[type="number"]');
-        const inheritanceSwitches = wrapper.findAllComponents('.sw-inheritance-switch');
+        const inheritanceSwitches = wrapper.findAllComponents(
+            '.sw-inheritance-switch.sw-settings-shipping-price-matrix__price-inherit-icon',
+        );
 
         expect(allPricesMatrix.length).toBeGreaterThan(0);
         expect(numberFields.length).toBeGreaterThan(0);
@@ -736,7 +738,9 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
 
         const allPricesMatrix = wrapper.findAllComponents('.sw-settings-shipping-price-matrix');
         const numberFields = wrapper.findAll('input[type="number"]');
-        const inheritanceSwitches = wrapper.findAllComponents('.sw-inheritance-switch');
+        const inheritanceSwitches = wrapper.findAllComponents(
+            '.sw-inheritance-switch.sw-settings-shipping-price-matrix__price-inherit-icon',
+        );
 
         expect(allPricesMatrix.length).toBeGreaterThan(0);
         expect(numberFields.length).toBeGreaterThan(0);


### PR DESCRIPTION
### 1. Why is this change necessary?
When using a theme config value from type `switch` or `checkbox` it is not possible to remove the inheritance in a child theme. The`sw-inheritance-wrapper` is created, but it doesn't render the `sw-inheritance-switch` because the label is not set. That the label is not set is correct behaviour, because the `switch` and `checkbox` fields come with their own label implementation.

<img width="732" height="193" alt="before" src="https://github.com/user-attachments/assets/89d5a513-9145-470d-8178-df039becaf27" />

### 2. What does this change do, exactly?
This change ensures the inheritance switch renders even when no label is present in the inherit wrapper. It includes a style adjustment for improved switch spacing and updates affected tests to target intended switch instances more precisely. These test refinements are necessary because broader selectors now match additional wrapper-level switches following this behavior change.

<img width="880" height="203" alt="after" src="https://github.com/user-attachments/assets/8a9674d1-d84b-436b-8b89-0a406120ea9b" />

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a parent theme containing a config value of type `switch` or `checkbox`.
2. Create a child theme that inherits the configuration from the parent theme.
3. Attempt to change this config value in the child theme.

### 4. Please link to the relevant issues (if any).
Closes #15203 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
