### PR TITLE
feat: add isEmpty method to Collection

### DIFF
--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -82,6 +82,14 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     }
 
     /**
+     * @phpstan-impure
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->elements);
+    }
+
+    /**
      * @return list<TKey>
      */
     public function getKeys(): array

--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -86,7 +86,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
      */
     public function isEmpty(): bool
     {
-        return empty($this->elements);
+        return $this->elements === [];
     }
 
     /**

--- a/tests/unit/Core/Framework/Struct/CollectionTest.php
+++ b/tests/unit/Core/Framework/Struct/CollectionTest.php
@@ -55,6 +55,18 @@ class CollectionTest extends TestCase
         static::assertCount(2, $collection);
     }
 
+    public function testIsEmpty(): void
+    {
+        $collection = new TestCollection();
+        static::assertTrue($collection->isEmpty());
+
+        $collection->add('a');
+        static::assertFalse($collection->isEmpty());
+
+        $collection->clear();
+        static::assertTrue($collection->isEmpty());
+    }
+
     public function testGetNumericKeys(): void
     {
         $collection = new TestCollection();


### PR DESCRIPTION
### 1. Why is this change necessary?
Checking whether a collection has items requires count() === 0. An isEmpty() method is more readable.

### 2. What does this change do, exactly?
Adds isEmpty(): bool to Collection. Returns true when elements array is empty.

### 4. Please link to the relevant issues (if any).
closes #14869

### 5. Checklist
- [x] I have written tests
- [x] I have read the contribution requirements

This contribution was developed with AI assistance (Claude Code).