### PR TITLE
fix: dynamic product groups not updating in storefront

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterDefinition;
-use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
+use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteResultHelper;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\UnmappedFieldException;
@@ -153,17 +153,13 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
             return null;
         }
 
-        $ids = $event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME);
-        $filterIds = $event->getPrimaryKeysWithPropertyChange(ProductStreamFilterDefinition::ENTITY_NAME, [
-            'type',
-            'field',
-            'value',
-            'operator',
-            'parameters',
-            'position',
-        ]);
+        if ($event->getEventByEntityName(ProductStreamFilterDefinition::ENTITY_NAME) === null) {
+            return null;
+        }
 
-        if ($ids === [] || $filterIds === []) {
+        $ids = ProductStreamWriteResultHelper::getAffectedStreamIds($event);
+
+        if ($ids === []) {
             return null;
         }
 

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterDefinition;
-use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
+use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteResultHelper;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Exception\UnmappedFieldException;
@@ -148,17 +148,13 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
             return null;
         }
 
-        $ids = $event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME);
-        $filterIds = $event->getPrimaryKeysWithPropertyChange(ProductStreamFilterDefinition::ENTITY_NAME, [
-            'type',
-            'field',
-            'value',
-            'operator',
-            'parameters',
-            'position',
-        ]);
+        if ($event->getEventByEntityName(ProductStreamFilterDefinition::ENTITY_NAME) === null) {
+            return null;
+        }
 
-        if ($ids === [] || $filterIds === []) {
+        $ids = ProductStreamWriteResultHelper::getAffectedStreamIds($event);
+
+        if ($ids === []) {
             return null;
         }
 

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
@@ -111,10 +111,6 @@ class ProductCrossSellingRoute extends AbstractProductCrossSellingRoute
         $tags = [];
 
         foreach ($elements as $element) {
-            if ($element->getStreamId() !== null) {
-                $tags[] = EntityCacheKeyGenerator::buildStreamTag($element->getStreamId());
-            }
-
             foreach ($element->getProducts() as $product) {
                 $tags[] = EntityCacheKeyGenerator::buildProductTag($product->getId());
 
@@ -148,6 +144,10 @@ class ProductCrossSellingRoute extends AbstractProductCrossSellingRoute
     {
         $productStreamId = $crossSelling->getProductStreamId();
         \assert(\is_string($productStreamId));
+
+        $this->cacheTagCollector->addTag(
+            EntityCacheKeyGenerator::buildStreamTag($productStreamId)
+        );
 
         $filters = $this->productStreamBuilder->buildFilters($productStreamId, $context->getContext());
 

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -104,6 +105,10 @@ class ProductListingRoute extends AbstractProductListingRoute
             && $category->get('productStreamId') !== null;
 
         if ($hasProductStream) {
+            $this->cacheTagCollector->addTag(
+                EntityCacheKeyGenerator::buildStreamTag($category->get('productStreamId'))
+            );
+
             $filters = $this->productStreamBuilder->buildFilters(
                 $category->get('productStreamId'),
                 $salesChannelContext->getContext()

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
@@ -65,7 +65,12 @@ class ProductStreamIndexer extends EntityIndexer
 
     public function update(EntityWrittenContainerEvent $event): ?EntityIndexingMessage
     {
-        $updates = $event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME);
+        $updates = [
+            ...$event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME),
+            ...ProductStreamWriteResultHelper::getAffectedStreamIds($event),
+        ];
+
+        $updates = array_unique($updates);
 
         if (!$updates) {
             return null;

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelper.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelper.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\ProductStream\DataAbstractionLayer;
+
+use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[Package('inventory')]
+final class ProductStreamWriteResultHelper
+{
+    /**
+     * @return list<string>
+     */
+    public static function getAffectedStreamIds(EntityWrittenContainerEvent $event): array
+    {
+        return self::getAffectedStreamIdsFromEvent(
+            $event->getEventByEntityName(ProductStreamFilterDefinition::ENTITY_NAME)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function getAffectedStreamIdsFromEvent(?EntityWrittenEvent $event): array
+    {
+        if ($event === null) {
+            return [];
+        }
+
+        $streamIds = [];
+
+        foreach ($event->getWriteResults() as $writeResult) {
+            $streamId = self::resolveStreamId($writeResult);
+            if ($streamId === null) {
+                continue;
+            }
+
+            $streamIds[$streamId] = true;
+        }
+
+        return array_keys($streamIds);
+    }
+
+    private static function resolveStreamId(EntityWriteResult $writeResult): ?string
+    {
+        $payload = $writeResult->getPayload();
+
+        $streamId = self::normalizeStreamId(
+            $payload['productStreamId'] ?? $payload['product_stream_id'] ?? null
+        );
+
+        if ($streamId !== null) {
+            return $streamId;
+        }
+
+        $existence = $writeResult->getExistence();
+        if ($existence === null) {
+            return null;
+        }
+
+        $state = $existence->getState();
+
+        return self::normalizeStreamId(
+            $state['product_stream_id'] ?? $state['productStreamId'] ?? null
+        );
+    }
+
+    private static function normalizeStreamId(mixed $streamId): ?string
+    {
+        if (!\is_string($streamId) || $streamId === '') {
+            return null;
+        }
+
+        if (Uuid::isValid($streamId)) {
+            return $streamId;
+        }
+
+        if (\strlen($streamId) === 16) {
+            return Uuid::fromBytesToHex($streamId);
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelper.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelper.php
@@ -34,39 +34,38 @@ final class ProductStreamWriteResultHelper
         $streamIds = [];
 
         foreach ($event->getWriteResults() as $writeResult) {
-            $streamId = self::resolveStreamId($writeResult);
-            if ($streamId === null) {
-                continue;
+            foreach (self::collectStreamIds($writeResult) as $streamId) {
+                $streamIds[$streamId] = true;
             }
-
-            $streamIds[$streamId] = true;
         }
 
         return array_keys($streamIds);
     }
 
-    private static function resolveStreamId(EntityWriteResult $writeResult): ?string
+    /**
+     * @return list<string>
+     */
+    private static function collectStreamIds(EntityWriteResult $writeResult): array
     {
-        $payload = $writeResult->getPayload();
+        $ids = [];
 
-        $streamId = self::normalizeStreamId(
+        $payload = $writeResult->getPayload();
+        $payloadId = self::normalizeStreamId(
             $payload['productStreamId'] ?? $payload['product_stream_id'] ?? null
         );
-
-        if ($streamId !== null) {
-            return $streamId;
+        if ($payloadId !== null) {
+            $ids[] = $payloadId;
         }
 
-        $existence = $writeResult->getExistence();
-        if ($existence === null) {
-            return null;
-        }
-
-        $state = $existence->getState();
-
-        return self::normalizeStreamId(
+        $state = $writeResult->getExistence()?->getState();
+        $stateId = self::normalizeStreamId(
             $state['product_stream_id'] ?? $state['productStreamId'] ?? null
         );
+        if ($stateId !== null) {
+            $ids[] = $stateId;
+        }
+
+        return $ids;
     }
 
     private static function normalizeStreamId(mixed $streamId): ?string

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -26,6 +26,7 @@ use Shopware\Core\Content\Product\Events\InvalidateProductCache;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
+use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteResultHelper;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Content\Sitemap\Event\SitemapGeneratedEvent;
 use Shopware\Core\Content\Sitemap\SalesChannel\SitemapRoute;
@@ -169,8 +170,19 @@ class CacheInvalidationSubscriber
     public function invalidateStreamIds(EntityWrittenContainerEvent $event): void
     {
         // invalidates all routes which are loaded based on a stream (e.G. category listing and cross selling)
-        $ids = array_map(EntityCacheKeyGenerator::buildStreamTag(...), $event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME));
-        $this->cacheInvalidator->invalidate($ids);
+        $streamIds = [
+            ...$event->getPrimaryKeys(ProductStreamDefinition::ENTITY_NAME),
+            ...ProductStreamWriteResultHelper::getAffectedStreamIds($event),
+        ];
+
+        $streamIds = array_values(array_unique($streamIds));
+
+        if ($streamIds === []) {
+            return;
+        }
+
+        $ids = array_map(EntityCacheKeyGenerator::buildStreamTag(...), $streamIds);
+        $this->cacheInvalidator->invalidate($ids, force: true);
     }
 
     public function invalidateCategoryRouteByCategoryIds(CategoryIndexerEvent $event): void

--- a/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\CrossSelling;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
@@ -13,9 +14,11 @@ use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFact
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\AbstractProductCrossSellingRoute;
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRoute;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
+use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterCollection;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
@@ -527,6 +530,70 @@ class CrossSellingRouteTest extends TestCase
         static::assertNotNull($element);
         static::assertCount(5, $element->getProducts());
         static::assertNotContains($productId, $element->getProducts()->getIds());
+    }
+
+    public function testCrossSellingUsingDynamicGroupUpdatesAfterSeparateFilterSync(): void
+    {
+        $productId = Uuid::randomHex();
+        $streamId = Uuid::randomHex();
+
+        $initialProductIds = array_column($this->createProducts(), 'id');
+        $replacementProductIds = array_column($this->createProducts(), 'id');
+
+        static::getContainer()->get('product_stream.repository')->create([
+            [
+                'id' => $streamId,
+                'name' => 'testStream',
+                'filters' => [
+                    [
+                        'type' => 'equalsAny',
+                        'field' => 'id',
+                        'value' => implode('|', $initialProductIds),
+                    ],
+                ],
+            ],
+        ], $this->salesChannelContext->getContext());
+
+        $productData = $this->getProductData($productId);
+        $productData['crossSellings'] = [[
+            'name' => 'Test Cross Selling',
+            'sortBy' => ProductCrossSellingDefinition::SORT_BY_PRICE,
+            'sortDirection' => FieldSorting::ASCENDING,
+            'active' => true,
+            'limit' => 10,
+            'productStreamId' => $streamId,
+        ]];
+        $this->productRepository->create([$productData], $this->salesChannelContext->getContext());
+
+        $result = $this->route->load($productId, new Request(), $this->salesChannelContext, new Criteria())->getResult();
+        $element = $result->first();
+        static::assertNotNull($element);
+        static::assertEqualsCanonicalizing(
+            $initialProductIds,
+            array_values($element->getProducts()->getIds()),
+        );
+
+        $filterId = static::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT LOWER(HEX(id)) FROM product_stream_filter WHERE product_stream_id = :streamId',
+            ['streamId' => Uuid::fromHexToBytes($streamId)],
+        );
+        static::assertIsString($filterId);
+
+        /** @var EntityRepository<ProductStreamFilterCollection> $productStreamFilterRepository */
+        $productStreamFilterRepository = static::getContainer()->get('product_stream_filter.repository');
+        $productStreamFilterRepository->update([[
+            'id' => $filterId,
+            'value' => implode('|', $replacementProductIds),
+        ]], Context::createDefaultContext());
+
+        $result = $this->route->load($productId, new Request(), $this->salesChannelContext, new Criteria())->getResult();
+        $element = $result->first();
+        static::assertNotNull($element);
+        static::assertEqualsCanonicalizing(
+            $replacementProductIds,
+            array_values($element->getProducts()->getIds()),
+            'Cross-selling must reflect updated product_stream_filter value even when the parent product_stream is untouched.',
+        );
     }
 
     private function createProductStream(bool $includesIsCloseoutProducts = false, bool $noStock = false, ?string $includedProductId = null): string

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
+use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterCollection;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -67,6 +68,11 @@ class ProductListingRouteTest extends TestCase
      */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<ProductStreamFilterCollection>
+     */
+    private EntityRepository $productStreamFilterRepository;
+
     protected function setUp(): void
     {
         $this->ids = new IdsCollection();
@@ -79,6 +85,10 @@ class ProductListingRouteTest extends TestCase
         /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->productRepository = $productRepository;
+
+        /** @var EntityRepository<ProductStreamFilterCollection> */
+        $productStreamFilterRepository = static::getContainer()->get('product_stream_filter.repository');
+        $this->productStreamFilterRepository = $productStreamFilterRepository;
     }
 
     public function testLoadProducts(): void
@@ -201,6 +211,43 @@ class ProductListingRouteTest extends TestCase
         static::assertCount(1, $response['elements']);
         static::assertSame('product', $response['elements'][0]['apiAlias']);
         static::assertSame($this->variantIds['greenL'], $response['elements'][0]['id']);
+    }
+
+    public function testLoadProductsUsingDynamicGroupUpdatesAfterSeparateFilterSync(): void
+    {
+        $this->createData('product_stream', $this->ids->create('productStream'));
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product-listing/' . $this->ids->get('category')
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertCount(1, $response['elements']);
+        static::assertContains($response['elements'][0]['id'], [$this->variantIds['redL'], $this->variantIds['redXl']]);
+
+        $filterId = static::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT LOWER(HEX(id)) FROM product_stream_filter WHERE product_stream_id = :streamId',
+            ['streamId' => Uuid::fromHexToBytes($this->ids->get('productStream'))]
+        );
+        static::assertIsString($filterId);
+
+        $this->productStreamFilterRepository->update([[
+            'id' => $filterId,
+            'field' => 'options.id',
+            'value' => $this->optionIds['green'],
+        ]], Context::createDefaultContext());
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product-listing/' . $this->ids->get('category')
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertCount(1, $response['elements']);
+        static::assertContains($response['elements'][0]['id'], [$this->variantIds['greenL'], $this->variantIds['greenXl']]);
     }
 
     public function testIncludes(): void

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
+use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterCollection;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -67,6 +68,11 @@ class ProductListingRouteTest extends TestCase
      */
     private EntityRepository $productRepository;
 
+    /**
+     * @var EntityRepository<ProductStreamFilterCollection>
+     */
+    private EntityRepository $productStreamFilterRepository;
+
     protected function setUp(): void
     {
         $this->ids = new IdsCollection();
@@ -79,6 +85,10 @@ class ProductListingRouteTest extends TestCase
         /** @var EntityRepository<ProductCollection> */
         $productRepository = static::getContainer()->get('product.repository');
         $this->productRepository = $productRepository;
+
+        /** @var EntityRepository<ProductStreamFilterCollection> */
+        $productStreamFilterRepository = static::getContainer()->get('product_stream_filter.repository');
+        $this->productStreamFilterRepository = $productStreamFilterRepository;
     }
 
     public function testLoadProducts(): void
@@ -148,6 +158,43 @@ class ProductListingRouteTest extends TestCase
         static::assertCount(1, $response['elements']);
         static::assertSame('product', $response['elements'][0]['apiAlias']);
         static::assertSame($this->variantIds['greenL'], $response['elements'][0]['id']);
+    }
+
+    public function testLoadProductsUsingDynamicGroupUpdatesAfterSeparateFilterSync(): void
+    {
+        $this->createData('product_stream', $this->ids->create('productStream'));
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product-listing/' . $this->ids->get('category')
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertCount(1, $response['elements']);
+        static::assertContains($response['elements'][0]['id'], [$this->variantIds['redL'], $this->variantIds['redXl']]);
+
+        $filterId = static::getContainer()->get(Connection::class)->fetchOne(
+            'SELECT LOWER(HEX(id)) FROM product_stream_filter WHERE product_stream_id = :streamId',
+            ['streamId' => Uuid::fromHexToBytes($this->ids->get('productStream'))]
+        );
+        static::assertIsString($filterId);
+
+        $this->productStreamFilterRepository->update([[
+            'id' => $filterId,
+            'field' => 'options.id',
+            'value' => $this->optionIds['green'],
+        ]], Context::createDefaultContext());
+
+        $this->browser->request(
+            'POST',
+            '/store-api/product-listing/' . $this->ids->get('category')
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertCount(1, $response['elements']);
+        static::assertContains($response['elements'][0]['id'], [$this->variantIds['greenL'], $this->variantIds['greenXl']]);
     }
 
     public function testIncludes(): void

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -78,11 +79,15 @@ class ProductStreamUpdaterTest extends TestCase
 
     public function testUpdaterWithFilterChange(): void
     {
+        $updatedStreamId = Uuid::randomHex();
+        $deletedStreamId = Uuid::randomHex();
         $connectionMock = $this->createMock(Connection::class);
         $messageBusMock = $this->createMock(MessageBusInterface::class);
-        $messageBusMock->expects($this->once())->method('dispatch')->willReturnCallback(static function ($message) {
+        $expectedMessages = [$updatedStreamId, $deletedStreamId];
+        $matcher = $this->exactly(\count($expectedMessages));
+        $messageBusMock->expects($matcher)->method('dispatch')->willReturnCallback(static function ($message) use ($matcher, $expectedMessages) {
             static::assertInstanceOf(ProductStreamMappingIndexingMessage::class, $message);
-            static::assertSame('product-stream-1', $message->getData());
+            static::assertSame($expectedMessages[$matcher->numberOfInvocations() - 1], $message->getData());
             static::assertSame('product_stream_mapping.indexer', $message->getIndexer());
 
             return new Envelope($message);
@@ -107,13 +112,19 @@ class ProductStreamUpdaterTest extends TestCase
         $containerEvent = new EntityWrittenContainerEvent(
             Context::createCLIContext(),
             new NestedEventCollection([
-                new EntityWrittenEvent(ProductStreamDefinition::ENTITY_NAME, [
-                    new EntityWriteResult('product-stream-1', [], ProductStreamDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE),
-                ], Context::createCLIContext()),
                 new EntityWrittenEvent(ProductStreamFilterDefinition::ENTITY_NAME, [
                     new EntityWriteResult('product-stream-filter-1', [
+                        'productStreamId' => $updatedStreamId,
                         'operator' => 'and',
                     ], ProductStreamFilterDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE),
+                    new EntityWriteResult('product-stream-filter-2', [], ProductStreamFilterDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_DELETE, new EntityExistence(
+                        ProductStreamFilterDefinition::ENTITY_NAME,
+                        ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                        true,
+                        false,
+                        false,
+                        ['product_stream_id' => Uuid::fromHexToBytes($deletedStreamId)]
+                    )),
                 ], Context::createCLIContext()),
             ]),
             []

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -71,11 +72,15 @@ class ProductStreamUpdaterTest extends TestCase
 
     public function testUpdaterWithFilterChange(): void
     {
+        $updatedStreamId = Uuid::randomHex();
+        $deletedStreamId = Uuid::randomHex();
         $connectionMock = $this->createMock(Connection::class);
         $messageBusMock = $this->createMock(MessageBusInterface::class);
-        $messageBusMock->expects($this->once())->method('dispatch')->willReturnCallback(static function ($message) {
+        $expectedMessages = [$updatedStreamId, $deletedStreamId];
+        $matcher = $this->exactly(\count($expectedMessages));
+        $messageBusMock->expects($matcher)->method('dispatch')->willReturnCallback(static function ($message) use ($matcher, $expectedMessages) {
             static::assertInstanceOf(ProductStreamMappingIndexingMessage::class, $message);
-            static::assertSame('product-stream-1', $message->getData());
+            static::assertSame($expectedMessages[$matcher->numberOfInvocations() - 1], $message->getData());
             static::assertSame('product_stream_mapping.indexer', $message->getIndexer());
 
             return new Envelope($message);
@@ -96,13 +101,19 @@ class ProductStreamUpdaterTest extends TestCase
         $containerEvent = new EntityWrittenContainerEvent(
             Context::createCLIContext(),
             new NestedEventCollection([
-                new EntityWrittenEvent(ProductStreamDefinition::ENTITY_NAME, [
-                    new EntityWriteResult('product-stream-1', [], ProductStreamDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE),
-                ], Context::createCLIContext()),
                 new EntityWrittenEvent(ProductStreamFilterDefinition::ENTITY_NAME, [
                     new EntityWriteResult('product-stream-filter-1', [
+                        'productStreamId' => $updatedStreamId,
                         'operator' => 'and',
                     ], ProductStreamFilterDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_UPDATE),
+                    new EntityWriteResult('product-stream-filter-2', [], ProductStreamFilterDefinition::ENTITY_NAME, EntityWriteResult::OPERATION_DELETE, new EntityExistence(
+                        ProductStreamFilterDefinition::ENTITY_NAME,
+                        ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                        true,
+                        false,
+                        false,
+                        ['product_stream_id' => Uuid::fromHexToBytes($deletedStreamId)]
+                    )),
                 ], Context::createCLIContext()),
             ]),
             []

--- a/tests/unit/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRouteTest.php
@@ -108,15 +108,76 @@ class ProductCrossSellingRouteTest extends TestCase
             )
         );
 
-        $this->cacheTagCollector->expects($this->once())
-            ->method('addTag')
-            ->with(
+        $calls = [
+            [EntityCacheKeyGenerator::buildStreamTag($streamId)],
+            [
                 EntityCacheKeyGenerator::buildProductTag($productId),
-                EntityCacheKeyGenerator::buildStreamTag($streamId),
                 EntityCacheKeyGenerator::buildProductTag($childId),
-                EntityCacheKeyGenerator::buildProductTag($childParentId)
-            );
+                EntityCacheKeyGenerator::buildProductTag($childParentId),
+            ],
+        ];
+        $matcher = $this->exactly(\count($calls));
+        $this->cacheTagCollector->expects($matcher)
+            ->method('addTag')
+            ->willReturnCallback(static function (string ...$tags) use ($matcher, $calls): void {
+                self::assertSame($calls[$matcher->numberOfInvocations() - 1], $tags);
+            });
 
         $this->route->load($productId, new Request(), Generator::generateSalesChannelContext(), new Criteria());
+    }
+
+    public function testLoadAlwaysAddsStreamTagForStreamCrossSelling(): void
+    {
+        $productId = Uuid::randomHex();
+        $crossSellingId = Uuid::randomHex();
+        $streamId = Uuid::randomHex();
+
+        $crossSelling = new ProductCrossSellingEntity();
+        $crossSelling->setUniqueIdentifier($crossSellingId);
+        $crossSelling->setType(ProductCrossSellingDefinition::TYPE_PRODUCT_STREAM);
+        $crossSelling->setProductStreamId($streamId);
+        $crossSelling->setProductId($productId);
+        $crossSelling->setLimit(10);
+        $crossSelling->setSortBy('name');
+        $crossSelling->setSortDirection('ASC');
+
+        $this->crossSellingRepository->method('search')->willReturn(
+            new EntitySearchResult(
+                'product_cross_selling',
+                1,
+                new ProductCrossSellingCollection([$crossSelling]),
+                null,
+                new Criteria(),
+                Context::createDefaultContext()
+            )
+        );
+
+        $this->listingLoader->method('load')->willReturn(
+            new EntitySearchResult(
+                'product',
+                0,
+                new ProductCollection(),
+                null,
+                new Criteria(),
+                Context::createDefaultContext()
+            )
+        );
+
+        $observedTags = [];
+        $this->cacheTagCollector
+            ->method('addTag')
+            ->willReturnCallback(static function (string ...$tags) use (&$observedTags): void {
+                foreach ($tags as $tag) {
+                    $observedTags[] = $tag;
+                }
+            });
+
+        $this->route->load($productId, new Request(), Generator::generateSalesChannelContext(), new Criteria());
+
+        static::assertContains(
+            EntityCacheKeyGenerator::buildStreamTag($streamId),
+            $observedTags,
+            'Stream tag must be added unconditionally so product_stream_filter writes invalidate cross-selling responses.'
+        );
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
@@ -106,6 +107,52 @@ class ProductListingRouteTest extends TestCase
         ], $criteria->getFilterFields());
 
         static::assertSame($streamId, $result->getStreamId());
+    }
+
+    public function testStreamTagIsAddedForProductStreams(): void
+    {
+        $categoryId = 'categoryId';
+        $streamId = 'streamId';
+        /** @var StaticEntityRepository<CategoryCollection> */
+        $categoryRepository = new StaticEntityRepository([new EntityCollection([
+            new PartialEntity(
+                [
+                    'id' => $categoryId,
+                    'productStreamId' => $streamId,
+                    'productAssignmentType' => CategoryDefinition::PRODUCT_ASSIGNMENT_TYPE_PRODUCT_STREAM,
+                ]
+            )])]);
+
+        $productStreamBuilder = $this->createMock(ProductStreamBuilderInterface::class);
+        $productStreamBuilder->method('buildFilters')->willReturn([]);
+
+        $cacheTagCollector = $this->createMock(CacheTagCollector::class);
+        $calls = [
+            [ProductListingRoute::buildName($categoryId)],
+            [EntityCacheKeyGenerator::buildStreamTag($streamId)],
+        ];
+        $matcher = $this->exactly(\count($calls));
+        $cacheTagCollector->expects($matcher)
+            ->method('addTag')
+            ->willReturnCallback(static function (string ...$tags) use ($matcher, $calls): void {
+                self::assertSame($calls[$matcher->numberOfInvocations() - 1], $tags);
+            });
+
+        $eventDispatcher = new EventDispatcher();
+        $controller = new ProductListingRoute(
+            $this->createMock(ProductListingLoader::class),
+            $categoryRepository,
+            $productStreamBuilder,
+            $cacheTagCollector,
+            new ExtensionDispatcher($eventDispatcher),
+        );
+
+        $controller->load(
+            $categoryId,
+            new Request(),
+            $this->createMock(SalesChannelContext::class),
+            new Criteria()
+        );
     }
 
     public function testClassIsBaseOfDecorationChain(): void

--- a/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
+++ b/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexerTest.php
@@ -13,15 +13,20 @@ use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexe
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexingMessage;
 use Shopware\Core\Content\ProductStream\ProductStreamCollection;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\OffsetQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\QueryStringParser;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -95,10 +100,56 @@ class ProductStreamIndexerTest extends TestCase
 
     public function testUpdate(): void
     {
-        $event = $this->createMock(EntityWrittenContainerEvent::class);
-        $event->expects($this->once())->method('getPrimaryKeys')->willReturn([123]);
+        $streamId = Uuid::randomHex();
+        $deletedStreamId = Uuid::randomHex();
 
-        static::assertInstanceOf(ProductStreamIndexingMessage::class, $this->indexer->update($event));
+        $message = $this->indexer->update(new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    ProductStreamDefinition::ENTITY_NAME,
+                    [
+                        new EntityWriteResult(
+                            $streamId,
+                            [],
+                            ProductStreamDefinition::ENTITY_NAME,
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                    ],
+                    Context::createDefaultContext(),
+                ),
+                new EntityWrittenEvent(
+                    'product_stream_filter',
+                    [
+                        new EntityWriteResult(
+                            Uuid::randomHex(),
+                            ['productStreamId' => $streamId],
+                            'product_stream_filter',
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                        new EntityWriteResult(
+                            Uuid::randomHex(),
+                            [],
+                            'product_stream_filter',
+                            EntityWriteResult::OPERATION_DELETE,
+                            new EntityExistence(
+                                'product_stream_filter',
+                                ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                                true,
+                                false,
+                                false,
+                                ['product_stream_id' => Uuid::fromHexToBytes($deletedStreamId)]
+                            ),
+                        ),
+                    ],
+                    Context::createDefaultContext(),
+                ),
+            ]),
+            [],
+        ));
+
+        static::assertInstanceOf(ProductStreamIndexingMessage::class, $message);
+        static::assertSame([$streamId, $deletedStreamId], $message->getData());
     }
 
     public function testHandle(): void

--- a/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelperTest.php
+++ b/tests/unit/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamWriteResultHelperTest.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ProductStream\DataAbstractionLayer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ProductStream\Aggregate\ProductStreamFilter\ProductStreamFilterDefinition;
+use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamWriteResultHelper;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ProductStreamWriteResultHelper::class)]
+class ProductStreamWriteResultHelperTest extends TestCase
+{
+    public function testReturnsEmptyWhenContainerHasNoFilterEvent(): void
+    {
+        $event = new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([]),
+            [],
+        );
+
+        static::assertSame([], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    public function testReturnsEmptyWhenEventIsNull(): void
+    {
+        static::assertSame([], ProductStreamWriteResultHelper::getAffectedStreamIdsFromEvent(null));
+    }
+
+    public function testCollectsStreamIdFromPayloadCamelCase(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['productStreamId' => $streamId],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_INSERT,
+            ),
+        ]);
+
+        static::assertSame([$streamId], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    public function testCollectsStreamIdFromPayloadSnakeCase(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['product_stream_id' => $streamId],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_INSERT,
+            ),
+        ]);
+
+        static::assertSame([$streamId], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    public function testCollectsStreamIdFromExistenceStateOnDelete(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                [],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_DELETE,
+                new EntityExistence(
+                    ProductStreamFilterDefinition::ENTITY_NAME,
+                    ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                    true,
+                    false,
+                    false,
+                    ['product_stream_id' => Uuid::fromHexToBytes($streamId)],
+                ),
+            ),
+        ]);
+
+        static::assertSame([$streamId], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    /**
+     * Regression: when a filter is reassigned from stream A to stream B, the payload
+     * exposes B and the existence state still holds A. Both must be invalidated so that
+     * neither stream's cached `api_filter` is left stale.
+     */
+    public function testReassignmentReturnsBothOldAndNewStreamIds(): void
+    {
+        $oldStreamId = Uuid::randomHex();
+        $newStreamId = Uuid::randomHex();
+
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['productStreamId' => $newStreamId],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_UPDATE,
+                new EntityExistence(
+                    ProductStreamFilterDefinition::ENTITY_NAME,
+                    ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                    true,
+                    false,
+                    false,
+                    ['product_stream_id' => Uuid::fromHexToBytes($oldStreamId)],
+                ),
+            ),
+        ]);
+
+        $ids = ProductStreamWriteResultHelper::getAffectedStreamIds($event);
+
+        static::assertCount(2, $ids);
+        static::assertContains($oldStreamId, $ids);
+        static::assertContains($newStreamId, $ids);
+    }
+
+    public function testDeduplicatesAcrossMultipleWriteResults(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['productStreamId' => $streamId],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_INSERT,
+            ),
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['productStreamId' => $streamId],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_UPDATE,
+            ),
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                [],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_DELETE,
+                new EntityExistence(
+                    ProductStreamFilterDefinition::ENTITY_NAME,
+                    ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                    true,
+                    false,
+                    false,
+                    ['product_stream_id' => Uuid::fromHexToBytes($streamId)],
+                ),
+            ),
+        ]);
+
+        static::assertSame([$streamId], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    public function testIgnoresWriteResultsWithoutAnyStreamId(): void
+    {
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                [],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_INSERT,
+            ),
+        ]);
+
+        static::assertSame([], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    public function testIgnoresEmptyStringStreamId(): void
+    {
+        $event = $this->buildContainerEvent([
+            new EntityWriteResult(
+                Uuid::randomHex(),
+                ['productStreamId' => ''],
+                ProductStreamFilterDefinition::ENTITY_NAME,
+                EntityWriteResult::OPERATION_INSERT,
+            ),
+        ]);
+
+        static::assertSame([], ProductStreamWriteResultHelper::getAffectedStreamIds($event));
+    }
+
+    /**
+     * @param list<EntityWriteResult> $writeResults
+     */
+    private function buildContainerEvent(array $writeResults): EntityWrittenContainerEvent
+    {
+        return new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    ProductStreamFilterDefinition::ENTITY_NAME,
+                    $writeResults,
+                    Context::createDefaultContext(),
+                ),
+            ]),
+            [],
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
@@ -407,6 +408,53 @@ class CacheInvalidationSubscriberTest extends TestCase
             });
 
         $subscriber->invalidateConfigKey(new SystemConfigChangedHook([], [], $salesChannelId, false));
+    }
+
+    public function testInvalidateStreamIdsWithProductStreamFilterWrites(): void
+    {
+        $streamId = Uuid::randomHex();
+        $deletedStreamId = Uuid::randomHex();
+        $subscriber = $this->createSubscriber();
+
+        $this->cacheInvalidator->expects($this->once())
+            ->method('invalidate')
+            ->with([
+                EntityCacheKeyGenerator::buildStreamTag($streamId),
+                EntityCacheKeyGenerator::buildStreamTag($deletedStreamId),
+            ]);
+
+        $subscriber->invalidateStreamIds(new EntityWrittenContainerEvent(
+            Context::createDefaultContext(),
+            new NestedEventCollection([
+                new EntityWrittenEvent(
+                    'product_stream_filter',
+                    [
+                        new EntityWriteResult(
+                            Uuid::randomHex(),
+                            ['productStreamId' => $streamId],
+                            'product_stream_filter',
+                            EntityWriteResult::OPERATION_UPDATE,
+                        ),
+                        new EntityWriteResult(
+                            Uuid::randomHex(),
+                            [],
+                            'product_stream_filter',
+                            EntityWriteResult::OPERATION_DELETE,
+                            new EntityExistence(
+                                'product_stream_filter',
+                                ['id' => Uuid::fromHexToBytes(Uuid::randomHex())],
+                                true,
+                                false,
+                                false,
+                                ['product_stream_id' => Uuid::fromHexToBytes($deletedStreamId)]
+                            ),
+                        ),
+                    ],
+                    Context::createDefaultContext(),
+                ),
+            ]),
+            [],
+        ));
     }
 
     public function createSnippetEvent(): EntityWrittenContainerEvent


### PR DESCRIPTION
## Summary

Fixes #8221

When a product stream's filters are edited in the Admin, the storefront keeps showing old products. The Admin preview and Store API show the correct results, but the storefront HTTP cache is never invalidated and the `api_filter` column is never rebuilt.

### Root cause

When saving stream filters in the Admin, only `product_stream_filter` rows are written — the `product_stream` entity itself is not touched. But both `ProductStreamIndexer::update()` and `CacheInvalidationSubscriber::invalidateStreamIds()` only watch for `product_stream` entity writes, so they miss the filter changes entirely.

Additionally, `invalidateStreamIds()` uses delayed cache invalidation (up to 5 minutes) instead of immediate purge.

### Changes

- **`ProductStreamWriteResultHelper`** (new): Extracts parent stream IDs from `product_stream_filter` write events
- **`ProductStreamIndexer::update()`**: Also triggers on `product_stream_filter` writes via the helper, rebuilding `api_filter` synchronously
- **`CacheInvalidationSubscriber::invalidateStreamIds()`**: Collects stream IDs from filter writes + uses `force: true` to bypass delayed invalidation
- **`ProductListingRoute`**: Adds product stream cache tags to HTTP response for tag-based invalidation

## Setup testing environment

### 1. Enable Redis cache + production HTTP cache

Add to `.env.local`:
```env
APP_ENV=prod
SHOPWARE_HTTP_CACHE_ENABLED=1
```

Create `config/packages/cache.yaml`:
```yaml
framework:
    cache:
        app: cache.adapter.redis
        default_redis_provider: '%env(REDIS_URL)%'
        pools:
            cache.object:
                default_lifetime: 172800
                tags: cache.tags
                adapters:
                    - cache.app
            cache.http:
                default_lifetime: 172800
                tags: cache.tags
                adapters:
                    - cache.app
            cache.tags:
                adapters:
                    - cache.app
```

### 2. Assign a product stream to a category

1. Go to **Admin > Catalogues > Product streams**
2. Create or pick a stream with a broad filter (e.g. `active = yes`)
3. Go to **Admin > Catalogues > Categories**
4. Pick a category, set **Product assignment** to "Dynamic product group"
5. Assign the stream from step 2
6. Save

### 3. Rebuild indexes and clear cache

```bash
bin/console dal:refresh:index
bin/console cache:clear
```

### 4. Verify products appear

Open the category page in the storefront. You should see products. Reload to confirm it's cached.

## Test the bug (on trunk, without fix)

1. In **Admin > Catalogues > Product streams**, edit the stream
2. Change the filter to match 0 products (e.g. product name contains `ZZZZ_NOTHING`)
3. Save
4. Reload the storefront category page → **BUG: still shows old products**
5. Run `bin/console dal:refresh:index` + `bin/console cache:clear` → products disappear (workaround)

## Test the fix (on this branch)

1. Repeat the same steps as above
2. After saving the stream filter in Admin → **reload storefront → products disappear immediately**
3. No `dal:refresh:index` or `cache:clear` needed

## Cleanup

Restore your local environment after testing:

```bash
# .env.local
APP_ENV=dev
# Remove SHOPWARE_HTTP_CACHE_ENABLED line

# Remove cache config
rm config/packages/cache.yaml

# Clear cache
bin/console cache:clear
```

## Test plan

- [x] Unit tests for `ProductStreamWriteResultHelper`
- [x] Unit tests for `CacheInvalidationSubscriber` stream invalidation
- [x] Unit tests for `ProductStreamIndexer` filter change detection
- [x] Unit tests for `ProductListingRoute` cache tag inclusion
- [x] Integration test for `ProductListingRoute`
- [x] Manual verification: edit stream in Admin → storefront updates immediately (no reindex)