### PR TITLE
fix: backport cms media custom field mapping to 6.6 #14648

### DIFF
--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -256,7 +256,6 @@ const missingTests = [
     'src/module/sw-cms/constant/sw-cms.constant.ts',
     'src/module/sw-cms/blocks/index.ts',
     'src/module/sw-cms/component/index.ts',
-    'src/module/sw-cms/component/sw-cms-mapping-field/index.ts',
     'src/module/sw-cms/component/sw-cms-page-select/index.ts',
     'src/module/sw-cms/component/sw-cms-product-box-preview/index.ts',
     'src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/index.ts',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/index.ts
@@ -11,7 +11,10 @@ export default Shopware.Component.wrapComponentConfig({
 
     compatConfig: Shopware.compatConfig,
 
-    inject: ['cmsService'],
+    inject: [
+        'cmsService',
+        'repositoryFactory',
+    ],
 
     props: {
         config: {
@@ -39,7 +42,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         entity: {
-            type: String,
+            type: String as PropType<Extract<keyof EntitySchema.Entities, string> | null>,
             required: false,
             default: null,
         },
@@ -56,6 +59,7 @@ export default Shopware.Component.wrapComponentConfig({
             mappingTypes: {} as unknown,
             allowedMappingTypes: [] as string[],
             demoValue: null as unknown,
+            demoValueFetchId: 0,
         };
     },
 
@@ -92,7 +96,7 @@ export default Shopware.Component.wrapComponentConfig({
 
         'cmsPageState.currentDemoEntity': {
             handler() {
-                this.updateDemoValue();
+                void this.updateDemoValue();
             },
         },
     },
@@ -104,7 +108,7 @@ export default Shopware.Component.wrapComponentConfig({
     methods: {
         createdComponent() {
             this.updateMappingTypes();
-            this.updateDemoValue();
+            void this.updateDemoValue();
         },
 
         updateMappingTypes() {
@@ -122,21 +126,47 @@ export default Shopware.Component.wrapComponentConfig({
             }
         },
 
-        updateDemoValue() {
+        async updateDemoValue() {
             if (this.config.source !== 'mapped') {
+                this.demoValueFetchId += 1;
+                this.demoValue = null;
+
                 return;
             }
 
-            this.demoValue = this.getDemoValue(this.config.value as string);
+            const fetchId = this.demoValueFetchId + 1;
+            this.demoValueFetchId = fetchId;
+
+            const demoValue = this.getDemoValue(this.config.value as string);
+            this.demoValue = demoValue;
+
+            if (this.valueTypes !== 'entity' || this.entity === null || typeof demoValue !== 'string') {
+                return;
+            }
+
+            try {
+                const entity = await this.repositoryFactory.create(this.entity).get(demoValue, Shopware.Context.api);
+
+                if (fetchId !== this.demoValueFetchId || !entity) {
+                    return;
+                }
+
+                this.demoValue = entity;
+            } catch {
+                if (fetchId === this.demoValueFetchId) {
+                    this.demoValue = demoValue;
+                }
+            }
         },
 
         onMappingSelect(property: string) {
             this.config.source = 'mapped';
             this.config.value = property;
-            this.demoValue = this.getDemoValue(property);
+            void this.updateDemoValue();
         },
 
         onMappingRemove() {
+            this.demoValueFetchId += 1;
             this.config.source = 'static';
             this.config.value = this.config.type === Array ? [] : null;
             this.demoValue = null;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.spec.js
@@ -1,0 +1,86 @@
+/**
+ * @sw-package discovery
+ */
+import { flushPromises, mount } from '@vue/test-utils';
+import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
+
+const mediaEntity = {
+    id: 'media-id',
+    url: 'http://shopware.com/custom-field-image.jpg',
+};
+
+async function createWrapper(config = { source: 'mapped', value: 'category.customFields.heroImage' }) {
+    return mount(
+        await wrapTestComponent('sw-cms-mapping-field', {
+            sync: true,
+        }),
+        {
+            props: {
+                config,
+                valueTypes: 'entity',
+                entity: 'media',
+                label: 'Media',
+            },
+            global: {
+                provide: {
+                    cmsService: Shopware.Service('cmsService'),
+                    repositoryFactory: {
+                        create: () => ({
+                            get: jest.fn().mockResolvedValue(mediaEntity),
+                        }),
+                    },
+                },
+                stubs: {
+                    'sw-context-button': true,
+                    'sw-context-menu-item': true,
+                    'mt-icon': true,
+                    'mt-banner': true,
+                },
+            },
+        },
+    );
+}
+
+describe('src/module/sw-cms/component/sw-cms-mapping-field', () => {
+    beforeAll(async () => {
+        await setupCmsEnvironment();
+    });
+
+    beforeEach(() => {
+        const cmsPageStore = Shopware.Store.get('cmsPage');
+        cmsPageStore.setCurrentMappingEntity('category');
+        cmsPageStore.setCurrentMappingTypes({
+            entity: {
+                media: ['category.customFields.heroImage'],
+            },
+        });
+        cmsPageStore.setCurrentDemoEntity({
+            customFields: {
+                heroImage: 'media-id',
+            },
+        });
+    });
+
+    it('resolves mapped media ids to media entities for entity previews', async () => {
+        const wrapper = await createWrapper();
+
+        await flushPromises();
+
+        expect(wrapper.vm.demoValue).toEqual(mediaEntity);
+    });
+
+    it('keeps object demo values unchanged', async () => {
+        Shopware.Store.get('cmsPage').setCurrentDemoEntity({
+            media: mediaEntity,
+        });
+
+        const wrapper = await createWrapper({
+            source: 'mapped',
+            value: 'category.media',
+        });
+
+        await flushPromises();
+
+        expect(wrapper.vm.demoValue).toEqual(mediaEntity);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.spec.js
@@ -33,8 +33,8 @@ async function createWrapper(config = { source: 'mapped', value: 'category.custo
                 stubs: {
                     'sw-context-button': true,
                     'sw-context-menu-item': true,
-                    'mt-icon': true,
-                    'mt-banner': true,
+                    'sw-icon': true,
+                    'sw-alert': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/component.spec.js
@@ -2,7 +2,7 @@
  * @sw-package discovery
  */
 
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 
 const mediaDataMock = {
@@ -19,6 +19,11 @@ async function createWrapper() {
             global: {
                 provide: {
                     cmsService: Shopware.Service('cmsService'),
+                    repositoryFactory: {
+                        create: () => ({
+                            get: jest.fn().mockResolvedValue(mediaDataMock),
+                        }),
+                    },
                 },
             },
             props: {
@@ -122,5 +127,34 @@ describe('src/module/sw-cms/elements/image/component', () => {
         expect(img.attributes('src')).toBe(
             wrapper.vm.assetFilter('administration/static/img/cms/preview_mountain_large.jpg'),
         );
+    });
+
+    it('should resolve mapped media ids from custom fields', async () => {
+        Shopware.Store.get('cmsPage').setCurrentDemoEntity({
+            customFields: {
+                heroImage: '1',
+            },
+        });
+
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            element: {
+                type: 'image',
+                config: {
+                    ...wrapper.props().element.config,
+                    media: {
+                        source: 'mapped',
+                        value: 'category.customFields.heroImage',
+                    },
+                },
+                data: {},
+            },
+        });
+
+        await flushPromises();
+
+        const img = wrapper.find('img');
+        expect(img.attributes('src')).toContain(mediaDataMock.url);
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
@@ -13,13 +13,27 @@ export default {
 
     compatConfig: Shopware.compatConfig,
 
-    inject: ['feature'],
+    inject: [
+        'feature',
+        'repositoryFactory',
+    ],
 
     mixins: [
         Mixin.getByName('cms-element'),
     ],
 
+    data() {
+        return {
+            mappedDemoMedia: null,
+            mappedDemoMediaFetchId: 0,
+        };
+    },
+
     computed: {
+        mediaRepository() {
+            return this.repositoryFactory.create('media');
+        },
+
         displayModeClass() {
             if (this.element.config.displayMode.value === 'standard') {
                 return null;
@@ -64,6 +78,10 @@ export default {
                     return demoMedia.url;
                 }
 
+                if (this.mappedDemoMedia?.url) {
+                    return this.mappedDemoMedia.url;
+                }
+
                 return staticFallBackImage;
             }
 
@@ -97,11 +115,13 @@ export default {
         'cmsPageState.currentDemoEntity': {
             handler() {
                 this.updateDemoValue(this.mediaConfigValue);
+                this.updateMappedDemoMedia();
             },
         },
 
         mediaConfigValue(value) {
             this.updateDemoValue(value);
+            this.updateMappedDemoMedia();
         },
     },
 
@@ -113,6 +133,7 @@ export default {
         createdComponent() {
             this.initElementConfig('image');
             this.initElementData('image');
+            this.updateMappedDemoMedia();
         },
 
         updateDemoValue(value) {
@@ -121,6 +142,42 @@ export default {
 
             if (isSourceStatic && mediaId && value !== mediaId) {
                 this.element.config.media.value = mediaId;
+            }
+        },
+
+        async updateMappedDemoMedia() {
+            const fetchId = this.mappedDemoMediaFetchId + 1;
+            this.mappedDemoMediaFetchId = fetchId;
+            this.mappedDemoMedia = null;
+
+            if (this.element?.config?.media?.source !== 'mapped' || !this.mediaConfigValue) {
+                return;
+            }
+
+            const demoMedia = this.getDemoValue(this.mediaConfigValue);
+
+            if (demoMedia?.url) {
+                this.mappedDemoMedia = demoMedia;
+
+                return;
+            }
+
+            if (typeof demoMedia !== 'string') {
+                return;
+            }
+
+            try {
+                const media = await this.mediaRepository.get(demoMedia, Shopware.Context.api);
+
+                if (fetchId !== this.mappedDemoMediaFetchId) {
+                    return;
+                }
+
+                this.mappedDemoMedia = media;
+            } catch {
+                if (fetchId === this.mappedDemoMediaFetchId) {
+                    this.mappedDemoMedia = null;
+                }
             }
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.spec.js
@@ -613,6 +613,14 @@ describe('module/sw-cms/service/cms.service.spec.js', () => {
                         customFieldType: 'datetime',
                     },
                 },
+                {
+                    id: '16a2beeb80f041c29390efa3432760dd',
+                    name: 'custom_media_field',
+                    type: 'text',
+                    config: {
+                        customFieldType: 'media',
+                    },
+                },
             ];
 
             const mockResponses = global.repositoryFactoryMock.responses;
@@ -815,6 +823,9 @@ describe('module/sw-cms/service/cms.service.spec.js', () => {
             await cmsService.addCustomFieldsToMappingTypes('product', mappings);
 
             expect(mappings).toEqual({
+                entity: {
+                    media: ['product.customFields.custom_media_field'],
+                },
                 string: [
                     'product.customFields.custom_text_field',
                     'product.customFields.custom_textarea_field',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -231,11 +231,22 @@ class CmsService {
 
         const customFields = await customFieldRepository.search(criteria, Shopware.Context.api);
         customFields.forEach((customField: Entity<'custom_field'>) => {
-            const propSchema: Property = {
-                type: customField.type,
-            };
+            const customFieldConfig = customField.config as { customFieldType?: string } | undefined;
 
-            this.handlePrimitivesMapping(propSchema, mappings, `${entityName}.customFields`, customField.name);
+            if (customFieldConfig?.customFieldType === 'media') {
+                this.addToMappingEntity(mappings, { entity: 'media' }, `${entityName}.customFields`, customField.name);
+
+                return;
+            }
+
+            this.handlePrimitivesMapping(
+                {
+                    type: customField.type,
+                },
+                mappings,
+                `${entityName}.customFields`,
+                customField.name,
+            );
         });
     }
 

--- a/src/Core/Content/Media/Cms/ImageCmsElementResolver.php
+++ b/src/Core/Content/Media/Cms/ImageCmsElementResolver.php
@@ -38,14 +38,44 @@ class ImageCmsElementResolver extends AbstractCmsElementResolver
 
         if (
             $mediaConfig === null
-            || $mediaConfig->isMapped()
             || $mediaConfig->isDefault()
             || $mediaConfig->getValue() === null
         ) {
             return null;
         }
 
-        $criteria = new Criteria([$mediaConfig->getStringValue()]);
+        $mediaId = null;
+
+        if ($mediaConfig->isMapped()) {
+            if (!$resolverContext instanceof EntityResolverContext) {
+                return null;
+            }
+
+            $mappedMedia = $this->resolveEntityValue($resolverContext->getEntity(), $mediaConfig->getStringValue());
+
+            if ($mappedMedia instanceof MediaEntity) {
+                return null;
+            }
+
+            if (
+                !\is_string($mappedMedia)
+                || $mappedMedia === ''
+            ) {
+                return null;
+            }
+
+            $mediaId = $mappedMedia;
+        }
+
+        if ($mediaConfig->isStatic()) {
+            $mediaId = $mediaConfig->getStringValue();
+        }
+
+        if ($mediaId === null) {
+            return null;
+        }
+
+        $criteria = new Criteria([$mediaId]);
 
         $criteriaCollection = new CriteriaCollection();
         $criteriaCollection->add('media_' . $slot->getUniqueIdentifier(), MediaDefinition::class, $criteria);
@@ -105,6 +135,24 @@ class ImageCmsElementResolver extends AbstractCmsElementResolver
             if ($media instanceof MediaEntity) {
                 $image->setMediaId($media->getUniqueIdentifier());
                 $image->setMedia($media);
+
+                return;
+            }
+
+            if (\is_string($media) && $media !== '') {
+                $image->setMediaId($media);
+
+                $searchResult = $result->get('media_' . $slot->getUniqueIdentifier());
+                if (!$searchResult) {
+                    return;
+                }
+
+                $mappedMedia = $searchResult->get($media);
+                if (!$mappedMedia instanceof MediaEntity) {
+                    return;
+                }
+
+                $image->setMedia($mappedMedia);
             }
         }
 

--- a/src/Core/Content/Media/Cms/YoutubeVideoCmsElementResolver.php
+++ b/src/Core/Content/Media/Cms/YoutubeVideoCmsElementResolver.php
@@ -26,11 +26,39 @@ class YoutubeVideoCmsElementResolver extends AbstractCmsElementResolver
     public function collect(CmsSlotEntity $slot, ResolverContext $resolverContext): ?CriteriaCollection
     {
         $mediaConfig = $slot->getFieldConfig()->get('previewMedia');
-        if ($mediaConfig === null || $mediaConfig->isMapped() || $mediaConfig->getValue() === null) {
+        if ($mediaConfig === null || $mediaConfig->getValue() === null) {
             return null;
         }
 
-        $criteria = new Criteria([$mediaConfig->getStringValue()]);
+        $mediaId = null;
+
+        if ($mediaConfig->isMapped()) {
+            if (!$resolverContext instanceof EntityResolverContext) {
+                return null;
+            }
+
+            $mappedMedia = $this->resolveEntityValue($resolverContext->getEntity(), $mediaConfig->getStringValue());
+
+            if ($mappedMedia instanceof MediaEntity) {
+                return null;
+            }
+
+            if (!\is_string($mappedMedia) || $mappedMedia === '') {
+                return null;
+            }
+
+            $mediaId = $mappedMedia;
+        }
+
+        if ($mediaConfig->isStatic()) {
+            $mediaId = $mediaConfig->getStringValue();
+        }
+
+        if ($mediaId === null) {
+            return null;
+        }
+
+        $criteria = new Criteria([$mediaId]);
 
         $criteriaCollection = new CriteriaCollection();
         $criteriaCollection->add('media_' . $slot->getUniqueIdentifier(), MediaDefinition::class, $criteria);
@@ -58,7 +86,27 @@ class YoutubeVideoCmsElementResolver extends AbstractCmsElementResolver
             if ($media instanceof MediaEntity) {
                 $image->setMediaId($media->getUniqueIdentifier());
                 $image->setMedia($media);
+
+                return;
             }
+
+            if (\is_string($media) && $media !== '') {
+                $image->setMediaId($media);
+
+                $searchResult = $result->get('media_' . $slot->getUniqueIdentifier());
+                if (!$searchResult) {
+                    return;
+                }
+
+                $mappedMedia = $searchResult->get($media);
+                if (!$mappedMedia instanceof MediaEntity) {
+                    return;
+                }
+
+                $image->setMedia($mappedMedia);
+            }
+
+            return;
         }
 
         if ($config->isStatic()) {

--- a/tests/integration/Core/Content/Media/Cms/Type/ImageTypeDataResolverTest.php
+++ b/tests/integration/Core/Content/Media/Cms/Type/ImageTypeDataResolverTest.php
@@ -88,6 +88,36 @@ class ImageTypeDataResolverTest extends TestCase
         static::assertEquals($expectedCriteria, $mediaCriteria);
     }
 
+    public function testCollectWithMappedMediaCustomFieldId(): void
+    {
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroImage' => 'media123']);
+
+        $resolverContext = new EntityResolverContext(
+            $this->createMock(SalesChannelContext::class),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('image');
+        $slot->setFieldConfig($fieldConfig);
+
+        $criteriaCollection = $this->imageResolver->collect($slot, $resolverContext);
+
+        static::assertNotNull($criteriaCollection);
+
+        $expectedCriteria = new Criteria(['media123']);
+        $mediaCriteria = $criteriaCollection->all()[MediaDefinition::class]['media_' . $slot->getUniqueIdentifier()];
+
+        static::assertEquals($expectedCriteria, $mediaCriteria);
+    }
+
     public function testEnrichWithEmptyConfig(): void
     {
         $resolverContext = new ResolverContext($this->createMock(SalesChannelContext::class), new Request());
@@ -369,6 +399,49 @@ class ImageTypeDataResolverTest extends TestCase
         $imageStruct = $slot->getData();
         static::assertInstanceOf(ImageStruct::class, $imageStruct);
         static::assertEmpty($imageStruct->getUrl());
+        static::assertSame('media123', $imageStruct->getMediaId());
+        static::assertSame($media, $imageStruct->getMedia());
+    }
+
+    public function testMediaWithMappedCustomFieldId(): void
+    {
+        $media = new MediaEntity();
+        $media->setUniqueIdentifier('media123');
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroImage' => 'media123']);
+
+        $resolverContext = new EntityResolverContext(
+            $this->createMock(SalesChannelContext::class),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $mediaSearchResult = new EntitySearchResult(
+            'media',
+            1,
+            new MediaCollection([$media]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $result = new ElementDataCollection();
+        $result->add('media_id', $mediaSearchResult);
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('image');
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->imageResolver->enrich($slot, $resolverContext, $result);
+
+        $imageStruct = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageStruct);
         static::assertSame('media123', $imageStruct->getMediaId());
         static::assertSame($media, $imageStruct->getMedia());
     }

--- a/tests/integration/Core/Content/Media/Cms/Type/YoutubeVideoTypeDataResolverTest.php
+++ b/tests/integration/Core/Content/Media/Cms/Type/YoutubeVideoTypeDataResolverTest.php
@@ -1,0 +1,250 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Media\Cms\Type;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\ImageStruct;
+use Shopware\Core\Content\Media\Cms\YoutubeVideoCmsElementResolver;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(YoutubeVideoCmsElementResolver::class)]
+class YoutubeVideoTypeDataResolverTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private YoutubeVideoCmsElementResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new YoutubeVideoCmsElementResolver();
+    }
+
+    public function testType(): void
+    {
+        static::assertSame('youtube-video', $this->resolver->getType());
+    }
+
+    public function testCollectWithEmptyConfig(): void
+    {
+        $resolverContext = new ResolverContext($this->createMock(SalesChannelContext::class), new Request());
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setConfig([]);
+        $slot->setFieldConfig(new FieldConfigCollection());
+
+        $criteriaCollection = $this->resolver->collect($slot, $resolverContext);
+
+        static::assertNull($criteriaCollection);
+    }
+
+    public function testCollectWithPreviewMediaId(): void
+    {
+        $resolverContext = new ResolverContext($this->createMock(SalesChannelContext::class), new Request());
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('previewMedia', FieldConfig::SOURCE_STATIC, 'media123'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setFieldConfig($fieldConfig);
+
+        $criteriaCollection = $this->resolver->collect($slot, $resolverContext);
+
+        static::assertNotNull($criteriaCollection);
+        static::assertCount(1, iterator_to_array($criteriaCollection));
+
+        $expectedCriteria = new Criteria(['media123']);
+        $mediaCriteria = $criteriaCollection->all()[MediaDefinition::class]['media_' . $slot->getUniqueIdentifier()];
+
+        static::assertEquals($expectedCriteria, $mediaCriteria);
+    }
+
+    public function testCollectWithMappedPreviewMediaCustomFieldId(): void
+    {
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroPreview' => 'media123']);
+
+        $resolverContext = new EntityResolverContext(
+            $this->createMock(SalesChannelContext::class),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setFieldConfig($fieldConfig);
+
+        $criteriaCollection = $this->resolver->collect($slot, $resolverContext);
+
+        static::assertNotNull($criteriaCollection);
+
+        $expectedCriteria = new Criteria(['media123']);
+        $mediaCriteria = $criteriaCollection->all()[MediaDefinition::class]['media_' . $slot->getUniqueIdentifier()];
+
+        static::assertEquals($expectedCriteria, $mediaCriteria);
+    }
+
+    public function testEnrichWithMappedPreviewMediaCustomFieldId(): void
+    {
+        $media = new MediaEntity();
+        $media->setUniqueIdentifier('media123');
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroPreview' => 'media123']);
+
+        $resolverContext = new EntityResolverContext(
+            $this->createMock(SalesChannelContext::class),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $mediaSearchResult = new EntitySearchResult(
+            'media',
+            1,
+            new MediaCollection([$media]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $result = new ElementDataCollection();
+        $result->add('media_id', $mediaSearchResult);
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $resolverContext, $result);
+
+        $imageStruct = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageStruct);
+        static::assertSame('media123', $imageStruct->getMediaId());
+        static::assertSame($media, $imageStruct->getMedia());
+    }
+
+    public function testEnrichWithEmptyConfig(): void
+    {
+        $resolverContext = new ResolverContext($this->createMock(SalesChannelContext::class), new Request());
+        $result = new ElementDataCollection();
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setConfig([]);
+        $slot->setFieldConfig(new FieldConfigCollection());
+
+        $this->resolver->enrich($slot, $resolverContext, $result);
+
+        $imageStruct = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageStruct);
+        static::assertEmpty($imageStruct->getMediaId());
+        static::assertEmpty($imageStruct->getMedia());
+    }
+
+    public function testEnrichWithPreviewMediaOnly(): void
+    {
+        $resolverContext = new ResolverContext($this->createMock(SalesChannelContext::class), new Request());
+
+        $media = new MediaEntity();
+        $media->setUniqueIdentifier('media123');
+
+        $mediaSearchResult = new EntitySearchResult(
+            'media',
+            1,
+            new MediaCollection([$media]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $result = new ElementDataCollection();
+        $result->add('media_id', $mediaSearchResult);
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('previewMedia', FieldConfig::SOURCE_STATIC, 'media123'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $resolverContext, $result);
+
+        $imageStruct = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageStruct);
+        static::assertSame('media123', $imageStruct->getMediaId());
+        static::assertSame($media, $imageStruct->getMedia());
+    }
+
+    public function testEnrichWithMappedPreviewMediaEntity(): void
+    {
+        $media = new MediaEntity();
+        $media->setUniqueIdentifier('media123');
+
+        $productMedia = new ProductMediaEntity();
+        $productMedia->setMedia($media);
+
+        $product = new ProductEntity();
+        $product->setCover($productMedia);
+
+        $resolverContext = new EntityResolverContext(
+            $this->createMock(SalesChannelContext::class),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $result = new ElementDataCollection();
+
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'cover.media'));
+
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('youtube-video');
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $resolverContext, $result);
+
+        $imageStruct = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageStruct);
+        static::assertSame('media123', $imageStruct->getMediaId());
+        static::assertSame($media, $imageStruct->getMedia());
+    }
+}

--- a/tests/unit/Core/Content/Media/Cms/ImageCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Media/Cms/ImageCmsElementResolverTest.php
@@ -1,0 +1,176 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Cms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\ImageStruct;
+use Shopware\Core\Content\Media\Cms\AbstractDefaultMediaResolver;
+use Shopware\Core\Content\Media\Cms\ImageCmsElementResolver;
+use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ImageCmsElementResolver::class)]
+class ImageCmsElementResolverTest extends TestCase
+{
+    public function testCollectReturnsNullWithMappedConfigAndResolverContextWithoutEntity(): void
+    {
+        $resolver = new ImageCmsElementResolver($this->createMock(AbstractDefaultMediaResolver::class));
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'),
+        ]));
+
+        $context = new ResolverContext(Generator::generateSalesChannelContext(), new Request());
+
+        static::assertNull($resolver->collect($slot, $context));
+    }
+
+    public function testCollectReturnsNullWithMappedConfigResolvedToMediaEntity(): void
+    {
+        $resolver = new ImageCmsElementResolver($this->createMock(AbstractDefaultMediaResolver::class));
+
+        $media = new MediaEntity();
+        $media->setId('media-1');
+
+        $productMedia = new ProductMediaEntity();
+        $productMedia->setMedia($media);
+
+        $product = new ProductEntity();
+        $product->setCover($productMedia);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'cover.media'),
+        ]));
+
+        static::assertNull($resolver->collect($slot, $context));
+    }
+
+    public function testCollectCreatesMediaCriteriaWithMappedStringId(): void
+    {
+        $resolver = new ImageCmsElementResolver($this->createMock(AbstractDefaultMediaResolver::class));
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroImage' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'),
+        ]));
+
+        $collection = $resolver->collect($slot, $context);
+
+        static::assertInstanceOf(CriteriaCollection::class, $collection);
+
+        $definitionData = $collection->all()[MediaDefinition::class] ?? null;
+        static::assertIsArray($definitionData);
+        static::assertArrayHasKey('media_slot-1', $definitionData);
+
+        $criteria = $definitionData['media_slot-1'];
+        static::assertInstanceOf(Criteria::class, $criteria);
+        static::assertSame(['media-1'], $criteria->getIds());
+    }
+
+    public function testEnrichMappedStringMediaSetsMediaIdAndMedia(): void
+    {
+        $resolver = new ImageCmsElementResolver($this->createMock(AbstractDefaultMediaResolver::class));
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroImage' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'),
+        ]));
+
+        $media = new MediaEntity();
+        $media->setId('media-1');
+
+        $searchResult = $this->createMock(EntitySearchResult::class);
+        $searchResult->method('get')->with('media-1')->willReturn($media);
+
+        $data = new ElementDataCollection();
+        $data->add('media_slot-1', $searchResult);
+
+        $resolver->enrich($slot, $context, $data);
+
+        $imageData = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageData);
+        static::assertSame('media-1', $imageData->getMediaId());
+        static::assertSame($media, $imageData->getMedia());
+    }
+
+    public function testEnrichMappedStringMediaSetsOnlyMediaIdWhenSearchResultMissing(): void
+    {
+        $resolver = new ImageCmsElementResolver($this->createMock(AbstractDefaultMediaResolver::class));
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroImage' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('media', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroImage'),
+        ]));
+
+        $resolver->enrich($slot, $context, new ElementDataCollection());
+
+        $imageData = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageData);
+        static::assertSame('media-1', $imageData->getMediaId());
+        static::assertNull($imageData->getMedia());
+    }
+}

--- a/tests/unit/Core/Content/Media/Cms/YoutubeVideoCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Media/Cms/YoutubeVideoCmsElementResolverTest.php
@@ -1,0 +1,175 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Cms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\ImageStruct;
+use Shopware\Core\Content\Media\Cms\YoutubeVideoCmsElementResolver;
+use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(YoutubeVideoCmsElementResolver::class)]
+class YoutubeVideoCmsElementResolverTest extends TestCase
+{
+    public function testCollectReturnsNullWithMappedConfigAndResolverContextWithoutEntity(): void
+    {
+        $resolver = new YoutubeVideoCmsElementResolver();
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'),
+        ]));
+
+        $context = new ResolverContext(Generator::generateSalesChannelContext(), new Request());
+
+        static::assertNull($resolver->collect($slot, $context));
+    }
+
+    public function testCollectReturnsNullWithMappedConfigResolvedToMediaEntity(): void
+    {
+        $resolver = new YoutubeVideoCmsElementResolver();
+
+        $media = new MediaEntity();
+        $media->setId('media-1');
+
+        $productMedia = new ProductMediaEntity();
+        $productMedia->setMedia($media);
+
+        $product = new ProductEntity();
+        $product->setCover($productMedia);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'cover.media'),
+        ]));
+
+        static::assertNull($resolver->collect($slot, $context));
+    }
+
+    public function testCollectCreatesMediaCriteriaWithMappedStringId(): void
+    {
+        $resolver = new YoutubeVideoCmsElementResolver();
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroPreview' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'),
+        ]));
+
+        $collection = $resolver->collect($slot, $context);
+
+        static::assertInstanceOf(CriteriaCollection::class, $collection);
+
+        $definitionData = $collection->all()[MediaDefinition::class] ?? null;
+        static::assertIsArray($definitionData);
+        static::assertArrayHasKey('media_slot-1', $definitionData);
+
+        $criteria = $definitionData['media_slot-1'];
+        static::assertInstanceOf(Criteria::class, $criteria);
+        static::assertSame(['media-1'], $criteria->getIds());
+    }
+
+    public function testEnrichMappedStringMediaSetsMediaIdAndMedia(): void
+    {
+        $resolver = new YoutubeVideoCmsElementResolver();
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroPreview' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'),
+        ]));
+
+        $media = new MediaEntity();
+        $media->setId('media-1');
+
+        $searchResult = $this->createMock(EntitySearchResult::class);
+        $searchResult->method('get')->with('media-1')->willReturn($media);
+
+        $data = new ElementDataCollection();
+        $data->add('media_slot-1', $searchResult);
+
+        $resolver->enrich($slot, $context, $data);
+
+        $imageData = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageData);
+        static::assertSame('media-1', $imageData->getMediaId());
+        static::assertSame($media, $imageData->getMedia());
+    }
+
+    public function testEnrichMappedStringMediaSetsOnlyMediaIdWhenSearchResultMissing(): void
+    {
+        $resolver = new YoutubeVideoCmsElementResolver();
+
+        $product = new ProductEntity();
+        $product->setCustomFields(['heroPreview' => 'media-1']);
+
+        $context = new EntityResolverContext(
+            Generator::generateSalesChannelContext(),
+            new Request(),
+            $this->createMock(ProductDefinition::class),
+            $product,
+        );
+
+        $slot = new CmsSlotEntity();
+        $slot->setId('slot-1');
+        $slot->setFieldConfig(new FieldConfigCollection([
+            new FieldConfig('previewMedia', FieldConfig::SOURCE_MAPPED, 'product.customFields.heroPreview'),
+        ]));
+
+        $resolver->enrich($slot, $context, new ElementDataCollection());
+
+        $imageData = $slot->getData();
+        static::assertInstanceOf(ImageStruct::class, $imageData);
+        static::assertSame('media-1', $imageData->getMediaId());
+        static::assertNull($imageData->getMedia());
+    }
+}


### PR DESCRIPTION
fixes: #14648 

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Media custom fields on entities like products and categories cannot be used as data sources for CMS image elements, even though they are configured as media types.
This prevents shop administrators from binding media custom fields to images in layouts and leads to confusing behaviour, because the same fields can incorrectly be selected in text elements instead.

### 2. What does this change do, exactly?

This change adjusts the CMS data mapping so that media-type custom fields are exposed as valid data sources for image elements (e.g. on product and category pages).
At the same time, media custom fields are no longer offered as mappings for text elements, aligning the UI and data mapping behaviour with the actual field type.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a custom field set with a custom field of type “media” for categories (and/or products).
2. Assign the custom field set to the corresponding entity so the field is available in the administration.
3. Open a category (or product) that uses a layout containing both an image element and a text element.
4. Edit the layout, select the image element, and open the data mapping dropdown: the media custom field is not available as a selectable source.
5. Select the text element in the same layout and open the data mapping dropdown: the same media custom field is incorrectly available as a selectable source.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

closes #14648

Version 6.6.x backport of #15597 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
