### PR TITLE
fix: enforce the settings card for AC channels

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -20,6 +20,12 @@ export default {
         'feature',
     ],
 
+    provide() {
+        return {
+            swSalesChannelDetailGetAgenticCommerceExportConfig: () => this.agenticCommerceExportConfig,
+        };
+    },
+
     mixins: [
         Mixin.getByName('notification'),
         Mixin.getByName('placeholder'),
@@ -185,11 +191,19 @@ export default {
         },
 
         loadEntityData() {
-            if (!this.$route.params.id) {
+            const hasRouteId = Boolean(this.$route.params.id);
+            const hasRouteTypeId = Boolean(this.$route.params.typeId);
+
+            if (!hasRouteId && hasRouteTypeId && this.salesChannel?.id) {
+                this.loadAgenticCommerceExportConfig();
                 return;
             }
 
-            if (this.$route.params.typeId) {
+            if (!hasRouteId) {
+                return;
+            }
+
+            if (hasRouteTypeId) {
                 this.loadAgenticCommerceExportConfig();
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/sw-sales-channel-detail.spec.js
@@ -18,8 +18,12 @@ const mockGet = jest.fn(() =>
         },
     }),
 );
+const mockGetSystemConfig = jest.fn(() => Promise.resolve([]));
+const mockGetSystemConfigValues = jest.fn(() => Promise.resolve({}));
 
-async function createWrapper() {
+async function createWrapper(routeParamsOrLegacyArg = { id: '1a2b3c4d' }) {
+    const routeParams = Array.isArray(routeParamsOrLegacyArg) ? { id: '1a2b3c4d' } : routeParamsOrLegacyArg;
+
     return mount(await wrapTestComponent('sw-sales-channel-detail', { sync: true }), {
         global: {
             stubs: {
@@ -56,16 +60,14 @@ async function createWrapper() {
                     getProductExportTemplateRegistry: () => ({}),
                 },
                 systemConfigApiService: {
-                    getConfig: () => Promise.resolve([]),
-                    getValues: () => Promise.resolve({}),
+                    getConfig: mockGetSystemConfig,
+                    getValues: mockGetSystemConfigValues,
                     batchSave: () => Promise.resolve(),
                 },
             },
             mocks: {
                 $route: {
-                    params: {
-                        id: '1a2b3c4d',
-                    },
+                    params: routeParams,
                     name: '',
                 },
             },
@@ -78,6 +80,8 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         global.activeAclRoles = [];
         mockSave.mockClear();
         mockGet.mockClear();
+        mockGetSystemConfig.mockClear();
+        mockGetSystemConfigValues.mockClear();
     });
 
     it('should disable the save button when privilege does not exist', async () => {
@@ -157,6 +161,54 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
                 }),
             }),
         );
+    });
+
+    it('should provide agentic commerce export config accessor for child views', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setData({
+            agenticCommerceExportConfig: [
+                {
+                    provider: 'open-ai',
+                    elements: [],
+                    values: {},
+                    isLoading: false,
+                },
+            ],
+        });
+
+        const provide = wrapper.vm.$options.provide.call(wrapper.vm);
+
+        expect(typeof provide.swSalesChannelDetailGetAgenticCommerceExportConfig).toBe('function');
+        expect(provide.swSalesChannelDetailGetAgenticCommerceExportConfig()).toEqual(wrapper.vm.agenticCommerceExportConfig);
+    });
+
+    it('should load agentic commerce export config in create flow when route has typeId but no id', async () => {
+        mockGetSystemConfig.mockResolvedValueOnce([
+            {
+                elements: [
+                    {
+                        name: 'core.openAiProductExport.returnPolicyUrl',
+                    },
+                ],
+            },
+        ]);
+
+        const wrapper = await createWrapper({
+            typeId: Shopware.Defaults.agenticCommerceTypeId,
+        });
+
+        wrapper.vm.salesChannel = {
+            id: 'new-sales-channel-id',
+            typeId: Shopware.Defaults.agenticCommerceTypeId,
+        };
+
+        await wrapper.vm.loadEntityData();
+        await flushPromises();
+
+        expect(mockGetSystemConfig).toHaveBeenCalledWith('core.openAiProductExport');
+        expect(mockGetSystemConfigValues).toHaveBeenCalledWith('core.openAiProductExport', 'new-sales-channel-id');
+        expect(wrapper.vm.agenticCommerceExportConfig[0].elements).toHaveLength(1);
     });
 
     it('should save without reloading entity data when saveOnLanguageChange is called', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -20,13 +20,17 @@ const FOREIGN_KEY_CONSTRAINT_VIOLATION_CODE = '1451';
 export default {
     template,
 
-    inject: [
-        'salesChannelService',
-        'productExportService',
-        'repositoryFactory',
-        'knownIpsService',
-        'acl',
-    ],
+    inject: {
+        salesChannelService: 'salesChannelService',
+        productExportService: 'productExportService',
+        repositoryFactory: 'repositoryFactory',
+        knownIpsService: 'knownIpsService',
+        acl: 'acl',
+        swSalesChannelDetailGetAgenticCommerceExportConfig: {
+            from: 'swSalesChannelDetailGetAgenticCommerceExportConfig',
+            default: () => [],
+        },
+    },
 
     emits: [
         'template-selected',
@@ -148,6 +152,18 @@ export default {
 
         isProductExportChannel() {
             return this.isProductComparison || this.isAgenticCommerce;
+        },
+
+        resolvedAgenticCommerceExportConfig() {
+            if (Array.isArray(this.agenticCommerceExportConfig) && this.agenticCommerceExportConfig.length > 0) {
+                return this.agenticCommerceExportConfig;
+            }
+
+            if (typeof this.swSalesChannelDetailGetAgenticCommerceExportConfig === 'function') {
+                return this.swSalesChannelDetailGetAgenticCommerceExportConfig() ?? [];
+            }
+
+            return [];
         },
 
         isHeadlessSalesChannel() {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -213,7 +213,7 @@
 
     <template v-if="isAgenticCommerce">
         <mt-card
-            v-for="configEntry in agenticCommerceExportConfig"
+            v-for="configEntry in resolvedAgenticCommerceExportConfig"
             :key="configEntry.provider"
             position-identifier="sw-sales-channel-detail-base-agentic-commerce-export-config-open-ai"
             :title="getAgenticCommerceExportCardTitle(configEntry)"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
@@ -19,7 +19,9 @@ responses.addResponse({
     },
 });
 
-async function createWrapper() {
+async function createWrapper(options = {}) {
+    const { props = {}, provide = {} } = options;
+
     return mount(await wrapTestComponent('sw-sales-channel-detail-base', { sync: true }), {
         global: {
             stubs: {
@@ -45,6 +47,7 @@ async function createWrapper() {
                 'sw-category-tree-field': true,
                 'mt-select': true,
                 'sw-custom-field-set-renderer': true,
+                'sw-form-field-renderer': true,
                 'mt-banner': true,
                 'sw-sales-channel-measurement': true,
                 'sw-time-ago': true,
@@ -73,6 +76,7 @@ async function createWrapper() {
                         },
                     }),
                 },
+                ...provide,
             },
             mocks: {
                 $t: jest.fn().mockImplementation((snippet) => snippet),
@@ -83,6 +87,7 @@ async function createWrapper() {
             salesChannel: {},
             productExport: {},
             customFieldSets: [],
+            ...props,
         },
     });
 }
@@ -1317,6 +1322,43 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-base', () => 
         });
 
         expect(wrapper.vm.unservedLanguageVariant).toBe('info');
+    });
+
+    it('should render agentic commerce export config from injected fallback when prop is not forwarded', async () => {
+        const wrapper = await createWrapper({
+            props: {
+                salesChannel: {
+                    typeId: Shopware.Defaults.agenticCommerceTypeId,
+                },
+            },
+            provide: {
+                swSalesChannelDetailGetAgenticCommerceExportConfig: () => [
+                    {
+                        provider: 'open-ai',
+                        elements: [
+                            {
+                                name: 'core.openAiProductExport.returnPolicyUrl',
+                                type: 'text',
+                                config: {
+                                    label: 'Return policy URL',
+                                },
+                            },
+                        ],
+                        values: {},
+                        isLoading: false,
+                    },
+                ],
+            },
+        });
+
+        expect(wrapper.vm.isAgenticCommerce).toBe(true);
+        expect(wrapper.vm.resolvedAgenticCommerceExportConfig).toHaveLength(1);
+
+        const card = wrapper.get(
+            'div.mt-card[position-identifier="sw-sales-channel-detail-base-agentic-commerce-export-config-open-ai"]',
+        );
+        expect(card.exists()).toBe(true);
+        expect(wrapper.findAll('sw-form-field-renderer-stub')).toHaveLength(1);
     });
 
     it('should not require a theme when activating an agentic commerce sales channel', async () => {


### PR DESCRIPTION
Show the settings, even when the sales channel details page is overwritten or modified by plugins.