### PR TITLE
fix: resolve magnifier zoom node lookup

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -441,7 +441,8 @@ export default class MagnifierPlugin extends Plugin {
         }
 
         const html = `<div class="magnifier-overlay  ${this.options.overlayClass}">&nbsp;</div>`;
-        this._overlay = container.insertAdjacentHTML('beforeend', html);
+        container.insertAdjacentHTML('beforeend', html);
+        this._overlay = container.querySelector(`.${this.options.overlayClass}`);
 
         this.$emitter.publish('createOverlay');
 
@@ -476,7 +477,8 @@ export default class MagnifierPlugin extends Plugin {
 
         this._zoomImageContainer.style.position = 'relative';
         const html = `<div class="magnifier-zoom-image  ${this.options.zoomImageClass}">&nbsp;</div>`;
-        this._zoomImage = this._zoomImageContainer.insertAdjacentHTML('beforeend', html);
+        this._zoomImageContainer.insertAdjacentHTML('beforeend', html);
+        this._zoomImage = this._zoomImageContainer.querySelector(`.${this.options.zoomImageClass}`);
 
         this.$emitter.publish('createZoomImage');
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/magnifier/magnifier.plugin.test.js
@@ -107,4 +107,48 @@ describe('MagnifierPlugin tests', () => {
             expect(magnifierPlugin._zoomImage.style.minHeight).toBe('500px');
         });
     });
+
+    describe('_createOverlay and _createZoomImage', () => {
+        test('should return the created elements instead of the insertAdjacentHTML return value', () => {
+            const imageContainer = document.querySelector('.js-magnifier-container');
+
+            const overlay = magnifierPlugin._createOverlay(imageContainer);
+            const zoomImage = magnifierPlugin._createZoomImage();
+
+            expect(overlay).toBeInstanceOf(HTMLElement);
+            expect(zoomImage).toBeInstanceOf(HTMLElement);
+            expect(imageContainer.querySelector('.js-magnifier-overlay')).toBe(overlay);
+            expect(document.querySelector('.js-magnifier-zoom-image-container .js-magnifier-zoom-image')).toBe(zoomImage);
+        });
+    });
+
+    describe('_onMouseMove', () => {
+        test('should continue the first hover flow when the zoom containers start empty', () => {
+            const imageContainer = document.querySelector('.js-magnifier-container');
+            const image = document.querySelector('.js-magnifier-image');
+
+            image.setAttribute('data-full-image', '/full/image.jpg');
+            Object.defineProperty(image, 'naturalWidth', { value: 1200, configurable: true });
+            Object.defineProperty(image, 'naturalHeight', { value: 800, configurable: true });
+            image.getBoundingClientRect = () => ({ width: 400, height: 300, top: 20, left: 10, right: 0, bottom: 0 });
+            imageContainer.getBoundingClientRect = () => ({ top: 20, left: 10, width: 400, height: 300, right: 0, bottom: 0 });
+
+            jest.spyOn(magnifierPlugin, '_isActive').mockReturnValue(true);
+            const setOverlayPositionSpy = jest.spyOn(magnifierPlugin, '_setOverlayPosition');
+            const setZoomImageSpy = jest.spyOn(magnifierPlugin, '_setZoomImage');
+
+            magnifierPlugin._zoomImageContainer.innerHTML = '';
+            magnifierPlugin._overlay = undefined;
+            magnifierPlugin._zoomImage = undefined;
+
+            expect(() => {
+                magnifierPlugin._onMouseMove({ pageX: 100, pageY: 120 }, imageContainer, image);
+            }).not.toThrow();
+
+            expect(magnifierPlugin._overlay).toBeInstanceOf(HTMLElement);
+            expect(magnifierPlugin._zoomImage).toBeInstanceOf(HTMLElement);
+            expect(setOverlayPositionSpy).toHaveBeenCalled();
+            expect(setZoomImageSpy).toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- Closes #14249
- Fixes the magnifier initialization path when the zoom containers start empty.
- Adds storefront regression coverage for the affected hover flow.

## Root Cause
The magnifier plugin stored the return value of `insertAdjacentHTML()` in plugin state even though that DOM API returns `undefined` instead of the inserted element.

## What Changed
- Resolve the inserted overlay and zoom image nodes from the DOM after insertion.
- Add focused storefront unit tests for the creation helpers and the first-hover path.

## Impact
- Prevents first-hover magnifier failures on affected storefront pages.
- Reduces regression risk with focused JS test coverage.