### PR TITLE
fix(cms): restore product slider settings text alignment (#15027)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
@@ -10,6 +10,7 @@
 
         .sw-cms-el-config-product-slider__tab-settings {
             display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(185px, 305px));
             gap: 0 30px;
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

This is a **regression** introduced in commit `425067f5ee0` (NEXT-39635 - Add new navigation options for product slider). During that refactor, the `grid-template-columns` property was accidentally removed from the `.sw-cms-el-config-product-slider__tab-settings` CSS rule, leaving a `display: grid` with `gap: 0 30px` but no column definition. This causes the settings tab of the CMS Product Slider element to render with incorrect text alignment — form labels and inputs overlap due to the missing row spacing.

### 2. What does this change do, exactly?

Restores the accidentally removed CSS line:

```css
grid-template-columns: repeat(auto-fit, minmax(185px, 305px));
```

This is the same pattern used by the cross-selling element config, which was not affected by the regression.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration
2. Navigate to a CMS Layout (e.g. a Landing Page)
3. Add a "Commerce > Product Slider" block
4. Click on the element and open the **Settings** tab
5. Observe that text labels and form fields are misaligned / overlapping

<img width="892" height="804" alt="image" src="https://github.com/user-attachments/assets/f3437d59-d9ed-4644-a16c-887e9ee90bf6" />


### 4. Please link to the relevant issues (if any).

- closes #15027

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - N/A — CSS-only bugfix, no API or behavior change.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
