### PR TITLE
fix: only show order cancellation for open orders

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -349,6 +349,11 @@ window.PluginManager.callPluginMethod(pluginName, methodName, ...args)
 
 * Deprecated block `page_product_detail_product_buy_button_label` in `Resources/views/storefront/component/product/card/action.html.twig` which will be removed in v6.8.0. Use block `component_product_box_action_buy_button_label` instead.
 
+### Order cancellation only shown for open orders
+
+The account order cancellation action is now only shown for orders in state `open`.
+This prevents customers from being offered an invalid cancel action for completed orders.
+
 ### Disabled runtime error overlay in webpack dev server
 
 The webpack dev server overlay for runtime errors has been disabled in hot-reload mode. The overlay frequently interrupted the development workflow by covering the entire viewport for non-critical runtime errors, making it difficult to interact with the storefront during development. Error details remain available in the browser console.

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
@@ -4,6 +4,7 @@
 {% set ORDER_TRANSACTION_STATE_CANCELLED = constant('Shopware\\Core\\Checkout\\Order\\Aggregate\\OrderTransaction\\OrderTransactionStates::STATE_CANCELLED') %}
 {% set ORDER_TRANSACTION_STATE_UNCONFIRMED = constant('Shopware\\Core\\Checkout\\Order\\Aggregate\\OrderTransaction\\OrderTransactionStates::STATE_UNCONFIRMED') %}
 {% set ALLOWED_TRANSACTION_STATES = constant('Shopware\\Core\\Checkout\\Order\\SalesChannel\\OrderService::ALLOWED_TRANSACTION_STATES') %}
+{% set ORDER_STATE_OPEN = constant('Shopware\\Core\\Checkout\\Order\\OrderStates::STATE_OPEN') %}
 {% set ORDER_STATE_CANCELLED = constant('Shopware\\Core\\Checkout\\Order\\OrderStates::STATE_CANCELLED') %}
 {% set PRODUCT_LINE_ITEM_TYPE = constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') %}
 
@@ -18,6 +19,7 @@
             ] %}
 
             {% set orderState = order.stateMachineState.technicalName %}
+            {% set allowOrderCancellation = orderState == ORDER_STATE_OPEN and config('core.cart.enableOrderRefunds') %}
             {% if feature('v6.8.0.0') %}
                 {% set orderPaymentState = order.primaryOrderTransaction.stateMachineState.technicalName %}
             {% else %}
@@ -145,7 +147,7 @@
                                     {% endblock %}
 
                                     {% block page_account_order_item_context_menu_cancel_order %}
-                                        {% if orderState != ORDER_STATE_CANCELLED and config('core.cart.enableOrderRefunds') %}
+                                        {% if allowOrderCancellation %}
 
                                             {% set modalId = 'cancelOrderModal-' ~ order.id %}
 
@@ -161,7 +163,7 @@
                             {% endblock %}
                         {% endblock %}
 
-                        {% if orderState != ORDER_STATE_CANCELLED %}
+                        {% if allowOrderCancellation %}
                             {% sw_include '@Storefront/storefront/page/account/order/cancel-order-modal.html.twig' %}
                         {% endif %}
                     </div>

--- a/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order/index.html.twig
@@ -4,9 +4,11 @@
     {% sw_include '@Storefront/storefront/page/account/order/header.html.twig' %}
 {% endblock %}
 
+{% set ORDER_STATE_OPEN = constant('Shopware\\Core\\Checkout\\Order\\OrderStates::STATE_OPEN') %}
 {% set orderState = page.order.stateMachineState.technicalName %}
 {% set showTaxPrice = config('core.cart.columnTaxInsteadUnitPrice') %}
 {% set showSubtotal = config('core.cart.showSubtotal') %}
+{% set allowOrderCancellation = orderState == ORDER_STATE_OPEN and config('core.cart.enableOrderRefunds') %}
 
 {% block page_checkout_confirm_header %}
     {% if page.errorCode == 'CHECKOUT__CUSTOMER_CANCELED_EXTERNAL_PAYMENT' %}
@@ -135,7 +137,7 @@
         </form>
 
         {% block page_checkout_aside_cancel_order_modal_toggle %}
-            {% if orderState != 'cancelled' and config('core.cart.enableOrderRefunds') %}
+            {% if allowOrderCancellation %}
                 <button type="button"
                         class="btn btn-light btn-block edit-order-cancel-order-modal-toggle-btn mt-3"
                         data-bs-toggle="modal"
@@ -146,7 +148,7 @@
         {% endblock %}
 
         {% block page_checkout_aside_cancel_order_modal_content %}
-            {% if orderState != 'cancelled' and config('core.cart.enableOrderRefunds') %}
+            {% if allowOrderCancellation %}
                 {% sw_include '@Storefront/storefront/page/account/order/cancel-order-modal.html.twig' %}
             {% endif %}
         {% endblock %}

--- a/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountOrderControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
+use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -21,6 +22,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Integration\Traits\OrderFixture;
 use Shopware\Core\Test\TestDefaults;
@@ -331,6 +333,82 @@ class AccountOrderControllerTest extends TestCase
         static::assertArrayHasKey(AccountOrderPageLoadedHook::HOOK_NAME, $traces);
     }
 
+    public function testOrderOverviewShowsCancelActionOnlyForOpenOrders(): void
+    {
+        $context = Context::createDefaultContext();
+        $customer = $this->createCustomer($context);
+
+        $openOrderId = Uuid::randomHex();
+        $openOrderData = $this->getOrderData($openOrderId, $context);
+        $openOrderData[0]['orderCustomer']['customer']['id'] = $customer->getId();
+        $openOrderData[0]['orderCustomer']['customer']['guest'] = false;
+        $openOrderData[0]['salesChannelId'] = $this->getStorefrontSalesChannelId($context);
+        $openOrderData[0]['deepLinkCode'] = Uuid::randomHex();
+
+        $completedOrderId = Uuid::randomHex();
+        $completedOrderData = $this->getOrderData($completedOrderId, $context);
+        $completedOrderData[0]['orderCustomer']['customer']['id'] = $customer->getId();
+        $completedOrderData[0]['orderCustomer']['customer']['guest'] = false;
+        $completedOrderData[0]['salesChannelId'] = $this->getStorefrontSalesChannelId($context);
+        $completedOrderData[0]['deepLinkCode'] = Uuid::randomHex();
+        $completedOrderData[0]['stateId'] = $this->getStateMachineState(OrderStates::STATE_MACHINE, OrderStates::STATE_COMPLETED);
+
+        static::getContainer()->get('order.repository')->create([$openOrderData[0]], $context);
+        static::getContainer()->get('order.repository')->create([$completedOrderData[0]], $context);
+
+        static::getContainer()->get(SystemConfigService::class)->set('core.cart.enableOrderRefunds', true);
+
+        $browser = $this->login($customer->getEmail());
+        $browser->request('GET', '/account/order');
+
+        $response = $browser->getResponse();
+        $content = (string) $response->getContent();
+
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode(), $content);
+        static::assertStringContainsString('cancelOrderModal-' . $openOrderId, $content);
+        static::assertStringNotContainsString('cancelOrderModal-' . $completedOrderId, $content);
+    }
+
+    public function testEditOrderPageShowsCancelActionOnlyForOpenOrders(): void
+    {
+        $context = Context::createDefaultContext();
+        $customer = $this->createCustomer($context);
+
+        $openOrderId = Uuid::randomHex();
+        $openOrderData = $this->getOrderData($openOrderId, $context);
+        $openOrderData[0]['orderCustomer']['customer']['id'] = $customer->getId();
+        $openOrderData[0]['orderCustomer']['customer']['guest'] = false;
+        $openOrderData[0]['salesChannelId'] = $this->getStorefrontSalesChannelId($context);
+        $openOrderData[0]['deepLinkCode'] = Uuid::randomHex();
+
+        $completedOrderId = Uuid::randomHex();
+        $completedOrderData = $this->getOrderData($completedOrderId, $context);
+        $completedOrderData[0]['orderCustomer']['customer']['id'] = $customer->getId();
+        $completedOrderData[0]['orderCustomer']['customer']['guest'] = false;
+        $completedOrderData[0]['salesChannelId'] = $this->getStorefrontSalesChannelId($context);
+        $completedOrderData[0]['deepLinkCode'] = Uuid::randomHex();
+        $completedOrderData[0]['stateId'] = $this->getStateMachineState(OrderStates::STATE_MACHINE, OrderStates::STATE_COMPLETED);
+
+        static::getContainer()->get('order.repository')->create([$openOrderData[0]], $context);
+        static::getContainer()->get('order.repository')->create([$completedOrderData[0]], $context);
+
+        static::getContainer()->get(SystemConfigService::class)->set('core.cart.enableOrderRefunds', true);
+
+        $browser = $this->login($customer->getEmail());
+
+        $browser->request('GET', '/account/order/edit/' . $openOrderId);
+        $openContent = (string) $browser->getResponse()->getContent();
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), $openContent);
+        static::assertStringContainsString('edit-order-cancel-order-modal-toggle-btn', $openContent);
+
+        $browser->request('GET', '/account/order/edit/' . $completedOrderId);
+        $completedContent = (string) $browser->getResponse()->getContent();
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode(), $completedContent);
+        static::assertStringNotContainsString('edit-order-cancel-order-modal-toggle-btn', $completedContent);
+    }
+
     /**
      * @deprecated tag:v6.8.0 - Will be removed without replacement
      */
@@ -491,5 +569,19 @@ class AccountOrderControllerTest extends TestCase
         static::getContainer()->get('product.repository')->create([$data], $context);
 
         return $productId;
+    }
+
+    private function getStorefrontSalesChannelId(Context $context): string
+    {
+        $criteria = new Criteria();
+        $criteria
+            ->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT))
+            ->addFilter(new EqualsFilter('active', true))
+            ->addFilter(new EqualsFilter('domains.url', $_SERVER['APP_URL']));
+
+        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->getEntities()->first();
+        static::assertNotNull($salesChannel);
+
+        return $salesChannel->getId();
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Completed orders still showed the storefront cancel action even though the order state machine no longer allowed the `cancel` transition. That exposed customers to an invalid action and resulted in an error when they tried to use it.

### 2. What does this change do, exactly?

It limits the storefront cancel-order action to orders in state `open` on both the account order overview and the order edit page. It also adds integration coverage for open vs. completed orders and documents the behavior change in `RELEASE_INFO-6.7.md`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable order cancellation under `Settings > Shopping cart`.
2. Create an order.
3. Change the order status to `Completed` in the administration.
4. Open the order in the storefront account area.
5. Notice that the cancel action is shown even though cancellation is not possible.
6. Trigger the action and observe the illegal state transition error.

### 4. Please link to the relevant issues (if any).

fixes https://github.com/shopware/shopware/issues/15489