### PR TITLE
fix: web installer db autofill from env

### DIFF
--- a/src/Core/Installer/Controller/DatabaseConfigurationController.php
+++ b/src/Core/Installer/Controller/DatabaseConfigurationController.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Installer\Controller;
 use Doctrine\DBAL\Exception\DriverException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Installer\Database\BlueGreenDeploymentService;
+use Shopware\Core\Maintenance\MaintenanceException;
 use Shopware\Core\Maintenance\System\Exception\DatabaseSetupException;
 use Shopware\Core\Maintenance\System\Service\DatabaseConnectionFactory;
 use Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter;
@@ -33,7 +34,7 @@ class DatabaseConfigurationController extends InstallerController
     public function databaseConfiguration(Request $request): Response
     {
         $session = $request->getSession();
-        $connectionInfo = $session->get(DatabaseConnectionInformation::class) ?? new DatabaseConnectionInformation();
+        $connectionInfo = $session->get(DatabaseConnectionInformation::class) ?? $this->getInitialConnectionInformation();
 
         if ($request->isMethod('GET')) {
             return $this->renderInstaller('@Installer/installer/database-configuration.html.twig', [
@@ -116,5 +117,17 @@ class DatabaseConfigurationController extends InstallerController
         }
 
         return new JsonResponse($result);
+    }
+
+    private function getInitialConnectionInformation(): DatabaseConnectionInformation
+    {
+        try {
+            $connectionInfo = DatabaseConnectionInformation::fromEnv();
+            $connectionInfo->assign(['password' => null]);
+
+            return $connectionInfo;
+        } catch (MaintenanceException) {
+            return new DatabaseConnectionInformation();
+        }
     }
 }

--- a/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Installer\Controller;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -64,8 +65,46 @@ class DatabaseConfigurationControllerTest extends TestCase
         $this->controller->setContainer($this->getInstallerContainer($this->twig, ['router' => $this->router]));
     }
 
+    #[BackupGlobals(true)]
     public function testDatabaseGetConfigurationRoute(): void
     {
+        $_SERVER['DATABASE_URL'] = 'mysql://shopware:secret@db.example:3307/shopware_prefill';
+
+        $expectedConnectionInfo = (new DatabaseConnectionInformation())->assign([
+            'hostname' => 'db.example',
+            'port' => 3307,
+            'username' => 'shopware',
+            'password' => null,
+            'databaseName' => 'shopware_prefill',
+        ]);
+
+        $this->twig->expects($this->once())->method('render')
+            ->with(
+                '@Installer/installer/database-configuration.html.twig',
+                array_merge($this->getDefaultViewParams(), [
+                    'connectionInfo' => $expectedConnectionInfo,
+                    'error' => null,
+                ])
+            )
+            ->willReturn('config');
+
+        $this->connectionFactory->expects($this->never())->method('getConnection');
+
+        $request = Request::create('/installer/database-configuration');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $response = $this->controller->databaseConfiguration($request);
+        static::assertSame('config', $response->getContent());
+
+        static::assertFalse($session->has(DatabaseConnectionInformation::class));
+    }
+
+    #[BackupGlobals(true)]
+    public function testDatabaseGetConfigurationRouteFallsBackOnInvalidDatabaseUrl(): void
+    {
+        $_SERVER['DATABASE_URL'] = 'not-a-valid-url';
+
         $this->twig->expects($this->once())->method('render')
             ->with(
                 '@Installer/installer/database-configuration.html.twig',

--- a/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
@@ -3,10 +3,10 @@
 namespace Shopware\Tests\Unit\Core\Installer\Controller;
 
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Installer\Controller\DatabaseConfigurationController;
 use Shopware\Core\Installer\Controller\InstallerController;
 use Shopware\Core\Installer\Database\BlueGreenDeploymentService;
@@ -31,6 +31,7 @@ use Twig\Environment;
 #[CoversClass(InstallerController::class)]
 class DatabaseConfigurationControllerTest extends TestCase
 {
+    use EnvTestBehaviour;
     use InstallerControllerTestTrait;
 
     private MockObject&Environment $twig;
@@ -65,10 +66,11 @@ class DatabaseConfigurationControllerTest extends TestCase
         $this->controller->setContainer($this->getInstallerContainer($this->twig, ['router' => $this->router]));
     }
 
-    #[BackupGlobals(true)]
     public function testDatabaseGetConfigurationRoute(): void
     {
-        $_SERVER['DATABASE_URL'] = 'mysql://shopware:secret@db.example:3307/shopware_prefill';
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://shopware:secret@db.example:3307/shopware_prefill',
+        ]);
 
         $expectedConnectionInfo = (new DatabaseConnectionInformation())->assign([
             'hostname' => 'db.example',
@@ -100,10 +102,11 @@ class DatabaseConfigurationControllerTest extends TestCase
         static::assertFalse($session->has(DatabaseConnectionInformation::class));
     }
 
-    #[BackupGlobals(true)]
     public function testDatabaseGetConfigurationRouteFallsBackOnInvalidDatabaseUrl(): void
     {
-        $_SERVER['DATABASE_URL'] = 'not-a-valid-url';
+        $this->setEnvVars([
+            'DATABASE_URL' => 'not-a-valid-url',
+        ]);
 
         $this->twig->expects($this->once())->method('render')
             ->with(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To avoid mistakes when entering database credentials and speed up installation.

### 2. What does this change do, exactly?
It autofills the database fields in the installer with default values.

### 3. Describe each step to reproduce the issue or behaviour.
Start the installer
Go to the database setup form
Database fields are automatically filled with default values from environment variables

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/7835

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
