### PR TITLE
ci: danger rule to block native time usage

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -183,6 +183,53 @@ return (new Config())
         );
     })
     ->useRule(function (Context $context): void {
+        $touchedPhp = $context->platform->pullRequest->getFiles()
+            ->filter(fn (File $f) => in_array($f->status, [File::STATUS_ADDED, File::STATUS_MODIFIED], true))
+            ->matches('src/**/*.php');
+
+        // exempt: migrations (point-in-time artifacts), hydrators (parse DB strings, not "now"),
+        // tests (use MockClock or fixed dates intentionally), profiling/measurement code.
+        $exemptPathPattern = '#(/Migration/|Hydrator\.php$|/Test/|/tests/|/Profiling/|Profiler|/DevOps/)#';
+
+        // matches: new \DateTime(), new DateTime(), new \DateTimeImmutable(), new DateTimeImmutable(),
+        // time(), microtime(...), strtotime(...). Argumentless DateTime[Immutable] only
+        $forbiddenCallPattern = '/(new\s+\\\\?DateTime(Immutable)?\s*\(\s*\)|\btime\s*\(\s*\)|\bmicrotime\s*\(|\bstrtotime\s*\()/';
+
+        $offenders = [];
+        foreach ($touchedPhp as $file) {
+            if (preg_match($exemptPathPattern, $file->name)) {
+                continue;
+            }
+
+            // only flag NEW lines (additions in the patch), not pre-existing usages,
+            // so unrelated edits to a file with legacy violations do not get blocked.
+            foreach (explode("\n", (string) $file->patch) as $line) {
+                if (str_starts_with($line, '+')
+                    && !str_starts_with($line, '+++')
+                    && preg_match($forbiddenCallPattern, $line)
+                ) {
+                    $offenders[] = $file->name;
+                    break;
+                }
+            }
+        }
+
+        if (count($offenders) > 0) {
+            $context->failure(
+                'Do not introduce native time reads (`new \DateTime()`, `new \DateTimeImmutable()`,'
+                . ' `time()`, `microtime()`, `strtotime()`).<br/>'
+                . 'Use `Psr\Clock\ClockInterface`'
+                . ' (see `src/Core/Checkout/Payment/Cleanup/CleanupPaymentTokenTaskHandler.php`'
+                . ' for `@internal` services and'
+                . ' `src/Core/Content/Product/IsNewDetector.php` for public classes whose'
+                . ' constructor is `@internal`),'
+                . ' or `Symfony\Component\Clock\ClockAwareTrait` when the constructor cannot change.<br/><br/>'
+                . 'Affected files:<br/>'
+                . implode('<br/>', array_unique($offenders))
+            );
+        }
+    })
+    ->useRule(function (Context $context): void {
         $changedTemplates = $context->platform->pullRequest->getFiles()
             ->filterStatus(File::STATUS_MODIFIED)
             ->matches('src/Storefront/Resources/views/*.twig')


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Native time reads (new \DateTime(), time(), etc.) make classes non-deterministic and prevent unit tests from asserting exact time boundaries. 

### 2. What does this change do, exactly?
Adds a Danger rule that fails PRs introducing native time reads in added/modified lines under src/


### 3. Describe each step to reproduce the issue or behaviour.
  1. Add $now = new \DateTime(); to any non-exempt PHP file under src/.                                                                                                                  
  2. Commit, push, open a PR.
  3. Danger CI fails and lists the offending file. 

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/15564

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
