### PR TITLE
fix: default plugin scaffold prompts to no

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -10,6 +10,11 @@ The login and OAuth token endpoints now support optional per user (`login_user`,
 
 ## Core
 
+### Plugin scaffolding prompts default to no
+
+Interactive `bin/console plugin:create` prompts for optional example scaffolding now default to `no`.
+Use the explicit scaffold flags or answer `yes` to generate optional example files.
+
 ### "Find best variant setting" is now applied for storefront filtering
 
 Users can now control which representative of variant products is shown in filtered listings via the Product settings "Preview best matching variant in search results and filtered listings".

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/AddScaffoldConfigDefaultBehaviour.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/AddScaffoldConfigDefaultBehaviour.php
@@ -28,7 +28,7 @@ trait AddScaffoldConfigDefaultBehaviour
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
+        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION, false)) {
             $config->addOption(self::OPTION_NAME, true);
         }
     }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGenerator.php
@@ -50,7 +50,7 @@ class StoreApiRouteGenerator implements ScaffoldingGenerator
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
+        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION, false)) {
             $config->addOption(self::OPTION_NAME, true);
             $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, true);
         }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
@@ -52,7 +52,7 @@ class StorefrontControllerGenerator implements ScaffoldingGenerator
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
+        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION, false)) {
             $config->addOption(self::OPTION_NAME, true);
             $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, true);
         }

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
@@ -38,7 +38,14 @@ class CommandGeneratorTest extends TestCase
         $input->method('getOption')->willReturn($getOptionResponse);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->method('confirm')->willReturn($confirmResponse);
+        if ($getOptionResponse) {
+            $io->expects($this->never())->method('confirm');
+        } else {
+            $io->expects($this->once())
+                ->method('confirm')
+                ->with('Do you want to create an example console command?', false)
+                ->willReturn($confirmResponse);
+        }
 
         (new CommandGenerator())
             ->addScaffoldConfig($configuration, $input, $io);

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
@@ -38,7 +38,14 @@ class StoreApiRouteGeneratorTest extends TestCase
         $input->method('getOption')->willReturn($getOptionResponse);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->method('confirm')->willReturn($confirmResponse);
+        if ($getOptionResponse) {
+            $io->expects($this->never())->method('confirm');
+        } else {
+            $io->expects($this->once())
+                ->method('confirm')
+                ->with('Do you want to create an example store-api route?', false)
+                ->willReturn($confirmResponse);
+        }
 
         (new StoreApiRouteGenerator())
             ->addScaffoldConfig($configuration, $input, $io);

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
@@ -38,7 +38,14 @@ class StorefrontControllerGeneratorTest extends TestCase
         $input->method('getOption')->willReturn($getOptionResponse);
 
         $io = $this->createMock(SymfonyStyle::class);
-        $io->method('confirm')->willReturn($confirmResponse);
+        if ($getOptionResponse) {
+            $io->expects($this->never())->method('confirm');
+        } else {
+            $io->expects($this->once())
+                ->method('confirm')
+                ->with('Do you want to create an example storefront controller?', false)
+                ->willReturn($confirmResponse);
+        }
 
         (new StorefrontControllerGenerator())
             ->addScaffoldConfig($configuration, $input, $io);


### PR DESCRIPTION
### 1. Why is this change necessary?

Interactive `bin/console plugin:create` currently defaults optional example scaffold prompts to yes. Pressing Enter can generate example files that are not wanted in CI, template, or scripted plugin bootstrapping flows.

### 2. What does this change do, exactly?

Optional scaffold confirmations now default to no. Explicit command flags and explicit yes answers still generate the optional scaffold files.

The shared scaffold prompt behavior and the two route generators that override it now pass `false` as the confirmation default. Unit tests assert that prompted scaffold options use the no default.

Local validation:
- `git diff --check HEAD~1..HEAD`
- PHP unit tests could not be run locally because this environment does not have PHP/composer installed.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `bin/console plugin:create TestPlugin Test` in interactive mode.
2. Press Enter at the optional example scaffold prompts.
3. Before this change, the optional scaffold is selected because the prompts default to yes.
4. After this change, optional scaffold files are only generated when answering yes or passing the corresponding option.

### 4. Please link to the relevant issues (if any).

- closes #16072

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
