### PR TITLE
fix: preserve sw_page_full_path from navigation target in page_change events

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.spec.js
@@ -149,7 +149,7 @@ describe('src/core/telemetry/index.js', () => {
             );
         });
 
-        it('does not emit page change event when navigating to the same route', async () => {
+        it('emits page change event on same-route navigations to capture query param changes', async () => {
             const telemetry = new Telemetry({ queries: [] });
             const eventBusSpy = jest.spyOn(Shopware.Utils.EventBus, 'emit');
 
@@ -178,7 +178,7 @@ describe('src/core/telemetry/index.js', () => {
             await router.push({ name: 'test' });
             await router.push({ name: 'test' });
 
-            expect(eventBusSpy).toHaveBeenCalledTimes(1);
+            expect(eventBusSpy).toHaveBeenCalledTimes(2);
         });
     });
 

--- a/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
+++ b/src/Administration/Resources/app/administration/src/core/telemetry/index.ts
@@ -94,10 +94,6 @@ export class Telemetry {
                     return;
                 }
 
-                if (to.name === from.name) {
-                    return;
-                }
-
                 this.dispatchEvent('page_change', { from, to });
             });
         });


### PR DESCRIPTION
### 1. Why is this change necessary?

After the product analytics decoupling, `sw_page_full_path` was missing query parameters on listing pages (e.g. `/sw/order/index` instead of `/sw/order/index?limit=25&page=1&...`).

This is because the admin navigates in two steps: first to the bare route, then query params are resolved as a second navigation. A guard was previously suppressing the second `page_change` event when the route name didn't change, so query params were never captured.

### 2. What does this change do, exactly?

Removes the `to.name === from.name` guard in `router.afterEach`. Same-route navigations (e.g. query param updates) now fire a `page_change` event, resulting in two `page_viewed` events per listing navigation — the first with the bare path, the second with the full URL including query params.

### 3. Describe each step to reproduce the issue or behaviour.

1. Navigate to the order listing page
2. Observe the `page_viewed` analytics event
3. `sw_page_full_path` contains only `/sw/order/index` — query params are missing

### 4. Please link to the relevant issues (if any).

Regression introduced during the product analytics provider-decoupling work.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them