### PR TITLE
fix: missing spacer reset on breakpoing lg

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_register.scss
@@ -13,6 +13,7 @@
 
             @include media-breakpoint-up(lg) {
                 @include make-col(8);
+                margin-bottom: 0;
             }
         }
 


### PR DESCRIPTION
<img width="802" height="719" alt="image" src="https://github.com/user-attachments/assets/bebcd195-f979-49de-ba1b-b5ffe1267857" />

### 1. Why is this change necessary?

In PR https://github.com/shopware/shopware/pull/15874 the margin reset on breakpoint `lg` was missing on "checkout/register" for selector `.checkout-main`.

### 2. What does this change do, exactly?

Add the margin reset so the margin is the same as before. 


