### PR TITLE
fix(administration): preserve admin search term on module switch

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -222,6 +222,10 @@ export default {
                 return;
             }
 
+            if (newValue.query.term === undefined) {
+                return;
+            }
+
             this.searchTerm = newValue.query.term ? newValue.query.term : '';
         },
 
@@ -452,11 +456,13 @@ export default {
         },
 
         setSearchType(type) {
+            const searchTerm = this.searchTerm.startsWith('#') ? '' : this.searchTerm;
+
             this.currentSearchType = type;
             this.showTypeSelectContainer = false;
             this.showModuleFiltersContainer = false;
             this.showResultsSearchTrends = false;
-            this.searchTerm = '';
+            this.searchTerm = searchTerm;
         },
 
         toggleOffCanvas() {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.html.twig
@@ -265,6 +265,7 @@
                 role="row"
                 tabindex="0"
                 @mouseenter="onMouseEnterSearchType(index)"
+                @keydown.enter.prevent="onClickType(type.entityName)"
                 @click="onClickType(type.entityName)"
             >
                 <span
@@ -333,6 +334,7 @@
                 role="row"
                 tabindex="0"
                 @mouseenter="onMouseEnterSearchType(index)"
+                @keydown.enter.prevent="onClickType(type.entityName)"
                 @click="onClickType(type.entityName)"
             >
                 <span

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.spec.js
@@ -450,6 +450,21 @@ describe('src/app/component/structure/sw-search-bar', () => {
         expect(wrapper.vm.searchTerm).toBe('Foo product');
     });
 
+    it('should keep the current search term in $route watcher when the new route has no term', async () => {
+        wrapper = await createWrapper({
+            initialSearchType: 'product',
+            initialSearch: 'shirt',
+        });
+
+        const route = {
+            query: {},
+        };
+
+        wrapper.vm.$options.watch.$route.call(wrapper.vm, route);
+
+        expect(wrapper.vm.searchTerm).toBe('shirt');
+    });
+
     it('should search with repository when no service is set in searchTypeService', async () => {
         wrapper = await createWrapper(
             {
@@ -578,6 +593,62 @@ describe('src/app/component/structure/sw-search-bar', () => {
         await moduleFilterItems.at(1).trigger('click');
 
         expect(moduleFilterSelect.text()).toBe('global.entities.product');
+    });
+
+    it('should change search bar type when activating module filters with keyboard', async () => {
+        wrapper = await createWrapper(
+            {
+                initialSearchType: '',
+            },
+            {
+                all: {
+                    entityName: '',
+                    placeholderSnippet: '',
+                    listingRoute: '',
+                },
+                ...searchTypeServiceTypes,
+            },
+        );
+
+        const moduleFilterSelect = wrapper.find('.sw-search-bar__type--v2');
+        await moduleFilterSelect.trigger('click');
+
+        const moduleFilterItems = wrapper.findAll(
+            '.sw-search-bar__types_module-filters-container .sw-search-bar__type-item',
+        );
+        await moduleFilterItems.at(1).trigger('keydown.enter');
+
+        expect(moduleFilterSelect.text()).toBe('global.entities.product');
+    });
+
+    it('should keep the search term when switching module filters', async () => {
+        wrapper = await createWrapper(
+            {
+                initialSearchType: '',
+            },
+            {
+                all: {
+                    entityName: '',
+                    placeholderSnippet: '',
+                    listingRoute: '',
+                },
+                ...searchTypeServiceTypes,
+            },
+        );
+
+        const searchInput = wrapper.find('.sw-search-bar__input');
+        await searchInput.setValue('shirt');
+
+        const moduleFilterSelect = wrapper.find('.sw-search-bar__type--v2');
+        await moduleFilterSelect.trigger('click');
+
+        const moduleFilterItems = wrapper.findAll(
+            '.sw-search-bar__types_module-filters-container .sw-search-bar__type-item',
+        );
+        await moduleFilterItems.at(2).trigger('click');
+
+        expect(wrapper.vm.searchTerm).toBe('shirt');
+        expect(searchInput.element.value).toBe('shirt');
     });
 
     it('should search with repository after selecting module filter', async () => {


### PR DESCRIPTION
## Summary
- Closes #11909.
- Preserves the current admin search term when switching module filters.
- Enables keyboard activation of module filter suggestions and adds regression coverage.

## Root Cause
The search bar only handled module filter selection through click interactions and reset `searchTerm` whenever the next route omitted `query.term`, which cleared existing search text during module changes.

## What Changed
- Added Enter-key activation for module filter entries in `sw-search-bar.html.twig`.
- Updated `sw-search-bar` state handling to preserve non-`#...` search text when changing modules and to ignore route updates that do not explicitly provide a new term.
- Added Jest coverage for keyboard selection, preserved search term behavior, and the route watcher case.

## Impact
Admin users can select module filters with the keyboard and switch modules without losing the current search text.
