### PR TITLE
test: fix flaky dst unit test 

### DIFF
--- a/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
@@ -78,7 +78,7 @@ class TimeRangeRuleTest extends TestCase
         $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
         $timezoneUTC = new \DateTimeZone('UTC');
 
-        $reference = new \DateTimeImmutable('12:00', $timezoneUTC);
+        $reference = new \DateTimeImmutable('2025-05-25 04:20:42', $timezoneUTC);
         $local = $reference->setTimezone($timezoneEuropeBerlin);
         $toTime = $local->format('H:i');
 
@@ -99,7 +99,7 @@ class TimeRangeRuleTest extends TestCase
         $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
         $timezoneUTC = new \DateTimeZone('UTC');
 
-        $reference = new \DateTimeImmutable('12:00', $timezoneUTC);
+        $reference = new \DateTimeImmutable('2025-05-25 04:20:42', $timezoneUTC);
         $local = $reference->setTimezone($timezoneEuropeBerlin);
         $toTime = $local->modify('-1 hour')->format('H:i');
 

--- a/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
@@ -75,42 +75,35 @@ class TimeRangeRuleTest extends TestCase
     {
         $rule = new TimeRangeRule();
 
-        $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
-        $timezoneUTC = new \DateTimeZone('UTC');
-
-        $reference = new \DateTimeImmutable('2025-05-25 04:20:42', $timezoneUTC);
-        $local = $reference->setTimezone($timezoneEuropeBerlin);
-        $toTime = $local->format('H:i');
+        // Convert the exact instant returned by getCurrentTime() into Berlin to derive toTime.
+        // This guarantees the mocked UTC time falls inside [00:00, toTime] in Europe/Berlin,
+        // regardless of DST (UTC+1 winter / UTC+2 summer).
+        $now = new \DateTimeImmutable('12:00', new \DateTimeZone('UTC'));
+        $toTime = $now->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('+1 hour')->format('H:i');
 
         $rule->assign(['fromTime' => '00:00', 'toTime' => $toTime, 'timezone' => 'Europe/Berlin']);
 
         $ruleScope = $this->createMock(RuleScope::class);
-        $ruleScope->method('getCurrentTime')->willReturn(new \DateTimeImmutable('12:00', new \DateTimeZone('UTC')));
+        $ruleScope->method('getCurrentTime')->willReturn($now);
 
-        $match = $rule->match($ruleScope);
-
-        static::assertTrue($match);
+        static::assertTrue($rule->match($ruleScope));
     }
 
     public function testIfOnSameDayOutOfTimeRangeWithDifferentTimezonesAndCurrentOffsetMatches(): void
     {
         $rule = new TimeRangeRule();
 
-        $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
-        $timezoneUTC = new \DateTimeZone('UTC');
-
-        $reference = new \DateTimeImmutable('2025-05-25 04:20:42', $timezoneUTC);
-        $local = $reference->setTimezone($timezoneEuropeBerlin);
-        $toTime = $local->modify('-1 hour')->format('H:i');
+        // toTime is one hour before the local Berlin equivalent of 12:00 UTC,
+        // so the mocked UTC time falls outside [00:00, toTime] in Europe/Berlin.
+        $now = new \DateTimeImmutable('12:00', new \DateTimeZone('UTC'));
+        $toTime = $now->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('-1 hour')->format('H:i');
 
         $rule->assign(['fromTime' => '00:00', 'toTime' => $toTime, 'timezone' => 'Europe/Berlin']);
 
         $ruleScope = $this->createMock(RuleScope::class);
-        $ruleScope->method('getCurrentTime')->willReturn(new \DateTimeImmutable('12:00', new \DateTimeZone('UTC')));
+        $ruleScope->method('getCurrentTime')->willReturn($now);
 
-        $match = $rule->match($ruleScope);
-
-        static::assertFalse($match);
+        static::assertFalse($rule->match($ruleScope));
     }
 
     public function testIfToTimeIsSmallerThanFromTimeMatchesCorrect(): void

--- a/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/TimeRangeRuleTest.php
@@ -78,8 +78,9 @@ class TimeRangeRuleTest extends TestCase
         $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
         $timezoneUTC = new \DateTimeZone('UTC');
 
-        $offset = $timezoneEuropeBerlin->getOffset(new \DateTimeImmutable('now', $timezoneUTC)) / 3600;
-        $toTime = (12 + $offset) . ':00';
+        $reference = new \DateTimeImmutable('12:00', $timezoneUTC);
+        $local = $reference->setTimezone($timezoneEuropeBerlin);
+        $toTime = $local->format('H:i');
 
         $rule->assign(['fromTime' => '00:00', 'toTime' => $toTime, 'timezone' => 'Europe/Berlin']);
 
@@ -98,8 +99,9 @@ class TimeRangeRuleTest extends TestCase
         $timezoneEuropeBerlin = new \DateTimeZone('Europe/Berlin');
         $timezoneUTC = new \DateTimeZone('UTC');
 
-        $offset = $timezoneEuropeBerlin->getOffset(new \DateTimeImmutable('now', $timezoneUTC)) / 3600;
-        $toTime = (11 + $offset) . ':00';
+        $reference = new \DateTimeImmutable('12:00', $timezoneUTC);
+        $local = $reference->setTimezone($timezoneEuropeBerlin);
+        $toTime = $local->modify('-1 hour')->format('H:i');
 
         $rule->assign(['fromTime' => '00:00', 'toTime' => $toTime, 'timezone' => 'Europe/Berlin']);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
See the issue attached, in pipeline CI during DST change this test can break

### 2. What does this change do, exactly?

Use DatetimeImmutable without `now` notion, and the tooling of Datetime classes for format

### 3. Describe each step to reproduce the issue or behaviour.

Run this during DST change on the pipeline
Run this locally with modified clock in docker to mimic the behaviour

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/15843

<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
