### PR TITLE
test: move ServiceDefinitionTest in devops suite

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,6 +48,7 @@ parameters:
             paths:
                 - tests/unit
                 - tests/integration
+                - tests/devops
                 - src/Core/Framework/Test/TestCaseBase/*.php
         -
             message: '#Service ".*" is private#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -139,7 +139,6 @@
             <file>tests/integration/Core/Framework/AdditionalPermissionValidationTest.php</file>
             <file>tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php</file>
             <file>tests/integration/Core/Framework/KernelTest.php</file>
-            <file>tests/integration/Core/Framework/ServiceDefinitionTest.php</file>
             <directory>tests/integration/Core/Framework/Adapter</directory>
             <directory>tests/integration/Core/Framework/Api</directory>
             <directory>tests/integration/Core/Framework/App</directory>

--- a/tests/devops/Core/Framework/ServiceDefinitionTest.php
+++ b/tests/devops/Core/Framework/ServiceDefinitionTest.php
@@ -1,8 +1,7 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Core\Framework;
+namespace Shopware\Tests\Devops\Core\Framework;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Log\Package;
@@ -20,7 +19,6 @@ use Symfony\Component\Finder\Finder;
  * @internal
  */
 #[Package('framework')]
-#[Group('slow')]
 class ServiceDefinitionTest extends TestCase
 {
     use KernelTestBehaviour;


### PR DESCRIPTION
### 1. Why is this change necessary?

**In short:**
Pipeline will gain time of execution for other jobs (batches of integration, blue-green, nightly, etc.)
Devops suite is taking 1 job to run and not multiple with db variations like integration

**In details:**
ServiceDefinitionTest is not a _true_ integration test in a sense of what we do (targeting one class in particular, calling the main methods and integrating concrete components, doing assertions on the results).

This is closer to static analysis & integrity, by adding safeguards on loading services against a test container, running linting command, checking some files existence.

We are missing potential other config files like the installer by having this definition test suite in integration.

### 2. What does this change do, exactly?

- Move ServiceDefinitionTest within devops suite folder
- Amend PHPStan configuration for the warning about service registration
- Remove ServiceDefinitionTest from phpunit.xml.dist for framework integration batches definition


### 3. Describe each step to reproduce the issue or behaviour.

Run locally:  
- `composer run phpunit -- --testsuite=devops --filter=ServiceDefinitionTest` (3 tests, one with deprecation due to xml interaction)
- `composer run phpunit -- --testsuite=core-framework-batch1 --filter=ServiceDefinitionTest` (no test executed)

Check the pipeline: devops job pass (with 3 new tests: 62 vs 59 before)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
