### PR TITLE
fix: Improve error message if clipboard functionality is not available

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de.json
@@ -181,7 +181,7 @@
     "sw-field": {
       "notification": {
         "notificationCopySuccessMessage": "Der Text wurde in die Zwischenablage kopiert.",
-        "notificationCopyFailureMessage": "Der Text konnte nicht in die Zwischenablage kopiert werden."
+        "notificationCopyFailureMessage": "Der Text konnte nicht in die Zwischenablage kopiert werden. Stelle sicher, dass du über eine sichere Verbindung (HTTPS) auf die Administration zugreifst, und versuche es erneut."
       },
       "titleShowPassword": "Passwort anzeigen",
       "titleHidePassword": "Passwort verbergen",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en.json
@@ -181,7 +181,7 @@
     "sw-field": {
       "notification": {
         "notificationCopySuccessMessage": "Text has been copied to clipboard.",
-        "notificationCopyFailureMessage": "Text could not be copied to clipboard."
+        "notificationCopyFailureMessage": "Text could not be copied to clipboard. Make sure you're accessing the administration via a secure connection (HTTPS) and try again."
       },
       "titleShowPassword": "Show password",
       "titleHidePassword": "Hide password",

--- a/src/Administration/Resources/app/administration/src/core/service/utils/dom.utils.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/dom.utils.spec.js
@@ -18,4 +18,22 @@ describe('src/core/service/utils/dom.utils.ts', () => {
 
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('string to be copied');
     });
+
+    it('should throw error if Clipboard API is not available', async () => {
+        const originalClipboard = navigator.clipboard;
+
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: undefined,
+        });
+
+        await expect(dom.copyStringToClipboard('string to be copied')).rejects.toThrow(
+            'Clipboard functionality is not available. Access the admin via a secure HTTPS connection and try again.',
+        );
+
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: originalClipboard,
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/core/service/utils/dom.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/dom.utils.ts
@@ -29,6 +29,13 @@ function getScrollbarWidth(element: HTMLElement): number {
 }
 
 async function copyStringToClipboard(stringToCopy: string): Promise<void> {
+    if (!navigator.clipboard) {
+        // Feature is only available in secure context. See https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard
+        throw new Error(
+            'Clipboard functionality is not available. Access the admin via a secure HTTPS connection and try again.',
+        );
+    }
+
     await navigator.clipboard.writeText(stringToCopy);
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It turns out, that the issue was my local setup, which doesn't use HTTPS or uses a domain containing `localhost`.

### 2. What does this change do, exactly?

Improve the error message, so it is clearer, why copying to the clipboard did not work

### 3. Describe each step to reproduce the issue or behaviour.

- Have a local dev setup without HTTPS and with a domain ending e.g. on `.local`.
- Try to copy the Saleschannel API access key

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/15624

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
