### PR TITLE
chore: Refactor usage of double square brackets for array annotation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,8 +29,8 @@
 /intellij.yaml export-ignore
 /LICENSE export-ignore
 /phpbench.json export-ignore
-/phpstan.neon export-ignore
-/phpstan-baseline.neon export-ignore
+/phpstan.neon.dist export-ignore
+/phpstan-baseline.php export-ignore
 /phpunit.xml.dist export-ignore
 /rector.php export-ignore
 /sonar-project.properties export-ignore

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1139,12 +1139,6 @@ $ignoreErrors[] = [
     'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
     'identifier' => 'shopware.domainException',
     'count' => 1,
-    'path' => __DIR__ . '/src/Core/Framework/Rule/Rule.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Throwing new exceptions within classes are not allowed. Please use domain exception pattern. See https://github.com/shopware/platform/blob/v6.4.20.0/adr/2022-02-24-domain-exceptions.md',
-    'identifier' => 'shopware.domainException',
-    'count' => 1,
     'path' => __DIR__ . '/src/Core/Framework/Store/Authentication/AbstractStoreRequestOptionsProvider.php',
 ];
 $ignoreErrors[] = [

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\Rule\RuleScope;
 use Shopware\Core\Framework\Util\ArrayComparator;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @final
@@ -62,9 +61,6 @@ class LineItemCustomFieldRule extends Rule
         return false;
     }
 
-    /**
-     * @return array|Constraint[][]
-     */
     public function getConstraints(): array
     {
         return CustomFieldRule::getConstraints($this->renderedField);

--- a/src/Core/Checkout/Cart/Rule/LineItemProductStatesRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemProductStatesRule.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @deprecated tag:v6.8.0 - reason:remove-rule - Use \Shopware\Core\Checkout\Cart\Rule\LineItemProductTypeRule instead.
@@ -50,8 +49,6 @@ class LineItemProductStatesRule extends Rule
     }
 
     /**
-     * @return array<string, array<int, Constraint>>
-     *
      * @deprecated tag:v6.8.0 - reason:remove-rule - Will be removed, as product states are deprecated.
      */
     public function getConstraints(): array

--- a/src/Core/Checkout/Cart/Rule/LineItemProductTypeRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemProductTypeRule.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @final
@@ -52,9 +51,6 @@ class LineItemProductTypeRule extends Rule
         return false;
     }
 
-    /**
-     * @return array<string, array<int, Constraint>>
-     */
     public function getConstraints(): array
     {
         return [

--- a/src/Core/Checkout/Cart/Rule/LineItemTagRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemTagRule.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
 use Shopware\Core\System\Tag\TagDefinition;
-use Symfony\Component\Validator\Constraint;
 
 /**
  * @final
@@ -51,9 +50,6 @@ class LineItemTagRule extends Rule
         return false;
     }
 
-    /**
-     * @return array|Constraint[][]
-     */
     public function getConstraints(): array
     {
         $constraints = [

--- a/src/Core/Checkout/Customer/Rule/BillingCountryRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingCountryRule.php
@@ -57,9 +57,6 @@ class BillingCountryRule extends Rule
         return RuleComparison::uuids($parameter, $this->countryIds, $this->operator);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     public function getConstraints(): array
     {
         $constraints = [

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -143,7 +143,7 @@ class CmsSlotsDataResolver
     }
 
     /**
-     * @param string[][] $directReads
+     * @param array<string, array<string>> $directReads
      *
      * @return array<string, EntitySearchResult<covariant EntityCollection<covariant Entity>>>
      */

--- a/src/Core/Content/Mail/Service/Mail.php
+++ b/src/Core/Content/Mail/Service/Mail.php
@@ -16,10 +16,11 @@ class Mail extends Email
     private array $attachmentUrls = [];
 
     /**
-     * @return mixed[]
+     * @return list<mixed>
      */
     public function __serialize(): array
     {
+        /** @var list<mixed> $data */
         $data = parent::__serialize();
 
         $data[] = $this->mailAttachmentsConfig;
@@ -29,7 +30,7 @@ class Mail extends Email
     }
 
     /**
-     * @param mixed[] $data
+     * @param list<mixed> $data
      */
     public function __unserialize(array $data): void
     {

--- a/src/Core/Content/ProductExport/Error/XmlValidationError.php
+++ b/src/Core/Content/ProductExport/Error/XmlValidationError.php
@@ -13,14 +13,14 @@ class XmlValidationError extends Error
     protected array $errorMessages;
 
     /**
-     * @param \LibXMLError[] $errors
+     * @param list<\LibXMLError> $errors
      */
     public function __construct(
         protected string $id,
         protected array $errors = []
     ) {
         $this->errorMessages = array_values(array_map(
-            static function (\LibXMLError $error) {
+            static function (\LibXMLError $error): ErrorMessage {
                 $errorMessage = new ErrorMessage();
                 $errorMessage->assign([
                     'message' => \sprintf('%s on line %d in column %d', trim($error->message), $error->line, $error->column),
@@ -49,7 +49,7 @@ class XmlValidationError extends Error
     }
 
     /**
-     * @return \LibXMLError[][]
+     * @return array{errors: list<\LibXMLError>}
      */
     public function getParameters(): array
     {

--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -68,7 +68,7 @@ class Context extends Struct
      * Extension are not serialized, as they could be anything and make problems during serialization,
      * for symfony serializer they are exlcuded by the #[Exclude] attribute already
      *
-     * @return array<mixed>
+     * @return list<mixed>
      */
     public function __serialize(): array
     {
@@ -88,7 +88,7 @@ class Context extends Struct
     }
 
     /**
-     * @param array<mixed> $data
+     * @param list<mixed> $data
      */
     public function __unserialize(array $data): void
     {

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -26,7 +26,7 @@ class CustomFieldRule
     /**
      * @param array<string, string|array<string, string>> $renderedField
      *
-     * @return array<string, array<int, mixed>>
+     * @return array<string, list<Constraint>>
      */
     public static function getConstraints(array $renderedField): array
     {
@@ -194,7 +194,7 @@ class CustomFieldRule
     /**
      * @param array<string, string|array<string, string>> $renderedField
      *
-     * @return Constraint[]
+     * @return list<Constraint>
      */
     private static function getRenderedFieldValueConstraints(array $renderedField): array
     {

--- a/src/Core/Framework/Rule/Rule.php
+++ b/src/Core/Framework/Rule/Rule.php
@@ -67,7 +67,7 @@ abstract class Rule extends Struct
      *   'propertyName2' => [new Constraint(), new OtherConstraint()],
      *  ]
      *
-     * @return array<string, array<Constraint>>
+     * @return array<string, list<Constraint>>
      */
     abstract public function getConstraints(): array;
 

--- a/src/Core/Framework/Rule/Rule.php
+++ b/src/Core/Framework/Rule/Rule.php
@@ -48,7 +48,7 @@ abstract class Rule extends Struct
         $ruleName = static::RULE_NAME;
 
         if ($ruleName === null) {
-            throw new \Error('Implement own getName or add RULE_NAME constant');
+            throw RuleException::ruleNameNotImplemented();
         }
 
         return $ruleName;

--- a/src/Core/Framework/Rule/RuleException.php
+++ b/src/Core/Framework/Rule/RuleException.php
@@ -18,6 +18,7 @@ class RuleException extends HttpException
     public const VALUE_NOT_SUPPORTED = 'CONTENT__RULE_VALUE_NOT_SUPPORTED';
     public const MULTIPLE_NOT_RULES = 'CONTENT__TOO_MANY_NOT_RULES';
     public const INVALID_DATE_RANGE_USAGE = 'FRAMEWORK__INVALID_DATE_RANGE_USAGE';
+    public const RULE_NAME_NOT_IMPLEMENTED = 'FRAMEWORK__RULE_NAME_NOT_IMPLEMENTED';
 
     public static function scriptExecutionFailed(string $hook, string $scriptName, \Throwable $previous): ScriptException
     {
@@ -75,6 +76,22 @@ class RuleException extends HttpException
             self::INVALID_DATE_RANGE_USAGE,
             'Invalid date range usage: {{ reason }}',
             ['reason' => $reason]
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
+     */
+    public static function ruleNameNotImplemented(): \Error|self
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \Error('Implement own getName or add RULE_NAME constant');
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::RULE_NAME_NOT_IMPLEMENTED,
+            'Implement own getName or add RULE_NAME constant',
         );
     }
 }

--- a/src/Core/Framework/Rule/ScriptRule.php
+++ b/src/Core/Framework/Rule/ScriptRule.php
@@ -28,7 +28,7 @@ class ScriptRule extends Rule
     protected string $script = '';
 
     /**
-     * @var array<string, Constraint[]>
+     * @var array<string, list<Constraint>>
      */
     protected array $constraints = [];
 
@@ -88,16 +88,13 @@ class ScriptRule extends Rule
         }
     }
 
-    /**
-     * @return array<string, Constraint[]>
-     */
     public function getConstraints(): array
     {
         return $this->constraints;
     }
 
     /**
-     * @param array<string, Constraint[]> $constraints
+     * @param array<string, list<Constraint>> $constraints
      */
     public function setConstraints(array $constraints): void
     {

--- a/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
@@ -23,12 +23,12 @@ class HookableEventCollector implements ResetInterface
     private const PRIVILEGES = 'privileges';
 
     /**
-     * @var string[][][]
+     * @var array<string, array{privileges: list<string>}>
      */
     private array $hookableEventNamesWithPrivileges = [];
 
     /**
-     * @var array<string>|null
+     * @var list<string>|null
      */
     private ?array $hookableEntities = null;
 
@@ -43,7 +43,7 @@ class HookableEventCollector implements ResetInterface
     }
 
     /**
-     * @return array<array<array<string>>>
+     * @return array<string, array{privileges: list<string>}>
      */
     public function getHookableEventNamesWithPrivileges(Context $context): array
     {
@@ -93,7 +93,7 @@ class HookableEventCollector implements ResetInterface
     /**
      * Dynamically discovers all hookable entities by checking for services tagged with 'shopware.entity.hookable'.
      *
-     * @return array<string>
+     * @return list<string>
      */
     public function getHookableEntities(): array
     {
@@ -120,7 +120,7 @@ class HookableEventCollector implements ResetInterface
             }
         }
 
-        $this->hookableEntities = array_unique($hookableEntities);
+        $this->hookableEntities = array_values(array_unique($hookableEntities));
 
         return $this->hookableEntities;
     }

--- a/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
+++ b/src/Core/Test/Stub/DataAbstractionLayer/StaticEntityRepository.php
@@ -202,7 +202,7 @@ class StaticEntityRepository extends EntityRepository
     }
 
     /**
-     * @param mixed[][] $data
+     * @param array<array<string, mixed|null>> $data
      */
     private function getDummyWriteResults(array $data, string $operation, Context $context): NestedEventCollection
     {

--- a/tests/unit/Core/Framework/Util/ArrayNormalizerTest.php
+++ b/tests/unit/Core/Framework/Util/ArrayNormalizerTest.php
@@ -34,7 +34,7 @@ class ArrayNormalizerTest extends TestCase
     }
 
     /**
-     * @return array<mixed>[][]
+     * @return list<array{array<string, mixed>, array<string, string>}>
      */
     public static function provideTestData(): array
     {

--- a/tests/unit/Core/Framework/Util/VersionParserTest.php
+++ b/tests/unit/Core/Framework/Util/VersionParserTest.php
@@ -24,7 +24,7 @@ class VersionParserTest extends TestCase
     }
 
     /**
-     * @return string[][]
+     * @return list<array{string, string, string}>
      */
     public static function provideVersions(): array
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

In preparation for #16008 the usage of double square brackets for array shapes needs to be refactored

### 2. What does this change do, exactly?

instead of `[][]` use properly described array annotations

### 4. Please link to the relevant issues (if any).
- relates to #16008 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
