### PR TITLE
test: fix flaky test DocumentRoute::testDownloadDocument

### DIFF
--- a/tests/integration/Storefront/Controller/DocumentControllerTest.php
+++ b/tests/integration/Storefront/Controller/DocumentControllerTest.php
@@ -12,9 +12,11 @@ use Shopware\Core\Checkout\Cart\Order\OrderPersister;
 use Shopware\Core\Checkout\Cart\PriceDefinitionFactory;
 use Shopware\Core\Checkout\Cart\Processor;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
+use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
 use Shopware\Core\Checkout\Document\Service\HtmlRenderer;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
@@ -22,6 +24,8 @@ use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -58,11 +62,22 @@ class DocumentControllerTest extends TestCase
 
     private DocumentGenerator $documentGenerator;
 
+    /**
+     * @var EntityRepository<DocumentCollection>
+     */
+    private EntityRepository $documentRepository;
+
+    private DocumentConfigLoader $documentConfigLoader;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->documentGenerator = static::getContainer()->get(DocumentGenerator::class);
+        $this->documentRepository = static::getContainer()->get('document.repository');
+        $this->documentConfigLoader = static::getContainer()->get(DocumentConfigLoader::class);
+        // Clear cached config from previous tests to ensure a fresh state
+        $this->documentConfigLoader->reset();
 
         $this->context = Context::createDefaultContext();
 
@@ -135,7 +150,7 @@ class DocumentControllerTest extends TestCase
 
         $response = $browser->getResponse();
 
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertSame($expectedFileContent, $response->getContent());
         static::assertSame($expectedContentType, $response->headers->get('content-type'));
 
@@ -196,10 +211,17 @@ class DocumentControllerTest extends TestCase
 
         $response = $browser->getResponse();
 
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
         static::assertNotEmpty($response->getContent());
+
+        $documentEntity = $this->documentRepository->search(new Criteria([$document->getId()]), $context)->getEntities()->first();
+        static::assertNotNull($documentEntity);
+
+        $documentConfig = $this->documentConfigLoader->load(InvoiceRenderer::TYPE, TestDefaults::SALES_CHANNEL, $context);
+        $expectedFilename = $documentConfig->getFilenamePrefix() . $documentEntity->getDocumentNumber() . $documentConfig->getFilenameSuffix();
+
         static::assertSame(
-            'inline; filename=invoice_1000.' . $expectedFileType,
+            'inline; filename=' . $expectedFilename . '.' . $expectedFileType,
             $response->headers->get('content-disposition')
         );
         static::assertStringContainsString(
@@ -317,7 +339,7 @@ class DocumentControllerTest extends TestCase
             ])
         );
         $response = $browser->getResponse();
-        static::assertSame(200, $response->getStatusCode());
+        static::assertSame(Response::HTTP_OK, $response->getStatusCode());
 
         return $browser;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Flaky in Nightly:
```
There was 1 failure:

1) Shopware\Tests\Integration\Storefront\Controller\DocumentControllerTest::testDownloadDocument with data set "with query param html" ('invoice', 'html', 'text/html', null, 'html')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'inline; filename=invoice_1000.html'
+'inline; filename=1000.html'

/home/runner/work/shopware/shopware/tests/integration/Storefront/Controller/DocumentControllerTest.php:20
```

see https://github.com/shopware/shopware/actions/runs/24431916227/job/71377988546


### 2. What does this change do, exactly?

- clear config loader to avoid null prefix
- use a dynamic name linked to document rather arbitrary 1000
- cleanup test shape (use properties)

### 3. Describe each step to reproduce the issue or behaviour.

Run integration suite with seed 1776217244

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
