### PR TITLE
fix: align translation icon in sw-snippet-field with meteor component…

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.html.twig
@@ -1,38 +1,40 @@
 {% block sw_snippet_field %}
 <div class="sw-snippet-field">
 
-    <mt-text-field
-        v-if="textField"
-        v-bind="$attrs"
-        class="sw-snippet-field__text"
-        :model-value="textValue"
-        :type="fieldType"
-        disabled
-    />
+    <div class="sw-snippet-field__input-wrapper">
+        <mt-text-field
+            v-if="textField"
+            v-bind="$attrs"
+            class="sw-snippet-field__text"
+            :model-value="textValue"
+            :type="fieldType"
+            disabled
+        />
 
-    <mt-textarea
-        v-else-if="textareaField"
-        v-bind="$attrs"
-        class="sw-snippet-field__textarea"
-        :model-value="textValue"
-        :type="fieldType"
-        disabled
-    />
+        <mt-textarea
+            v-else-if="textareaField"
+            v-bind="$attrs"
+            class="sw-snippet-field__textarea"
+            :model-value="textValue"
+            :type="fieldType"
+            disabled
+        />
 
-    <sw-loader
-        v-if="isLoading"
-        size="16px"
-    />
-    <mt-icon
-        v-else
-        v-tooltip="{
-            message: $t('global.sw-snippet-field.tooltip'),
-        }"
-        class="sw-snippet-field__icon"
-        name="regular-globe-stand"
-        size="16px"
-        @click="openEditModal()"
-    />
+        <sw-loader
+            v-if="isLoading"
+            size="16px"
+        />
+        <mt-icon
+            v-else
+            v-tooltip="{
+                message: $t('global.sw-snippet-field.tooltip'),
+            }"
+            class="sw-snippet-field__icon"
+            name="regular-globe-stand"
+            size="16px"
+            @click="openEditModal()"
+        />
+    </div>
 
     <sw-snippet-field-edit-modal
         v-if="showEditModal"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.scss
@@ -1,21 +1,29 @@
 @import "~scss/variables";
 
 .sw-snippet-field {
-    position: relative;
-
     .sw-block-field input {
         padding-right: 32px;
     }
 
+    .sw-snippet-field__input-wrapper {
+        position: relative;
+
+        // Override meteor component margin to align the translation icon correctly
+        .mt-field {
+            margin-bottom: 0 !important;
+        }
+    }
+
     .sw-snippet-field__icon {
         position: absolute;
-        bottom: 16px;
         right: 16px;
+        bottom: 16px;
         color: $color-shopware-brand-500;
         cursor: pointer;
     }
 
-    .sw-snippet-field__text input {
+    .sw-snippet-field__text input,
+    .sw-snippet-field__textarea textarea {
         padding-right: 40px;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The `sw-snippet-field` component's translation icon (globe icon) is mispositioned when used with Meteor form components (`mt-text-field`, `mt-textarea`). The icon appears below the input field instead of inside it, because the Meteor `.mt-field` wrapper has a `margin-bottom: 32px` that shifts the icon out of the visible input area.

### 2. What does this change do, exactly?

1. Wraps the input field and icon in a new `sw-snippet-field__input-wrapper` div that serves as the positioning context (`position: relative`)
2. Overrides the Meteor `.mt-field` margin inside the wrapper so the icon aligns correctly with the input border
3. Adds `padding-right` for `mt-textarea` to prevent text overlapping the icon (previously only `mt-text-field` had this)

### before
<img width="1010" height="654" alt="image" src="https://github.com/user-attachments/assets/38ca9b1e-dff4-4e5f-a09a-87402f2df8e1" />


### after
<img width="1039" height="630" alt="image" src="https://github.com/user-attachments/assets/f3b5fb41-32d4-4af7-9caf-5163324ac987" />


### 3. Describe each step to reproduce the issue or behaviour.

1. Install and activate an app that uses `sw-snippet-field` in its `config.xml` (e.g. SwagCustomNotification)
2. Open the app configuration in the Administration (Extensions → My Extensions → Configure)
3. Observe that the translation icons (blue globe) for text and textarea fields are positioned below the input fields instead of inside them

### 4. Please link to the relevant issues (if any).

- relates #15797

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - N/A — CSS/template fix for a private component, no API change.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them