### PR TITLE
test: experiment tracking of mailEvent and forced build

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -602,7 +602,6 @@ jobs:
   update-66-67:
       name: "PHP update 6.6 -> 6.7"
       runs-on: ubuntu-24.04
-      if: inputs.nightly == 'true'
       env:
           APP_ENV: test
           APP_URL: http://localhost:8000
@@ -659,7 +658,7 @@ jobs:
             run: bin/console theme:refresh
 
           - name: Run integration tests
-            run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure
+            run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --stop-on-error --stop-on-failure --random-order-seed 1775785348
 
   # this allows us to specifiy just one required job/check
   # this is not practical with matrix jobs directly, because you've to specify all permutations
@@ -674,6 +673,7 @@ jobs:
       - php-security
       - blue-green-66-67
       - blue-green-67-68
+      - update-66-67
 
     runs-on: Ubuntu-latest
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   acceptance:
+    if: false
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -69,6 +70,7 @@ jobs:
           report-prefix: playwright-reports
 
   acceptance-tests-changed:
+    if: false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -97,6 +99,7 @@ jobs:
           artifact-prefix: "ats-changed"
 
   phpunit-matrix:
+    if: false
     runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
@@ -112,6 +115,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
   phpunit:
+    if: false
     name: "${{ matrix.php}} ${{ matrix.test.testsuite }}${{ matrix.test.path }} ${{ matrix.db }} ${{ matrix.opensearch != 'opensearchproject/opensearch:3' && matrix.opensearch || '' }}"
     needs:
       - phpunit-matrix
@@ -198,8 +202,8 @@ jobs:
 
 
   win-checkout:
+    if: false
     runs-on: windows-latest
-    if: ${{ github.event_name != 'pull_request' }}
     name: "Windows check"
 
     steps:
@@ -209,6 +213,7 @@ jobs:
       - name: Clone platform
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 4
   php-security:
+    if: false
     runs-on: ubuntu-24.04
     name: "Composer dependencies"
     env:
@@ -233,8 +238,8 @@ jobs:
       - name: Run on platform
         run: ./local-php-security-checker
   code-ql:
+    if: false
     name: Analyze
-    if: ${{ github.repository == 'shopware/shopware' }}
     runs-on: ubuntu-24.04
 
     strategy:
@@ -263,6 +268,7 @@ jobs:
         uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 #  v4.32.3
 
   tested-update-versions:
+    if: false
     name: tested-versions
     runs-on: ubuntu-24.04
     outputs:
@@ -276,6 +282,7 @@ jobs:
         uses: shopware/github-actions/versions@main
 
   acceptance-update:
+    if: false
     needs: tested-update-versions
     runs-on: ubuntu-24.04
     strategy:
@@ -462,6 +469,7 @@ jobs:
             echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
 
   blue-green-67-68:
+    if: false
     name: "PHP blue green 6.7 -> 6.8 -> 6.7"
     runs-on: ubuntu-24.04
     env:
@@ -520,6 +528,7 @@ jobs:
         run: php .github/bin/blue-green-check.php
 
   blue-green-66-67:
+    if: false
     name: "PHP blue green 6.6 -> 6.7 -> 6.6"
     runs-on: ubuntu-24.04
     env:
@@ -682,5 +691,5 @@ jobs:
         with:
           # allowed-failures: docs, linters
           # allow all jobs to be skipped in case of a PR run
-          allowed-skips: acceptance, phpunit, win-checkout, code-ql, acceptance-update, blue-green-66-67
+          allowed-skips: acceptance, acceptance-tests-changed, phpunit-matrix, phpunit, win-checkout, php-security, code-ql, tested-update-versions, acceptance-update, blue-green-66-67, blue-green-67-68
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,9 +63,9 @@ jobs:
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   downstream:
+    if: false
     uses: ./.github/workflows/downstream.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   prepare-release: # This will only execute dry-runs and push current trunk to the many-repos

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -189,5 +189,7 @@
         <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\Datadog\DatadogExtension"/>
         <!-- Enable to see the db side effects of the tests. -->
 <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
+        <!-- Enable to trace unexpected mail.sent dispatches (captures a stack trace per dispatch per test). -->
+<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTraceExtension"/>-->
     </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -190,6 +190,8 @@
         <!-- Enable to see the db side effects of the tests. -->
 <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
         <!-- Enable to trace unexpected mail.sent dispatches (captures a stack trace per dispatch per test). -->
-        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTraceExtension"/>
+        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTraceExtension">
+            <parameter name="stopBeforeTest" value="Shopware\Tests\Integration\Core\Checkout\Order\SalesChannel\OrderRouteTest::testSetSamePaymentMethodToOrder"/>
+        </bootstrap>
     </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -190,6 +190,6 @@
         <!-- Enable to see the db side effects of the tests. -->
 <!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\DatabaseDiff\DatabaseDiffExtension"/>-->
         <!-- Enable to trace unexpected mail.sent dispatches (captures a stack trace per dispatch per test). -->
-<!--        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTraceExtension"/>-->
+        <bootstrap class="Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTraceExtension"/>
     </extensions>
 </phpunit>

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
@@ -9,6 +9,7 @@ use PHPUnit\TextUI\Configuration\Configuration;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\BeforeTestMethodCalledSubscriber;
 use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestFinishedSubscriber;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestRunnerFinishedSubscriber;
 
 /**
  * Diagnostic extension: captures a stack trace for every mail.sent dispatch and prints
@@ -26,6 +27,7 @@ class MailEventTraceExtension implements Extension
         $facade->registerSubscribers(
             new BeforeTestMethodCalledSubscriber($tracer),
             new TestFinishedSubscriber($tracer),
+            new TestRunnerFinishedSubscriber($tracer),
         );
     }
 }

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
@@ -7,8 +7,8 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\BeforeTestMethodCalledSubscriber;
 use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestFinishedSubscriber;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestPreparedSubscriber;
 use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestRunnerFinishedSubscriber;
 
 /**
@@ -22,10 +22,11 @@ class MailEventTraceExtension implements Extension
 {
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {
-        $tracer = new MailEventTracer();
+        $stopBeforeTest = $parameters->has('stopBeforeTest') ? $parameters->get('stopBeforeTest') : '';
+        $tracer = new MailEventTracer($stopBeforeTest);
 
         $facade->registerSubscribers(
-            new BeforeTestMethodCalledSubscriber($tracer),
+            new TestPreparedSubscriber($tracer),
             new TestFinishedSubscriber($tracer),
             new TestRunnerFinishedSubscriber($tracer),
         );

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTraceExtension.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\BeforeTestMethodCalledSubscriber;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber\TestFinishedSubscriber;
+
+/**
+ * Diagnostic extension: captures a stack trace for every mail.sent dispatch and prints
+ * them after each test. Enable in phpunit.xml.dist to locate unexpected mail dispatches.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class MailEventTraceExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $tracer = new MailEventTracer();
+
+        $facade->registerSubscribers(
+            new BeforeTestMethodCalledSubscriber($tracer),
+            new TestFinishedSubscriber($tracer),
+        );
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace;
+
+use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MailEventTracer
+{
+    /** @var list<string> */
+    private array $traces = [];
+
+    private ?EventDispatcherInterface $dispatcher = null;
+
+    private ?\Closure $listener = null;
+
+    public function install(): void
+    {
+        $this->traces = [];
+
+        try {
+            $container = KernelLifecycleManager::getKernel()->getContainer();
+            $this->dispatcher = $container->get('event_dispatcher');
+        } catch (\Throwable) {
+            return;
+        }
+
+        $this->listener = function (MailSentEvent $event): void {
+            $this->traces[] = \sprintf(
+                "Subject: %s\n%s",
+                $event->getSubject(),
+                (new \Exception())->getTraceAsString(),
+            );
+        };
+
+        $this->dispatcher->addListener(MailSentEvent::class, $this->listener, \PHP_INT_MAX);
+    }
+
+    public function reportAndUninstall(string $testDescription): void
+    {
+        if ($this->dispatcher !== null && $this->listener !== null) {
+            $this->dispatcher->removeListener(MailSentEvent::class, $this->listener);
+        }
+
+        if ($this->traces !== []) {
+            echo \PHP_EOL . \sprintf('[MailEventTrace] %s dispatched %d mail.sent event(s):', $testDescription, \count($this->traces)) . \PHP_EOL;
+
+            foreach ($this->traces as $i => $trace) {
+                echo \sprintf('  #%d %s', $i + 1, $trace) . \PHP_EOL;
+            }
+        }
+
+        $this->traces = [];
+        $this->dispatcher = null;
+        $this->listener = null;
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
@@ -27,9 +27,25 @@ class MailEventTracer
 
     private ?\Closure $listener = null;
 
-    public function install(): void
+    private bool $stopped = false;
+
+    public function __construct(private readonly string $stopBeforeTest = '')
     {
-        $this->traces = [];
+    }
+
+    public function install(string $testId): void
+    {
+        if ($this->stopped) {
+            return;
+        }
+
+        if ($this->stopBeforeTest !== '' && $testId === $this->stopBeforeTest) {
+            $this->stopped = true;
+
+            return;
+        }
+
+        $this->currentTraces = [];
 
         try {
             $container = KernelLifecycleManager::getKernel()->getContainer();
@@ -80,12 +96,37 @@ class MailEventTracer
 
     public function report(): void
     {
-        foreach ($this->allTraces as ['test' => $test, 'traces' => $traces]) {
-            echo \PHP_EOL . \sprintf('[MailEventTrace] %s dispatched %d mail.sent event(s):', $test, \count($traces)) . \PHP_EOL;
+        if ($this->allTraces === []) {
+            return;
+        }
 
-            foreach ($traces as $i => $trace) {
-                echo \sprintf('  #%d %s', $i + 1, $trace) . \PHP_EOL;
+        // Deduplicate: group by unique call stack so the same source location
+        // shared across many tests collapses into one entry with a count.
+        /** @var array<string, array{subjects: list<string>, count: int, example: string}> $groups */
+        $groups = [];
+
+        foreach ($this->allTraces as ['test' => $test, 'traces' => $traces]) {
+            foreach ($traces as $trace) {
+                [$subject, $frames] = \explode("\n", $trace, 2) + [1 => ''];
+
+                if (!isset($groups[$frames])) {
+                    $groups[$frames] = ['subjects' => [], 'count' => 0, 'example' => $test];
+                }
+
+                ++$groups[$frames]['count'];
+
+                if (!\in_array($subject, $groups[$frames]['subjects'], true)) {
+                    $groups[$frames]['subjects'][] = $subject;
+                }
             }
+        }
+
+        foreach ($groups as $frames => $group) {
+            echo \PHP_EOL . \sprintf('[MailEventTrace] %dx — e.g. %s', $group['count'], $group['example']) . \PHP_EOL;
+            foreach ($group['subjects'] as $subject) {
+                echo '  ' . $subject . \PHP_EOL;
+            }
+            echo $frames . \PHP_EOL;
         }
     }
 }

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
@@ -14,9 +14,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class MailEventTracer
 {
     /**
+     * @var list<array{test: string, traces: list<string>}>
+     */
+    private array $allTraces = [];
+
+    /**
      * @var list<string>
      */
-    private array $traces = [];
+    private array $currentTraces = [];
 
     private ?EventDispatcherInterface $dispatcher = null;
 
@@ -44,7 +49,7 @@ class MailEventTracer
         $this->listener = function (MailSentEvent $event): void {
             $frames = \array_filter(
                 \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS),
-                static fn (array $frame): bool => isset($frame['file']) && !\str_contains($frame['file'], \DIRECTORY_SEPARATOR . 'vendor' . \DIRECTORY_SEPARATOR),
+                static fn (array $frame): bool => isset($frame['file']) && \str_contains($frame['file'], \DIRECTORY_SEPARATOR . 'tests' . \DIRECTORY_SEPARATOR),
             );
 
             $trace = \implode("\n", \array_map(
@@ -52,28 +57,35 @@ class MailEventTracer
                 \array_values($frames),
             ));
 
-            $this->traces[] = \sprintf("Subject: %s\n%s", $event->getSubject(), $trace);
+            $this->currentTraces[] = \sprintf("Subject: %s\n%s", $event->getSubject(), $trace);
         };
 
         $this->dispatcher->addListener(MailSentEvent::class, $this->listener, \PHP_INT_MAX);
     }
 
-    public function reportAndUninstall(string $testDescription): void
+    public function collectAndUninstall(string $testDescription): void
     {
         if ($this->dispatcher !== null && $this->listener !== null) {
             $this->dispatcher->removeListener(MailSentEvent::class, $this->listener);
         }
 
-        if ($this->traces !== []) {
-            echo \PHP_EOL . \sprintf('[MailEventTrace] %s dispatched %d mail.sent event(s):', $testDescription, \count($this->traces)) . \PHP_EOL;
+        if ($this->currentTraces !== []) {
+            $this->allTraces[] = ['test' => $testDescription, 'traces' => $this->currentTraces];
+        }
 
-            foreach ($this->traces as $i => $trace) {
+        $this->currentTraces = [];
+        $this->dispatcher = null;
+        $this->listener = null;
+    }
+
+    public function report(): void
+    {
+        foreach ($this->allTraces as ['test' => $test, 'traces' => $traces]) {
+            echo \PHP_EOL . \sprintf('[MailEventTrace] %s dispatched %d mail.sent event(s):', $test, \count($traces)) . \PHP_EOL;
+
+            foreach ($traces as $i => $trace) {
                 echo \sprintf('  #%d %s', $i + 1, $trace) . \PHP_EOL;
             }
         }
-
-        $this->traces = [];
-        $this->dispatcher = null;
-        $this->listener = null;
     }
 }

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/MailEventTracer.php
@@ -13,7 +13,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[Package('framework')]
 class MailEventTracer
 {
-    /** @var list<string> */
+    /**
+     * @var list<string>
+     */
     private array $traces = [];
 
     private ?EventDispatcherInterface $dispatcher = null;
@@ -31,12 +33,26 @@ class MailEventTracer
             return;
         }
 
+        // If the test already registered a MailSentEvent listener in setUp,
+        // it is explicitly handling mail — skip tracing for this test.
+        if ($this->dispatcher->getListeners(MailSentEvent::class) !== []) {
+            $this->dispatcher = null;
+
+            return;
+        }
+
         $this->listener = function (MailSentEvent $event): void {
-            $this->traces[] = \sprintf(
-                "Subject: %s\n%s",
-                $event->getSubject(),
-                (new \Exception())->getTraceAsString(),
+            $frames = \array_filter(
+                \debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS),
+                static fn (array $frame): bool => isset($frame['file']) && !\str_contains($frame['file'], \DIRECTORY_SEPARATOR . 'vendor' . \DIRECTORY_SEPARATOR),
             );
+
+            $trace = \implode("\n", \array_map(
+                static fn (array $frame): string => \sprintf('  %s(%d)', $frame['file'], $frame['line'] ?? 0),
+                \array_values($frames),
+            ));
+
+            $this->traces[] = \sprintf("Subject: %s\n%s", $event->getSubject(), $trace);
         };
 
         $this->dispatcher->addListener(MailSentEvent::class, $this->listener, \PHP_INT_MAX);

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/BeforeTestMethodCalledSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/BeforeTestMethodCalledSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber;
+
+use PHPUnit\Event\Test\BeforeTestMethodCalled;
+use PHPUnit\Event\Test\BeforeTestMethodCalledSubscriber as BeforeTestMethodCalledSubscriberInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTracer;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class BeforeTestMethodCalledSubscriber implements BeforeTestMethodCalledSubscriberInterface
+{
+    public function __construct(private readonly MailEventTracer $tracer)
+    {
+    }
+
+    public function notify(BeforeTestMethodCalled $event): void
+    {
+        $this->tracer->install();
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestFinishedSubscriber.php
@@ -19,6 +19,6 @@ class TestFinishedSubscriber implements FinishedSubscriber
 
     public function notify(Finished $event): void
     {
-        $this->tracer->reportAndUninstall($event->test()->id());
+        $this->tracer->collectAndUninstall($event->test()->id());
     }
 }

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestFinishedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber;
+
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTracer;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class TestFinishedSubscriber implements FinishedSubscriber
+{
+    public function __construct(private readonly MailEventTracer $tracer)
+    {
+    }
+
+    public function notify(Finished $event): void
+    {
+        $this->tracer->reportAndUninstall($event->test()->id());
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestPreparedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestPreparedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber;
+
+use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PreparedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTracer;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class TestPreparedSubscriber implements PreparedSubscriber
+{
+    public function __construct(private readonly MailEventTracer $tracer)
+    {
+    }
+
+    public function notify(Prepared $event): void
+    {
+        $this->tracer->install($event->test()->id());
+    }
+}

--- a/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestRunnerFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/Extension/MailEventTrace/Subscriber/TestRunnerFinishedSubscriber.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\Subscriber;
+
+use PHPUnit\Event\TestRunner\Finished;
+use PHPUnit\Event\TestRunner\FinishedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\Extension\MailEventTrace\MailEventTracer;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class TestRunnerFinishedSubscriber implements FinishedSubscriber
+{
+    public function __construct(private readonly MailEventTracer $tracer)
+    {
+    }
+
+    public function notify(Finished $event): void
+    {
+        $this->tracer->report();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Not to be merged / released.

Experiment to track which test is leaking MailEvent

### 2. What does this change do, exactly?

Custom extension tracking, forced build with determined seed from previous failure

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
