### PR TITLE
fix: Add specific ACL checks for routes that render twig templates

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -170,6 +170,10 @@ This information is used to enrich the generated OpenAPI schema with `enum` valu
 By default, `Choice` is non-strict and does not affect write validation.
 If you want to enforce values on write, set `strict: true` when creating the flag; the write layer will then validate the input for supported field types (string, int, float).
 
+### Deprecated `/api/_action/mail-template/validate` route
+
+The `/api/_action/mail-template/validate` route is deprecated and will be removed without replacement in v6.8.0.0, as it was not used and did not provide any significant value.
+
 ## Core
 
 ### Changed behaviour of default fields in EntityDefinition

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -55,6 +55,10 @@ The following methods are now abstract and must be implemented by extensions. Th
 - `confirmWithResponse()` returns `SuccessResponse`
 - `unsubscribeWithResponse()` returns `SuccessResponse`
 
+## Removed `/api/_action/mail-template/validate` route
+
+The `/api/_action/mail-template/validate` route has been removed without replacement, as it was not used and did not provide any significant value.
+
 </details>
 
 # Core

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -162,6 +162,10 @@ export default {
             };
         },
 
+        previewAllowed() {
+            return !this.isLoading && !this.showPreview && this.hasTemplateData && this.acl.can('mail_templates.editor')
+        },
+
         showPreview() {
             if (
                 this.mailTemplate.contentHtml === undefined ||

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -163,7 +163,7 @@ export default {
         },
 
         previewAllowed() {
-            return !this.isLoading && !this.showPreview && this.hasTemplateData && this.acl.can('mail_templates.editor')
+            return !this.isLoading && !this.showPreview && this.hasTemplateData && this.acl.can('mail_templates.editor');
         },
 
         showPreview() {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -427,7 +427,7 @@
             <sw-sidebar-item
                 icon="regular-eye"
                 :title="$tc('sw-mail-template.detail.sidebar.titleShowPreview')"
-                :disabled="isLoading || showPreview || !hasTemplateData || !acl.can('mail_templates.editor')"
+                :disabled="!previewAllowed"
                 class="sw-mail-template-detail__show-preview-sidebar"
                 @click="onClickShowPreview"
             />

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -427,7 +427,7 @@
             <sw-sidebar-item
                 icon="regular-eye"
                 :title="$tc('sw-mail-template.detail.sidebar.titleShowPreview')"
-                :disabled="isLoading || showPreview || !hasTemplateData"
+                :disabled="isLoading || showPreview || !hasTemplateData || !acl.can('mail_templates.editor')"
                 class="sw-mail-template-detail__show-preview-sidebar"
                 @click="onClickShowPreview"
             />

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -66,7 +66,8 @@ class MailActionController extends AbstractController
     #[Route(
         path: '/api/_action/mail-template/validate',
         name: 'api.action.mail_template.validate',
-        methods: [Request::METHOD_POST]
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['mail_template:update']],
+        methods: [Request::METHOD_POST],
     )]
     public function validate(RequestDataBag $post, Context $context): JsonResponse
     {
@@ -80,6 +81,7 @@ class MailActionController extends AbstractController
     #[Route(
         path: '/api/_action/mail-template/build',
         name: 'api.action.mail_template.build',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['mail_template:update']],
         methods: [Request::METHOD_POST]
     )]
     public function build(RequestDataBag $post, Context $context): JsonResponse

--- a/src/Core/Content/MailTemplate/Api/MailActionController.php
+++ b/src/Core/Content/MailTemplate/Api/MailActionController.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\MailTemplate\MailTemplateException;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -63,6 +64,9 @@ class MailActionController extends AbstractController
         return new JsonResponse(['size' => mb_strlen($message ? $message->toString() : '')]);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
+     */
     #[Route(
         path: '/api/_action/mail-template/validate',
         name: 'api.action.mail_template.validate',
@@ -71,6 +75,11 @@ class MailActionController extends AbstractController
     )]
     public function validate(RequestDataBag $post, Context $context): JsonResponse
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The API endpoint "/api/_action/mail-template/validate" is deprecated and will be removed in v6.8.0.0 without replacement.'
+        );
+
         $this->templateRenderer->initialize();
         $this->templateRenderer->render($post->get('contentHtml', ''), [], $context);
         $this->templateRenderer->render($post->get('contentPlain', ''), [], $context);

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -57,7 +57,12 @@ class SeoActionController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/seo-url-template/validate', name: 'api.seo-url-template.validate', methods: ['POST'])]
+    #[Route(
+        path: '/api/_action/seo-url-template/validate',
+        name: 'api.seo-url-template.validate',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo-url-template:update']],
+        methods: ['POST']
+    )]
     public function validate(Request $request, Context $context): JsonResponse
     {
         $context->setConsiderInheritance(true);
@@ -71,7 +76,12 @@ class SeoActionController extends AbstractController
         return new JsonResponse();
     }
 
-    #[Route(path: '/api/_action/seo-url-template/preview', name: 'api.seo-url-template.preview', methods: ['POST'])]
+    #[Route(
+        path: '/api/_action/seo-url-template/preview',
+        name: 'api.seo-url-template.preview',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo-url-template:update']],
+        methods: ['POST']
+    )]
     public function preview(Request $request, Context $context): Response
     {
         $this->validateSeoUrlTemplate($request);

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -61,7 +61,7 @@ class SeoActionController extends AbstractController
         path: '/api/_action/seo-url-template/validate',
         name: 'api.seo-url-template.validate',
         defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo-url-template:update']],
-        methods: ['POST']
+        methods: [Request::METHOD_POST]
     )]
     public function validate(Request $request, Context $context): JsonResponse
     {
@@ -80,7 +80,7 @@ class SeoActionController extends AbstractController
         path: '/api/_action/seo-url-template/preview',
         name: 'api.seo-url-template.preview',
         defaults: [PlatformRequest::ATTRIBUTE_ACL => ['seo-url-template:update']],
-        methods: ['POST']
+        methods: [Request::METHOD_POST]
     )]
     public function preview(Request $request, Context $context): Response
     {
@@ -109,7 +109,7 @@ class SeoActionController extends AbstractController
         return new JsonResponse($preview);
     }
 
-    #[Route(path: '/api/_action/seo-url-template/context', name: 'api.seo-url-template.context', methods: ['POST'])]
+    #[Route(path: '/api/_action/seo-url-template/context', name: 'api.seo-url-template.context', methods: [Request::METHOD_POST])]
     public function getSeoUrlContext(RequestDataBag $data, Context $context): JsonResponse
     {
         $routeName = $data->get('routeName');
@@ -141,7 +141,7 @@ class SeoActionController extends AbstractController
         return new JsonResponse($mapping->getSeoPathInfoContext());
     }
 
-    #[Route(path: '/api/_action/seo-url/canonical', name: 'api.seo-url.canonical', methods: ['PATCH'])]
+    #[Route(path: '/api/_action/seo-url/canonical', name: 'api.seo-url.canonical', methods: [Request::METHOD_PATCH])]
     public function updateCanonicalUrl(RequestDataBag $seoUrl, Context $context): Response
     {
         if (!$seoUrl->has('routeName')) {
@@ -186,7 +186,7 @@ class SeoActionController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/seo-url/create-custom-url', name: 'api.seo-url.create', methods: ['POST'])]
+    #[Route(path: '/api/_action/seo-url/create-custom-url', name: 'api.seo-url.create', methods: [Request::METHOD_POST])]
     public function createCustomSeoUrls(RequestDataBag $dataBag, Context $context): Response
     {
         /** @var ParameterBag $dataBag */
@@ -243,7 +243,7 @@ class SeoActionController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/seo-url-template/default/{routeName}', name: 'api.seo-url-template.default', methods: ['GET'])]
+    #[Route(path: '/api/_action/seo-url-template/default/{routeName}', name: 'api.seo-url-template.default', methods: [Request::METHOD_GET])]
     public function getDefaultSeoTemplate(string $routeName, Context $context): JsonResponse
     {
         $seoUrlRoute = $this->seoUrlRouteRegistry->findByRouteName($routeName);

--- a/src/Core/Framework/Store/Api/FirstRunWizardController.php
+++ b/src/Core/Framework/Store/Api/FirstRunWizardController.php
@@ -38,7 +38,7 @@ class FirstRunWizardController extends AbstractController
     ) {
     }
 
-    #[Route(path: '/api/_action/store/frw/start', name: 'api.custom.store.frw.start', methods: ['POST'])]
+    #[Route(path: '/api/_action/store/frw/start', name: 'api.custom.store.frw.start', methods: [Request::METHOD_POST])]
     public function frwStart(Context $context): JsonResponse
     {
         try {
@@ -50,7 +50,7 @@ class FirstRunWizardController extends AbstractController
         return new JsonResponse();
     }
 
-    #[Route(path: '/api/_action/store/language-plugins', name: 'api.custom.store.language-plugins', methods: ['GET'])]
+    #[Route(path: '/api/_action/store/language-plugins', name: 'api.custom.store.language-plugins', methods: [Request::METHOD_GET])]
     public function getLanguagePluginList(Context $context): JsonResponse
     {
         $plugins = $this->pluginRepo->search(new Criteria(), $context)->getEntities();
@@ -68,7 +68,7 @@ class FirstRunWizardController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/store/demo-data-plugins', name: 'api.custom.store.demo-data-plugins', methods: ['GET'])]
+    #[Route(path: '/api/_action/store/demo-data-plugins', name: 'api.custom.store.demo-data-plugins', methods: [Request::METHOD_GET])]
     public function getDemoDataPluginList(Context $context): JsonResponse
     {
         $plugins = $this->pluginRepo->search(new Criteria(), $context)->getEntities();
@@ -86,7 +86,7 @@ class FirstRunWizardController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/store/recommendation-regions', name: 'api.custom.store.recommendation-regions', methods: ['GET'])]
+    #[Route(path: '/api/_action/store/recommendation-regions', name: 'api.custom.store.recommendation-regions', methods: [Request::METHOD_GET])]
     public function getRecommendationRegions(Context $context): JsonResponse
     {
         try {
@@ -101,7 +101,7 @@ class FirstRunWizardController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/store/recommendations', name: 'api.custom.store.recommendations', methods: ['GET'])]
+    #[Route(path: '/api/_action/store/recommendations', name: 'api.custom.store.recommendations', methods: [Request::METHOD_GET])]
     public function getRecommendations(Request $request, Context $context): JsonResponse
     {
         $region = $request->query->has('region') ? (string) $request->query->get('region') : null;
@@ -122,7 +122,12 @@ class FirstRunWizardController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/store/frw/login', name: 'api.custom.store.frw.login', methods: ['POST'])]
+    #[Route(
+        path: '/api/_action/store/frw/login',
+        name: 'api.custom.store.frw.login',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['system_config:update']],
+        methods: [Request::METHOD_POST]
+    )]
     public function frwLogin(RequestDataBag $requestDataBag, Context $context): JsonResponse
     {
         $shopwareId = $requestDataBag->get('shopwareId');
@@ -141,7 +146,7 @@ class FirstRunWizardController extends AbstractController
         return new JsonResponse();
     }
 
-    #[Route(path: '/api/_action/store/license-domains', name: 'api.custom.store.license-domains', methods: ['GET'])]
+    #[Route(path: '/api/_action/store/license-domains', name: 'api.custom.store.license-domains', methods: [Request::METHOD_GET])]
     public function getDomainList(Context $context): JsonResponse
     {
         try {
@@ -156,7 +161,12 @@ class FirstRunWizardController extends AbstractController
         ]);
     }
 
-    #[Route(path: '/api/_action/store/verify-license-domain', name: 'api.custom.store.verify-license-domain', methods: ['POST'])]
+    #[Route(
+        path: '/api/_action/store/verify-license-domain',
+        name: 'api.custom.store.verify-license-domain',
+        defaults: [PlatformRequest::ATTRIBUTE_ACL => ['system_config:update']],
+        methods: [Request::METHOD_POST]
+    )]
     public function verifyDomain(QueryDataBag $params, Context $context): JsonResponse
     {
         $domain = $params->get('domain') ?? '';
@@ -171,7 +181,7 @@ class FirstRunWizardController extends AbstractController
         return new JsonResponse(['data' => $domainStruct]);
     }
 
-    #[Route(path: '/api/_action/store/frw/finish', name: 'api.custom.store.frw.finish', methods: ['POST'])]
+    #[Route(path: '/api/_action/store/frw/finish', name: 'api.custom.store.frw.finish', methods: [Request::METHOD_POST])]
     public function frwFinish(QueryDataBag $params, Context $context): JsonResponse
     {
         $failed = $params->getBoolean('failed');


### PR DESCRIPTION
### 1. Why is this change necessary?
There was no specific ACL on routes that do render twig templates

### 2. What does this change do, exactly?
Add the ACLs
