### PR TITLE
fix: number ranges starting from zero (backport 6.6.x)

### DIFF
--- a/src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
+++ b/src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
@@ -78,12 +78,12 @@ class NumberRangeValueGenerator implements NumberRangeValueGeneratorInterface
     }
 
     /**
-     * @return array{id: string, pattern: string, start: ?int}
+     * @return array{id: string, pattern: string, start: int}
      */
     private function getConfiguration(string $definition, ?string $salesChannelId): array
     {
         if ($salesChannelId) {
-            /** @var array{id: string, pattern: string, start: ?int}|false $config */
+            /** @var array{id: string, pattern: string, start: int}|false $config */
             $config = $this->connection->fetchAssociative('
                 SELECT LOWER(HEX(`number_range`.`id`)) AS `id`, `number_range`.`pattern`, `number_range`.`start`
                 FROM number_range
@@ -95,7 +95,7 @@ class NumberRangeValueGenerator implements NumberRangeValueGeneratorInterface
                 ORDER BY number_range.global ASC, number_range_type.global ASC
             ', ['typeName' => $definition, 'salesChannelId' => Uuid::fromHexToBytes($salesChannelId)]);
         } else {
-            /** @var array{id: string, pattern: string, start: ?int}|false $config */
+            /** @var array{id: string, pattern: string, start: int}|false $config */
             $config = $this->connection->fetchAssociative('
                 SELECT LOWER(HEX(`number_range`.`id`)) AS `id`, `number_range`.`pattern`, `number_range`.`start`
                 FROM number_range
@@ -109,9 +109,7 @@ class NumberRangeValueGenerator implements NumberRangeValueGeneratorInterface
             throw new NoConfigurationException($definition, $salesChannelId);
         }
 
-        if ($config['start']) {
-            $config['start'] = (int) $config['start'];
-        }
+        $config['start'] = (int) $config['start'];
 
         return $config;
     }

--- a/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementSqlStorage.php
+++ b/src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementSqlStorage.php
@@ -7,7 +7,13 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Integration\Core\System\NumberRange\ValueGenerator\IncrementSqlStorageTest;
 
+/**
+ * @codeCoverageIgnore tested via integration test,
+ *
+ * @see IncrementSqlStorageTest
+ */
 #[Package('framework')]
 class IncrementSqlStorage extends AbstractIncrementStorage
 {
@@ -56,9 +62,9 @@ class IncrementSqlStorage extends AbstractIncrementStorage
         );
         $lastNumber = $result->fetchOne();
 
-        $start = $config['start'] ?? 1;
+        $start = (int) ($config['start'] ?? 1);
 
-        if (!$lastNumber || (int) $lastNumber < $start) {
+        if ($lastNumber === false || (int) $lastNumber < $start) {
             $nextNumber = $start;
         } else {
             $nextNumber = $lastNumber + 1;

--- a/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
+++ b/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
@@ -4,21 +4,16 @@ namespace Shopware\Tests\Integration\Core\System\NumberRange;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
 use Shopware\Core\System\NumberRange\NumberRangeCollection;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
-use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternDate;
-use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternIncrement;
-use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry;
 
 /**
  * @internal
@@ -37,42 +32,6 @@ class NumberRangeValueGeneratorTest extends TestCase
         $this->connection = static::getContainer()->get(Connection::class);
         $this->setupDatabase();
         $this->context = Context::createDefaultContext();
-    }
-
-    public function testGenerateStandardPattern(): void
-    {
-        $value = $this->getGenerator('Pre_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_5_suf', $value);
-    }
-
-    public function testGenerateDatePattern(): void
-    {
-        $value = $this->getGenerator('Pre_{date}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_suf', $value);
-    }
-
-    public function testGenerateDateWithFormatPattern(): void
-    {
-        $value = $this->getGenerator('Pre_{date_ymd}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals('Pre_' . date('ymd') . '_suf', $value);
-    }
-
-    public function testGenerateAllPatterns(): void
-    {
-        $value = $this->getGenerator('Pre_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals(
-            'Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
-            $value
-        );
-    }
-
-    public function testGenerateExtraCharsAllPatterns(): void
-    {
-        $value = $this->getGenerator('Pre_!"§$%&/()=_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, $this->context, null);
-        static::assertEquals(
-            'Pre_!"§$%&/()=_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
-            $value
-        );
     }
 
     public function testGetConfiguration(): void
@@ -136,24 +95,27 @@ class NumberRangeValueGeneratorTest extends TestCase
         static::assertEquals('20000', $value);
     }
 
-    private function getGenerator(string $pattern): NumberRangeValueGenerator
+    public function testGetValueStartingFromZero(): void
     {
-        $incrPattern = $this->createMock(ValueGeneratorPatternIncrement::class);
-        $incrPattern->method('getPatternId')->willReturn('n');
-        $incrPattern->method('generate')->willReturn('5');
+        /** @var NumberRangeValueGenerator $realGenerator */
+        $realGenerator = static::getContainer()->get(NumberRangeValueGeneratorInterface::class);
 
-        $patternReg = new ValueGeneratorPatternRegistry([$incrPattern, new ValueGeneratorPatternDate()]);
+        /** @var EntityRepository<NumberRangeCollection> $numberRange */
+        $numberRange = static::getContainer()->get('number_range.repository');
 
-        $connection = $this->createMock(Connection::class);
-        $connection->expects($this->once())
-            ->method('fetchAssociative')
-            ->willReturn(['id' => Uuid::randomHex(), 'pattern' => $pattern, 'start' => 1]);
+        $search = $numberRange->search((new Criteria())->addFilter(new EqualsFilter('type.technicalName', 'order')), $this->context)
+            ->getEntities()
+            ->first();
 
-        return new NumberRangeValueGenerator(
-            $patternReg,
-            static::getContainer()->get('event_dispatcher'),
-            $connection,
-        );
+        static::assertNotNull($search);
+
+        static::getContainer()->get('number_range.repository')->update([[
+            'id' => $search->getId(),
+            'start' => 0,
+        ]], $this->context);
+
+        $value = $realGenerator->getValue('order', $this->context, Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
+        static::assertSame('0', $value);
     }
 
     private function setupDatabase(): void

--- a/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
+++ b/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
@@ -56,6 +56,32 @@ class IncrementSqlStorageTest extends TestCase
         static::assertEquals(12, $this->storage->reserve($config));
     }
 
+    public function testReserveReturnsWithZeroStartValues(): void
+    {
+        $config = [
+            'id' => Uuid::randomHex(),
+            'start' => 0,
+            'pattern' => 'n',
+        ];
+
+        $this->storage->set($config['id'], 0);
+
+        static::assertSame(1, $this->storage->reserve($config));
+        static::assertSame(2, $this->storage->reserve($config));
+    }
+
+    public function testReserveReturnsWithZeroStartValuesAndNoValueStored(): void
+    {
+        $config = [
+            'id' => Uuid::randomHex(),
+            'start' => 0,
+            'pattern' => 'n',
+        ];
+
+        static::assertSame(0, $this->storage->reserve($config));
+        static::assertSame(1, $this->storage->reserve($config));
+    }
+
     public function testReserveReturnsWithoutStartAndUnset(): void
     {
         $config = [
@@ -116,6 +142,32 @@ class IncrementSqlStorageTest extends TestCase
 
         static::assertEquals(10, $this->storage->preview($config));
         static::assertEquals(10, $this->storage->preview($config));
+    }
+
+    public function testPreviewReturnsWithZeroStartValues(): void
+    {
+        $config = [
+            'id' => Uuid::randomHex(),
+            'start' => 0,
+            'pattern' => 'n',
+        ];
+
+        $this->storage->set($config['id'], 0);
+
+        static::assertSame(1, $this->storage->preview($config));
+        static::assertSame(1, $this->storage->preview($config));
+    }
+
+    public function testPreviewReturnsWithZeroStartValuesAndNoValueStored(): void
+    {
+        $config = [
+            'id' => Uuid::randomHex(),
+            'start' => 0,
+            'pattern' => 'n',
+        ];
+
+        static::assertSame(0, $this->storage->preview($config));
+        static::assertSame(0, $this->storage->preview($config));
     }
 
     public function testPreviewWillReturnStartValueIfItHigherThanCurrentIncrementValue(): void

--- a/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
@@ -40,7 +40,6 @@ class ErrorResponseFactoryTest extends TestCase
             ? $data['errors'][0]['trace']
             : $data['errors'][0]['meta']['trace'];
 
-
         static::assertSame(\PHPUnit\Metadata\Api\DataProvider::class, $stack[1]['class']);
         static::assertSame('dataProvidedByMethods', $stack[1]['function']);
 

--- a/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/tests/unit/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
@@ -40,8 +40,6 @@ class ErrorResponseFactoryTest extends TestCase
             ? $data['errors'][0]['trace']
             : $data['errors'][0]['meta']['trace'];
 
-        static::assertSame(self::class, $stack[0]['class']);
-        static::assertSame('getResponseFromExceptionProvider', $stack[0]['function']);
 
         static::assertSame(\PHPUnit\Metadata\Api\DataProvider::class, $stack[1]['class']);
         static::assertSame('dataProvidedByMethods', $stack[1]['function']);

--- a/tests/unit/Core/System/NumberRange/ValueGenerator/NumberRangeValueGeneratorTest.php
+++ b/tests/unit/Core/System/NumberRange/ValueGenerator/NumberRangeValueGeneratorTest.php
@@ -1,0 +1,145 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\NumberRange\ValueGenerator;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\NumberRange\NumberRangeEvents;
+use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementSqlStorage;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternDate;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternIncrement;
+use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(NumberRangeValueGenerator::class)]
+class NumberRangeValueGeneratorTest extends TestCase
+{
+    public function testGeneratedNumberValue(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'id' => Uuid::randomHex(),
+                'pattern' => 'ABC{n}',
+                'start' => 0,
+            ]);
+
+        $result = $this->createMock(Result::class);
+        $result->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn('1');
+
+        $connection->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($result);
+
+        $numberRangeValueGenerator = new NumberRangeValueGenerator(
+            new ValueGeneratorPatternRegistry([
+                new ValueGeneratorPatternIncrement(
+                    new IncrementSqlStorage($connection),
+                ),
+            ]),
+            $dispatcher,
+            $connection,
+        );
+
+        $value = $numberRangeValueGenerator->getValue(OrderDefinition::ENTITY_NAME, Context::createDefaultContext(), null, false);
+        static::assertSame('ABC1', $value);
+    }
+
+    public function testGeneratedEventIsDispatched(): void
+    {
+        $dispatcher = new EventDispatcher();
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn([
+                'id' => Uuid::randomHex(),
+                'pattern' => '{n}',
+                'start' => 0,
+            ]);
+
+        $numberRangeValueGenerator = new NumberRangeValueGenerator(
+            new ValueGeneratorPatternRegistry([]),
+            $dispatcher,
+            $connection,
+        );
+
+        $post = $this->createMock(CallableClass::class);
+        $post->expects($this->exactly(1))->method('__invoke');
+        $dispatcher->addListener(NumberRangeEvents::NUMBER_RANGE_GENERATED, $post);
+
+        $numberRangeValueGenerator->getValue(OrderDefinition::ENTITY_NAME, Context::createDefaultContext(), null, false);
+    }
+
+    public function testGenerateStandardPattern(): void
+    {
+        $value = $this->getGenerator('Pre_{n}_suf')->getValue(ProductDefinition::class, Context::createDefaultContext(), null);
+        static::assertSame('Pre_5_suf', $value);
+    }
+
+    public function testGenerateDatePattern(): void
+    {
+        $value = $this->getGenerator('Pre_{date}_suf')->getValue(ProductDefinition::class, Context::createDefaultContext(), null);
+        static::assertSame('Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_suf', $value);
+    }
+
+    public function testGenerateDateWithFormatPattern(): void
+    {
+        $value = $this->getGenerator('Pre_{date_ymd}_suf')->getValue(ProductDefinition::class, Context::createDefaultContext(), null);
+        static::assertSame('Pre_' . date('ymd') . '_suf', $value);
+    }
+
+    public function testGenerateAllPatterns(): void
+    {
+        $value = $this->getGenerator('Pre_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, Context::createDefaultContext(), null);
+        static::assertSame(
+            'Pre_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
+            $value
+        );
+    }
+
+    public function testGenerateExtraCharsAllPatterns(): void
+    {
+        $value = $this->getGenerator('Pre_!"§$%&/()=_{date}_{date_ymd}_{n}_suf')->getValue(ProductDefinition::class, Context::createDefaultContext(), null);
+        static::assertSame(
+            'Pre_!"§$%&/()=_' . date(ValueGeneratorPatternDate::STANDARD_FORMAT) . '_' . date('ymd') . '_5_suf',
+            $value
+        );
+    }
+
+    private function getGenerator(string $pattern): NumberRangeValueGenerator
+    {
+        $incrPattern = $this->createMock(ValueGeneratorPatternIncrement::class);
+        $incrPattern->method('getPatternId')->willReturn('n');
+        $incrPattern->method('generate')->willReturn('5');
+
+        $patternReg = new ValueGeneratorPatternRegistry([$incrPattern, new ValueGeneratorPatternDate()]);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAssociative')
+            ->willReturn(['id' => Uuid::randomHex(), 'pattern' => $pattern, 'start' => 1]);
+
+        return new NumberRangeValueGenerator(
+            $patternReg,
+            new EventDispatcher(),
+            $connection,
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Backport of https://github.com/shopware/shopware/pull/15711

By design i didn't backport the deprecation and the change of the exception