### PR TITLE
fix: Sorting on  is reversed

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/index.js
@@ -193,7 +193,7 @@ export default {
         getCriteriaTemplate(fieldName) {
             return {
                 field: fieldName,
-                order: 'asc',
+                order: fieldName === 'product.createdAt' ? 'desc' : 'asc',
                 priority: 1,
                 naturalSorting: 0,
             };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/sw-settings-listing-option-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing-option-base/sw-settings-listing-option-base.spec.js
@@ -237,6 +237,24 @@ describe('src/module/sw-settings-listing/page/sw-settings-listing-option-base', 
         ]);
     });
 
+    it('should default createdAt criteria to descending order', async () => {
+        expect(wrapper.vm.getCriteriaTemplate('product.createdAt')).toEqual({
+            field: 'product.createdAt',
+            order: 'desc',
+            priority: 1,
+            naturalSorting: 0,
+        });
+    });
+
+    it('should keep other criteria on ascending order by default', async () => {
+        expect(wrapper.vm.getCriteriaTemplate('product.name')).toEqual({
+            field: 'product.name',
+            order: 'asc',
+            priority: 1,
+            naturalSorting: 0,
+        });
+    });
+
     it('should throw an success notification when saving custom fields', async () => {
         // mock notification function
         wrapper.vm.createNotificationSuccess = jest.fn();


### PR DESCRIPTION

### Actual behaviour

I have a dynamic product group of products that were added in the last 30 days, which I show in a seperate category sorted on "newest".

When I check the site, the oldest product in that list is first and the newest is last. So it seems `created_at` is adcending.

### Expected behaviour

I would expect when I sort on "newest", the newest product comes first. So `created_at` should be descending.

### How to reproduce

Create a new category and sort the products on "newest". You will see the oldest product comes first.