### PR TITLE
perf: Improve SEO URL `path_info`-index

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,14 +6,6 @@
 
 ## Core
 
-### Improved SEO URL index for faster hreflang lookup
-
-Changed the `idx.path_info` index on the `seo_url` table to a composite index that covers all columns used in the hreflang URL lookup query, where the new order prioritizes high-cardinality equality filters and uses prefix indexing, to reduce the overall size of the index:
-
-```sql
-INDEX idx.path_info (path_info(255), is_canonical, sales_channel_id, language_id, seo_path_info(255))
-```
-
 ## Administration
 
 ## Storefront

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,14 @@
 
 ## Core
 
+### Improved SEO URL index for faster hreflang lookup
+
+Changed the `idx.path_info` index on the `seo_url` table to a composite index that covers all columns used in the hreflang URL lookup query, where the new order prioritizes high-cardinality equality filters and uses prefix indexing, to reduce the overall size of the index:
+
+```sql
+INDEX idx.path_info (path_info(255), is_canonical, sales_channel_id, language_id, seo_path_info(255))
+```
+
 ## Administration
 
 ## Storefront

--- a/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
+++ b/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
@@ -20,7 +20,7 @@ class Migration1774895840AddPerformanceImprovedSeoUrlIndex extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        if (TableHelper::indexSpansColumns($connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info'])) {
+        if (TableHelper::indexExists($connection, 'seo_url', 'idx.path_info') && TableHelper::indexSpansColumns($connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info'])) {
             return;
         }
 

--- a/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
+++ b/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1774895840AddPerformanceImprovedSeoUrlIndex extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1774895840;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (TableHelper::indexSpansColumns($connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info'])) {
+            return;
+        }
+
+        if (TableHelper::indexExists($connection, 'seo_url', 'idx.path_info')) {
+            $connection->executeStatement('DROP INDEX `idx.path_info` ON `seo_url`');
+        }
+
+        $connection->executeStatement('
+            CREATE INDEX `idx.path_info` ON `seo_url` (
+                `path_info`(255),
+                `is_canonical`,
+                `sales_channel_id`,
+                `language_id`,
+                `seo_path_info`(255)
+            )
+        ');
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
+++ b/src/Core/Migration/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndex.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('inventory')]
 class Migration1774895840AddPerformanceImprovedSeoUrlIndex extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/tests/migration/Core/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndexTest.php
+++ b/tests/migration/Core/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndexTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1774895840AddPerformanceImprovedSeoUrlIndex;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1774895840AddPerformanceImprovedSeoUrlIndex::class)]
+class Migration1774895840AddPerformanceImprovedSeoUrlIndexTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testIndexIsCreated(): void
+    {
+        if (TableHelper::indexExists($this->connection, 'seo_url', 'idx.path_info')) {
+            $this->connection->executeStatement('DROP INDEX `idx.path_info` ON `seo_url`');
+        }
+
+        $migration = new Migration1774895840AddPerformanceImprovedSeoUrlIndex();
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::indexExists($this->connection, 'seo_url', 'idx.path_info'));
+        static::assertTrue(TableHelper::indexSpansColumns($this->connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info']));
+    }
+
+    public function testMigrationIsIdempotent(): void
+    {
+        $migration = new Migration1774895840AddPerformanceImprovedSeoUrlIndex();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::indexSpansColumns($this->connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info']));
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndexTest.php
+++ b/tests/migration/Core/V6_7/Migration1774895840AddPerformanceImprovedSeoUrlIndexTest.php
@@ -32,17 +32,9 @@ class Migration1774895840AddPerformanceImprovedSeoUrlIndexTest extends TestCase
 
         $migration = new Migration1774895840AddPerformanceImprovedSeoUrlIndex();
         $migration->update($this->connection);
+        $migration->update($this->connection);
 
         static::assertTrue(TableHelper::indexExists($this->connection, 'seo_url', 'idx.path_info'));
-        static::assertTrue(TableHelper::indexSpansColumns($this->connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info']));
-    }
-
-    public function testMigrationIsIdempotent(): void
-    {
-        $migration = new Migration1774895840AddPerformanceImprovedSeoUrlIndex();
-        $migration->update($this->connection);
-        $migration->update($this->connection);
-
         static::assertTrue(TableHelper::indexSpansColumns($this->connection, 'seo_url', 'idx.path_info', ['path_info', 'is_canonical', 'sales_channel_id', 'language_id', 'seo_path_info']));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The updated index is to improve the following query:
https://github.com/shopware/shopware/blob/trunk/src/Core/Content/Seo/HreflangLoader.php#L171-L174

### 2. What does this change do, exactly?
Change the order of the indexed fields, such that we first filter on the equality filters first and then on the `IN(...)` condition. Also include the `seo_path_info` from the select, such that the value can be directly fetched from the index.

Also the index is now a prefix index, such that it is much smaller (`1057` vs `3037`), and we usually have URLs lower than 255 characters. The prefix indices can still be used for filtering, even if the URLs are longer.

Not sure if it should be mentioned in the `RELEASE_INFO-6.7.md`.

### 3. Describe each step to reproduce the issue or behaviour.
Have a large `seo_url` database table and look at the performance of the Hreflang Loader SQL performance.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
