### PR TITLE
fix: sales channel context language

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -158,7 +158,7 @@ export default Component.wrapComponentConfig({
 
         salesChannelCriteria(): CriteriaType {
             const criteria = new Criteria();
-            criteria.addAssociation('languages')
+            criteria.addAssociation('languages');
             criteria.addFilter(Criteria.equals('active', true));
 
             if (this.customer?.boundSalesChannelId) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -378,15 +378,15 @@ export default Component.wrapComponentConfig({
         },
 
         checkContextLanguage() {
-            const isExists = (this.customer?.salesChannel?.languages || []).some(
+            const exists = (this.customer?.salesChannel?.languages || []).some(
                 (language) => language.id === Context.api.systemLanguageId,
             );
 
-            if (!isExists && this.customer?.salesChannel?.languageId) {
+            if (!exists && this.customer?.salesChannel?.languageId) {
                 Store.get('context').api.languageId = this.customer.salesChannel.languageId;
             }
 
-            if (isExists && !Store.get('context').isSystemDefaultLanguage) {
+            if (exists && !Store.get('context').isSystemDefaultLanguage) {
                 Store.get('context').resetLanguageToDefault();
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -158,6 +158,7 @@ export default Component.wrapComponentConfig({
 
         salesChannelCriteria(): CriteriaType {
             const criteria = new Criteria();
+            criteria.addAssociation('languages')
             criteria.addFilter(Criteria.equals('active', true));
 
             if (this.customer?.boundSalesChannelId) {
@@ -229,17 +230,7 @@ export default Component.wrapComponentConfig({
 
             this.customer = await this.customerRepository.get(item.id, Context.api, this.customerCriterion);
 
-            const isExists = (this.customer?.salesChannel?.languages || []).some(
-                (language) => language.id === Context.api.systemLanguageId,
-            );
-
-            if (!isExists && this.customer?.salesChannel?.languageId) {
-                Store.get('context').api.languageId = this.customer.salesChannel.languageId;
-            }
-
-            if (isExists && !Store.get('context').isSystemDefaultLanguage) {
-                Store.get('context').resetLanguageToDefault();
-            }
+            this.checkContextLanguage();
 
             // If the customer belongs to a sales channel not in the allowed list and has no bound sales channel.
             if (!this.customer?.boundSalesChannelId) {
@@ -334,12 +325,15 @@ export default Component.wrapComponentConfig({
             return ids;
         },
 
-        onSalesChannelChange(salesChannelId: string): void {
+        onSalesChannelChange(salesChannelId: string, salesChannel: Entity<'sales_channel'>): void {
             if (!this.customer) {
                 return;
             }
 
             this.customer.salesChannelId = salesChannelId;
+            this.customer.salesChannel = salesChannel;
+
+            this.checkContextLanguage();
         },
 
         onCloseSalesChannelSelectModal() {
@@ -381,6 +375,20 @@ export default Component.wrapComponentConfig({
             this.customer = this.customerDraft;
 
             this.showCustomerChangesModal = false;
+        },
+
+        checkContextLanguage() {
+            const isExists = (this.customer?.salesChannel?.languages || []).some(
+                (language) => language.id === Context.api.systemLanguageId,
+            );
+
+            if (!isExists && this.customer?.salesChannel?.languageId) {
+                Store.get('context').api.languageId = this.customer.salesChannel.languageId;
+            }
+
+            if (isExists && !Store.get('context').isSystemDefaultLanguage) {
+                Store.get('context').resetLanguageToDefault();
+            }
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
@@ -164,10 +164,12 @@ async function createWrapper() {
                                     {
                                         id: '1234',
                                         name: 'Lazada',
+                                        languageId: '8888',
                                     },
                                     {
                                         id: '123456',
                                         name: 'Tiki',
+                                        languageId: '5678',
                                     },
                                 ]);
                             }
@@ -470,7 +472,6 @@ describe('src/module/sw-order/view/sw-order-customer-grid', () => {
         await flushPromises();
 
         const handleSelectCustomerSpy = jest.spyOn(wrapper.vm, 'handleSelectCustomer');
-        const checkContextLanguageSpy = jest.spyOn(wrapper.vm, 'checkContextLanguage');
 
         const firstRow = wrapper.find('.sw-data-grid__body .sw-data-grid__row--0');
         await firstRow.find('.sw-field__radio-input input').setChecked(true);
@@ -497,7 +498,7 @@ describe('src/module/sw-order/view/sw-order-customer-grid', () => {
         expect(handleSelectCustomerSpy).toHaveBeenCalled();
 
         // First call on customer select, second call after sales channel select
-        expect(checkContextLanguageSpy).toHaveBeenCalledTimes(2);
+        expect(Shopware.Store.get('context').api.languageId).toBe('8888');
     });
 
     it('should show sales channel select modal when customer sales channel is not in the allowed list and has no bound sales channel', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
@@ -470,6 +470,7 @@ describe('src/module/sw-order/view/sw-order-customer-grid', () => {
         await flushPromises();
 
         const handleSelectCustomerSpy = jest.spyOn(wrapper.vm, 'handleSelectCustomer');
+        const checkContextLanguageSpy = jest.spyOn(wrapper.vm, 'checkContextLanguage');
 
         const firstRow = wrapper.find('.sw-data-grid__body .sw-data-grid__row--0');
         await firstRow.find('.sw-field__radio-input input').setChecked(true);
@@ -494,6 +495,9 @@ describe('src/module/sw-order/view/sw-order-customer-grid', () => {
         await buttonSelect.trigger('click');
 
         expect(handleSelectCustomerSpy).toHaveBeenCalled();
+
+        // First call on customer select, second call after sales channel select
+        expect(checkContextLanguageSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should show sales channel select modal when customer sales channel is not in the allowed list and has no bound sales channel', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Wrongly context language can be provided, when creating a new order via admin

### 2. What does this change do, exactly?
Validate the right sales channel language, when selecting the sales channel

### 3. Describe each step to reproduce the issue or behaviour.
- Create a Sales Channel and select the Languages as German.
- Use English for administration
- Add new order → Select customer → select Sales Channel above

### 4. Please link to the relevant issues (if any).
- fixes https://github.com/shopware/shopware/issues/11389

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
