### PR TITLE
fix: prevent visible br tag in import variants warning

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
@@ -7,7 +7,9 @@
             class="sw-import-export-importer__variants-warning"
         >
             {% block sw_import_export_importer_product_variants_warning_text %}
-            <span>{{ $tc('sw-import-export.importer.variantsWarning') }}</span>
+            <span
+                v-html="$sanitize($tc('sw-import-export.importer.variantsWarning'))"
+            ></span>
 
             <div class="sw-import-export-importer__variants-warning-links">
                 <mt-link


### PR DESCRIPTION
### 1. Why is this change necessary?

The variants warning in the import/export importer contains HTML formatting in its translated snippet, but it was rendered as plain text. As a result, the `<br>` tag was shown visibly in the warning message instead of being rendered as a line break.

### 2. What does this change do, exactly?

This change renders the `sw-import-export.importer.variantsWarning` snippet via `$sanitize(...)` so the translated HTML is displayed correctly and still passed through Shopware's sanitizer.

### 3. Describe each step to reproduce the issue or behaviour.

1. Shopware Administration: navigate to Settings -> Import/Export
2. Select a `default_product` profile
3. Enable product variants import.
4. Check the variants warning banner.
5. Before this change, the warning displayed the literal `<br>` tag as text.
<img width="821" height="721" alt="Screenshot 2026-04-10 at 16 46 04" src="https://github.com/user-attachments/assets/0004f8ea-46aa-433e-a5ff-e00ffa1ffbe5" />
6. After this change, the line break is rendered correctly.
<img width="820" height="816" alt="Screenshot 2026-04-10 at 16 52 14" src="https://github.com/user-attachments/assets/ae8a07a3-7005-4cb1-ab17-7fa18c860a5d" />


### 4. Please link to the relevant issues (if any).

N/A
