### PR TITLE
fix: Elasticsearch product search can fail with a 500 when a boolean custom field is configured as searchable and the search term is plain text

### DIFF
--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -117,16 +117,23 @@ class TokenQueryBuilder
             return $this->buildTextMatchQuery($token, $config);
         }
 
+        $normalizedToken = $this->normalizeToken($token, $field);
+
+        if ($normalizedToken === null) {
+            return null;
+        }
+
+        return new TermQuery($config->getField(), $normalizedToken, ['boost' => $config->getRanking()]);
+    }
+
+    private function normalizeToken(string $token, Field $field): bool|int|float|string|null
+    {
         if ($field instanceof BoolField) {
-            $token = match ($token) {
+            return match ($token) {
                 '1', 'true' => true,
                 '0', 'false' => false,
                 default => null,
             };
-
-            if ($token === null) {
-                return null;
-            }
         }
 
         if ($field instanceof IntField || $field instanceof FloatField || $field instanceof PriceField) {
@@ -134,10 +141,10 @@ class TokenQueryBuilder
                 return null;
             }
 
-            $token = $field instanceof IntField ? (int) $token : (float) $token;
+            return $field instanceof IntField ? (int) $token : (float) $token;
         }
 
-        return new TermQuery($config->getField(), $token, ['boost' => $config->getRanking()]);
+        return $token;
     }
 
     private function isTextField(Field $field): bool

--- a/src/Elasticsearch/TokenQueryBuilder.php
+++ b/src/Elasticsearch/TokenQueryBuilder.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
@@ -114,6 +115,18 @@ class TokenQueryBuilder
     {
         if ($this->isTextField($field)) {
             return $this->buildTextMatchQuery($token, $config);
+        }
+
+        if ($field instanceof BoolField) {
+            $token = match ($token) {
+                '1', 'true' => true,
+                '0', 'false' => false,
+                default => null,
+            };
+
+            if ($token === null) {
+                return null;
+            }
         }
 
         if ($field instanceof IntField || $field instanceof FloatField || $field instanceof PriceField) {

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -491,7 +491,7 @@ class TokenQueryBuilderTest extends TestCase
             ]),
         ];
 
-        yield 'Test multiple custom fields with text term' => [
+        yield 'Test invalid boolean custom field token still matches text custom fields' => [
             'config' => [
                 self::config(field: 'customFields.evolvesBool', ranking: 600),
                 self::config(field: 'customFields.evolvesText', ranking: 500),
@@ -522,6 +522,28 @@ class TokenQueryBuilderTest extends TestCase
             'expected' => self::disMax([
                 self::term($prefixCfLang1 . 'evolvesBool', true, 600),
                 self::term($prefixCfLang2 . 'evolvesBool', true, 480),
+            ]),
+        ];
+
+        yield 'Test boolean custom field with numeric true term' => [
+            'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
+            ],
+            'term' => '1',
+            'expected' => self::disMax([
+                self::term($prefixCfLang1 . 'evolvesBool', true, 600),
+                self::term($prefixCfLang2 . 'evolvesBool', true, 480),
+            ]),
+        ];
+
+        yield 'Test boolean custom field with numeric false term' => [
+            'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
+            ],
+            'term' => '0',
+            'expected' => self::disMax([
+                self::term($prefixCfLang1 . 'evolvesBool', false, 600),
+                self::term($prefixCfLang2 . 'evolvesBool', false, 480),
             ]),
         ];
     }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
@@ -56,6 +57,7 @@ class TokenQueryBuilderTest extends TestCase
         $this->tokenQueryBuilder = new TokenQueryBuilder(
             $this->getRegistry(),
             new CustomFieldServiceMock([
+                'evolvesBool' => new BoolField('evolvesBool', 'evolvesBool'),
                 'evolvesInt' => new IntField('evolvesInt', 'evolvesInt'),
                 'evolvesFloat' => new FloatField('evolvesFloat', 'evolvesFloat'),
                 'evolvesText' => new StringField('evolvesText', 'evolvesText'),
@@ -340,6 +342,7 @@ class TokenQueryBuilderTest extends TestCase
 
         yield 'Test multiple custom fields with terms' => [
             'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
                 self::config(field: 'customFields.evolvesText', ranking: 500),
                 self::config(field: 'customFields.evolvesInt', ranking: 400),
                 self::config(field: 'customFields.evolvesFloat', ranking: 500),
@@ -456,6 +459,7 @@ class TokenQueryBuilderTest extends TestCase
 
         yield 'Test multiple custom fields with numeric term' => [
             'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
                 self::config(field: 'customFields.evolvesText', ranking: 500),
                 self::config(field: 'customFields.evolvesInt', ranking: 400),
                 self::config(field: 'customFields.evolvesFloat', ranking: 500),
@@ -489,6 +493,7 @@ class TokenQueryBuilderTest extends TestCase
 
         yield 'Test multiple custom fields with text term' => [
             'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
                 self::config(field: 'customFields.evolvesText', ranking: 500),
                 self::config(field: 'customFields.evolvesInt', ranking: 400),
                 self::config(field: 'customFields.evolvesFloat', ranking: 500),
@@ -506,6 +511,17 @@ class TokenQueryBuilderTest extends TestCase
                     self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                     self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                 ], 400),
+            ]),
+        ];
+
+        yield 'Test boolean custom field with boolean term' => [
+            'config' => [
+                self::config(field: 'customFields.evolvesBool', ranking: 600),
+            ],
+            'term' => 'true',
+            'expected' => self::disMax([
+                self::term($prefixCfLang1 . 'evolvesBool', true, 600),
+                self::term($prefixCfLang2 . 'evolvesBool', true, 480),
             ]),
         ];
     }
@@ -598,9 +614,9 @@ class TokenQueryBuilderTest extends TestCase
     }
 
     /**
-     * @return array{term: array<string, array{value: string|int|float, boost: int|float}>}
+     * @return array{term: array<string, array{value: string|int|float|bool, boost: int|float}>}
      */
-    private static function term(string $field, string|int|float $query, int|float $boost): array
+    private static function term(string $field, string|int|float|bool $query, int|float $boost): array
     {
         $normalizedBoost = ($boost === 1 || $boost === 1.0) ? 1 : (float) $boost;
 


### PR DESCRIPTION
This pull request adds support for boolean custom fields in the `TokenQueryBuilder` used for Elasticsearch queries. The changes ensure that boolean fields can be correctly matched and queried using tokens like `'true'`, `'false'`, `'1'`, and `'0'`. Additionally, comprehensive tests have been added to verify this new functionality.

**Support for boolean custom fields in Elasticsearch queries:**

* Updated `TokenQueryBuilder` to recognize and handle `BoolField` instances, mapping string tokens such as `'true'`, `'false'`, `'1'`, and `'0'` to their corresponding boolean values. Queries with invalid boolean tokens are ignored. [[1]](diffhunk://#diff-9c48eff1fdced4de4d952d1e387709003bb2e58eb383339b1a5b137fee6f513dR18) [[2]](diffhunk://#diff-9c48eff1fdced4de4d952d1e387709003bb2e58eb383339b1a5b137fee6f513dR120-R131)

* Before:

https://github.com/user-attachments/assets/5be673e0-7977-4dfe-b081-a9706515d657

* After: 

https://github.com/user-attachments/assets/3b81031b-e8a3-4d20-b3d4-2a3df482f5e2


