### PR TITLE
feat: allow system config overrides in staging mode

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -119,6 +119,25 @@ The same `thumbnails` payload shape is accepted by `POST /api/_action/media/{id}
 It is now possible to use libraries like [`doctrine-mysql-come-back`](https://github.com/facile-it/doctrine-mysql-come-back), which wrap the default DBAL connection.
 More information on how to set up, can be found here: https://developer.shopware.com/docs/guides/hosting/infrastructure/database.html#setup-for-long-running-environments
 
+### System config overrides in staging mode
+
+The `system:setup:staging` command now supports pre-configuring system config keys during staging setup. Both global and sales channel-specific values can be set, following the same YAML structure used for [static system configuration](https://developer.shopware.com/docs/guides/hosting/configurations/shopware/static-system-config.md).
+
+Use `default` for global config values and sales channel IDs for channel-specific overrides:
+
+```yaml
+shopware:
+  staging:
+    system_config:
+      default:
+        core.mailerSettings.smtpHost: "smtp.staging.local"
+        core.listing.allowBuyInListing: false
+      0188da12724970b9b4a708298259b171:
+        core.mailerSettings.smtpHost: "smtp.other.staging.local"
+```
+
+When `bin/console system:setup:staging` is executed, the configured keys are written to the database via `SystemConfigService`.
+
 ## API
 
 ### Deprecation of newsletter route methods

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -903,6 +903,13 @@ class Configuration implements ConfigurationInterface
                         ->booleanNode('check_for_existence')->defaultTrue()->end()
                     ->end()
                 ->end()
+                ->arrayNode('system_config')
+                    ->useAttributeAsKey('scope')
+                    ->arrayPrototype()
+                        ->useAttributeAsKey('key')
+                        ->variablePrototype()->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Maintenance/DependencyInjection/services.xml
+++ b/src/Core/Maintenance/DependencyInjection/services.xml
@@ -146,6 +146,7 @@
             <argument>%shopware.staging.mailing.disable_delivery%</argument>
             <argument>%shopware.staging.sales_channel.domain_rewrite%</argument>
             <argument>%shopware.staging.extensions.disable%</argument>
+            <argument>%shopware.staging.system_config%</argument>
 
             <tag name="console.command"/>
         </service>
@@ -173,6 +174,12 @@
             <argument type="service" id="Symfony\Component\HttpKernel\KernelInterface"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\ExtensionLifecycleService"/>
+
+            <tag name="kernel.event_listener"/>
+        </service>
+
+        <service id="Shopware\Core\Maintenance\Staging\Handler\StagingSystemConfigHandler">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
 
             <tag name="kernel.event_listener"/>
         </service>

--- a/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
+++ b/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
@@ -29,6 +29,7 @@ class SystemSetupStagingCommand extends Command
     /**
      * @param list<DomainRewriteRule> $domainMappings
      * @param list<string> $extensionsToDisable
+     * @param array<string, array<string, mixed>> $systemConfigOverrides
      */
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
@@ -36,6 +37,7 @@ class SystemSetupStagingCommand extends Command
         public readonly bool $disableMailDelivery,
         public readonly array $domainMappings,
         private readonly array $extensionsToDisable,
+        private readonly array $systemConfigOverrides = [],
     ) {
         parent::__construct();
     }
@@ -59,6 +61,7 @@ class SystemSetupStagingCommand extends Command
             $this->disableMailDelivery,
             $this->domainMappings,
             $this->extensionsToDisable,
+            $this->systemConfigOverrides,
         );
         $this->eventDispatcher->dispatch($event);
 

--- a/src/Core/Maintenance/Staging/Event/SetupStagingEvent.php
+++ b/src/Core/Maintenance/Staging/Event/SetupStagingEvent.php
@@ -21,6 +21,7 @@ class SetupStagingEvent
     /**
      * @param list<DomainRewriteRule> $domainMappings
      * @param list<string> $extensionsToDisable
+     * @param array<string, array<string, mixed>> $systemConfigOverrides
      */
     public function __construct(
         public readonly Context $context,
@@ -28,6 +29,7 @@ class SetupStagingEvent
         public readonly bool $disableMailDelivery = true,
         public readonly array $domainMappings = [],
         public readonly array $extensionsToDisable = [],
+        public readonly array $systemConfigOverrides = [],
     ) {
     }
 }

--- a/src/Core/Maintenance/Staging/Handler/StagingSystemConfigHandler.php
+++ b/src/Core/Maintenance/Staging/Handler/StagingSystemConfigHandler.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Maintenance\Staging\Handler;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+readonly class StagingSystemConfigHandler
+{
+    public function __construct(
+        private SystemConfigService $systemConfigService
+    ) {
+    }
+
+    public function __invoke(SetupStagingEvent $event): void
+    {
+        if ($event->systemConfigOverrides === []) {
+            return;
+        }
+
+        foreach ($event->systemConfigOverrides as $scope => $config) {
+            $salesChannelId = $scope === 'default' ? null : $scope;
+
+            foreach ($config as $key => $value) {
+                $this->systemConfigService->set($key, $value, $salesChannelId, true);
+
+                if ($salesChannelId === null) {
+                    $event->io->info(\sprintf('Set system config "%s".', $key));
+                } else {
+                    $event->io->info(\sprintf('Set system config "%s" for sales channel "%s".', $key, $salesChannelId));
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
@@ -45,12 +45,22 @@ class SystemSetupStagingCommandTest extends TestCase
             ['match' => '/old-path', 'type' => 'prefix', 'replace' => '/new-path'],
         ];
 
+        $systemConfigOverrides = [
+            'default' => [
+                'core.someKey' => 'someValue',
+            ],
+            'a1b2c3d4e5f6' => [
+                'core.someKey' => 'channelValue',
+            ],
+        ];
+
         $command = new SystemSetupStagingCommand(
             $eventDispatcher,
             $configService,
             true,
             $routeMappings,
             ['MyDisabledExtension'],
+            $systemConfigOverrides,
         );
 
         $tester = new CommandTester($command);
@@ -67,6 +77,7 @@ class SystemSetupStagingCommandTest extends TestCase
         static::assertSame($routeMappings, $event->domainMappings);
         static::assertTrue($event->disableMailDelivery);
         static::assertSame(['MyDisabledExtension'], $event->extensionsToDisable);
+        static::assertSame($systemConfigOverrides, $event->systemConfigOverrides);
     }
 
     public function testRunNoInteractionWithForce(): void

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Maintenance\Staging\Handler;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
+use Shopware\Core\Maintenance\Staging\Handler\StagingSystemConfigHandler;
+use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @internal
+ */
+#[CoversClass(StagingSystemConfigHandler::class)]
+class StagingSystemConfigHandlerTest extends TestCase
+{
+    public function testEmptyOverrides(): void
+    {
+        $config = new StaticSystemConfigService();
+        $handler = new StagingSystemConfigHandler($config);
+
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $this->createMock(SymfonyStyle::class),
+            true,
+            [],
+            [],
+        ));
+
+        static::assertNull($config->get('core.someKey'));
+    }
+
+    public function testSetsDefaultConfigOverrides(): void
+    {
+        $config = new StaticSystemConfigService();
+        $handler = new StagingSystemConfigHandler($config);
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(static::exactly(2))->method('info');
+
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $io,
+            true,
+            [],
+            [],
+            [
+                'default' => [
+                    'core.someKey' => 'someValue',
+                    'core.anotherKey' => true,
+                ],
+            ],
+        ));
+
+        static::assertSame('someValue', $config->get('core.someKey'));
+        static::assertTrue($config->get('core.anotherKey'));
+    }
+
+    public function testSetsSalesChannelConfigOverrides(): void
+    {
+        $config = new StaticSystemConfigService();
+        $handler = new StagingSystemConfigHandler($config);
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(static::exactly(2))->method('info');
+
+        $salesChannelId = 'a1b2c3d4e5f6';
+
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $io,
+            true,
+            [],
+            [],
+            [
+                $salesChannelId => [
+                    'core.someKey' => 'channelValue',
+                    'core.anotherKey' => 42,
+                ],
+            ],
+        ));
+
+        static::assertSame('channelValue', $config->get('core.someKey', $salesChannelId));
+        static::assertSame(42, $config->get('core.anotherKey', $salesChannelId));
+    }
+
+    public function testSetsDefaultAndSalesChannelOverrides(): void
+    {
+        $config = new StaticSystemConfigService();
+        $handler = new StagingSystemConfigHandler($config);
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(static::exactly(3))->method('info');
+
+        $salesChannelId = 'a1b2c3d4e5f6';
+
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $io,
+            true,
+            [],
+            [],
+            [
+                'default' => [
+                    'core.someKey' => 'globalValue',
+                ],
+                $salesChannelId => [
+                    'core.someKey' => 'channelValue',
+                    'core.anotherKey' => 42,
+                ],
+            ],
+        ));
+
+        static::assertSame('globalValue', $config->get('core.someKey'));
+        static::assertSame('channelValue', $config->get('core.someKey', $salesChannelId));
+        static::assertSame(42, $config->get('core.anotherKey', $salesChannelId));
+    }
+
+    public function testSetsOverridesForMultipleSalesChannels(): void
+    {
+        $config = new StaticSystemConfigService();
+        $handler = new StagingSystemConfigHandler($config);
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->expects(static::exactly(4))->method('info');
+
+        $channelOne = 'a1b2c3d4e5f6';
+        $channelTwo = 'f6e5d4c3b2a1';
+
+        $handler(new SetupStagingEvent(
+            Context::createDefaultContext(),
+            $io,
+            true,
+            [],
+            [],
+            [
+                'default' => [
+                    'core.sharedKey' => 'global',
+                ],
+                $channelOne => [
+                    'core.sharedKey' => 'channel-one-value',
+                    'core.uniqueKey' => 'only-channel-one',
+                ],
+                $channelTwo => [
+                    'core.sharedKey' => 'channel-two-value',
+                ],
+            ],
+        ));
+
+        static::assertSame('global', $config->get('core.sharedKey'));
+        static::assertSame('channel-one-value', $config->get('core.sharedKey', $channelOne));
+        static::assertSame('only-channel-one', $config->get('core.uniqueKey', $channelOne));
+        static::assertSame('channel-two-value', $config->get('core.sharedKey', $channelTwo));
+        static::assertNull($config->get('core.uniqueKey', $channelTwo));
+    }
+}

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
@@ -38,7 +38,7 @@ class StagingSystemConfigHandlerTest extends TestCase
         $handler = new StagingSystemConfigHandler($config);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->expects(static::exactly(2))->method('info');
+        $io->expects($this->exactly(2))->method('info');
 
         $handler(new SetupStagingEvent(
             Context::createDefaultContext(),
@@ -64,7 +64,7 @@ class StagingSystemConfigHandlerTest extends TestCase
         $handler = new StagingSystemConfigHandler($config);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->expects(static::exactly(2))->method('info');
+        $io->expects($this->exactly(2))->method('info');
 
         $salesChannelId = 'a1b2c3d4e5f6';
 
@@ -92,7 +92,7 @@ class StagingSystemConfigHandlerTest extends TestCase
         $handler = new StagingSystemConfigHandler($config);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->expects(static::exactly(3))->method('info');
+        $io->expects($this->exactly(3))->method('info');
 
         $salesChannelId = 'a1b2c3d4e5f6';
 
@@ -124,7 +124,7 @@ class StagingSystemConfigHandlerTest extends TestCase
         $handler = new StagingSystemConfigHandler($config);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->expects(static::exactly(4))->method('info');
+        $io->expects($this->exactly(4))->method('info');
 
         $channelOne = 'a1b2c3d4e5f6';
         $channelTwo = 'f6e5d4c3b2a1';


### PR DESCRIPTION
### 1. Why is this change necessary?

> Wanted to test the new Xiaomi AI model

Currently the staging mode setup (`system:setup:staging`) supports configuring mail delivery, sales channel domains, and extensions, but there is no way to pre-configure system config keys. Users who need specific staging configurations (e.g. SMTP hosts, feature flags) have to set them manually after running the command.

### 2. What does this change do, exactly?

Adds a new `shopware.staging.system_config` configuration node that allows setting system config keys during staging setup. It follows the same YAML structure as the existing [static system configuration](https://developer.shopware.com/docs/guides/hosting/configurations/shopware/static-system-config.md):

- `default` scope for global config values
- Sales channel ID scopes for channel-specific overrides

A new `StagingSystemConfigHandler` event listener processes these overrides when `system:setup:staging` is dispatched.

**Example configuration:**
```yaml
shopware:
  staging:
    system_config:
      default:
        core.mailerSettings.smtpHost: "smtp.staging.local"
        core.listing.allowBuyInListing: false
      0188da12724970b9b4a708298259b171:
        core.mailerSettings.smtpHost: "smtp.other.staging.local"
```

### 3. Describe each step to reproduce the issue or behaviour.

1. Add system config overrides to `config/packages/staging.yaml` as shown above
2. Run `bin/console system:setup:staging`
3. The configured keys are now set in the system config database table

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them