### PR TITLE
fix: rerender iframe when changing locationId in admin extensions

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -8,6 +8,11 @@
 
 ## Administration
 
+### Re-render iframe integrations when location changes
+
+Iframe-based Administration extensions now re-render correctly when their `locationId` changes.
+This fixes stale iframe content when switching locations in Meteor Admin SDK integrations and also prevents unnecessary full-page reloads.
+
 ## Storefront
 
 ### Order cancellation only shown for open orders

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
@@ -39,6 +39,7 @@
 
         <sw-iframe-renderer
             v-if="componentSection.props?.locationId && !componentSection.props?.tabs"
+            :key="componentSection.props.locationId"
             :src="componentSection.src"
             :location-id="componentSection.props.locationId"
         />
@@ -46,6 +47,7 @@
     <div v-else-if="componentSection.component === 'div'">
         <sw-iframe-renderer
             v-if="componentSection.props?.locationId"
+            :key="componentSection.props.locationId"
             :src="componentSection.src"
             :location-id="componentSection.props.locationId"
         />

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/sw-extension-teaser-popover.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/sw-extension-teaser-popover.html.twig
@@ -35,6 +35,7 @@
 
             <sw-iframe-renderer
                 v-else-if="popoverComponent.component === 'custom'"
+                :key="popoverComponent.props?.locationTriggerId"
                 :src="popoverComponent.src"
                 :location-id="popoverComponent.props?.locationTriggerId"
             />
@@ -49,6 +50,7 @@
             @mouseleave="onMouseLeaveContent"
         >
             <sw-iframe-renderer
+                :key="popoverComponent.props?.locationId"
                 :src="popoverComponent.src"
                 :location-id="popoverComponent.props?.locationId"
             />

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.html.twig
@@ -17,6 +17,7 @@
         >
             <sw-iframe-renderer
                 v-if="modal.locationId"
+                :key="modal.locationId"
                 :src="modal.baseUrl"
                 :location-id="modal.locationId"
             />

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
@@ -77,6 +77,7 @@
 
             <section class="sw-sidebar-renderer__content">
                 <sw-iframe-renderer
+                    :key="sidebar.locationId"
                     :src="sidebar.baseUrl"
                     :location-id="sidebar.locationId"
                     :full-screen="false"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/sw-cms-el-location-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/component/sw-cms-el-location-renderer.html.twig
@@ -1,6 +1,7 @@
 {% block sw_cms_el_location_renderer %}
 <div class="sw-cms-el-location-renderer">
     <sw-iframe-renderer
+        :key="elementLocation"
         :src="src"
         :location-id="elementLocation"
     />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/sw-cms-el-config-location-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/sw-cms-el-config-location-renderer.html.twig
@@ -1,6 +1,7 @@
 {% block sw_cms_el_config_location_renderer %}
 <div class="sw-cms-el-config-location-renderer">
     <sw-iframe-renderer
+        :key="elementLocation"
         :src="src"
         :location-id="configLocation"
     />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/sw-cms-el-config-location-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/config/sw-cms-el-config-location-renderer.html.twig
@@ -1,7 +1,7 @@
 {% block sw_cms_el_config_location_renderer %}
 <div class="sw-cms-el-config-location-renderer">
     <sw-iframe-renderer
-        :key="elementLocation"
+        :key="configLocation"
         :src="src"
         :location-id="configLocation"
     />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/preview/sw-cms-el-preview-location-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/location-renderer/preview/sw-cms-el-preview-location-renderer.html.twig
@@ -1,6 +1,7 @@
 {% block sw_cms_el_preview_location_renderer %}
 <div class="sw-cms-el-preview-location-renderer">
     <sw-iframe-renderer
+        :key="previewLocation"
         :src="src"
         :location-id="previewLocation"
     />

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.html.twig
@@ -53,6 +53,7 @@
         {% block sw_extension_sdk_module_content_iframe_renderer %}
         <sw-iframe-renderer
             v-if="!isLoading"
+            :key="module.locationId"
             ref="iframeRenderer"
             :src="module.baseUrl"
             :location-id="module.locationId"

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
@@ -12,6 +12,27 @@ const mockModule = {
     baseUrl: 'http://example.com',
 };
 
+const iframeRendererStub = {
+    name: 'sw-iframe-renderer',
+    props: [
+        'src',
+    ],
+    template: '<div class="sw-iframe-renderer-stub"><iframe ref="iframe" :src="src" /></div>',
+};
+
+const routerLinkStub = {
+    props: {
+        to: {
+            type: [
+                String,
+                Object,
+            ],
+            required: true,
+        },
+    },
+    template: '<a @click="$router.push(to)"></a>',
+};
+
 async function createWrapper(back = null, push = jest.fn()) {
     return mount(await wrapTestComponent('sw-extension-sdk-module', { sync: true }), {
         props: {
@@ -23,22 +44,11 @@ async function createWrapper(back = null, push = jest.fn()) {
                 'sw-page': await wrapTestComponent('sw-page'),
                 'sw-loader': true,
                 'sw-my-apps-error-page': true,
-                'sw-iframe-renderer': true,
+                'sw-iframe-renderer': iframeRendererStub,
                 'sw-language-switch': true,
                 'sw-context-menu-item': true,
                 'sw-context-button': true,
-                'router-link': {
-                    props: {
-                        to: {
-                            type: [
-                                String,
-                                Object,
-                            ],
-                            required: true,
-                        },
-                    },
-                    template: '<a @click="$router.push(to)"></a>',
-                },
+                'router-link': routerLinkStub,
                 'sw-search-bar': true,
                 'sw-app-topbar-button': true,
                 'sw-app-topbar-sidebar': true,
@@ -68,6 +78,10 @@ describe('src/module/sw-extension-sdk/page/sw-extension-sdk-module', () => {
 
     beforeEach(async () => {
         wrapper = await createWrapper();
+        const store = Shopware.Store.get('extensionSdkModules');
+        store.modules = [];
+        store.smartBarButtons = [];
+        store.hiddenSmartBars = [];
     });
 
     it('@slow should time out without menu item after 7000ms', async () => {
@@ -142,5 +156,23 @@ describe('src/module/sw-extension-sdk/page/sw-extension-sdk-module', () => {
         });
 
         expect(wrapper.find('.smart-bar__content').exists()).toBeFalsy();
+    });
+
+    it('should rerender the iframe renderer when location id changes', async () => {
+        const store = Shopware.Store.get('extensionSdkModules');
+        const moduleId = await store.addModule(mockModule);
+        await wrapper.setProps({
+            id: moduleId,
+        });
+        const initialInstance = wrapper.findComponent(iframeRendererStub);
+
+        store.modules[0].locationId = 'jest-next';
+        await wrapper.vm.$nextTick();
+
+        const rerenderedInstance = wrapper.findComponent(iframeRendererStub);
+
+        expect(mockModule.locationId).not.toBe('jest-next');
+        expect(wrapper.vm.module.locationId).toBe('jest-next');
+        expect(initialInstance.vm).not.toBe(rerenderedInstance.vm);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Closes https://github.com/shopware/meteor/issues/432.
Closes https://github.com/shopware/shopware/issues/15925.

Previously, changing the locationId either resulted in a full-page reload or triggered two executions of the extension's iframe, once with the old locationId and once with the correct locationId.

### 2. What does this change do, exactly?
- The `sw-iframe-renderer` just gets completely rerendered as soon as the locationId changes.
- Adds a key property to all instances of `sw-iframe-renderer` to trigger force rerender.
- Adds a test case to `sw-extension-sdk-module` to confirm that the component gets rerendered 

### 3. Describe each step to reproduce the issue or behaviour.
Described in both issues.
