### PR TITLE
fix: querySelector returns null when no element is found and not false

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/cross-selling/cross-selling.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cross-selling/cross-selling.plugin.js
@@ -29,7 +29,7 @@ export default class CrossSellingPlugin extends Plugin {
 
         const slider = correspondingContent.querySelector(this.options.productSliderSelector);
 
-        if (slider === false) {
+        if (slider === null) {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `_rebuildCrossSellingSlider` method checks for the existence of a product slider using `querySelector`, but compares the result against false. Since querySelector never returns false (only Element or null), the early return  
  is never triggered.This causes a TypeError when no slider is found

### 2. What does this change do, exactly?
Changes the condition from slider === false to slider === null so the early return works correctly when querySelector finds no matching element.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
