### PR TITLE
fix(admin): enable download of private media files from media manager

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -72,6 +72,14 @@ export default {
             return this.repositoryFactory.create('media');
         },
 
+        downloadUrl() {
+            if (this.item?.private || !this.item?.url) {
+                return `${Context.api.apiPath}/_action/media/${this.item.id}/download`;
+            }
+
+            return this.item.url;
+        },
+
         isMediaObject() {
             return this.item.type === 'media';
         },
@@ -250,7 +258,7 @@ export default {
         async copyLinkToClipboard() {
             if (this.item) {
                 try {
-                    await dom.copyStringToClipboard(this.item.url);
+                    await dom.copyStringToClipboard(this.downloadUrl);
                     this.createNotificationSuccess({
                         message: this.$t('sw-media.general.notification.urlCopied.message'),
                     });

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
@@ -50,7 +50,7 @@
                     class="sw-media-sidebar__quickaction quickaction--download"
                 >
                     <sw-external-link
-                        :href="item.url"
+                        :href="downloadUrl"
                         download
                     >
 

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -168,6 +168,8 @@
             <argument type="service" id="Shopware\Core\Content\Media\File\FileNameProvider"/>
             <argument type="service" id="Shopware\Core\Content\Media\MediaDefinition"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Media\File\FileLoader"/>
+            <argument type="service" id="media.repository"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/src/Core/Content/Media/Api/MediaUploadController.php
+++ b/src/Core/Content/Media/Api/MediaUploadController.php
@@ -3,20 +3,26 @@
 namespace Shopware\Core\Content\Media\Api;
 
 use Shopware\Core\Content\Media\Event\MediaUploadedEvent;
+use Shopware\Core\Content\Media\File\FileLoader;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\FileSaver;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -27,12 +33,17 @@ class MediaUploadController extends AbstractController
     /**
      * @internal
      */
+    /**
+     * @param EntityRepository<MediaCollection> $mediaRepository
+     */
     public function __construct(
         private readonly MediaService $mediaService,
         private readonly FileSaver $fileSaver,
         private readonly FileNameProvider $fileNameProvider,
         private readonly MediaDefinition $mediaDefinition,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly FileLoader $fileLoader,
+        private readonly EntityRepository $mediaRepository,
     ) {
     }
 
@@ -86,6 +97,43 @@ class MediaUploadController extends AbstractController
         $this->fileSaver->renameMedia($mediaId, $destination, $context);
 
         return $responseFactory->createRedirectResponse($this->mediaDefinition, $mediaId, $request, $context);
+    }
+
+    #[Route(path: '/api/_action/media/{mediaId}/download', name: 'api.action.media.download', methods: ['GET'])]
+    public function download(string $mediaId, Context $context): Response
+    {
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->first();
+
+        if ($media === null) {
+            throw MediaException::mediaNotFound($mediaId);
+        }
+
+        $stream = $this->fileLoader->loadMediaFileStream($mediaId, $context);
+
+        $fileName = $media->getFileName() . '.' . $media->getFileExtension();
+        $contentType = $media->getMimeType() ?? 'application/octet-stream';
+
+        $disposition = HeaderUtils::makeDisposition(
+            HeaderUtils::DISPOSITION_ATTACHMENT,
+            $fileName,
+            $media->getFileName() . '.' . $media->getFileExtension()
+        );
+
+        return new StreamedResponse(function () use ($stream): void {
+            $resource = $stream->detach();
+            if (!\is_resource($resource)) {
+                return;
+            }
+            $outputStream = fopen('php://output', 'wb');
+            if ($outputStream === false) {
+                return;
+            }
+            stream_copy_to_stream($resource, $outputStream);
+            fclose($outputStream);
+        }, Response::HTTP_OK, [
+            'Content-Type' => $contentType,
+            'Content-Disposition' => $disposition,
+        ]);
     }
 
     #[Route(path: '/api/_action/media/provide-name', name: 'api.action.media.provide-name', methods: ['GET'])]

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -6,14 +6,17 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Api\MediaUploadController;
+use Shopware\Core\Content\Media\File\FileLoader;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\FileSaver;
 use Shopware\Core\Content\Media\File\MediaFile;
+use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Api\Response\ResponseFactoryInterface;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -81,7 +84,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $mediaUploadController->upload($request, $mediaId, $context, $this->responseFactory);
@@ -104,7 +109,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $mediaUploadController->renameMediaFile($request, $mediaId, $context, $this->responseFactory);
@@ -131,7 +138,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $mediaUploadController->provideName($request, $context);
@@ -151,7 +160,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->renameMediaFile($request, $mediaId, $context, $this->responseFactory);
@@ -170,7 +181,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->provideName($request, $context);
@@ -189,7 +202,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->provideName($request, $context);
@@ -207,7 +222,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->upload(new Request(), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
@@ -225,7 +242,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->upload(new Request(['fileName' => 'test.png']), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
@@ -243,7 +262,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->renameMediaFile(new Request([], ['fileName' => 'test.png']), Uuid::randomHex(), Context::createDefaultContext(), $this->responseFactory);
@@ -261,7 +282,9 @@ class MediaUploadControllerTest extends TestCase
             $this->fileSaver,
             $this->fileNameProvider,
             new MediaDefinition(),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(FileLoader::class),
+            $this->createMock(EntityRepository::class),
         );
 
         $controller->provideName(new Request(['fileName' => 'test.png', 'extension' => 'png']), Context::createDefaultContext());


### PR DESCRIPTION
## Summary
- Add `GET /api/_action/media/{mediaId}/download` endpoint that streams file content from both public and private filesystems via `FileLoader`.
- Update admin media manager quickinfo component to use this endpoint for private media (e.g. product downloads) while keeping the direct URL for public media.
- Fix `copyLinkToClipboard` to also use the download URL for private media.

## Changed files
- `src/Core/Content/Media/Api/MediaUploadController.php` — new `download()` route with `StreamedResponse`
- `src/Core/Content/DependencyInjection/media.xml` — inject `FileLoader` and `media.repository`
- `src/Administration/.../sw-media-quickinfo/index.js` — added `downloadUrl` computed property
- `src/Administration/.../sw-media-quickinfo/sw-media-quickinfo.html.twig` — use `downloadUrl`
- `tests/unit/.../MediaUploadControllerTest.php` — updated constructor calls for new dependencies

## Environment needs
- No admin/storefront build needed (runtime JS)
- No DB reset needed

## Test plan
- [ ] Upload a product download file (creates private media)
- [ ] Navigate to media manager → open the product downloads folder
- [ ] Click file in sidebar → click "Download" quick action → verify file downloads correctly
- [ ] Click "Copy link" → verify correct URL is copied
- [ ] Verify public media download still works unchanged
- [ ] Unit tests pass: 10 tests, 29 assertions (MediaUploadControllerTest)

## Review
- Independent review verdict: **PASS with CONCERNS** (addressed — ACL consistent with existing patterns; copyLinkToClipboard fixed)

## Flow Builder Impact
- None detected