### PR TITLE
docs(consent): update readmes for revision-aware consent flow

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/consent/Readme.md
+++ b/src/Administration/Resources/app/administration/src/core/consent/Readme.md
@@ -19,6 +19,8 @@ Each consent entry contains revision metadata in addition to the raw status:
 - if a consent has no revisions, `status === 'accepted'` is enough
 - if a consent has revisions, `isAccepted()` only returns `true` when `acceptedRevision === latestRevision`
 
+> **Note:** this differs from the PHP `ConsentState::isAccepted()`, which only checks the status and is not revision-aware. The JS `isAccepted()` is equivalent to the PHP `isCurrent()` method. If you need the raw status check without revision awareness, read `consent.status === 'accepted'` directly.
+
 If you need to distinguish "accepted, but outdated" from "not accepted", use `consentStore.isStale()`.
 
 ```ts

--- a/src/Administration/Resources/app/administration/src/core/consent/Readme.md
+++ b/src/Administration/Resources/app/administration/src/core/consent/Readme.md
@@ -9,6 +9,18 @@ In the Administration, we can now use this system to read and update the consent
 Everything you need to read a consent state and react to consent changes is available in the `useConsentStore` composable.
 The pinia store returned from it, gives you access to read a consent's state.
 
+Each consent entry contains revision metadata in addition to the raw status:
+
+- `acceptedRevision`: the revision that was accepted last, or `null`
+- `latestRevision`: the current revision defined by the backend, or `null`
+
+`consentStore.isAccepted()` is revision-aware:
+
+- if a consent has no revisions, `status === 'accepted'` is enough
+- if a consent has revisions, `isAccepted()` only returns `true` when `acceptedRevision === latestRevision`
+
+If you need to distinguish "accepted, but outdated" from "not accepted", use `consentStore.isStale()`.
+
 ```ts
 import useConsentStore from 'src/core/consent/consent.store'
 
@@ -21,12 +33,18 @@ const consentState = computed(() => consentStore.consents?.your_consent.status ?
 if (consentStore.isAccepted('your_consent')) {
     // do something
 }
+
+if (consentStore.isStale('your_consent')) {
+    // consent was accepted before, but not for the current revision
+}
 ```
 
 ## Update a consent state
 
 To update the current state of a consent, it is mandatory to use the actions `accept` and `revoke` from the store.
 This will also update the state across all tabs in the browser. Don't use the api services directly.
+
+The store intentionally accepts without sending a cached revision from the client. The backend resolves the current latest revision server-side, which avoids avoidable failures when the latest revision changed after the last `list()` call.
 
 ```ts
 import useConsentStore from 'src/core/consent/consent.store'
@@ -70,6 +88,8 @@ Shopware.Utils.EventBus.off('consent', eventHandler);
         actor: string | null;
         status: 'unset' | 'declined' | 'accepted' | 'revoked';
         updatedAt: string | null;
+        acceptedRevision: string | null;
+        latestRevision: string | null;
     };
     timestamp: Date;
 }

--- a/src/Core/System/Consent/README.md
+++ b/src/Core/System/Consent/README.md
@@ -15,6 +15,8 @@
  - Both `declined` and `revoked` indicate that a user was prompted to consent but declined. The difference is that `declined` is used when the user initially declines consent, while `revoked` is used when a user who previously accepted consent decides to revoke it later.
  So the difference between this two is, that you know that a declined consent was never accepted, while a revoked consent was accepted until it's current `updated_at` date.
  - Actor: The username of the Admin user who made the last change to a consent decision.
+ - Revision: A consent definition can declare a `latestRevision`. When present, accepted states also carry an `acceptedRevision`.
+ - Current vs stale acceptance: An accepted consent can still be stale. `ConsentState::isAccepted()` only checks the raw state, `ConsentState::isCurrent()` checks whether the accepted revision still matches the latest revision, and `ConsentState::isStale()` indicates an accepted but outdated revision.
 
  Examples
  - Admin user scope
@@ -36,6 +38,7 @@
    public function getScopeName(): string;          // Name of the scope (see ConsentScope implementations)
    public function getSince(): \DateTimeImmutable;  // Introduction date of the consent
    public function getRequiredPermissions(): array; // Array of permission strings required to accept/revoke this consent
+   public function getLatestRevision(): ?string;    // Current revision of the consent, or null if this consent does not use revisions
  }
  ```
 
@@ -82,9 +85,11 @@ The main API of the module is the `ConsentService` class.
      - Returns the state of all consents in the system for the given context. For example, when the context resolves to an admin user, this method will return the states for system scopes and only their states for admin user scopes. In other words, the current admin user will see only *their* state, not other admin users.
    - `getConsentState(string $name, Context $context): ConsentState`
      - Returns the `ConsentState` for a single consent and context combination.
-   - `acceptConsent(string $name, Context $context): void`
+   - `acceptConsent(string $name, Context $context, ?string $revision = null): ConsentState`
      - Persists state as `ACCEPTED` for the given consent and context combination.
-   - `revokeConsent(string $name, Context $context): void`
+     - If no revision is provided, the latest revision from the consent definition is accepted implicitly.
+     - If a revision is provided explicitly, it must still match the latest revision or the service throws `ConsentException::invalidRevision()`.
+   - `revokeConsent(string $name, Context $context): ConsentState`
      - Persists state as `REVOKED` for the given consent and context combination.
 
 ## HTTP API
@@ -99,10 +104,11 @@ Events
    - Dispatched after persisting a revocation. Carries: `name`, `scopeName`, `identifier`.
 
 ### Persistence
-The consent state is stored in the database table: `consent_state`. When a consent is neither accepted nor revoked, the state is considered `requested`. This initial state is not stored in the database.
+The consent state is stored in the database table: `consent_state`. When a consent has no stored record yet, the state is interpreted as `unset`. This initial state is not stored in the database.
+
+The `revision` column stores the accepted revision only. Non-accepted states clear the stored revision.
 
 ## Adding a new consent
  1) Implement a `ConsentDefinition` class
  2) Register it as a service and tag it with `shopware.consent.definition`.
  3) If you need a new scope, implement `ConsentScope`, register it as a service, and tag it with `shopware.consent.scope`. Ensure it resolves both the identifier and actor from the `Context` or throws an appropriate `ConsentException`.
-

--- a/src/Core/System/Consent/README.md
+++ b/src/Core/System/Consent/README.md
@@ -38,7 +38,7 @@
    public function getScopeName(): string;          // Name of the scope (see ConsentScope implementations)
    public function getSince(): \DateTimeImmutable;  // Introduction date of the consent
    public function getRequiredPermissions(): array; // Array of permission strings required to accept/revoke this consent
-   public function getLatestRevision(): ?string;    // Current revision of the consent, or null if this consent does not use revisions
+   public function getLatestRevision(): ?string;    // Current revision of the consent, or null if unused; remote-backed revisions must be cached
  }
  ```
 


### PR DESCRIPTION
### 1. Why is this change necessary?

  The consent documentation no longer matched the current implementation after the revision-aware consent work was merged. In particular, the readmes still described consent acceptance as status-only and did not explain revision metadata, stale consents, or the current acceptance flow in the Administration.

  ### 2. What does this change do, exactly?

  This updates the consent readmes in the core and Administration to reflect the current behavior.

  It documents:
  - `acceptedRevision` and `latestRevision`
  - the difference between accepted, current, and stale consent states
  - the revision-aware behavior of `consentStore.isAccepted()` and `consentStore.isStale()`
  - that the Administration accepts without sending a cached revision and lets the backend resolve the latest revision
  - the current `ConsentService::acceptConsent(..., ?string $revision = null)` contract
  - corrected persistence and API details that were outdated in the existing docs

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Open the consent readmes in:
     - `src/Core/System/Consent/README.md`
     - `src/Administration/Resources/app/administration/src/core/consent/Readme.md`
  2. Compare them with the current implementation in:
     - `src/Core/System/Consent/DTO/ConsentState.php`
     - `src/Core/System/Consent/Service/ConsentService.php`
     - `src/Administration/Resources/app/administration/src/core/consent/consent.store.ts`
  3. Notice that the previous docs did not describe revision-aware consent handling and still contained outdated API and persistence details.

  ### 4. Please link to the relevant issues (if any).

  Relates to the merged consent revision work in platform PR #14899.

  ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it
  affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [x] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them
