### PR TITLE
fix: Reset domain field if storefront sales channel is changed

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -728,7 +728,15 @@ export default {
         },
 
         onStorefrontSelectionChange(storefrontSalesChannelId) {
+            this.productExport.salesChannelDomainId = null;
+            this.productExport.salesChannelDomain = null;
+            this.loadStorefrontDomains(storefrontSalesChannelId);
+
             this.salesChannelRepository.get(storefrontSalesChannelId).then((entity) => {
+                if (!entity) {
+                    return;
+                }
+
                 this.salesChannel.languageId = entity.languageId;
                 this.salesChannel.currencyId = entity.currencyId;
                 this.salesChannel.paymentMethodId = entity.paymentMethodId;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
@@ -1537,4 +1537,24 @@ describe('src/module/sw-sales-channel/view/sw-sales-channel-detail-base', () => 
 
         expect(wrapper.vm.salesChannel.configuration).toEqual(newConfig);
     });
+
+    it('should reset salesChannelDomainId when storefront sales channel changes', async () => {
+        const wrapper = await createWrapper({
+            props: {
+                salesChannel: {
+                    typeId: PRODUCT_COMPARISON_TYPE_ID,
+                },
+                productExport: {
+                    salesChannelDomainId: 'old-domain-id',
+                    salesChannelDomain: { id: 'old-domain-id' },
+                    storefrontSalesChannelId: 'old-sales-channel-id',
+                },
+            },
+        });
+
+        wrapper.vm.onStorefrontSelectionChange('new-sales-channel-id');
+
+        expect(wrapper.vm.productExport.salesChannelDomainId).toBeNull();
+        expect(wrapper.vm.productExport.salesChannelDomain).toBeNull();
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
For sales channels type product comparison or agentic commerce , if you want to change Storefront Sales Channel field , the Storefront domain is not reset

### 2. What does this change do, exactly?

https://github.com/user-attachments/assets/4e387c2b-377f-4775-8824-9cb30189327c



### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
