### PR TITLE
fix: tax calculation for bulk edit price when not set

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -1138,6 +1138,7 @@ export default {
         onProcessData() {
             let hasListPrice = false;
             let hasRegulationPrice = false;
+            let hasPriceChange = false;
 
             Object.keys(this.bulkEditProduct).forEach((key) => {
                 const bulkEditField = cloneDeep(this.bulkEditProduct[key]);
@@ -1147,14 +1148,25 @@ export default {
 
                 if (key === 'listPrice') {
                     hasListPrice = true;
+                    hasPriceChange = true;
 
                     return;
                 }
 
                 if (key === 'regulationPrice') {
                     hasRegulationPrice = true;
+                    hasPriceChange = true;
 
                     return;
+                }
+
+                if (
+                    [
+                        'price',
+                        'purchasePrices',
+                    ].includes(key)
+                ) {
+                    hasPriceChange = true;
                 }
 
                 let bulkEditValue = this.product[key];
@@ -1200,6 +1212,14 @@ export default {
 
                 this.bulkEditSelected.push(change);
             });
+
+            if (hasPriceChange && !this.bulkEditProduct.taxId?.isChanged && this.taxRate?.id) {
+                this.bulkEditSelected.push({
+                    field: 'taxId',
+                    type: 'overwrite',
+                    value: this.taxRate.id,
+                });
+            }
 
             if (hasListPrice) {
                 this.processListPrice();

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -662,6 +662,26 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
         expect(wrapper.vm.bulkEditProduct.price.value).toBeTruthy();
     });
 
+    it('should add default taxId when price is changed without selecting tax change', async () => {
+        const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
+
+        await flushPromises();
+
+        const priceFieldsForm = wrapper.find('.sw-bulk-edit-change-field-price');
+        const priceGrossInput = priceFieldsForm.find('input');
+        await priceGrossInput.setValue('6');
+        await flushPromises();
+
+        await priceFieldsForm.find('.sw-bulk-edit-change-field__change input').setValue('checked');
+
+        wrapper.vm.onProcessData();
+
+        const taxChangeField = wrapper.vm.bulkEditSelected.find((field) => field.field === 'taxId');
+        expect(taxChangeField).toBeDefined();
+        expect(taxChangeField.type).toBe('overwrite');
+        expect(taxChangeField.value).toBe('rate1');
+    });
+
     it('should be getting the list price when the price field is exists', async () => {
         const wrapper = await createWrapper({}, { name: 'sw.bulk.edit.product', params: { parentId: 'null' } });
 


### PR DESCRIPTION
This pull request enhances the bulk edit functionality for products by ensuring that when a price-related field is changed, the corresponding `taxId` is automatically included in the update if it hasn't been explicitly changed by the user. This helps prevent inconsistencies and ensures tax information stays in sync with price changes. Additionally, a new test has been added to verify this behavior.

**Bulk edit logic improvements:**

* Added a check in `onProcessData` to detect changes to any price-related fields (`price`, `purchasePrices`, `listPrice`, `regulationPrice`). If such a change is detected and the `taxId` hasn't been explicitly modified, the default `taxId` is automatically added to the bulk edit selection. [[1]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R1141) [[2]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R1151-R1169) [[3]](diffhunk://#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R1214-R1221)

