### PR TITLE
chore: Prepare Framework namespace for PHPStan update

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -54,6 +54,9 @@ return [
         preg_quote('REMOVED: Method Shopware\Core\Framework\App\Lifecycle\Persister\TaxProviderPersister#updateTaxProviders() was removed', '/'),
 
         // Constants should be `float` to reflect the expected type
-        preg_quote('CHANGED: Value of constant Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking::', '/')
+        preg_quote('CHANGED: Value of constant Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking::', '/'),
+
+        // Return type is still of type "self" but more specific. Could never be something different from the InvalidSortQueryException, so this should be fine
+        'CHANGED: The return type of Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DataAbstractionLayerException.* changed from self to (?:the non-covariant )?Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\InvalidSortQueryException',
     ],
 ];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -331,12 +331,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/Field/Flag/Runtime.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\WriteProtected\:\:getAllowedScopes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtected.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\StateMachineStateField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -637,12 +631,6 @@ parameters:
 			path: src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\Plugin\\KernelPluginLoader\\StaticKernelPluginLoader\:\:__construct\(\) has parameter \$plugins with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoader.php
-
-		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
 			identifier: shopware.domainException
 			count: 1
@@ -677,12 +665,6 @@ parameters:
 			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/RateLimiter/Policy/TimeBackoffLimiter.php
-
-		-
-			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
-			identifier: shopware.domainException
-			count: 2
-			path: src/Core/Framework/Routing/Annotation/CriteriaValueResolver.php
 
 		-
 			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
@@ -917,24 +899,6 @@ parameters:
 			identifier: shopware.domainException
 			count: 4
 			path: src/Core/System/User/Api/UserValidationController.php
-
-		-
-			message: '#^Method Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:__construct\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Test/Integration/Helper/MailEventListener.php
-
-		-
-			message: '#^Method Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:get\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Test/Integration/Helper/MailEventListener.php
-
-		-
-			message: '#^Property Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:\$events type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Test/Integration/Helper/MailEventListener.php
 
 		-
 			message: '#^Method Shopware\\Elasticsearch\\DependencyInjection\\ElasticsearchExtension\:\:addConfig\(\) has parameter \$options with no value type specified in iterable type array\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -215,3 +215,10 @@ parameters:
         -
             identifier: missingType.property
             path: tests/unit/Core/DevOps/Docs/Script/_fixtures/hooks/*
+
+        # Many tests are checking DAL write errors with `WriteException` containing `WriteConstraintViolationException`.
+        # As `WriteException` can also contain other exceptions, it is hard to teach PHPStan without touching each test, that in those tests only `WriteConstraintViolationException` are present.
+        # A Generic type for `WriteException` is not applicable, as it can contain different exceptions types at the same time.
+        -
+            message: "#Offset 'source' might not exist on array{status: string, code: #"
+            path: tests

--- a/src/Core/DevOps/Test/AnnotationTagTester.php
+++ b/src/Core/DevOps/Test/AnnotationTagTester.php
@@ -147,8 +147,8 @@ class AnnotationTagTester
             throw new \InvalidArgumentException('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared.');
         }
         $properties = [
-            $match[1] => (string) $match[2],
-            $match[3] => (string) $match[4],
+            $match[1] => $match[2],
+            $match[3] => $match[4],
         ];
 
         match (true) {

--- a/src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
+++ b/src/Core/Framework/Adapter/Asset/FallbackUrlPackage.php
@@ -39,7 +39,7 @@ class FallbackUrlPackage extends UrlPackage
         $request = $this->requestStack?->getMainRequest() ?? new Request(server: $_SERVER);
 
         if ($request->getHost() === '') {
-            $requestUrl = EnvironmentHelper::getVariable('APP_URL');
+            $requestUrl = (string) EnvironmentHelper::getVariable('APP_URL');
         } else {
             $basePath = $request->getSchemeAndHttpHost() . $request->getBasePath();
             $requestUrl = rtrim($basePath, '/') . '/';

--- a/src/Core/Framework/Adapter/Cache/Http/CachePolicyProvider.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CachePolicyProvider.php
@@ -68,7 +68,7 @@ readonly class CachePolicyProvider
             }
         }
 
-        $policy = $this->policies[$policyName] ?? null;
+        $policy = $this->policies[$policyName ?? ''] ?? null;
         if ($policy === null) {
             return CachePolicy::noStore();
         }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheStateValidator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheStateValidator.php
@@ -61,7 +61,7 @@ class CacheStateValidator
 
         $cookie = Cookie::create(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);
 
-        $responseStates = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY)[$cookie->getDomain()][$cookie->getPath()][$cookie->getName()] ?? null;
+        $responseStates = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY)[$cookie->getDomain() ?? ''][$cookie->getPath()][$cookie->getName()] ?? null;
 
         if ($responseStates) {
             // if the response contains a state cookie, we use it instead of the request cookie

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -160,7 +160,7 @@ class HttpCacheKeyGenerator
 
             $responseCookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
 
-            $responseCookie = $responseCookies[$cookie->getDomain()][$cookie->getPath()][$cookieName] ?? null;
+            $responseCookie = $responseCookies[$cookie->getDomain() ?? ''][$cookie->getPath()][$cookieName] ?? null;
 
             if ($responseCookie) {
                 // if the response contains the cookie, we use it instead of the request cookie

--- a/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
+++ b/src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
@@ -21,6 +21,7 @@ class AppTemplateIterator implements \IteratorAggregate
     /**
      * @internal
      *
+     * @param \IteratorAggregate<int, string> $templateIterator
      * @param EntityRepository<TemplateCollection> $templateRepository
      */
     public function __construct(

--- a/src/Core/Framework/Api/Context/ContextValueResolver.php
+++ b/src/Core/Framework/Api/Context/ContextValueResolver.php
@@ -12,6 +12,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 #[Package('framework')]
 class ContextValueResolver implements ValueResolverInterface
 {
+    /**
+     * @return \Generator<Context>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): \Generator
     {
         if ($argument->getType() !== Context::class) {

--- a/src/Core/Framework/Api/Controller/ApiController.php
+++ b/src/Core/Framework/Api/Controller/ApiController.php
@@ -728,6 +728,7 @@ class ApiController extends AbstractController
             $events = $this->executeWriteOperation($definition, $payload, $context, $type);
             $entityIds = $events->getEventByEntityName($definition->getEntityName())?->getIds() ?? [];
             $entityId = array_last($entityIds);
+            \assert($entityId !== null);
 
             $foreignKey = $parentDefinition->getFields()->getByStorageName($association->getStorageName());
             \assert($foreignKey !== null);

--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -228,6 +228,7 @@ class UserController extends AbstractController
         $events = $context->scope(Context::SYSTEM_SCOPE, fn (Context $context) => $this->userRepository->upsert([$data], $context));
         $eventIds = $events->getEventByEntityName(UserDefinition::ENTITY_NAME)?->getIds() ?? [];
         $entityId = array_last($eventIds);
+        \assert(\is_string($entityId), 'There should be a user ID, as it just was written');
 
         return $factory->createRedirectResponse($this->userRepository->getDefinition(), $entityId, $request, $context);
     }

--- a/src/Core/Framework/Api/EventListener/ErrorResponseFactory.php
+++ b/src/Core/Framework/Api/EventListener/ErrorResponseFactory.php
@@ -10,9 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * @phpstan-type DefaultExceptionData array{code: string, status: string, title: string, detail: string|null, meta?: array{trace: array<int|string, mixed>, file: string, line: int, previous?: mixed}}
- *
- * @phpstan-import-type ErrorData from ShopwareHttpException as ShopwareExceptionData
+ * @phpstan-import-type ErrorData from ShopwareHttpException
  */
 #[Package('framework')]
 class ErrorResponseFactory
@@ -32,7 +30,7 @@ class ErrorResponseFactory
     }
 
     /**
-     * @return array<DefaultExceptionData|ShopwareExceptionData>
+     * @return array<ErrorData>
      */
     public function getErrorsFromException(\Throwable $exception, bool $debug = false): array
     {
@@ -42,9 +40,7 @@ class ErrorResponseFactory
                 $errors[] = $error;
             }
 
-            $errors = $this->convert($errors);
-
-            return $errors;
+            return $this->convert($errors);
         }
 
         return [$this->convertExceptionToError($exception, $debug)];
@@ -56,11 +52,11 @@ class ErrorResponseFactory
             return $exception->getHttpStatusCode();
         }
 
-        if ($exception instanceof ShopwareHttpException || $exception instanceof HttpException) {
+        if ($exception instanceof HttpException) {
             return $exception->getStatusCode();
         }
 
-        return 500;
+        return Response::HTTP_INTERNAL_SERVER_ERROR;
     }
 
     /**
@@ -72,7 +68,7 @@ class ErrorResponseFactory
     }
 
     /**
-     * @return DefaultExceptionData
+     * @return ErrorData
      */
     private function convertExceptionToError(\Throwable $exception, bool $debug = false): array
     {
@@ -81,7 +77,7 @@ class ErrorResponseFactory
         $error = [
             'code' => (string) $exception->getCode(),
             'status' => (string) $statusCode,
-            'title' => (string) (Response::$statusTexts[$statusCode] ?? 'unknown status'),
+            'title' => Response::$statusTexts[$statusCode] ?? 'unknown status',
             'detail' => $exception->getMessage(),
         ];
 
@@ -106,9 +102,9 @@ class ErrorResponseFactory
     }
 
     /**
-     * @param array<string|int, mixed> $array
+     * @param array<int, mixed> $array
      *
-     * @return array<string|int, mixed>
+     * @return array<int, mixed>
      */
     private function convert(array $array): array
     {

--- a/src/Core/Framework/Api/Exception/ExpectationFailedException.php
+++ b/src/Core/Framework/Api/Exception/ExpectationFailedException.php
@@ -12,17 +12,9 @@ class ExpectationFailedException extends ShopwareHttpException
     /**
      * @param list<string> $fails
      */
-    public function __construct(private readonly array $fails)
+    public function __construct(array $fails)
     {
-        parent::__construct('API Expectations failed');
-    }
-
-    /**
-     * @return array<string>
-     */
-    public function getParameters(): array
-    {
-        return $this->fails;
+        parent::__construct('API Expectations failed', ['fails' => $fails]);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Api/Response/ResponseFactoryInterfaceValueResolver.php
+++ b/src/Core/Framework/Api/Response/ResponseFactoryInterfaceValueResolver.php
@@ -17,6 +17,9 @@ class ResponseFactoryInterfaceValueResolver implements ValueResolverInterface
     {
     }
 
+    /**
+     * @return \Generator<ResponseFactoryInterface>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): \Generator
     {
         if ($argument->getType() !== ResponseFactoryInterface::class) {

--- a/src/Core/Framework/App/Checkout/Gateway/AppCheckoutGateway.php
+++ b/src/Core/Framework/App/Checkout/Gateway/AppCheckoutGateway.php
@@ -104,13 +104,18 @@ class AppCheckoutGateway implements CheckoutGatewayInterface
     private function collectCommandsFromAppResponse(AppCheckoutGatewayResponse $commands, CheckoutGatewayCommandCollection $collected): void
     {
         foreach ($commands->getCommands() as $payload) {
-            if (!isset($payload['command'], $payload['payload'])) {
-                $this->logger->logOrThrowException(CheckoutGatewayException::payloadInvalid($payload['command'] ?? null));
+            if (!isset($payload['command'])) {
+                $this->logger->logOrThrowException(CheckoutGatewayException::payloadInvalid());
 
                 continue;
             }
 
             $commandKey = $payload['command'];
+            if (!isset($payload['payload'])) {
+                $this->logger->logOrThrowException(CheckoutGatewayException::payloadInvalid($commandKey));
+
+                continue;
+            }
 
             if (!$this->registry->hasAppCommand($commandKey)) {
                 $this->logger->logOrThrowException(CheckoutGatewayException::handlerNotFound($commandKey));

--- a/src/Core/Framework/App/Context/Gateway/AppContextGateway.php
+++ b/src/Core/Framework/App/Context/Gateway/AppContextGateway.php
@@ -92,13 +92,18 @@ class AppContextGateway
         $collected = new ContextGatewayCommandCollection();
 
         foreach ($response->getCommands() as $payload) {
-            if (!isset($payload['command'], $payload['payload'])) {
-                $this->logger->logOrThrowException(GatewayException::payloadInvalid($payload['command'] ?? null));
+            if (!isset($payload['command'])) {
+                $this->logger->logOrThrowException(GatewayException::payloadInvalid());
 
                 continue;
             }
 
             $commandKey = $payload['command'];
+            if (!isset($payload['payload'])) {
+                $this->logger->logOrThrowException(GatewayException::payloadInvalid($commandKey));
+
+                continue;
+            }
 
             if (!$this->registry->hasAppCommand($commandKey)) {
                 $this->logger->logOrThrowException(GatewayException::handlerNotFound($commandKey));

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -88,7 +88,7 @@ abstract class Bundle extends SymfonyBundle
     }
 
     /**
-     * @return SymfonyBundle[]
+     * @return list<SymfonyBundle>
      */
     public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -275,7 +275,7 @@ class DataAbstractionLayerException extends HttpException
         );
     }
 
-    public static function invalidSortQuery(string $message, string $path = ''): self
+    public static function invalidSortQuery(string $message, string $path = ''): InvalidSortQueryException
     {
         return new InvalidSortQueryException(
             $message,

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/JoinGroupBuilder.php
@@ -36,8 +36,8 @@ class JoinGroupBuilder
      * - A `JoinGroup` is generated when a to-many association is filtered by more than one `multi-filter`
      * - An "empty" filter will not lead to a join group (example `new EqualsFilter('product.tags.id', null)`)
      *
-     * @param Filter[] $filters
-     * @param string[] $additionalFields
+     * @param list<Filter> $filters
+     * @param list<string> $additionalFields
      *
      * @return list<Filter>
      */
@@ -82,9 +82,11 @@ class JoinGroupBuilder
     }
 
     /**
-     * @param Filter[] $filters
+     * @param array<Filter> $filters
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed> Returned array shape looks like this:
+     *                              array<string(random-uuid), array{self::NOT_RELEVANT?: list<Filter>, operator: MultiFilter::CONNECTION_*, negated: bool, string(association-name): list<Filter>}>
+     *                              `association-name` is different for each call, but such array shape could not be handled by PHPStan, see https://github.com/phpstan/phpstan/issues/8438
      */
     private function recursion(array $filters, EntityDefinition $definition, string $operator, bool $negated): array
     {
@@ -188,10 +190,10 @@ class JoinGroupBuilder
     }
 
     /**
-     * @param array<string, mixed> $mapped
-     * @param string[] $fields
+     * @param array<string, array<string, mixed>> $mapped
+     * @param list<string> $fields
      *
-     * @return string[]
+     * @return list<string>
      */
     private function getDuplicates(array $mapped, array $fields): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/FetchModeHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/FetchModeHelper.php
@@ -53,6 +53,9 @@ class FetchModeHelper
         foreach ($result as $row) {
             $index = $row[$groupKey];
             unset($row[$groupKey]);
+            if ($index === null) {
+                continue;
+            }
 
             $rows[$index][] = $mapper ? $mapper($row) : $row;
         }
@@ -81,6 +84,9 @@ class FetchModeHelper
         foreach ($result as $row) {
             $index = $row[$groupKey];
             unset($row[$groupKey]);
+            if ($index === null) {
+                continue;
+            }
 
             $rows[$index] = $row;
         }

--- a/src/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtection.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtection.php
@@ -9,11 +9,13 @@ abstract class EntityProtection
 {
     /**
      * Returns a readable name for the flag
+     *
+     * @return \Generator<string>
      */
     abstract public function parse(): \Generator;
 
     /**
-     * Can be overriden if protection is aware of different scopes
+     * Can be overridden if protection is aware of different scopes
      */
     public function isAllowed(string $scope): bool
     {

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  *
  * This event is dispatched during the version merge process and allows listeners to manipulate the writes array before they are applied.
  *
- * @phpstan-type WriteOperation array<string, array<int, mixed>>
+ * @phpstan-type WriteOperation array<string, list<array<string, mixed>>>
  * @phpstan-type Writes array{
  *     insert: WriteOperation,
  *     update: WriteOperation,

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactory.php
@@ -132,10 +132,10 @@ class EntityLoadedEventFactory
      */
     private function map(Entity $entity, array &$mapping): void
     {
-        $mapping[$entity->getInternalEntityName()][] = $entity;
+        $internalEntityName = $entity->getInternalEntityName() ?? '';
+        $mapping[$internalEntityName][] = $entity;
 
-        $vars = $entity->getVars();
-        foreach ($vars as $value) {
+        foreach ($entity->getVars() as $value) {
             if ($value instanceof Entity) {
                 $this->map($value, $mapping);
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
@@ -7,6 +7,17 @@ use Shopware\Core\Framework\ShopwareException;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @phpstan-type SearchErrorData array{
+ *     status: string,
+ *     code: string,
+ *     title: string,
+ *     detail: string,
+ *     source: array{pointer: string},
+ *     meta: array{parameters: array<string, mixed>},
+ *     trace?: string
+ * }
+ */
 #[Package('framework')]
 class SearchRequestException extends ShopwareHttpException
 {
@@ -37,19 +48,23 @@ class SearchRequestException extends ShopwareHttpException
         throw $this;
     }
 
+    /**
+     * @return \Generator<SearchErrorData>
+     */
     public function getErrors(bool $withTrace = false): \Generator
     {
         foreach ($this->exceptions as $pointer => $innerExceptions) {
-            /** @var ShopwareException $exception */
             foreach ($innerExceptions as $exception) {
                 $parameters = [];
+                $code = (string) $exception->getCode();
                 if ($exception instanceof ShopwareException) {
                     $parameters = $exception->getParameters();
+                    $code = $exception->getErrorCode();
                 }
 
                 $error = [
                     'status' => (string) $this->getStatusCode(),
-                    'code' => $exception->getErrorCode(),
+                    'code' => $code,
                     'title' => Response::$statusTexts[Response::HTTP_BAD_REQUEST],
                     'detail' => $exception->getMessage(),
                     'source' => ['pointer' => $pointer],

--- a/src/Core/Framework/DataAbstractionLayer/Field/Field.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Field.php
@@ -51,6 +51,11 @@ abstract class Field extends Struct
         return 0;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return static natively
+     *
+     * @return static
+     */
     public function setFlags(Flag ...$flags): self
     {
         $this->flags = [];
@@ -64,6 +69,11 @@ abstract class Field extends Struct
         return $this;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return static natively
+     *
+     * @return static
+     */
     public function addFlags(Flag ...$flags): self
     {
         foreach ($flags as $flag) {
@@ -74,7 +84,11 @@ abstract class Field extends Struct
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return static natively
+     *
      * @param class-string<Flag> $class
+     *
+     * @return static
      */
     public function removeFlag(string $class): self
     {
@@ -130,6 +144,11 @@ abstract class Field extends Struct
         return $this->description;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return static natively
+     *
+     * @return static
+     */
     public function setDescription(string $description): self
     {
         $this->description = $description;

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/Choice.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/Choice.php
@@ -33,6 +33,9 @@ class Choice extends Flag
         return $this->strict;
     }
 
+    /**
+     * @return \Generator<string, array{choices: list<string|bool|int|float>, strict: bool}>
+     */
     public function parse(): \Generator
     {
         yield 'choice' => [

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/Flag.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/Flag.php
@@ -9,6 +9,8 @@ abstract class Flag
 {
     /**
      * Returns a readable name for the flag
+     *
+     * @return \Generator<string, bool|string|float|list<list<string>>|array<string, string|null>|array{choices: list<string|bool|int|float>, strict: bool}>
      */
     abstract public function parse(): \Generator;
 }

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtected.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtected.php
@@ -19,6 +19,9 @@ class WriteProtected extends Flag
         }
     }
 
+    /**
+     * @return list<string>
+     */
     public function getAllowedScopes(): array
     {
         return array_keys($this->allowedScopes);
@@ -29,6 +32,9 @@ class WriteProtected extends Flag
         return isset($this->allowedScopes[$scope]);
     }
 
+    /**
+     * @return \Generator<string, list<list<string>>>
+     */
     public function parse(): \Generator
     {
         yield 'write_protected' => [

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/FieldSerializerInterface.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/FieldSerializerInterface.php
@@ -23,7 +23,9 @@ interface FieldSerializerInterface
     public function normalize(Field $field, array $data, WriteParameterBag $parameters): array;
 
     /**
-     * Encodes the provided DAL value to a persitable storage value
+     * Encodes the provided DAL value to a persistable storage value
+     *
+     * @return \Generator<string, mixed>
      */
     public function encode(Field $field, EntityExistence $existence, KeyValuePair $data, WriteParameterBag $parameters): \Generator;
 

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslationsAssociationFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/TranslationsAssociationFieldSerializer.php
@@ -41,7 +41,6 @@ class TranslationsAssociationFieldSerializer implements FieldSerializerInterface
         $value = $data[$key] ?? null;
 
         $path = $parameters->getPath() . '/' . $key;
-        /** @var EntityTranslationDefinition $referenceDefinition */
         $referenceDefinition = $field->getReferenceDefinition();
 
         if ($value === null) {
@@ -174,6 +173,8 @@ class TranslationsAssociationFieldSerializer implements FieldSerializerInterface
      * @throws ExpectedArrayException
      * @throws MissingSystemTranslationException
      * @throws MissingTranslationLanguageException
+     *
+     * @return \Generator<array{}>
      */
     private function map(
         TranslationsAssociationField $field,
@@ -185,8 +186,10 @@ class TranslationsAssociationFieldSerializer implements FieldSerializerInterface
         $value = $data->getValue();
         $path = $parameters->getPath() . '/' . $key;
 
-        /** @var EntityTranslationDefinition $referenceDefinition */
         $referenceDefinition = $field->getReferenceDefinition();
+        if (!$referenceDefinition instanceof EntityTranslationDefinition) {
+            return;
+        }
 
         if (!\is_array($value)) {
             throw DataAbstractionLayerException::expectedArray($path);
@@ -207,10 +210,9 @@ class TranslationsAssociationFieldSerializer implements FieldSerializerInterface
             return;
         }
 
-        $languageIds = array_keys($value);
         // the translation in the system language is always required for new entities,
         // if there is at least one required translated field
-        if ($referenceDefinition->hasRequiredField() && !\in_array(Defaults::LANGUAGE_SYSTEM, $languageIds, true)) {
+        if ($referenceDefinition->hasRequiredField() && !\array_key_exists(Defaults::LANGUAGE_SYSTEM, $value)) {
             throw DataAbstractionLayerException::missingSystemTranslation($path . '/' . Defaults::LANGUAGE_SYSTEM);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -492,7 +492,7 @@ class Criteria extends Struct implements \Stringable
     }
 
     /**
-     * @param array<string>|array<int, array<string>> $ids
+     * @param array<IDStructure> $ids
      */
     public function cloneForRead(array $ids = []): Criteria
     {

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
@@ -36,7 +36,7 @@ use Shopware\Core\Framework\Log\Package;
  * @phpstan-type SuffixFilterType array{type: 'suffix', field: string, value: mixed}
  * @phpstan-type RangeFilterType array{type: 'range'|'until'|'since', field: string, value?: mixed, parameters: array<string, mixed>}
  * @phpstan-type EqualsAnyFilterType array{type: 'equalsAny', field: string, value: mixed}
- * @phpstan-type Query array{type: string, field?: string, value?: mixed, parameters?: array{operator: RangeFilter::*}, queries?: list<array{type: string, field?: string, value?: mixed}>}
+ * @phpstan-type Query array{type: string, field?: string, value?: mixed, parameters?: array{operator: RangeFilter::*}, queries?: list<array{type: string, field?: string, value?: mixed}>|null}
  */
 #[Package('framework')]
 class QueryStringParser

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -524,9 +524,9 @@ class VersionManager
     }
 
     /**
-     * @param array<string, string> $payload
+     * @param array<string, mixed> $payload
      *
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     private function addVersionToPayload(array $payload, EntityDefinition $definition, string $versionId): array
     {
@@ -662,9 +662,9 @@ class VersionManager
 
     /**
      * @param array<string> $entityId
-     * @param array<string|int, mixed> $payload
+     * @param array<string, mixed> $payload
      *
-     * @return array<string|int, mixed>
+     * @return array<string, mixed>
      */
     private function addTranslationToPayload(array $entityId, array $payload, EntityDefinition $definition, VersionCommitEntity $commit): array
     {
@@ -738,7 +738,7 @@ class VersionManager
     }
 
     /**
-     * @return array{insert:array<string, array<int, mixed>>, update:array<string, array<int, mixed>>, delete:array<string, array<int, mixed>>}
+     * @return array{insert:array<string, list<array<string, mixed>>>, update:array<string, list<array<string, mixed>>>, delete:array<string, list<array<string, mixed>>>}
      */
     private function buildWrites(VersionCommitCollection $commits): array
     {
@@ -783,7 +783,7 @@ class VersionManager
     }
 
     /**
-     * @param array{insert:array<string, array<int, mixed>>, update:array<string, array<int, mixed>>, delete:array<string, array<int, mixed>>} $writes
+     * @param array{insert:array<string, list<array<string, mixed>>>, update:array<string, list<array<string, mixed>>>, delete:array<string, list<array<string, mixed>>>} $writes
      */
     private function executeWrites(array $writes, WriteContext $liveContext): WriteResult
     {

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
@@ -67,8 +67,7 @@ class WriteException extends ShopwareHttpException
                 continue;
             }
 
-            $errorFactory = new ErrorResponseFactory();
-            yield from $errorFactory->getErrorsFromException($innerException, $withTrace);
+            yield from (new ErrorResponseFactory())->getErrorsFromException($innerException, $withTrace);
         }
     }
 
@@ -77,10 +76,7 @@ class WriteException extends ShopwareHttpException
         $messages = [];
 
         foreach ($this->getErrors() as $index => $error) {
-            $pointer = $error['source']['pointer'] ?? '/';
-            \assert(\is_string($pointer));
-            \assert(\is_string($error['detail']));
-            $messages[] = \sprintf('%d. [%s] %s', $index + 1, $pointer, $error['detail']);
+            $messages[] = \sprintf('%d. [%s] %s', $index + 1, $error['source']['pointer'] ?? '/', $error['detail']);
         }
 
         $messagesString = implode(\PHP_EOL, $messages);

--- a/src/Core/Framework/Migration/Command/MigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/MigrationCommand.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Migration\Exception\UnknownMigrationSourceException;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\MigrationStep;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -37,6 +38,9 @@ class MigrationCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     protected function getMigrationGenerator(MigrationCollection $collection, ?int $until, ?int $limit): \Generator
     {
         yield from $collection->migrateInSteps($until, $limit);

--- a/src/Core/Framework/Migration/Command/MigrationDestructiveCommand.php
+++ b/src/Core/Framework/Migration/Command/MigrationDestructiveCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationException;
+use Shopware\Core\Framework\Migration\MigrationStep;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,6 +34,9 @@ class MigrationDestructiveCommand extends MigrationCommand
         );
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     protected function getMigrationGenerator(MigrationCollection $collection, ?int $until, ?int $limit): \Generator
     {
         yield from $collection->migrateDestructiveInSteps($until, $limit);

--- a/src/Core/Framework/Migration/MigrationCollection.php
+++ b/src/Core/Framework/Migration/MigrationCollection.php
@@ -42,6 +42,9 @@ class MigrationCollection
         $insertQuery->execute();
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     public function migrateInSteps(?int $until = null, ?int $limit = null): \Generator
     {
         return $this->migrationRuntime->migrate($this->migrationSource, $until, $limit);
@@ -55,6 +58,9 @@ class MigrationCollection
         return iterator_to_array($this->migrateInSteps($until, $limit));
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     public function migrateDestructiveInSteps(?int $until = null, ?int $limit = null): \Generator
     {
         return $this->migrationRuntime->migrateDestructive($this->migrationSource, $until, $limit);

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -19,6 +19,9 @@ class MigrationRuntime
     ) {
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     public function migrate(MigrationSource $source, ?int $until = null, ?int $limit = null): \Generator
     {
         $migrations = $this->getExecutableMigrations($source, $until, $limit);
@@ -49,6 +52,9 @@ class MigrationRuntime
         }
     }
 
+    /**
+     * @return \Generator<class-string<MigrationStep>>
+     */
     public function migrateDestructive(MigrationSource $source, ?int $until = null, ?int $limit = null): \Generator
     {
         $migrations = $this->getExecutableDestructiveMigrations($source, $until, $limit);

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -18,6 +19,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @phpstan-import-type PluginInfo from KernelPluginLoader
+ */
 #[AsCommand(
     name: 'plugin:list',
     description: 'Lists all plugins',
@@ -30,8 +34,10 @@ class PluginListCommand extends Command
      *
      * @param EntityRepository<PluginCollection> $pluginRepo
      */
-    public function __construct(private readonly EntityRepository $pluginRepo, private readonly ComposerPluginLoader $composerPluginLoader)
-    {
+    public function __construct(
+        private readonly EntityRepository $pluginRepo,
+        private readonly ComposerPluginLoader $composerPluginLoader
+    ) {
         parent::__construct();
     }
 
@@ -90,6 +96,8 @@ class PluginListCommand extends Command
             $pluginActive = $plugin->getActive();
             $pluginInstalled = $plugin->getInstalledAt();
             $pluginUpgradeable = $plugin->getUpgradeVersion();
+            $pluginComposerName = $plugin->getComposerName() ?? '';
+            $isComposerInstalled = $pluginComposerName !== '' && ($composerInstalled[$pluginComposerName] ?? false);
 
             $pluginTable[] = [
                 $plugin->getName(),
@@ -101,11 +109,11 @@ class PluginListCommand extends Command
                 $pluginInstalled ? 'Yes' : 'No',
                 $pluginActive ? 'Yes' : 'No',
                 $pluginUpgradeable ? 'Yes' : 'No',
-                isset($composerInstalled[$plugin->getComposerName()]) ? 'Yes' : 'No',
+                $isComposerInstalled ? 'Yes' : 'No',
             ];
 
-            if (isset($composerInstalled[$plugin->getComposerName()])) {
-                $composerInstalledAndRegistered[$plugin->getComposerName()] = true;
+            if ($isComposerInstalled) {
+                $composerInstalledAndRegistered[$pluginComposerName] = true;
             }
 
             if ($pluginActive) {
@@ -158,7 +166,7 @@ class PluginListCommand extends Command
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, PluginInfo>
      */
     private function getComposerPluginLoaderPackages(): array
     {

--- a/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\Util\IOStreamHelper;
 class ComposerPluginLoader extends KernelPluginLoader
 {
     /**
-     * @return array<PluginInfo>
+     * @return list<PluginInfo>
      */
     public function fetchPluginInfos(): array
     {

--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -15,13 +15,22 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * @phpstan-type PluginInfo array{ baseClass: string, name: string, active: bool, path: string, version: string|null, autoload: array<string, string[]>, managedByComposer: bool, composerName: string }
+ * @phpstan-type PluginInfo array{
+ *     baseClass: string,
+ *     name: string,
+ *     active: bool,
+ *     path: string,
+ *     version: string|null,
+ *     autoload: array<string, string[]>,
+ *     managedByComposer: bool,
+ *     composerName: string
+ * }
  */
 #[Package('framework')]
 abstract class KernelPluginLoader extends Bundle
 {
     /**
-     * @var array<int, PluginInfo>
+     * @var list<PluginInfo>
      */
     protected array $pluginInfos = [];
 
@@ -45,7 +54,7 @@ abstract class KernelPluginLoader extends Bundle
     final public function getPluginDir(string $projectDir): string
     {
         // absolute path
-        if (mb_strpos($this->pluginDir, '/') === 0) {
+        if (str_starts_with($this->pluginDir, '/')) {
             return $this->pluginDir;
         }
 
@@ -55,7 +64,7 @@ abstract class KernelPluginLoader extends Bundle
     /**
      * Basic information required for instantiating the plugins
      *
-     * @return array<int, PluginInfo>
+     * @return list<PluginInfo>
      */
     final public function getPluginInfos(): array
     {
@@ -73,7 +82,7 @@ abstract class KernelPluginLoader extends Bundle
 
     /**
      * @param array<string, mixed> $kernelParameters
-     * @param array<int, string> $loadedBundles
+     * @param list<string> $loadedBundles
      *
      * @return \Traversable<Bundle>
      */
@@ -89,7 +98,7 @@ abstract class KernelPluginLoader extends Bundle
             $additionalBundles = $plugin->getAdditionalBundles($additionalBundleParameters);
             [$preLoaded, $postLoaded] = $this->splitBundlesIntoPreAndPost($additionalBundles);
 
-            foreach ([...\array_values($preLoaded), $plugin, ...\array_values($postLoaded)] as $bundle) {
+            foreach ([...$preLoaded, $plugin, ...$postLoaded] as $bundle) {
                 if (!\in_array($bundle->getName(), $loadedBundles, true)) {
                     yield $bundle;
                     $loadedBundles[] = $bundle->getName();
@@ -279,7 +288,6 @@ abstract class KernelPluginLoader extends Bundle
                 continue;
             }
 
-            /** @var Plugin $plugin */
             $plugin = new $className((bool) $pluginData['active'], $pluginData['path'], $projectDir);
 
             if (!$plugin instanceof Plugin) {
@@ -293,9 +301,9 @@ abstract class KernelPluginLoader extends Bundle
     }
 
     /**
-     * @param Bundle[] $bundles
+     * @param list<Bundle> $bundles
      *
-     * @return array<Bundle[]>
+     * @return array{list<Bundle>, list<Bundle>}
      */
     private function splitBundlesIntoPreAndPost(array $bundles): array
     {
@@ -313,6 +321,6 @@ abstract class KernelPluginLoader extends Bundle
         \ksort($pre);
         \ksort($post);
 
-        return [$pre, $post];
+        return [array_values($pre), array_values($post)];
     }
 }

--- a/src/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoader.php
@@ -5,9 +5,15 @@ namespace Shopware\Core\Framework\Plugin\KernelPluginLoader;
 use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @phpstan-import-type PluginInfo from KernelPluginLoader
+ */
 #[Package('framework')]
 class StaticKernelPluginLoader extends KernelPluginLoader
 {
+    /**
+     * @param list<PluginInfo> $plugins
+     */
     public function __construct(
         ClassLoader $classLoader,
         ?string $pluginDir = null,

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -629,11 +629,12 @@ class PluginLifecycleService
         $pluginLoader = $this->container->get(KernelPluginLoader::class);
 
         $plugins = $pluginLoader->getPluginInfos();
-        foreach ($plugins as $i => $pluginData) {
+        foreach ($plugins as &$pluginData) {
             if ($pluginData['baseClass'] === $plugin->getBaseClass()) {
-                $plugins[$i]['active'] = $plugin->getActive();
+                $pluginData['active'] = $plugin->getActive();
             }
         }
+        unset($pluginData);
 
         if (!$plugin->getActive()) {
             $this->clearEntityExtensions($pluginNamespace);

--- a/src/Core/Framework/Plugin/Requirement/Exception/RequirementStackException.php
+++ b/src/Core/Framework/Plugin/Requirement/Exception/RequirementStackException.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 class RequirementStackException extends ShopwareHttpException
 {
     /**
-     * @var RequirementException[]
+     * @var list<RequirementException>
      */
     private readonly array $requirements;
 
@@ -18,7 +18,7 @@ class RequirementStackException extends ShopwareHttpException
         string $method,
         RequirementException ...$requirements
     ) {
-        $this->requirements = $requirements;
+        $this->requirements = array_values($requirements);
 
         parent::__construct(
             'Could not {{ method }} plugin, got {{ failureCount }} failure(s). {{ errors }}',
@@ -41,7 +41,7 @@ class RequirementStackException extends ShopwareHttpException
     }
 
     /**
-     * @return RequirementException[]
+     * @return list<RequirementException>
      */
     public function getRequirements(): array
     {

--- a/src/Core/Framework/Routing/Annotation/CriteriaValueResolver.php
+++ b/src/Core/Framework/Routing/Annotation/CriteriaValueResolver.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
@@ -24,26 +25,27 @@ class CriteriaValueResolver implements ValueResolverInterface
     ) {
     }
 
+    /**
+     * @return \Generator<Criteria>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): \Generator
     {
         if ($argument->getType() !== Criteria::class) {
             return;
         }
 
-        /** @var string|null $entity */
-        $entity = $request->attributes->get(PlatformRequest::ATTRIBUTE_ENTITY);
-
-        if (!$entity) {
+        $entity = $request->attributes->getString(PlatformRequest::ATTRIBUTE_ENTITY);
+        if ($entity === '') {
             $route = $request->attributes->get('_route');
 
-            throw new \RuntimeException('Missing _entity route default for route: ' . $route);
+            throw RoutingException::missingRouteAttribute('default "_entity" value', $route);
         }
 
         $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
         if (!$context instanceof Context) {
             $route = $request->attributes->get('_route');
 
-            throw new \RuntimeException('Missing context for route ' . $route);
+            throw RoutingException::missingRouteAttribute('context', $route);
         }
 
         yield $this->criteriaBuilder->handleRequest(

--- a/src/Core/Framework/Routing/QueryDataBagResolver.php
+++ b/src/Core/Framework/Routing/QueryDataBagResolver.php
@@ -11,6 +11,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 #[Package('framework')]
 class QueryDataBagResolver implements ValueResolverInterface
 {
+    /**
+     * @return \Generator<QueryDataBag>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): \Generator
     {
         if ($argument->getType() !== QueryDataBag::class) {

--- a/src/Core/Framework/Routing/RequestDataBagResolver.php
+++ b/src/Core/Framework/Routing/RequestDataBagResolver.php
@@ -11,6 +11,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 #[Package('framework')]
 class RequestDataBagResolver implements ValueResolverInterface
 {
+    /**
+     * @return \Generator<RequestDataBag>
+     */
     public function resolve(Request $request, ArgumentMetadata $argument): \Generator
     {
         if ($argument->getType() !== RequestDataBag::class) {

--- a/src/Core/Framework/Routing/RoutingException.php
+++ b/src/Core/Framework/Routing/RoutingException.php
@@ -28,6 +28,7 @@ class RoutingException extends HttpException
     public const MISSING_PRIVILEGE = 'FRAMEWORK__ROUTING_MISSING_PRIVILEGE';
     public const INVALID_ROUTE_SCOPE = 'FRAMEWORK__ROUTING_INVALID_ROUTE_SCOPE';
     public const MISSING_MAIN_REQUEST = 'FRAMEWORK__MAIN_REQUEST_MISSING';
+    public const MISSING_ROUTE_ATTRIBUTE = 'FRAMEWORK__ROUTING_ROUTE_ATTRIBUTE_MISSING';
 
     public static function invalidRequestParameter(string $name): self
     {
@@ -143,6 +144,16 @@ class RoutingException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::MISSING_MAIN_REQUEST,
             'Unable to check the request scope without main request.'
+        );
+    }
+
+    public static function missingRouteAttribute(string $routeAttribute, string $route): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::MISSING_ROUTE_ATTRIBUTE,
+            'Route attribute "{{ routeAttribute }}" on route "{{ route }}" is missing.',
+            ['routeAttribute' => $routeAttribute, 'route' => $route],
         );
     }
 }

--- a/src/Core/Framework/Script/Debugging/ScriptTraces.php
+++ b/src/Core/Framework/Script/Debugging/ScriptTraces.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Service\ResetInterface;
 class ScriptTraces extends AbstractDataCollector implements ResetInterface
 {
     /**
-     * @var array<string, mixed>
+     * @var array<string, list<array{name: string, took: float, output: array<string|int, mixed>, deprecations: array<string, int>}>>
      */
     protected array $traces = [];
 
@@ -100,6 +100,11 @@ class ScriptTraces extends AbstractDataCollector implements ResetInterface
 
     public function getTook(): float
     {
+        /**
+         * `data` is the same as the `traces` property
+         *
+         * @var array<string, list<array{name: string, took: float, output: array<string|int, mixed>, deprecations: array<string, int>}>> $data
+         */
         $data = $this->data instanceof Data ? $this->data->getIterator() : $this->data;
 
         $took = 0.0;
@@ -158,7 +163,7 @@ class ScriptTraces extends AbstractDataCollector implements ResetInterface
     /**
      * @internal
      *
-     * @return array<string, mixed>
+     * @return array<string|int, mixed>
      */
     public function getOutput(string $name, int $index): array
     {

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -117,10 +117,14 @@ class ScriptLoader implements EventSubscriberInterface
                 continue;
             }
 
-            if (!isset($appIncludes[$script['app_id']])) {
-                $includes = array_filter($scripts, static fn (array $include) => $include['hook'] === 'include' && $include['app_id'] === $script['app_id']);
+            $scriptByAppId = $script['app_id'] ?? '';
+            if ($scriptByAppId === '') {
+                continue;
+            }
+            if (!isset($appIncludes[$scriptByAppId])) {
+                $includes = array_filter($scripts, static fn (array $include): bool => $include['hook'] === 'include' && $include['app_id'] === $scriptByAppId);
 
-                $appIncludes[$script['app_id']] = array_map(function (array $include): Script {
+                $appIncludes[$scriptByAppId] = array_map(function (array $include): Script {
                     return new Script(
                         $include['scriptName'],
                         $include['script'],
@@ -132,7 +136,7 @@ class ScriptLoader implements EventSubscriberInterface
                 }, $includes);
             }
 
-            $includes = $appIncludes[$script['app_id']];
+            $includes = $appIncludes[$scriptByAppId];
 
             $dates = [...[new \DateTimeImmutable($script['lastModified'])], ...array_column($includes, 'lastModified')];
 

--- a/src/Core/Framework/Script/Facade/ArrayFacade.php
+++ b/src/Core/Framework/Script/Facade/ArrayFacade.php
@@ -183,6 +183,8 @@ class ArrayFacade implements \IteratorAggregate, \ArrayAccess, \Countable
 
     /**
      * @internal should not be used directly, loop over an array facade directly inside twig instead
+     *
+     * @return \Generator<array<string|int, mixed>>
      */
     public function getIterator(): \Generator
     {

--- a/src/Core/Framework/ShopwareException.php
+++ b/src/Core/Framework/ShopwareException.php
@@ -10,7 +10,7 @@ interface ShopwareException extends \Throwable
     public function getErrorCode(): string;
 
     /**
-     * @return array<string|int, mixed|null>
+     * @return array<string, mixed>
      */
     public function getParameters(): array;
 }

--- a/src/Core/Framework/ShopwareHttpException.php
+++ b/src/Core/Framework/ShopwareHttpException.php
@@ -7,7 +7,23 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * @phpstan-type ErrorData array{status: string, code: string, title: string, detail: string, meta: array{parameters: array<string, mixed>}, trace?: array<int, mixed>}
+ * @phpstan-type ErrorData array{
+ *     status: string,
+ *     code: string|null,
+ *     title?: string,
+ *     detail: string|\Stringable|null,
+ *     template?: string,
+ *     meta?: array{
+ *         parameters?: array<string, mixed>,
+ *         documentationLink?: string,
+ *         trace?: array<int, mixed>,
+ *         file?: string,
+ *         line?: int,
+ *         previous?: mixed
+ *     },
+ *     source?: array{pointer: string},
+ *     trace?: array<int, mixed>|string
+ * }
  */
 #[Package('framework')]
 abstract class ShopwareHttpException extends HttpException implements ShopwareException
@@ -36,6 +52,9 @@ abstract class ShopwareHttpException extends HttpException implements ShopwareEx
         return Response::HTTP_INTERNAL_SERVER_ERROR;
     }
 
+    /**
+     * @return \Generator<ErrorData>
+     */
     public function getErrors(bool $withTrace = false): \Generator
     {
         yield $this->getCommonErrorData($withTrace);
@@ -58,14 +77,14 @@ abstract class ShopwareHttpException extends HttpException implements ShopwareEx
     }
 
     /**
-     * @return ErrorData
+     * @return array{status: string, code: string, title: string, detail: string, meta: array{parameters: array<string, mixed>}, trace?: array<int, mixed>}
      */
     protected function getCommonErrorData(bool $withTrace = false): array
     {
         $error = [
             'status' => (string) $this->getStatusCode(),
             'code' => $this->getErrorCode(),
-            'title' => (string) (Response::$statusTexts[$this->getStatusCode()] ?? 'unknown status'),
+            'title' => Response::$statusTexts[$this->getStatusCode()] ?? 'unknown status',
             'detail' => $this->getMessage(),
             'meta' => [
                 'parameters' => $this->getParameters(),

--- a/src/Core/Framework/Store/Exception/StoreApiException.php
+++ b/src/Core/Framework/Store/Exception/StoreApiException.php
@@ -7,6 +7,16 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\StoreException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @phpstan-type StoreApiErrorData array{
+ *     code: string,
+ *     status: string,
+ *     title: string,
+ *     detail: string,
+ *     meta: array{documentationLink: string},
+ *     trace?: string
+ * }
+ */
 #[Package('checkout')]
 class StoreApiException extends StoreException
 {
@@ -43,6 +53,9 @@ class StoreApiException extends StoreException
         return 'FRAMEWORK__STORE_ERROR';
     }
 
+    /**
+     * @return \Generator<StoreApiErrorData>
+     */
     public function getErrors(bool $withTrace = false): \Generator
     {
         $error = [

--- a/src/Core/Framework/Struct/ArrayEntity.php
+++ b/src/Core/Framework/Struct/ArrayEntity.php
@@ -12,6 +12,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class ArrayEntity extends Entity implements \ArrayAccess
 {
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed with next major version, as it is unused
+     */
     protected ?string $_entityName = 'array-entity';
 
     /**

--- a/src/Core/Framework/Util/ArrayNormalizer.php
+++ b/src/Core/Framework/Util/ArrayNormalizer.php
@@ -46,6 +46,7 @@ class ArrayNormalizer
                 $first = mb_strstr($key, '.', true);
                 $rest = mb_strstr($key, '.');
                 // occurrence of dot is checked in if clause, so `mb_strstr` can't return false and the assert should not cause an exception
+                \assert(\is_string($first));
                 \assert(\is_string($rest));
 
                 if (isset($result[$first])) {

--- a/src/Core/Framework/Util/HtmlSanitizer.php
+++ b/src/Core/Framework/Util/HtmlSanitizer.php
@@ -26,7 +26,7 @@ class HtmlSanitizer implements ResetInterface
     public function __construct(
         ?string $cacheDir = null,
         private readonly bool $cacheEnabled = true,
-        private array $sets = [],
+        private readonly array $sets = [],
         private readonly array $fieldSets = [],
         private readonly bool $enabled = true
     ) {
@@ -110,7 +110,7 @@ class HtmlSanitizer implements ResetInterface
         }
 
         if (!$override) {
-            $sets = $this->fieldSets[$field]['sets'] ?? ['basic'];
+            $sets = $this->fieldSets[(string) $field]['sets'] ?? ['basic'];
 
             foreach ($sets as $set) {
                 if (isset($this->sets[$set]['tags'])) {

--- a/src/Core/Framework/Validation/Exception/ConstraintViolationException.php
+++ b/src/Core/Framework/Validation/Exception/ConstraintViolationException.php
@@ -2,19 +2,31 @@
 
 namespace Shopware\Core\Framework\Validation\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
+/**
+ * @phpstan-type ConstraintErrorData array{
+ *     code: string|null,
+ *     status: '400',
+ *     title: 'Constraint violation error',
+ *     detail: string|\Stringable,
+ *     meta: array{parameters: array<string, mixed>},
+ *     source: array{pointer: string},
+ *     trace?: array<int, mixed>
+ * }
+ */
 #[Package('framework')]
 class ConstraintViolationException extends ShopwareHttpException
 {
     private readonly ConstraintViolationList $violations;
 
     /**
-     * @param array<mixed> $inputData
+     * @param array<array-key, mixed> $inputData
      */
     public function __construct(
         ConstraintViolationList $violations,
@@ -27,8 +39,16 @@ class ConstraintViolationException extends ShopwareHttpException
         parent::__construct('Caught {{ count }} violation errors.', ['count' => $violations->count()]);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement as it is unused
+     */
     public function getRootViolations(): ConstraintViolationList
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __FUNCTION__, 'v6.8.0.0'),
+        );
+
         $violations = new ConstraintViolationList();
         foreach ($this->violations as $violation) {
             if ($violation->getPropertyPath() === '') {
@@ -56,7 +76,9 @@ class ConstraintViolationException extends ShopwareHttpException
     }
 
     /**
-     * @return array<mixed>
+     * Is used in Twig template files
+     *
+     * @return array<array-key, mixed>
      */
     public function getInputData(): array
     {
@@ -68,9 +90,11 @@ class ConstraintViolationException extends ShopwareHttpException
         return 'FRAMEWORK__CONSTRAINT_VIOLATION';
     }
 
+    /**
+     * @return \Generator<ConstraintErrorData>
+     */
     public function getErrors(bool $withTrace = false): \Generator
     {
-        /** @var ConstraintViolation $violation */
         foreach ($this->violations as $violation) {
             $error = [
                 'code' => $violation->getCode(),
@@ -100,7 +124,6 @@ class ConstraintViolationException extends ShopwareHttpException
 
     private function mapErrorCodes(ConstraintViolationList $violations): void
     {
-        /** @var ConstraintViolation $violation */
         foreach ($violations as $key => $violation) {
             if ($constraint = $violation->getConstraint()) {
                 try {

--- a/src/Core/Framework/Validation/WriteConstraintViolationException.php
+++ b/src/Core/Framework/Validation/WriteConstraintViolationException.php
@@ -8,6 +8,17 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolationList;
 
+/**
+ * @phpstan-type WriteConstraintErrorData array{
+ *     code: string,
+ *     status: string,
+ *     detail: string|\Stringable,
+ *     template: string,
+ *     meta: array{parameters: array<string, mixed>},
+ *     source: array{pointer: string},
+ *     trace?: array<int, mixed>
+ * }
+ */
 #[Package('framework')]
 class WriteConstraintViolationException extends DataAbstractionLayerException implements WriteFieldException, ConstraintViolationExceptionInterface
 {
@@ -63,6 +74,9 @@ class WriteConstraintViolationException extends DataAbstractionLayerException im
         return $result;
     }
 
+    /**
+     * @return \Generator<WriteConstraintErrorData>
+     */
     public function getErrors(bool $withTrace = false): \Generator
     {
         foreach ($this->getViolations() as $violation) {

--- a/src/Core/Installer/Controller/FinishController.php
+++ b/src/Core/Installer/Controller/FinishController.php
@@ -69,7 +69,14 @@ class FinishController extends InstallerController
             }
 
             $redirect->headers->setCookie(
-                Cookie::create('bearerAuth', json_encode($loginTokenData, \JSON_THROW_ON_ERROR), time() + $data['expires_in'], ($appUrlInfo['path'] ?? '') . '/admin', $appUrlInfo['host'], null, false)
+                Cookie::create(
+                    'bearerAuth',
+                    json_encode($loginTokenData, \JSON_THROW_ON_ERROR),
+                    time() + $data['expires_in'],
+                    ($appUrlInfo['path'] ?? '') . '/admin',
+                    $appUrlInfo['host'] ?? null,
+                    httpOnly: false
+                )
             );
         } catch (TransferException) {
             // ignore and don't automatically log in

--- a/src/Core/Test/Integration/Helper/MailEventListener.php
+++ b/src/Core/Test/Integration/Helper/MailEventListener.php
@@ -10,15 +10,25 @@ use Shopware\Core\Content\Flow\Events\FlowSendMailActionEvent;
  */
 class MailEventListener
 {
+    /**
+     * @var array<string, list<FlowSendMailActionEvent>>
+     */
     private array $events = [];
 
+    /**
+     * @param array<string, string> $mapping
+     */
     public function __construct(private readonly array $mapping)
     {
     }
 
     public function __invoke(FlowSendMailActionEvent $event): void
     {
-        $name = $this->mapping[$event->getMailTemplate()->getMailTemplateTypeId()];
+        $mailTemplateTypeId = $event->getMailTemplate()->getMailTemplateTypeId();
+        if ($mailTemplateTypeId === null) {
+            return;
+        }
+        $name = $this->mapping[$mailTemplateTypeId];
 
         $this->events[$name][] = $event;
     }
@@ -33,8 +43,11 @@ class MailEventListener
         return !empty($this->events[$type]);
     }
 
+    /**
+     * @return ($type is string ? list<FlowSendMailActionEvent> : array<string, list<FlowSendMailActionEvent>>)
+     */
     public function get(?string $type = null): array
     {
-        return $type ? $this->events[$type] : $this->events;
+        return $type !== null ? $this->events[$type] : $this->events;
     }
 }

--- a/src/Core/Test/Integration/Traits/TestShortHands.php
+++ b/src/Core/Test/Integration/Traits/TestShortHands.php
@@ -142,10 +142,7 @@ trait TestShortHands
         static::assertTrue($listener->sent($type), \sprintf('Mail with type %s was not sent', $type));
     }
 
-    /**
-     * @return mixed
-     */
-    protected function mailListener(\Closure $closure)
+    protected function mailListener(\Closure $closure): mixed
     {
         $mapping = static::getContainer()->get(Connection::class)
             ->fetchAllKeyValue('SELECT LOWER(HEX(id)), technical_name FROM mail_template_type');

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
@@ -397,6 +397,7 @@ class StaticKernelPluginLoaderTest extends TestCase
             $classLoader = $this->classLoader;
         }
 
+        /** @phpstan-ignore argument.type (For test purposes it is enough to not provide fully fledged plugin information) */
         return new StaticKernelPluginLoader($classLoader, plugins: $plugins);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Prepare Framework namespace for the PHPStan update in https://github.com/shopware/shopware/pull/15179

### 2. What does this change do, exactly?

Fix PHPStan issues

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
