### PR TITLE
fix: Use deliveryTime association instead of deliveryMedia in buy-box backport

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/buy-box.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/buy-box.spec.js
@@ -11,4 +11,19 @@ describe('src/module/sw-cms/elements/buy-box', () => {
         config: 'sw-cms-el-config-buy-box',
         preview: 'sw-cms-el-preview-buy-box',
     });
+
+    it('registers the product criteria with the deliveryTime association', async () => {
+        await import('src/module/sw-cms/elements/buy-box');
+
+        const cmsService = Shopware.Service('cmsService');
+        const elementConfig = cmsService.getCmsElementConfigByName('buy-box');
+
+        expect(elementConfig.defaultConfig.product.entity.criteria.associations).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    association: 'deliveryTime',
+                }),
+            ]),
+        );
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/index.ts
@@ -32,7 +32,7 @@ Shopware.Service('cmsService').registerCmsElement({
             required: true,
             entity: {
                 name: 'product',
-                criteria: new Shopware.Data.Criteria(1, 25).addAssociation('deliveryMedia'),
+                criteria: new Shopware.Data.Criteria(1, 25).addAssociation('deliveryTime'),
             },
         },
         alignment: {


### PR DESCRIPTION
backport of #16106

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
