### PR TITLE
fix: Adapt translation to include agentic commerce

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
@@ -38,7 +38,7 @@
       "buttonShowDetails": "Details",
       "buttonBack": "Zurück",
       "titleDescription": "Informationen",
-      "messageNoProductStreams": "Um Produktvergleiche anzulegen, musst Du zunächst eine dynamische Produktgruppe erstellen."
+      "messageNoProductStreams": "Um Produktvergleiche oder Agentic Commerce anzulegen, musst Du zunächst eine dynamische Produktgruppe erstellen."
     },
     "detail": {
       "messageSaveSuccess": "Der Verkaufskanal \"{name}\" wurde erfolgreich gespeichert.",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
@@ -38,7 +38,7 @@
       "buttonShowDetails": "Details",
       "buttonBack": "Zurück",
       "titleDescription": "Informationen",
-      "messageNoProductStreams": "Um Produktvergleiche oder Agentic Commerce anzulegen, musst Du zunächst eine dynamische Produktgruppe erstellen."
+      "messageNoProductStreams": "Um Produktvergleiche oder Agentic-Commerce-Vertriebskanäle zu erstellen, musst Du zunächst eine dynamische Produktgruppe erstellen."
     },
     "detail": {
       "messageSaveSuccess": "Der Verkaufskanal \"{name}\" wurde erfolgreich gespeichert.",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
@@ -38,7 +38,7 @@
       "buttonShowDetails": "Show details",
       "buttonBack": "Back",
       "titleDescription": "Information",
-      "messageNoProductStreams": "In order to use product comparisons a dynamic product group has to be created first."
+      "messageNoProductStreams": "In order to use product comparisons or agentic commerce a dynamic product group has to be created first."
     },
     "detail": {
       "messageSaveSuccess": "Sales Channel \"{name}\" saved.",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
@@ -38,7 +38,7 @@
       "buttonShowDetails": "Show details",
       "buttonBack": "Back",
       "titleDescription": "Information",
-      "messageNoProductStreams": "In order to use product comparisons or agentic commerce a dynamic product group has to be created first."
+      "messageNoProductStreams": "In order to use product comparisons or agentic commerce sales channels, a dynamic product group has to be created first."
     },
     "detail": {
       "messageSaveSuccess": "Sales Channel \"{name}\" saved.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Adapt modal translation to include agentic commerce type

### 2. What does this change do, exactly?
<img width="1360" height="784" alt="Screenshot 2026-04-08 at 14 26 47" src="https://github.com/user-attachments/assets/0a90bf61-423b-4281-bbc7-1be02dd8d5aa" />


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
