### PR TITLE
fix: date-range rule datepicker invalid time offset

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -912,6 +912,9 @@ Use the parent blocks instead
 ## File accessibility changed from public to private
 `administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js`
 
+## The following template blocks have been replaced due to a typo in their name
+* `sw_condiiton_date_range_field_to_date` -> `sw_condition_date_range_field_to_date`
+
 ## Removed .png and .jpg images
 
 In favor of WebP the following images have been removed:

--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -1269,6 +1269,7 @@
  "sw_condition_customer_custom_field_value",
  "sw_condition_date_range_field_from_date",
  "sw_condition_date_range_field_timezone",
+ "sw_condition_date_range_field_to_date",
  "sw_condition_date_range_field_use_time",
  "sw_condition_generic_field_operator",
  "sw_condition_generic_fields",

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
@@ -54,12 +54,7 @@ export default {
         fromDate: {
             get() {
                 this.ensureValueExist();
-
-                if (this.condition.value.fromDate) {
-                    return `${this.condition.value.fromDate}+00:00`;
-                }
-
-                return null;
+                return this.condition.value.fromDate ? `${this.condition.value.fromDate}.000Z` : null;
             },
             set(fromDate) {
                 this.ensureValueExist();
@@ -74,11 +69,7 @@ export default {
         toDate: {
             get() {
                 this.ensureValueExist();
-                if (this.condition.value.toDate) {
-                    return `${this.condition.value.toDate}+00:00`;
-                }
-
-                return null;
+                return this.condition.value.toDate ? `${this.condition.value.toDate}.000Z` : null;
             },
             set(toDate) {
                 this.ensureValueExist();

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
@@ -25,6 +25,7 @@
     />
     {% endblock %}
 
+    {% block sw_condition_date_range_field_to_date %}
     {% block sw_condiiton_date_range_field_to_date %}
     <mt-datepicker
         v-model="toDate"
@@ -36,6 +37,7 @@
         :disabled="disabled || undefined"
         :placeholder="$t('sw-datepicker.date.placeholder')"
     />
+    {% endblock %}
     {% endblock %}
 
     {% block sw_condition_date_range_field_timezone %}

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.html.twig
@@ -26,6 +26,7 @@
     {% endblock %}
 
     {% block sw_condition_date_range_field_to_date %}
+    {# @deprecated tag:v6.8.0 - Block will be removed. Use `sw_condition_date_range_field_to_date` instead. #}
     {% block sw_condiiton_date_range_field_to_date %}
     <mt-datepicker
         v-model="toDate"

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
@@ -122,7 +122,7 @@ describe('component/rule/sw-condition-date-range', () => {
         await flushPromises();
 
         expect(fromDateInput.attributes('value')).toBe('1900/01/01');
-        expect(wrapper.vm.fromDate).toBe('1900-01-01T00:00:00+00:00');
+        expect(wrapper.vm.fromDate).toBe('1900-01-01T00:00:00.000Z');
     });
 
     it('should select a fromDate with time', async () => {
@@ -163,7 +163,7 @@ describe('component/rule/sw-condition-date-range', () => {
         await flushPromises();
 
         expect(fromDateInput.attributes('value')).toBe('1900/01/01, 12:30');
-        expect(wrapper.vm.fromDate).toBe('1900-01-01T12:30:00+00:00');
+        expect(wrapper.vm.fromDate).toBe('1900-01-01T12:30:00.000Z');
     });
 
     it('should select a toDate without time', async () => {
@@ -192,7 +192,7 @@ describe('component/rule/sw-condition-date-range', () => {
         await flushPromises();
 
         expect(fromDateInput.attributes('value')).toBe('1900/01/01');
-        expect(wrapper.vm.toDate).toBe('1900-01-01T23:59:59+00:00');
+        expect(wrapper.vm.toDate).toBe('1900-01-01T23:59:59.000Z');
     });
 
     it('should select a toDate with time', async () => {
@@ -233,6 +233,6 @@ describe('component/rule/sw-condition-date-range', () => {
         await flushPromises();
 
         expect(fromDateInput.attributes('value')).toBe('1900/01/01, 12:30');
-        expect(wrapper.vm.toDate).toBe('1900-01-01T12:30:00+00:00');
+        expect(wrapper.vm.toDate).toBe('1900-01-01T12:30:00.000Z');
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the UI & the internal value of a datepicker in the date-range rule are getting set to the UTC time
- Only the internal value should be set to the UTC time, while the UI should stay in the local PC time
- This happens, because the timezone is missing in the get method, because we correctly trim it in the `formatDate` method

### 2. What does this change do, exactly?
- Correctly add the missing timezone offset for the `get` method in the date-range rule datepicker
- Fix typo in twig block `sw_condiiton_date_range_field_to_date` -> `sw_condition_date_range_field_to_date`

### 3. Describe each step to reproduce the issue or behaviour.
- Create a new rule with your local pc time <> UTC
- Select a datetime value from a datepicker in the date-range rule
- The datetime in the ui & internal will go back to the UTC time (only internal should go to utc)

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
