### PR TITLE
fix: Add prefix to e-mail validation path 

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.spec.ts
@@ -28,7 +28,7 @@ describe('core/service/api/validation.api.service.ts', () => {
         it('should return true', async () => {
             const { validationApiService, clientMock } = createValidationApiService();
 
-            clientMock.onPost('/validation/email').reply(204, {});
+            clientMock.onPost('/_action/validation/email').reply(204, {});
 
             const result = await validationApiService.validateEmailAddress('anyValid@email.com');
 
@@ -38,7 +38,7 @@ describe('core/service/api/validation.api.service.ts', () => {
         it('should return false because email is invalid', async () => {
             const { validationApiService, clientMock } = createValidationApiService();
 
-            clientMock.onPost('/validation/email').reply(422, {});
+            clientMock.onPost('/_action/validation/email').reply(422, {});
 
             const result = await validationApiService.validateEmailAddress('invalid@email');
 
@@ -48,7 +48,7 @@ describe('core/service/api/validation.api.service.ts', () => {
         it('should return false because exception occurred', async () => {
             const { validationApiService, clientMock } = createValidationApiService();
 
-            clientMock.onPost('/validation/email').reply(() => {
+            clientMock.onPost('/_action/validation/email').reply(() => {
                 throw Error('an error occurred');
             });
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.ts
@@ -17,7 +17,7 @@ export default class ValidationApiService extends ApiService {
     }
 
     async validateEmailAddress(email: string) {
-        const apiRoute = `/${this.getApiBasePath()}/email`;
+        const apiRoute = `/${this.getApiBasePath(undefined, '_action')}/email`;
         if (!/.+@.+\..+/.test(email)) {
             return Promise.resolve(false);
         }

--- a/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.ts
@@ -17,7 +17,7 @@ export default class ValidationApiService extends ApiService {
     }
 
     async validateEmailAddress(email: string) {
-        const apiRoute = `/${this.getApiBasePath(undefined, '_action')}/email`;
+        const apiRoute = `/${this.getApiBasePath('email', '_action')}`;
         if (!/.+@.+\..+/.test(email)) {
             return Promise.resolve(false);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

Saving the profile in the administration was not possible, because the email validation failed because of a 404 error. See https://github.com/shopware/shopware/issues/15805 for a detailled description.

### 2. What does this change do, exactly?

It adds the `_action` prefix to the validation route to call the right endpoint and prevent a 404 error.


### 3. Describe each step to reproduce the issue or behaviour.

- Log into the administration
- Open your profile
- Make any change (e.g. the timezone)
- Click save
- You get a notification saying "Invalid e-mail address" because the validation endpoint is wrong

### 4. Please link to the relevant issues (if any).

Closes https://github.com/shopware/shopware/issues/15805
