### PR TITLE
fix: reset product detail state on route change

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -487,6 +487,8 @@ export default {
 
     watch: {
         productId() {
+            // Prevent stale parent/variant state from surviving a detail-route switch.
+            Shopware.Store.get('swProductDetail').$reset();
             this.createdComponent();
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -1133,4 +1133,33 @@ describe('module/sw-product/page/sw-product-detail', () => {
         await flushPromises();
         expect(store.parentProduct).toEqual({});
     });
+
+    it('should clear stale variant data when switching between existing product detail routes', async () => {
+        const store = Shopware.Store.get('swProductDetail');
+        const getFunction = jest.fn(() => Promise.resolve({ id: 'parent-123', variation: [] }));
+
+        await wrapper.unmount();
+
+        wrapper = await createWrapper(
+            () => Promise.resolve([]),
+            getFunction,
+            'parent-123',
+        );
+
+        await flushPromises();
+
+        store.product = {
+            id: 'variant-old',
+            parentId: 'parent-old',
+            variation: [],
+        };
+        store.parentProduct = { id: 'parent-old', name: 'Old Parent' };
+
+        getFunction.mockImplementation(() => new Promise(() => {}));
+
+        await wrapper.setProps({ productId: 'variant-456' });
+        await nextTick();
+
+        expect(store.parentProduct).toEqual({});
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -252,6 +252,8 @@ describe('module/sw-product/page/sw-product-detail', () => {
         await wrapper.setProps({
             productId: '1234',
         });
+        Shopware.Store.get('swProductDetail').product = { parentId: 'parent-id' };
+        await nextTick();
 
         const contextButton = wrapper.find('.sw-product-settings-mode');
         expect(contextButton.exists()).toBeFalsy();
@@ -1140,11 +1142,7 @@ describe('module/sw-product/page/sw-product-detail', () => {
 
         await wrapper.unmount();
 
-        wrapper = await createWrapper(
-            () => Promise.resolve([]),
-            getFunction,
-            'parent-123',
-        );
+        wrapper = await createWrapper(() => Promise.resolve([]), getFunction, 'parent-123');
 
         await flushPromises();
 


### PR DESCRIPTION
## Summary
Fixes #6797 by clearing stale product-detail store state when switching between existing product detail routes.

## Root Cause
State from a previous product detail route could leak into the next one, which broke the reported variant overview flow after saving SEO settings.

## What Changed
- reset the swProductDetail store when productId changes between existing routes
- add a regression spec for route-switch state reset

## Impact
Opening another product after a previous detail flow no longer reuses stale detail state.
