### PR TITLE
fix: restore digital product flag padding

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.scss
@@ -22,7 +22,7 @@
 
     .sw-product-list__digital-indicator {
         height: var(--scale-size-24);
-        padding: var(--scale-size-4) var(--scale-size8);
+        padding: var(--scale-size-4) var(--scale-size-8);
         margin: 0 0 0 var(--scale-size-8);
         min-width: auto;
         vertical-align: middle;


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration product list renders the digital product flag without horizontal padding because the SCSS uses an invalid design token. This regressed the visual spacing of the label and is reported in `#16103`.

### 2. What does this change do, exactly?

It fixes the typo in the product list digital indicator styles by replacing `var(--scale-size8)` with the valid `var(--scale-size-8)` token. That restores the intended horizontal padding for the digital product flag in the Administration list.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a digital product in the Administration.
2. Open `admin#/sw/product/index`.
3. Observe the digital product flag in the product list.
4. Before this change, the label text is flush against the border because the horizontal padding declaration is ignored.

### 4. Please link to the relevant issues (if any).

- closes #16103

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
