### PR TITLE
fix: batch media uploads to prevent browser and server overload (#11571)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -494,7 +494,8 @@ export default {
                 };
             });
 
-            await this.mediaRepository.saveAll(syncEntities, Context.api);
+            await this.mediaRepository.sync(syncEntities, Context.api);
+
             await this.mediaService.addUploads(this.uploadTag, uploadData);
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
@@ -10,6 +10,7 @@ async function createWrapper(customOptions = {}) {
         create: () => ({}),
         save: () => Promise.resolve({}),
         saveAll: () => Promise.resolve({}),
+        sync: () => Promise.resolve({}),
     };
 
     return mount(await wrapTestComponent('sw-media-upload-v2', { sync: true }), {
@@ -276,6 +277,7 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
                                 create: () => ({}),
                                 save: () => Promise.resolve({}),
                                 saveAll: () => Promise.resolve({}),
+                                sync: () => Promise.resolve({}),
                             }),
                         },
                         mediaService: {
@@ -343,6 +345,7 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
                                 create: () => ({}),
                                 save: () => Promise.resolve({}),
                                 saveAll: () => Promise.resolve({}),
+                                sync: () => Promise.resolve({}),
                             }),
                         },
                         mediaService: {
@@ -531,14 +534,14 @@ describe('src/app/component/media/sw-media-upload-v2', () => {
                 uploadTag: 'my-upload',
             },
         });
-        wrapper.vm.mediaRepository.saveAll = jest.fn();
+        wrapper.vm.mediaRepository.sync = jest.fn().mockResolvedValue({});
 
         await wrapper.vm.handleUpload([
             new File([''], 'foo.jpg'),
             new File([''], 'bar.gif'),
         ]);
 
-        expect(wrapper.vm.mediaRepository.saveAll).toHaveBeenCalled();
+        expect(wrapper.vm.mediaRepository.sync).toHaveBeenCalled();
     });
 
     it('should show a single preview in single mode', async () => {

--- a/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.js
@@ -25,6 +25,7 @@ class MediaApiService extends ApiService {
         this.uploads = [];
         this.$listeners = {};
         this.cacheDefaultFolder = {};
+        this.maxConcurrentUploads = 10;
     }
 
     hasListeners(uploadTag) {
@@ -148,41 +149,55 @@ class MediaApiService extends ApiService {
         const totalUploads = affectedUploads.length;
         let successUploads = 0;
         let failureUploads = 0;
-        return Promise.all(
-            affectedUploads.map((task) => {
-                if (task.running) {
-                    return Promise.resolve();
-                }
 
-                task.running = true;
-                return this._startUpload(task, tag)
-                    .then(() => {
-                        task.running = false;
-                        successUploads += 1;
-                        affectedListeners.forEach((listener) => {
-                            listener(
-                                this._createUploadEvent(UploadEvents.UPLOAD_FINISHED, tag, {
-                                    targetId: task.targetId,
-                                    successAmount: successUploads,
-                                    failureAmount: failureUploads,
-                                    totalAmount: totalUploads,
-                                }),
-                            );
-                        });
-                    })
-                    .catch((cause) => {
-                        task.error = cause;
-                        task.running = false;
-                        failureUploads += 1;
-                        task.successAmount = successUploads;
-                        task.failureAmount = failureUploads;
-                        task.totalAmount = totalUploads;
-                        affectedListeners.forEach((listener) => {
-                            listener(this._createUploadEvent(UploadEvents.UPLOAD_FAILED, tag, task));
-                        });
+        const iterator = affectedUploads[Symbol.iterator]();
+
+        const runWorker = () => {
+            const { value: task, done } = iterator.next();
+
+            if (done) {
+                return Promise.resolve();
+            }
+
+            if (task.running) {
+                return runWorker();
+            }
+
+            task.running = true;
+
+            return this._startUpload(task, tag)
+                .then(() => {
+                    task.running = false;
+                    successUploads += 1;
+                    affectedListeners.forEach((listener) => {
+                        listener(
+                            this._createUploadEvent(UploadEvents.UPLOAD_FINISHED, tag, {
+                                targetId: task.targetId,
+                                successAmount: successUploads,
+                                failureAmount: failureUploads,
+                                totalAmount: totalUploads,
+                            }),
+                        );
                     });
-            }),
-        );
+                })
+                .catch((cause) => {
+                    task.error = cause;
+                    task.running = false;
+                    failureUploads += 1;
+                    task.successAmount = successUploads;
+                    task.failureAmount = failureUploads;
+                    task.totalAmount = totalUploads;
+                    affectedListeners.forEach((listener) => {
+                        listener(this._createUploadEvent(UploadEvents.UPLOAD_FAILED, tag, task));
+                    });
+                })
+                .then(() => runWorker());
+        };
+
+        const workerCount = Math.min(this.maxConcurrentUploads, affectedUploads.length);
+        const workers = Array.from({ length: workerCount }, () => runWorker());
+
+        return Promise.all(workers);
     }
 
     _startUpload(task, uploadTag = null) {

--- a/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media.api.service.spec.js
@@ -167,6 +167,175 @@ describe('storeService', () => {
         spyRepository.mockRestore();
     });
 
+    it('limits concurrent uploads to maxConcurrentUploads', async () => {
+        const mediaApiService = getMediaApiService();
+        mediaApiService.maxConcurrentUploads = 2;
+
+        let concurrent = 0;
+        let maxConcurrent = 0;
+        const resolvers = [];
+
+        jest.spyOn(mediaApiService, '_startUpload').mockImplementation(() => {
+            concurrent += 1;
+            maxConcurrent = Math.max(maxConcurrent, concurrent);
+
+            return new Promise((resolve) => {
+                resolvers.push(() => {
+                    concurrent -= 1;
+                    resolve();
+                });
+            });
+        });
+
+        const tag = 'test-concurrency';
+        for (let i = 0; i < 6; i++) {
+            mediaApiService.addUpload(tag, {
+                src: new File([''], `file-${i}.jpg`),
+                targetId: `id-${i}`,
+                fileName: `file-${i}`,
+                extension: 'jpg',
+            });
+        }
+
+        const uploadPromise = mediaApiService.runUploads(tag);
+
+        // Wait for the initial workers to start
+        await new Promise(process.nextTick);
+
+        // Only 2 should be running concurrently
+        expect(concurrent).toBe(2);
+        expect(maxConcurrent).toBe(2);
+
+        // Resolve first two uploads
+        resolvers.shift()();
+        resolvers.shift()();
+        await new Promise(process.nextTick);
+
+        // Next two should have started
+        expect(concurrent).toBe(2);
+        expect(maxConcurrent).toBe(2);
+
+        // Resolve remaining uploads
+        while (resolvers.length > 0) {
+            resolvers.shift()();
+            await new Promise(process.nextTick);
+        }
+
+        await uploadPromise;
+        expect(maxConcurrent).toBe(2);
+    });
+
+    it('completes all uploads even with concurrency limit', async () => {
+        const mediaApiService = getMediaApiService();
+        mediaApiService.maxConcurrentUploads = 3;
+
+        const completed = [];
+        jest.spyOn(mediaApiService, '_startUpload').mockImplementation((task) => {
+            completed.push(task.targetId);
+            return Promise.resolve();
+        });
+
+        const tag = 'test-complete-all';
+        const totalFiles = 10;
+        for (let i = 0; i < totalFiles; i++) {
+            mediaApiService.addUpload(tag, {
+                src: new File([''], `file-${i}.jpg`),
+                targetId: `id-${i}`,
+                fileName: `file-${i}`,
+                extension: 'jpg',
+            });
+        }
+
+        await mediaApiService.runUploads(tag);
+        expect(completed).toHaveLength(totalFiles);
+    });
+
+    it('fires UPLOAD_FINISHED events with correct counts during concurrent uploads', async () => {
+        const mediaApiService = getMediaApiService();
+        mediaApiService.maxConcurrentUploads = 2;
+
+        jest.spyOn(mediaApiService, '_startUpload').mockResolvedValue();
+
+        const events = [];
+        const tag = 'test-events';
+        mediaApiService.addListener(tag, (event) => {
+            if (event.action === UploadEvents.UPLOAD_FINISHED) {
+                events.push(event.payload);
+            }
+        });
+
+        for (let i = 0; i < 4; i++) {
+            mediaApiService.addUpload(tag, {
+                src: new File([''], `file-${i}.jpg`),
+                targetId: `id-${i}`,
+                fileName: `file-${i}`,
+                extension: 'jpg',
+            });
+        }
+
+        await mediaApiService.runUploads(tag);
+
+        expect(events).toHaveLength(4);
+        events.forEach((payload) => {
+            expect(payload.totalAmount).toBe(4);
+        });
+        // Last event should have all uploads as successful
+        expect(events[events.length - 1].successAmount).toBe(4);
+        expect(events[events.length - 1].failureAmount).toBe(0);
+    });
+
+    it('continues processing after a failed upload', async () => {
+        const mediaApiService = getMediaApiService();
+        mediaApiService.maxConcurrentUploads = 2;
+
+        jest.spyOn(mediaApiService, '_startUpload').mockImplementation((task) => {
+            if (task.targetId === 'id-1') {
+                return Promise.reject(new Error('upload failed'));
+            }
+            return Promise.resolve();
+        });
+
+        const finishedIds = [];
+        const failedIds = [];
+        const tag = 'test-errors';
+        mediaApiService.addListener(tag, (event) => {
+            if (event.action === UploadEvents.UPLOAD_FINISHED) {
+                finishedIds.push(event.payload.targetId);
+            }
+            if (event.action === UploadEvents.UPLOAD_FAILED) {
+                failedIds.push(event.payload.targetId);
+            }
+        });
+
+        for (let i = 0; i < 4; i++) {
+            mediaApiService.addUpload(tag, {
+                src: new File([''], `file-${i}.jpg`),
+                targetId: `id-${i}`,
+                fileName: `file-${i}`,
+                extension: 'jpg',
+            });
+        }
+
+        await mediaApiService.runUploads(tag);
+
+        expect(failedIds).toEqual(['id-1']);
+        expect(finishedIds).toHaveLength(3);
+        expect(finishedIds).toContain('id-0');
+        expect(finishedIds).toContain('id-2');
+        expect(finishedIds).toContain('id-3');
+    });
+
+    it('resolves immediately when no uploads are queued', async () => {
+        const mediaApiService = getMediaApiService();
+        const result = await mediaApiService.runUploads('non-existent-tag');
+        expect(result).toBeUndefined();
+    });
+
+    it('uses default maxConcurrentUploads of 10', () => {
+        const mediaApiService = getMediaApiService();
+        expect(mediaApiService.maxConcurrentUploads).toBe(10);
+    });
+
     it('assigns video cover via API route', async () => {
         const mediaApiService = getMediaApiService();
         const httpClientPostSpy = jest.spyOn(mediaApiService.httpClient, 'post').mockResolvedValue({


### PR DESCRIPTION
### 1. Why is this change necessary?

When uploading a large batch of media files (e.g. 1000 images) via the Media Manager, all files are processed simultaneously. This causes excessive browser memory usage, server overload (PHP-FPM worker pool exhaustion), and upload failures. The browser UI becomes unresponsive and the entire shop can freeze.

### 2. What does this change do, exactly?

Two changes:

1. **`MediaApiService.runUploads()`**: Replaces `Promise.all()` over all uploads with a worker pool pattern that limits concurrent uploads to `maxConcurrentUploads` (default: 10). Workers pick tasks from a shared iterator, so at most 10 file uploads run in parallel.

2. **`sw-media-upload-v2.handleUpload()`**: Replaces `mediaRepository.saveAll()` (which fires N individual API calls via `Promise.all()`) with `mediaRepository.sync()`, which creates all media entities in a single `_action/sync` request. For 1000 files this reduces entity creation from ~55s to ~2s.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to Content > Media in the Admin
2. Click "Upload file" and select ~1000 images
3. **Before**: Browser freezes, uploads stall at some point, shop becomes unresponsive
4. **After**: All 1000 files upload successfully, browser and shop remain responsive

### 4. Please link to the relevant issues (if any).

- closes #11571

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - N/A — internal UI behavior change, no public API affected
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
