### PR TITLE
fix(storefront): sync search widget aria references

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -12,6 +12,8 @@ export default class SearchWidgetPlugin extends Plugin {
         searchWidgetResultItemSelector: '.js-result',
         searchWidgetInputFieldSelector: 'input[type=search]',
         searchWidgetButtonFieldSelector: 'button[type=submit]',
+        searchWidgetResultListboxSelector: '#search-suggest-listbox',
+        searchWidgetResultInfoSelector: '#search-suggest-result-info',
         searchWidgetUrlDataAttribute: 'data-url',
         searchWidgetCollapseButtonSelector: '.js-search-toggle-btn',
         searchWidgetCollapseClass: 'collapsed',
@@ -204,6 +206,7 @@ export default class SearchWidgetPlugin extends Plugin {
                 const searchWidgetButtonField = this.el.querySelector(this.options.searchWidgetButtonFieldSelector);
                 searchWidgetButtonField.insertAdjacentHTML('afterend', content);
 
+                this._setAccessibilityAttributes();
                 this._inputField.setAttribute('aria-expanded', 'true');
 
                 const searchSuggest = document.querySelector(this.options.searchWidgetResultSelector);
@@ -234,9 +237,27 @@ export default class SearchWidgetPlugin extends Plugin {
         const results = document.querySelectorAll(this.options.searchWidgetResultSelector);
         results.forEach(result => result.remove());
 
+        this._removeAccessibilityAttributes();
         this._inputField.setAttribute('aria-expanded', 'false');
 
         this.$emitter.publish('clearSuggestResults');
+    }
+
+    _setAccessibilityAttributes() {
+        const listbox = document.querySelector(this.options.searchWidgetResultListboxSelector);
+        if (listbox) {
+            this._inputField.setAttribute('aria-controls', listbox.id);
+        }
+
+        const resultInfo = document.querySelector(this.options.searchWidgetResultInfoSelector);
+        if (resultInfo) {
+            this._inputField.setAttribute('aria-describedby', resultInfo.id);
+        }
+    }
+
+    _removeAccessibilityAttributes() {
+        this._inputField.removeAttribute('aria-controls');
+        this._inputField.removeAttribute('aria-describedby');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -291,7 +291,16 @@ describe('SearchPlugin Tests', () => {
     });
 
     test('_suggest should handle successful AJAX request', async () => {
-        const mockResponse = '<div class="js-search-result"><div class="js-result"><a href="#">Test Result</a></div></div>';
+        const mockResponse = `
+            <div class="search-suggest js-search-result">
+                <ul id="search-suggest-listbox">
+                    <li class="js-result">
+                        <a href="#">Test Result</a>
+                    </li>
+                    <li id="search-suggest-result-info">1 result</li>
+                </ul>
+            </div>
+        `;
         global.fetch = jest.fn().mockResolvedValue({
             text: () => Promise.resolve(mockResponse)
         });
@@ -309,7 +318,42 @@ describe('SearchPlugin Tests', () => {
         await new Promise(process.nextTick);
         expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('afterSuggest');
         expect(searchPlugin._inputField.getAttribute('aria-expanded')).toBe('true');
+        expect(searchPlugin._inputField.getAttribute('aria-controls')).toBe('search-suggest-listbox');
+        expect(searchPlugin._inputField.getAttribute('aria-describedby')).toBe('search-suggest-result-info');
         expect(searchPlugin.searchSuggestLinks.length).toBe(1);
+    });
+
+    test('_clearSuggestResults should remove dynamic accessibility references', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true" data-url="/search" class="js-search-form">
+                <input
+                    type="search"
+                    name="search"
+                    autocapitalize="off"
+                    autocomplete="off"
+                    aria-controls="search-suggest-listbox"
+                    aria-describedby="search-suggest-result-info"
+                >
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result">
+                    <ul id="search-suggest-listbox">
+                        <li id="search-suggest-result-info">1 result</li>
+                    </ul>
+                </div>
+            </form>
+        `;
+
+        const formElement = document.getElementById('search-widget');
+        const searchPlugin = new SearchPlugin(formElement);
+        searchPlugin.$emitter.publish = jest.fn();
+
+        searchPlugin._clearSuggestResults();
+
+        expect(searchPlugin._inputField.hasAttribute('aria-controls')).toBe(false);
+        expect(searchPlugin._inputField.hasAttribute('aria-describedby')).toBe(false);
+        expect(searchPlugin._inputField.getAttribute('aria-expanded')).toBe('false');
+        expect(document.querySelector('.js-search-result')).toBeNull();
     });
 
     test('_suggest should handle failed AJAX request', async () => {

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -25,9 +25,7 @@
                                     aria-label="{{ 'header.searchPlaceholder'|trans|striptags }}"
                                     role="combobox"
                                     aria-autocomplete="list"
-                                    aria-controls="search-suggest-listbox"
                                     aria-expanded="false"
-                                    aria-describedby="search-suggest-result-info"
                                     value="{{ page.searchTerm }}">
                             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The storefront header search input currently renders `aria-controls="search-suggest-listbox"` and `aria-describedby="search-suggest-result-info"` before the suggest markup exists in the DOM. That leaves the initial page in an invalid accessibility state and triggers the audit failure reported in `shopware/shopware#14036`.

### 2. What does this change do, exactly?

It removes the static ARIA references from the base Twig template and lets the search widget add them only after the suggest popup has been inserted, then removes them again when the popup is cleared. The change also updates the storefront Jest test to cover both setting and removing those dynamic accessibility attributes.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a storefront page with the standard header search.
2. Inspect `#header-main-search-input` before typing into the field.
3. Observe that `aria-controls` and `aria-describedby` reference IDs that do not exist yet.

