### PR TITLE
test: skips full test instead of just step, which causes second step …

### DIFF
--- a/tests/acceptance/tests/Visual/Administration/Media.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/Media.spec.ts
@@ -1,6 +1,6 @@
 import { test, assertScreenshot, setViewport, replaceElementsIndividually } from '@fixtures/AcceptanceTest';
 
-test('Visual: Administration media page', { 
+test.skip('Visual: Administration media page', { 
     tag: '@Visual',
     annotation: {
         type: 'issue',
@@ -11,8 +11,7 @@ test('Visual: Administration media page', {
     AdminMediaListing,
 }) => {
 
-    await test.step('Creates a screenshot of the media page.', async step => {
-        step.skip();
+    await test.step('Creates a screenshot of the media page.', async () => {
         await ShopAdmin.goesTo(AdminMediaListing.url());
         await setViewport(AdminMediaListing.page, {
             scrollableElementVertical: AdminMediaListing.scrollableElementVertical,


### PR DESCRIPTION
…to fail

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Originally just the 1st test step was skipped due to a [valid bug](https://github.com/shopware/shopware/issues/15882) but this causes the second step to fail, as it depends on the navigation in the first.

### 2. What does this change do, exactly?

Skips the whole test until https://github.com/shopware/shopware/issues/15882 is fixed.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
