### PR TITLE
fix: restore inherited disabled state for Meteor system config fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -362,7 +362,7 @@ export default {
             bind.inheritedValue = this.getInheritedValue(element);
             bind.isInheritanceField = mapInheritance?.isInheritField;
             bind.isInherited = mapInheritance?.isInherited;
-            bind.disabled = element.config?.disabled;
+            bind.disabled = mapInheritance?.isInherited || element.config?.disabled;
 
             // Handle datepicker date/datetime value format
             if (element.type === 'date') {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -362,7 +362,7 @@ export default {
             bind.inheritedValue = this.getInheritedValue(element);
             bind.isInheritanceField = mapInheritance?.isInheritField;
             bind.isInherited = mapInheritance?.isInherited;
-            bind.disabled = mapInheritance?.isInherited || element.config?.disabled;
+            bind.disabled = element.config?.disabled;
 
             // Handle datepicker date/datetime value format
             if (element.type === 'date') {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
@@ -858,7 +858,11 @@ describe('src/module/sw-settings/component/sw-system-config/sw-system-config', (
             expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBeUndefined();
 
             // remove inheritance
-            await inheritanceSwitch.find('.mt-icon').trigger('click');
+            if (config.legacy) {
+                await inheritanceSwitch.find('.mt-icon').trigger('click');
+            } else {
+                await inheritanceSwitch.trigger('click');
+            }
 
             // check if inheritance switch is not inherit anymore
             field = wrapper.find(`.sw-system-config--field-${kebabCase(name)}`);
@@ -926,7 +930,11 @@ describe('src/module/sw-settings/component/sw-system-config/sw-system-config', (
             expect(inheritanceSwitch.attributes('aria-label')).toBe('Link inheritance');
 
             // restore inheritance
-            await inheritanceSwitch.find('.mt-icon').trigger('click');
+            if (config.legacy) {
+                await inheritanceSwitch.find('.mt-icon').trigger('click');
+            } else {
+                await inheritanceSwitch.trigger('click');
+            }
             await flushPromises();
 
             // check if inheritance switch is not inherit anymore
@@ -994,7 +1002,11 @@ describe('src/module/sw-settings/component/sw-system-config/sw-system-config', (
             expect(inheritanceSwitch.attributes('aria-label')).toBe('Link inheritance');
 
             // restore inheritance
-            await inheritanceSwitch.find('.mt-icon').trigger('click');
+            if (config.legacy) {
+                await inheritanceSwitch.find('.mt-icon').trigger('click');
+            } else {
+                await inheritanceSwitch.trigger('click');
+            }
 
             // check if inheritance switch is not inherit anymore
             field = wrapper.find(`.sw-system-config--field-${kebabCase(name)}`);


### PR DESCRIPTION
### 1. Why is this change necessary?

The original change fixed one side of the inheritance issue in `sw-system-config`: Meteor inheritance toggles must stay clickable so inherited values can be unlinked/restored again.

However, removing inherited state from the generic `disabled` binding introduced a regression for Meteor-rendered fields like `mt-select` and `mt-colorpicker`. Those fields rely on `disabled` to correctly reflect inherited read-only state.

### 2. What does this change do, exactly?

This restores inherited disabled-state propagation for Meteor-rendered system config fields:

```js
bind.disabled = mapInheritance?.isInherited || element.config?.disabled;
```

This is the Shopware-side follow-up needed so inherited Meteor fields are disabled again while keeping the intended inheritance behavior intact.

### 3. Dependency / blocker information

This PR depends on the upstream Meteor fix for inherited switch fields:

- `shopware/meteor#1102`

That Meteor fix makes sure inherited `mt-switch` fields can remain disabled **without** disabling the inheritance toggle itself.

At the moment, the clean end-to-end fix is blocked until Shopware consumes a Meteor release/version that contains `shopware/meteor#1102`.

Without that upstream version:

- restoring the `disabled` propagation fixes the Jest regression for Meteor select/colorpicker fields
- but inherited Meteor switch fields may still be unable to unlink in the browser

### 4. Describe each step to reproduce the issue or behaviour.

1. Open the administration.
2. Navigate to **Settings > Log-in and sign-up**.
3. Switch to a non-default sales channel.
4. Look at inherited Meteor-rendered config fields.
5. Observe that inherited select/colorpicker-like fields no longer correctly reflect disabled state without this follow-up.

### 5. Please link to the relevant issues (if any).

- closes #15998
- related: #15797
- upstream dependency: `shopware/meteor#1102`