### PR TITLE
fix: missing reference content with one row advanced pricing

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -161,8 +161,8 @@
                                     </span>
                                 {% endblock %}
 
-                                {% if product.calculatedPrices|length == 0 %}
-                                    {% set price = product.calculatedPrice %}
+                                {% if product.calculatedPrices|length <= 1 %}
+                                    {% set price = product.calculatedPrices.first ?? product.calculatedPrice %}
 
                                     {% if price.referencePrice is not null %}
                                         {% block buy_widget_price_unit_reference_content %}


### PR DESCRIPTION
### 1. Why is this change necessary?

When a product has exactly one advanced price row, the buy widget still reads its reference content from `product.calculatedPrice` only for the `calculatedPrices|length == 0` case. In the one-row advanced pricing case, the effective price data comes from `product.calculatedPrices.first`, so the reference content is missing on the storefront product detail page.

### 2. What does this change do, exactly?

This change aligns the reference content handling in `buy-widget.html.twig` with the existing single-price rendering logic:

- treat `product.calculatedPrices|length <= 1` as the single-price case
- resolve the price from `product.calculatedPrices.first ?? product.calculatedPrice`
- render the reference content from that resolved price

That keeps the existing behavior for products without advanced pricing and restores the missing reference content for products with exactly one advanced price row.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or edit a product with purchase unit / reference price data.
2. Add exactly one advanced price row to the product.
3. Open the product detail page in the storefront.
4. Check the buy widget price unit area.

Before this change, the reference content is missing.
After this change, the reference content is rendered again for the one-row advanced pricing case.

### 4. Please link to the relevant issues (if any).

- closes #16253

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
