### PR TITLE
fix: set correct position when adding media via bulk edit

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/product/sw-bulk-edit-product-media/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/product/sw-bulk-edit-product-media/index.js
@@ -108,6 +108,7 @@ export default {
 
             const newMedia = this.productMediaRepository.create(Shopware.Context.api);
             newMedia.mediaId = media.id;
+            newMedia.position = this.product.media.length + 1;
             newMedia.media = {
                 url: media.url,
                 id: media.id,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-base.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-base.handler.js
@@ -239,6 +239,10 @@ class BulkEditBaseHandler {
             editableProperties.push(mappingReferenceField);
         }
 
+        // Subclasses may decorate each newly built record, e.g. to assign a per-entity position.
+        // Returns null when there is nothing to decorate.
+        const decorateRecord = this._getOneToManyRecordDecorator(change, existAssociations);
+
         changeItems.forEach((changeItem) => {
             const original = changeItem;
             // Clean non-editable fields
@@ -266,6 +270,10 @@ class BulkEditBaseHandler {
                     delete this.groupedPayload.delete[referenceEntity][key];
                 }
 
+                if (decorateRecord) {
+                    decorateRecord(record, entityId);
+                }
+
                 const actualChange = this._getOneToManyChange(record, localKey, mappingReferenceField, association);
 
                 if (actualChange === null || Object.keys(actualChange).length === 0) {
@@ -276,6 +284,16 @@ class BulkEditBaseHandler {
                 this.groupedPayload.upsert[referenceEntity][key].push(actualChange);
             });
         });
+    }
+
+    /**
+     * @private
+     *
+     * Hook for subclasses to decorate each newly built OneToMany record (e.g. assign a per-entity position).
+     * Returns a `(record, entityId) => void` callback, or null when no decoration is needed.
+     */
+    _getOneToManyRecordDecorator() {
+        return null;
     }
 
     /**

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
@@ -337,6 +337,56 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
 
         return price;
     }
+
+    /**
+     * @private
+     *
+     * Bulk-adding media must append each image after the product's own existing media, so the position is
+     * computed per product as the highest existing position + 1, instead of sharing a single value across all
+     * selected products. Using the highest existing position (not the count) keeps it collision-free even when
+     * a product's positions are non-contiguous, e.g. images at positions 1 and 3 get the new image at 4.
+     */
+    _getOneToManyRecordDecorator(change, existAssociations) {
+        if (change.referenceEntity !== 'product_media' || change.type !== 'add') {
+            return null;
+        }
+
+        const nextPositionByEntity = {};
+        this.entityIds.forEach((entityId) => {
+            nextPositionByEntity[entityId] = this._maxMediaPosition(existAssociations, change.referenceKey, entityId) + 1;
+        });
+
+        return (record, entityId) => {
+            record.position = nextPositionByEntity[entityId];
+            nextPositionByEntity[entityId] += 1;
+        };
+    }
+
+    /**
+     * @private
+     *
+     * Highest media position currently stored for a product, derived from the prefetched associations.
+     * Returns -1 when the product has no media yet, so the first appended image starts at position 0.
+     */
+    _maxMediaPosition(existAssociations, referenceKey, entityId) {
+        let maxPosition = -1;
+
+        Object.values(existAssociations).forEach((associations) => {
+            associations.forEach((association) => {
+                if (association[referenceKey] !== entityId) {
+                    return;
+                }
+
+                const position = Number.isFinite(association.position) ? association.position : 0;
+
+                if (position > maxPosition) {
+                    maxPosition = position;
+                }
+            });
+        });
+
+        return maxPosition;
+    }
 }
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.spec.js
@@ -677,14 +677,17 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
                             {
                                 productId: 'product_1',
                                 mediaId: 'media_1',
+                                position: 1,
                             },
                             {
                                 productId: 'product_2',
                                 mediaId: 'media_1',
+                                position: 0,
                             },
                             {
                                 productId: 'product_2',
                                 mediaId: 'media_2',
+                                position: 1,
                             },
                         ],
                     },
@@ -1097,6 +1100,7 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
                             .map((v, k) => ({
                                 productId: 'product_1',
                                 mediaId: `media_${k}`,
+                                position: k,
                             })),
                     },
                 },
@@ -1373,6 +1377,9 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
                         id: {
                             type: 'uuid',
                         },
+                        position: {
+                            type: 'int',
+                        },
                         media: {
                             type: 'association',
                             relation: 'many_to_one',
@@ -1454,6 +1461,85 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
             expect(await handler.buildBulkSyncPayload(input)).toEqual(output);
 
             spy.mockRestore();
+
+            spyRepository.mockRestore();
+        });
+
+        it('appends bulk-added media at each product own next position', async () => {
+            // Scenario: product_1 & product_2 have 2 images (positions 1, 2), product_3 has 3 images
+            // (positions 1, 2, 3). Adding one image via bulk edit must append it at position 3 for product_1 and
+            // product_2, but at position 4 for product_3 - a per-product position, not a single shared one.
+            const scopedHandler = getBulkEditProductHandler();
+            scopedHandler.groupedPayload = { upsert: {}, delete: {} };
+            scopedHandler.entityName = 'product';
+            scopedHandler.entityIds = [
+                'product_1',
+                'product_2',
+                'product_3',
+            ];
+
+            Shopware.EntityDefinition = EntityDefinitionFactory;
+            Shopware.EntityDefinition.add('product', {
+                entity: 'product',
+                properties: {
+                    id: { type: 'uuid' },
+                    media: {
+                        type: 'association',
+                        relation: 'one_to_many',
+                        entity: 'product_media',
+                        localField: 'id',
+                        referenceField: 'productId',
+                    },
+                },
+            });
+            Shopware.EntityDefinition.add('product_media', {
+                entity: 'product_media',
+                properties: {
+                    id: { type: 'uuid' },
+                    position: { type: 'int' },
+                    media: { type: 'association', relation: 'many_to_one', entity: 'media' },
+                },
+            });
+            Shopware.EntityDefinition.add('media', {
+                entity: 'media',
+                properties: { id: { type: 'uuid' } },
+            });
+
+            const existingMedia = [
+                { id: 'pm_1_1', productId: 'product_1', mediaId: 'media_a', position: 1 },
+                { id: 'pm_1_2', productId: 'product_1', mediaId: 'media_b', position: 2 },
+                { id: 'pm_2_1', productId: 'product_2', mediaId: 'media_a', position: 1 },
+                { id: 'pm_2_2', productId: 'product_2', mediaId: 'media_b', position: 2 },
+                { id: 'pm_3_1', productId: 'product_3', mediaId: 'media_a', position: 1 },
+                { id: 'pm_3_2', productId: 'product_3', mediaId: 'media_b', position: 2 },
+                { id: 'pm_3_3', productId: 'product_3', mediaId: 'media_c', position: 3 },
+            ];
+
+            const spyRepository = jest.spyOn(scopedHandler.repositoryFactory, 'create').mockImplementation(() => {
+                return {
+                    search: async (criteria) => {
+                        const response = paginate(existingMedia, criteria);
+                        response.total = existingMedia.length;
+
+                        return Promise.resolve(response);
+                    },
+                };
+            });
+
+            const payload = await scopedHandler.buildBulkSyncPayload([
+                {
+                    type: 'add',
+                    field: 'media',
+                    mappingReferenceField: 'mediaId',
+                    value: [{ mediaId: 'media_new' }],
+                },
+            ]);
+
+            expect(payload['upsert-product_media'].payload).toEqual([
+                { productId: 'product_1', mediaId: 'media_new', position: 3 },
+                { productId: 'product_2', mediaId: 'media_new', position: 3 },
+                { productId: 'product_3', mediaId: 'media_new', position: 4 },
+            ]);
 
             spyRepository.mockRestore();
         });


### PR DESCRIPTION
## Summary
- Set `position` on new `product_media` entities in bulk edit `addMedia()` method, matching the pattern used by the normal product detail form.

Fixes #5393

## Test plan
- [ ] Add two images to a product with positions 1 & 2
- [ ] Use bulk edit to add a third image
- [ ] Verify the third image gets position 3 (not 1)

## Flow Builder Impact
- None