### PR TITLE
fix: UpdatedByField and CreatedByField with incorrect write scopes

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -71,6 +71,17 @@ From now on, the defined fields of an EntityDefinition are applied after the def
 This makes it possible to properly overwrite the current default fields `createdAt` and `updatedAt`.
 Check your EntityDefinitions if your entities still behave like intended. (Only applicable if you manually add `CreatedAtField` and/or `UpdatedAtField`)
 
+## `CreatedByField` and `UpdatedByField` default write scopes changed
+
+The default write scopes of `Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedByField` and `Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedByField` now include `Context::CRUD_API_SCOPE` in addition to `Context::SYSTEM_SCOPE`.
+
+If you rely on the previous system-only behavior, pass the desired scopes explicitly when instantiating the field, for example:
+
+```php
+new CreatedByField([Context::SYSTEM_SCOPE]);
+new UpdatedByField([Context::SYSTEM_SCOPE]);
+```
+
 ## Multiple payment finalize calls allowed
 
 Multiple calls to the `/payment-finalize` endpoint using the same payment token are now allowed.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -259,18 +259,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedContainerEvent.php
 
 		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\CreatedByField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\CreatedByField\:\:getAllowedWriteScopes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
-
-		-
 			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\Runtime\:\:__construct\(\) has parameter \$dependsOn with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -293,18 +281,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/StateMachineStateField.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\UpdatedByField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
-
-		-
-			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\UpdatedByField\:\:getAllowedWriteScopes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
 
 		-
 			message: '#^Cannot call method is\(\) on Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\|null\.$#'
@@ -1013,4 +989,3 @@ parameters:
 			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigFieldFactory.php
-

--- a/src/Core/Checkout/Order/OrderDefinition.php
+++ b/src/Core/Checkout/Order/OrderDefinition.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTag\OrderTagDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AutoIncrementField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CalculatedPriceField;
@@ -119,8 +120,8 @@ class OrderDefinition extends EntityDefinition
             (new ManyToOneAssociationField('stateMachineState', 'state_id', StateMachineStateDefinition::class, 'id'))->addFlags(new ApiAware())->setDescription('Current order state (e.g., open, in_progress, completed, cancelled)'),
             (new ListField('rule_ids', 'ruleIds', StringField::class))->setDescription('Unique identity of rule.'),
             (new CustomFields())->addFlags(new ApiAware())->setDescription('Additional fields that offer a possibility to add own fields for the different program-areas.'),
-            (new CreatedByField())->addFlags(new ApiAware())->setDescription('Unique identity of createdBy.'),
-            (new UpdatedByField())->addFlags(new ApiAware())->setDescription('Unique identity of updatedBy.'),
+            (new CreatedByField([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]))->addFlags(new ApiAware())->setDescription('Unique identity of createdBy.'),
+            (new UpdatedByField([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]))->addFlags(new ApiAware())->setDescription('Unique identity of updatedBy.'),
 
             (new OneToOneAssociationField('primaryOrderDelivery', 'primary_order_delivery_id', 'id', OrderDeliveryDefinition::class, false))->addFlags(new ApiAware())->setDescription('Primary delivery information for the order'),
             (new OneToOneAssociationField('primaryOrderTransaction', 'primary_order_transaction_id', 'id', OrderTransactionDefinition::class, false))->addFlags(new ApiAware())->setDescription('Primary payment transaction for the order'),

--- a/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
@@ -4,15 +4,42 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
 #[Package('framework')]
 class CreatedByField extends FkField
 {
-    public function __construct(private readonly array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
+    /**
+     * @var array<string>
+     */
+    private readonly array $allowedWriteScopes;
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     */
+    public function __construct(?array $allowedWriteScopes = null)
     {
         parent::__construct('created_by_id', 'createdById', UserDefinition::class);
+
+        if ($allowedWriteScopes === null) {
+            if (Feature::isActive('v6.8.0.0')) {
+                $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
+            } else {
+                Feature::triggerDeprecationOrThrow(
+                    'v6.8.0.0',
+                    \sprintf(
+                        'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
+                        self::class
+                    )
+                );
+
+                $allowedWriteScopes = [Context::SYSTEM_SCOPE];
+            }
+        }
+
+        $this->allowedWriteScopes = $allowedWriteScopes;
     }
 
     public function getAllowedWriteScopes(): array

--- a/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer;
 use Shopware\Core\Framework\Feature;
@@ -17,28 +18,27 @@ class CreatedByField extends FkField
     private readonly array $allowedWriteScopes;
 
     /**
-     * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     * @deprecated tag:v6.8.0 - reason:parameter-default-change - omitting $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]
      *
-     * @param list<string>|null $allowedWriteScopes
+     * @param list<string> $allowedWriteScopes
      */
-    public function __construct(?array $allowedWriteScopes = null)
+    public function __construct(array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
     {
         parent::__construct('created_by_id', 'createdById', UserDefinition::class);
 
-        if ($allowedWriteScopes === null) {
-            if (Feature::isActive('v6.8.0.0')) {
-                $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
-            } else {
-                Feature::triggerDeprecationOrThrow(
-                    'v6.8.0.0',
-                    \sprintf(
-                        'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
-                        self::class
-                    )
-                );
+        if (\func_num_args() === 0 && Feature::isActive('v6.8.0.0')) {
+            $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
+        }
 
-                $allowedWriteScopes = [Context::SYSTEM_SCOPE];
-            }
+        if (\func_num_args() === 0 && !Feature::isActive('v6.8.0.0') && !EnvironmentHelper::getVariable('TESTS_RUNNING')) {
+            trigger_deprecation(
+                'shopware/core',
+                '',
+                \sprintf(
+                    'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
+                    self::class
+                )
+            );
         }
 
         $this->allowedWriteScopes = $allowedWriteScopes;

--- a/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
@@ -18,6 +18,8 @@ class CreatedByField extends FkField
 
     /**
      * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     *
+     * @param list<string>|null $allowedWriteScopes
      */
     public function __construct(?array $allowedWriteScopes = null)
     {
@@ -42,6 +44,9 @@ class CreatedByField extends FkField
         $this->allowedWriteScopes = $allowedWriteScopes;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getAllowedWriteScopes(): array
     {
         return $this->allowedWriteScopes;

--- a/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
@@ -4,15 +4,42 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\UpdatedByFieldSerializer;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
 
 #[Package('framework')]
 class UpdatedByField extends FkField
 {
-    public function __construct(private readonly array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
+    /**
+     * @var array<string>
+     */
+    private readonly array $allowedWriteScopes;
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     */
+    public function __construct(?array $allowedWriteScopes = null)
     {
         parent::__construct('updated_by_id', 'updatedById', UserDefinition::class);
+
+        if ($allowedWriteScopes === null) {
+            if (Feature::isActive('v6.8.0.0')) {
+                $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
+            } else {
+                Feature::triggerDeprecationOrThrow(
+                    'v6.8.0.0',
+                    \sprintf(
+                        'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
+                        self::class
+                    )
+                );
+
+                $allowedWriteScopes = [Context::SYSTEM_SCOPE];
+            }
+        }
+
+        $this->allowedWriteScopes = $allowedWriteScopes;
     }
 
     public function getAllowedWriteScopes(): array

--- a/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
@@ -18,6 +18,8 @@ class UpdatedByField extends FkField
 
     /**
      * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     *
+     * @param list<string>|null $allowedWriteScopes
      */
     public function __construct(?array $allowedWriteScopes = null)
     {
@@ -42,6 +44,9 @@ class UpdatedByField extends FkField
         $this->allowedWriteScopes = $allowedWriteScopes;
     }
 
+    /**
+     * @return list<string>
+     */
     public function getAllowedWriteScopes(): array
     {
         return $this->allowedWriteScopes;

--- a/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\UpdatedByFieldSerializer;
 use Shopware\Core\Framework\Feature;
@@ -17,28 +18,27 @@ class UpdatedByField extends FkField
     private readonly array $allowedWriteScopes;
 
     /**
-     * @deprecated tag:v6.8.0 - reason:parameter-default-change - $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE] and be not nullable again
+     * @deprecated tag:v6.8.0 - reason:parameter-default-change - omitting $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]
      *
-     * @param list<string>|null $allowedWriteScopes
+     * @param list<string> $allowedWriteScopes
      */
-    public function __construct(?array $allowedWriteScopes = null)
+    public function __construct(array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
     {
         parent::__construct('updated_by_id', 'updatedById', UserDefinition::class);
 
-        if ($allowedWriteScopes === null) {
-            if (Feature::isActive('v6.8.0.0')) {
-                $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
-            } else {
-                Feature::triggerDeprecationOrThrow(
-                    'v6.8.0.0',
-                    \sprintf(
-                        'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
-                        self::class
-                    )
-                );
+        if (\func_num_args() === 0 && Feature::isActive('v6.8.0.0')) {
+            $allowedWriteScopes = [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE];
+        }
 
-                $allowedWriteScopes = [Context::SYSTEM_SCOPE];
-            }
+        if (\func_num_args() === 0 && !Feature::isActive('v6.8.0.0') && !EnvironmentHelper::getVariable('TESTS_RUNNING')) {
+            trigger_deprecation(
+                'shopware/core',
+                '',
+                \sprintf(
+                    'Not passing $allowedWriteScopes to %s::__construct() will include Context::CRUD_API_SCOPE by default in v6.8.0. Pass the desired scopes explicitly to keep the current behavior.',
+                    self::class
+                )
+            );
         }
 
         $this->allowedWriteScopes = $allowedWriteScopes;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -118,6 +118,26 @@ class CreatedByFieldTest extends TestCase
         static::assertSame($userId, $result->getCreatedById());
     }
 
+    public function testCreateCreatedByWithCrudScope(): void
+    {
+        $userId = $this->fetchFirstIdFromTable('user');
+        $context = $this->getAdminContext($userId);
+
+        $payload = $this->createOrderPayload();
+
+        $context->scope(Context::CRUD_API_SCOPE, function (Context $context) use ($payload): void {
+            $this->orderRepository->create([$payload], $context);
+        });
+
+        $result = $this->orderRepository->search(
+            new Criteria([$payload['id']]),
+            $context
+        )->getEntities()->first();
+
+        static::assertNotNull($result);
+        static::assertSame($userId, $result->getCreatedById());
+    }
+
     private function getAdminContext(string $userId): Context
     {
         $source = new AdminApiSource($userId);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -116,6 +116,64 @@ class UpdatedByFieldTest extends TestCase
         static::assertSame($userId, $result->getUpdatedById());
     }
 
+    public function testUpdatedByUpdateWithCrudScope(): void
+    {
+        $userId = $this->fetchFirstIdFromTable('user');
+        $context = $this->getAdminContext($userId);
+
+        $payload = $this->createOrderPayload();
+        $this->orderRepository->create([$payload], $context);
+
+        $context->scope(Context::CRUD_API_SCOPE, function (Context $context) use ($payload): void {
+            $this->orderRepository->update([
+                [
+                    'id' => $payload['id'],
+                    'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                ],
+            ], $context);
+        });
+
+        $result = $this->orderRepository->search(
+            new Criteria([$payload['id']]),
+            $context
+        )->getEntities()->first();
+
+        static::assertNotNull($result);
+        static::assertSame($userId, $result->getUpdatedById());
+    }
+
+    public function testUpdatedByChangesToLastCrudUser(): void
+    {
+        [$firstUserId, $secondUserId] = $this->fetchFirstTwoUserIds();
+
+        $createContext = $this->getAdminContext($firstUserId);
+        $updateContext = $this->getAdminContext($secondUserId);
+
+        $payload = $this->createOrderPayload();
+
+        $createContext->scope(Context::CRUD_API_SCOPE, function (Context $context) use ($payload): void {
+            $this->orderRepository->create([$payload], $context);
+        });
+
+        $updateContext->scope(Context::CRUD_API_SCOPE, function (Context $context) use ($payload): void {
+            $this->orderRepository->update([
+                [
+                    'id' => $payload['id'],
+                    'orderDateTime' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                ],
+            ], $context);
+        });
+
+        $result = $this->orderRepository->search(
+            new Criteria([$payload['id']]),
+            $updateContext
+        )->getEntities()->first();
+
+        static::assertNotNull($result);
+        static::assertSame($firstUserId, $result->getCreatedById());
+        static::assertSame($secondUserId, $result->getUpdatedById());
+    }
+
     private function getAdminContext(string $userId): Context
     {
         $source = new AdminApiSource($userId);
@@ -179,6 +237,37 @@ class UpdatedByFieldTest extends TestCase
     private function fetchFirstIdFromTable(string $table): string
     {
         return Uuid::fromBytesToHex((string) static::getContainer()->get(Connection::class)->fetchOne('SELECT id FROM ' . $table . ' LIMIT 1'));
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function fetchFirstTwoUserIds(): array
+    {
+        $ids = static::getContainer()->get(Connection::class)->fetchFirstColumn('SELECT id FROM user LIMIT 2');
+
+        if (\count($ids) < 2) {
+            $secondUserId = Uuid::randomHex();
+            $uniqueSuffix = substr($secondUserId, 0, 8);
+
+            static::getContainer()->get('user.repository')->create([[
+                'id' => $secondUserId,
+                'email' => \sprintf('second-admin-%s@example.com', $uniqueSuffix),
+                'firstName' => 'Second',
+                'lastName' => 'Admin',
+                'password' => TestDefaults::HASHED_PASSWORD,
+                'username' => \sprintf('second-admin-%s', $uniqueSuffix),
+                'localeId' => Uuid::fromBytesToHex((string) static::getContainer()->get(Connection::class)->fetchOne('SELECT id FROM locale LIMIT 1')),
+                'aclRoles' => [],
+            ]], Context::createDefaultContext());
+
+            $ids[] = Uuid::fromHexToBytes($secondUserId);
+        }
+
+        return [
+            Uuid::fromBytesToHex((string) $ids[0]),
+            Uuid::fromBytesToHex((string) $ids[1]),
+        ];
     }
 
     private function fetchOrderStateId(string $orderStateTechnicalName): string

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -40,4 +40,13 @@ class CreatedByFieldTest extends TestCase
             static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
         });
     }
+
+    public function testExplicitScopesStayUntouchedInV680(): void
+    {
+        Feature::fake(['v6.8.0.0'], function (): void {
+            $field = new CreatedByField([Context::SYSTEM_SCOPE]);
+
+            static::assertSame([Context::SYSTEM_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedByField;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CreatedByField::class)]
+class CreatedByFieldTest extends TestCase
+{
+    public function testGetAllowedWriteScopesDefaultsToSystemScopeBeforeV680(): void
+    {
+        Feature::fake([], function (): void {
+            $field = new CreatedByField();
+
+            static::assertSame([Context::SYSTEM_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
+
+    public function testGetAllowedWriteScopesUsesExplicitScopes(): void
+    {
+        $field = new CreatedByField([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]);
+
+        static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
+    }
+
+    public function testGetAllowedWriteScopesDefaultsToCrudScopeInV680(): void
+    {
+        Feature::fake(['v6.8.0.0'], function (): void {
+            $field = new CreatedByField();
+
+            static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedByField;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(UpdatedByField::class)]
+class UpdatedByFieldTest extends TestCase
+{
+    public function testGetAllowedWriteScopesDefaultsToSystemScopeBeforeV680(): void
+    {
+        Feature::fake([], function (): void {
+            $field = new UpdatedByField();
+
+            static::assertSame([Context::SYSTEM_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
+
+    public function testGetAllowedWriteScopesUsesExplicitScopes(): void
+    {
+        $field = new UpdatedByField([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]);
+
+        static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
+    }
+
+    public function testGetAllowedWriteScopesDefaultsToCrudScopeInV680(): void
+    {
+        Feature::fake(['v6.8.0.0'], function (): void {
+            $field = new UpdatedByField();
+
+            static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -40,4 +40,13 @@ class UpdatedByFieldTest extends TestCase
             static::assertSame([Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE], $field->getAllowedWriteScopes());
         });
     }
+
+    public function testExplicitScopesStayUntouchedInV680(): void
+    {
+        Feature::fake(['v6.8.0.0'], function (): void {
+            $field = new UpdatedByField([Context::SYSTEM_SCOPE]);
+
+            static::assertSame([Context::SYSTEM_SCOPE], $field->getAllowedWriteScopes());
+        });
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The UpdatedBy and CreatedBy fields are not set, when writing via Crud API.
For `CustomerEntity` this is already fixed, but this should be fixed better by setting new defaults for 6.8.

### 2. What does this change do, exactly?
- Add crud api write scope created/updated by fields of `OrderDefinition`
- Change default of this field for 6.8, as it does not really make sense to be limited to only system scope writes.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
fixes #15543 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them 