### PR TITLE
chore: enforce FQN simplify by cs fixer

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -18,6 +18,10 @@ return (new Config())
         'class_attributes_separation' => ['elements' => ['property' => 'one', 'method' => 'one']],
         'concat_space' => ['spacing' => 'one'],
         'declare_strict_types' => true,
+        'fully_qualified_strict_types' => [
+            'import_symbols' => true,
+            'phpdoc_tags' => [],
+        ],
         'fopen_flags' => false,
         'general_phpdoc_annotation_remove' => ['annotations' => ['copyright', 'category']],
         'linebreak_after_opening_tag' => false,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,7 +20,7 @@ return (new Config())
         'declare_strict_types' => true,
         'fully_qualified_strict_types' => [
             'import_symbols' => true,
-            'phpdoc_tags' => [],
+            'phpdoc_tags' => ['param', 'phpstan-param', 'phpstan-return', 'phpstan-var', 'return', 'see', 'throws', 'var'],
         ],
         'fopen_flags' => false,
         'general_phpdoc_annotation_remove' => ['annotations' => ['copyright', 'category']],

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,7 +20,6 @@ return (new Config())
         'declare_strict_types' => true,
         'fully_qualified_strict_types' => [
             'import_symbols' => true,
-            'phpdoc_tags' => ['param', 'phpstan-param', 'phpstan-return', 'phpstan-var', 'return', 'see', 'throws', 'var'],
         ],
         'fopen_flags' => false,
         'general_phpdoc_annotation_remove' => ['annotations' => ['copyright', 'category']],

--- a/src/Core/Checkout/Cart/Price/Struct/PriceDefinitionInterface.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PriceDefinitionInterface.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Cart\Price\Struct;
 
+use Shopware\Core\Checkout\Cart\Calculator;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Validator\Constraint;
 
@@ -17,7 +18,7 @@ interface PriceDefinitionInterface
      * @see QuantityPriceDefinition
      * @see AbsolutePriceDefinition
      * @see PercentagePriceDefinition
-     * @see \Shopware\Core\Checkout\Cart\Calculator
+     * @see Calculator
      */
     public function getType(): string;
 

--- a/src/Core/Content/Cms/Exception/PageNotFoundException.php
+++ b/src/Core/Content/Cms/Exception/PageNotFoundException.php
@@ -2,12 +2,13 @@
 
 namespace Shopware\Core\Content\Cms\Exception;
 
+use Shopware\Core\Content\Cms\CmsException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed, use {@see \Shopware\Core\Content\Cms\CmsException::pageNotFound} instead
+ * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed, use {@see CmsException::pageNotFound} instead
  */
 #[Package('discovery')]
 class PageNotFoundException extends ShopwareHttpException

--- a/src/Core/Content/Media/Infrastructure/Path/SqlMediaLocationBuilder.php
+++ b/src/Core/Content/Media/Infrastructure/Path/SqlMediaLocationBuilder.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Integration\Core\Content\Media\Infrastructure\Path\MediaLocationBuilderTest;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @codeCoverageIgnore
  *
- * @see \Shopware\Tests\Integration\Core\Content\Media\Infrastructure\Path\MediaLocationBuilderTest
+ * @see MediaLocationBuilderTest
  */
 #[Package('discovery')]
 class SqlMediaLocationBuilder implements MediaLocationBuilder

--- a/src/Core/Content/Media/Infrastructure/Path/SqlMediaPathStorage.php
+++ b/src/Core/Content/Media/Infrastructure/Path/SqlMediaPathStorage.php
@@ -7,11 +7,12 @@ use Shopware\Core\Content\Media\Core\Application\MediaPathStorage;
 use Shopware\Core\Framework\DataAbstractionLayer\Util\StatementHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Integration\Core\Content\Media\Infrastructure\Path\MediaPathStorageTest;
 
 /**
  * @codeCoverageIgnore
  *
- * @see \Shopware\Tests\Integration\Core\Content\Media\Infrastructure\Path\MediaPathStorageTest
+ * @see MediaPathStorageTest
  */
 #[Package('discovery')]
 class SqlMediaPathStorage implements MediaPathStorage

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Api\StoreApiResponseListener;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -45,7 +46,7 @@ class StoreApiSeoResolver implements EventSubscriberInterface
     }
 
     /**
-     * This subscriber has to trigger before the {@see \Shopware\Core\System\SalesChannel\Api\StoreApiResponseListener},
+     * This subscriber has to trigger before the {@see StoreApiResponseListener},
      * because it requires access to the `StoreApiResponse`'s struct object, which is not available after encoding it.
      */
     public static function getSubscribedEvents(): array

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/NoRuntimeExceptionInDomainExceptionsRule.php
@@ -8,6 +8,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
@@ -31,7 +32,7 @@ class NoRuntimeExceptionInDomainExceptionsRule implements Rule
     /**
      * @param ClassMethod $node
      *
-     * @return array<int, \PHPStan\Rules\RuleError|string>
+     * @return array<int, RuleError|string>
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/src/Core/Framework/Adapter/Twig/TokenParser/EmbedTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/EmbedTokenParser.php
@@ -11,6 +11,7 @@ use Twig\Node\Expression\Variable\ContextVariable;
 use Twig\Node\Node;
 use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
+use Twig\TokenParser\IncludeTokenParser;
 
 /**
  * @internal
@@ -81,7 +82,7 @@ final class EmbedTokenParser extends AbstractTokenParser
     }
 
     /**
-     * @see \Twig\TokenParser\IncludeTokenParser::parseArguments
+     * @see IncludeTokenParser::parseArguments
      *
      * @return array{0: ?AbstractExpression, 1: bool, 2: bool}
      */

--- a/src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
+++ b/src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Util\UtilException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
+use Shopware\Tests\Integration\Core\Framework\Api\EventListener\SalesChannelAuthenticationListenerTest;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -26,7 +27,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @codeCoverageIgnore Tested via an integration test
  *
- * @see \Shopware\Tests\Integration\Core\Framework\Api\EventListener\SalesChannelAuthenticationListenerTest
+ * @see SalesChannelAuthenticationListenerTest
  */
 #[Package('framework')]
 class SalesChannelAuthenticationListener implements EventSubscriberInterface

--- a/src/Core/Framework/App/Lifecycle/Persister/TemplatePersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/TemplatePersister.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycleContext;
 use Shopware\Core\Framework\App\Template\AbstractTemplateLoader;
 use Shopware\Core\Framework\App\Template\TemplateCollection;
+use Shopware\Core\Framework\App\Template\TemplateStateService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -91,7 +92,7 @@ class TemplatePersister implements PersisterInterface
          * only clear cache when we are in an update context
          * otherwise cache is cleared on template active/deactivate
          *
-         * @see \Shopware\Core\Framework\App\Template\TemplateStateService::updateAppTemplates
+         * @see TemplateStateService::updateAppTemplates
          **/
         if ($needsCacheClear && !$context->isInstall) {
             $this->cacheClearer->clearHttpCache();

--- a/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
+++ b/src/Core/Framework/App/ShopId/Fingerprint/InstallationPath.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\App\ShopId\Fingerprint;
 use Shopware\Core\Framework\App\ShopId\Fingerprint;
 use Shopware\Core\Framework\App\ShopId\FingerprintCustomCompare;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Unit\Core\Framework\App\ShopId\Fingerprint\InstallationPathTest;
 
 /**
  * @internal
@@ -39,7 +40,7 @@ readonly class InstallationPath implements Fingerprint, FingerprintCustomCompare
      * A partial change at the end is low score
      * A partial change at the beginning or drastic change is a high score
      *
-     * @see \Shopware\Tests\Unit\Core\Framework\App\ShopId\Fingerprint\InstallationPathTest::testCompare for examples
+     * @see InstallationPathTest::testCompare for examples
      */
     public function compare(?string $storedStamp): int
     {

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -36,13 +36,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Reader\EntityReaderTest;
 
 use function Symfony\Component\String\u;
 
 /**
  * @internal
  *
- * @codeCoverageIgnore - Covered by integration test {@see \Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Reader\EntityReaderTest}
+ * @codeCoverageIgnore - Covered by integration test {@see EntityReaderTest}
  */
 #[Package('framework')]
 class EntityReader implements EntityReaderInterface

--- a/src/Core/Framework/Migration/ColumnExistsTrait.php
+++ b/src/Core/Framework/Migration/ColumnExistsTrait.php
@@ -3,13 +3,15 @@
 namespace Shopware\Core\Framework\Migration;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Framework\Util\UtilException;
 
 trait ColumnExistsTrait
 {
     /**
-     * @deprecated tag:v6.8.0 - reason:exception-change - Will throw {@see \Shopware\Core\Framework\Util\UtilException} instead of {@see \Doctrine\DBAL\Exception\TableNotFoundException}
+     * @deprecated tag:v6.8.0 - reason:exception-change - Will throw {@see UtilException} instead of {@see TableNotFoundException}
      *
      * @param non-empty-string $table
      */

--- a/src/Core/Framework/Migration/MigrationStep.php
+++ b/src/Core/Framework/Migration/MigrationStep.php
@@ -11,6 +11,7 @@ use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Framework\Util\UtilException;
 
 #[Package('framework')]
 abstract class MigrationStep
@@ -84,7 +85,7 @@ abstract class MigrationStep
     }
 
     /**
-     * @deprecated tag:v6.8.0 - reason:exception-change - Will throw {@see \Shopware\Core\Framework\Util\UtilException} instead of {@see TableNotFoundException}
+     * @deprecated tag:v6.8.0 - reason:exception-change - Will throw {@see UtilException} instead of {@see TableNotFoundException}
      *
      * @param non-empty-string $table
      */

--- a/src/Core/Framework/Store/Helper/PermissionCategorization.php
+++ b/src/Core/Framework/Store/Helper/PermissionCategorization.php
@@ -149,6 +149,10 @@ use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyDefinition;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryDefinition;
 use Shopware\Core\System\User\UserDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
+use Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition;
+use Shopware\Storefront\Theme\ThemeDefinition;
 
 /**
  * @internal
@@ -182,19 +186,19 @@ class PermissionCategorization
     private const CATEGORY_ADDITIONAL_PRIVILEGES = 'additional_privileges';
 
     /**
-     * @see \Shopware\Storefront\Theme\ThemeDefinition::ENTITY_NAME
+     * @see ThemeDefinition::ENTITY_NAME
      */
     private const THEME_ENTITY_NAME = 'theme';
     /**
-     * @see \Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition::ENTITY_NAME
+     * @see ThemeTranslationDefinition::ENTITY_NAME
      */
     private const THEME_TRANSLATION_ENTITY_NAME = 'theme_translation';
     /**
-     * @see \Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition::ENTITY_NAME
+     * @see ThemeMediaDefinition::ENTITY_NAME
      */
     private const THEME_MEDIA_ENTITY_NAME = 'theme_media';
     /**
-     * @see \Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition::ENTITY_NAME
+     * @see ThemeSalesChannelDefinition::ENTITY_NAME
      */
     private const THEME_SALES_CHANNEL_ENTITY_NAME = 'theme_sales_channel';
 

--- a/src/Core/Framework/Util/Database/TableHelper.php
+++ b/src/Core/Framework/Util/Database/TableHelper.php
@@ -13,9 +13,10 @@ use Doctrine\DBAL\Schema\Index as DbalIndex;
 use Doctrine\DBAL\Schema\Name\UnqualifiedName;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\UtilException;
+use Shopware\Tests\Integration\Core\Framework\Util\Database\TableHelperTest;
 
 /**
- * Covered by {@see \Shopware\Tests\Integration\Core\Framework\Util\Database\TableHelperTest}
+ * Covered by {@see TableHelperTest}
  *
  * @final
  *

--- a/src/Core/Framework/Util/Filesystem.php
+++ b/src/Core/Framework/Util/Filesystem.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Integration\Core\Framework\Util\FilesystemTest;
 use Symfony\Component\Filesystem\Filesystem as Io;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
@@ -13,7 +14,7 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @codeCoverageIgnore
  *
- * @see \Shopware\Tests\Integration\Core\Framework\Util\FilesystemTest
+ * @see FilesystemTest
  */
 #[Package('framework')]
 class Filesystem

--- a/src/Core/Framework/Util/HtmlSanitizer.php
+++ b/src/Core/Framework/Util/HtmlSanitizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Unit\Core\Framework\Util\HtmlSanitizerTest;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('framework')]
@@ -43,7 +44,7 @@ class HtmlSanitizer implements ResetInterface
         }
 
         /** Fix double encoding
-         * @see \Shopware\Tests\Unit\Core\Framework\Util\HtmlSanitizerTest::testSanitizeHtmlEntities()
+         * @see HtmlSanitizerTest::testSanitizeHtmlEntities()
          */
         $text = htmlspecialchars_decode($text, \ENT_QUOTES | \ENT_HTML5);
 

--- a/src/Core/Migration/V6_7/Migration1775200002RecalculateProductDisplayGroupHash.php
+++ b/src/Core/Migration/V6_7/Migration1775200002RecalculateProductDisplayGroupHash.php
@@ -4,17 +4,21 @@ namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\Subscriber\RegisteredIndexerSubscriber;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 
 /**
  * Schedules a product index pass that runs only the variant listing updater ({@see ProductIndexer::VARIANT_LISTING_UPDATER}),
- * which recalculates {@see \Shopware\Core\Content\Product\ProductEntity::displayGroup} with the same logic as a full product
- * index. Execution is deferred until post-install/update flows process {@see \Shopware\Core\Framework\Migration\IndexerQueuer}
- * (for example after {@see \Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent}), so migrations stay fast even on
+ * which recalculates {@see ProductEntity::displayGroup} with the same logic as a full product
+ * index. Execution is deferred until post-install/update flows process {@see IndexerQueuer}
+ * (for example after {@see UpdatePostFinishEvent}), so migrations stay fast even on
  * large catalogs.
  *
- * After update, {@see \Shopware\Core\Framework\DataAbstractionLayer\Indexing\Subscriber\RegisteredIndexerSubscriber} runs the product indexer
+ * After update, {@see RegisteredIndexerSubscriber} runs the product indexer
  * with a computed skip list ({@code array_diff} of {@see ProductIndexer::getOptions()} and the registered option names),
  * so only the variant-listing updater executes.
  *

--- a/src/Core/Profiling/Integration/Datadog.php
+++ b/src/Core/Profiling/Integration/Datadog.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Profiling\Integration;
 
 use DDTrace\Contracts\Tracer;
 use DDTrace\GlobalTracer;
+use DDTrace\Tag;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -28,7 +29,7 @@ class Datadog implements ProfilerInterface
             $category = 'shopware.' . $category;
         }
 
-        /** @see \DDTrace\Tag::SERVICE_NAME */
+        /** @see Tag::SERVICE_NAME */
         $tags = array_merge(['service.name' => $category], $tags);
         /** @var Tracer */
         $tracer = GlobalTracer::get();

--- a/src/Core/System/CustomEntity/Schema/CustomEntitySchemaUpdater.php
+++ b/src/Core/System/CustomEntity/Schema/CustomEntitySchemaUpdater.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Integration\Core\System\CustomEntity\CustomEntityTest;
 use Symfony\Component\Lock\LockFactory;
 
 /**
@@ -14,7 +15,7 @@ use Symfony\Component\Lock\LockFactory;
  *
  * @phpstan-import-type CustomEntityField from SchemaUpdater
  *
- * @codeCoverageIgnore - Tested with integration test {@see \Shopware\Tests\Integration\Core\System\CustomEntity\CustomEntityTest}
+ * @codeCoverageIgnore - Tested with integration test {@see CustomEntityTest}
  */
 #[Package('framework')]
 class CustomEntitySchemaUpdater

--- a/src/Core/System/CustomEntity/Xml/Config/CustomEntityConfigurationException.php
+++ b/src/Core/System/CustomEntity/Xml/Config/CustomEntityConfigurationException.php
@@ -5,10 +5,11 @@ namespace Shopware\Core\System\CustomEntity\Xml\Config;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException} instead
+ * @deprecated tag:v6.8.0 - will be removed, use {@see CustomEntityException} instead
  */
 #[Package('framework')]
 class CustomEntityConfigurationException extends HttpException
@@ -18,7 +19,7 @@ class CustomEntityConfigurationException extends HttpException
     final public const INVALID_REFERENCES = 'CUSTOM_ENTITY_INVALID_REFERENCES';
 
     /**
-     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::entityNotGiven} instead
+     * @deprecated tag:v6.8.0 - will be removed, use {@see CustomEntityException::entityNotGiven} instead
      *
      * @param string[] $entities
      */
@@ -45,7 +46,7 @@ class CustomEntityConfigurationException extends HttpException
     }
 
     /**
-     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::duplicateReferences} instead
+     * @deprecated tag:v6.8.0 - will be removed, use {@see CustomEntityException::duplicateReferences} instead
      *
      * @param string[] $duplicates
      */
@@ -80,7 +81,7 @@ class CustomEntityConfigurationException extends HttpException
     }
 
     /**
-     * @deprecated tag:v6.8.0 - will be removed, use {@see \Shopware\Core\System\CustomEntity\CustomEntityException::invalidReferences} instead
+     * @deprecated tag:v6.8.0 - will be removed, use {@see CustomEntityException::invalidReferences} instead
      *
      * @param string[] $invalidRefs
      */

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Content\MeasurementSystem\MeasurementUnits;
 use Shopware\Core\Content\MeasurementSystem\MeasurementUnitTypeEnum;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Adapter\Twig\SwTwigFunction;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
@@ -219,7 +220,7 @@ class SalesChannelContext extends Struct
     public function getToken(): string
     {
         /**
-         * @see \Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::getAttribute
+         * @see SwTwigFunction::getAttribute
          * Inside Twig rendering context, the token is not allowed to be accessed as it might expose sensitive information
          * when the data is dumped into outputted HTML.
          */

--- a/src/Core/Test/Stub/Doctrine/QueryBuilderDataExtractor.php
+++ b/src/Core/Test/Stub/Doctrine/QueryBuilderDataExtractor.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Test\Stub\Doctrine;
 
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
+use Doctrine\DBAL\Query\From;
 use Doctrine\DBAL\Query\Join;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Shopware\Core\Framework\Log\Package;
@@ -40,7 +41,7 @@ class QueryBuilderDataExtractor
         \assert(\is_array($from));
         $result = [];
         foreach ($from as $fromObject) {
-            \assert($fromObject instanceof \Doctrine\DBAL\Query\From);
+            \assert($fromObject instanceof From);
             $result[] = $fromObject->table;
         }
 

--- a/src/Storefront/Controller/Exception/StorefrontException.php
+++ b/src/Storefront/Controller/Exception/StorefrontException.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Twig\Error\Error as TwigError;
 
 #[Package('framework')]
@@ -135,7 +136,7 @@ class StorefrontException extends HttpException
     }
 
     /**
-     * Throwing the custom exception allows to still catch {@see \Symfony\Component\Routing\Exception\RouteNotFoundException} as usual
+     * Throwing the custom exception allows to still catch {@see RouteNotFoundException} as usual
      */
     public static function routeNotFound(string $route, ?\Throwable $previous = null): StorefrontRouteNotFoundException
     {

--- a/src/Storefront/Framework/Media/Exception/MediaValidatorMissingException.php
+++ b/src/Storefront/Framework/Media/Exception/MediaValidatorMissingException.php
@@ -5,9 +5,10 @@ namespace Shopware\Storefront\Framework\Media\Exception;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Storefront\Framework\StorefrontFrameworkException;
 
 /**
- * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed, use {@see \Shopware\Storefront\Framework\StorefrontFrameworkException::mediaValidatorMissing} instead
+ * @deprecated tag:v6.8.0 - reason:remove-exception - Will be removed, use {@see StorefrontFrameworkException::mediaValidatorMissing} instead
  */
 #[Package('discovery')]
 class MediaValidatorMissingException extends ShopwareHttpException

--- a/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
@@ -6,14 +6,16 @@ use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\AbstractThemePathBuilder;
+use Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask;
+use Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTaskHandler;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * @internal
  *
  * @deprecated tag:v6.8.0 - Will be removed. Unused theme files are now deleted with a scheduled task.
- * @see \Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask
- * @see \Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTaskHandler
+ * @see DeleteThemeFilesTask
+ * @see DeleteThemeFilesTaskHandler
  */
 #[AsMessageHandler]
 #[Package('framework')]

--- a/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesMessage.php
@@ -5,13 +5,15 @@ namespace Shopware\Storefront\Theme\Message;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
+use Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask;
+use Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTaskHandler;
 
 /**
  * used to delay the deletion of theme files
  *
  * @deprecated tag:v6.8.0 - Will be removed. Unused theme files are now deleted with a scheduled task.
- * @see \Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTask
- * @see \Shopware\Storefront\Theme\ScheduledTask\DeleteThemeFilesTaskHandler
+ * @see DeleteThemeFilesTask
+ * @see DeleteThemeFilesTaskHandler
  */
 #[Package('framework')]
 class DeleteThemeFilesMessage implements AsyncMessageInterface

--- a/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
+++ b/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
@@ -2,10 +2,12 @@
 
 namespace Shopware\Tests\Integration\Core\Content\LandingPage\SalesChannel;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -160,7 +162,7 @@ class LandingPageRouteTest extends TestCase
             [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
         );
 
-        $response = static::getContainer()->get(\Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute::class)->load(
+        $response = static::getContainer()->get(LandingPageRoute::class)->load(
             $landingPageId,
             new Request(),
             $salesChannelContext,
@@ -249,7 +251,7 @@ class LandingPageRouteTest extends TestCase
 
     private function getLocaleId(string $code): string
     {
-        $localeId = static::getContainer()->get(\Doctrine\DBAL\Connection::class)->fetchOne(
+        $localeId = static::getContainer()->get(Connection::class)->fetchOne(
             'SELECT LOWER(HEX(id)) FROM locale WHERE code = :code',
             ['code' => $code],
         );

--- a/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\FeatureFlag;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Tests\Unit\Core\Framework\FeatureTest;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -31,7 +32,7 @@ class IdleFeatureFlagTest extends TestCase
         'FEATURE_NEXT_123',
         'FEATURE_NEXT_1234',
         'FEATURE_NEXT_1235',
-        'FEATURE_NEXT_0000', /** @see \Shopware\Tests\Unit\Core\Framework\FeatureTest */
+        'FEATURE_NEXT_0000', /** @see FeatureTest */
     ];
 
     private static string $featureAllValue;

--- a/tests/integration/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
+++ b/tests/integration/Core/System/SystemConfig/Service/ConfigurationServiceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\UtilException;
 use Shopware\Core\System\SystemConfig\Service\AppConfigReader;
@@ -73,7 +74,7 @@ class ConfigurationServiceTest extends TestCase
     }
 
     /**
-     * @param list<\Shopware\Core\Framework\Plugin> $plugins
+     * @param list<Plugin> $plugins
      */
     private function createConfigurationService(array $plugins): ConfigurationService
     {

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\SalesChannel\ResetPasswordRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -56,7 +57,7 @@ class ResetPasswordRouteTest extends TestCase
                 1,
                 $recoveryCollection,
                 null,
-                new \Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria(),
+                new Criteria(),
                 $this->createMock(SalesChannelContext::class)->getContext()
             ));
 

--- a/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
+++ b/tests/unit/Core/Content/Category/Subscriber/CategorySubscriberTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWriteEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
@@ -315,7 +316,7 @@ class CategorySubscriberTest extends TestCase
     }
 
     /**
-     * @param array<\Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand> $commands
+     * @param array<WriteCommand> $commands
      */
     private function dispatchEvent(CategorySubscriber $subscriber, array $commands): void
     {

--- a/tests/unit/Core/DevOps/Docs/Script/HooksReferenceGeneratorTest.php
+++ b/tests/unit/Core/DevOps/Docs/Script/HooksReferenceGeneratorTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\DevOps\Docs\Script\ServiceReferenceGenerator;
 use Shopware\Core\Framework\Script\Execution\Hook;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Twig\Environment;
+use Twig\Loader\LoaderInterface;
 
 /**
  * @internal
@@ -63,7 +64,7 @@ class HooksReferenceGeneratorTest extends TestCase
 
         $this->twig = $this->createMock(Environment::class);
         $this->twig->method('render')->willReturn('');
-        $this->twig->method('getLoader')->willReturn(static::createStub(\Twig\Loader\LoaderInterface::class));
+        $this->twig->method('getLoader')->willReturn(static::createStub(LoaderInterface::class));
 
         $this->container = $this->createMock(ContainerInterface::class);
         $this->serviceReferenceGenerator = $this->createMock(ServiceReferenceGenerator::class);

--- a/tests/unit/Core/DevOps/Docs/Script/_fixtures/ServiceWithShopwareReturnType.php
+++ b/tests/unit/Core/DevOps/Docs/Script/_fixtures/ServiceWithShopwareReturnType.php
@@ -2,13 +2,15 @@
 
 namespace Shopware\Tests\Unit\Core\DevOps\Docs\Script\_fixtures;
 
+use Shopware\Core\DevOps\Docs\Script\ServiceReferenceGenerator;
+
 /**
  * @script-service data_loading
  */
 class ServiceWithShopwareReturnType
 {
     /**
-     * @return \Shopware\Core\DevOps\Docs\Script\ServiceReferenceGenerator
+     * @return ServiceReferenceGenerator
      */
     public function foo(): void
     {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiDefinitio
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiSchemaBuilder;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\StoreApiGenerator;
 use Shopware\Core\Framework\Api\ApiException;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Tests\Unit\Core\Framework\Api\ApiDefinition\Generator\_fixtures\CustomBundleWithApiSchema\ShopwareBundleWithName;
@@ -774,7 +775,7 @@ class StoreApiGeneratorTest extends TestCase
         $foundDefinitionWithAssociations = false;
 
         foreach ($this->definitionRegistry->getDefinitions() as $definition) {
-            if (!$definition instanceof \Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition) {
+            if (!$definition instanceof EntityDefinition) {
                 continue;
             }
 

--- a/tests/unit/Core/Framework/App/Validation/Requirements/PublicAccessTest.php
+++ b/tests/unit/Core/Framework/App/Validation/Requirements/PublicAccessTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Manifest\Xml\Meta\Metadata;
 use Shopware\Core\Framework\App\Validation\Requirements\PublicAccess;
 use Shopware\Core\Framework\App\Validation\Requirements\SecureUrlValidator;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
@@ -192,7 +193,7 @@ class PublicAccessTest extends TestCase
     private function createManifestMock(string $appName = 'test-app'): Manifest
     {
         $manifest = $this->createMock(Manifest::class);
-        $metadata = \Shopware\Core\Framework\App\Manifest\Xml\Meta\Metadata::fromArray([
+        $metadata = Metadata::fromArray([
             'name' => $appName,
             'label' => [],
             'author' => 'myApp',

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Query/ScoreQueryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Query/ScoreQueryTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Search\Query;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 
@@ -18,7 +19,7 @@ class ScoreQueryTest extends TestCase
         $scoreQuery = new ScoreQuery(new ContainsFilter('productNumber', '123456'), 100);
 
         /**
-         * @see \Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator::getCriteriaHash
+         * @see EntityCacheKeyGenerator::getCriteriaHash
          */
         $json = json_encode($scoreQuery, \JSON_THROW_ON_ERROR);
 

--- a/tests/unit/Core/Framework/Migration/AddColumnTraitTest.php
+++ b/tests/unit/Core/Framework/Migration/AddColumnTraitTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\MySQLSchemaManager;
 use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Migration\AddColumnTrait;
 
@@ -118,7 +119,7 @@ class AddColumnTraitTest extends TestCase
     }
 
     /**
-     * @return Connection&\PHPUnit\Framework\MockObject\MockObject
+     * @return Connection&MockObject
      */
     private function createConnectionMock(bool $columnExists): Connection
     {

--- a/tests/unit/Core/Framework/Webhook/WebhookDispatcherTest.php
+++ b/tests/unit/Core/Framework/Webhook/WebhookDispatcherTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Webhook;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\Webhook\AclPrivilegeCollection;
 use Shopware\Core\Framework\Webhook\Hookable;
 use Shopware\Core\Framework\Webhook\Service\WebhookManager;
 use Shopware\Core\Framework\Webhook\WebhookDispatcher;
@@ -203,7 +204,7 @@ class TestEvent implements Hookable
         return [];
     }
 
-    public function isAllowed(string $appId, \Shopware\Core\Framework\Webhook\AclPrivilegeCollection $permissions): bool
+    public function isAllowed(string $appId, AclPrivilegeCollection $permissions): bool
     {
         return true;
     }

--- a/tests/unit/Storefront/Controller/StorybookControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorybookControllerTest.php
@@ -15,6 +15,8 @@ use Shopware\Storefront\Storybook\StorybookService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 use Twig\Loader\ArrayLoader;
 use Twig\TemplateWrapper;
 
@@ -142,7 +144,7 @@ class StorybookControllerTest extends TestCase
         $this->storybookService->method('getThemeId')->willReturn(null);
         $this->storybookService->method('resolveComponentProps')->willReturn([]);
 
-        $this->twig->renderException = new \Twig\Error\RuntimeError('Template rendering failed');
+        $this->twig->renderException = new RuntimeError('Template rendering failed');
 
         $response = $this->createController('dev')->storybook('my-button', $this->createStorybookRequest());
 
@@ -167,7 +169,7 @@ class StorybookControllerTest extends TestCase
         $this->storybookService->method('getThemeId')->willReturn(null);
         $this->storybookService->method('resolveComponentProps')->willReturn([]);
 
-        $this->twig->createTemplateException = new \Twig\Error\SyntaxError('Unexpected token');
+        $this->twig->createTemplateException = new SyntaxError('Unexpected token');
 
         $response = $this->createController('dev')->storybook('my-button', $this->createStorybookRequest());
 

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -15,7 +15,9 @@ use Shopware\Storefront\Page\Robots\RobotsPage;
 use Shopware\Storefront\Page\Robots\RobotsPageLoadedEvent;
 use Shopware\Storefront\Page\Robots\RobotsPageLoader;
 use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
+use Shopware\Storefront\Page\Robots\Struct\RobotsDirective;
 use Shopware\Storefront\Page\Robots\Struct\RobotsDirectiveType;
+use Shopware\Storefront\Page\Robots\Struct\RobotsUserAgentBlock;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -583,7 +585,7 @@ class RobotsPageLoaderTest extends TestCase
     /**
      * Helper to assert that User-agent blocks have correct directive types
      *
-     * @param array<\Shopware\Storefront\Page\Robots\Struct\RobotsUserAgentBlock> $globalBlocks
+     * @param array<RobotsUserAgentBlock> $globalBlocks
      */
     private function assertUserAgentBlocksHaveCorrectDirectiveTypes(array $globalBlocks): void
     {
@@ -614,7 +616,7 @@ class RobotsPageLoaderTest extends TestCase
     /**
      * Collects and sorts all directive types from given blocks
      *
-     * @param array<\Shopware\Storefront\Page\Robots\Struct\RobotsUserAgentBlock> $blocks
+     * @param array<RobotsUserAgentBlock> $blocks
      *
      * @return list<RobotsDirectiveType>
      */
@@ -635,7 +637,7 @@ class RobotsPageLoaderTest extends TestCase
     /**
      * Asserts that directives contain specific paths for a given directive type
      *
-     * @param array<\Shopware\Storefront\Page\Robots\Struct\RobotsDirective> $directives
+     * @param array<RobotsDirective> $directives
      * @param list<string> $expectedPaths
      */
     private function assertDirectivePaths(array $directives, RobotsDirectiveType $type, array $expectedPaths): void

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
@@ -193,7 +194,7 @@ class ThemeMergedConfigBuilderTest extends TestCase
                 // If the criteria has a filter for a specific ID, find that theme
                 $filters = $criteria->getFilters();
                 foreach ($filters as $filter) {
-                    if ($filter instanceof \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter
+                    if ($filter instanceof EqualsFilter
                         && $filter->getField() === 'id') {
                         $searchId = (string) $filter->getValue();
                         $foundTheme = $themeCollection->get($searchId);


### PR DESCRIPTION
### 1. Why is this change necessary?

Seeing more and more **Fully Qualified Name** (FQN) rather than its short name:
 e.g. `\Shopware\Whatever\Anything` should be `Anything` 

It's not possible to catch manually all the PR, especially in tests realm which is not (yet) treated as first class citizen. 
This will save time for everyone.

### 2. What does this change do, exactly?

- Change the configuration of our cs fixer to enforce simplification of FQN
- Leave natives out of it: e.g. `\DateTime(...`
- Fix all existing violations

### 3. Describe each step to reproduce the issue or behaviour.

Run `composer run cs-fix` locally

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
