### PR TITLE
fix(storefront): stop duplicating robots.txt rules from User-agent

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -43,6 +43,14 @@ This helps merchants spot internal notes directly from the list view without ope
 
 ## Storefront
 
+### `robots.txt` no longer duplicates path rules from custom User-agent blocks
+
+Domain-specific `robots.txt` rules that are written as `User-agent` blocks are now emitted only inside those blocks in the rendered `robots.txt` file.
+Path directives from those blocks are no longer repeated in the preceding unscoped section, which removes duplicate `Allow`/`Disallow` lines when several bots are configured.
+
+If you subscribe to `RobotsPageLoadedEvent` and read `DomainRuleStruct::getDirectives()`, note that this list now contains only directives that appear before the first `User-agent` line in the configuration (the legacy format without an explicit bot block).
+Rules from `User-agent` blocks remain available on `RobotsPage::getGlobalUserAgentBlocks()`.
+
 ### Order cancellation only shown for open orders
 
 The account order cancellation action is now only shown for orders in state `open`.

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -69,12 +69,7 @@ class DomainRuleStruct extends Struct
 
     private function initializeFromParsed(ParsedRobots $parsed): void
     {
-        $allDirectives = array_merge(
-            $parsed->orphanedPathDirectives,
-            ...array_map(static fn (RobotsUserAgentBlock $block) => $block->getPathDirectives(), $parsed->userAgentBlocks)
-        );
-
-        foreach ($allDirectives as $directive) {
+        foreach ($parsed->orphanedPathDirectives as $directive) {
             $directiveWithPath = $directive->withBasePath($this->basePath);
             $this->directives[] = $directiveWithPath;
 

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -197,6 +197,36 @@ class RobotsPageLoaderTest extends TestCase
         static::assertEquals(['https://example.com/sitemap.xml'], $page->getSitemaps());
     }
 
+    public function testLoadWithOrphanedPathDirectivesAndUserAgentBlocks(): void
+    {
+        $request = new Request(server: ['HTTP_HOST' => 'example.com']);
+        $context = Context::createDefaultContext();
+        $salesChannelId = 'test-sales-channel-id';
+
+        $domain = $this->createExampleComDomain($salesChannelId);
+        $domains = [$domain];
+
+        $this->robotsPageLoader = $this->setupLoaderWithDomains($domains, [
+            'core.basicInformation.robotsRules' => "Disallow: /orphan/\n\nUser-agent: Googlebot\nDisallow: /google-only/\n",
+        ]);
+
+        $this->setupEventDispatcherExpectation();
+
+        $page = $this->robotsPageLoader->load($request, $context);
+
+        $domainRule = $page->getDomainRules()->first();
+        static::assertInstanceOf(DomainRuleStruct::class, $domainRule);
+        static::assertCount(1, $domainRule->getDirectives());
+        static::assertSame(RobotsDirectiveType::DISALLOW, $domainRule->getDirectives()[0]->type);
+        static::assertSame('/orphan/', $domainRule->getDirectives()[0]->value);
+
+        static::assertCount(1, $page->getGlobalUserAgentBlocks());
+        static::assertSame('Googlebot', $page->getGlobalUserAgentBlocks()[0]->userAgent);
+        static::assertCount(1, $page->getGlobalUserAgentBlocks()[0]->directives);
+        static::assertSame(RobotsDirectiveType::DISALLOW, $page->getGlobalUserAgentBlocks()[0]->directives[0]->type);
+        static::assertSame('/google-only/', $page->getGlobalUserAgentBlocks()[0]->directives[0]->value);
+    }
+
     public function testLoadWithHttpAndHttpsDomains(): void
     {
         $request = new Request(server: ['HTTP_HOST' => 'example.com']);
@@ -319,7 +349,7 @@ class RobotsPageLoaderTest extends TestCase
         $this->assertDirectivePaths($directives, RobotsDirectiveType::DISALLOW, ['/account/', '/en/private/']);
         $this->assertDirectivePaths($directives, RobotsDirectiveType::ALLOW, ['/en/api/', '/widgets/']);
 
-        // Domain rules should still exist but only contain the path directives for each domain
+        // Domain rules still exist per matched domain; path directives live only in User-agent blocks
         $domainRules = $page->getDomainRules();
         $firstDomainRule = $domainRules->first();
         $secondDomainRule = $domainRules->last();
@@ -330,8 +360,8 @@ class RobotsPageLoaderTest extends TestCase
         static::assertSame('', $firstDomainRule->getBasePath());
         static::assertSame('/en', $secondDomainRule->getBasePath());
 
-        static::assertCount(2, $firstDomainRule->getDirectives());
-        static::assertCount(2, $secondDomainRule->getDirectives());
+        static::assertCount(0, $firstDomainRule->getDirectives());
+        static::assertCount(0, $secondDomainRule->getDirectives());
     }
 
     public function testLoadWithUserAgentBlocksOnlyNonPathDirectives(): void
@@ -407,8 +437,15 @@ class RobotsPageLoaderTest extends TestCase
         $this->assertDirectivePaths($directives, RobotsDirectiveType::DISALLOW, ['/account/', '/en/private/']);
         $this->assertDirectivePaths($directives, RobotsDirectiveType::ALLOW, ['/en/api/', '/widgets/']);
 
-        // Domain rules should also exist with the same path directives
-        static::assertCount(2, $page->getDomainRules());
+        $domainRules = $page->getDomainRules();
+        static::assertCount(2, $domainRules);
+
+        $firstDomainRule = $domainRules->first();
+        $lastDomainRule = $domainRules->last();
+        static::assertNotNull($firstDomainRule);
+        static::assertNotNull($lastDomainRule);
+        static::assertCount(0, $firstDomainRule->getDirectives());
+        static::assertCount(0, $lastDomainRule->getDirectives());
     }
 
     public function testLoadWithMultipleDifferentUserAgentBlocks(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Custom `robots.txt` rules that use several `User-agent` blocks were merged incorrectly: every `Allow`/`Disallow` from those blocks was also emitted once in the unscoped section at the top of the file. That produced duplicate lines (for example five times `Allow: /` for five bots) and could attach bot-specific paths to the wrong scope when default rules still printed `User-agent: *` first. See GitHub issue #16099.

### 2. What does this change do, exactly?

`DomainRuleStruct` now fills `getDirectives()` only from `ParsedRobots::orphanedPathDirectives` (path directives that appear in the admin text before the first `User-agent:` line). Path directives that belong to a `User-agent` block are no longer duplicated into that list; they stay only on `RobotsPage::getGlobalUserAgentBlocks()`, which the storefront template already renders after the flat section.

Unit tests were updated, a regression test was added for mixed orphan plus `User-agent` input, and `RELEASE_INFO-6.7.md` documents the behaviour for subscribers to `RobotsPageLoadedEvent`.

### 3. Describe each step to reproduce the issue or behaviour.

**Previous bug**

1. Administration: Settings → Basic information, pick a storefront sales channel.
2. Enable “Disable default robots.txt rules”.
3. In “Domain specific robots.txt rules”, paste several blocks such as `User-agent: Googlebot-Image`, `Allow: /`, then the same for other user agents (see issue).
4. Save, clear HTTP cache, open `https://your-domain/robots.txt`.
5. Observe repeated `Allow: /` (and other path lines) in the block above the `User-agent:` lines, once per configured bot block.

**After this PR**

Repeat steps 1–4. The repeated lines in the unscoped section are gone; each path rule from a `User-agent` block appears only under that bot’s block. Orphan lines (paths before the first `User-agent:`) still appear in the flat section as before.

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/16099

### What changes for developers and what is no longer possible

**Observable `robots.txt` output**

- You no longer get duplicate path directives in the first (unscoped) section that were only meant for specific crawlers inside `User-agent` blocks.
- Relying on “the same path directive printed twice” (flat section plus `User-agent` block) is no longer possible; that was a bug, not a supported feature.

**PHP / events**

- Code that reads `DomainRuleStruct::getDirectives()` (or the `page.domainRules` Twig loop) and expects it to contain **every** `Allow`/`Disallow` from the admin textarea, including lines that sit under `User-agent:` in the config, must be updated: those directives are only on `RobotsPage::getGlobalUserAgentBlocks()` now. Orphan-only configs are unchanged.

**Still supported**

- Legacy-style rules with only `Disallow:` / `Allow:` lines and no `User-agent:` block (orphaned directives): still rendered in the flat section with sales channel base path applied.
- Mix of orphans first, then `User-agent` blocks: orphans stay in the flat section; bot-specific lines stay under each `User-agent`.

### Example robots.txt (conceptual before / after)

Admin textarea (same in both cases; “defaults disabled” as in the issue):

    User-agent: Googlebot-Image
    Allow: /

    User-agent: Googlebot
    Allow: /

    User-agent: AdsBot-Google
    Allow: /

**Before (excerpt of rendered file)** — flat section wrongly repeated every block’s `Allow: /`:

    Disallow: /account/
    Disallow: /checkout/
    Disallow: /widgets/
    Allow: /widgets/cms/
    Allow: /widgets/menu/offcanvas
    Allow: /
    Allow: /
    Allow: /
    User-agent: Googlebot-Image
    Allow: /
    User-agent: Googlebot
    Allow: /
    User-agent: AdsBot-Google
    Allow: /
    Sitemap: https://example.com/sitemap.xml

**After (same excerpt)** — only real orphans in the flat section; each `Allow: /` for a bot appears once under that bot:

    Disallow: /account/
    Disallow: /checkout/
    Disallow: /widgets/
    Allow: /widgets/cms/
    Allow: /widgets/menu/offcanvas

    User-agent: Googlebot-Image
    Allow: /
    User-agent: Googlebot
    Allow: /
    User-agent: AdsBot-Google
    Allow: /
    Sitemap: https://example.com/sitemap.xml

(Exact default lines depend on staging flag and other config; the important difference is the removal of the repeated `Allow: /` lines that only came from flattening `User-agent` blocks.)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
