### PR TITLE
fix: Clear translated cms overrides on layout change

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -71,7 +71,7 @@ export default {
     methods: {
         onLayoutSelect(selectedLayout) {
             this.category.cmsPageId = selectedLayout;
-            this.category.slotConfig = null;
+            this.resetSlotConfig();
         },
 
         onLayoutReset() {
@@ -102,6 +102,14 @@ export default {
 
         closeLayoutModal() {
             this.showLayoutSelectionModal = false;
+        },
+
+        resetSlotConfig() {
+            this.category.slotConfig = null;
+
+            this.category.translations?.forEach((translation) => {
+                translation.slotConfig = null;
+            });
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.spec.js
@@ -6,7 +6,12 @@ import { mount } from '@vue/test-utils';
 const categoryId = 'some-category-id';
 const cmsPageId = 'some-cms-page-id';
 
-async function createWrapper() {
+async function createWrapper(
+    category = {
+        id: categoryId,
+        cmsPageId,
+    },
+) {
     return mount(await wrapTestComponent('sw-category-layout-card', { sync: true }), {
         global: {
             stubs: {
@@ -45,10 +50,7 @@ async function createWrapper() {
             },
         },
         props: {
-            category: {
-                id: categoryId,
-                cmsPageId,
-            },
+            category,
         },
     });
 }
@@ -182,5 +184,41 @@ describe('src/module/sw-category/component/sw-category-layout-card', () => {
             name: 'sw.cms.detail',
             params: { id: cmsPageId },
         });
+    });
+
+    it('should reset translated slotConfig overrides when changing the layout', async () => {
+        const translatedSlotConfig = {
+            staleSlotId: {
+                content: {
+                    value: 'stale override',
+                },
+            },
+        };
+
+        const category = {
+            id: categoryId,
+            cmsPageId,
+            slotConfig: {
+                currentSlotId: {
+                    content: {
+                        value: 'current override',
+                    },
+                },
+            },
+            translations: [
+                {
+                    languageId: 'some-other-language-id',
+                    slotConfig: translatedSlotConfig,
+                },
+            ],
+        };
+
+        const wrapper = await createWrapper(category);
+
+        wrapper.vm.onLayoutSelect('new-layout-id');
+
+        expect(category.cmsPageId).toBe('new-layout-id');
+        expect(category.slotConfig).toBeNull();
+        expect(category.translations[0].slotConfig).toBeNull();
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/index.js
@@ -141,7 +141,7 @@ export default {
             }
 
             this.product.cmsPageId = cmsPageId;
-            this.product.slotConfig = null;
+            this.resetSlotConfig();
             Shopware.Store.get('swProductDetail').product = this.product;
         },
 
@@ -174,6 +174,14 @@ export default {
             if (slotContent && slotContent.value) {
                 slotContent.value = element.config.content.value;
             }
+        },
+
+        resetSlotConfig() {
+            this.product.slotConfig = null;
+
+            this.product.translations?.forEach((translation) => {
+                translation.slotConfig = null;
+            });
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.spec.js
@@ -202,6 +202,38 @@ describe('src/module/sw-product/view/sw-product-detail-layout', () => {
         expect(wrapper.vm.currentPage.id).toBe('cmsPageId');
     });
 
+    it('should reset translated slotConfig overrides when changing the layout', async () => {
+        const wrapper = await createWrapper();
+        Store.get('swProductDetail').product = {
+            id: '1',
+            slotConfig: {
+                currentSlotId: {
+                    content: {
+                        value: 'current override',
+                    },
+                },
+            },
+            translations: [
+                {
+                    languageId: 'de-DE',
+                    slotConfig: {
+                        staleSlotId: {
+                            content: {
+                                value: 'stale override',
+                            },
+                        },
+                    },
+                },
+            ],
+        };
+
+        wrapper.vm.onSelectLayout('cmsPageId');
+        await nextTick();
+
+        expect(wrapper.vm.product.slotConfig).toBeNull();
+        expect(wrapper.vm.product.translations[0].slotConfig).toBeNull();
+    });
+
     it('should be able to reset a product page layout', async () => {
         const wrapper = await createWrapper();
         await wrapper.vm.onResetLayout();


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/15984

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

## 1. Why is this change necessary?

  When a CMS layout is reassigned on products, categories, or landing pages, Shopware only resets the current entity `slotConfig`. Translated `slotConfig` values can remain persisted in other language rows.

  These stale overrides no longer belong to the currently assigned layout, but they can still influence later inheritance and editing behavior. This leads to inconsistent entity-level CMS override handling across
  languages after a layout change.

  ## 2. What does this change do, exactly?

  This change clears entity-level CMS `slotConfig` overrides not only for the currently edited entity, but also for its loaded translations when the assigned layout changes in Administration.

  The cleanup is applied to the layout assignment flow for:
  - products
  - categories
  - landing pages

  This ensures that old translated overrides from a previously assigned layout are removed together with the current override state.

  ## 3. Describe each step to reproduce the issue or behaviour.

  1. Create two different CMS layouts, for example `Layout A` and `Layout B`.
  2. Assign `Layout A` to a product, category, or landing page.
  3. Override CMS content on entity level in one language and in at least one additional language.
  4. Change the assigned layout from `Layout A` to `Layout B` and save.
  5. Inspect the entity translations again or switch languages in Administration.

  Before this change:
  - the current entity `slotConfig` was reset
  - translated `slotConfig` values from other languages could remain persisted
  - these stale overrides could later interfere with inheritance or editing behaviour

  After this change:
  - the entity-level CMS overrides are cleared consistently for the entity and its translations when the layout changes


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
