### PR TITLE
fix: missing attachements on document email

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
@@ -6,7 +6,7 @@ import './sw-order-send-document-modal.scss';
  */
 
 const { Filter } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Criteria, EntityCollection } = Shopware.Data;
 
 /**
  * @sw-package checkout
@@ -82,6 +82,7 @@ export default {
         mailTemplateSendCriteria() {
             const criteria = new Criteria(1, 25);
             criteria.addAssociation('mailTemplateType');
+            criteria.addAssociation('media.media');
 
             return criteria;
         },
@@ -200,6 +201,14 @@ export default {
             this.mailTemplateRepository
                 .get(this.mailTemplateId, apiContext, this.mailTemplateSendCriteria)
                 .then((mailTemplate) => {
+                    const mediaCollection = new EntityCollection('/media', 'media', Shopware.Context.api);
+
+                    mailTemplate.media.forEach((mediaAssoc) => {
+                        if (mediaAssoc.languageId === Shopware.Context.api.languageId) {
+                            mediaCollection.push(mediaAssoc.media);
+                        }
+                    });
+
                     this.mailService
                         .sendMailTemplate(
                             this.recipient,
@@ -211,9 +220,7 @@ export default {
                                     recipient: this.recipient,
                                 },
                             },
-                            {
-                                getIds: () => {},
-                            },
+                            mediaCollection,
                             this.order.salesChannelId,
                             false,
                             [this.document.id],

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
@@ -236,7 +236,7 @@ export default {
                         )
                         .catch(() => {
                             this.createNotificationError({
-                                message: this.$tc('sw-order.documentSendModal.errorMessage'),
+                                message: this.$t('sw-order.documentSendModal.errorMessage'),
                             });
                             this.$emit('modal-close');
                         })

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
@@ -435,7 +435,7 @@ describe('src/module/sw-order/component/sw-order-send-document-modal', () => {
                             recipient: mockOrderWithMailHeaderFooter.orderCustomer.email,
                         },
                     });
-                    expect(mailTemplateMedia.length).toBe(1);
+                    expect(mailTemplateMedia).toHaveLength(1);
                     expect(mailTemplateMedia[0]).toEqual(mockMailTemplates[0].media.first().media);
                     expect(salesChannelId).toEqual(mockOrderWithMailHeaderFooter.salesChannelId);
                     expect(testMode).toBe(false);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.spec.js
@@ -1,6 +1,7 @@
 import { mount } from '@vue/test-utils';
 import uuid from 'test/_helper_/uuid';
 import EntityCollection from 'src/core/data/entity-collection.data';
+import Entity from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 
 /**
  * @sw-package checkout
@@ -96,6 +97,18 @@ const mockMailTemplates = [
         },
         contentHtml: '<div>Cancellation email template content.</div>\n',
         subject: 'Nex document for your order',
+        media: new EntityCollection('/mail-template-media', 'mail-template-media', null, null, [
+            new Entity(
+                'mail-template-media-id',
+                'mail-template-media',
+                {
+                    id: 'mail-template-media-is',
+                    languageId: Shopware.Context.api.languageId,
+                    media: new Entity('media-id', 'media', { id: 'media-id' }, []),
+                },
+                [],
+            ),
+        ]),
     },
     {
         id: uuid.get('delivery_mail'),
@@ -396,42 +409,64 @@ describe('src/module/sw-order/component/sw-order-send-document-modal', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
+        wrapper.vm.mailService.sendMailTemplate = jest
+            .fn()
+            .mockImplementation(
+                (
+                    recipientMail,
+                    recipient,
+                    mailTemplate,
+                    mailTemplateMedia,
+                    salesChannelId,
+                    testMode = false,
+                    documentIds = [],
+                    templateData = null,
+                    mailTemplateTypeId = null,
+                    mailTemplateId = null,
+                    additionalHeaders = {},
+                ) => {
+                    expect(recipientMail).toEqual(mockOrderWithMailHeaderFooter.orderCustomer.email);
+                    expect(recipient).toBe(
+                        `${mockOrderWithMailHeaderFooter.orderCustomer.firstName} ${mockOrderWithMailHeaderFooter.orderCustomer.lastName}`,
+                    );
+                    expect(mailTemplate).toEqual({
+                        ...mockMailTemplates[0],
+                        ...{
+                            recipient: mockOrderWithMailHeaderFooter.orderCustomer.email,
+                        },
+                    });
+                    expect(mailTemplateMedia.length).toBe(1);
+                    expect(mailTemplateMedia[0]).toEqual(mockMailTemplates[0].media.first().media);
+                    expect(salesChannelId).toEqual(mockOrderWithMailHeaderFooter.salesChannelId);
+                    expect(testMode).toBe(false);
+                    expect(documentIds).toEqual([mockDocuments[0].id]);
+                    expect(templateData).toEqual({
+                        order: mockOrderWithMailHeaderFooter,
+                        salesChannel: mockOrderWithMailHeaderFooter.salesChannel,
+                        document: mockDocuments[0],
+                        a11yDocuments: [
+                            {
+                                documentId: mockDocuments[0].id,
+                                deepLinkCode: mockDocuments[0].deepLinkCode,
+                                fileExtension: 'html',
+                            },
+                        ],
+                    });
+                    expect(mailTemplateTypeId).toBeNull();
+                    expect(mailTemplateId).toBeNull();
+                    expect(additionalHeaders).toEqual(Shopware.Context.api);
+
+                    return Promise.resolve();
+                },
+            );
+
         await wrapper.findByText('button', 'sw-order.documentCard.labelSendDocument').trigger('click');
         await flushPromises();
 
         expect(wrapper.vm.mailService.sendMailTemplate).toHaveBeenCalledTimes(1);
-        expect(wrapper.vm.mailService.sendMailTemplate).toHaveBeenCalledWith(
-            mockOrderWithMailHeaderFooter.orderCustomer.email,
-            `${mockOrderWithMailHeaderFooter.orderCustomer.firstName} ${mockOrderWithMailHeaderFooter.orderCustomer.lastName}`,
-            {
-                ...mockMailTemplates[0],
-                ...{
-                    recipient: mockOrderWithMailHeaderFooter.orderCustomer.email,
-                },
-            },
-            {
-                getIds: expect.any(Function),
-            },
-            mockOrderWithMailHeaderFooter.salesChannelId,
-            false,
-            [mockDocuments[0].id],
-            {
-                order: mockOrderWithMailHeaderFooter,
-                salesChannel: mockOrderWithMailHeaderFooter.salesChannel,
-                document: mockDocuments[0],
-                a11yDocuments: [
-                    {
-                        documentId: mockDocuments[0].id,
-                        deepLinkCode: mockDocuments[0].deepLinkCode,
-                        fileExtension: 'html',
-                    },
-                ],
-            },
-            null,
-            null,
-            Shopware.Context.api,
-        );
         expect(wrapper.emitted('document-sent')).toHaveLength(1);
+
+        jest.resetAllMocks();
     });
 
     it('should show an error when the email sending fails', async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When sending a document via email in the "Order" section, the media that are attached to the specific mail template were not included in the sent email.

### 2. What does this change do, exactly?
With this change, the associated media of an email template get loaded and their ids are provided as `mediaIds` to the specific endpoint.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add an atatchement to a document email (e.g. invoice)
2. Create a product, customer and with both an order
3. Create the corresponding document on the order and send it
4.a The set attachement is there (with fix)
4.b The set attachement is not there (without fix)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
closes #15959 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
