### PR TITLE
fix: reset property option selection after delete

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
@@ -124,6 +124,7 @@ export default {
             }
 
             Promise.allSettled(Object.values(this.selection).map((option) => this.onOptionDelete(option))).then(() => {
+                this.resetSelectionState();
                 this.refreshOptionList();
             });
         },
@@ -179,6 +180,11 @@ export default {
             this.$refs.grid.load().then(() => {
                 this.isLoading = false;
             });
+        },
+
+        resetSelectionState() {
+            this.selection = null;
+            this.deleteButtonDisabled = true;
         },
 
         onOptionEdit(option) {

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
@@ -63,6 +63,7 @@ function getOptionRepository() {
         create: () => ({
             get: () => Promise.resolve(),
         }),
+        delete: jest.fn(() => Promise.resolve()),
         save: jest.fn(() => Promise.resolve()),
     };
 }
@@ -257,5 +258,22 @@ describe('module/sw-property/component/sw-property-option-list', () => {
 
         expect(nameColumn).toBeTruthy();
         expect(nameColumn.naturalSorting).toBe(true);
+    });
+
+    it('should reset selection state after deleting selected options', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const selectedOption = propertyGroup.options[0];
+
+        wrapper.vm.$refs.grid.load = jest.fn(() => Promise.resolve());
+
+        wrapper.vm.onGridSelectionChanged({ [selectedOption.id]: selectedOption }, 1);
+        wrapper.vm.onDeleteOptions();
+        await flushPromises();
+
+        expect(wrapper.vm.optionRepository.delete).toHaveBeenCalledWith(selectedOption.id);
+        expect(wrapper.vm.selection).toBeNull();
+        expect(wrapper.vm.deleteButtonDisabled).toBe(true);
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
@@ -264,7 +264,13 @@ describe('module/sw-property/component/sw-property-option-list', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        const selectedOption = propertyGroup.options[0];
+        const selectedOption = {
+            ...propertyGroup.options[0],
+            _isNew: false,
+            isNew() {
+                return this._isNew;
+            },
+        };
 
         wrapper.vm.$refs.grid.load = jest.fn(() => Promise.resolve());
 


### PR DESCRIPTION
## Summary
Fixes #9943 by clearing stale selection state after property options are deleted.

## Root Cause
The option list refreshed after deletion, but the component kept its previous selection state and delete-button state.

## What Changed
- reset local selection state after bulk delete completes
- disable the delete action until a new selection is made
- add a regression spec for deleting selected options

## Impact
The property option list now returns to a consistent state after deletion instead of behaving like removed rows are still selected.
