### PR TITLE
fix: admin es index throws even without errors

### DIFF
--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -266,7 +266,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
         $result = $this->client->bulk($arguments);
 
-        if (\is_array($result) && isset($result['errors'])) {
+        if (\is_array($result) && ((bool) $result['errors'] ?? false) !== false) {
             $errors = $this->parseErrors($result);
 
             throw ElasticsearchException::indexingError($errors);

--- a/src/Elasticsearch/Admin/AdminSearchRegistry.php
+++ b/src/Elasticsearch/Admin/AdminSearchRegistry.php
@@ -266,7 +266,7 @@ class AdminSearchRegistry implements EventSubscriberInterface
 
         $result = $this->client->bulk($arguments);
 
-        if (\is_array($result) && ((bool) $result['errors'] ?? false) !== false) {
+        if (\is_array($result) && ((bool) ($result['errors'] ?? false)) !== false) {
             $errors = $this->parseErrors($result);
 
             throw ElasticsearchException::indexingError($errors);


### PR DESCRIPTION
### 1. Why is this change necessary?
OpenSearch adds `errors: false` to the request, after the remove of empty and only checking if the key was set we now did throw an exception even when there where no errors

### 2. What does this change do, exactly?
Check that the value for `errors` is not falsy

### 3. Describe each step to reproduce the issue or behaviour.
try to run `bin/console es:admin:index`

### 4. Please link to the relevant issues (if any).
Regression from: https://github.com/shopware/shopware/commit/9d814e97ea9563f52a4f1336b7bd7d277dfe7325#diff-a064faf259b0d781b728139a3821770d7db9196b4e3a718c4133a9e98c284f80R147-R269

That broke our cloud deploys: https://jarvis.svc.swstage.store/kraftwork/logs/jxdwoch39dpkakhe27ztdj/temporal/2026-03-26/00/1774486621304058605_10118663467373187939_106.log

