### PR TITLE
fix: allow extending validationMessages before form-validation-config

### DIFF
--- a/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
@@ -1,11 +1,11 @@
 {% block form_validation_config %}
-    {% set validationMessages = {
+    {% set validationMessages = validationMessages|default({})|merge({
         required: 'error.VIOLATION::IS_BLANK_ERROR'|trans|sw_sanitize,
         email: 'error.VIOLATION::INVALID_EMAIL_FORMAT_ERROR'|trans|sw_sanitize,
         confirmation: 'error.VIOLATION::NOT_EQUAL_ERROR'|trans|sw_sanitize,
         minLength: 'error.VIOLATION::TOO_SHORT_ERROR'|trans|sw_sanitize,
         grecaptcha: 'error.VIOLATION::RECAPTCHA_COOKIE_REQUIRED'|trans|sw_sanitize,
-    } %}
+    }) %}
 
     <script>
         window.validationMessages = JSON.parse('{{ validationMessages|json_encode|escape('js') }}');


### PR DESCRIPTION
The `form-validation-config.html.twig` template currently overwrites
`validationMessages` with `{% set %}`, which means themes or plugins
cannot add custom validation message keys before this block runs.

Switching to `validationMessages|default({})|merge({...})` preserves
any keys set before the block while still providing the core defaults.
A plugin can now define additional messages in a parent template and
they will be included in `window.validationMessages`.

Fixes #15659