### PR TITLE
fix: disable runtime errors overlay in webpack dev server

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -240,6 +240,10 @@ custom timeouts, retry strategies, or HTTP protocol version for S3 operations.
 
 * Deprecated block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` which will be removed in v6.8.0. Use block `component_product_box_action_buy_button_label` instead.
 
+### Disabled runtime error overlay in webpack dev server
+
+The webpack dev server overlay for runtime errors has been disabled in hot-reload mode. The overlay frequently interrupted the development workflow by covering the entire viewport for non-critical runtime errors, making it difficult to interact with the storefront during development. Error details remain available in the browser console.
+
 ### `HEAD`-requests do not trigger the registration double-opt-in
 
 As some mail clients send `HEAD` requests to links which are contained in emails, the registration double-opt-in was sometimes already confirmed, as Symfony treats `HEAD`-requests the same as `GET`-request. Now `HEAD`-requests do not trigger the registration double-opt-in anymore, only "real" `GET`-requests.

--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -501,6 +501,7 @@ const mergedCoreConfig = merge([
                         overlay: {
                             warnings: false,
                             errors: true,
+                            runtimeErrors: false,
                         },
                     },
                     headers: {


### PR DESCRIPTION
### 1. Why is this change necessary?

The webpack dev server runtime error overlay frequently covers the entire viewport during hot-reload development, blocking interaction with the storefront for non-critical runtime errors. This significantly disrupts the development workflow.

<img width="1721" height="1270" alt="image" src="https://github.com/user-attachments/assets/aaf72d1f-99c9-4834-a23c-822437685572" />


### 2. What does this change do, exactly?

Disables the `runtimeErrors` option in the webpack dev server client overlay configuration. Compile errors and warnings remain unaffected. Runtime error details are still available in the browser console.

### 3. Describe each step to reproduce the issue or behaviour.

1. Start the storefront in hot-reload mode (`MODE=hot`)
2. Trigger a runtime error in the storefront JavaScript
3. Previously: a full-screen overlay blocks the page
4. Now: the error is logged to the browser console without blocking the UI

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them