### PR TITLE
test: debug ApiRouteScope failure, to seek dirty tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   rufus:
+    if: false
     name: Rufus
     runs-on: ubuntu-24.04
     steps:
@@ -46,6 +47,7 @@ jobs:
             NIGHTLY=${{ inputs.nightly }}
 
   commercial:
+    if: false
     name: Commercial
     runs-on: ubuntu-24.04
     steps:
@@ -71,6 +73,7 @@ jobs:
             NIGHTLY=${{ inputs.nightly }}\nUPSTREAM_EVENT_NAME=${{ github.event_name }}
 
   mergeability-check:
+    if: false
     name: Downstream Mergeability Check
     runs-on: ubuntu-latest
     steps:
@@ -140,7 +143,7 @@ jobs:
             }
 
   downstream-check:
-    if: always()
+    if: false
     needs:
     - rufus
     - commercial

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -659,7 +659,7 @@ jobs:
             run: bin/console theme:refresh
 
           - name: Run integration tests
-            run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+            run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --random-order-seed=1775715749 --stop-on-error
 
   # this allows us to specifiy just one required job/check
   # this is not practical with matrix jobs directly, because you've to specify all permutations

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   acceptance:
+    if: false
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -69,6 +70,7 @@ jobs:
           report-prefix: playwright-reports
 
   acceptance-tests-changed:
+    if: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -97,6 +99,7 @@ jobs:
           artifact-prefix: "ats-changed"
 
   phpunit-matrix:
+    if: false
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -112,6 +115,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   phpunit:
+    if: false
     name: "${{ matrix.php}} ${{ matrix.test.testsuite }}${{ matrix.test.path }} ${{ matrix.db }} ${{ matrix.opensearch != 'opensearchproject/opensearch:3' && matrix.opensearch || '' }}"
     needs:
       - phpunit-matrix
@@ -198,8 +202,8 @@ jobs:
 
 
   win-checkout:
+    if: false
     runs-on: windows-latest
-    if: ${{ github.event_name != 'pull_request' }}
     name: "Windows check"
 
     steps:
@@ -209,6 +213,7 @@ jobs:
       - name: Clone platform
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 4
   php-security:
+    if: false
     runs-on: ubuntu-24.04
     name: "Composer dependencies"
     env:
@@ -233,8 +238,8 @@ jobs:
       - name: Run on platform
         run: ./local-php-security-checker
   code-ql:
+    if: false
     name: Analyze
-    if: ${{ github.repository == 'shopware/shopware' }}
     runs-on: ubuntu-24.04
 
     strategy:
@@ -263,6 +268,7 @@ jobs:
         uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 #  v4.32.3
 
   tested-update-versions:
+    if: false
     name: tested-versions
     runs-on: ubuntu-24.04
     outputs:
@@ -276,6 +282,7 @@ jobs:
         uses: shopware/github-actions/versions@main
 
   acceptance-update:
+    if: false
     needs: tested-update-versions
     runs-on: ubuntu-24.04
     strategy:
@@ -462,6 +469,7 @@ jobs:
             echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
 
   blue-green-67-68:
+    if: false
     name: "PHP blue green 6.7 -> 6.8 -> 6.7"
     runs-on: ubuntu-24.04
     env:
@@ -520,6 +528,7 @@ jobs:
         run: php .github/bin/blue-green-check.php
 
   blue-green-66-67:
+    if: false
     name: "PHP blue green 6.6 -> 6.7 -> 6.6"
     runs-on: ubuntu-24.04
     env:
@@ -602,7 +611,7 @@ jobs:
   update-66-67:
       name: "PHP update 6.6 -> 6.7"
       runs-on: ubuntu-24.04
-      if: inputs.nightly == 'true'
+      # if: inputs.nightly == 'true'
       env:
           APP_ENV: test
           APP_URL: http://localhost:8000
@@ -664,7 +673,7 @@ jobs:
   # this allows us to specifiy just one required job/check
   # this is not practical with matrix jobs directly, because you've to specify all permutations
   check:
-    if: always()
+    if: false
     needs:
       - acceptance
       - phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -189,5 +189,7 @@
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\Datadog\DatadogExtension"/>
         <!-- Enable to see the db side effects of the tests. -->
 <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
+        <!-- Enable to identify tests that leave unreleased requests on the RequestStack. -->
+        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\RequestStackDirtyExtension"/>
     </extensions>
 </phpunit>

--- a/src/Core/Test/PHPUnit/Extension/RequestStackDirty/RequestStackDirtyExtension.php
+++ b/src/Core/Test/PHPUnit/Extension/RequestStackDirty/RequestStackDirtyExtension.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\Subscriber\TestFinishedSubscriber;
+use Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\Subscriber\TestPreparationStartedSubscriber;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class RequestStackDirtyExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $stackDepth = new StackDepth();
+
+        $facade->registerSubscribers(
+            new TestPreparationStartedSubscriber($stackDepth),
+            new TestFinishedSubscriber($stackDepth)
+        );
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/RequestStackDirty/StackDepth.php
+++ b/src/Core/Test/PHPUnit/Extension/RequestStackDirty/StackDepth.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class StackDepth
+{
+    public int $before = 0;
+}

--- a/src/Core/Test/PHPUnit/Extension/RequestStackDirty/Subscriber/TestFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/RequestStackDirty/Subscriber/TestFinishedSubscriber.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\Subscriber;
+
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\StackDepth;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class TestFinishedSubscriber implements FinishedSubscriber
+{
+    public function __construct(private readonly StackDepth $stackDepth)
+    {
+    }
+
+    public function notify(Finished $event): void
+    {
+        $after = TestPreparationStartedSubscriber::currentDepth();
+
+        if ($after > $this->stackDepth->before) {
+            echo \PHP_EOL . \sprintf(
+                '[RequestStack dirty] %s left %d unreleased request(s) on the stack (was %d, now %d)',
+                $event->test()->id(),
+                $after - $this->stackDepth->before,
+                $this->stackDepth->before,
+                $after,
+            ) . \PHP_EOL;
+        }
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/RequestStackDirty/Subscriber/TestPreparationStartedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/RequestStackDirty/Subscriber/TestPreparationStartedSubscriber.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\Subscriber;
+
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Kernel;
+use Shopware\Core\Test\PHPUnit\Extension\RequestStackDirty\StackDepth;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class TestPreparationStartedSubscriber implements PreparationStartedSubscriber
+{
+    public function __construct(private readonly StackDepth $stackDepth)
+    {
+    }
+
+    public function notify(PreparationStarted $event): void
+    {
+        $this->stackDepth->before = self::currentDepth();
+    }
+
+    public static function currentDepth(): int
+    {
+        $kernelProperty = new \ReflectionProperty(KernelLifecycleManager::class, 'kernel');
+        $kernel = $kernelProperty->getValue();
+
+        if (!$kernel instanceof Kernel) {
+            return 0;
+        }
+
+        try {
+            $stack = $kernel->getContainer()->get('request_stack');
+        } catch (\Throwable) {
+            return 0;
+        }
+
+        if (!$stack instanceof RequestStack) {
+            return 0;
+        }
+
+        $requestsProperty = new \ReflectionProperty(RequestStack::class, 'requests');
+
+        return \count($requestsProperty->getValue($stack));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Not to be released.

Beside fixing in another PR the missing check over Context
https://github.com/shopware/shopware/blob/45fc0dcf85a3db49ab271bdec1941b0464ce3bb2/src/Core/Framework/Routing/ApiRouteScope.php#L23-L25

We want to identify which tests are leaving bad state and if we can fix them

### 2. What does this change do, exactly?

Adds an extension to track the state of RequestStack between integration tests, sometime we can end up with empty Context in request attribute which leads to hard failure with ApiRouteScope

Forces the full integration suite with a determined seed (from another failed run)

### 3. Describe each step to reproduce the issue or behaviour.

Run locally `php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --random-order-seed=1775715749 --stop-on-error`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
