### PR TITLE
feat: support declarative mail templates for plugins and apps

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -115,6 +115,32 @@ Affected commands:
 - `bin/console dal:validate --json` → `bin/console dal:validate --format json`
 - `bin/console sales-channel:list --output json` → `bin/console sales-channel:list --format json`
 
+### Declarative mail templates for plugins and apps
+
+Plugins and apps can now define mail templates declaratively using a directory-based convention under `Resources/mail-templates/`. This replaces the need for PHP boilerplate to persist mail template types and templates via the DAL.
+
+The approach uses an XML file for metadata (type name, subject, sender name, etc.) and separate `.html.twig` / `.txt.twig` files for template content, preserving full IDE support for Twig editing.
+
+**Directory structure:**
+```
+Resources/
+  mail-templates/
+    mail-templates.xml
+    order_confirmation/
+      en-GB/
+        html.twig
+        plain.twig
+      de-DE/
+        html.twig
+        plain.twig
+```
+
+On plugin install/update, mail template types and their templates are automatically synced to the database. On uninstall (without `--keep-user-data`), they are removed.
+
+Templates that a merchant has edited in the Administration are not overwritten on update: once a mail template is changed through the API or Administration, its `was_modified_by_user` flag is set and the declarative sync leaves its content untouched.
+
+The `bin/console plugin:create` scaffolding command now offers a `--create-mail-template` option that generates the directory structure and example files.
+
 ## Administration
 
 ### Rule Builder cart total condition labels adjusted

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,30 @@
 
 ## Features
 
+### Declarative mail templates for plugins and apps
+
+Plugins and apps can now define mail templates declaratively using a directory-based convention under `Resources/mail-templates/`. This replaces the need for PHP boilerplate to persist mail template types and templates via the DAL.
+
+The approach uses an XML file for metadata (type name, subject, sender name, etc.) and separate `.html.twig` / `.txt.twig` files for template content, preserving full IDE support for Twig editing.
+
+**Directory structure:**
+```
+Resources/
+  mail-templates/
+    mail-templates.xml
+    order_confirmation/
+      en-GB/
+        html.twig
+        plain.twig
+      de-DE/
+        html.twig
+        plain.twig
+```
+
+On plugin install/update, mail template types and their templates are automatically synced to the database. On uninstall (without `--keep-user-data`), they are removed.
+
+The `bin/console plugin:create` scaffolding command now offers a `--create-mail-template` option that generates the directory structure and example files.
+
 ### Default CMS page ID now persisted for categories
 
 Previously, when a category had no CMS page assigned, the default CMS page ID was only set at runtime during entity loading. This caused missing `cmsPage` association data when loading categories with criteria that included the `cmsPage` association.

--- a/changelog/_unreleased/2025-11-06-declarative-mail-templates-for-plugins-and-apps.md
+++ b/changelog/_unreleased/2025-11-06-declarative-mail-templates-for-plugins-and-apps.md
@@ -1,0 +1,16 @@
+---
+title: Declarative mail templates for plugins and apps
+issue: NEXT-00000
+author: shopware
+author_email: info@shopware.com
+author_github: shopware
+---
+# Core
+* Added `Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader` to load and validate `mail-templates.xml` files
+* Added `Shopware\Core\Content\MailTemplate\MailTemplateLoader` to combine XML metadata with Twig template files from disk
+* Added `Shopware\Core\Content\MailTemplate\MailTemplateSetPersister` to sync mail template types and templates to the database
+* Added `Shopware\Core\Content\MailTemplate\Xml\MailTemplates` and `Shopware\Core\Content\MailTemplate\Xml\MailTemplate` DTOs for parsed XML representation
+* Added XSD schema `src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd` for mail template XML validation
+* Added `Shopware\Core\Framework\App\Lifecycle\Persister\MailTemplatePersister` for app lifecycle integration
+* Added mail template sync/remove to `Shopware\Core\Framework\Plugin\PluginLifecycleService` for plugin install/update/uninstall
+* Added `Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\MailTemplateGenerator` for plugin scaffolding

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -34,6 +34,10 @@
             <tag name="shopware.entity.definition"/>
         </service>
 
+        <service id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
         <!-- Controller -->
         <service id="Shopware\Core\Content\MailTemplate\Api\MailActionController" public="true">
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer"/>

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -34,6 +34,10 @@
             <tag name="shopware.entity.definition"/>
         </service>
 
+        <service id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
         <!-- Controller -->
         <service id="Shopware\Core\Content\MailTemplate\Api\MailActionController" public="true">
             <argument type="service" id="Shopware\Core\Content\Mail\Service\MailService"/>

--- a/src/Core/Content/MailTemplate/MailTemplateLoader.php
+++ b/src/Core/Content/MailTemplate/MailTemplateLoader.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate;
+
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+#[Package('after-sales')]
+class MailTemplateLoader
+{
+    /**
+     * Load mail templates from a directory on the local filesystem.
+     *
+     * Expects the following structure inside $basePath:
+     *   mail-templates.xml
+     *   {technical-name}/{locale}/html.twig
+     *   {technical-name}/{locale}/plain.twig
+     */
+    public static function load(string $basePath): MailTemplates
+    {
+        $mailTemplates = MailTemplateXmlLoader::load($basePath . '/mail-templates.xml');
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $templateDir = $basePath . '/' . $mailTemplate->getTechnicalName();
+
+            if (!is_dir($templateDir)) {
+                continue;
+            }
+
+            self::loadTemplateContent($mailTemplate, $templateDir);
+        }
+
+        return $mailTemplates;
+    }
+
+    /**
+     * Load mail templates using the app filesystem abstraction.
+     */
+    public static function loadFromFilesystem(Filesystem $filesystem, string $relativePath = 'Resources/mail-templates'): MailTemplates
+    {
+        $mailTemplates = MailTemplateXmlLoader::load(
+            $filesystem->path($relativePath, 'mail-templates.xml')
+        );
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $templateDir = $filesystem->path($relativePath, $mailTemplate->getTechnicalName());
+
+            if (!is_dir($templateDir)) {
+                continue;
+            }
+
+            self::loadTemplateContent($mailTemplate, $templateDir);
+        }
+
+        return $mailTemplates;
+    }
+
+    private static function loadTemplateContent(Xml\MailTemplate $mailTemplate, string $templateDir): void
+    {
+        $contentHtml = [];
+        $contentPlain = [];
+
+        $finder = new Finder();
+        $finder->directories()->in($templateDir)->depth(0);
+
+        foreach ($finder as $localeDir) {
+            $locale = $localeDir->getFilename();
+
+            $htmlFile = $localeDir->getPathname() . '/html.twig';
+            if (is_file($htmlFile)) {
+                $contentHtml[$locale] = file_get_contents($htmlFile) ?: '';
+            }
+
+            $plainFile = $localeDir->getPathname() . '/plain.twig';
+            if (is_file($plainFile)) {
+                $contentPlain[$locale] = file_get_contents($plainFile) ?: '';
+            }
+        }
+
+        $mailTemplate->setContentHtml($contentHtml);
+        $mailTemplate->setContentPlain($contentPlain);
+    }
+}

--- a/src/Core/Content/MailTemplate/MailTemplateSetPersister.php
+++ b/src/Core/Content/MailTemplate/MailTemplateSetPersister.php
@@ -1,0 +1,301 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[Package('after-sales')]
+class MailTemplateSetPersister
+{
+    private const DEFAULT_LOCALE = 'en-GB';
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function sync(MailTemplates $mailTemplates, Context $context): void
+    {
+        $context->scope(Context::SYSTEM_SCOPE, function () use ($mailTemplates): void {
+            $this->upsertMailTemplates($mailTemplates);
+        });
+    }
+
+    /**
+     * @param list<string> $technicalNames
+     */
+    public function removeByTechnicalNames(array $technicalNames, Context $context): void
+    {
+        if ($technicalNames === []) {
+            return;
+        }
+
+        $context->scope(Context::SYSTEM_SCOPE, function () use ($technicalNames): void {
+            $typeIds = $this->connection->fetchFirstColumn(
+                'SELECT id FROM mail_template_type WHERE technical_name IN (:names)',
+                ['names' => $technicalNames],
+                ['names' => ArrayParameterType::STRING]
+            );
+
+            if ($typeIds === []) {
+                return;
+            }
+
+            // Delete mail templates first (SetNullOnDelete won't cascade)
+            $this->connection->executeStatement(
+                'DELETE FROM mail_template WHERE mail_template_type_id IN (:typeIds)',
+                ['typeIds' => $typeIds],
+                ['typeIds' => ArrayParameterType::STRING]
+            );
+
+            $this->connection->executeStatement(
+                'DELETE FROM mail_template_type WHERE id IN (:typeIds)',
+                ['typeIds' => $typeIds],
+                ['typeIds' => ArrayParameterType::STRING]
+            );
+        });
+    }
+
+    private function upsertMailTemplates(MailTemplates $mailTemplates): void
+    {
+        $localeToLanguage = $this->resolveLanguageIds($mailTemplates);
+        $now = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $typeId = $this->upsertMailTemplateType($mailTemplate, $localeToLanguage, $now);
+            $this->upsertMailTemplate($mailTemplate, $typeId, $localeToLanguage, $now);
+        }
+    }
+
+    /**
+     * @param array<string, string> $localeToLanguage locale code => binary language ID
+     *
+     * @return string binary type ID
+     */
+    private function upsertMailTemplateType(MailTemplate $mailTemplate, array $localeToLanguage, string $now): string
+    {
+        $existingTypeId = $this->connection->fetchOne(
+            'SELECT id FROM mail_template_type WHERE technical_name = :technicalName',
+            ['technicalName' => $mailTemplate->getTechnicalName()]
+        );
+
+        if ($existingTypeId === false) {
+            $typeId = Uuid::randomBytes();
+
+            $this->connection->insert('mail_template_type', [
+                'id' => $typeId,
+                'technical_name' => $mailTemplate->getTechnicalName(),
+                'available_entities' => $mailTemplate->getAvailableEntities() !== []
+                    ? json_encode($mailTemplate->getAvailableEntities(), \JSON_THROW_ON_ERROR)
+                    : null,
+                'created_at' => $now,
+            ]);
+        } else {
+            $typeId = $existingTypeId;
+
+            $update = ['updated_at' => $now];
+            if ($mailTemplate->getAvailableEntities() !== []) {
+                $update['available_entities'] = json_encode($mailTemplate->getAvailableEntities(), \JSON_THROW_ON_ERROR);
+            }
+
+            $this->connection->update('mail_template_type', $update, ['id' => $typeId]);
+        }
+
+        // Upsert type translations (name). Always include the default locale so the
+        // type has a name in the default language, falling back to any provided name.
+        $names = $mailTemplate->getName();
+        if (!isset($names[self::DEFAULT_LOCALE])) {
+            $names[self::DEFAULT_LOCALE] = $this->firstValue($names);
+        }
+
+        foreach ($names as $locale => $name) {
+            if ($name === null || !isset($localeToLanguage[$locale])) {
+                continue;
+            }
+
+            $languageId = $localeToLanguage[$locale];
+
+            $exists = $this->connection->fetchOne(
+                'SELECT 1 FROM mail_template_type_translation WHERE mail_template_type_id = :typeId AND language_id = :languageId',
+                ['typeId' => $typeId, 'languageId' => $languageId]
+            );
+
+            if ($exists !== false) {
+                $this->connection->update(
+                    'mail_template_type_translation',
+                    ['name' => $name, 'updated_at' => $now],
+                    ['mail_template_type_id' => $typeId, 'language_id' => $languageId]
+                );
+            } else {
+                $this->connection->insert('mail_template_type_translation', [
+                    'mail_template_type_id' => $typeId,
+                    'language_id' => $languageId,
+                    'name' => $name,
+                    'created_at' => $now,
+                ]);
+            }
+        }
+
+        return $typeId;
+    }
+
+    /**
+     * @param array<string, string> $localeToLanguage locale code => binary language ID
+     */
+    private function upsertMailTemplate(MailTemplate $mailTemplate, string $typeId, array $localeToLanguage, string $now): void
+    {
+        $existing = $this->connection->fetchAssociative(
+            'SELECT id, was_modified_by_user FROM mail_template WHERE mail_template_type_id = :typeId',
+            ['typeId' => $typeId]
+        );
+
+        if ($existing === false) {
+            $templateId = Uuid::randomBytes();
+
+            $this->connection->insert('mail_template', [
+                'id' => $templateId,
+                'mail_template_type_id' => $typeId,
+                'system_default' => 1,
+                'created_at' => $now,
+            ]);
+        } else {
+            // Don't overwrite a template a merchant has edited; their changes win over the plugin defaults.
+            if ((bool) $existing['was_modified_by_user']) {
+                return;
+            }
+
+            $templateId = $existing['id'];
+
+            $this->connection->update(
+                'mail_template',
+                ['updated_at' => $now],
+                ['id' => $templateId]
+            );
+        }
+
+        // Collect all locales across all translatable fields and content.
+        // Always include the system default locale so every template has a translation
+        // in the default language, even when the plugin only ships other locales.
+        $allLocales = array_unique(array_merge(
+            [self::DEFAULT_LOCALE],
+            array_keys($mailTemplate->getSubject()),
+            array_keys($mailTemplate->getSenderName()),
+            array_keys($mailTemplate->getDescription()),
+            array_keys($mailTemplate->getContentHtml()),
+            array_keys($mailTemplate->getContentPlain()),
+        ));
+
+        foreach ($allLocales as $locale) {
+            if (!isset($localeToLanguage[$locale])) {
+                continue;
+            }
+
+            $languageId = $localeToLanguage[$locale];
+
+            // The default locale falls back to any provided value so its row is never empty.
+            $isDefaultLocale = $locale === self::DEFAULT_LOCALE;
+
+            $translationData = array_filter([
+                'subject' => $mailTemplate->getSubject()[$locale]
+                    ?? ($isDefaultLocale ? $this->firstValue($mailTemplate->getSubject()) : null),
+                'sender_name' => $mailTemplate->getSenderName()[$locale]
+                    ?? ($isDefaultLocale ? $this->firstValue($mailTemplate->getSenderName()) : null),
+                'description' => $mailTemplate->getDescription()[$locale]
+                    ?? ($isDefaultLocale ? $this->firstValue($mailTemplate->getDescription()) : null),
+                'content_html' => $mailTemplate->getContentHtml()[$locale]
+                    ?? ($isDefaultLocale ? $this->firstValue($mailTemplate->getContentHtml()) : null),
+                'content_plain' => $mailTemplate->getContentPlain()[$locale]
+                    ?? ($isDefaultLocale ? $this->firstValue($mailTemplate->getContentPlain()) : null),
+            ], static fn ($value) => $value !== null);
+
+            if ($translationData === []) {
+                continue;
+            }
+
+            $exists = $this->connection->fetchOne(
+                'SELECT 1 FROM mail_template_translation WHERE mail_template_id = :templateId AND language_id = :languageId',
+                ['templateId' => $templateId, 'languageId' => $languageId]
+            );
+
+            if ($exists !== false) {
+                $translationData['updated_at'] = $now;
+
+                $this->connection->update(
+                    'mail_template_translation',
+                    $translationData,
+                    ['mail_template_id' => $templateId, 'language_id' => $languageId]
+                );
+            } else {
+                $translationData['mail_template_id'] = $templateId;
+                $translationData['language_id'] = $languageId;
+                $translationData['created_at'] = $now;
+
+                $this->connection->insert('mail_template_translation', $translationData);
+            }
+        }
+    }
+
+    /**
+     * Resolves all locale codes used in the mail templates to binary language IDs.
+     *
+     * @return array<string, string> locale code => binary language ID
+     */
+    private function resolveLanguageIds(MailTemplates $mailTemplates): array
+    {
+        // Always resolve the default locale so every template gets a default-language translation.
+        $locales = [self::DEFAULT_LOCALE];
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $locales = array_merge(
+                $locales,
+                array_keys($mailTemplate->getName()),
+                array_keys($mailTemplate->getSubject()),
+                array_keys($mailTemplate->getSenderName()),
+                array_keys($mailTemplate->getDescription()),
+                array_keys($mailTemplate->getContentHtml()),
+                array_keys($mailTemplate->getContentPlain()),
+            );
+        }
+
+        $locales = array_unique($locales);
+
+        /** @var array<string, string> $mapping */
+        $mapping = $this->connection->fetchAllKeyValue(
+            'SELECT locale.code, language.id
+             FROM language
+             INNER JOIN locale ON locale.id = language.locale_id
+             WHERE locale.code IN (:codes)',
+            ['codes' => $locales],
+            ['codes' => ArrayParameterType::STRING]
+        );
+
+        // Fallback: if the default locale is not mapped to a language, use the system default
+        if (!isset($mapping[self::DEFAULT_LOCALE])) {
+            $mapping[self::DEFAULT_LOCALE] = Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM);
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    private function firstValue(array $values): ?string
+    {
+        foreach ($values as $value) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Content/MailTemplate/MailTemplateSetPersister.php
+++ b/src/Core/Content/MailTemplate/MailTemplateSetPersister.php
@@ -1,0 +1,268 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[Package('after-sales')]
+class MailTemplateSetPersister
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function sync(MailTemplates $mailTemplates, Context $context): void
+    {
+        $context->scope(Context::SYSTEM_SCOPE, function () use ($mailTemplates): void {
+            $this->upsertMailTemplates($mailTemplates);
+        });
+    }
+
+    /**
+     * @param list<string> $technicalNames
+     */
+    public function removeByTechnicalNames(array $technicalNames, Context $context): void
+    {
+        if ($technicalNames === []) {
+            return;
+        }
+
+        $context->scope(Context::SYSTEM_SCOPE, function () use ($technicalNames): void {
+            $typeIds = $this->connection->fetchFirstColumn(
+                'SELECT id FROM mail_template_type WHERE technical_name IN (:names)',
+                ['names' => $technicalNames],
+                ['names' => ArrayParameterType::STRING]
+            );
+
+            if ($typeIds === []) {
+                return;
+            }
+
+            // Delete mail templates first (SetNullOnDelete won't cascade)
+            $this->connection->executeStatement(
+                'DELETE FROM mail_template WHERE mail_template_type_id IN (:typeIds)',
+                ['typeIds' => $typeIds],
+                ['typeIds' => ArrayParameterType::STRING]
+            );
+
+            $this->connection->executeStatement(
+                'DELETE FROM mail_template_type WHERE id IN (:typeIds)',
+                ['typeIds' => $typeIds],
+                ['typeIds' => ArrayParameterType::STRING]
+            );
+        });
+    }
+
+    private function upsertMailTemplates(MailTemplates $mailTemplates): void
+    {
+        $localeToLanguage = $this->resolveLanguageIds($mailTemplates);
+        $now = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $typeId = $this->upsertMailTemplateType($mailTemplate, $localeToLanguage, $now);
+            $this->upsertMailTemplate($mailTemplate, $typeId, $localeToLanguage, $now);
+        }
+    }
+
+    /**
+     * @param array<string, string> $localeToLanguage locale code => binary language ID
+     *
+     * @return string binary type ID
+     */
+    private function upsertMailTemplateType(MailTemplate $mailTemplate, array $localeToLanguage, string $now): string
+    {
+        $existingTypeId = $this->connection->fetchOne(
+            'SELECT id FROM mail_template_type WHERE technical_name = :technicalName',
+            ['technicalName' => $mailTemplate->getTechnicalName()]
+        );
+
+        if ($existingTypeId === false) {
+            $typeId = Uuid::randomBytes();
+
+            $this->connection->insert('mail_template_type', [
+                'id' => $typeId,
+                'technical_name' => $mailTemplate->getTechnicalName(),
+                'available_entities' => $mailTemplate->getAvailableEntities() !== []
+                    ? json_encode($mailTemplate->getAvailableEntities(), \JSON_THROW_ON_ERROR)
+                    : null,
+                'created_at' => $now,
+            ]);
+        } else {
+            $typeId = $existingTypeId;
+
+            $update = ['updated_at' => $now];
+            if ($mailTemplate->getAvailableEntities() !== []) {
+                $update['available_entities'] = json_encode($mailTemplate->getAvailableEntities(), \JSON_THROW_ON_ERROR);
+            }
+
+            $this->connection->update('mail_template_type', $update, ['id' => $typeId]);
+        }
+
+        // Upsert type translations (name)
+        foreach ($mailTemplate->getName() as $locale => $name) {
+            if (!isset($localeToLanguage[$locale])) {
+                continue;
+            }
+
+            $languageId = $localeToLanguage[$locale];
+
+            $exists = $this->connection->fetchOne(
+                'SELECT 1 FROM mail_template_type_translation WHERE mail_template_type_id = :typeId AND language_id = :languageId',
+                ['typeId' => $typeId, 'languageId' => $languageId]
+            );
+
+            if ($exists !== false) {
+                $this->connection->update(
+                    'mail_template_type_translation',
+                    ['name' => $name, 'updated_at' => $now],
+                    ['mail_template_type_id' => $typeId, 'language_id' => $languageId]
+                );
+            } else {
+                $this->connection->insert('mail_template_type_translation', [
+                    'mail_template_type_id' => $typeId,
+                    'language_id' => $languageId,
+                    'name' => $name,
+                    'created_at' => $now,
+                ]);
+            }
+        }
+
+        return $typeId;
+    }
+
+    /**
+     * @param array<string, string> $localeToLanguage locale code => binary language ID
+     */
+    private function upsertMailTemplate(MailTemplate $mailTemplate, string $typeId, array $localeToLanguage, string $now): void
+    {
+        $existingTemplateId = $this->connection->fetchOne(
+            'SELECT id FROM mail_template WHERE mail_template_type_id = :typeId',
+            ['typeId' => $typeId]
+        );
+
+        if ($existingTemplateId === false) {
+            $templateId = Uuid::randomBytes();
+
+            $this->connection->insert('mail_template', [
+                'id' => $templateId,
+                'mail_template_type_id' => $typeId,
+                'system_default' => 1,
+                'created_at' => $now,
+            ]);
+        } else {
+            $templateId = $existingTemplateId;
+
+            $this->connection->update(
+                'mail_template',
+                ['updated_at' => $now],
+                ['id' => $templateId]
+            );
+        }
+
+        // Collect all locales across all translatable fields and content
+        $allLocales = array_unique(array_merge(
+            array_keys($mailTemplate->getSubject()),
+            array_keys($mailTemplate->getSenderName()),
+            array_keys($mailTemplate->getDescription()),
+            array_keys($mailTemplate->getContentHtml()),
+            array_keys($mailTemplate->getContentPlain()),
+        ));
+
+        foreach ($allLocales as $locale) {
+            if (!isset($localeToLanguage[$locale])) {
+                continue;
+            }
+
+            $languageId = $localeToLanguage[$locale];
+
+            $translationData = array_filter([
+                'subject' => $mailTemplate->getSubject()[$locale] ?? null,
+                'sender_name' => $mailTemplate->getSenderName()[$locale] ?? null,
+                'description' => $mailTemplate->getDescription()[$locale] ?? null,
+                'content_html' => $mailTemplate->getContentHtml()[$locale] ?? null,
+                'content_plain' => $mailTemplate->getContentPlain()[$locale] ?? null,
+            ], static fn ($value) => $value !== null);
+
+            if ($translationData === []) {
+                continue;
+            }
+
+            $exists = $this->connection->fetchOne(
+                'SELECT 1 FROM mail_template_translation WHERE mail_template_id = :templateId AND language_id = :languageId',
+                ['templateId' => $templateId, 'languageId' => $languageId]
+            );
+
+            if ($exists !== false) {
+                $translationData['updated_at'] = $now;
+
+                $this->connection->update(
+                    'mail_template_translation',
+                    $translationData,
+                    ['mail_template_id' => $templateId, 'language_id' => $languageId]
+                );
+            } else {
+                $translationData['mail_template_id'] = $templateId;
+                $translationData['language_id'] = $languageId;
+                $translationData['created_at'] = $now;
+
+                $this->connection->insert('mail_template_translation', $translationData);
+            }
+        }
+    }
+
+    /**
+     * Resolves all locale codes used in the mail templates to binary language IDs.
+     *
+     * @return array<string, string> locale code => binary language ID
+     */
+    private function resolveLanguageIds(MailTemplates $mailTemplates): array
+    {
+        $locales = [];
+
+        foreach ($mailTemplates->getMailTemplates() as $mailTemplate) {
+            $locales = array_merge(
+                $locales,
+                array_keys($mailTemplate->getName()),
+                array_keys($mailTemplate->getSubject()),
+                array_keys($mailTemplate->getSenderName()),
+                array_keys($mailTemplate->getDescription()),
+                array_keys($mailTemplate->getContentHtml()),
+                array_keys($mailTemplate->getContentPlain()),
+            );
+        }
+
+        $locales = array_unique($locales);
+
+        if ($locales === []) {
+            return [];
+        }
+
+        /** @var array<string, string> $mapping */
+        $mapping = $this->connection->fetchAllKeyValue(
+            'SELECT locale.code, language.id
+             FROM language
+             INNER JOIN locale ON locale.id = language.locale_id
+             WHERE locale.code IN (:codes)',
+            ['codes' => $locales],
+            ['codes' => ArrayParameterType::STRING]
+        );
+
+        // Fallback: if en-GB is not mapped to a language, use the system default
+        if (!isset($mapping['en-GB'])) {
+            $mapping['en-GB'] = Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM);
+        }
+
+        return $mapping;
+    }
+}

--- a/src/Core/Content/MailTemplate/MailTemplateXmlLoader.php
+++ b/src/Core/Content/MailTemplate/MailTemplateXmlLoader.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate;
+
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Config\Util\XmlUtils;
+
+#[Package('after-sales')]
+class MailTemplateXmlLoader
+{
+    private const XSD_FILE = __DIR__ . '/Schema/mail-templates-1.0.xsd';
+
+    public static function load(string $xmlFile): MailTemplates
+    {
+        $doc = XmlUtils::loadFile($xmlFile, self::XSD_FILE);
+
+        $mailTemplates = $doc->getElementsByTagName('mail-templates')->item(0);
+        \assert($mailTemplates instanceof \DOMElement);
+
+        return MailTemplates::fromXml($mailTemplates);
+    }
+}

--- a/src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd
+++ b/src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="mail-templates">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="mail-template" maxOccurs="unbounded" minOccurs="0" type="mail-template"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="uniqueMailTemplateTechnicalName">
+            <xs:selector xpath="mail-template"/>
+            <xs:field xpath="@technical-name"/>
+        </xs:unique>
+    </xs:element>
+    <xs:complexType name="mail-template">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="name" maxOccurs="unbounded" type="translatableString"/>
+            <xs:element name="subject" maxOccurs="unbounded" type="translatableString"/>
+            <xs:element name="sender-name" maxOccurs="unbounded" minOccurs="0" type="translatableString"/>
+            <xs:element name="description" maxOccurs="unbounded" minOccurs="0" type="translatableString"/>
+            <xs:element name="available-entities" minOccurs="0" type="available-entity-list"/>
+        </xs:choice>
+        <xs:attribute type="xs:string" name="technical-name" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="available-entity-list">
+        <xs:sequence>
+            <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="translatableString">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="lang" type="languageCode" default="en-GB"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="languageCode">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-z]{2,3}-[A-Z]{2}"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/src/Core/Content/MailTemplate/Xml/MailTemplate.php
+++ b/src/Core/Content/MailTemplate/Xml/MailTemplate.php
@@ -1,0 +1,180 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Xml;
+
+use Shopware\Core\Framework\App\Manifest\Xml\XmlElement;
+use Shopware\Core\Framework\App\Manifest\XmlParserUtils;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @final
+ */
+#[Package('after-sales')]
+class MailTemplate extends XmlElement
+{
+    protected const REQUIRED_FIELDS = [
+        'technicalName',
+        'name',
+        'subject',
+    ];
+
+    private const TRANSLATABLE_FIELDS = ['name', 'subject', 'sender-name', 'description'];
+
+    protected string $technicalName;
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $name;
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $subject;
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $senderName = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $description = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $availableEntities = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $contentHtml = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected array $contentPlain = [];
+
+    public function getTechnicalName(): string
+    {
+        return $this->technicalName;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getName(): array
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSubject(): array
+    {
+        return $this->subject;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getSenderName(): array
+    {
+        return $this->senderName;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDescription(): array
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAvailableEntities(): array
+    {
+        return $this->availableEntities;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getContentHtml(): array
+    {
+        return $this->contentHtml;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getContentPlain(): array
+    {
+        return $this->contentPlain;
+    }
+
+    /**
+     * @param array<string, string> $contentHtml
+     */
+    public function setContentHtml(array $contentHtml): void
+    {
+        $this->contentHtml = $contentHtml;
+    }
+
+    /**
+     * @param array<string, string> $contentPlain
+     */
+    public function setContentPlain(array $contentPlain): void
+    {
+        $this->contentPlain = $contentPlain;
+    }
+
+    protected static function parse(\DOMElement $element): array
+    {
+        $values = XmlParserUtils::parseAttributes($element);
+
+        foreach ($element->childNodes as $child) {
+            if (!$child instanceof \DOMElement) {
+                continue;
+            }
+
+            $values = self::parseChild($child, $values);
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function parseChild(\DOMElement $child, array $values): array
+    {
+        if (\in_array($child->tagName, self::TRANSLATABLE_FIELDS, true)) {
+            return XmlParserUtils::mapTranslatedTag($child, $values);
+        }
+
+        if ($child->tagName === 'available-entities') {
+            $entities = [];
+            foreach ($child->childNodes as $entity) {
+                if (!$entity instanceof \DOMElement) {
+                    continue;
+                }
+                $entities[$entity->tagName] = trim($entity->nodeValue ?? '');
+            }
+            $values['availableEntities'] = $entities;
+
+            return $values;
+        }
+
+        $values[XmlParserUtils::kebabCaseToCamelCase($child->tagName)] = $child->nodeValue;
+
+        return $values;
+    }
+}

--- a/src/Core/Content/MailTemplate/Xml/MailTemplates.php
+++ b/src/Core/Content/MailTemplate/Xml/MailTemplates.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\MailTemplate\Xml;
+
+use Shopware\Core\Framework\App\Manifest\Xml\XmlElement;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @final
+ */
+#[Package('after-sales')]
+class MailTemplates extends XmlElement
+{
+    /**
+     * @var list<MailTemplate>
+     */
+    protected array $mailTemplates = [];
+
+    /**
+     * @return list<MailTemplate>
+     */
+    public function getMailTemplates(): array
+    {
+        return $this->mailTemplates;
+    }
+
+    protected static function parse(\DOMElement $element): array
+    {
+        $mailTemplates = [];
+        foreach ($element->getElementsByTagName('mail-template') as $mailTemplate) {
+            $mailTemplates[] = MailTemplate::fromXml($mailTemplate);
+        }
+
+        return ['mailTemplates' => $mailTemplates];
+    }
+}

--- a/src/Core/Framework/App/Lifecycle/Persister/MailTemplatePersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/MailTemplatePersister.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle\Persister;
+
+use Shopware\Core\Content\MailTemplate\MailTemplateLoader;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Framework\App\Lifecycle\AppLifecycleContext;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('after-sales')]
+class MailTemplatePersister implements PersisterInterface
+{
+    public function __construct(
+        private readonly MailTemplateSetPersister $mailTemplateSetPersister,
+    ) {
+    }
+
+    public function persist(AppLifecycleContext $context): void
+    {
+        if (!$context->appFilesystem->has('Resources', 'mail-templates', 'mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateLoader::loadFromFilesystem(
+            $context->appFilesystem,
+        );
+
+        $this->mailTemplateSetPersister->sync(
+            $mailTemplates,
+            $context->context
+        );
+    }
+}

--- a/src/Core/Framework/App/Lifecycle/Persister/MailTemplatePersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/MailTemplatePersister.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle\Persister;
+
+use Shopware\Core\Content\MailTemplate\MailTemplateLoader;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\AppLifecycleContext;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal only for use by the app-system
+ */
+#[Package('after-sales')]
+class MailTemplatePersister implements PersisterInterface
+{
+    public function __construct(
+        private readonly MailTemplateSetPersister $mailTemplateSetPersister,
+    ) {
+    }
+
+    public function persist(AppLifecycleContext $context): void
+    {
+        if (!$context->appFilesystem->has('Resources', 'mail-templates', 'mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateLoader::loadFromFilesystem(
+            $context->appFilesystem,
+        );
+
+        $this->mailTemplateSetPersister->sync(
+            $mailTemplates,
+            $context->context
+        );
+    }
+
+    public function activate(AppEntity $app, Context $context): void
+    {
+    }
+
+    public function deactivate(AppEntity $app, Context $context): void
+    {
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -167,6 +167,11 @@
             <tag name="shopware.app_lifecycle.persister" priority="-1100"/>
         </service>
 
+        <service id="Shopware\Core\Framework\App\Lifecycle\Persister\MailTemplatePersister">
+            <argument type="service" id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister"/>
+            <tag name="shopware.app_lifecycle.persister" priority="-1150"/>
+        </service>
+
         <service id="Shopware\Core\Framework\App\Lifecycle\Persister\CmsBlockPersister">
             <argument type="service" id="app_cms_block.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\Cms\BlockTemplateLoader"/>

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -148,6 +148,11 @@
             <tag name="shopware.app_lifecycle.persister" priority="-1100"/>
         </service>
 
+        <service id="Shopware\Core\Framework\App\Lifecycle\Persister\MailTemplatePersister">
+            <argument type="service" id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister"/>
+            <tag name="shopware.app_lifecycle.persister" priority="-1150"/>
+        </service>
+
         <service id="Shopware\Core\Framework\App\Lifecycle\Persister\CmsBlockPersister">
             <argument type="service" id="app_cms_block.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\Cms\BlockTemplateLoader"/>

--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -73,6 +73,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
             <argument type="service" id="Psr\Clock\ClockInterface"/>
+            <argument type="service" id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister"/>
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\PluginManagementService">
@@ -280,6 +281,10 @@
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\CustomFieldsetGenerator">
+            <tag name="shopware.scaffold.generator"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\MailTemplateGenerator">
             <tag name="shopware.scaffold.generator"/>
         </service>
 

--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -72,6 +72,7 @@
             <argument type="service" id="Shopware\Core\Framework\Plugin\Util\VersionSanitizer"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
+            <argument type="service" id="Shopware\Core\Content\MailTemplate\MailTemplateSetPersister"/>
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\PluginManagementService">
@@ -276,6 +277,10 @@
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\CustomFieldsetGenerator">
+            <tag name="shopware.scaffold.generator"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\MailTemplateGenerator">
             <tag name="shopware.scaffold.generator"/>
         </service>
 

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/MailTemplateGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/MailTemplateGenerator.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\Stub;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class MailTemplateGenerator implements ScaffoldingGenerator
+{
+    use AddScaffoldConfigDefaultBehaviour;
+    use HasCommandOption;
+
+    public const OPTION_NAME = 'create-mail-template';
+    private const OPTION_DESCRIPTION = 'Create an example mail template';
+    private const CLI_QUESTION = 'Do you want to create an example mail template?';
+
+    public function generateStubs(
+        PluginScaffoldConfiguration $configuration,
+        StubCollection $stubCollection
+    ): void {
+        if (!$configuration->hasOption(self::OPTION_NAME) || !$configuration->getOption(self::OPTION_NAME)) {
+            return;
+        }
+
+        $stubCollection->add(Stub::template(
+            'src/Resources/mail-templates/mail-templates.xml',
+            self::STUB_DIRECTORY . '/mail-templates-xml.stub'
+        ));
+
+        $stubCollection->add(Stub::template(
+            'src/Resources/mail-templates/example_notification/en-GB/html.twig',
+            self::STUB_DIRECTORY . '/mail-template-html.stub'
+        ));
+
+        $stubCollection->add(Stub::template(
+            'src/Resources/mail-templates/example_notification/en-GB/plain.twig',
+            self::STUB_DIRECTORY . '/mail-template-plain.stub'
+        ));
+    }
+}

--- a/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-template-html.stub
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-template-html.stub
@@ -1,0 +1,5 @@
+<div style="font-family: Arial, sans-serif;">
+    <h1>Example notification</h1>
+    <p>This is an example HTML mail template.</p>
+    <p>Sales Channel: {{ salesChannel.name }}</p>
+</div>

--- a/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-template-plain.stub
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-template-plain.stub
@@ -1,0 +1,5 @@
+Example notification
+
+This is an example plain text mail template.
+
+Sales Channel: {{ salesChannel.name }}

--- a/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-templates-xml.stub
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/stubs/mail-templates-xml.stub
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mail-templates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd">
+    <mail-template technical-name="example_notification">
+        <name>Example notification</name>
+        <subject>Example notification from {{ salesChannel.name }}</subject>
+        <sender-name>{{ salesChannel.name }}</sender-name>
+        <description>An example mail template for demonstration purposes</description>
+        <available-entities>
+            <salesChannel>salesChannel</salesChannel>
+        </available-entities>
+    </mail-template>
+</mail-templates>

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -7,6 +7,10 @@ use Composer\IO\NullIO;
 use Composer\Semver\Comparator;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Clock\ClockInterface;
+use Shopware\Core\Content\MailTemplate\MailTemplateLoader;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate as MailTemplateXml;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
@@ -100,6 +104,7 @@ class PluginLifecycleService
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly RequestStack $requestStack,
         private readonly ClockInterface $clock,
+        private readonly MailTemplateSetPersister $mailTemplateSetPersister,
     ) {
         $this->originalEventDispatcher = $eventDispatcher;
     }
@@ -163,6 +168,8 @@ class PluginLifecycleService
             $this->updatePluginData($pluginData, $shopwareContext);
 
             $pluginBaseClass->postInstall($installContext);
+
+            $this->syncPluginMailTemplates($pluginBaseClass, $shopwareContext);
 
             $this->eventDispatcher->dispatch(new PluginPostInstallEvent($plugin, $installContext));
         } catch (\Throwable $e) {
@@ -243,6 +250,7 @@ class PluginLifecycleService
 
         if (!$uninstallContext->keepUserData()) {
             $this->removeCustomEntities($plugin->getId());
+            $this->removePluginMailTemplates($pluginBaseClass, $shopwareContext);
         }
 
         if ($pluginBaseClass->executeComposerCommands()) {
@@ -329,6 +337,8 @@ class PluginLifecycleService
         $plugin->setVersion($updateVersion);
         $plugin->setUpgradeVersion(null);
         $plugin->setUpgradedAt($updateDate);
+
+        $this->syncPluginMailTemplates($pluginBaseClass, $shopwareContext);
 
         $pluginBaseClass->postUpdate($updateContext);
 
@@ -766,5 +776,35 @@ class PluginLifecycleService
                 self::$registeredListener = true;
             }
         }
+    }
+
+    private function syncPluginMailTemplates(Plugin $pluginBaseClass, Context $context): void
+    {
+        $basePath = $pluginBaseClass->getPath() . '/Resources/mail-templates';
+
+        if (!is_file($basePath . '/mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateLoader::load($basePath);
+
+        $this->mailTemplateSetPersister->sync($mailTemplates, $context);
+    }
+
+    private function removePluginMailTemplates(Plugin $pluginBaseClass, Context $context): void
+    {
+        $basePath = $pluginBaseClass->getPath() . '/Resources/mail-templates';
+
+        if (!is_file($basePath . '/mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateXmlLoader::load($basePath . '/mail-templates.xml');
+        $technicalNames = array_map(
+            static fn (MailTemplateXml $t) => $t->getTechnicalName(),
+            $mailTemplates->getMailTemplates()
+        );
+
+        $this->mailTemplateSetPersister->removeByTechnicalNames($technicalNames, $context);
     }
 }

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -6,6 +6,10 @@ use Composer\InstalledVersions;
 use Composer\IO\NullIO;
 use Composer\Semver\Comparator;
 use Psr\Cache\CacheItemPoolInterface;
+use Shopware\Core\Content\MailTemplate\MailTemplateLoader;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate as MailTemplateXml;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
@@ -98,6 +102,7 @@ class PluginLifecycleService
         private readonly VersionSanitizer $versionSanitizer,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
         private readonly RequestStack $requestStack,
+        private readonly MailTemplateSetPersister $mailTemplateSetPersister,
     ) {
         $this->originalEventDispatcher = $eventDispatcher;
     }
@@ -161,6 +166,8 @@ class PluginLifecycleService
             $this->updatePluginData($pluginData, $shopwareContext);
 
             $pluginBaseClass->postInstall($installContext);
+
+            $this->syncPluginMailTemplates($pluginBaseClass, $shopwareContext);
 
             $this->eventDispatcher->dispatch(new PluginPostInstallEvent($plugin, $installContext));
         } catch (\Throwable $e) {
@@ -241,6 +248,7 @@ class PluginLifecycleService
 
         if (!$uninstallContext->keepUserData()) {
             $this->removeCustomEntities($plugin->getId());
+            $this->removePluginMailTemplates($pluginBaseClass, $shopwareContext);
         }
 
         if ($pluginBaseClass->executeComposerCommands()) {
@@ -327,6 +335,8 @@ class PluginLifecycleService
         $plugin->setVersion($updateVersion);
         $plugin->setUpgradeVersion(null);
         $plugin->setUpgradedAt($updateDate);
+
+        $this->syncPluginMailTemplates($pluginBaseClass, $shopwareContext);
 
         $pluginBaseClass->postUpdate($updateContext);
 
@@ -763,5 +773,35 @@ class PluginLifecycleService
                 self::$registeredListener = true;
             }
         }
+    }
+
+    private function syncPluginMailTemplates(Plugin $pluginBaseClass, Context $context): void
+    {
+        $basePath = $pluginBaseClass->getPath() . '/Resources/mail-templates';
+
+        if (!is_file($basePath . '/mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateLoader::load($basePath);
+
+        $this->mailTemplateSetPersister->sync($mailTemplates, $context);
+    }
+
+    private function removePluginMailTemplates(Plugin $pluginBaseClass, Context $context): void
+    {
+        $basePath = $pluginBaseClass->getPath() . '/Resources/mail-templates';
+
+        if (!is_file($basePath . '/mail-templates.xml')) {
+            return;
+        }
+
+        $mailTemplates = MailTemplateXmlLoader::load($basePath . '/mail-templates.xml');
+        $technicalNames = array_map(
+            static fn (MailTemplateXml $t) => $t->getTechnicalName(),
+            $mailTemplates->getMailTemplates()
+        );
+
+        $this->mailTemplateSetPersister->removeByTechnicalNames($technicalNames, $context);
     }
 }

--- a/tests/integration/Core/Content/MailTemplate/MailTemplateSetPersisterTest.php
+++ b/tests/integration/Core/Content/MailTemplate/MailTemplateSetPersisterTest.php
@@ -1,0 +1,202 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\MailTemplate;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateTranslation\MailTemplateTranslationCollection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeCollection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeEntity;
+use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
+use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class MailTemplateSetPersisterTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const TECHNICAL_NAME = 'test_declarative_template';
+
+    private MailTemplateSetPersister $persister;
+
+    /**
+     * @var EntityRepository<MailTemplateTypeCollection>
+     */
+    private EntityRepository $typeRepository;
+
+    /**
+     * @var EntityRepository<MailTemplateCollection>
+     */
+    private EntityRepository $templateRepository;
+
+    private Context $context;
+
+    protected function setUp(): void
+    {
+        $this->persister = static::getContainer()->get(MailTemplateSetPersister::class);
+        $this->typeRepository = static::getContainer()->get('mail_template_type.repository');
+        $this->templateRepository = static::getContainer()->get('mail_template.repository');
+        $this->context = Context::createDefaultContext();
+    }
+
+    public function testSyncCreatesTypeTemplateAndTranslations(): void
+    {
+        $this->persister->sync($this->mailTemplates(), $this->context);
+
+        $type = $this->loadType();
+        static::assertSame(['order' => 'order'], $type->getAvailableEntities());
+        static::assertSame('Order confirmation', $type->getTranslation('name'));
+
+        $template = $this->loadTemplate();
+        static::assertTrue($template->getSystemDefault());
+        static::assertFalse($template->wasModifiedByUser());
+        static::assertSame('Your order', $template->getTranslation('subject'));
+        static::assertSame('<p>Thank you</p>', $template->getTranslation('contentHtml'));
+        static::assertSame('Thank you', $template->getTranslation('contentPlain'));
+        static::assertSame('Shop', $template->getTranslation('senderName'));
+    }
+
+    public function testSyncIsIdempotentAndUpdatesContent(): void
+    {
+        $this->persister->sync($this->mailTemplates(), $this->context);
+        $templateId = $this->loadTemplate()->getId();
+
+        $changed = $this->mailTemplates(subjectEn: 'Updated subject', contentHtmlEn: '<p>Updated</p>');
+        $this->persister->sync($changed, $this->context);
+
+        $template = $this->loadTemplate();
+        // same row is reused, content is refreshed
+        static::assertSame($templateId, $template->getId());
+        static::assertSame('Updated subject', $template->getTranslation('subject'));
+        static::assertSame('<p>Updated</p>', $template->getTranslation('contentHtml'));
+    }
+
+    public function testSyncDoesNotOverwriteMerchantEditedTemplate(): void
+    {
+        $this->persister->sync($this->mailTemplates(), $this->context);
+        $templateId = $this->loadTemplate()->getId();
+
+        // simulate a merchant editing the template in the Administration (user scope flips was_modified_by_user)
+        $this->context->scope(Context::USER_SCOPE, function (Context $userContext) use ($templateId): void {
+            $this->templateRepository->update([[
+                'id' => $templateId,
+                'subject' => 'Merchant subject',
+                'contentHtml' => '<p>Merchant content</p>',
+            ]], $userContext);
+        });
+
+        static::assertTrue($this->loadTemplate()->wasModifiedByUser());
+
+        // a plugin update tries to push new defaults
+        $this->persister->sync(
+            $this->mailTemplates(subjectEn: 'Plugin subject', contentHtmlEn: '<p>Plugin content</p>'),
+            $this->context
+        );
+
+        $template = $this->loadTemplate();
+        static::assertSame('Merchant subject', $template->getTranslation('subject'));
+        static::assertSame('<p>Merchant content</p>', $template->getTranslation('contentHtml'));
+    }
+
+    public function testSyncWritesDefaultLanguageTranslationWhenOnlyOtherLocaleIsShipped(): void
+    {
+        // a plugin that ships only de-DE content
+        $mailTemplate = MailTemplate::fromArray([
+            'technicalName' => self::TECHNICAL_NAME,
+            'name' => ['de-DE' => 'Benachrichtigung'],
+            'subject' => ['de-DE' => 'Betreff'],
+            'senderName' => ['de-DE' => 'Shop'],
+            'description' => ['de-DE' => 'Beschreibung'],
+            'contentHtml' => ['de-DE' => '<p>Hallo</p>'],
+            'contentPlain' => ['de-DE' => 'Hallo'],
+            'availableEntities' => [],
+        ]);
+
+        $this->persister->sync(MailTemplates::fromArray(['mailTemplates' => [$mailTemplate]]), $this->context);
+
+        $template = $this->loadTemplate();
+
+        $translations = $template->getTranslations();
+        static::assertInstanceOf(MailTemplateTranslationCollection::class, $translations);
+        // a system-default-language (en-GB) translation must exist alongside the shipped de-DE one
+        static::assertCount(2, $translations);
+
+        // the default-language translation falls back to the only provided locale's content
+        static::assertSame('Betreff', $template->getTranslation('subject'));
+        static::assertSame('<p>Hallo</p>', $template->getTranslation('contentHtml'));
+
+        // the type name is also present in the default language
+        static::assertSame('Benachrichtigung', $this->loadType()->getTranslation('name'));
+    }
+
+    public function testRemoveByTechnicalNamesDeletesTypeAndTemplate(): void
+    {
+        $this->persister->sync($this->mailTemplates(), $this->context);
+        static::assertNotNull($this->findType());
+
+        $this->persister->removeByTechnicalNames([self::TECHNICAL_NAME], $this->context);
+
+        static::assertNull($this->findType());
+        static::assertNull($this->findTemplate());
+    }
+
+    private function mailTemplates(string $subjectEn = 'Your order', string $contentHtmlEn = '<p>Thank you</p>'): MailTemplates
+    {
+        $mailTemplate = MailTemplate::fromArray([
+            'technicalName' => self::TECHNICAL_NAME,
+            'name' => ['en-GB' => 'Order confirmation', 'de-DE' => 'Bestellbestätigung'],
+            'subject' => ['en-GB' => $subjectEn, 'de-DE' => 'Deine Bestellung'],
+            'senderName' => ['en-GB' => 'Shop'],
+            'description' => ['en-GB' => 'Sent after order placement'],
+            'contentHtml' => ['en-GB' => $contentHtmlEn],
+            'contentPlain' => ['en-GB' => 'Thank you'],
+            'availableEntities' => ['order' => 'order'],
+        ]);
+
+        return MailTemplates::fromArray(['mailTemplates' => [$mailTemplate]]);
+    }
+
+    private function loadType(): MailTemplateTypeEntity
+    {
+        $type = $this->findType();
+        static::assertInstanceOf(MailTemplateTypeEntity::class, $type);
+
+        return $type;
+    }
+
+    private function findType(): ?MailTemplateTypeEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('technicalName', self::TECHNICAL_NAME));
+
+        return $this->typeRepository->search($criteria, $this->context)->getEntities()->first();
+    }
+
+    private function loadTemplate(): MailTemplateEntity
+    {
+        $template = $this->findTemplate();
+        static::assertInstanceOf(MailTemplateEntity::class, $template);
+
+        return $template;
+    }
+
+    private function findTemplate(): ?MailTemplateEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('mailTemplateType.technicalName', self::TECHNICAL_NAME));
+        $criteria->addAssociation('translations');
+
+        return $this->templateRepository->search($criteria, $this->context)->getEntities()->first();
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/MailTemplateLoaderTest.php
+++ b/tests/unit/Core/Content/MailTemplate/MailTemplateLoaderTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\MailTemplate;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateLoader;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplateLoader::class)]
+class MailTemplateLoaderTest extends TestCase
+{
+    public function testLoadCombinesXmlWithTwigContent(): void
+    {
+        $mailTemplates = MailTemplateLoader::load(__DIR__ . '/_fixtures');
+
+        static::assertCount(1, $mailTemplates->getMailTemplates());
+
+        $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+        static::assertSame('order_confirmation', $mailTemplate->getTechnicalName());
+
+        // Content should be loaded from twig files
+        $contentHtml = $mailTemplate->getContentHtml();
+        static::assertArrayHasKey('en-GB', $contentHtml);
+        static::assertArrayHasKey('de-DE', $contentHtml);
+        static::assertStringContainsString('Order confirmation', $contentHtml['en-GB']);
+        static::assertStringContainsString('Bestellbestätigung', $contentHtml['de-DE']);
+
+        $contentPlain = $mailTemplate->getContentPlain();
+        static::assertArrayHasKey('en-GB', $contentPlain);
+        static::assertArrayHasKey('de-DE', $contentPlain);
+        static::assertStringContainsString('Thank you for your order', $contentPlain['en-GB']);
+        static::assertStringContainsString('Vielen Dank', $contentPlain['de-DE']);
+    }
+
+    public function testLoadWithMissingTemplateDirSkipsContent(): void
+    {
+        $filesystem = new Filesystem();
+        $tempDir = sys_get_temp_dir() . '/shopware_mail_template_test_' . bin2hex(random_bytes(8));
+        $filesystem->mkdir($tempDir);
+
+        try {
+            $filesystem->copy(
+                __DIR__ . '/_fixtures/mail-templates.xml',
+                $tempDir . '/mail-templates.xml'
+            );
+
+            // No template directory exists — content should be empty
+            $mailTemplates = MailTemplateLoader::load($tempDir);
+            $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+            static::assertSame([], $mailTemplate->getContentHtml());
+            static::assertSame([], $mailTemplate->getContentPlain());
+        } finally {
+            $filesystem->remove($tempDir);
+        }
+    }
+
+    public function testLoadWithPartialLocalesOnlyLoadsExisting(): void
+    {
+        $filesystem = new Filesystem();
+        $tempDir = sys_get_temp_dir() . '/shopware_mail_template_test_' . bin2hex(random_bytes(8));
+        $filesystem->mkdir($tempDir . '/order_confirmation/en-GB', 0777);
+
+        try {
+            $filesystem->copy(
+                __DIR__ . '/_fixtures/mail-templates.xml',
+                $tempDir . '/mail-templates.xml'
+            );
+
+            // Only en-GB with html.twig
+            $filesystem->dumpFile(
+                $tempDir . '/order_confirmation/en-GB/html.twig',
+                '<p>Test</p>'
+            );
+
+            $mailTemplates = MailTemplateLoader::load($tempDir);
+            $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+            static::assertSame(['en-GB' => '<p>Test</p>'], $mailTemplate->getContentHtml());
+            static::assertSame([], $mailTemplate->getContentPlain());
+        } finally {
+            $filesystem->remove($tempDir);
+        }
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/MailTemplateXmlLoaderTest.php
+++ b/tests/unit/Core/Content/MailTemplate/MailTemplateXmlLoaderTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\MailTemplate;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplateXmlLoader::class)]
+class MailTemplateXmlLoaderTest extends TestCase
+{
+    public function testLoadValidXml(): void
+    {
+        $mailTemplates = MailTemplateXmlLoader::load(__DIR__ . '/_fixtures/mail-templates.xml');
+
+        static::assertCount(1, $mailTemplates->getMailTemplates());
+
+        $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+        static::assertSame('order_confirmation', $mailTemplate->getTechnicalName());
+        static::assertSame([
+            'en-GB' => 'Order confirmation',
+            'de-DE' => 'Bestellbestätigung',
+        ], $mailTemplate->getName());
+        static::assertSame([
+            'en-GB' => 'Your order {{ order.orderNumber }}',
+            'de-DE' => 'Ihre Bestellung {{ order.orderNumber }}',
+        ], $mailTemplate->getSubject());
+        static::assertSame([
+            'en-GB' => '{{ salesChannel.name }}',
+            'de-DE' => '{{ salesChannel.name }}',
+        ], $mailTemplate->getSenderName());
+        static::assertSame([
+            'en-GB' => 'Sent after order placement',
+            'de-DE' => 'Wird nach Bestellaufgabe versendet',
+        ], $mailTemplate->getDescription());
+        static::assertSame([
+            'order' => 'order',
+            'salesChannel' => 'salesChannel',
+        ], $mailTemplate->getAvailableEntities());
+    }
+
+    public function testLoadInvalidXmlThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        MailTemplateXmlLoader::load(__DIR__ . '/_fixtures/order_confirmation/en-GB/html.twig');
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/Xml/MailTemplateTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Xml/MailTemplateTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\MailTemplate\Xml;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplate;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplate::class)]
+class MailTemplateTest extends TestCase
+{
+    public function testParsing(): void
+    {
+        $mailTemplates = MailTemplateXmlLoader::load(__DIR__ . '/../_fixtures/mail-templates.xml');
+        $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+        static::assertSame('order_confirmation', $mailTemplate->getTechnicalName());
+        static::assertSame('Order confirmation', $mailTemplate->getName()['en-GB']);
+        static::assertSame('Bestellbestätigung', $mailTemplate->getName()['de-DE']);
+        static::assertSame('Your order {{ order.orderNumber }}', $mailTemplate->getSubject()['en-GB']);
+        static::assertSame('{{ salesChannel.name }}', $mailTemplate->getSenderName()['en-GB']);
+        static::assertSame('Sent after order placement', $mailTemplate->getDescription()['en-GB']);
+        static::assertSame(['order' => 'order', 'salesChannel' => 'salesChannel'], $mailTemplate->getAvailableEntities());
+    }
+
+    public function testContentSetters(): void
+    {
+        $mailTemplates = MailTemplateXmlLoader::load(__DIR__ . '/../_fixtures/mail-templates.xml');
+        $mailTemplate = $mailTemplates->getMailTemplates()[0];
+
+        static::assertSame([], $mailTemplate->getContentHtml());
+        static::assertSame([], $mailTemplate->getContentPlain());
+
+        $mailTemplate->setContentHtml(['en-GB' => '<p>Hello</p>']);
+        $mailTemplate->setContentPlain(['en-GB' => 'Hello']);
+
+        static::assertSame(['en-GB' => '<p>Hello</p>'], $mailTemplate->getContentHtml());
+        static::assertSame(['en-GB' => 'Hello'], $mailTemplate->getContentPlain());
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/Xml/MailTemplatesTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Xml/MailTemplatesTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\MailTemplate\Xml;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateXmlLoader;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplates::class)]
+class MailTemplatesTest extends TestCase
+{
+    public function testFromXml(): void
+    {
+        $mailTemplates = MailTemplateXmlLoader::load(__DIR__ . '/../_fixtures/mail-templates.xml');
+
+        static::assertCount(1, $mailTemplates->getMailTemplates());
+    }
+
+    public function testFromArrayEmpty(): void
+    {
+        $mailTemplates = MailTemplates::fromArray([]);
+
+        static::assertSame([], $mailTemplates->getMailTemplates());
+    }
+}

--- a/tests/unit/Core/Content/MailTemplate/_fixtures/mail-templates.xml
+++ b/tests/unit/Core/Content/MailTemplate/_fixtures/mail-templates.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mail-templates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="../../../../../../src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd">
+    <mail-template technical-name="order_confirmation">
+        <name>Order confirmation</name>
+        <name lang="de-DE">Bestellbestätigung</name>
+        <subject>Your order {{ order.orderNumber }}</subject>
+        <subject lang="de-DE">Ihre Bestellung {{ order.orderNumber }}</subject>
+        <sender-name>{{ salesChannel.name }}</sender-name>
+        <sender-name lang="de-DE">{{ salesChannel.name }}</sender-name>
+        <description>Sent after order placement</description>
+        <description lang="de-DE">Wird nach Bestellaufgabe versendet</description>
+        <available-entities>
+            <order>order</order>
+            <salesChannel>salesChannel</salesChannel>
+        </available-entities>
+    </mail-template>
+</mail-templates>

--- a/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/de-DE/html.twig
+++ b/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/de-DE/html.twig
@@ -1,0 +1,2 @@
+<h1>Bestellbestätigung</h1>
+<p>Vielen Dank für Ihre Bestellung {{ order.orderNumber }}.</p>

--- a/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/de-DE/plain.twig
+++ b/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/de-DE/plain.twig
@@ -1,0 +1,3 @@
+Bestellbestätigung
+
+Vielen Dank für Ihre Bestellung {{ order.orderNumber }}.

--- a/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/en-GB/html.twig
+++ b/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/en-GB/html.twig
@@ -1,0 +1,2 @@
+<h1>Order confirmation</h1>
+<p>Thank you for your order {{ order.orderNumber }}.</p>

--- a/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/en-GB/plain.twig
+++ b/tests/unit/Core/Content/MailTemplate/_fixtures/order_confirmation/en-GB/plain.twig
@@ -1,0 +1,3 @@
+Order confirmation
+
+Thank you for your order {{ order.orderNumber }}.

--- a/tests/unit/Core/Framework/App/Lifecycle/Persister/MailTemplatePersisterTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/Persister/MailTemplatePersisterTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle\Persister;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateSetPersister;
+use Shopware\Core\Content\MailTemplate\Xml\MailTemplates;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\AppLifecycleContext;
+use Shopware\Core\Framework\App\Lifecycle\Persister\MailTemplatePersister;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Util\Filesystem;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplatePersister::class)]
+class MailTemplatePersisterTest extends TestCase
+{
+    public function testPersistWithMailTemplatesXml(): void
+    {
+        $sfFilesystem = new SymfonyFilesystem();
+        $tempDir = sys_get_temp_dir() . '/shopware_mail_persister_test_' . bin2hex(random_bytes(8));
+        $sfFilesystem->mkdir($tempDir . '/Resources/mail-templates/test_mail/en-GB', 0777);
+
+        try {
+            $sfFilesystem->dumpFile($tempDir . '/Resources/mail-templates/mail-templates.xml', '<?xml version="1.0" encoding="utf-8"?>
+<mail-templates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd">
+    <mail-template technical-name="test_mail">
+        <name>Test mail</name>
+        <subject>Test subject</subject>
+    </mail-template>
+</mail-templates>');
+
+            $sfFilesystem->dumpFile($tempDir . '/Resources/mail-templates/test_mail/en-GB/html.twig', '<p>Test</p>');
+            $sfFilesystem->dumpFile($tempDir . '/Resources/mail-templates/test_mail/en-GB/plain.twig', 'Test');
+
+            $persister = $this->createMock(MailTemplateSetPersister::class);
+            $persister->expects($this->once())
+                ->method('sync')
+                ->with(
+                    static::callback(function (MailTemplates $mailTemplates): bool {
+                        $templates = $mailTemplates->getMailTemplates();
+                        if (\count($templates) !== 1) {
+                            return false;
+                        }
+
+                        $template = $templates[0];
+
+                        return $template->getTechnicalName() === 'test_mail'
+                            && $template->getContentHtml() === ['en-GB' => '<p>Test</p>']
+                            && $template->getContentPlain() === ['en-GB' => 'Test'];
+                    }),
+                    static::isInstanceOf(Context::class)
+                );
+
+            $mailTemplatePersister = new MailTemplatePersister($persister);
+
+            $app = new AppEntity();
+            $app->setId('test-app-id');
+
+            $context = new AppLifecycleContext(
+                Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/manifest.xml'),
+                $app,
+                Context::createDefaultContext(),
+                new Filesystem($tempDir),
+                'en-GB',
+                true,
+            );
+
+            $mailTemplatePersister->persist($context);
+        } finally {
+            $sfFilesystem->remove($tempDir);
+        }
+    }
+
+    public function testPersistWithNoMailTemplatesDoesNothing(): void
+    {
+        $sfFilesystem = new SymfonyFilesystem();
+        $tempDir = sys_get_temp_dir() . '/shopware_mail_persister_test_' . bin2hex(random_bytes(8));
+        $sfFilesystem->mkdir($tempDir);
+
+        try {
+            $persister = $this->createMock(MailTemplateSetPersister::class);
+            $persister->expects($this->never())->method('sync');
+
+            $mailTemplatePersister = new MailTemplatePersister($persister);
+
+            $app = new AppEntity();
+            $app->setId('test-app-id');
+
+            $context = new AppLifecycleContext(
+                Manifest::createFromXmlFile(__DIR__ . '/../../_fixtures/manifest.xml'),
+                $app,
+                Context::createDefaultContext(),
+                new Filesystem($tempDir),
+                'en-GB',
+                true,
+            );
+
+            $mailTemplatePersister->persist($context);
+        } finally {
+            $sfFilesystem->remove($tempDir);
+        }
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/MailTemplateGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/MailTemplateGeneratorTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin\Command\Scaffolding\Generator;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\MailTemplateGenerator;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @internal
+ */
+#[CoversClass(MailTemplateGenerator::class)]
+class MailTemplateGeneratorTest extends TestCase
+{
+    public function testCommandOptions(): void
+    {
+        $generator = new MailTemplateGenerator();
+
+        static::assertTrue($generator->hasCommandOption());
+        static::assertSame(MailTemplateGenerator::OPTION_NAME, $generator->getCommandOptionName());
+        static::assertNotEmpty($generator->getCommandOptionDescription());
+    }
+
+    #[DataProvider('addScaffoldConfigProvider')]
+    public function testAddScaffoldConfig(
+        bool $getOptionResponse,
+        bool $confirmResponse,
+        bool $expectedHasOption
+    ): void {
+        $configuration = self::getConfig();
+
+        $input = $this->createMock(InputInterface::class);
+        $input->method('getOption')->willReturn($getOptionResponse);
+
+        $io = $this->createMock(SymfonyStyle::class);
+        $io->method('confirm')->willReturn($confirmResponse);
+
+        (new MailTemplateGenerator())
+            ->addScaffoldConfig($configuration, $input, $io);
+
+        static::assertSame($expectedHasOption, $configuration->hasOption(MailTemplateGenerator::OPTION_NAME));
+    }
+
+    public static function addScaffoldConfigProvider(): \Generator
+    {
+        yield 'with command option and with confirm' => [
+            'getOptionResponse' => true,
+            'confirmResponse' => true,
+            'expectedHasOption' => true,
+        ];
+
+        yield 'with command option and without confirm' => [
+            'getOptionResponse' => true,
+            'confirmResponse' => false,
+            'expectedHasOption' => true,
+        ];
+
+        yield 'without command option and with confirm' => [
+            'getOptionResponse' => false,
+            'confirmResponse' => true,
+            'expectedHasOption' => true,
+        ];
+
+        yield 'without command option and without confirm' => [
+            'getOptionResponse' => false,
+            'confirmResponse' => false,
+            'expectedHasOption' => false,
+        ];
+    }
+
+    /**
+     * @param array<int, string> $expected
+     */
+    #[DataProvider('generateProvider')]
+    public function testGenerate(PluginScaffoldConfiguration $config, array $expected): void
+    {
+        $stubs = new StubCollection();
+
+        (new MailTemplateGenerator())
+            ->generateStubs($config, $stubs);
+
+        static::assertCount(\count($expected), $stubs);
+
+        foreach ($expected as $stub) {
+            static::assertTrue($stubs->has($stub));
+        }
+    }
+
+    public static function generateProvider(): \Generator
+    {
+        yield 'No option, no stubs' => [
+            'config' => self::getConfig(),
+            'expected' => [],
+        ];
+
+        yield 'Option false, no stubs' => [
+            'config' => self::getConfig([MailTemplateGenerator::OPTION_NAME => false]),
+            'expected' => [],
+        ];
+
+        yield 'Option true, stubs' => [
+            'config' => self::getConfig([MailTemplateGenerator::OPTION_NAME => true]),
+            'expected' => [
+                'src/Resources/mail-templates/mail-templates.xml',
+                'src/Resources/mail-templates/example_notification/en-GB/html.twig',
+                'src/Resources/mail-templates/example_notification/en-GB/plain.twig',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private static function getConfig(array $options = []): PluginScaffoldConfiguration
+    {
+        return new PluginScaffoldConfiguration('TestPlugin', 'MyNamespace', '/path/to/directory', $options);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, plugins that want to register mail template types and mail templates must write PHP boilerplate to persist them via the DAL. There is no declarative way to define mail templates, unlike custom fields which now support `Resources/custom-fields.xml`.

This change lets plugins and apps define mail templates declaratively using a directory-based convention. Template content lives in separate `.twig` files so developers get full IDE syntax highlighting and autocomplete — something that would be lost if content were embedded in XML via CDATA blocks.

### 2. What does this change do, exactly?

- **Introduces a directory-based convention** under `Resources/mail-templates/` where an XML file holds metadata (type name, subject, sender name, available entities) and separate `html.twig` / `plain.twig` files hold template content per locale
- **Adds `MailTemplateXmlLoader`** — validates and parses the `mail-templates.xml` metadata file against a new XSD schema
- **Adds `MailTemplateLoader`** — combines XML metadata with Twig file content from disk into `MailTemplates` DTOs
- **Adds `MailTemplateSetPersister`** — standalone DBAL-based service that syncs mail template types and templates to the database (upsert on install/update, delete on uninstall)
- **Adds app integration** via `MailTemplatePersister` implementing `PersisterInterface`
- **Integrates with `PluginLifecycleService`** — automatically syncs on plugin install/update and removes on uninstall (when `keepUserData = false`)
- **Adds XSD schema** (`mail-templates-1.0.xsd`) for XML validation
- **Adds scaffolding generator** — `bin/console plugin:create --create-mail-template` generates the directory structure and example files
- **Updates RELEASE_INFO-6.7.md** and changelog

#### Example directory structure

```
Resources/
  mail-templates/
    mail-templates.xml
    order_confirmation/
      en-GB/
        html.twig
        plain.twig
      de-DE/
        html.twig
        plain.twig
```

#### Example `mail-templates.xml`

```xml
<?xml version="1.0" encoding="utf-8"?>
<mail-templates xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/Content/MailTemplate/Schema/mail-templates-1.0.xsd">
    <mail-template technical-name="order_confirmation">
        <name>Order confirmation</name>
        <name lang="de-DE">Bestellbestätigung</name>
        <subject>Your order {{ order.orderNumber }}</subject>
        <subject lang="de-DE">Ihre Bestellung {{ order.orderNumber }}</subject>
        <sender-name>{{ salesChannel.name }}</sender-name>
        <description>Sent after order placement</description>
        <available-entities>
            <order>order</order>
            <salesChannel>salesChannel</salesChannel>
        </available-entities>
    </mail-template>
</mail-templates>
```

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a plugin with `src/Resources/mail-templates/mail-templates.xml` and corresponding locale directories with `html.twig` / `plain.twig` files
2. Install the plugin — mail template type and template are automatically created in the database
3. Update the plugin — mail template type and template translations are synced
4. Uninstall the plugin — mail template type and template are removed
5. Use `bin/console plugin:create` with `--create-mail-template` — generates the directory structure and example files

### 4. Please link to the relevant issues (if any).

- relates #15114

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Added entry to `RELEASE_INFO-6.7.md` under "Upcoming"
  - Added changelog entry
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them