### PR TITLE
test: fix flaky DocumentControllerTest

### DIFF
--- a/tests/integration/Storefront/Controller/DocumentControllerTest.php
+++ b/tests/integration/Storefront/Controller/DocumentControllerTest.php
@@ -56,9 +56,13 @@ class DocumentControllerTest extends TestCase
 
     private Context $context;
 
+    private DocumentGenerator $documentGenerator;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->documentGenerator = static::getContainer()->get(DocumentGenerator::class);
 
         $this->context = Context::createDefaultContext();
 
@@ -96,7 +100,7 @@ class DocumentControllerTest extends TestCase
 
         $operation = new DocumentGenerateOperation($orderId, FileTypes::PDF, [], null, true);
 
-        $document = static::getContainer()->get(DocumentGenerator::class)->generate(
+        $document = $this->documentGenerator->generate(
             InvoiceRenderer::TYPE,
             [$operation->getOrderId() => $operation],
             $context,
@@ -115,7 +119,7 @@ class DocumentControllerTest extends TestCase
 
         $request->query->set('extension', 'pdf');
 
-        $documentIdStruct = static::getContainer()->get(DocumentGenerator::class)->upload(
+        $documentIdStruct = $this->documentGenerator->upload(
             $document->getId(),
             $context,
             $request
@@ -145,6 +149,9 @@ class DocumentControllerTest extends TestCase
         static::assertSame(404, $browser->getResponse()->getStatusCode());
     }
 
+    /**
+     * @param array<string, string> $operationConfig
+     */
     #[DataProvider('provideFileTypeParams')]
     public function testDownloadDocument(
         string $documentType,
@@ -153,21 +160,27 @@ class DocumentControllerTest extends TestCase
         ?string $pathParameter,
         ?string $queryParameter,
         ?string $acceptHeader = null,
+        array $operationConfig = [],
     ): void {
         $context = Context::createDefaultContext();
 
         $cart = $this->generateDemoCart(1);
         $orderId = $this->persistCart($cart);
 
-        $operation = new DocumentGenerateOperation($orderId);
+        $operation = new DocumentGenerateOperation($orderId, FileTypes::PDF, $operationConfig);
 
-        $document = static::getContainer()->get(DocumentGenerator::class)->generate(
+        $result = $this->documentGenerator->generate(
             $documentType,
             [$operation->getOrderId() => $operation],
             $context,
-        )->getSuccess()->first();
+        );
 
-        static::assertNotNull($document);
+        $document = $result->getSuccess()->first();
+
+        static::assertNotNull($document, implode(', ', array_map(
+            static fn (\Throwable $e) => $e->getMessage(),
+            $result->getErrors(),
+        )));
 
         $browser = $this->login(self::CUSTOMER_EMAIL_ADDRESS);
 
@@ -219,6 +232,22 @@ class DocumentControllerTest extends TestCase
             'expectedContentType' => ZugferdRenderer::FILE_CONTENT_TYPE,
             'pathParameter' => ZugferdRenderer::FILE_EXTENSION,
             'queryParameter' => null,
+            'acceptHeader' => null,
+            'operationConfig' => [
+                'vatId' => 'DE123456789',
+                'bankBic' => 'DEUTDEDBFRA',
+                'bankIban' => 'DE89370400440532013000',
+                'bankName' => 'Deutsche Bank',
+                'taxOffice' => 'Finanzamt Musterstadt',
+                'companyUrl' => 'https://www.shopware.com',
+                'companyName' => 'Example Company',
+                'companyEmail' => 'mail@shopware.com',
+                'companyPhone' => '+49 123 4567890',
+                'paymentDueDate' => '+30 days',
+                'executiveDirector' => 'Max Mustermann',
+                'placeOfFulfillment' => 'Musterstadt',
+                'placeOfJurisdiction' => 'Musterstadt',
+            ],
         ];
 
         yield 'without params pdf should be returned' => [
@@ -248,7 +277,7 @@ class DocumentControllerTest extends TestCase
 
         $operation = new DocumentGenerateOperation($orderId);
 
-        $document = static::getContainer()->get(DocumentGenerator::class)->generate(
+        $document = $this->documentGenerator->generate(
             InvoiceRenderer::TYPE,
             [$operation->getOrderId() => $operation],
             $context,


### PR DESCRIPTION
### 1. Why is this change necessary?
This test is breaking the nightly with `seed 1774230033`
https://github.com/shopware/shopware/actions/runs/23417755910/job/68116474709

```
There was 1 failure:

1) Shopware\Tests\Integration\Storefront\Controller\DocumentControllerTest::testDownloadDocument with data set "with path param xml" ('zugferd_invoice', 'xml', 'application/xml', 'xml', null)
Failed asserting that null is not null.

/home/runner/work/shopware/shopware/tests/integration/Storefront/Controller/DocumentControllerTest.php:170
```

This is happening because ZugferdRenderer::createDocument() catches DocumentException silently (adds it to errors, not success). The ZugferdDocumentValidator requires seller data (company name, VAT ID, bank details, etc.) to pass XRechnung 3 validation. The 'with path param xml' data provider entry had no operationConfig, so $operationConfig defaulted to [], the config was empty, and the validator threw DocumentException::electronicInvoiceViolation().

### 2. What does this change do, exactly?

- highlight hidden error message
- provide missing configuration
- simplify readability with a property

Would that still fail, this time we will have more than a failure of document null, we will get the error messages


### 3. Describe each step to reproduce the issue or behaviour.

Run the tests (all integration suite) with the seed `1774230033`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
