### PR TITLE
test: validate ATS tax price branch

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "1.21.1",
-        "@shopware-ag/acceptance-test-suite": "12.8.3",
+        "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#fix/tax-price-locater-account-order",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -1082,9 +1082,8 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "12.8.3",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.8.3.tgz",
-      "integrity": "sha512-UQk07BtPmscxsbOUN5Zy/IEfIRUVGiajq99cMAgd440Y37tvhwQPM6nGri26sG4PgzKJzwK4o+MqcMx/m4wM2A==",
+      "version": "12.8.4",
+      "resolved": "git+ssh://git@github.com/shopware/acceptance-test-suite.git#7aeb3c37e851b14fb93a48de1310112fbd8985e7",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "1.21.1",
-        "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#fix/tax-price-locater-account-order",
+        "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#7aeb3c37e851b14fb93a48de1310112fbd8985e7",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "1.21.1",
-    "@shopware-ag/acceptance-test-suite": "12.8.3",
+    "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#fix/tax-price-locater-account-order",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "1.21.1",
-    "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#fix/tax-price-locater-account-order",
+    "@shopware-ag/acceptance-test-suite": "github:shopware/acceptance-test-suite#7aeb3c37e851b14fb93a48de1310112fbd8985e7",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"


### PR DESCRIPTION
## Summary
- update `tests/acceptance` to consume `shopware/acceptance-test-suite#fix/tax-price-locater-account-order`
- pin the lockfile to ATS commit `7aeb3c37e851b14fb93a48de1310112fbd8985e7`
- validate that the checkout tax-rate acceptance spec loads against the branch dependency before release

## Verification
- `npm install @shopware-ag/acceptance-test-suite@github:shopware/acceptance-test-suite#fix/tax-price-locater-account-order` in `tests/acceptance`
- `npm ls @shopware-ag/acceptance-test-suite`
- `APP_URL=http://localhost npx playwright test tests/Checkout/CheckoutWithDifferentTaxRates.spec.ts --list`

## Context
This is a temporary validation PR for the ATS fix on `fix/tax-price-locater-account-order` before releasing a new ATS package.