### PR TITLE
chore: Prepare tests for PHPStan update

### DIFF
--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Type/CollectionHasSpecifyingExtensionTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Type/CollectionHasSpecifyingExtensionTest.php
@@ -20,7 +20,9 @@ class CollectionHasSpecifyingExtensionTest extends TypeInferenceTestCase
             // because of the autoload issue we can not use data providers as phpstan does itself,
             // therefore we need to rely on this hacks
             $assertType = array_shift($args);
+            static::assertIsString($assertType);
             $file = array_shift($args);
+            static::assertIsString($file);
 
             $this->assertFileAsserts($assertType, $file, ...$args);
         }

--- a/tests/integration/Core/Checkout/Cart/Facade/CartFacadeTest.php
+++ b/tests/integration/Core/Checkout/Cart/Facade/CartFacadeTest.php
@@ -128,7 +128,7 @@ class CartFacadeTest extends TestCase
     public function testRemove(): void
     {
         $context = static::getContainer()->get(SalesChannelContextFactory::class)
-            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL, []);
+            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
 
         $hook = new CartHook($this->createCart(), $context);
         $cart = static::getContainer()->get(CartFacadeHookFactory::class)->factory($hook, $this->script);
@@ -146,7 +146,7 @@ class CartFacadeTest extends TestCase
     }
 
     /**
-     * @param array<string, ExpectedPrice|null> $expectations
+     * @param array<string, ExpectedPrice|array<string, array<string, array<string, array<string, ExpectedPrice>|ExpectedPrice>|ExpectedPrice>|ExpectedPrice>|null> $expectations
      */
     #[DataProvider('scriptProvider')]
     public function testScripts(string $hook, array $expectations, ?\Closure $closure = null): void
@@ -160,9 +160,6 @@ class CartFacadeTest extends TestCase
             ->factory($hook, $this->script);
 
         static::getContainer()->get(ScriptExecutor::class)->execute($hook);
-
-        // add {% do debug.dump('foo') %} to debug scripts
-        //         dump(static::getContainer()->get(ScriptTraces::class)->getTraces());
 
         $this->assertItems($service, $expectations);
 
@@ -372,7 +369,7 @@ class CartFacadeTest extends TestCase
     }
 
     /**
-     * @param array<string, ExpectedPrice|null> $expectations
+     * @param array<string, ExpectedPrice|array<string, array<string, array<string, array<string, ExpectedPrice>|ExpectedPrice>|ExpectedPrice>|ExpectedPrice>|null> $expectations
      */
     private function assertItems(ItemsFacade|CartFacade|LineItemCollection $scope, array $expectations): void
     {
@@ -399,12 +396,15 @@ class CartFacadeTest extends TestCase
             }
 
             $price = $expected['price'];
+            static::assertInstanceOf(ExpectedPrice::class, $price);
             static::assertInstanceOf(ItemFacade::class, $item);
             static::assertInstanceOf(PriceFacade::class, $item->getPrice());
             static::assertSame($price->getUnitPrice(), $item->getPrice()->getUnit(), print_r($item->getItem(), true));
             static::assertSame($price->getTotalPrice(), $item->getPrice()->getTotal());
 
-            $this->assertItems($item->getChildren(), $expected['children']);
+            $children = $expected['children'];
+            static::assertIsArray($children);
+            $this->assertItems($item->getChildren(), $children);
         }
     }
 

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
@@ -164,6 +164,8 @@ class PromotionDiscountCompositionTest extends TestCase
                 TestDefaults::SALES_CHANNEL,
                 [SalesChannelContextService::CUSTOMER_ID => $this->createCustomer()]
             );
+        $customerId1 = $context->getCustomerId();
+        static::assertNotNull($customerId1);
 
         $productId1 = Uuid::randomHex();
         $productId2 = Uuid::randomHex();
@@ -190,7 +192,7 @@ class PromotionDiscountCompositionTest extends TestCase
         static::assertSame(1, $promotion->getOrderCount());
         static::assertNotNull($context->getCustomer());
         static::assertSame(
-            [$context->getCustomerId() => 1],
+            [$customerId1 => 1],
             $promotion->getOrdersPerCustomerCount()
         );
 
@@ -205,22 +207,20 @@ class PromotionDiscountCompositionTest extends TestCase
         // verify that the promotion has a total order count of 1 and the current customer is although tracked
         static::assertSame(2, $promotion->getOrderCount());
         static::assertSame(
-            [$context->getCustomerId() => 2],
+            [$customerId1 => 2],
             $promotion->getOrdersPerCustomerCount()
         );
 
-        $customerId1 = $context->getCustomerId();
-
-        $context = static::getContainer()->get(SalesChannelContextFactory::class)
+        $context2 = static::getContainer()->get(SalesChannelContextFactory::class)
             ->create(
                 Uuid::randomHex(),
                 TestDefaults::SALES_CHANNEL,
                 [SalesChannelContextService::CUSTOMER_ID => $this->createCustomer()]
             );
 
-        static::assertNotNull($context->getCustomer());
+        static::assertNotNull($context2->getCustomer());
         // order promotion with two products and another customer
-        $this->orderWithPromotion($code, [$productId1, $productId2], $context);
+        $this->orderWithPromotion($code, [$productId1, $productId2], $context2);
 
         $promotion = $this->promotionRepository
             ->search(new Criteria([$promotionId]), Context::createDefaultContext())
@@ -229,7 +229,7 @@ class PromotionDiscountCompositionTest extends TestCase
 
         static::assertSame(3, $promotion->getOrderCount());
         $expected = [
-            $context->getCustomerId() => 1,
+            $context2->getCustomer()->getId() => 1,
             $customerId1 => 2,
         ];
 

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRouteTest.php
@@ -391,18 +391,18 @@ class ChangeCustomerProfileRouteTest extends TestCase
     }
 
     /**
+     * @param list<string|true|null>|null $vatIds
      * @param array<string, bool> $constraint
-     * @param array<string|null>|null $vatIds
      * @param array<string>|null $expectedVatIds
      */
     #[DataProvider('dataProviderVatIds')]
     public function testChangeVatIdsOfCommercialAccount(?array $vatIds, array $constraint, bool $shouldBeValid, ?array $expectedVatIds): void
     {
-        if (isset($constraint['required']) && $constraint['required']) {
+        if (($constraint['required'] ?? false) === true) {
             $this->setVatIdOfTheCountryToBeRequired();
         }
 
-        if (isset($constraint['validateFormat']) && $constraint['validateFormat']) {
+        if (($constraint['validateFormat'] ?? false) === true) {
             $this->setVatIdOfTheCountryToValidateFormat();
         }
 

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
@@ -72,7 +72,7 @@ class UpsertAddressRouteTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $data
+     * @param array<string, string|null> $data
      */
     #[DataProvider('addressDataProvider')]
     public function testCreateAddress(array $data): void

--- a/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
@@ -192,7 +192,7 @@ class CreditNoteRendererTest extends TestCase
     /**
      * @param array<int, int> $possibleTaxes
      * @param array<int, int> $creditPrices
-     * @param array<string, int> $additionalConfig
+     * @param array<string, int|string|array<string, string>> $additionalConfig
      */
     #[DataProvider('creditNoteRendererDataProvider')]
     public function testRender(
@@ -328,7 +328,6 @@ class CreditNoteRendererTest extends TestCase
                     $rendered->getContent()
                 );
             },
-            null,
         ];
 
         yield 'render credit_note without credit items' => [

--- a/tests/integration/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/DeliveryNoteRendererTest.php
@@ -181,7 +181,6 @@ class DeliveryNoteRendererTest extends TestCase
         $order = $caughtEvent->getOrders()->get($orderId);
         static::assertNotNull($order);
 
-        static::assertInstanceOf(RenderedDocument::class, $rendered);
         static::assertCount(1, $caughtEvent->getOrders());
         static::assertStringContainsString('<html lang="en-GB">', $rendered->getContent());
         static::assertStringContainsString('</html>', $rendered->getContent());

--- a/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/StornoRendererTest.php
@@ -165,7 +165,7 @@ class StornoRendererTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $additionalConfig
+     * @param array{documentNumber: string, fileTypes: list<string>, custom?: array<string, string>} $additionalConfig
      */
     #[DataProvider('stornoNoteRendererDataProvider')]
     public function testRender(array $additionalConfig, \Closure $assertionCallback): void
@@ -221,7 +221,6 @@ class StornoRendererTest extends TestCase
         static::assertNotNull($order);
         static::assertArrayHasKey($orderId, $processedTemplate->getSuccess());
         $rendered = $processedTemplate->getSuccess()[$orderId];
-        static::assertInstanceOf(RenderedDocument::class, $rendered);
         static::assertStringContainsString('<html lang="en-GB">', $rendered->getContent());
         static::assertStringContainsString('</html>', $rendered->getContent());
         $assertionCallback($rendered);
@@ -250,6 +249,9 @@ class StornoRendererTest extends TestCase
         );
     }
 
+    /**
+     * @return \Generator<string, array{array{documentNumber: string, fileTypes: list<string>, custom?: array<string, string>}, \Closure}>
+     */
     public static function stornoNoteRendererDataProvider(): \Generator
     {
         yield 'render storno successfully' => [

--- a/tests/integration/Core/Checkout/Document/Service/PdfRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/PdfRendererTest.php
@@ -8,7 +8,6 @@ use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
-use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
@@ -96,7 +95,6 @@ class PdfRendererTest extends TestCase
         );
 
         static::assertArrayHasKey($orderId, $processedTemplate->getSuccess());
-        static::assertInstanceOf(RenderedDocument::class, $processedTemplate->getSuccess()[$orderId]);
 
         $rendered = $processedTemplate->getSuccess()[$orderId];
 

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -95,13 +95,15 @@ class SendMailActionTest extends TestCase
     }
 
     /**
-     * @param array<string>|null $documentTypeIds
-     * @param array<string, mixed> $recipients
+     * @param array{type: 'customer'|'admin'|'custom'} $recipients
+     * @param list<string>|array{}|array{data: array<string, string>} $documentTypeIds
      */
     #[DataProvider('sendMailProvider')]
-    public function testEmailSend(array $recipients, ?array $documentTypeIds = [], ?bool $hasOrderSettingAttachment = true): void
+    public function testEmailSend(array $recipients, array $documentTypeIds = [], bool $hasOrderSettingAttachment = true): void
     {
+        /** @var EntityRepository<DocumentCollection> $documentRepository */
         $documentRepository = static::getContainer()->get('document.repository');
+        /** @var EntityRepository<OrderCollection> $orderRepository */
         $orderRepository = static::getContainer()->get('order.repository');
 
         $criteria = new Criteria();
@@ -122,15 +124,15 @@ class SendMailActionTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('transactions.stateMachineState');
-        /** @var OrderEntity $order */
         $order = $orderRepository->search($criteria, $context->getContext())->first();
+        static::assertNotNull($order);
         $event = new CheckoutOrderPlacedEvent($context, $order);
 
         $documentIdOlder = null;
         $documentIdNewer = null;
         $documentIds = [];
 
-        if ($documentTypeIds !== null && $documentTypeIds !== [] || $hasOrderSettingAttachment) {
+        if ($documentTypeIds !== [] || $hasOrderSettingAttachment) {
             $documentIdOlder = $this->createDocumentWithFile($orderId, $context->getContext());
             $documentIdNewer = $this->createDocumentWithFile($orderId, $context->getContext());
             $documentIds[] = $documentIdNewer;
@@ -220,14 +222,20 @@ class SendMailActionTest extends TestCase
 
                 break;
             case 'custom':
-                static::assertSame($mailService->data['recipients'], $recipients['data']);
+                $data = $recipients['data'] ?? null;
+                static::assertSame($mailService->data['recipients'], $data);
 
                 break;
             default:
-                static::assertSame($mailService->data['recipients'], [$order->getOrderCustomer()?->getEmail() => $order->getOrderCustomer()?->getFirstName() . ' ' . $order->getOrderCustomer()?->getLastName()]);
+                $email = $order->getOrderCustomer()?->getEmail();
+                static::assertNotNull($email);
+                static::assertSame(
+                    $mailService->data['recipients'],
+                    [$email => $order->getOrderCustomer()?->getFirstName() . ' ' . $order->getOrderCustomer()?->getLastName()]
+                );
         }
 
-        if ($documentTypeIds !== null && $documentTypeIds !== []) {
+        if ($documentTypeIds !== []) {
             $criteria = new Criteria(array_filter([$documentIdOlder, $documentIdNewer]));
             $documents = $documentRepository->search($criteria, $context->getContext());
 
@@ -248,9 +256,9 @@ class SendMailActionTest extends TestCase
     }
 
     /**
-     * @return iterable<string, mixed>
+     * @return \Generator<string, array{0: array{type: 'customer'|'admin'|'custom'}, 1?: list<string>|array{}|array{data: array<string, string>}, 2?: bool}>
      */
-    public static function sendMailProvider(): iterable
+    public static function sendMailProvider(): \Generator
     {
         yield 'Test send mail default' => [['type' => 'customer']];
         yield 'Test send mail admin' => [['type' => 'admin']];
@@ -1011,7 +1019,6 @@ class SendMailActionTest extends TestCase
         $documentGenerator = static::getContainer()->get(DocumentGenerator::class);
 
         $operation = new DocumentGenerateOperation($orderId, FileTypes::PDF, []);
-        /** @var DocumentEntity $document */
         $document = $documentGenerator->generate($documentType, [$orderId => $operation], $context)->getSuccess()->first();
 
         static::assertNotNull($document);
@@ -1019,16 +1026,14 @@ class SendMailActionTest extends TestCase
         return $document->getId();
     }
 
-    private static function getDocIdByType(string $documentType): ?string
+    private static function getDocIdByType(string $documentType): string
     {
-        $document = KernelLifecycleManager::getConnection()->fetchFirstColumn(
+        return (string) KernelLifecycleManager::getConnection()->fetchOne(
             'SELECT LOWER(HEX(`id`)) FROM `document_type` WHERE `technical_name` = :documentType',
             [
                 'documentType' => $documentType,
             ]
         );
-
-        return $document !== [] ? $document[0] : '';
     }
 
     private function retrieveMailTemplateId(): string

--- a/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
+++ b/tests/integration/Core/Content/ImportExport/Api/ImportExportProfileApiTest.php
@@ -200,6 +200,7 @@ class ImportExportProfileApiTest extends TestCase
             $data[$idx]['technicalName'] = $technicalName;
 
             $removedProperty = array_pop($properties);
+            static::assertNotNull($removedProperty);
             $expectData[$id] = $data[$idx];
             unset($data[$idx][$removedProperty]);
             unset($data[$idx]['id']);

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
@@ -280,7 +280,7 @@ class ImportExportFileRepositoryTest extends TestCase
     /**
      * Prepare a defined number of test data.
      *
-     * @return array<string, mixed>
+     * @return non-empty-array<string, mixed>
      */
     protected function prepareImportExportFileTestData(int $num = 1, string $add = ''): array
     {
@@ -297,6 +297,7 @@ class ImportExportFileRepositoryTest extends TestCase
                 'accessToken' => Random::getBase64UrlString(32),
             ];
         }
+        static::assertNotSame([], $data);
 
         return $data;
     }

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportLogRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportLogRepositoryTest.php
@@ -280,13 +280,12 @@ class ImportExportLogRepositoryTest extends TestCase
 
             // Remove property before write
             $property = array_pop($properties);
-            if ($property === 'id') {
+            if ($property === 'id' || $property === null) {
                 continue;
             }
             unset($upsertData[$id][$property]);
         }
 
-        static::assertNotEmpty($upsertData);
         $this->logRepository->upsert(array_values($upsertData), $this->context);
 
         $records = $this->connection->fetchAllAssociative('SELECT * FROM import_export_log');
@@ -380,7 +379,7 @@ class ImportExportLogRepositoryTest extends TestCase
     /**
      * Prepare a defined number of test data.
      *
-     * @return array<string, array<string, mixed>>
+     * @return non-empty-array<string, array<string, mixed>>
      */
     protected function prepareImportExportLogTestData(int $num = 1, string $add = ''): array
     {
@@ -421,6 +420,7 @@ class ImportExportLogRepositoryTest extends TestCase
                 'config' => ['profile' => $profile],
             ];
         }
+        static::assertNotSame([], $data);
 
         return $data;
     }

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportProfileRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportProfileRepositoryTest.php
@@ -249,7 +249,7 @@ class ImportExportProfileRepositoryTest extends TestCase
 
             // Remove property before write
             $property = array_pop($properties);
-            if ($property === 'id') {
+            if ($property === 'id' || $property === null) {
                 continue;
             }
             unset($upsertData[$id][$property]);
@@ -354,7 +354,7 @@ class ImportExportProfileRepositoryTest extends TestCase
     /**
      * Prepare a defined number of test data.
      *
-     * @return array<string, array<string, mixed>>
+     * @return non-empty-array<string, array<string, mixed>>
      */
     protected function prepareImportExportProfileTestData(int $num = 1, string $add = ''): array
     {
@@ -374,6 +374,8 @@ class ImportExportProfileRepositoryTest extends TestCase
                 'mapping' => ['Mapping ' . $i => 'Value ' . $i . $add],
             ];
         }
+
+        static::assertNotSame([], $data);
 
         return $data;
     }

--- a/tests/integration/Core/Content/ImportExport/Subscriber/ProductCategoryPathsSubscriberTest.php
+++ b/tests/integration/Core/Content/ImportExport/Subscriber/ProductCategoryPathsSubscriberTest.php
@@ -35,7 +35,12 @@ class ProductCategoryPathsSubscriberTest extends TestCase
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, array{
+     *     categoriesToWrite: list<array<string, mixed>>,
+     *     record: array{categories: array{}|list<array{id: string}>},
+     *     row: array<string, string>,
+     *     assertion: list<array<string, string>>
+     * }>
      */
     public static function provideCategoryPaths(): array
     {
@@ -267,10 +272,10 @@ class ProductCategoryPathsSubscriberTest extends TestCase
     }
 
     /**
-     * @param array<array<string, mixed|null>> $categoriesToWrite
-     * @param array<array<string, mixed|null>> $record
-     * @param array<array<string>> $row
-     * @param array<array<string>> $assertion
+     * @param list<array<string, mixed>> $categoriesToWrite
+     * @param array{categories: array{}|list<array{id: string}>} $record
+     * @param array<string, string> $row
+     * @param list<array<string, string>> $assertion
      */
     #[DataProvider('provideCategoryPaths')]
     public function testCategoryPathToAssignment(array $categoriesToWrite, array $record, array $row, array $assertion): void

--- a/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
@@ -203,7 +203,7 @@ class MailHeaderFooterRepositoryTest extends TestCase
     /**
      * Prepare a defined number of test data.
      *
-     * @return array<string, array<string, mixed>>
+     * @return non-empty-array<string, array<string, mixed>>
      */
     private function prepareHeaderFooterTestData(int $num = 1, string $add = ''): array
     {
@@ -222,6 +222,7 @@ class MailHeaderFooterRepositoryTest extends TestCase
                 'footerHtml' => \sprintf('<h1>Test footer %d %s </h1>', $i, $add),
             ];
         }
+        static::assertNotSame([], $data);
 
         return $data;
     }

--- a/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
+++ b/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
@@ -34,7 +34,7 @@ class NewsletterRecipientServiceTest extends TestCase
     use IntegrationTestBehaviour;
 
     /**
-     * @param array<int, array<int, array<string, string|null>>> $testData
+     * @param array{email: string|null, salutationId: string|null, option: string|null} $testData
      */
     #[DataProvider('dataProvider_testSubscribeNewsletterExpectsConstraintViolationException')]
     public function testSubscribeNewsletterExpectsConstraintViolationException(array $testData): void
@@ -42,17 +42,17 @@ class NewsletterRecipientServiceTest extends TestCase
         $this->installTestData();
         $dataBag = new RequestDataBag($testData);
 
-        self::expectException(ConstraintViolationException::class);
+        $this->expectException(ConstraintViolationException::class);
 
         $salesChannelContextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
 
         static::getContainer()->get(NewsletterSubscribeRoute::class)
-            ->subscribe($dataBag, $context, false);
+            ->subscribeWithResponse($dataBag, $context, false);
     }
 
     /**
-     * @return array<int, array<int, array<string, string|null>>>
+     * @return list<array{array{email: string|null, salutationId: string|null, option: string|null}}>
      */
     public static function dataProvider_testSubscribeNewsletterExpectsConstraintViolationException(): array
     {
@@ -70,10 +70,10 @@ class NewsletterRecipientServiceTest extends TestCase
         $testDataEmail5 = ['email' => 'notValid@foo.', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339', 'option' => 'subscribe'];
 
         // test not valid option
-        $testDataOption1 = ['option' => '', 'email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339'];
-        $testDataOption2 = ['option' => 'notValid', 'email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339'];
-        $testDataOption3 = ['option' => 'unitTest', 'email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339'];
-        $testDataOption4 = ['option' => 'otherValue', 'email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339'];
+        $testDataOption1 = ['email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339', 'option' => ''];
+        $testDataOption2 = ['email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339', 'option' => 'notValid'];
+        $testDataOption3 = ['email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339', 'option' => 'unitTest'];
+        $testDataOption4 = ['email' => 'valid@email.foo', 'salutationId' => 'ad165c1faac14059832b6258ac0a7339', 'option' => 'otherValue'];
 
         return [
             [$testData1],
@@ -124,7 +124,7 @@ class NewsletterRecipientServiceTest extends TestCase
             ],
             'domains' => [
                 [
-                    'url' => 'http://test.de',
+                    'url' => 'https://test.de',
                     'currencyId' => Defaults::CURRENCY,
                     'languageId' => Defaults::LANGUAGE_SYSTEM,
                     'snippetSetId' => $this->getRandomId('snippet_set'),
@@ -139,9 +139,9 @@ class NewsletterRecipientServiceTest extends TestCase
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), $id);
         static::getContainer()
             ->get(NewsletterSubscribeRoute::class)
-            ->subscribe($dataBag, $context, false);
+            ->subscribeWithResponse($dataBag, $context, false);
 
-        /** @var EntityRepository<NewsletterRecipientCollection> */
+        /** @var EntityRepository<NewsletterRecipientCollection> $repository */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', $email));
@@ -157,13 +157,13 @@ class NewsletterRecipientServiceTest extends TestCase
     {
         $dataBag = new RequestDataBag(['hash' => 'notExistentHash']);
 
-        self::expectException(NewsletterException::class);
+        $this->expectException(NewsletterException::class);
 
         $salesChannelContextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
         static::getContainer()
             ->get(NewsletterConfirmRoute::class)
-            ->confirm($dataBag, $context);
+            ->confirmWithResponse($dataBag, $context);
     }
 
     public function testConfirmSubscribeNewsletterExpectsConstraintViolationException(): void
@@ -172,13 +172,13 @@ class NewsletterRecipientServiceTest extends TestCase
 
         $dataBag = new RequestDataBag(['em' => 'notValidHash', 'hash' => 'b4b45f58088d41289490db956ca19af7']);
 
-        self::expectException(ConstraintViolationException::class);
+        $this->expectException(ConstraintViolationException::class);
 
         $salesChannelContextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
         static::getContainer()
             ->get(NewsletterConfirmRoute::class)
-            ->confirm($dataBag, $context);
+            ->confirmWithResponse($dataBag, $context);
     }
 
     public function testConfirmSubscribeNewsletterExpectedUpdatedDatabaseRow(): void
@@ -196,9 +196,9 @@ class NewsletterRecipientServiceTest extends TestCase
 
         static::getContainer()
             ->get(NewsletterConfirmRoute::class)
-            ->confirm($dataBag, $context);
+            ->confirmWithResponse($dataBag, $context);
 
-        /** @var EntityRepository<NewsletterRecipientCollection> */
+        /** @var EntityRepository<NewsletterRecipientCollection> $repository */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
 
         $criteria = new Criteria();
@@ -222,13 +222,13 @@ class NewsletterRecipientServiceTest extends TestCase
             'option' => 'unsubscribe',
         ]);
 
-        self::expectException(NewsletterException::class);
+        $this->expectException(NewsletterException::class);
 
         $salesChannelContextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
         static::getContainer()
             ->get(NewsletterUnsubscribeRoute::class)
-            ->unsubscribe($dataBag, $context);
+            ->unsubscribeWithResponse($dataBag, $context);
     }
 
     public function testConfirmSubscribeNewsletterExpectsUpdatedDatabaseRow(): void
@@ -246,7 +246,7 @@ class NewsletterRecipientServiceTest extends TestCase
         $context = $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
         static::getContainer()
             ->get(NewsletterUnsubscribeRoute::class)
-            ->unsubscribe($dataBag, $context);
+            ->unsubscribeWithResponse($dataBag, $context);
 
         /** @var EntityRepository<NewsletterRecipientCollection> $repository */
         $repository = static::getContainer()->get('newsletter_recipient.repository');
@@ -264,11 +264,8 @@ class NewsletterRecipientServiceTest extends TestCase
 
     private function getRandomId(string $table): string
     {
-        /** @var string $id */
-        $id = static::getContainer()->get(Connection::class)
+        return static::getContainer()->get(Connection::class)
             ->fetchOne('SELECT LOWER(HEX(id)) FROM ' . $table);
-
-        return $id;
     }
 
     private function installTestData(): void

--- a/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
@@ -315,9 +315,9 @@ class ProductCartProcessorTest extends TestCase
     }
 
     /**
-     * @param array{type: string} $testedFeature
+     * @param array{type: string, id: string|null, name: string|null, position: int} $testedFeature
      * @param array<string, mixed> $productData
-     * @param array{type: string, value: array{price: string}, label: string} $expectedFeature
+     * @param array{type: string, value: mixed, label: string} $expectedFeature
      */
     #[DataProvider('productFeatureProvider')]
     #[Group('slow')]
@@ -352,11 +352,11 @@ class ProductCartProcessorTest extends TestCase
     }
 
     /**
-     * @return array{
-     *     0: array{type: string},
-     *     1: array<string, mixed>,
-     *     2: array{type: string, value: mixed, label: string}
-     *     }[]
+     * @return list<array{
+     *     array{type: string, id: string|null, name: string|null, position: int},
+     *     array<string, mixed>,
+     *     array{type: string, value: mixed, label: string}
+     * }>
      */
     public static function productFeatureProvider(): array
     {
@@ -1041,11 +1041,11 @@ class ProductCartProcessorTest extends TestCase
     }
 
     /**
-     * @param array{type: string}[]|null $features
+     * @param list<array{type: string, id: string|null, name: string|null, position: int}> $features
      *
      * @return array<string, mixed>
      */
-    private function createFeatureSet(?array $features = []): array
+    private function createFeatureSet(array $features): array
     {
         return [
             'id' => $this->ids->create('product-feature-set'),

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -93,9 +93,7 @@ class ProductSearchRouteTest extends TestCase
 
         $browser->request(
             'POST',
-            '/store-api/search?search=Test-Product',
-            [
-            ]
+            '/store-api/search?search=Test-Product'
         );
         static::assertIsString($browser->getResponse()->getContent());
         $response = \json_decode($browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -312,7 +310,7 @@ class ProductSearchRouteTest extends TestCase
     }
 
     /**
-     * @param array<string, bool> $searchTerms
+     * @param array<array-key, bool> $searchTerms
      */
     #[DataProvider('searchTestCases')]
     public function testProductSearch(string $productNumber, array $searchTerms, ?string $languageId): void
@@ -371,7 +369,7 @@ class ProductSearchRouteTest extends TestCase
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, array{string, array<array-key, bool>, string|null}>
      */
     public static function searchTestCases(): array
     {

--- a/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
+++ b/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
@@ -1090,8 +1090,8 @@ class ProductLoadedSubscriberTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $product
-     * @param array<string, string> $expected
+     * @param array<string, mixed> $product
+     * @param list<array<string, string>> $expected
      */
     #[DataProvider('optionCases')]
     public function testOptionSorting(array $product, array $expected, Criteria $criteria): void
@@ -1130,7 +1130,7 @@ class ProductLoadedSubscriberTest extends TestCase
     }
 
     /**
-     * @return array<mixed>
+     * @return list<array{array<string, mixed>, list<array<string, string>>}>
      */
     public static function optionCases(): array
     {
@@ -1154,7 +1154,7 @@ class ProductLoadedSubscriberTest extends TestCase
         $optionsDescCriteria->getAssociation('options')->addSorting(new FieldSorting('name', 'DESC'));
 
         return [
-            1 => [
+            [
                 array_merge($defaults, [
                     'options' => [
                         [
@@ -1181,7 +1181,7 @@ class ProductLoadedSubscriberTest extends TestCase
                 ],
                 $optionsAscCriteria,
             ],
-            2 => [
+            [
                 array_merge($defaults, [
                     'options' => [
                         [

--- a/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonEntityEncoderTest.php
@@ -290,4 +290,18 @@ class JsonEntityEncoderTest extends TestCase
 
         static::assertSame(['translated' => [], 'id' => 'test-id-2', 'apiAlias' => 'partial'], $actual);
     }
+
+    public function testArrayEntity(): void
+    {
+        $encoder = static::getContainer()->get(JsonEntityEncoder::class);
+
+        $definition = new CustomFieldTestDefinition();
+        $definition->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
+
+        $struct2 = new ArrayEntity();
+        $struct2->set('id', 'test-id-2');
+        $actual = $encoder->encode(new Criteria(), $definition, $struct2, SerializationFixture::API_BASE_URL);
+
+        static::assertSame(['translated' => [], 'id' => 'test-id-2', 'apiAlias' => 'array'], $actual);
+    }
 }

--- a/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
+++ b/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
@@ -111,7 +111,9 @@ class ApiRoutesHaveASchemaTest extends TestCase
                 $routesFromPathParameter = $this->getRoutesFromSchemaDefinitionPath($path, $routeSchema);
                 foreach ($routesFromPathParameter as $routeFromPathParameter) {
                     if (\in_array($routeFromPathParameter, $missingRoutes, true)) {
-                        unset($schemaRoutes[$path], $missingRoutes[array_search($routeFromPathParameter, $missingRoutes, true)]);
+                        $missingRouteKey = array_search($routeFromPathParameter, $missingRoutes, true);
+                        static::assertNotFalse($missingRouteKey);
+                        unset($schemaRoutes[$path], $missingRoutes[$missingRouteKey]);
                     }
                 }
                 $missingRoutes = array_values($missingRoutes);

--- a/tests/integration/Core/Framework/CustomField/CustomFieldServiceTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldServiceTest.php
@@ -40,24 +40,23 @@ class CustomFieldServiceTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return list<array{CustomFieldTypes::*, class-string<Field>}>
      */
     public static function attributeFieldTestProvider(): array
     {
         return [
-            [
-                CustomFieldTypes::BOOL, BoolField::class,
-                CustomFieldTypes::DATETIME, DateTimeField::class,
-                CustomFieldTypes::FLOAT, FloatField::class,
-                CustomFieldTypes::HTML, LongTextField::class,
-                CustomFieldTypes::INT, IntField::class,
-                CustomFieldTypes::JSON, JsonField::class,
-                CustomFieldTypes::TEXT, LongTextField::class,
-            ],
+            [CustomFieldTypes::BOOL, BoolField::class],
+            [CustomFieldTypes::DATETIME, DateTimeField::class],
+            [CustomFieldTypes::FLOAT, FloatField::class],
+            [CustomFieldTypes::HTML, LongTextField::class],
+            [CustomFieldTypes::INT, IntField::class],
+            [CustomFieldTypes::JSON, JsonField::class],
+            [CustomFieldTypes::TEXT, LongTextField::class],
         ];
     }
 
     /**
+     * @param CustomFieldTypes::* $attributeType
      * @param class-string<Field> $expectedFieldClass
      */
     #[DataProvider('attributeFieldTestProvider')]
@@ -69,10 +68,7 @@ class CustomFieldServiceTest extends TestCase
         ];
         $this->attributeRepository->create([$attribute], Context::createDefaultContext());
 
-        static::assertInstanceOf(
-            $expectedFieldClass,
-            $this->attributeService->getCustomField('test_attr')
-        );
+        static::assertInstanceOf($expectedFieldClass, $this->attributeService->getCustomField('test_attr'));
     }
 
     public function testOnlyGetActive(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -72,7 +72,7 @@ class EntityRepositoryTest extends TestCase
 
     protected function setUp(): void
     {
-        /** @var EntityRepository<CategoryCollection> */
+        /** @var EntityRepository<CategoryCollection> $categoryRepository */
         $categoryRepository = $this->createRepository(CategoryDefinition::class);
 
         $this->categoryRepository = $categoryRepository;
@@ -99,7 +99,7 @@ class EntityRepositoryTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $products
+     * @param list<array<string, mixed>> $products
      * @param array<string> $expected
      */
     #[DataProvider('productPropertiesQueryProvider')]
@@ -1573,7 +1573,7 @@ class EntityRepositoryTest extends TestCase
         $snippetRepo = $this->createRepository(SnippetDefinition::class);
         $snippetSetId = $this->getSnippetSetIdForLocale('en-GB');
 
-        static::expectException(WriteException::class);
+        $this->expectException(WriteException::class);
         $snippetRepo->create([
             [
                 'id' => Uuid::randomHex(),
@@ -1616,7 +1616,7 @@ class EntityRepositoryTest extends TestCase
                 'taxStatus' => 'gross',
                 'totalPrice' => 100,
                 'positionPrice' => 1,
-            ]),
+            ], \JSON_THROW_ON_ERROR),
             'currency_id' => Uuid::fromHexToBytes(Defaults::CURRENCY),
             'state_id' => Uuid::randomBytes(),
             'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
@@ -1646,7 +1646,7 @@ class EntityRepositoryTest extends TestCase
             'order_id' => Uuid::fromHexToBytes($orderId),
             'payment_method_id' => Uuid::fromHexToBytes($payment),
             'state_id' => $stateId,
-            'amount' => json_encode(['unitPrice' => 100]),
+            'amount' => json_encode(['unitPrice' => 100], \JSON_THROW_ON_ERROR),
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ];
     }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ConfigJsonFieldSerializerTest.php
@@ -54,37 +54,28 @@ class ConfigJsonFieldSerializerTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<int, array<int|string, array<string, int>|int|string>|bool|float|int|string|null>>>
+     * @return list<list<string|int|float|false|array<string, mixed>|list<int>|null>>
      */
     public static function serializerProvider(): array
     {
         return [
-            [['string']],
-            [[11234]],
-            [[11234.123243]],
-            [[
-                [
-                    'foo' => 'sadfsadf',
-                    'bar' => [
-                        'a' => 1234,
-                    ],
-                ],
-            ]],
-            [[
-                [1, 2, 3],
-            ]],
-            [[null]],
-            [[false]],
-            [[0]],
-            [['']],
+            ['string'],
+            [11234],
+            [11234.123243],
+            [['foo' => 'sadfsadf', 'bar' => ['a' => 1234]]],
+            [[1, 2, 3]],
+            [null],
+            [false],
+            [0],
+            [''],
         ];
     }
 
     /**
-     * @param array<string, int>|int|string|bool|float|null $input
+     * @param float|false|int|string|array<string, mixed>|list<int>|null $input
      */
     #[DataProvider('serializerProvider')]
-    public function testSerializer($input): void
+    public function testSerializer(array|float|false|int|string|null $input): void
     {
         $kvPair = new KeyValuePair('password', $input, true);
         $encoded = $this->serializer->encode($this->field, $this->existence, $kvPair, $this->parameters)->current();

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
@@ -53,7 +53,7 @@ class JsonFieldSerializerTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, array<string, string>|float|int|string>|JsonField|string|null>>
+     * @return list<array{JsonField, array<string, mixed>|null, string|null}>
      */
     public static function encodeProvider(): array
     {
@@ -74,11 +74,10 @@ class JsonFieldSerializerTest extends TestCase
     }
 
     /**
-     * @param string|null $input
-     * @param array<string, string|float|int> $expected
+     * @param array<string, mixed>|null $input
      */
     #[DataProvider('encodeProvider')]
-    public function testEncode(JsonField $field, $input, $expected): void
+    public function testEncode(JsonField $field, ?array $input, ?string $expected): void
     {
         $field->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
 
@@ -89,7 +88,7 @@ class JsonFieldSerializerTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, array<string, array<string, string>|float|int|string>|JsonField|string|null>>
+     * @return list<array{JsonField, string|null, array<string, mixed>|null}>
      */
     public static function decodeProvider(): array
     {
@@ -111,11 +110,10 @@ class JsonFieldSerializerTest extends TestCase
     }
 
     /**
-     * @param string|null $input
-     * @param array<string, string|float|int> $expected
+     * @param array<string, mixed>|null $expected
      */
     #[DataProvider('decodeProvider')]
-    public function testDecode(JsonField $field, $input, $expected): void
+    public function testDecode(JsonField $field, ?string $input, ?array $expected): void
     {
         $field->compile(static::getContainer()->get(DefinitionInstanceRegistry::class));
         $actual = $this->serializer->decode($field, $input);

--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -28,7 +28,7 @@ class FeatureTest extends TestCase
     public static string $customCacheId = 'beef3f0ee9c61829627676afd6294bb029';
 
     /**
-     * @var string[]
+     * @var list<string>
      */
     private array $fixtureFlags = [
         'FEATURE_NEXT_101',
@@ -247,6 +247,14 @@ class FeatureTest extends TestCase
         static::assertTrue(Feature::isActive('FEATURE_NEXT_102'));
     }
 
+    /**
+     * @return \Generator<string, array{
+     *     list<string>|array<string, array<string, bool>>,
+     *     array<string, string>,
+     *     string,
+     *     bool
+     * }>
+     */
     public static function isActiveDataProvider(): \Generator
     {
         yield 'registered active feature' => [
@@ -569,7 +577,7 @@ class FeatureTest extends TestCase
     }
 
     /**
-     * @param array<string, array{name?: string, default?: bool, major?: bool, description?: string}> $featureConfig
+     * @param array<string, FeatureFlagConfig>|list<string> $featureConfig
      * @param array<string, string> $env
      */
     #[DataProvider('isActiveDataProvider')]

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
@@ -26,7 +26,7 @@ class StaticKernelPluginLoaderTest extends TestCase
 
     public function testNoPlugins(): void
     {
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, []);
+        $loader = $this->createKernelPluginLoaderWithPlugins([]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertEmpty($loader->getPluginInfos());
@@ -36,7 +36,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testNoKernelPluginsWithoutInit(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
 
         static::assertCount(1, $loader->getPluginInfos());
         static::assertEmpty($loader->getPluginInstances()->all());
@@ -45,7 +45,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testKernelPluginsAfterInit(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertCount(1, $loader->getPluginInfos());
@@ -61,7 +61,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         $active->setBaseClass('SomeNotExistingBaseClass');
 
         $plugins = [$active->jsonSerialize()];
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, $plugins);
+        $loader = $this->createKernelPluginLoaderWithPlugins($plugins);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertCount(1, $loader->getPluginInfos());
@@ -76,7 +76,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         $active->setManagedByComposer(true);
         $plugins = [$active->jsonSerialize()];
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, $plugins);
+        $loader = $this->createKernelPluginLoaderWithPlugins($plugins);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertCount(1, $loader->getPluginInfos());
@@ -90,7 +90,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         unset($active['autoload']);
         $plugins = [$active];
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, $plugins);
+        $loader = $this->createKernelPluginLoaderWithPlugins($plugins);
 
         $this->expectException(KernelPluginLoaderException::class);
         $this->expectExceptionMessage('Failed to load plugin "SwagTestPlugin". Reason: Unable to register plugin "SwagTestPlugin\SwagTestPlugin" in autoload. Required property `autoload` missing.');
@@ -103,7 +103,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         $active->setAutoload([]);
         $plugins = [$active->jsonSerialize()];
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, $plugins);
+        $loader = $this->createKernelPluginLoaderWithPlugins($plugins);
 
         $this->expectException(KernelPluginLoaderException::class);
         $this->expectExceptionMessage('Failed to load plugin "SwagTestPlugin". Reason: Unable to register plugin "SwagTestPlugin\SwagTestPlugin" in autoload. Required property `psr-4` or `psr-0` missing in property autoload.');
@@ -113,7 +113,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testGetPluginInstance(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertCount(1, $loader->getPluginInfos());
@@ -127,7 +127,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testGetPluginInstanceNotActive(): void
     {
         $pluginData = $this->getInstalledInactivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$pluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$pluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertCount(1, $loader->getPluginInfos());
@@ -142,10 +142,10 @@ class StaticKernelPluginLoaderTest extends TestCase
     {
         $projectDir = TEST_PROJECT_DIR;
 
-        $loader = new StaticKernelPluginLoader($this->classLoader);
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory();
         static::assertSame($projectDir . '/custom/plugins', $loader->getPluginDir($projectDir));
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, 'foo/bar');
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory('foo/bar');
         static::assertSame($projectDir . '/foo/bar', $loader->getPluginDir($projectDir));
     }
 
@@ -153,23 +153,23 @@ class StaticKernelPluginLoaderTest extends TestCase
     {
         $projectDir = TEST_PROJECT_DIR;
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, $projectDir . '/custom/plugins');
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory($projectDir . '/custom/plugins');
         static::assertSame($projectDir . '/custom/plugins', $loader->getPluginDir($projectDir));
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, '/foo/bar');
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory('/foo/bar');
         static::assertSame('/foo/bar', $loader->getPluginDir($projectDir));
     }
 
     public function testGetClassLoader(): void
     {
-        $loader = new StaticKernelPluginLoader($this->classLoader);
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory();
         static::assertSame($this->classLoader, $loader->getClassLoader());
     }
 
     public function testGetBundlesNoInit(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
 
         $bundles = iterator_to_array($loader->getBundles());
 
@@ -178,7 +178,7 @@ class StaticKernelPluginLoaderTest extends TestCase
 
     public function testGetBundlesNoPlugins(): void
     {
-        $loader = new StaticKernelPluginLoader($this->classLoader);
+        $loader = $this->createKernelPluginLoaderWithOptionalPluginDirectory();
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $bundles = iterator_to_array($loader->getBundles());
@@ -190,7 +190,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testGetBundles(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $bundles = iterator_to_array($loader->getBundles());
@@ -206,9 +206,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
         $activePluginDataWithUnneededBundles = $this->getActivePluginWithBundle()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [
-            $activePluginData, $activePluginDataWithUnneededBundles,
-        ]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData, $activePluginDataWithUnneededBundles]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $bundles = iterator_to_array($loader->getBundles([], ['FrameworkBundle']));
@@ -224,7 +222,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testGetBundlesNoActive(): void
     {
         $pluginData = $this->getInstalledInactivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$pluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$pluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $bundles = iterator_to_array($loader->getBundles());
@@ -239,7 +237,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         /** @phpstan-ignore argument.type (for test purpose) */
         $plugin->setBaseClass(SwagTestFake::class);
 
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$plugin->jsonSerialize()]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$plugin->jsonSerialize()]);
 
         $this->expectException(KernelPluginLoaderException::class);
         $this->expectExceptionMessage('Failed to load plugin "SwagTestPlugin". Reason: Plugin class "SwagTestPlugin\SwagTestFake" must extend "Shopware\Core\Framework\Plugin"');
@@ -249,7 +247,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testBuildNoInitShouldNotChangeContainer(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
 
         $emptyContainer = new ContainerBuilder();
         $container = new ContainerBuilder();
@@ -263,7 +261,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testBuildInactivePluginShouldNotChangeContainer(): void
     {
         $pluginData = $this->getInstalledInactivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$pluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$pluginData]);
 
         $emptyContainer = new ContainerBuilder();
         $container = new ContainerBuilder();
@@ -277,7 +275,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testBuild(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $container = new ContainerBuilder();
@@ -292,7 +290,7 @@ class StaticKernelPluginLoaderTest extends TestCase
     public function testBuildWithExistingDefinition(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
-        $loader = new StaticKernelPluginLoader($this->classLoader, null, [$activePluginData]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$activePluginData]);
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         $container = new ContainerBuilder();
@@ -326,7 +324,7 @@ class StaticKernelPluginLoaderTest extends TestCase
             TEST_PROJECT_DIR . '/custom/plugins/TestPlugin/src',
         ], false);
 
-        $loader = new StaticKernelPluginLoader($classLoader, null, [$plugin->jsonSerialize()]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$plugin->jsonSerialize()], $classLoader);
         $loader->initializePlugins(TEST_PROJECT_DIR);
     }
 
@@ -345,7 +343,7 @@ class StaticKernelPluginLoaderTest extends TestCase
         $this->expectException(KernelPluginLoaderException::class);
         $this->expectExceptionMessage('Failed to load plugin "SwagTestPlugin". Reason: Plugin dir /custom/plugins/TestPlugin needs to be a sub-directory of the project dir ' . TEST_PROJECT_DIR);
 
-        $loader = new StaticKernelPluginLoader($classLoader, null, [$plugin->jsonSerialize()]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$plugin->jsonSerialize()], $classLoader);
         $loader->initializePlugins(TEST_PROJECT_DIR);
     }
 
@@ -365,7 +363,7 @@ class StaticKernelPluginLoaderTest extends TestCase
             TEST_PROJECT_DIR . '/custom/plugins/TestPlugin/src',
         ], false);
 
-        $loader = new StaticKernelPluginLoader($classLoader, null, [$plugin->jsonSerialize()]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$plugin->jsonSerialize()], $classLoader);
         $loader->initializePlugins(TEST_PROJECT_DIR);
     }
 
@@ -386,7 +384,24 @@ class StaticKernelPluginLoaderTest extends TestCase
             TEST_PROJECT_DIR . '/custom/plugins/TestPlugin/components',
         ], false);
 
-        $loader = new StaticKernelPluginLoader($classLoader, null, [$plugin->jsonSerialize()]);
+        $loader = $this->createKernelPluginLoaderWithPlugins([$plugin->jsonSerialize()], $classLoader);
         $loader->initializePlugins(TEST_PROJECT_DIR);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $plugins
+     */
+    private function createKernelPluginLoaderWithPlugins(array $plugins, ?ClassLoader $classLoader = null): StaticKernelPluginLoader
+    {
+        if ($classLoader === null) {
+            $classLoader = $this->classLoader;
+        }
+
+        return new StaticKernelPluginLoader($classLoader, plugins: $plugins);
+    }
+
+    private function createKernelPluginLoaderWithOptionalPluginDirectory(?string $pluginDirectory = null): StaticKernelPluginLoader
+    {
+        return new StaticKernelPluginLoader($this->classLoader, $pluginDirectory);
     }
 }

--- a/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
@@ -126,6 +126,7 @@ class SeoUrlRepositoryTest extends TestCase
 
     public function testEmptySeoUrlCollection(): void
     {
+        /** @phpstan-ignore argument.type (Intentionally providing an empty generator for test purpose) */
         $registry = new SeoUrlRouteRegistry($this->emptyGenerator());
         static::assertSame([], (array) $registry->getSeoUrlRoutes());
 
@@ -133,6 +134,9 @@ class SeoUrlRepositoryTest extends TestCase
         static::assertSame([], (array) $registry->getSeoUrlRoutes());
     }
 
+    /**
+     * @return \Generator<array{}>
+     */
     private function emptyGenerator(): \Generator
     {
         yield from [];

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookLoaderTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookLoaderTest.php
@@ -9,7 +9,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Test\Store\ExtensionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\Service\WebhookLoader;
 use Shopware\Core\Framework\Webhook\Webhook;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -178,7 +177,6 @@ class WebhookLoaderTest extends TestCase
 
         static::assertCount(1, $permissions);
         static::assertArrayHasKey($aclRoleId, $permissions);
-        static::assertInstanceOf(AclPrivilegeCollection::class, $permissions[$aclRoleId]);
 
         static::assertTrue($permissions[$aclRoleId]->isAllowed('customer', 'read'));
         static::assertTrue($permissions[$aclRoleId]->isAllowed('customer', 'create'));

--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextTest.php
@@ -507,14 +507,12 @@ class SalesChannelContextTest extends TestCase
             false,
             false,
             false,
-            true,
         ];
 
         yield 'Logged in as guest, but guest not allowed' => [
             true,
             true,
             false,
-            true,
         ];
     }
 

--- a/tests/integration/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/integration/Core/System/Snippet/SnippetServiceTest.php
@@ -235,7 +235,7 @@ class SnippetServiceTest extends TestCase
     }
 
     /**
-     * @param array<int, array<int, MessageCatalogue|array<int|string, string>>> $expectedResult
+     * @param array<string, string> $expectedResult
      */
     #[DataProvider('dataProviderForTestGetStorefrontSnippets')]
     public function testGetStorefrontSnippets(MessageCatalogueInterface $catalog, array $expectedResult): void
@@ -335,14 +335,23 @@ class SnippetServiceTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, MessageCatalogue|array<int|string, string>>>
+     * @return list<array{MessageCatalogue, array<string, string>}>
      */
     public static function dataProviderForTestGetStorefrontSnippets(): array
     {
         return [
-            [new MessageCatalogue('en', []), []],
-            [new MessageCatalogue('en', ['messages' => ['a' => 'a']]), ['a' => 'a']],
-            [new MessageCatalogue('en', ['messages' => ['a' => 'a', 'b' => 'b']]), ['a' => 'a', 'b' => 'b']],
+            [
+                new MessageCatalogue('en', []),
+                [],
+            ],
+            [
+                new MessageCatalogue('en', ['messages' => ['a' => 'a']]),
+                ['a' => 'a'],
+            ],
+            [
+                new MessageCatalogue('en', ['messages' => ['a' => 'a', 'b' => 'b']]),
+                ['a' => 'a', 'b' => 'b'],
+            ],
         ];
     }
 

--- a/tests/integration/Core/System/Snippet/Subscriber/CustomFieldSubscriberTest.php
+++ b/tests/integration/Core/System/Snippet/Subscriber/CustomFieldSubscriberTest.php
@@ -55,7 +55,7 @@ class CustomFieldSubscriberTest extends TestCase
 
     /**
      * @param list<string> $snippetSets
-     * @param list<array{id: string, name: string, customFields: list<array{id: string, name: string, type: string, config: array{label: array<string, string>}}>}> $customFieldSets
+     * @param list<array{id: string, name?: string, customFields: list<array{id: string, name?: string, type?: string, config: array{label?: array<string, string>}}>}> $customFieldSets
      * @param array<string, array<string, string>> $expectedSnippets
      */
     #[DataProvider('snippetAndCustomFieldProvider')]
@@ -88,11 +88,21 @@ class CustomFieldSubscriberTest extends TestCase
         static::assertSame($expectedCount, (int) $snippetCount[0]);
         foreach ($snippets as $locale => $languageSnippets) {
             foreach ($languageSnippets as $snippet) {
-                static::assertSame($expectedSnippets[$locale][$snippet['translation_key']], $snippet['value']);
+                $snippetKey = $snippet['translation_key'];
+                static::assertNotNull($snippetKey);
+                static::assertSame($expectedSnippets[$locale][$snippetKey], $snippet['value']);
             }
         }
     }
 
+    /**
+     * @return \Generator<string, array{
+     *     snippetSets: list<string>,
+     *     customFieldSets: list<array{id: string, name?: string, customFields: list<array{id: string, name?: string, type?: string, config: array{label?: array<string, string>}}>}>,
+     *     expectedSnippets: array<string, array<string, string>>,
+     *     expectedCount: int
+     * }>
+     */
     public static function snippetAndCustomFieldProvider(): \Generator
     {
         $customFieldSet = Uuid::randomHex();

--- a/tests/integration/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
+++ b/tests/integration/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
@@ -23,8 +23,8 @@ class SystemConfigValidatorTest extends TestCase
     use KernelTestBehaviour;
 
     /**
-     * @param array<string, array<string, string|int|null>> $inputValues
-     * @param array{elements: array{config: array<string, int|string|bool>, name: string}[]} $formConfigs
+     * @param array<string, array<string, string|null>> $inputValues
+     * @param list<array{elements: list<array{name: string, config: array{required?: bool, maxLength?: int}}>}> $formConfigs
      */
     #[DataProvider('validateProvider')]
     public function testValidate(array $inputValues, array $formConfigs, bool $expectErrors): void
@@ -32,7 +32,7 @@ class SystemConfigValidatorTest extends TestCase
         $configurationServiceMock = $this->createMock(ConfigurationService::class);
         $validator = new SystemConfigValidator(
             $configurationServiceMock,
-            $this->getContainer()->get(DataValidator::class)
+            self::getContainer()->get(DataValidator::class)
         );
 
         $configurationServiceMock
@@ -43,11 +43,18 @@ class SystemConfigValidatorTest extends TestCase
         $contextMock = Context::createDefaultContext();
 
         if ($expectErrors) {
-            self::expectException(ConstraintViolationException::class);
+            $this->expectException(ConstraintViolationException::class);
         }
         $validator->validate($inputValues, $contextMock);
     }
 
+    /**
+     * @return \Generator<string, array{
+     *     inputValues: array<string, array<string, string|null>>,
+     *     formConfigs: list<array{elements: list<array{name: string, config: array{required?: bool, maxLength?: int}}>}>,
+     *     expectErrors: bool
+     * }>
+     */
     public static function validateProvider(): \Generator
     {
         yield 'Validate success with required rule' => [

--- a/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Elasticsearch\Test\AdminElasticsearchTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -62,8 +63,8 @@ class AdminSearchControllerTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $data
-     * @param array<string> $expectedPromotions
+     * @param array{term: string, entities: list<string>} $data
+     * @param list<string> $expectedPromotions
      */
     #[Depends('testIndexing')]
     #[DataProvider('providerSearchCases')]
@@ -72,7 +73,7 @@ class AdminSearchControllerTest extends TestCase
         $this->getBrowser()->request('POST', '/api/_admin/es-search', [], [], [], json_encode($data, \JSON_THROW_ON_ERROR) ?: null);
         $response = $this->getBrowser()->getResponse();
 
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         $content = json_decode($response->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 
@@ -92,9 +93,9 @@ class AdminSearchControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array<string, string|array<string>>, array<string>}>
+     * @return \Generator<string, array{array{term: string, entities: list<string>}, list<string>}>
      */
-    public static function providerSearchCases(): iterable
+    public static function providerSearchCases(): \Generator
     {
         yield 'search with normal term' => [
             [

--- a/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -32,13 +32,15 @@ class ElasticsearchIndexerTest extends TestCase
     public function testFirstIndexDoesNotCreateTask(): void
     {
         $c = static::getContainer()->get(Connection::class);
-        static::assertEmpty($c->fetchAllAssociative('SELECT * FROM elasticsearch_index_task'));
+        $beforeResult = $c->fetchAllAssociative('SELECT * FROM elasticsearch_index_task');
+        static::assertSame([], $beforeResult);
 
         $indexer = static::getContainer()->get(ElasticsearchIndexer::class);
         static::assertNotNull($indexer);
         $indexer->iterate(null);
 
-        static::assertEmpty($c->fetchAllAssociative('SELECT * FROM elasticsearch_index_task'));
+        $afterResult = $c->fetchAllAssociative('SELECT * FROM elasticsearch_index_task');
+        static::assertSame([], $afterResult);
     }
 
     public function testSecondIndexingCreatesTask(): void

--- a/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -170,8 +170,8 @@ class ProductSearchQueryBuilderTest extends TestCase
     }
 
     /**
-     * @param array<string> $config
-     * @param array<string> $expectedProducts
+     * @param list<string> $config
+     * @param list<string> $expectedProducts
      */
     #[Depends('testIndexing')]
     #[DataProvider('providerSearchCases')]
@@ -245,9 +245,9 @@ class ProductSearchQueryBuilderTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array<string>, string, array<string>}>
+     * @return \Generator<string, array{list<string>, string, list<string>}>
      */
-    public static function providerSearchCases(): iterable
+    public static function providerSearchCases(): \Generator
     {
         yield 'search inside description' => [
             ['name', 'description'],

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -55,7 +55,9 @@ class SearchCasesTest extends TestCase
 
         $scores = [];
         foreach ($result->getData() as $item) {
-            $scores[self::$ids->getKey((string) $item['id'])] = $item['_score'];
+            $key = self::$ids->getKey((string) $item['id']);
+            static::assertNotNull($key);
+            $scores[$key] = $item['_score'];
         }
 
         static::assertSame(

--- a/tests/integration/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/integration/Storefront/Controller/StorefrontControllerTest.php
@@ -101,6 +101,7 @@ class StorefrontControllerTest extends TestCase
         );
 
         preg_match('/window\.activeRouteParameters = \'([^\']*)\';/', $content, $matches);
+        static::assertArrayHasKey(1, $matches);
         $escapedJson = $matches[1];
 
         // Verify dangerous characters are properly escaped

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -54,8 +54,8 @@ class RequestTransformerTest extends TestCase
     }
 
     /**
-     * @param array<string, string|array<string, string>> $salesChannels
-     * @param ExpectedRequest[] $requests
+     * @param list<SalesChannel> $salesChannels
+     * @param list<ExpectedRequest> $requests
      */
     #[DataProvider('domainProvider')]
     public function testDomainResolving(array $salesChannels, array $requests): void
@@ -93,7 +93,7 @@ class RequestTransformerTest extends TestCase
     }
 
     /**
-     * @return array<string, array{0: SalesChannel[], 1: ExpectedRequest[]}>
+     * @return array<string, array{0: list<SalesChannel>, 1: list<ExpectedRequest>}>
      */
     public static function domainProvider(): array
     {

--- a/tests/migration/Core/V6_6/Migration1703850843FixSearchConfigTest.php
+++ b/tests/migration/Core/V6_6/Migration1703850843FixSearchConfigTest.php
@@ -39,7 +39,7 @@ class Migration1703850843FixSearchConfigTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param list<array<string, mixed>> $input
      * @param array<string, mixed> $expected
      */
     #[DataProvider('migrationProvider')]
@@ -209,7 +209,7 @@ class Migration1703850843FixSearchConfigTest extends TestCase
     /**
      * @param array<mixed> $fields
      *
-     * @return array<mixed>
+     * @return array<string, mixed>
      */
     private static function module(string $key, array $fields): array
     {
@@ -218,6 +218,8 @@ class Migration1703850843FixSearchConfigTest extends TestCase
 
     /**
      * @param array<mixed> $fields
+     *
+     * @return \Generator<string, array<string, mixed>>
      */
     private static function resolve(string $key, array $fields): \Generator
     {

--- a/tests/migration/Core/V6_6/Migration1715081559AdjustSentMailActionOnReviewSentTest.php
+++ b/tests/migration/Core/V6_6/Migration1715081559AdjustSentMailActionOnReviewSentTest.php
@@ -53,10 +53,7 @@ class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
             )
             ->fetchAssociative();
 
-        static::assertSame(
-            $expectedConfig,
-            json_decode($result['config'] ?? '', true)
-        );
+        static::assertSame($expectedConfig, json_decode($result['config'] ?? '', true));
     }
 
     /**
@@ -75,7 +72,7 @@ class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
             ],
             'missingActionName' => [
                 'actionName' => null,
-                'config' => json_encode(self::getConfig($mailTemplateId)),
+                'config' => json_encode(self::getConfig($mailTemplateId), \JSON_THROW_ON_ERROR),
                 'expectedConfig' => [
                     'recipient' => [
                         'data' => [],
@@ -87,7 +84,7 @@ class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
             ],
             'wrongMailTemplateId' => [
                 'actionName' => 'action.mail.send',
-                'config' => json_encode(self::getConfig($wrongMailTemplateId)),
+                'config' => json_encode(self::getConfig($wrongMailTemplateId), \JSON_THROW_ON_ERROR),
                 'expectedConfig' => [
                     'recipient' => [
                         'data' => [],
@@ -99,7 +96,7 @@ class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
             ],
             'validEntry' => [
                 'actionName' => 'action.mail.send',
-                'config' => json_encode(self::getConfig($mailTemplateId)),
+                'config' => json_encode(self::getConfig($mailTemplateId), \JSON_THROW_ON_ERROR),
                 'expectedConfig' => [
                     'recipient' => [
                         'data' => [],
@@ -111,7 +108,7 @@ class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
             ],
             'corruptedConfig' => [
                 'actionName' => 'action.mail.send',
-                'config' => json_encode(self::getCorruptedConfig()),
+                'config' => json_encode(self::getCorruptedConfig(), \JSON_THROW_ON_ERROR),
                 'expectedConfig' => [
                     'recipient' => [
                         'data' => [],

--- a/tests/migration/Core/V6_6/Migration1716196653AddTechnicalNameToImportExportProfileTest.php
+++ b/tests/migration/Core/V6_6/Migration1716196653AddTechnicalNameToImportExportProfileTest.php
@@ -65,8 +65,8 @@ class Migration1716196653AddTechnicalNameToImportExportProfileTest extends TestC
     }
 
     /**
-     * @param array<int, string> $names
-     * @param array<int, string> $expectedTechnicalNames
+     * @param list<string|null> $names
+     * @param list<string> $expectedTechnicalNames
      */
     #[DataProvider('nameProvider')]
     public function testGeneratedTechnicalName(array $names, array $expectedTechnicalNames): void

--- a/tests/migration/Core/V6_6/Migration1721202771UpdateDefaultSearchConfigTest.php
+++ b/tests/migration/Core/V6_6/Migration1721202771UpdateDefaultSearchConfigTest.php
@@ -39,7 +39,7 @@ class Migration1721202771UpdateDefaultSearchConfigTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $input
+     * @param list<array<string, mixed>> $input
      * @param array<string, mixed> $expected
      */
     #[DataProvider('migrationProvider')]
@@ -156,9 +156,9 @@ class Migration1721202771UpdateDefaultSearchConfigTest extends TestCase
     }
 
     /**
-     * @param array<mixed> $fields
+     * @param list<string> $fields
      *
-     * @return array<mixed>
+     * @return array<string, mixed>
      */
     private static function module(string $key, array $fields): array
     {
@@ -167,6 +167,8 @@ class Migration1721202771UpdateDefaultSearchConfigTest extends TestCase
 
     /**
      * @param array<mixed> $fields
+     *
+     * @return \Generator<string, array<string, mixed>>
      */
     private static function resolve(string $key, array $fields): \Generator
     {

--- a/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
+++ b/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
@@ -31,6 +31,7 @@ class Migration1742897274RegistrationSalutationToggleConfigTest extends TestCase
 
         $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => true], $newConfiguration[$id]);
@@ -47,6 +48,7 @@ class Migration1742897274RegistrationSalutationToggleConfigTest extends TestCase
 
         $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => false], $newConfiguration[$id]);

--- a/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1743064966CartConfigSubtotalTaxColumnTest.php
@@ -33,6 +33,7 @@ class Migration1743064966CartConfigSubtotalTaxColumnTest extends TestCase
 
         $newConfiguration = $this->getConditionValues($key);
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => true], $newConfiguration[$id]);
@@ -47,6 +48,7 @@ class Migration1743064966CartConfigSubtotalTaxColumnTest extends TestCase
 
         $newConfiguration = $this->getConditionValues($key);
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => false], $newConfiguration[$id]);

--- a/tests/migration/Core/V6_7/Migration1759390536CartConfigShowTosCheckboxTest.php
+++ b/tests/migration/Core/V6_7/Migration1759390536CartConfigShowTosCheckboxTest.php
@@ -32,6 +32,7 @@ class Migration1759390536CartConfigShowTosCheckboxTest extends TestCase
 
         $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => false], $newConfiguration[$id]);
@@ -46,6 +47,7 @@ class Migration1759390536CartConfigShowTosCheckboxTest extends TestCase
 
         $newConfiguration = $this->getConditionValues();
         $id = array_key_first($newConfiguration);
+        static::assertNotNull($id);
 
         static::assertCount(1, $newConfiguration);
         static::assertSame(['_value' => true], $newConfiguration[$id]);

--- a/tests/migration/Core/V6_7/Migration1768545319RevocationRequestMailTemplateTest.php
+++ b/tests/migration/Core/V6_7/Migration1768545319RevocationRequestMailTemplateTest.php
@@ -72,7 +72,7 @@ class Migration1768545319RevocationRequestMailTemplateTest extends TestCase
         $this->delete('mail_template_type', $mailTemplateTypeId);
     }
 
-    private function delete(string $table, ?string $id, ?string $identifier = 'id'): void
+    private function delete(string $table, ?string $id, string $identifier = 'id'): void
     {
         if (!\is_string($id)) {
             return;

--- a/tests/performance/bench/BenchExtension.php
+++ b/tests/performance/bench/BenchExtension.php
@@ -21,7 +21,7 @@ class BenchExtension implements ExtensionInterface
     public function load(Container $container): void
     {
         if (!$this->resolver instanceof OptionsResolver) {
-            throw new \Exception(self::class . '::configure must be called before running the load method');
+            throw new \LogicException(self::class . '::configure must be called before running the load method');
         }
 
         $_SERVER['APP_ENV'] = 'test';
@@ -87,10 +87,7 @@ class BenchExtension implements ExtensionInterface
         $this->resolver = $resolver;
     }
 
-    /**
-     * @return mixed
-     */
-    public static function parseEnvVar(string $varName, mixed $default = false)
+    public static function parseEnvVar(string $varName, mixed $default = false): mixed
     {
         if (isset($_SERVER[$varName])) {
             return filter_var($_SERVER[$varName], \FILTER_VALIDATE_BOOLEAN);
@@ -99,6 +96,9 @@ class BenchExtension implements ExtensionInterface
         return $default;
     }
 
+    /**
+     * @return \Generator<string>
+     */
     private function findFixtures(string $fixturePath): \Generator
     {
         if (is_file($fixturePath) && preg_match('/\.php$/', basename($fixturePath))) {
@@ -108,9 +108,7 @@ class BenchExtension implements ExtensionInterface
             if (\is_array($directory)) {
                 foreach ($directory as $subName) {
                     if (!preg_match('/^\.+$/', $subName)) {
-                        foreach ($this->findFixtures($fixturePath . \DIRECTORY_SEPARATOR . $subName) as $fixture) {
-                            yield $fixture;
-                        }
+                        yield from $this->findFixtures($fixturePath . \DIRECTORY_SEPARATOR . $subName);
                     }
                 }
             }

--- a/tests/unit/Administration/Framework/Twig/ViteFileAccessorDecoratorTest.php
+++ b/tests/unit/Administration/Framework/Twig/ViteFileAccessorDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Administration\Framework\Twig;
 
+use Pentatrion\ViteBundle\Service\FileAccessor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10,6 +11,7 @@ use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
+use Symfony\Component\Asset\Package as AssetPackage;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle as SymfonyBundle;
@@ -30,7 +32,7 @@ class ViteFileAccessorDecoratorTest extends TestCase
         ],
     ];
 
-    private MockObject&\Symfony\Component\Asset\Package $packageMock;
+    private MockObject&AssetPackage $packageMock;
 
     private ViteFileAccessorDecorator $decorator;
 
@@ -60,27 +62,21 @@ class ViteFileAccessorDecoratorTest extends TestCase
     }
 
     /**
-     * @param list<string> $assetKeys
+     * @param array{'entryPoints', string, 'js', 0} $assetKeys
      */
     #[DataProvider('getDataProvider')]
     public function testGetData(bool $pullFromCache, string $configName, array $assetKeys, string $expectedAssetUrl): void
     {
         if ($pullFromCache) {
-            $this->decorator->getData($configName, ViteFileAccessorDecorator::ENTRYPOINTS);
+            $this->decorator->getData($configName, FileAccessor::ENTRYPOINTS);
         }
 
-        $result = $this->decorator->getData($configName, ViteFileAccessorDecorator::ENTRYPOINTS);
+        $result = $this->decorator->getData($configName, FileAccessor::ENTRYPOINTS);
 
         // Dynamically check the keys
-        $previousValue = null;
+        $firstArrayKey = array_shift($assetKeys);
+        $previousValue = $result[$firstArrayKey];
         foreach ($assetKeys as $key) {
-            // First iteration: get value from service result
-            if ($previousValue === null) {
-                static::assertArrayHasKey($key, $result);
-                $previousValue = $result[$key];
-                continue;
-            }
-
             // Use the previous collected value to check the next key
             static::assertArrayHasKey($key, $previousValue);
             $previousValue = $previousValue[$key];
@@ -91,39 +87,39 @@ class ViteFileAccessorDecoratorTest extends TestCase
     }
 
     /**
-     * @return array<int, array<int, string|bool>>
+     * @return list<array{string, string, bool}>
      */
     public static function hasFileProvider(): array
     {
         return [
             [
                 '_default',
-                ViteFileAccessorDecorator::ENTRYPOINTS,
+                FileAccessor::ENTRYPOINTS,
                 true,
             ],
             [
                 '_default',
-                ViteFileAccessorDecorator::MANIFEST,
+                FileAccessor::MANIFEST,
                 true,
             ],
             [
                 'TestBundle',
-                ViteFileAccessorDecorator::ENTRYPOINTS,
+                FileAccessor::ENTRYPOINTS,
                 true,
             ],
             [
                 'TestBundle',
-                ViteFileAccessorDecorator::MANIFEST,
+                FileAccessor::MANIFEST,
                 true,
             ],
             [
                 'invalid',
-                ViteFileAccessorDecorator::MANIFEST,
+                FileAccessor::MANIFEST,
                 false,
             ],
             [
                 'invalid',
-                ViteFileAccessorDecorator::ENTRYPOINTS,
+                FileAccessor::ENTRYPOINTS,
                 false,
             ],
             [
@@ -135,7 +131,7 @@ class ViteFileAccessorDecoratorTest extends TestCase
     }
 
     /**
-     * @return list<list<bool|string|list<string|int>>>
+     * @return list<array{bool, string, array{'entryPoints', string, 'js', 0}, string}>
      */
     public static function getDataProvider(): array
     {

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -85,6 +85,7 @@ class SnippetFinderTest extends TestCase
 
         $expectedSnippets = $this->getSnippetFixtures();
         $key = array_key_first($expectedSnippets);
+        static::assertNotNull($key);
         static::assertSame($expectedSnippets[$key], $snippets[$key]);
     }
 

--- a/tests/unit/Core/Checkout/Cart/Facade/ScriptPriceStubsTest.php
+++ b/tests/unit/Core/Checkout/Cart/Facade/ScriptPriceStubsTest.php
@@ -25,7 +25,7 @@ class ScriptPriceStubsTest extends TestCase
     private const USD_ID = Defaults::LANGUAGE_SYSTEM;
 
     /**
-     * @param array<string, array{gross:float, net:float}> $prices
+     * @param array<array-key, array{gross:float, net:float, linked?: bool, currencyId?: string}> $prices
      */
     #[DataProvider('priceCases')]
     public function testPriceFactory(array $prices, PriceCollection $expected): void

--- a/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/OrderConverterTest.php
@@ -104,12 +104,12 @@ class OrderConverterTest extends TestCase
     }
 
     /**
-     * @param class-string<\Throwable> $exceptionClass
+     * @param class-string<\Throwable>|null $exceptionClass
      */
     #[DataProvider('assembleSalesChannelContextData')]
-    public function testAssembleSalesChannelContext(string $exceptionClass, string $manipulateOrder = ''): void
+    public function testAssembleSalesChannelContext(?string $exceptionClass, string $manipulateOrder = ''): void
     {
-        if ($exceptionClass !== '') {
+        if ($exceptionClass !== null) {
             $this->expectException($exceptionClass);
         }
 
@@ -134,9 +134,7 @@ class OrderConverterTest extends TestCase
                 ];
 
                 if (!Feature::isActive('v6.8.0.0')) {
-                    $expectedOptions = array_merge($expectedOptions, [
-                        SalesChannelContextService::SHIPPING_METHOD_ID => 'order-delivery-shipping-method-id',
-                    ]);
+                    $expectedOptions[SalesChannelContextService::SHIPPING_METHOD_ID] = 'order-delivery-shipping-method-id';
                 }
 
                 static::assertSame($expectedOptions, $options);
@@ -150,7 +148,7 @@ class OrderConverterTest extends TestCase
     }
 
     /**
-     * @return list<list<string>>
+     * @return list<array{0: class-string<\Throwable>|null, 1?: string}>
      */
     public static function assembleSalesChannelContextData(): array
     {
@@ -167,7 +165,7 @@ class OrderConverterTest extends TestCase
                 AddressNotFoundException::class,
             ],
             [
-                '',
+                null,
             ],
         ];
     }

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemCustomFieldRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemCustomFieldRuleTest.php
@@ -45,8 +45,7 @@ class LineItemCustomFieldRuleTest extends TestCase
 
     public function testGetConstraints(): void
     {
-        $rule = new LineItemCustomFieldRule();
-        $ruleConstraints = $rule->getConstraints();
+        $ruleConstraints = (new LineItemCustomFieldRule())->getConstraints();
 
         static::assertArrayHasKey('operator', $ruleConstraints, 'Rule Constraint operator is not defined');
         static::assertArrayHasKey('renderedField', $ruleConstraints, 'Rule Constraint renderedField is not defined');
@@ -112,7 +111,7 @@ class LineItemCustomFieldRuleTest extends TestCase
     public function testWithoutCustomField(): void
     {
         $rule = self::setupBoolRule(false);
-        $scope = new LineItemScope($this->createLineItem(), $this->salesChannelContext);
+        $scope = new LineItemScope(self::createLineItem(), $this->salesChannelContext);
         static::assertFalse($rule->match($scope));
 
         $rule->assign(['operator' => Rule::OPERATOR_NEQ]);
@@ -163,38 +162,38 @@ class LineItemCustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @param bool|string|null $customFieldValueInLineItem
+     * @param list<int>|bool|string|null $customFieldValueInLineItem
      */
     #[DataProvider('customFieldCartScopeProvider')]
     public function testCustomFieldCartScope(
         LineItemCustomFieldRule $rule,
-        $customFieldValueInLineItem,
+        array|bool|string|null $customFieldValueInLineItem,
         bool $result
     ): void {
         $lineItemCollection = new LineItemCollection([
             $this->createLineItemWithCustomFields([self::CUSTOM_FIELD_NAME => $customFieldValueInLineItem]),
         ]);
 
-        $cart = $this->createCart($lineItemCollection);
+        $cart = self::createCart($lineItemCollection);
         $scope = new CartRuleScope($cart, $this->salesChannelContext);
         static::assertSame($result, $rule->match($scope));
     }
 
     /**
-     * @param bool|string|null $customFieldValueInLineItem
+     * @param list<int>|bool|string|null $customFieldValueInLineItem
      */
     #[DataProvider('customFieldCartScopeProvider')]
     public function testCustomFieldCartScopeNested(
         LineItemCustomFieldRule $rule,
-        $customFieldValueInLineItem,
+        array|bool|string|null $customFieldValueInLineItem,
         bool $result
     ): void {
         $lineItemCollection = new LineItemCollection([
             $this->createLineItemWithCustomFields([self::CUSTOM_FIELD_NAME => $customFieldValueInLineItem]),
         ]);
 
-        $containerLineItem = $this->createContainerLineItem($lineItemCollection);
-        $cart = $this->createCart(new LineItemCollection([$containerLineItem]));
+        $containerLineItem = self::createContainerLineItem($lineItemCollection);
+        $cart = self::createCart(new LineItemCollection([$containerLineItem]));
 
         $scope = new CartRuleScope($cart, $this->salesChannelContext);
         static::assertSame($result, $rule->match($scope));
@@ -257,7 +256,7 @@ class LineItemCustomFieldRuleTest extends TestCase
      */
     private function createLineItemWithCustomFields(array $customFields = []): LineItem
     {
-        return $this->createLineItem()->setPayloadValue('customFields', $customFields);
+        return self::createLineItem()->setPayloadValue('customFields', $customFields);
     }
 
     private static function setupFloatRule(string|float $customFieldValue): LineItemCustomFieldRule

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemPropertyValueRuleTest.php
@@ -133,17 +133,15 @@ class LineItemPropertyValueRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{bool, list<string>, list<string>, string}>
+     * @return \Generator<string, array{bool, list<string>, list<string>, string}>
      */
-    public static function getMatchValues(): iterable
+    public static function getMatchValues(): \Generator
     {
         $id = Uuid::randomHex();
 
-        return [
-            yield 'should match when property id is included' => [true, [$id], [$id, Uuid::randomHex()], Rule::OPERATOR_EQ],
-            yield 'should not match when property id is not included' => [false, [$id], [Uuid::randomHex()], Rule::OPERATOR_EQ],
-            yield 'should match when property id is not included' => [true, [$id, Uuid::randomHex()], [Uuid::randomHex()], Rule::OPERATOR_NEQ],
-            yield 'should not match when property id is included' => [false, [$id, Uuid::randomHex()], [$id], Rule::OPERATOR_NEQ],
-        ];
+        yield 'should match when property id is included' => [true, [$id], [$id, Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'should not match when property id is not included' => [false, [$id], [Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'should match when property id is not included' => [true, [$id, Uuid::randomHex()], [Uuid::randomHex()], Rule::OPERATOR_NEQ];
+        yield 'should not match when property id is included' => [false, [$id, Uuid::randomHex()], [$id], Rule::OPERATOR_NEQ];
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemVariantValueRuleTest.php
@@ -133,17 +133,15 @@ class LineItemVariantValueRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{bool, list<string>, list<string>, string}>
+     * @return \Generator<string, array{bool, list<string>, list<string>, string}>
      */
-    public static function getMatchValues(): iterable
+    public static function getMatchValues(): \Generator
     {
         $id = Uuid::randomHex();
 
-        return [
-            yield 'should match when option id is included' => [true, [$id], [$id, Uuid::randomHex()], Rule::OPERATOR_EQ],
-            yield 'should not match when option id is not included' => [false, [$id], [Uuid::randomHex()], Rule::OPERATOR_EQ],
-            yield 'should match when option id is not included' => [true, [$id, Uuid::randomHex()], [Uuid::randomHex()], Rule::OPERATOR_NEQ],
-            yield 'should not match when option id is included' => [false, [$id, Uuid::randomHex()], [$id], Rule::OPERATOR_NEQ],
-        ];
+        yield 'should match when option id is included' => [true, [$id], [$id, Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'should not match when option id is not included' => [false, [$id], [Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'should match when option id is not included' => [true, [$id, Uuid::randomHex()], [Uuid::randomHex()], Rule::OPERATOR_NEQ];
+        yield 'should not match when option id is included' => [false, [$id, Uuid::randomHex()], [$id], Rule::OPERATOR_NEQ];
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Subscriber/AddressHashSubscriberTest.php
+++ b/tests/unit/Core/Checkout/Customer/Subscriber/AddressHashSubscriberTest.php
@@ -27,11 +27,8 @@ class AddressHashSubscriberTest extends TestCase
         $this->subscriber = new AddressHashSubscriber();
     }
 
-    /**
-     * @param array<string, string|null> $expectedStruct
-     */
     #[DataProvider('generateProvider')]
-    public function testGenerate(CustomerAddressEntity|OrderAddressEntity $address, string $expectedHash, array $expectedStruct): void
+    public function testGenerate(CustomerAddressEntity|OrderAddressEntity $address, string $expectedHash): void
     {
         $event = new EntityLoadedEvent(
             new CustomerAddressDefinition(),
@@ -64,13 +61,11 @@ class AddressHashSubscriberTest extends TestCase
         yield 'OrderAddressEntity' => [
             (new OrderAddressEntity())->assign($address),
             '949c5f5f8ea7e6b2ff979c8b6d5f54a9c57394d9bc56a3e62a7ecbaa309b1192',
-            [...$address, 'extensions' => []],
         ];
 
         yield 'CustomerAddressEntity' => [
             (new CustomerAddressEntity())->assign($address),
             '949c5f5f8ea7e6b2ff979c8b6d5f54a9c57394d9bc56a3e62a7ecbaa309b1192',
-            [...$address, 'extensions' => []],
         ];
     }
 }

--- a/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/unit/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -17,7 +17,6 @@ use Shopware\Core\Checkout\Document\DocumentEntity;
 use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
-use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
@@ -50,7 +49,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * @internal
  *
  * @phpstan-type OrderSettings array{accountType: string, isCountryCompanyTaxFree: bool, setOrderDelivery: bool, setShippingCountry: bool, setEuCountry: bool, shouldCheckVatIdPattern?: bool, validVat?: bool}
- * @phpstan-type InvoiceConfig array{displayAdditionalNoteDelivery: bool, deliveryCountries: array<string>}
+ * @phpstan-type InvoiceConfig array{displayAdditionalNoteDelivery: bool}
  */
 #[Package('after-sales')]
 #[CoversClass(InvoiceRenderer::class)]
@@ -138,7 +137,6 @@ class InvoiceRendererTest extends TestCase
         static::assertCount(1, $successResults);
         static::assertCount(0, $result->getErrors());
         static::assertArrayHasKey($orderId, $successResults);
-        static::assertInstanceOf(RenderedDocument::class, $successResults[$orderId]);
 
         static::assertNotNull($successResults[$orderId]->getOrder());
         static::assertNotNull($successResults[$orderId]->getContext());

--- a/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -315,7 +315,7 @@ class DocumentGeneratorTest extends TestCase
     }
 
     /**
-     * @param array<string, string|null> $mediaIds
+     * @param list<string|null> $mediaIds
      * @param array<string, DocumentGenerateOperation> $operations
      */
     #[DataProvider('generateDataProvider')]

--- a/tests/unit/Core/Checkout/Order/OrderAddressServiceTest.php
+++ b/tests/unit/Core/Checkout/Order/OrderAddressServiceTest.php
@@ -22,16 +22,13 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 
 /**
  * @internal
- *
- * @phpstan-import-type BillingAddressMapping from OrderAddressService
- * @phpstan-import-type ShippingAddressMapping from OrderAddressService
  */
 #[CoversClass(OrderAddressService::class)]
 #[Package('checkout')]
 class OrderAddressServiceTest extends TestCase
 {
     /**
-     * @param list<BillingAddressMapping|ShippingAddressMapping> $mappings
+     * @param list<array{customerAddressId?: string, type?: string, deliveryId?: string}> $mappings
      */
     #[DataProvider('provideInvalidMappings')]
     public function testValidateInvalidMapping(array $mappings): void
@@ -45,6 +42,7 @@ class OrderAddressServiceTest extends TestCase
 
         $this->expectException(OrderException::class);
 
+        /** @phpstan-ignore argument.type (Intentionally wrong array shape for test purpose) */
         $orderAddressService->updateOrderAddresses(Uuid::randomHex(), $mappings, Context::createDefaultContext());
     }
 

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
@@ -123,7 +123,9 @@ class PromotionCollectorTest extends TestCase
 
     public function testPromotionWithInvalidOrderCountPerCustomerCount(): void
     {
-        $cart = $this->prepareCart([Uuid::randomHex(), Uuid::randomHex()], Uuid::randomHex(), 1, 2, 1, [$this->context->getCustomerId() => 1]);
+        $customerId = $this->context->getCustomerId();
+        static::assertNotNull($customerId);
+        $cart = $this->prepareCart([Uuid::randomHex(), Uuid::randomHex()], Uuid::randomHex(), 1, 2, 1, [$customerId => 1]);
         $cartDataCollection = new CartDataCollection();
 
         $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
@@ -241,13 +243,15 @@ class PromotionCollectorTest extends TestCase
         $discountId2 = Uuid::randomHex();
         $promotionId = Uuid::randomHex();
 
+        $customerId = $this->context->getCustomerId();
+        static::assertNotNull($customerId);
         $cart = $this->prepareCart(
             [$discountId1, $discountId2],
             $promotionId,
             1,
             1,
             1,
-            [$this->context->getCustomerId() => 1]
+            [$customerId => 1]
         );
         $cart->addExtension(OrderConverter::ORIGINAL_ID, new IdStruct(Uuid::randomHex()));
 

--- a/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeVersionMergeEvent;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
+ * @phpstan-import-type Writes from BeforeVersionMergeEvent
+ *
  * @internal
  */
 #[CoversClass(CmsVersionMergeSubscriber::class)]
@@ -25,16 +27,8 @@ class CmsVersionMergeSubscriberTest extends TestCase
     }
 
     /**
-     * @param array{
-     *      insert: array<string, array<int, mixed>>,
-     *      update: array<string, array<int, mixed>>,
-     *      delete: array<string, array<int, mixed>>
-     *  } $writes
-     * @param array{
-     *      insert: array<string, array<int, mixed>>,
-     *      update: array<string, array<int, mixed>>,
-     *      delete: array<string, array<int, mixed>>
-     *  } $expectedWrites
+     * @param Writes $writes
+     * @param Writes $expectedWrites
      */
     #[DataProvider('versionMergeEventDataProvider')]
     public function testOnVersionMerge(array $writes, array $expectedWrites): void
@@ -61,10 +55,12 @@ class CmsVersionMergeSubscriberTest extends TestCase
             'writes' => [
                 'insert' => ['cms_slot' => [['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1]]],
                 'delete' => [],
+                'update' => [],
             ],
             'expectedWrites' => [
                 'insert' => ['cms_slot' => [['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1]]],
                 'delete' => [],
+                'update' => [],
             ],
         ];
 
@@ -77,6 +73,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
                 'delete' => ['cms_block' => [
                     ['id' => $blockId1, 'versionId' => $versionId1],
                 ]],
+                'update' => [],
             ],
             'expectedWrites' => [
                 'insert' => ['cms_slot' => [
@@ -85,6 +82,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
                 'delete' => ['cms_block' => [
                     ['id' => $blockId1, 'versionId' => $versionId1],
                 ]],
+                'update' => [],
             ],
         ];
 
@@ -96,6 +94,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
                 'delete' => ['cms_block' => [
                     ['id' => $blockId1, 'versionId' => $versionId2],
                 ]],
+                'update' => [],
             ],
             'expectedWrites' => [
                 'insert' => ['cms_slot' => [
@@ -104,6 +103,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
                 'delete' => ['cms_block' => [
                     ['id' => $blockId1, 'versionId' => $versionId2],
                 ]],
+                'update' => [],
             ],
         ];
     }

--- a/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializerTest.php
+++ b/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializerTest.php
@@ -24,7 +24,7 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 class PriceSerializerTest extends TestCase
 {
     /**
-     * @param Price|array<string, array<string, mixed>>|null $prices
+     * @param Price|list<Price>|array<array-key, array<string, mixed>>|null $prices
      * @param array<string, array<string, mixed>>|null $expected
      */
     #[DataProvider('unserializedPrices')]

--- a/tests/unit/Core/Content/ImportExport/Service/SupportedFeaturesServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/SupportedFeaturesServiceTest.php
@@ -21,8 +21,8 @@ class SupportedFeaturesServiceTest extends TestCase
     }
 
     /**
-     * @param iterable<string> $entities
-     * @param iterable<string> $fileTypes
+     * @param iterable<string|int|float|true|array{}|\stdClass|null> $entities
+     * @param iterable<string|int|float|true|array{}|\stdClass|null> $fileTypes
      * @param class-string<\Throwable>|null $expectedException
      */
     #[DataProvider('constructDataProvider')]
@@ -37,6 +37,7 @@ class SupportedFeaturesServiceTest extends TestCase
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
+        /** @phpstan-ignore argument.type,argument.type (Intentionally pass wrong types) */
         new SupportedFeaturesService($entities, $fileTypes);
 
         $this->expectNotToPerformAssertions();

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/ImportStrategyTestCase.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/ImportStrategyTestCase.php
@@ -29,6 +29,9 @@ abstract class ImportStrategyTestCase extends TestCase
         $this->repository = $this->createMock(EntityRepository::class);
     }
 
+    /**
+     * @return \Generator<string, array{config: Config, method: 'create'|'update'|'upsert'}>
+     */
     public static function importProvider(): \Generator
     {
         yield 'createEntities' => [

--- a/tests/unit/Core/Content/Media/Commands/DeleteNotUsedMediaCommandTest.php
+++ b/tests/unit/Core/Content/Media/Commands/DeleteNotUsedMediaCommandTest.php
@@ -359,9 +359,9 @@ class DeleteNotUsedMediaCommandTest extends TestCase
     }
 
     /**
-     * @param array<int> $batches
+     * @param list<int> $batches
      *
-     * @return callable(): \Generator
+     * @return callable(): \Generator<MediaEntity>
      */
     private function generatorOfMedia(array $batches): callable
     {

--- a/tests/unit/Core/Content/Media/Core/Application/MediaUrlLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/MediaUrlLoaderTest.php
@@ -21,7 +21,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 class MediaUrlLoaderTest extends TestCase
 {
     /**
-     * @param array<string, string> $expected
+     * @param array<string, string|null> $expected
      */
     #[DataProvider('loadedProvider')]
     public function testLoad(IdsCollection $ids, PartialEntity $entity, array $expected): void

--- a/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Metadata/MetadataLoaderTest.php
@@ -146,8 +146,8 @@ class MetadataLoaderTest extends TestCase
     }
 
     /**
-     * @param array<string, string>|null $expected
-     * @param array<string, string>|null $extractMetadata
+     * @param array<string, string|int>|null $expected
+     * @param array<string, string|int>|null $extractMetadata
      */
     #[DataProvider('fileTypeDataProvider')]
     public function testLoadFromFile(

--- a/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
+++ b/tests/unit/Core/Content/Media/ScheduledTask/CleanupCorruptedMediaHandlerTest.php
@@ -150,7 +150,7 @@ class CleanupCorruptedMediaHandlerTest extends TestCase
             static fn (RangeFilter $filter): bool => $filter->getField() === 'id'
         ));
 
-        static::assertNotEmpty($idRangeFilters);
+        static::assertArrayHasKey(0, $idRangeFilters);
         $idRangeFilter = $idRangeFilters[0];
 
         static::assertTrue($idRangeFilter->hasParameter(RangeFilter::GT));

--- a/tests/unit/Core/Content/Media/Subscriber/MediaVisibilityRestrictionSubscriberTest.php
+++ b/tests/unit/Core/Content/Media/Subscriber/MediaVisibilityRestrictionSubscriberTest.php
@@ -57,10 +57,7 @@ class MediaVisibilityRestrictionSubscriberTest extends TestCase
         );
         $subscriber->securePrivateMediaAggregation($aggregatingEvent);
 
-        static::assertSame(
-            $countAggregation,
-            $criteria->getAggregations()[\array_key_first($criteria->getAggregations())]
-        );
+        static::assertSame($countAggregation, array_first($criteria->getAggregations()));
     }
 
     public function testSecurePrivateFlagIgnoresNonMediaEntities(): void
@@ -86,10 +83,7 @@ class MediaVisibilityRestrictionSubscriberTest extends TestCase
         );
         $subscriber->securePrivateMediaAggregation($aggregatingEvent);
 
-        static::assertSame(
-            $countAggregation,
-            $criteria->getAggregations()[\array_key_first($criteria->getAggregations())]
-        );
+        static::assertSame($countAggregation, array_first($criteria->getAggregations()));
     }
 
     public function testSecurePrivateFoldersMediaFolder(): void

--- a/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
+++ b/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
@@ -321,7 +321,7 @@ class NewsletterSubscribeRouteTest extends TestCase
     }
 
     /**
-     * @param array{isDoubleOptIn: bool, doubleOptInRegistered: bool} $doiSettings
+     * @param array{'core.newsletter.doubleOptIn': bool, 'core.newsletter.doubleOptInRegistered': bool} $doiSettings
      * @param array{id: string, email: string} $customerData
      * @param array{id: string, email: string} $recipientData
      */

--- a/tests/unit/Core/Content/Product/ProductMaxPurchaseCalculatorTest.php
+++ b/tests/unit/Core/Content/Product/ProductMaxPurchaseCalculatorTest.php
@@ -28,7 +28,7 @@ class ProductMaxPurchaseCalculatorTest extends TestCase
     }
 
     /**
-     * @param array<array<string>> $entityData
+     * @param array<string, int|bool> $entityData
      */
     #[DataProvider('cases')]
     public function testCalculate(array $entityData, int $expected): void

--- a/tests/unit/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzerTest.php
+++ b/tests/unit/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzerTest.php
@@ -33,7 +33,7 @@ class ProductSearchKeywordAnalyzerTest extends TestCase
     /**
      * @param array<string, mixed> $productData
      * @param array<int, array{field: string, tokenize: bool, ranking: int}> $configFields
-     * @param array<int, string> $expected
+     * @param list<int|string> $expected
      */
     #[DataProvider('analyzeCases')]
     public function testAnalyze(array $productData, array $configFields, array $expected): void
@@ -70,7 +70,7 @@ class ProductSearchKeywordAnalyzerTest extends TestCase
      *
      * @param array<string, mixed> $productData
      * @param array<int, array{field: string, tokenize: bool, ranking: int}> $configFields
-     * @param array<int, string> $expected
+     * @param list<int|string> $expected
      */
     #[DataProvider('analyzeCases')]
     public function testAnalyzeWithIgnoredErrorNoticeReporting(array $productData, array $configFields, array $expected): void
@@ -83,9 +83,9 @@ class ProductSearchKeywordAnalyzerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{0:array<string, array<string, string|array<int|string, string|array<int|string>>>|int|string|TagCollection>, 1:array<int, array{field: string, tokenize: bool, ranking: int}>, 2:array<int, int|string>}>
+     * @return \Generator<string, array{0:array<string, array<string, string|array<int|string, string|array<int|string>>>|int|string|TagCollection>, 1:array<int, array{field: string, tokenize: bool, ranking: int}>, 2:list<int|string>}>
      */
-    public static function analyzeCases(): iterable
+    public static function analyzeCases(): \Generator
     {
         $tag1 = new TagEntity();
         $tag1->setId('tag-1');

--- a/tests/unit/Core/Content/Product/Stock/OrderStockSubscriberTest.php
+++ b/tests/unit/Core/Content/Product/Stock/OrderStockSubscriberTest.php
@@ -187,7 +187,7 @@ class OrderStockSubscriberTest extends TestCase
      * @param list<array{id: string, quantity: string, referenced_id: string}> $beforeState
      * @param list<array{id: string, quantity: string, referenced_id: string}> $afterState
      * @param list<array{lineItemId: string, productId: string, quantityBefore: int, newQuantity: int}> $expectedUpdates
-     * @param list<array{type: 'insert'|'delete'|'update', id: string, state: array<string, mixed>}> $commands
+     * @param list<array{type: 'insert', id: string}|array{type: 'delete', id: string}|array{type: 'update', id: string, state: array<string, mixed>}> $commands
      */
     #[DataProvider('orderItemWriteProvider')]
     public function testOrderItemWrites(array $beforeState, array $afterState, array $expectedUpdates, array $commands): void

--- a/tests/unit/Core/Content/Product/Subscriber/ProductSubscriberTest.php
+++ b/tests/unit/Core/Content/Product/Subscriber/ProductSubscriberTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\ProductMaxPurchaseCalculator;
 use Shopware\Core\Content\Product\ProductVariationBuilder;
+use Shopware\Core\Content\Product\PropertyGroupSorter;
 use Shopware\Core\Content\Product\SalesChannel\Price\AbstractProductPriceCalculator;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
@@ -206,8 +207,7 @@ class ProductSubscriberTest extends TestCase
         $productVariationBuilder = $this->createMock(ProductVariationBuilder::class);
         $productVariationBuilder->expects($this->once())->method('build');
 
-        $propertyGroupSorter = $this->createMock(AbstractPropertyGroupSorter::class);
-        $propertyGroupSorter->expects($this->once())->method('sort');
+        $propertyGroupSorter = new PropertyGroupSorter();
 
         $subscriber = new ProductSubscriber(
             $productVariationBuilder,
@@ -371,7 +371,7 @@ class ProductSubscriberTest extends TestCase
     }
 
     /**
-     * @param array<string, float> $productDimensions
+     * @param array<string, float|string|null> $productDimensions
      * @param array<string, string> $headers
      * @param array<string, ConvertedUnit> $expectedFinalValues
      */
@@ -721,7 +721,7 @@ class ProductSubscriberTest extends TestCase
     }
 
     /**
-     * @param array<string, float> $payload
+     * @param array<string, float|string> $payload
      * @param array<string, string> $headers
      * @param array<string, bool> $hasFieldReturns
      * @param array<string, float> $expectedConversions

--- a/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
@@ -283,23 +283,6 @@ class TranslatorTest extends TestCase
         ];
     }
 
-    public static function provideTracingExamples(): \Generator
-    {
-        yield 'disabled' => [
-            false,
-            [
-                'shopware.translator',
-            ],
-        ];
-
-        yield 'enabled' => [
-            true,
-            [
-                'translator.foo',
-            ],
-        ];
-    }
-
     private static function createRequest(?string $salesChannelId, ?string $snippetSetId): Request
     {
         return new Request(

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidFilterQueryException;
-use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidSortQueryException;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
@@ -89,7 +88,6 @@ class DataAbstractionLayerExceptionTest extends TestCase
     {
         $e = DataAbstractionLayerException::invalidSortQuery('foo', 'baz');
 
-        static::assertInstanceOf(InvalidSortQueryException::class, $e);
         static::assertSame('foo', $e->getMessage());
         static::assertSame('baz', $e->getParameters()['path']);
         static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolverTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/CriteriaFieldsResolverTest.php
@@ -41,7 +41,7 @@ class CriteriaFieldsResolverTest extends TestCase
     }
 
     /**
-     * @param array<int, mixed> $expected
+     * @param array<string, array{}|array<string, array{}>> $expected
      */
     #[DataProvider('resolveFieldsProvider')]
     public function testResolveFields(Criteria $criteria, array $expected): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilderTest.php
@@ -66,8 +66,8 @@ class JoinGroupBuilderTest extends TestCase
     }
 
     /**
-     * @param array<Filter> $filters
-     * @param array<CriteriaPartInterface> $expected
+     * @param list<Filter> $filters
+     * @param list<CriteriaPartInterface> $expected
      */
     #[DataProvider('nestedGroupingProvider')]
     public function testNestedGrouping(array $filters, array $expected): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilderTest.php
@@ -53,6 +53,7 @@ class QueryBuilderTest extends TestCase
         $sql = $this->queryBuilder->getSQL();
         $matches = [];
         preg_match('/-- (.+)\n/', $sql, $matches);
+        static::assertArrayHasKey(1, $matches);
         static::assertSame($title, $matches[1]);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParserTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParserTest.php
@@ -323,7 +323,7 @@ class QueryStringParserTest extends TestCase
     }
 
     /**
-     * @param EqualsAnyFilterType $filter
+     * @param array{type: 'equalsAll', field?: string, value?: mixed} $filter
      */
     #[DataProvider('equalsAllFilterDataProvider')]
     public function testEqualsAllFilter(array $filter, ?Filter $expectedFilter, bool $expectException): void
@@ -337,6 +337,9 @@ class QueryStringParserTest extends TestCase
         static::assertEquals($expectedFilter, $result);
     }
 
+    /**
+     * @return \Generator<string, array{array{type: 'equalsAll', field?: string, value?: mixed}, Filter|null, bool}>
+     */
     public static function equalsAllFilterDataProvider(): \Generator
     {
         yield 'With empty value' => [['type' => 'equalsAll', 'field' => 'foo', 'value' => ''], null, true];

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoaderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoaderTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class SearchConfigLoaderTest extends TestCase
 {
     /**
-     * @param array<non-falsy-string, array<array{and_logic: string, field: string, tokenize: int, ranking: float}>> $configKeyedByLanguageId
+     * @param array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float}>> $configKeyedByLanguageId
      * @param array<array{and_logic: string, field: string, tokenize: int, ranking: float}> $expectedResult
      */
     #[DataProvider('loadDataProvider')]
@@ -75,7 +75,7 @@ class SearchConfigLoaderTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{configKeyedByLanguageId: array<string, array<array{and_logic: string, field: string, tokenize: int, ranking: float}>>, expectedResult: array<array{and_logic: string, field: string, tokenize: int, ranking: float}>}>
+     * @return iterable<string, array{configKeyedByLanguageId: array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float}>>, expectedResult: array<array{and_logic: string, field: string, tokenize: int, ranking: float}>}>
      */
     public static function loadDataProvider(): iterable
     {
@@ -83,7 +83,7 @@ class SearchConfigLoaderTest extends TestCase
             'configKeyedByLanguageId' => [
                 Defaults::LANGUAGE_SYSTEM => [[
                     'and_logic' => 'and',
-                    'excluded_terms' => json_encode(['term1', 'term2']),
+                    'excluded_terms' => json_encode(['term1', 'term2'], \JSON_THROW_ON_ERROR),
                     'min_search_length' => 5,
                     'field' => 'name',
                     'tokenize' => 1,
@@ -109,12 +109,12 @@ class SearchConfigLoaderTest extends TestCase
                     'field' => 'name',
                     'tokenize' => 1,
                     'ranking' => 100.0,
-                    'excluded_terms' => json_encode(['term1', 'term2']),
+                    'excluded_terms' => json_encode(['term1', 'term2'], \JSON_THROW_ON_ERROR),
                     'min_search_length' => 5,
                 ]],
                 Uuid::randomHex() => [[
                     'and_logic' => 'and',
-                    'excluded_terms' => json_encode(['term3', 'term4']),
+                    'excluded_terms' => json_encode(['term3', 'term4'], \JSON_THROW_ON_ERROR),
                     'min_search_length' => 15,
                     'field' => 'name',
                     'tokenize' => 0,

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/WriteInputValidatorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/WriteInputValidatorTest.php
@@ -17,12 +17,12 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class WriteInputValidatorTest extends TestCase
 {
     /**
-     * @param array<array<string, mixed|null>> $input
+     * @param array<array-key, array<array-key, string>> $input
      */
     #[DataProvider('invalidWriteInputProvider')]
     public function testInvalidWriteInputs(array $input): void
     {
-        static::expectException(DataAbstractionLayerException::class);
+        $this->expectException(DataAbstractionLayerException::class);
 
         WriteInputValidator::validate($input);
     }

--- a/tests/unit/Core/Framework/MessageQueue/MessageHandlerCompilerPassTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/MessageHandlerCompilerPassTest.php
@@ -17,8 +17,8 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 class MessageHandlerCompilerPassTest extends TestCase
 {
     /**
-     * @param array<string, string> $existingTagAttributes
-     * @param array<string, string> $expectedTagAttributes
+     * @param array<string, string|int> $existingTagAttributes
+     * @param array<string, string|int> $expectedTagAttributes
      */
     #[DataProvider('tagProvider')]
     public function testAddsTagsAttributesFromAttribute(array $existingTagAttributes, array $expectedTagAttributes): void

--- a/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class PluginCreateCommandTest extends TestCase
 {
     /**
-     * @param array<string, string> $arguments
+     * @param array<string, string|true> $arguments
      * @param list<string> $inputs
      * @param array<int, array<string, mixed>> $generators
      */

--- a/tests/unit/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoaderTest.php
+++ b/tests/unit/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoaderTest.php
@@ -28,10 +28,12 @@ class KernelPluginLoaderTest extends TestCase
             [
                 [
                     'name' => 'ExampleBundle',
+                    'version' => '1.0.0',
                     'baseClass' => ExampleBundle::class,
                     'path' => __DIR__ . '/../_fixtures/ExampleBundle',
                     'active' => true,
                     'managedByComposer' => false,
+                    'composerName' => 'Swag\ExampleBundle',
                     'autoload' => [
                         'psr-4' => [
                             'ExampleBundle\\' => '',
@@ -58,10 +60,12 @@ class KernelPluginLoaderTest extends TestCase
             [
                 [
                     'name' => 'ExampleBundle',
+                    'version' => '1.0.0',
                     'baseClass' => ExampleBundle::class,
                     'path' => __DIR__ . '/../_fixtures/ExampleBundle',
                     'active' => true,
                     'managedByComposer' => true,
+                    'composerName' => 'Swag\ExampleBundle',
                     'autoload' => [
                         'psr-4' => [
                             'ExampleBundle\\' => '',

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -133,10 +133,12 @@ class AssetServiceTest extends TestCase
             [
                 [
                     'name' => 'ExampleBundle',
+                    'version' => '1.0.0',
                     'baseClass' => ExampleBundle::class,
                     'path' => __DIR__ . '/_fixtures/ExampleBundle',
                     'active' => true,
                     'managedByComposer' => false,
+                    'composerName' => 'Swag\ExampleBundle',
                     'autoload' => [
                         'psr-4' => [
                             'ExampleBundle' => '',

--- a/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
@@ -46,14 +46,14 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string>|string|bool|float> $customFields
-     * @param array<string>|bool|string|int|null $renderedFieldValue
-     * @param array<string, string> $config
+     * @param array<string, string|float|bool|list<string>|null> $customFields
+     * @param string|float|bool|list<string>|null $renderedFieldValue
+     * @param array{componentName: string}|array{} $config
      */
     #[DataProvider('customFieldRuleMatchDataProvider')]
     public function testCustomFieldRuleMatchesValues(
         array $customFields,
-        array|bool|string|int|null $renderedFieldValue,
+        array|bool|string|float|null $renderedFieldValue,
         string $type,
         string $operator,
         bool $isMatching,
@@ -69,9 +69,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string|int, array<string>|string|bool|float|null>|bool|string|int|null>>
+     * @return \Generator<string, array{array<string, string|float|bool|list<string>|null>, string|float|bool|list<string>|null, string, string, bool, 5?: array{componentName: string}}>
      */
-    public static function customFieldRuleMatchDataProvider(): iterable
+    public static function customFieldRuleMatchDataProvider(): \Generator
     {
         // All boolean custom field types should behave the same
         yield from self::boolTypeDataProvider(CustomFieldTypes::BOOL);
@@ -164,9 +164,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string, bool>|bool|string|null>>
+     * @return \Generator<string, array{array<string, bool>, bool|string|null, string, string, bool}>
      */
-    private static function boolTypeDataProvider(string $boolCustomFieldType): iterable
+    private static function boolTypeDataProvider(string $boolCustomFieldType): \Generator
     {
         yield $boolCustomFieldType . ': does not match missing value equals bool true' => [
             [],
@@ -354,9 +354,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string, null>|bool|string>>
+     * @return \Generator<string, array{array<string, null>, string, string, string, bool}>
      */
-    private static function textTypeDataProvider(): iterable
+    private static function textTypeDataProvider(): \Generator
     {
         yield 'does match null not equals "testValue"' => [
             [self::CUSTOM_FIELD_NAME => null],
@@ -376,9 +376,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string, string>|bool|string>>
+     * @return \Generator<string, array{array<string, string>, string, string, string, bool}>
      */
-    private static function stringTypeDataProvider(): iterable
+    private static function stringTypeDataProvider(): \Generator
     {
         yield 'does match same strings on equals' => [
             [self::CUSTOM_FIELD_NAME => 'my_test_value'],
@@ -398,13 +398,13 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string, float>|bool|string|int>>
+     * @return \Generator<string, array{array<string, float>, float, string, string, bool}>
      */
-    private static function floatTypeDataProvider(): iterable
+    private static function floatTypeDataProvider(): \Generator
     {
         yield 'does match same float on equals' => [
             [self::CUSTOM_FIELD_NAME => 123.0],
-            123,
+            123.0,
             'float',
             Rule::OPERATOR_EQ,
             true,
@@ -412,9 +412,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string|int, array<string>|string>|bool|string|null>>
+     * @return \Generator<string, array{array<string, list<string>>, list<string>|null, string, string, bool, 5?: array{componentName: string}}>
      */
-    private static function selectTypeDataProvider(): iterable
+    private static function selectTypeDataProvider(): \Generator
     {
         yield 'does not match selected options equals null' => [
             [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
@@ -525,9 +525,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string,string>|bool|string>>
+     * @return \Generator<string, array{array<string, string>, string, string, string, bool}>
      */
-    private static function datetimeTypeDataProvider(): iterable
+    private static function datetimeTypeDataProvider(): \Generator
     {
         yield 'does not match missing value equals datetime' => [
             [],
@@ -651,9 +651,9 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array<array<string, string>|bool|string>>
+     * @return \Generator<string, array{array<string, string>, string, string, string, bool}>
      */
-    private static function dateTypeDataProvider(): iterable
+    private static function dateTypeDataProvider(): \Generator
     {
         yield 'does not match missing value equals date' => [
             [],

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -390,7 +390,7 @@ class DateRangeRuleTest extends TestCase
     }
 
     /**
-     * @param array<string, string|bool|\DateTime> $options
+     * @param array<string, string|bool|\DateTime|null> $options
      */
     #[DataProvider('provideInvalidDateAndTimezoneFormats')]
     public function testAssignPreservesInvalidFormatsForValidators(array $options): void

--- a/tests/unit/Core/Framework/Sso/Config/LoginConfigServiceTest.php
+++ b/tests/unit/Core/Framework/Sso/Config/LoginConfigServiceTest.php
@@ -55,7 +55,7 @@ class LoginConfigServiceTest extends TestCase
     }
 
     /**
-     * @param array{use_default: bool, client_id: non-empty-string, client_secret: non-empty-string, redirect_uri: non-empty-string, base_url: non-empty-string, authorize_path: non-empty-string, token_path: non-empty-string, jwks_path: non-empty-string, scope: non-empty-string, register_url: non-empty-string} $rawConfig
+     * @param array<string, mixed> $rawConfig
      */
     #[DataProvider('getConfigErrorsTestDataProvider')]
     public function testGetConfigErrors(array $rawConfig, string $exceptionMessage): void

--- a/tests/unit/Core/Framework/Store/Exception/StoreApiExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/Exception/StoreApiExceptionTest.php
@@ -89,10 +89,8 @@ class StoreApiExceptionTest extends TestCase
             )
         );
 
-        $exception = new StoreApiException($clientException);
-
-        foreach ($exception->getErrors() as $error) {
-            static::assertSame('title', $error['title']);
+        foreach ((new StoreApiException($clientException))->getErrors() as $error) {
+            static::assertSame('title', $error['title'] ?? null);
         }
     }
 
@@ -108,10 +106,8 @@ class StoreApiExceptionTest extends TestCase
             )
         );
 
-        $exception = new StoreApiException($clientException);
-
-        foreach ($exception->getErrors() as $error) {
-            static::assertSame('https://shopware.docs', $error['meta']['documentationLink']);
+        foreach ((new StoreApiException($clientException))->getErrors() as $error) {
+            static::assertSame('https://shopware.docs', $error['meta']['documentationLink'] ?? null);
         }
     }
 
@@ -136,10 +132,10 @@ class StoreApiExceptionTest extends TestCase
         foreach ($exception->getErrors(true) as $error) {
             static::assertSame('FRAMEWORK__STORE_ERROR', $error['code']);
             static::assertSame((string) Response::HTTP_INTERNAL_SERVER_ERROR, $error['status']);
-            static::assertSame('title', $error['title']);
+            static::assertSame('title', $error['title'] ?? null);
             static::assertSame('description', $error['detail']);
-            static::assertSame('https://shopware.docs', $error['meta']['documentationLink']);
-            static::assertIsString($error['trace']);
+            static::assertSame('https://shopware.docs', $error['meta']['documentationLink'] ?? null);
+            static::assertIsString($error['trace'] ?? null);
         }
     }
 }

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -397,6 +397,7 @@ class WebhookManagerTest extends TestCase
     private function prepareWebhook(string $eventName, bool $onlyLiveVersion = false, array $acl = ['product:read']): Webhook
     {
         $webhook = $this->getWebhook($eventName, $onlyLiveVersion);
+        static::assertIsString($webhook->appAclRoleId);
 
         $this->webhookLoader->expects($this->once())
             ->method('getWebhooks')

--- a/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
+++ b/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
@@ -185,11 +185,17 @@ class DatabaseMigratorTest extends TestCase
         ], $result);
     }
 
+    /**
+     * @return \Generator<string>
+     */
     private function nonEmptyGenerator(): \Generator
     {
         yield 'migration';
     }
 
+    /**
+     * @return \Generator<null>
+     */
     private function emptyGenerator(): \Generator
     {
         yield from [];

--- a/tests/unit/Core/Installer/Requirements/EnvironmentRequirementsValidatorTest.php
+++ b/tests/unit/Core/Installer/Requirements/EnvironmentRequirementsValidatorTest.php
@@ -24,9 +24,9 @@ use Shopware\Core\Installer\Requirements\Struct\SystemCheck;
 class EnvironmentRequirementsValidatorTest extends TestCase
 {
     /**
-     * @param array<string, string> $composerOverrides
+     * @param array<string, string|false> $composerOverrides
      * @param array<string, Link> $requires
-     * @param SystemCheck[] $expectedChecks
+     * @param list<SystemCheck> $expectedChecks
      */
     #[DataProvider('composerRequirementsProvider')]
     public function testValidateRequirements(?string $coreComposerName, array $composerOverrides, array $requires, array $expectedChecks): void

--- a/tests/unit/Core/Maintenance/System/Service/ShopConfiguratorTest.php
+++ b/tests/unit/Core/Maintenance/System/Service/ShopConfiguratorTest.php
@@ -165,7 +165,7 @@ class ShopConfiguratorTest extends TestCase
     /**
      * @param array<string, string> $expectedStateTranslations
      * @param array<string, string> $expectedMissingTranslations
-     * @param callable(string, array<string, string>): void $insertCallback
+     * @param callable(string, array<string, string>): int $insertCallback
      */
     #[DataProvider('countryStateTranslationsProvider')]
     public function testSetDefaultLanguageShouldAddMissingCountryStatesTranslations(

--- a/tests/unit/Core/Service/ServiceRegistry/ClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistry/ClientTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Service\ServiceRegistry\ServiceEntry;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -23,24 +24,36 @@ class ClientTest extends TestCase
     {
         yield 'not-json' => [''];
 
-        yield 'no-services-key' => [json_encode(['blah' => [1, 2, 3]])];
+        yield 'no-services-key' => [json_encode(['blah' => [1, 2, 3]], \JSON_THROW_ON_ERROR)];
 
-        yield 'not-correct-list' => [json_encode(['services' => [1, 2, 3]])];
+        yield 'not-correct-list' => [json_encode(['services' => [1, 2, 3]], \JSON_THROW_ON_ERROR)];
 
-        yield 'not-correct-service-definition' => [json_encode(['services' => [['not-valid' => 1]]])];
+        yield 'not-correct-service-definition' => [json_encode(['services' => [['not-valid' => 1]]], \JSON_THROW_ON_ERROR)];
 
-        yield 'missing-label' => [json_encode(['services' => [['name' => 'SomeService']]])];
+        yield 'missing-label' => [json_encode(['services' => [['name' => 'SomeService']]], \JSON_THROW_ON_ERROR)];
 
-        yield 'missing-host' => [json_encode(['services' => [['name' => 'SomeService', 'label' => 'SomeService']]])];
+        yield 'missing-host' => [json_encode(['services' => [['name' => 'SomeService', 'label' => 'SomeService']]], \JSON_THROW_ON_ERROR)];
 
-        yield 'missing-app-endpoint' => [json_encode(['services' => [['name' => 'SomeService', 'label' => 'SomeService', 'host' => 'https://www.someservice.com']]])];
+        yield 'missing-app-endpoint' => [
+            json_encode([
+                'services' => [
+                    [
+                        'name' => 'SomeService',
+                        'label' => 'SomeService',
+                        'host' => 'https://www.someservice.com',
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR),
+        ];
 
-        yield '1-valid-1-invalid' => [json_encode([
-            'services' => [
-                ['name' => 'SomeService', 'label' => 'SomeService', 'host' => 'https://www.someservice.com', 'app-endpoint' => '/register'],
-                ['not-valid' => 1],
-            ],
-        ])];
+        yield '1-valid-1-invalid' => [
+            json_encode([
+                'services' => [
+                    ['name' => 'SomeService', 'label' => 'SomeService', 'host' => 'https://www.someservice.com', 'app-endpoint' => '/register'],
+                    ['not-valid' => 1],
+                ],
+            ], \JSON_THROW_ON_ERROR),
+        ];
     }
 
     #[DataProvider('invalidResponseProvider')]
@@ -59,7 +72,7 @@ class ClientTest extends TestCase
     public function testFailRequestReturnsEmptyListOfServices(): void
     {
         $client = new MockHttpClient([
-            $response = new MockResponse('', ['http_code' => 503]),
+            $response = new MockResponse('', ['http_code' => Response::HTTP_SERVICE_UNAVAILABLE]),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
@@ -78,7 +91,7 @@ class ClientTest extends TestCase
         ];
 
         $client = new MockHttpClient([
-            $response = new MockResponse((string) json_encode($service)),
+            $response = new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
@@ -110,7 +123,7 @@ class ClientTest extends TestCase
         ];
 
         $client = new MockHttpClient([
-            new MockResponse((string) json_encode($service)),
+            new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
@@ -144,8 +157,8 @@ class ClientTest extends TestCase
         ];
 
         $client = new MockHttpClient([
-            new MockResponse((string) json_encode($services1)),
-            new MockResponse((string) json_encode($services2)),
+            new MockResponse((string) json_encode($services1, \JSON_THROW_ON_ERROR)),
+            new MockResponse((string) json_encode($services2, \JSON_THROW_ON_ERROR)),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);
@@ -172,8 +185,8 @@ class ClientTest extends TestCase
         ];
 
         $client = new MockHttpClient([
-            $response1 = new MockResponse((string) json_encode($servicesPage1)),
-            $response2 = new MockResponse((string) json_encode($servicesPage2)),
+            $response1 = new MockResponse((string) json_encode($servicesPage1, \JSON_THROW_ON_ERROR)),
+            $response2 = new MockResponse((string) json_encode($servicesPage2, \JSON_THROW_ON_ERROR)),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $client);
@@ -208,7 +221,7 @@ class ClientTest extends TestCase
     public function testSaveConsentSuccess(): void
     {
         $client = new MockHttpClient([
-            $response = new MockResponse('', ['http_code' => 202]), // Changed from 200 to 202 (HTTP_ACCEPTED)
+            $response = new MockResponse('', ['http_code' => Response::HTTP_ACCEPTED]), // Changed from 200 to 202 (HTTP_ACCEPTED)
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -231,7 +244,7 @@ class ClientTest extends TestCase
     public function testSaveConsentThrowsExceptionOnFailure(): void
     {
         $client = new MockHttpClient([
-            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => Response::HTTP_INTERNAL_SERVER_ERROR]),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -251,7 +264,7 @@ class ClientTest extends TestCase
     public function testSaveConsentThrowsExceptionOnNonAcceptedStatusCode(): void
     {
         $client = new MockHttpClient([
-            new MockResponse('', ['http_code' => 200]), // 200 is not HTTP_ACCEPTED (202)
+            new MockResponse('', ['http_code' => Response::HTTP_OK]), // 200 is not HTTP_ACCEPTED (202)
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -272,7 +285,7 @@ class ClientTest extends TestCase
     public function testRevokeConsentSuccess(): void
     {
         $client = new MockHttpClient([
-            $response = new MockResponse('', ['http_code' => 202]), // Changed from 200 to 202 (HTTP_ACCEPTED)
+            $response = new MockResponse('', ['http_code' => Response::HTTP_ACCEPTED]), // Changed from 200 to 202 (HTTP_ACCEPTED)
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -286,19 +299,19 @@ class ClientTest extends TestCase
     public function testRevokeConsentThrowsExceptionOnFailure(): void
     {
         $client = new MockHttpClient([
-            new MockResponse('', ['http_code' => 500]),
+            new MockResponse('', ['http_code' => Response::HTTP_INTERNAL_SERVER_ERROR]),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
 
-        $this->expectException(ServiceException::class);
+        $this->expectExceptionObject(ServiceException::consentRevokeFailed('Unexpected response status code: 500'));
         $registryClient->revokeConsent('service-123');
     }
 
     public function testRevokeConsentThrowsExceptionOnNonAcceptedStatusCode(): void
     {
         $client = new MockHttpClient([
-            new MockResponse('', ['http_code' => 200]), // 200 is not HTTP_ACCEPTED (202)
+            new MockResponse('', ['http_code' => Response::HTTP_OK]), // 200 is not HTTP_ACCEPTED (202)
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -315,7 +328,7 @@ class ClientTest extends TestCase
                 ['name' => 'MyCoolService1', 'host' => 'https://coolservice1.com', 'label' => 'My Cool Service 1', 'app-endpoint' => '/app-endpoint'],
             ],
         ];
-        $servicePayload = (string) json_encode($service);
+        $servicePayload = (string) json_encode($service, \JSON_THROW_ON_ERROR);
         $expectedUrl = 'https://www.shopware.com/api/service/?page=1&limit=10';
         $clientWithSlash = new MockHttpClient([$responseWithSlash = new MockResponse($servicePayload)]);
         $registryClientWithSlash = new ServiceRegistryClient('https://www.shopware.com/', 'https://example.com', $clientWithSlash);
@@ -358,7 +371,7 @@ class ClientTest extends TestCase
         $zipUrl = 'https://files.example.com/missing.zip';
 
         $client = new MockHttpClient([
-            new MockResponse('', ['http_code' => 404]),
+            new MockResponse('', ['http_code' => Response::HTTP_NOT_FOUND]),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://example.com', 'https://example.com', $client);
@@ -370,7 +383,7 @@ class ClientTest extends TestCase
 
     public static function nonZipContentTypeProvider(): \Generator
     {
-        yield 'json' => ['application/json', json_encode(['ok' => true])];
+        yield 'json' => ['application/json', json_encode(['ok' => true], \JSON_THROW_ON_ERROR)];
         yield 'html' => ['text/html; charset=UTF-8', '<html><body>Not a zip</body></html>'];
     }
 
@@ -381,7 +394,7 @@ class ClientTest extends TestCase
 
         $client = new MockHttpClient([
             new MockResponse($body, [
-                'http_code' => 200,
+                'http_code' => Response::HTTP_OK,
                 'response_headers' => ['Content-Type: ' . $contentType],
             ]),
         ]);
@@ -399,7 +412,7 @@ class ClientTest extends TestCase
         ];
 
         $client = new MockHttpClient([
-            $response = new MockResponse((string) json_encode($service)),
+            $response = new MockResponse((string) json_encode($service, \JSON_THROW_ON_ERROR)),
         ]);
 
         $registryClient = new ServiceRegistryClient('https://www.shopware.com', 'https://example.com', $client);

--- a/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
+++ b/tests/unit/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaTest.php
@@ -170,8 +170,7 @@ class AdminUiXmlSchemaTest extends TestCase
             ['custom_entity_field']
         );
 
-        $detail = $customEntityTest->getDetail();
-        $tabs = $detail->getTabs();
+        $tabs = $customEntityTest->getDetail()->getTabs();
         static::assertCount(1, $tabs->getContent());
 
         $cards = $this->checkTab($tabs->getContent()[0], 'main');
@@ -214,7 +213,9 @@ class AdminUiXmlSchemaTest extends TestCase
         foreach ($columns->getContent() as $column) {
             static::assertInstanceOf(Column::class, $column);
             static::assertContains($column->getRef(), $refs);
-            unset($refs[array_search($column->getRef(), $refs, true)]);
+            $position = array_search($column->getRef(), $refs, true);
+            static::assertIsInt($position);
+            unset($refs[$position]);
         }
         static::assertCount(0, $refs);
     }
@@ -248,7 +249,9 @@ class AdminUiXmlSchemaTest extends TestCase
             static::assertInstanceOf(CardField::class, $cardField);
             static::assertContains($cardField->getRef(), $refs);
 
-            unset($refs[array_search($cardField->getRef(), $refs, true)]);
+            $position = array_search($cardField->getRef(), $refs, true);
+            static::assertIsInt($position);
+            unset($refs[$position]);
         }
         static::assertCount(0, $refs);
     }

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -4,7 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\CheckoutPermissions;
 use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\Log\Package;
@@ -82,31 +82,34 @@ class SalesChannelContextTest extends TestCase
     public function testWithPermissions(): void
     {
         $salesChannelContext = Generator::generateSalesChannelContext();
-        static::assertEmpty($salesChannelContext->getPermissions());
+        $permissionsBefore = $salesChannelContext->getPermissions();
+        static::assertSame([], $permissionsBefore);
 
         $called = false;
         $salesChannelContext->withPermissions(
-            [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
+            [CheckoutPermissions::PERSIST_CART_ERRORS => true],
             static function (SalesChannelContext $context) use (&$called): void {
                 $called = true;
 
-                static::assertTrue($context->hasPermission(AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION));
+                static::assertTrue($context->hasPermission(CheckoutPermissions::PERSIST_CART_ERRORS));
             },
         );
 
         static::assertTrue($called);
-        static::assertEmpty($salesChannelContext->getPermissions());
+        $permissionsAfter = $salesChannelContext->getPermissions();
+        static::assertSame([], $permissionsAfter);
     }
 
     public function testWithPermissionsWithLockedPermissions(): void
     {
         $salesChannelContext = Generator::generateSalesChannelContext();
         $salesChannelContext->lockPermissions();
-        static::assertEmpty($salesChannelContext->getPermissions());
+        $permissionsBefore = $salesChannelContext->getPermissions();
+        static::assertSame([], $permissionsBefore);
 
         $called = false;
         $salesChannelContext->withPermissions(
-            [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
+            [CheckoutPermissions::PERSIST_CART_ERRORS => true],
             static function (SalesChannelContext $context) use (&$called): void {
                 $called = true;
 
@@ -115,7 +118,8 @@ class SalesChannelContextTest extends TestCase
         );
 
         static::assertTrue($called);
-        static::assertEmpty($salesChannelContext->getPermissions());
+        $permissionsAfter = $salesChannelContext->getPermissions();
+        static::assertSame([], $permissionsAfter);
     }
 
     public function testSalesChannelContextStateFunctionPassesResetsAndKeepsState(): void
@@ -152,7 +156,7 @@ class SalesChannelContextTest extends TestCase
         // fake twig rendering context, see `\Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute()`
         FieldVisibility::$isInTwigRenderingContext = true;
 
-        static::expectExceptionObject(SalesChannelException::contextTokenNotAccessible());
+        $this->expectExceptionObject(SalesChannelException::contextTokenNotAccessible());
         $salesChannelContext->getToken();
     }
 }

--- a/tests/unit/Core/System/Snippet/Command/Util/CountryAgnosticFileLinterTest.php
+++ b/tests/unit/Core/System/Snippet/Command/Util/CountryAgnosticFileLinterTest.php
@@ -36,8 +36,6 @@ class CountryAgnosticFileLinterTest extends TestCase
 
     private MockObject&Finder $finder;
 
-    private MockObject&Filesystem $filesystem;
-
     /**
      * @var MockObject&EntityRepository<PluginCollection>
      */
@@ -52,7 +50,7 @@ class CountryAgnosticFileLinterTest extends TestCase
     {
         // Mock Finder to avoid filesystem scanning
         $this->finder = $this->createMock(Finder::class);
-        $this->filesystem = $this->createMock(Filesystem::class);
+        $filesystem = $this->createMock(Filesystem::class);
         $this->pluginRepository = $this->createMock(EntityRepository::class);
         $this->appRepository = $this->createMock(EntityRepository::class);
 
@@ -67,7 +65,7 @@ class CountryAgnosticFileLinterTest extends TestCase
         $this->finder->method('in')->willReturnSelf();
 
         $this->fileLinter = new CountryAgnosticFileLinter(
-            $this->filesystem,
+            $filesystem,
             $this->pluginRepository,
             $this->appRepository,
             $this->finder,
@@ -201,8 +199,8 @@ class CountryAgnosticFileLinterTest extends TestCase
 
     public function testGetFinderWithExtensionPaths(): void
     {
-        $pluginSearchResult = $this->createPluginSearchResult('/path/to/plugin1', 'plugin-id-1');
-        $appSearchResult = $this->createAppSearchResult('/path/to/app1', 'app-id-1');
+        $pluginSearchResult = $this->createPluginSearchResult();
+        $appSearchResult = $this->createAppSearchResult();
 
         $this->pluginRepository->expects($this->once())->method('search')->willReturn($pluginSearchResult);
         $this->appRepository->expects($this->once())->method('search')->willReturn($appSearchResult);
@@ -219,7 +217,7 @@ class CountryAgnosticFileLinterTest extends TestCase
                 return $this->finder;
             });
 
-        $options = $this->createOptionsWithExtensions('MyPlugin,MyApp');
+        $options = $this->createOptionsWithExtensions();
 
         $this->finder->method('count')->willReturn(0);
         $this->finder->method('getIterator')->willReturn(new \ArrayIterator([]));
@@ -231,11 +229,11 @@ class CountryAgnosticFileLinterTest extends TestCase
     /**
      * @return EntitySearchResult<PluginCollection>
      */
-    private function createPluginSearchResult(string $path, string $id): EntitySearchResult
+    private function createPluginSearchResult(): EntitySearchResult
     {
         $plugin = new PluginEntity();
-        $plugin->setPath($path);
-        $plugin->setUniqueIdentifier($id);
+        $plugin->setPath('/path/to/plugin1');
+        $plugin->setUniqueIdentifier('plugin-id-1');
 
         $collection = new PluginCollection([$plugin]);
 
@@ -252,11 +250,11 @@ class CountryAgnosticFileLinterTest extends TestCase
     /**
      * @return EntitySearchResult<AppCollection>
      */
-    private function createAppSearchResult(string $path, string $id): EntitySearchResult
+    private function createAppSearchResult(): EntitySearchResult
     {
         $app = new AppEntity();
-        $app->setPath($path);
-        $app->setUniqueIdentifier($id);
+        $app->setPath('/path/to/app1');
+        $app->setUniqueIdentifier('app-id-1');
 
         $collection = new AppCollection([$app]);
 
@@ -270,13 +268,13 @@ class CountryAgnosticFileLinterTest extends TestCase
         );
     }
 
-    private function createOptionsWithExtensions(string $extensions): LintedTranslationFileOptions
+    private function createOptionsWithExtensions(): LintedTranslationFileOptions
     {
         $input = $this->createMock(InputInterface::class);
         $input->method('getOption')->willReturnMap([
             ['fix', false],
             ['all', false],
-            ['extensions', $extensions],
+            ['extensions', 'MyPlugin,MyApp'],
             ['ignore', ''],
             ['dir', ''],
         ]);
@@ -294,8 +292,9 @@ class CountryAgnosticFileLinterTest extends TestCase
     private function hydrateFixingCollection(LintedTranslationFileStruct $lintedFileStruct): LintedTranslationFileStruct
     {
         foreach ($lintedFileStruct->getFixableFiles()->getMapping() as $fileOptions) {
-            $selection = array_key_first($fileOptions);
-            $lintedFileStruct->addToFixingCollection($fileOptions[$selection]);
+            $firstFileOption = array_first($fileOptions);
+            static::assertNotNull($firstFileOption);
+            $lintedFileStruct->addToFixingCollection($firstFileOption);
         }
 
         return $lintedFileStruct;

--- a/tests/unit/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetServiceTest.php
@@ -68,9 +68,9 @@ class SnippetServiceTest extends TestCase
     }
 
     /**
-     * @param list<string> $catalogueMessages
-     * @param \Throwable|list<string> $expected
-     * @param list<string> $databaseSnippets
+     * @param \Throwable|array<string, string> $expected
+     * @param array<string, string> $catalogueMessages
+     * @param array<string, string> $databaseSnippets
      */
     #[DataProvider('getStorefrontSnippetsDataProvider')]
     public function testGetStorefrontSnippets(

--- a/tests/unit/Core/System/SystemConfig/SystemConfigServiceTest.php
+++ b/tests/unit/Core/System/SystemConfig/SystemConfigServiceTest.php
@@ -141,21 +141,4 @@ class SystemConfigServiceTest extends TestCase
         static::assertInstanceOf(SystemConfigChangedHook::class, $dispatchedHook);
         static::assertFalse($dispatchedHook->silent);
     }
-
-    public static function provideTracingExamples(): \Generator
-    {
-        yield 'disabled' => [
-            false,
-            [
-                'global.system.config',
-            ],
-        ];
-
-        yield 'enabled' => [
-            true,
-            [
-                'config.test',
-            ],
-        ];
-    }
 }

--- a/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
+++ b/tests/unit/Core/System/SystemConfig/Validation/SystemConfigValidatorTest.php
@@ -21,7 +21,7 @@ class SystemConfigValidatorTest extends TestCase
 {
     /**
      * @param array<string, mixed> $inputValues
-     * @param array<string, mixed> $formConfigs
+     * @param list<array<string, mixed>> $formConfigs
      */
     #[DataProvider('dataProviderTestValidateSuccess')]
     public function testValidateSuccess(array $inputValues, array $formConfigs): void
@@ -49,7 +49,7 @@ class SystemConfigValidatorTest extends TestCase
 
     /**
      * @param array<string, mixed> $inputValues
-     * @param array<string, mixed> $formConfigs
+     * @param list<array<string, mixed>> $formConfigs
      */
     #[DataProvider('dataProviderTestValidateFailure')]
     public function testValidateFailure(array $inputValues, array $formConfigs): void
@@ -75,7 +75,7 @@ class SystemConfigValidatorTest extends TestCase
 
     /**
      * @param array<string, mixed> $inputValues
-     * @param array<string, mixed> $formConfigs
+     * @param list<array<string, mixed>> $formConfigs
      */
     #[DataProvider('dataProviderTestValidateSuccess')]
     public function testValidateWithEmptyConfig(array $inputValues, array $formConfigs): void

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -101,7 +101,7 @@ class ProductSearchQueryBuilderTest extends TestCase
 
     /**
      * @param array{array{and_logic: string, field: string, tokenize: int, ranking: float}} $config
-     * @param array{string: mixed} $expected
+     * @param array<string, mixed> $expected
      */
     #[DataProvider('buildSingleLanguageProvider')]
     public function testBuildSingleLanguage(array $config, string $term, array $expected): void
@@ -117,8 +117,8 @@ class ProductSearchQueryBuilderTest extends TestCase
     }
 
     /**
-     * @param array{array{and_logic: string, field: string, tokenize: int, ranking: int}} $config
-     * @param array{string: mixed} $expected
+     * @param array{array{and_logic: string, field: string, tokenize: int, ranking: int|float}} $config
+     * @param array<string, mixed> $expected
      */
     #[DataProvider('buildMultipleLanguageProvider')]
     public function testBuildMultipleLanguages(array $config, string $term, array $expected): void
@@ -502,7 +502,7 @@ class ProductSearchQueryBuilderTest extends TestCase
     }
 
     /**
-     * @param array{array{and_logic: string, field: string, tokenize: int, ranking: float}}|null $config
+     * @param array{array{and_logic: string, field: string, tokenize: int, ranking: int|float}}|null $config
      */
     private function getBuilder(?array $config): ProductSearchQueryBuilder
     {

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -185,8 +185,8 @@ class TokenQueryBuilderTest extends TestCase
     }
 
     /**
-     * @param SearchFieldConfig[] $config
-     * @param array{string: mixed} $expected
+     * @param list<SearchFieldConfig> $config
+     * @param array<string, mixed> $expected
      */
     #[DataProvider('buildSingleLanguageProvider')]
     public function testBuildSingleLanguage(array $config, string $term, array $expected): void
@@ -203,8 +203,8 @@ class TokenQueryBuilderTest extends TestCase
     }
 
     /**
-     * @param SearchFieldConfig[] $config
-     * @param array{string: mixed} $expected
+     * @param list<SearchFieldConfig> $config
+     * @param array<string, mixed> $expected
      */
     #[DataProvider('buildMultipleLanguageProvider')]
     public function testBuildMultipleLanguages(array $config, string $term, array $expected): void
@@ -221,9 +221,9 @@ class TokenQueryBuilderTest extends TestCase
     }
 
     /**
-     * @return iterable<array-key, array{config: SearchFieldConfig[], term: string, expected: array<string, mixed>}>
+     * @return \Generator<array{config: list<SearchFieldConfig>, term: string, expected: array<string, mixed>}>
      */
-    public static function buildSingleLanguageProvider(): iterable
+    public static function buildSingleLanguageProvider(): \Generator
     {
         $prefix = 'customFields.' . Defaults::LANGUAGE_SYSTEM . '.';
 
@@ -333,7 +333,7 @@ class TokenQueryBuilderTest extends TestCase
     }
 
     /**
-     * @return iterable<array-key, array{config: SearchFieldConfig[], term: string, expected: array<string, mixed>}>
+     * @return iterable<array-key, array{config: list<SearchFieldConfig>, term: string, expected: array<string, mixed>}>
      */
     public static function buildMultipleLanguageProvider(): iterable
     {

--- a/tests/unit/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCompilerTest.php
@@ -198,7 +198,7 @@ class ThemeCompilerTest extends TestCase
     }
 
     /**
-     * @param array<string> $config
+     * @param array<string, mixed> $config
      */
     #[DataProvider('configForDumpVariables')]
     public function testDumpVariables(array $config, string $expected): void

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -18,7 +18,7 @@ use Shopware\Storefront\Theme\Validator\SCSSValidator;
 class SCSSValidatorTest extends TestCase
 {
     /**
-     * @param array<string, string> $data
+     * @param array<string, string|bool|int> $data
      */
     #[DataProvider('sanitizeDataProvider')]
     public function testValidateSanitize(array $data, string|bool|null $expected): void
@@ -29,13 +29,13 @@ class SCSSValidatorTest extends TestCase
     }
 
     /**
-     * @param array<string, string> $data
+     * @param array<string, string|bool|int> $data
      */
     #[DataProvider('validateDataProvider')]
     public function testValidateNoSanitize(array $data, string|bool|null $expected, bool $throwsException = false): void
     {
         if ($throwsException) {
-            self::expectException(ThemeException::class);
+            $this->expectException(ThemeException::class);
         }
 
         $returned = SCSSValidator::validate(new ScssPhpCompiler(), $data);
@@ -50,7 +50,7 @@ class SCSSValidatorTest extends TestCase
     public function testValidateNoSanitizeRegex(array $data, string|bool|null $expected, bool $throwsException = false): void
     {
         if ($throwsException) {
-            self::expectException(ThemeException::class);
+            $this->expectException(ThemeException::class);
         }
 
         $returned = SCSSValidator::validate(new ScssPhpCompiler(), $data, ['^\$.*']);


### PR DESCRIPTION
### 1. Why is this change necessary?

Prepare parts of the code for the PHPStan update https://github.com/shopware/shopware/pull/15179

### 2. What does this change do, exactly?

Fix PHPStan issues

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
