### PR TITLE
fix: sync variant purchase price inheritance

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -843,8 +843,11 @@ export default {
         },
 
         syncVariantPriceInheritance() {
-            const priceInherited = this.product.price == null;
-            const purchasePricesInherited = this.product.purchasePrices == null;
+            // Variant overview can leave inherited fields unset (`undefined`) instead of normalizing them to `null`.
+            // Arrays still represent explicit variant-owned prices, so only nullish values count as inherited here.
+            const priceInherited = this.product.price === null || this.product.price === undefined;
+            const purchasePricesInherited =
+                this.product.purchasePrices === null || this.product.purchasePrices === undefined;
 
             // Price is inherited — purchasePrices must also inherit
             if (priceInherited) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -843,8 +843,8 @@ export default {
         },
 
         syncVariantPriceInheritance() {
-            const priceInherited = this.product.price === null;
-            const purchasePricesInherited = this.product.purchasePrices === null;
+            const priceInherited = this.product.price == null;
+            const purchasePricesInherited = this.product.purchasePrices == null;
 
             // Price is inherited — purchasePrices must also inherit
             if (priceInherited) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -1005,6 +1005,39 @@ describe('module/sw-product/page/sw-product-detail', () => {
         ]);
     });
 
+    it('should sync purchasePrices from parent when price is not inherited but purchasePrices is undefined', async () => {
+        wrapper = await createWrapper(
+            () => Promise.resolve([]),
+            (id) => {
+                if (id === 'parent-id') {
+                    return Promise.resolve({
+                        id: 'parent-id',
+                        price: [{ currencyId: undefined, net: 84, gross: 100, linked: true }],
+                        purchasePrices: [{ currencyId: undefined, net: 42, gross: 50, linked: true }],
+                    });
+                }
+
+                return Promise.resolve({
+                    id: 'variant-id',
+                    parentId: 'parent-id',
+                    price: [{ currencyId: undefined, net: 84, gross: 100, linked: true }],
+                    purchasePrices: undefined,
+                });
+            },
+        );
+
+        await wrapper.setProps({
+            productId: '1234',
+        });
+
+        await wrapper.vm.loadProduct();
+        await flushPromises();
+
+        expect(wrapper.vm.product.purchasePrices).toEqual([
+            { currencyId: undefined, gross: 50, net: 42, linked: true },
+        ]);
+    });
+
     it('should ignore purchase price if its set', async () => {
         wrapper = await createWrapper(
             () => Promise.resolve([]),


### PR DESCRIPTION
## Summary
- Fixes variant purchase price fields staying disabled after price inheritance is removed from the variant overview.

## Root Cause
- `sw-product-detail` only treated `purchasePrices === null` as inherited when loading a variant.
- Variants updated through the overview can arrive with `purchasePrices` undefined instead, so the detail page skipped the parent sync and left the purchase price fields inactive.

## What Changed
- Treat nullish `price` and `purchasePrices` values as inherited in `syncVariantPriceInheritance()`.
- Add a regression spec covering variants whose own `price` exists while `purchasePrices` is undefined.

## Impact
- Variant purchase price gross and net fields stay editable regardless of whether price inheritance was removed in the overview or directly in the variant.