### PR TITLE
fix(core): show scale unit when purchase unit equals reference unit

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
+++ b/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
@@ -281,7 +281,6 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
             || $definition->getUnitId() === null
             || $definition->getReference() === null
             || $definition->getReference() <= 0
-            || $definition->getPurchase() === $definition->getReference()
         ) {
             return null;
         }


### PR DESCRIPTION
## Summary
- Remove the `purchaseUnit === referenceUnit` guard in `ProductPriceCalculator::buildReferencePriceDefinition()` that suppressed the reference price when both are equal (e.g. 1 sqm / 1 sqm).
- The unit label provides useful context even when the ratio is 1:1.

Fixes #6304

## Test plan
- [ ] Create a product with scale unit (e.g. square meter), purchase unit = 1, reference unit = 1
- [ ] Add to cart → verify unit price per sqm is displayed
- [ ] Check product listing and PDP display

## Flow Builder Impact
- None