### PR TITLE
fix: ignore missing storefront captcha from deactivated plugins

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/captcha/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/base.html.twig
@@ -9,6 +9,7 @@
         {% for capchaKey, captcha in captchas %}
             {% if captcha.isActive %}
                 {% sw_include '@Storefront/storefront/component/captcha/%s.html.twig'|format(capchaKey)
+                    ignore missing
                     with {
                         additionalClass: additionalClass,
                         formId: 'form-%s'|format(formId)


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If a plugin using captcha is deactivated the pages with form are not loaded correctly.

### 2. What does this change do, exactly?
Ignores missing captcha from deactivated plugins

### 3. Describe each step to reproduce the issue or behaviour.
- activate a plugin using an external captcha or create one with a placeholder
- deactivate the plugin
- visit login page
- before the fix you will see an error instead of the page
- after the fix missing component will be ignored and page will be loaded

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/7090

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
