### PR TITLE
fix: harden revocation ats

### DIFF
--- a/tests/acceptance/tests/Forms/RevocationRequestForm.spec.ts
+++ b/tests/acceptance/tests/Forms/RevocationRequestForm.spec.ts
@@ -4,20 +4,34 @@ test(
     'As a merchant, I want to switch on and off the revocation request form',
     { tag: ['@Form', '@Revocation', '@Storefront'] },
     async ({ ShopCustomer, StorefrontHome, TestDataService }) => {
-        test.slow();
+        const revocationFormButton = () => {
+            return StorefrontHome.page.getByRole('link', { name: /Revoke a contract|Vertrag widerrufen/i });
+        };
+
+        const openStorefrontHome = async () => {
+            await ShopCustomer.goesTo(`${StorefrontHome.url()}?a=${Date.now()}`);
+        };
 
         await test.step('Visit the home page to check there is no revocation button', async () => {
             await TestDataService.setSystemConfig({ 'core.basicInformation.showRevocationButton': false });
-            await ShopCustomer.goesTo(StorefrontHome.url());
-            const revocationFormButton = StorefrontHome.page.getByText(/Revoke a contract|Vertrag widerrufen/);
-            await expect(revocationFormButton).toBeHidden();
+
+            await ShopCustomer.expects(async () => {
+                await openStorefrontHome();
+                await expect(revocationFormButton()).toBeHidden();
+            }).toPass({
+                intervals: [1_000, 2_500],
+            });
         });
 
         await test.step('Enables the revocation button and check if it is visible', async () => {
             await TestDataService.setSystemConfig({ 'core.basicInformation.showRevocationButton': true });
-            await ShopCustomer.goesTo(StorefrontHome.url());
-            const revocationFormButton = StorefrontHome.page.getByText(/Revoke a contract|Vertrag widerrufen/);
-            await expect(revocationFormButton).toBeVisible();
+
+            await ShopCustomer.expects(async () => {
+                await openStorefrontHome();
+                await expect(revocationFormButton()).toBeVisible();
+            }).toPass({
+                intervals: [1_000, 2_500],
+            });
         });
     }
 );


### PR DESCRIPTION
could not find a reason for failure but tried to harden flakiness of revocation ats

### Changes

- role based selector
- cache busting query with `Date.now()`
- retry assertion