### PR TITLE
fix: dynamic product groups broken with safari

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.html.twig
@@ -26,6 +26,7 @@
         v-if="showDismissable"
         class="sw-label__dismiss"
         :title="$tc('global.default.remove')"
+        @mousedown.prevent
         @click.prevent.stop="$emit('dismiss')"
     >
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.spec.js
@@ -17,14 +17,45 @@ async function createWrapper(propsData = {}) {
 
 describe('src/app/component/base/sw-label', () => {
     it('should be dismissable', async () => {
-        const wrapper = await createWrapper({ dismissable: true });
+        const wrapper = await createWrapper({
+            dismissable: true,
+            onDismiss: () => {},
+        });
 
-        expect(wrapper.find('sw-label__dismiss')).toBeTruthy();
+        expect(wrapper.find('.sw-label__dismiss').exists()).toBe(true);
     });
 
     it('should not be dismissable', async () => {
-        const wrapper = await createWrapper({ dismissable: false });
+        const wrapper = await createWrapper({
+            dismissable: false,
+            onDismiss: () => {},
+        });
 
-        expect(wrapper.find('sw-label__dismiss').exists()).toBeFalsy();
+        expect(wrapper.find('.sw-label__dismiss').exists()).toBe(false);
+    });
+
+    it('should prevent mousedown and emit dismiss only on click', async () => {
+        const wrapper = await createWrapper({
+            dismissable: true,
+            onDismiss: () => {},
+        });
+
+        const dismissButton = wrapper.find('.sw-label__dismiss');
+        const mousedownEvent = new MouseEvent('mousedown', {
+            bubbles: true,
+            cancelable: true,
+        });
+
+        dismissButton.element.dispatchEvent(mousedownEvent);
+
+        await wrapper.vm.$nextTick();
+
+        expect(mousedownEvent.defaultPrevented).toBe(true);
+        expect(wrapper.emitted('dismiss')).toBeUndefined();
+
+        await dismissButton.trigger('click');
+
+        expect(wrapper.emitted('dismiss')).toHaveLength(1);
+        expect(wrapper.emitted('selected')).toBeUndefined();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.scss
@@ -82,6 +82,10 @@
     }
 
     .sw-entity-multi-select {
+        .sw-select-selection-list {
+            width: 100%;
+        }
+
         .sw-select-selection-list__load-more {
             margin-top: 0;
 


### PR DESCRIPTION
### Shopware Version

6.7.8.1 / Cloud

### Affected area / extension

Platform(Default)

### Actual behaviour

If we create and save a dynamic product group with the condition "Product > One of > ...", it will no longer be possible to remove the top entries in Safari.

<img width="2882" height="1514" alt="Image" src="https://github.com/user-attachments/assets/5b912255-2f53-4711-aefd-a92ba98912c7" />

Checked with:
maxOS: 15.6 (24G84)
Safari: Version 18.6 (20621.3.11.11.3)

### Expected behaviour

.

### How to reproduce

.