### PR TITLE
fix: remove dependency on maltyxx/images-generator

### DIFF
--- a/src/Core/Framework/Demodata/Command/DemodataCommand.php
+++ b/src/Core/Framework/Demodata/Command/DemodataCommand.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Demodata\Command;
 
 use Bezhanov\Faker\Provider\Commerce;
 use Faker\Factory;
-use Maltyxx\ImagesGenerator\ImagesGeneratorProvider;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Promotion\PromotionDefinition;
@@ -58,7 +57,7 @@ class DemodataCommand extends Command
         private readonly DemodataService $demodataService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly string $kernelEnv,
-        private readonly array $requiredClasses = [Factory::class, Commerce::class, ImagesGeneratorProvider::class],
+        private readonly array $requiredClasses = [Factory::class, Commerce::class],
     ) {
         parent::__construct();
     }
@@ -134,6 +133,8 @@ class DemodataCommand extends Command
             ['Entity', 'Items', 'Time'],
             $demoContext->getTimings()
         );
+
+        $io->info('Run "bin/console dal:refresh:index" to refresh all indices after generating demo data.');
 
         return self::SUCCESS;
     }

--- a/src/Core/Framework/Demodata/DemodataService.php
+++ b/src/Core/Framework/Demodata/DemodataService.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Demodata;
 
 use Faker\Factory;
 use Faker\Generator;
-use Maltyxx\ImagesGenerator\ImagesGeneratorProvider;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
@@ -79,7 +78,6 @@ class DemodataService
     {
         $faker = Factory::create('de-DE');
         $faker->addProvider(new Commerce($faker));
-        $faker->addProvider(new ImagesGeneratorProvider($faker));
 
         return $faker;
     }

--- a/src/Core/Framework/Demodata/Generator/MediaGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/MediaGenerator.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Demodata\Generator;
 
 use Doctrine\DBAL\Connection;
 use Faker\Generator;
-use Maltyxx\ImagesGenerator\ImagesGeneratorProvider;
 use Shopware\Core\Content\Media\Aggregate\MediaDefaultFolder\MediaDefaultFolderCollection;
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\File\FileNameProvider;
@@ -103,6 +102,10 @@ class MediaGenerator implements DemodataGeneratorInterface
                 $context->getContext()
             );
 
+            if (str_starts_with($file, sys_get_temp_dir())) {
+                unlink($file);
+            }
+
             $context->getConsole()->progressAdvance(1);
         }
 
@@ -164,21 +167,59 @@ class MediaGenerator implements DemodataGeneratorInterface
             return $images[array_rand($images)]->getPathname();
         }
 
+        $faker = $context->getFaker();
+
+        /** @var positive-int $width */
+        $width = $faker->numberBetween(600, 800);
+        /** @var positive-int $height */
+        $height = $faker->numberBetween(400, 600);
+
+        $image = imagecreate($width, $height);
+        \assert($image !== false);
+
+        imagecolorallocate($image, 0xD8, 0xDD, 0xE6);
+
         /** @var string $text */
-        $text = $context->getFaker()->words(1, true);
+        $text = $faker->words(1, true);
 
-        $provider = new ImagesGeneratorProvider(new Generator());
+        // Render text at built-in font size, then scale up to fill the image
+        $font = 5;
+        $charWidth = imagefontwidth($font);
+        $charHeight = imagefontheight($font);
+        $textWidth = $charWidth * \strlen($text);
 
-        return $provider->imageGenerator(
-            null,
-            $context->getFaker()->numberBetween(600, 800),
-            $context->getFaker()->numberBetween(400, 600),
-            'jpg',
-            true,
-            $text,
-            '#d8dde6',
-            '#333333'
+        /** @var positive-int $textImageWidth */
+        $textImageWidth = $textWidth + 2;
+        /** @var positive-int $textImageHeight */
+        $textImageHeight = $charHeight + 2;
+
+        $textImage = imagecreate($textImageWidth, $textImageHeight);
+        \assert($textImage !== false);
+        imagecolorallocate($textImage, 0xD8, 0xDD, 0xE6);
+        $textImageColor = (int) imagecolorallocate($textImage, 0x33, 0x33, 0x33);
+        imagestring($textImage, $font, 1, 1, $text, $textImageColor);
+
+        $scale = min(($width - 20) / $textImageWidth, ($height - 20) / $textImageHeight);
+        $scaledWidth = (int) ($textImageWidth * $scale);
+        $scaledHeight = (int) ($textImageHeight * $scale);
+
+        imagecopyresized(
+            $image,
+            $textImage,
+            (int) (($width - $scaledWidth) / 2),
+            (int) (($height - $scaledHeight) / 2),
+            0,
+            0,
+            $scaledWidth,
+            $scaledHeight,
+            $textImageWidth,
+            $textImageHeight,
         );
+
+        $filePath = sys_get_temp_dir() . '/' . Uuid::randomHex() . '.jpg';
+        imagejpeg($image, $filePath);
+
+        return $filePath;
     }
 
     private function getOrCreateDefaultFolder(DemodataContext $context, bool $isDownloadFolder = false): ?string


### PR DESCRIPTION
### 1. Why is this change necessary?

The composer package `maltyxx/images-generator` has been deleted from GitHub, breaking pipelines for anyone still pulling it. The core should not depend on this package at all — not even transitively through `shopware/dev-tools`.

### 2. What does this change do, exactly?

- **MediaGenerator**: Replaces `ImagesGeneratorProvider` usage with inline PHP GD code (`imagecreate` + `imagestring` + `imagecopyresized`) to generate placeholder images with centered, scaled-up text. Also cleans up temporary files after `persistFileToMedia` consumes them.
- **DemodataService**: Removes the `ImagesGeneratorProvider` Faker provider registration.
- **DemodataCommand**: Removes `ImagesGeneratorProvider::class` from the required dependency check. Adds an info message to run `dal:refresh:index` after generating demo data.

### 3. Describe each step to reproduce the issue or behaviour.

1. Remove/don't have `shopware/dev-tools` >= 1.5.1 installed
2. Run `APP_ENV=prod bin/console framework:demodata`
3. Previously this would fail because `maltyxx/images-generator` could not be pulled
4. After this change, image generation works with just PHP GD (no external package)

### 4. Please link to the relevant issues (if any).

- closes #15839

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them