### PR TITLE
fix: migrate line item stock rule to actual stock and deprecate product.availableStock

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
@@ -457,12 +457,6 @@ Application.addServiceProviderDecorator('ruleConditionDataProviderService', (rul
         scopes: ['lineItem'],
         group: 'item',
     });
-    ruleConditionService.addCondition('cartLineItemStock', {
-        component: 'sw-condition-generic-line-item',
-        label: 'global.sw-condition.condition.lineItemStockRule',
-        scopes: ['lineItem'],
-        group: 'item',
-    });
     ruleConditionService.addCondition('cartLineItemActualStock', {
         component: 'sw-condition-generic-line-item',
         label: 'global.sw-condition.condition.lineItemActualStockRule',

--- a/src/Core/Checkout/Cart/Rule/LineItemStockRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemStockRule.php
@@ -16,6 +16,8 @@ use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
 
 /**
+ * @deprecated tag:v6.8.0 - reason:remove-rule - Use \Shopware\Core\Checkout\Cart\Rule\LineItemActualStockRule instead.
+ *
  * @final
  */
 #[Package('fundamentals@after-sales')]
@@ -33,6 +35,9 @@ class LineItemStockRule extends Rule
         parent::__construct();
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-rule - Use \Shopware\Core\Checkout\Cart\Rule\LineItemActualStockRule instead.
+     */
     public function match(RuleScope $scope): bool
     {
         if ($scope instanceof LineItemScope) {
@@ -46,6 +51,9 @@ class LineItemStockRule extends Rule
         return false;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-rule - Use \Shopware\Core\Checkout\Cart\Rule\LineItemActualStockRule instead.
+     */
     public function getConstraints(): array
     {
         return [
@@ -54,6 +62,9 @@ class LineItemStockRule extends Rule
         ];
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:remove-rule - Use \Shopware\Core\Checkout\Cart\Rule\LineItemActualStockRule instead.
+     */
     public function getConfig(): RuleConfig
     {
         return (new RuleConfig())

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -164,7 +164,7 @@ class ProductDefinition extends EntityDefinition
             (new BoolField('active', 'active'))->addFlags(new ApiAware(), new Inherited())->setDescription('When boolean value is `true`, the products are available for selection in the storefront for purchase.'),
             (new BoolField('available', 'available'))->addFlags(new ApiAware(), new WriteProtected())->setDescription('Indicates weather the product is available or not.'),
             (new BoolField('is_closeout', 'isCloseout'))->addFlags(new ApiAware(), new Inherited())->setDescription('When the value is set to true, the product is hidden when sold out.'),
-            (new IntField('available_stock', 'availableStock'))->addFlags(new ApiAware(), new WriteProtected())->setDescription('Indicates the number of products still available. This value results from the stock minus the open orders.'),
+            (new IntField('available_stock', 'availableStock'))->addFlags(new ApiAware(), new WriteProtected(), new Deprecated('v6.7.8.2', 'v6.8.0.0', 'stock'))->setDescription('Indicates the number of products still available. This value results from the stock minus the open orders.'),
             (new IntField('stock', 'stock'))->addFlags(new ApiAware(), new Required())->setDescription('Indicates the number of products available.'),
 
             (new ListField('variation', 'variation', StringField::class))->addFlags(new Runtime(['options.name', 'options.group.name']))->setDescription('Internal field.'),

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -72,6 +72,9 @@ class ProductEntity extends Entity implements \Stringable
 
     protected int $stock;
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed. Use stock instead.
+     */
     protected ?int $availableStock = null;
 
     protected bool $available;
@@ -987,13 +990,29 @@ class ProductEntity extends Entity implements \Stringable
         $this->variation = $variation;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed. Use getStock instead.
+     */
     public function getAvailableStock(): ?int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, 'getAvailableStock', 'v6.8.0.0', 'getStock')
+        );
+
         return $this->availableStock;
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed. Use setStock instead.
+     */
     public function setAvailableStock(int $availableStock): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, 'setAvailableStock', 'v6.8.0.0', 'setStock')
+        );
+
         $this->availableStock = $availableStock;
     }
 

--- a/src/Core/Migration/V6_7/Migration1774366000MigrateLineItemStockRuleCondition.php
+++ b/src/Core/Migration/V6_7/Migration1774366000MigrateLineItemStockRuleCondition.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1774366000MigrateLineItemStockRuleCondition extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1774366000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $ruleIds = $connection->fetchFirstColumn(
+            'SELECT DISTINCT `rule_id` FROM `rule_condition` WHERE `type` = :oldType',
+            ['oldType' => 'cartLineItemStock']
+        );
+
+        if ($ruleIds === []) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'UPDATE `rule_condition`
+             SET `type` = :newType
+             WHERE `type` = :oldType',
+            [
+                'newType' => 'cartLineItemActualStock',
+                'oldType' => 'cartLineItemStock',
+            ]
+        );
+
+        $connection->executeStatement(
+            'UPDATE `rule` SET `payload` = NULL WHERE `id` IN (:ruleIds)',
+            ['ruleIds' => $ruleIds],
+            ['ruleIds' => ArrayParameterType::BINARY]
+        );
+
+        $this->registerIndexer($connection, 'rule.indexer');
+    }
+}

--- a/tests/acceptance/tasks/ShopAdmin/RuleBuilder/CreateRule.ts
+++ b/tests/acceptance/tasks/ShopAdmin/RuleBuilder/CreateRule.ts
@@ -40,7 +40,7 @@ export const CreateRule = base.extend<{ CreateRule: Task }, FixtureTypes>({
                                                             type: 'andContainer',
                                                             children: [
                                                                 {
-                                                                    type: 'cartLineItemStock',
+                                                                    type: 'cartLineItemActualStock',
                                                                     value: {
                                                                         stock: testConfig.stock,
                                                                         operator: '>=',

--- a/tests/acceptance/tests/Settings/RuleBuilderCreate.spec.ts
+++ b/tests/acceptance/tests/Settings/RuleBuilderCreate.spec.ts
@@ -58,7 +58,7 @@ test('As an admin user, I want to create a rule', { tag: '@Rule' }, async ({
         await ShopAdmin.expects(AdminRuleDetail.conditionLineItemGoodsTotalValue).toHaveValue(testConfig.quantity.toString());
         await AdminRuleDetail.conditionLineItemGoodsTotalFilter.click();
         await ShopAdmin.expects(AdminRuleDetail.conditionFilterModal).toBeVisible();
-        await ShopAdmin.expects(AdminRuleDetail.conditionSelectField.getByText('Item available')).toBeVisible();
+        await ShopAdmin.expects(AdminRuleDetail.conditionSelectField.getByText('Item in stock')).toBeVisible();
         await ShopAdmin.expects(AdminRuleDetail.conditionCartLineItemInStockOperator).toHaveText('Is greater than / equal to');
         await ShopAdmin.expects(AdminRuleDetail.conditionCartLineItemInStockValue).toHaveValue(testConfig.stock.toString());
         await AdminRuleDetail.conditionFilterModalCloseButtonX.click();

--- a/tests/migration/Core/V6_7/Migration1774366000MigrateLineItemStockRuleConditionTest.php
+++ b/tests/migration/Core/V6_7/Migration1774366000MigrateLineItemStockRuleConditionTest.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\IndexerQueuer;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1774366000MigrateLineItemStockRuleCondition;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(Migration1774366000MigrateLineItemStockRuleCondition::class)]
+class Migration1774366000MigrateLineItemStockRuleConditionTest extends TestCase
+{
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    private string $oldRuleId;
+
+    private string $oldConditionId;
+
+    private string $otherRuleId;
+
+    private string $otherConditionId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->getContainer()->get(Connection::class);
+
+        $this->oldRuleId = Uuid::randomBytes();
+        $this->oldConditionId = Uuid::randomBytes();
+        $this->otherRuleId = Uuid::randomBytes();
+        $this->otherConditionId = Uuid::randomBytes();
+    }
+
+    public function testMigration(): void
+    {
+        $this->createTestRulesAndConditions();
+
+        $migration = new Migration1774366000MigrateLineItemStockRuleCondition();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $oldCondition = $this->connection->fetchAssociative(
+            'SELECT `type`, `value` FROM `rule_condition` WHERE `id` = :id',
+            ['id' => $this->oldConditionId]
+        );
+
+        static::assertIsArray($oldCondition);
+        static::assertSame('cartLineItemActualStock', $oldCondition['type']);
+        static::assertEquals(
+            [
+                'operator' => '>=',
+                'stock' => 10,
+            ],
+            json_decode((string) $oldCondition['value'], true, 512, \JSON_THROW_ON_ERROR)
+        );
+
+        $checkPayloadSql = 'SELECT `payload` FROM `rule` WHERE `id` = :id';
+        static::assertNull($this->connection->fetchOne($checkPayloadSql, ['id' => $this->oldRuleId]));
+        static::assertSame('{"keep":true}', $this->connection->fetchOne($checkPayloadSql, ['id' => $this->otherRuleId]));
+
+        $indexers = (new IndexerQueuer($this->connection))->getIndexers();
+        static::assertArrayHasKey('rule.indexer', $indexers);
+    }
+
+    public function createTestRulesAndConditions(): void
+    {
+        $createdAt = (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
+
+        $this->connection->insert('rule', [
+            'id' => $this->oldRuleId,
+            'name' => 'old line item stock rule',
+            'priority' => 1,
+            'payload' => '{"oldPayload":true}',
+            'invalid' => 0,
+            'module_types' => null,
+            'custom_fields' => null,
+            'created_at' => $createdAt,
+            'updated_at' => null,
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => $this->oldConditionId,
+            'rule_id' => $this->oldRuleId,
+            'parent_id' => null,
+            'type' => 'cartLineItemStock',
+            'value' => json_encode([
+                'operator' => '>=',
+                'stock' => 10,
+            ], \JSON_THROW_ON_ERROR),
+            'position' => 1,
+            'custom_fields' => null,
+            'created_at' => $createdAt,
+            'updated_at' => null,
+        ]);
+
+        $this->connection->insert('rule', [
+            'id' => $this->otherRuleId,
+            'name' => 'actual stock rule',
+            'priority' => 1,
+            'payload' => '{"keep":true}',
+            'invalid' => 0,
+            'module_types' => null,
+            'custom_fields' => null,
+            'created_at' => $createdAt,
+            'updated_at' => null,
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => $this->otherConditionId,
+            'rule_id' => $this->otherRuleId,
+            'parent_id' => null,
+            'type' => 'cartLineItemActualStock',
+            'value' => json_encode([
+                'operator' => '>=',
+                'stock' => 5,
+            ], \JSON_THROW_ON_ERROR),
+            'position' => 1,
+            'custom_fields' => null,
+            'created_at' => $createdAt,
+            'updated_at' => null,
+        ]);
+    }
+}

--- a/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductBoxCmsElementResolverTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -185,8 +186,11 @@ class ProductBoxCmsElementResolverTest extends TestCase
         $product = new SalesChannelProductEntity();
         $product->setId($productId);
         $product->setStock($availableStock);
-        $product->setAvailableStock($availableStock);
         $product->setIsCloseout($closeout);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            $product->setAvailableStock($availableStock);
+        }
 
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);

--- a/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/Type/ProductBoxTypeDataResolverTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\PropertyNotFoundException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -132,9 +133,12 @@ class ProductBoxTypeDataResolverTest extends TestCase
 
         $product = new SalesChannelProductEntity();
         $product->setId('product123');
-        $product->setAvailableStock($availableStock);
         $product->setStock($availableStock);
         $product->setIsCloseout($closeout);
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            $product->setAvailableStock($availableStock);
+        }
 
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);


### PR DESCRIPTION
…ct.availableStock

closes: #7790 

- Deprecate `ProductEntity.availableStock`
- Remove the rule for this property (`cartLineItemStock`)
- Migrate existing rules from (`cartLineItemStock`) to (`cartLineItemActualStock`) using `ProductEntity.stock`
