### PR TITLE
ci: audits only for changed projects plus nightly audit issues

### DIFF
--- a/.github/bin/js/README.md
+++ b/.github/bin/js/README.md
@@ -11,7 +11,8 @@ Central registry of all package.json files with utilities for validation and mat
 - `npx esno package-discovery.ts list` - List all tracked package.json files
 - `npx esno package-discovery.ts find` - Find all package.json files in repository
 - `npx esno package-discovery.ts validate` - Validate all found files are tracked
-- `npx esno package-discovery.ts matrix` - Generate GitHub Actions matrix
+- `npx esno package-discovery.ts matrix` - Generate the full GitHub Actions matrix
+- `npx esno package-discovery.ts matrix --changed-files-file <path>` - Generate a filtered matrix for tracked packages touched by changed manifests, lockfiles, or audit scripts
 
 ### `check-pinned-dependencies.ts`
 Validates that all dependencies use exact versions (no `^` or `~` prefixes).
@@ -23,6 +24,8 @@ npx esno check-pinned-dependencies.ts
 
 ### `run-npm-audit.ts`
 Shared audit logic used by per-project `scripts/runNpmAudit.ts` wrappers. Exports `runNpmAudit(options)` which runs `npm audit`, filters advisories matching the given GHSA/CVE identifiers, and suggests using `overrides` or adding to the ignore list when vulnerabilities are found.
+
+The script also supports direct execution for projects without package-local wrappers and writes a normalized JSON summary when `NPM_AUDIT_RESULT_FILE` is set. CI uses that result file to aggregate scheduled audit failures into a single GitHub issue update.
 
 Each project with known false-positives or unfixable advisories has a thin `scripts/runNpmAudit.ts` wrapper:
 ```typescript
@@ -64,7 +67,9 @@ The workflow automatically:
 
 - **Package Completeness**: Ensures all package.json files are tracked
 - **Dependency Pinning**: Validates all dependencies use exact versions
-- **Security Audits**: Runs npm audit on all packages in parallel
-- **Dynamic Scaling**: New packages are automatically included in all checks
+- **Security Audits**: Runs changed-package audits for PRs and pushes to `trunk`
+- **Full Scheduled Audits**: Runs all package audits for scheduled and manual executions
+- **Issue Reporting**: Creates or updates one GitHub issue when a scheduled audit fails
+- **Dynamic Scaling**: New packages are automatically included once added to the registry
 
 No manual workflow updates needed - just update the package list!

--- a/.github/bin/js/aggregate-npm-audit-results.ts
+++ b/.github/bin/js/aggregate-npm-audit-results.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+interface FixAvailable {
+  name: string;
+  version: string;
+  isSemVerMajor: boolean;
+}
+
+interface RootAdvisory {
+  ghsa: string | null;
+  title: string;
+  severity: string;
+  url: string;
+  packageName: string;
+  range: string;
+  affectedPackages: string[];
+  fixAvailable: false | FixAvailable;
+}
+
+interface AuditExecutionResult {
+  packageName: string;
+  workingDirectory: string;
+  ignoredCount: number;
+  status: 'passed' | 'failed';
+  advisoryCount: number;
+  advisories: RootAdvisory[];
+  error?: string;
+}
+
+interface IssuePayload {
+  issueTitle: string;
+  issueBody: string;
+  commentBody: string;
+}
+
+const ISSUE_TITLE = 'Nightly npm audit failures';
+const ISSUE_MARKER = '<!-- nightly-npm-audit-failures -->';
+
+function collectJsonFiles(directory: string): string[] {
+  const entries = readdirSync(directory, { withFileTypes: true });
+
+  return entries.flatMap((entry) => {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return collectJsonFiles(fullPath);
+    }
+
+    return entry.isFile() && entry.name.endsWith('.json') ? [fullPath] : [];
+  });
+}
+
+function parseResults(directory: string): AuditExecutionResult[] {
+  const jsonFiles = collectJsonFiles(resolve(directory));
+  return jsonFiles.map((filePath) => JSON.parse(readFileSync(filePath, 'utf8')) as AuditExecutionResult);
+}
+
+function formatAdvisory(advisory: RootAdvisory): string {
+  const advisoryUrl = advisory.ghsa
+    ? `https://github.com/advisories/${advisory.ghsa}`
+    : advisory.url || 'No advisory URL';
+
+  return `- ${advisory.severity}: ${advisory.title} (${advisory.packageName} ${advisory.range}) ${advisoryUrl}`;
+}
+
+function buildReportLines(results: AuditExecutionResult[]): string[] {
+  const failedResults = results
+    .filter((result) => result.status === 'failed')
+    .sort((left, right) => left.packageName.localeCompare(right.packageName));
+
+  if (failedResults.length === 0) {
+    throw new Error('No failed audit results found.');
+  }
+
+  const runUrl = process.env['GITHUB_SERVER_URL'] && process.env['GITHUB_REPOSITORY'] && process.env['GITHUB_RUN_ID']
+    ? `${process.env['GITHUB_SERVER_URL']}/${process.env['GITHUB_REPOSITORY']}/actions/runs/${process.env['GITHUB_RUN_ID']}`
+    : 'GitHub Actions run URL unavailable';
+  const refName = process.env['GITHUB_REF_NAME'] ?? 'unknown-ref';
+  const repository = process.env['GITHUB_REPOSITORY'] ?? 'unknown-repository';
+
+  const lines = [
+    `Repository: ${repository}`,
+    `Ref: ${refName}`,
+    `Run: ${runUrl}`
+  ];
+
+  for (const result of failedResults) {
+    lines.push('');
+    lines.push(`### ${result.packageName}`);
+    lines.push(`Path: \`${result.workingDirectory}\``);
+    if (result.error) {
+      lines.push(`- audit execution failed: ${result.error}`);
+    }
+    result.advisories.forEach((advisory) => lines.push(formatAdvisory(advisory)));
+  }
+
+  return lines;
+}
+
+function buildIssuePayload(results: AuditExecutionResult[]): IssuePayload {
+  const reportLines = buildReportLines(results);
+  const issueBody = [
+    ISSUE_MARKER,
+    '# Nightly npm audit failures',
+    '',
+    'This issue tracks failing scheduled npm audits. New nightly failures are added as comments.',
+    '',
+    'Latest failure:',
+    '',
+    ...reportLines
+  ].join('\n').trimEnd();
+  const commentBody = [
+    ISSUE_MARKER,
+    '## Nightly audit failure update',
+    '',
+    ...reportLines
+  ].join('\n').trimEnd();
+
+  return {
+    issueTitle: ISSUE_TITLE,
+    issueBody,
+    commentBody
+  };
+}
+
+function main(): void {
+  const resultDirectory = process.argv[2];
+  const payloadFile = process.argv[3];
+
+  if (!resultDirectory || !payloadFile) {
+    console.error('Usage: node aggregate-npm-audit-results.ts <result-directory> <payload-file>');
+    process.exit(1);
+  }
+
+  const stats = statSync(resultDirectory, { throwIfNoEntry: false });
+  if (!stats || !stats.isDirectory()) {
+    console.error(`Audit result directory not found: ${resultDirectory}`);
+    process.exit(1);
+  }
+
+  const results = parseResults(resultDirectory);
+  if (results.length === 0) {
+    console.error(`No audit result JSON files found in ${resultDirectory}`);
+    process.exit(1);
+  }
+
+  const payload = buildIssuePayload(results);
+
+  writeFileSync(payloadFile, `${JSON.stringify(payload)}\n`, 'utf8');
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/.github/bin/js/package-discovery.ts
+++ b/.github/bin/js/package-discovery.ts
@@ -8,6 +8,21 @@ interface PackageInfo {
   hasCustomAuditScript?: boolean;
 }
 
+interface AuditMatrixEntry {
+  name: string;
+  path: string;
+  workingDirectory: string;
+  hasCustomAuditScript: boolean;
+  customAuditScriptPath: string | null;
+  artifactName: string;
+}
+
+const FULL_AUDIT_TRIGGER_FILES = new Set([
+  // Changes to shared audit behavior or package registry should re-run audits for every tracked package.
+  '.github/bin/js/run-npm-audit.ts',
+  '.github/bin/js/package-discovery.ts'
+]);
+
 /**
  * Expected package.json files that should be audited with their metadata
  */
@@ -72,6 +87,33 @@ export function getWorkingDirectoryFromPath(packageJsonPath: string): string {
   return packageJsonPath.replace('/package.json', '');
 }
 
+export function getPackageLockPath(packageJsonPath: string): string {
+  return packageJsonPath.replace('/package.json', '/package-lock.json');
+}
+
+export function getCustomAuditScriptPath(packageJsonPath: string): string {
+  return `${getWorkingDirectoryFromPath(packageJsonPath)}/scripts/runNpmAudit.ts`;
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/^[.]\//, '');
+}
+
+function getArtifactName(packageJsonPath: string): string {
+  return `npm-audit-${normalizePath(getWorkingDirectoryFromPath(packageJsonPath)).replace(/[^a-zA-Z0-9]+/g, '-')}`;
+}
+
+function toAuditMatrixEntry(pkg: PackageInfo): AuditMatrixEntry {
+  return {
+    name: pkg.name,
+    path: pkg.path,
+    workingDirectory: getWorkingDirectoryFromPath(pkg.path),
+    hasCustomAuditScript: pkg.hasCustomAuditScript || false,
+    customAuditScriptPath: pkg.hasCustomAuditScript ? getCustomAuditScriptPath(pkg.path) : null,
+    artifactName: getArtifactName(pkg.path)
+  };
+}
+
 /**
  * Find all package.json files in the repository
  */
@@ -115,22 +157,53 @@ export function validatePackageCompleteness(): {
 /**
  * Generate GitHub Actions matrix for audit jobs
  */
-export function generateAuditMatrix(): {
-  include: Array<{
-    name: string;
-    path: string;
-    workingDirectory: string;
-    hasCustomAuditScript: boolean;
-  }>;
+export function generateAuditMatrix(changedFiles: string[] = []): {
+  include: AuditMatrixEntry[];
 } {
+  const normalizedChangedFiles = changedFiles
+    .map(file => normalizePath(file.trim()))
+    .filter(Boolean);
+
+  if (
+    normalizedChangedFiles.length === 0 ||
+    normalizedChangedFiles.some(file => FULL_AUDIT_TRIGGER_FILES.has(file))
+  ) {
+    return {
+      include: EXPECTED_PACKAGE_JSON_FILES.map(toAuditMatrixEntry)
+    };
+  }
+
+  const changedFileSet = new Set(normalizedChangedFiles);
+  const filteredPackages = EXPECTED_PACKAGE_JSON_FILES.filter((pkg) => {
+    const packageJsonPath = normalizePath(pkg.path);
+    const packageLockPath = normalizePath(getPackageLockPath(pkg.path));
+
+    if (changedFileSet.has(packageJsonPath) || changedFileSet.has(packageLockPath)) {
+      return true;
+    }
+
+    if (pkg.hasCustomAuditScript) {
+      return changedFileSet.has(normalizePath(getCustomAuditScriptPath(pkg.path)));
+    }
+
+    return false;
+  });
+
   return {
-    include: EXPECTED_PACKAGE_JSON_FILES.map(pkg => ({
-      name: pkg.name,
-      path: pkg.path,
-      workingDirectory: getWorkingDirectoryFromPath(pkg.path),
-      hasCustomAuditScript: pkg.hasCustomAuditScript || false
-    }))
+    include: filteredPackages.map(toAuditMatrixEntry)
   };
+}
+
+function readChangedFilesFromFile(filePath: string): string[] {
+  try {
+    return execSync(`cat "${filePath}"`, { encoding: 'utf8', cwd: process.cwd() })
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read changed files from ${filePath}: ${errorMessage}`);
+  }
 }
 
 /**
@@ -157,7 +230,11 @@ function main(): void {
 
     case 'matrix':
       try {
-        const matrix = generateAuditMatrix();
+        const changedFiles =
+          args[1] === '--changed-files-file' && args[2]
+            ? readChangedFilesFromFile(args[2])
+            : [];
+        const matrix = generateAuditMatrix(changedFiles);
         console.log(JSON.stringify(matrix));
       } catch (error) {
         console.error('Error:', error instanceof Error ? error.message : String(error));
@@ -199,7 +276,7 @@ function main(): void {
       console.log('Commands:');
       console.log('  list     - List expected package.json files');
       console.log('  find     - Find all package.json files in repository');
-      console.log('  matrix   - Generate GitHub Actions matrix for audit jobs');
+      console.log('  matrix [--changed-files-file <path>] - Generate GitHub Actions matrix for audit jobs');
       console.log('  validate - Validate package completeness');
       process.exit(1);
   }

--- a/.github/bin/js/run-npm-audit.ts
+++ b/.github/bin/js/run-npm-audit.ts
@@ -1,8 +1,16 @@
 import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
 export interface NpmAuditOptions {
     ignoredCVEs?: string[];
     ignoredGHSAs?: string[];
+}
+
+interface FixAvailable {
+    name: string;
+    version: string;
+    isSemVerMajor: boolean;
 }
 
 interface AuditVia {
@@ -25,11 +33,7 @@ interface AuditVulnerability {
     effects: string[];
     fixAvailable:
         | boolean
-        | {
-              name: string;
-              version: string;
-              isSemVerMajor: boolean;
-          };
+        | FixAvailable;
 }
 
 interface AuditResult {
@@ -46,11 +50,17 @@ interface RootAdvisory {
     affectedPackages: string[];
     fixAvailable:
         | false
-        | {
-              name: string;
-              version: string;
-              isSemVerMajor: boolean;
-          };
+        | FixAvailable;
+}
+
+interface AuditExecutionResult {
+    packageName: string;
+    workingDirectory: string;
+    ignoredCount: number;
+    status: 'passed' | 'failed';
+    advisoryCount: number;
+    advisories: RootAdvisory[];
+    error?: string;
 }
 
 function extractGHSA(url: string): string | null {
@@ -75,8 +85,7 @@ function fetchAuditReport(): AuditResult {
         if (execErr.stdout) {
             auditRaw = execErr.stdout.toString();
         } else {
-            console.error('Error running npm audit:', execErr.message ?? String(err));
-            process.exit(1);
+            throw new Error(`Error running npm audit: ${execErr.message ?? String(err)}`);
         }
     }
 
@@ -84,8 +93,7 @@ function fetchAuditReport(): AuditResult {
         return JSON.parse(auditRaw) as AuditResult;
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.error('Failed to parse npm audit JSON:', message);
-        process.exit(1);
+        throw new Error(`Failed to parse npm audit JSON: ${message}`);
     }
 }
 
@@ -264,6 +272,24 @@ function printSuggestions(advisories: RootAdvisory[]): void {
     }
 }
 
+function getAuditPackageName(): string {
+    return process.env['NPM_AUDIT_PACKAGE_NAME'] ?? process.cwd().split('/').pop() ?? 'unknown-package';
+}
+
+function getAuditWorkingDirectory(): string {
+    return process.env['NPM_AUDIT_WORKING_DIRECTORY'] ?? process.cwd();
+}
+
+function writeAuditResult(result: AuditExecutionResult): void {
+    const resultFile = process.env['NPM_AUDIT_RESULT_FILE'];
+    if (!resultFile) {
+        return;
+    }
+
+    mkdirSync(dirname(resultFile), { recursive: true });
+    writeFileSync(resultFile, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+}
+
 /**
  * Run npm audit in the current working directory, filtering out advisories
  * matching the given GHSA and CVE identifiers.
@@ -275,24 +301,61 @@ export function runNpmAudit(options: NpmAuditOptions = {}): void {
     );
     const ignoredCVEs = new Set(options.ignoredCVEs ?? []);
     const totalIgnored = ignoredGHSAs.size + ignoredCVEs.size;
+    const packageName = getAuditPackageName();
+    const workingDirectory = getAuditWorkingDirectory();
 
-    const audit = fetchAuditReport();
-    filterIgnored(audit, ignoredGHSAs, ignoredCVEs);
+    try {
+        const audit = fetchAuditReport();
+        filterIgnored(audit, ignoredGHSAs, ignoredCVEs);
 
-    const remaining = Object.values(audit.vulnerabilities).filter(
-        (pkg) => Array.isArray(pkg.via) && pkg.via.length > 0,
-    );
+        const remaining = Object.values(audit.vulnerabilities).filter(
+            (pkg) => Array.isArray(pkg.via) && pkg.via.length > 0,
+        );
 
-    // Only remaining vulnerabilities block the pipeline. Advisories are
-    // printed for visibility but intentionally do not cause a failure, so
-    // newly published advisories don't immediately break unrelated PRs.
-    if (remaining.length === 0) {
-        console.log(`No vulnerabilities (${totalIgnored} ignored).`);
-        return;
+        // Only remaining vulnerabilities block the pipeline. Advisories are
+        // printed for visibility but intentionally do not cause a failure, so
+        // newly published advisories don't immediately break unrelated PRs.
+        if (remaining.length === 0) {
+            writeAuditResult({
+                packageName,
+                workingDirectory,
+                ignoredCount: totalIgnored,
+                status: 'passed',
+                advisoryCount: 0,
+                advisories: [],
+            });
+            console.log(`No vulnerabilities (${totalIgnored} ignored).`);
+            return;
+        }
+
+        const advisories = buildRootAdvisories(audit);
+        writeAuditResult({
+            packageName,
+            workingDirectory,
+            ignoredCount: totalIgnored,
+            status: 'failed',
+            advisoryCount: advisories.length,
+            advisories,
+        });
+        printAdvisories(advisories, remaining.length);
+        printSuggestions(advisories);
+        process.exit(1);
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        writeAuditResult({
+            packageName,
+            workingDirectory,
+            ignoredCount: totalIgnored,
+            status: 'failed',
+            advisoryCount: 0,
+            advisories: [],
+            error: message,
+        });
+        console.error(message);
+        process.exit(1);
     }
+}
 
-    const advisories = buildRootAdvisories(audit);
-    printAdvisories(advisories, remaining.length);
-    printSuggestions(advisories);
-    process.exit(1);
+if (import.meta.url === `file://${process.argv[1]}`) {
+    runNpmAudit();
 }

--- a/.github/bin/js/run-npm-audit.ts
+++ b/.github/bin/js/run-npm-audit.ts
@@ -63,6 +63,11 @@ interface AuditExecutionResult {
     error?: string;
 }
 
+interface PresentIdentifiers {
+    ghsas: Set<string>;
+    cves: Set<string>;
+}
+
 function extractGHSA(url: string): string | null {
     const match = url.match(/(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})/);
     return match?.[1] ?? null;
@@ -112,6 +117,65 @@ function isIgnored(via: AuditVia, ignoredGHSAs: Set<string>, ignoredCVEs: Set<st
     }
 
     return false;
+}
+
+function collectPresentIdentifiers(audit: AuditResult): PresentIdentifiers {
+    const ghsas = new Set<string>();
+    const cves = new Set<string>();
+
+    for (const pkg of Object.values(audit.vulnerabilities)) {
+        if (!pkg || !Array.isArray(pkg.via)) {
+            continue;
+        }
+
+        for (const via of pkg.via) {
+            if (typeof via !== 'object') {
+                continue;
+            }
+
+            const ghsa = via.url ? extractGHSA(via.url) : null;
+            if (ghsa) {
+                ghsas.add(ghsa);
+            }
+
+            for (const cve of extractCVEs(via)) {
+                cves.add(cve);
+            }
+        }
+    }
+
+    return { ghsas, cves };
+}
+
+function printUnusedIgnores(
+    presentIdentifiers: PresentIdentifiers,
+    ignoredGHSAs: Set<string>,
+    ignoredCVEs: Set<string>,
+): void {
+    const unusedGHSAs = [...ignoredGHSAs].filter((ghsa) => !presentIdentifiers.ghsas.has(ghsa));
+    const unusedCVEs = [...ignoredCVEs].filter((cve) => !presentIdentifiers.cves.has(cve));
+
+    if (unusedGHSAs.length === 0 && unusedCVEs.length === 0) {
+        return;
+    }
+
+    console.warn('--- Cleanup suggestions ---\n');
+
+    if (unusedGHSAs.length > 0) {
+        console.warn('Ignored GHSA entries no longer present in npm audit output:');
+        for (const ghsa of unusedGHSAs) {
+            console.warn(`  - https://github.com/advisories/${ghsa}`);
+        }
+        console.warn('');
+    }
+
+    if (unusedCVEs.length > 0) {
+        console.warn('Ignored CVE entries no longer present in npm audit output:');
+        for (const cve of unusedCVEs) {
+            console.warn(`  - ${cve}`);
+        }
+        console.warn('');
+    }
 }
 
 function filterIgnored(audit: AuditResult, ignoredGHSAs: Set<string>, ignoredCVEs: Set<string>): void {
@@ -306,7 +370,9 @@ export function runNpmAudit(options: NpmAuditOptions = {}): void {
 
     try {
         const audit = fetchAuditReport();
+        const presentIdentifiers = collectPresentIdentifiers(audit);
         filterIgnored(audit, ignoredGHSAs, ignoredCVEs);
+        printUnusedIgnores(presentIdentifiers, ignoredGHSAs, ignoredCVEs);
 
         const remaining = Object.values(audit.vulnerabilities).filter(
             (pkg) => Array.isArray(pkg.via) && pkg.via.length > 0,

--- a/.github/workflows/npm-audit-check.yml
+++ b/.github/workflows/npm-audit-check.yml
@@ -1,5 +1,9 @@
 name: Audit check for NPM packages
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   workflow_dispatch:
   schedule:
@@ -12,6 +16,7 @@ on:
       - "**/package-lock.json"
       - "**/scripts/runNpmAudit.ts"
       - ".github/bin/js/run-npm-audit.ts"
+      - ".github/bin/js/package-discovery.ts"
   pull_request:
     types: [opened, synchronize]
     paths:
@@ -19,6 +24,7 @@ on:
       - "**/package-lock.json"
       - "**/scripts/runNpmAudit.ts"
       - ".github/bin/js/run-npm-audit.ts"
+      - ".github/bin/js/package-discovery.ts"
 
 jobs:
   check-package-completeness:
@@ -55,20 +61,40 @@ jobs:
     name: Generate audit matrix
     needs: [check-package-completeness, check-pinned-dependencies]
     runs-on: ubuntu-latest
+    env:
+      USE_CHANGED_PACKAGE_MATRIX: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+      IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 24
 
+      - name: Collect changed files
+        if: ${{ env.USE_CHANGED_PACKAGE_MATRIX == 'true' }}
+        run: |
+          if [ "${IS_PULL_REQUEST}" = "true" ]; then
+            git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > "$RUNNER_TEMP/npm-audit-changed-files.txt"
+          else
+            git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > "$RUNNER_TEMP/npm-audit-changed-files.txt"
+          fi
+
       - name: Generate matrix
         id: generate-matrix
         run: |
-          matrix=$(node ./.github/bin/js/package-discovery.ts matrix)
+          matrix=$(
+            if [ "${USE_CHANGED_PACKAGE_MATRIX}" = "true" ]; then
+              node ./.github/bin/js/package-discovery.ts matrix --changed-files-file "$RUNNER_TEMP/npm-audit-changed-files.txt"
+            else
+              node ./.github/bin/js/package-discovery.ts matrix
+            fi
+          )
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   audit-packages:
@@ -90,13 +116,92 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: ${{ matrix.workingDirectory }}
+        env:
+          # Keep install output focused on dependency installation. The audit runs explicitly in the next step.
+          NPM_CONFIG_AUDIT: false
 
-      - name: Run audit (standard)
-        if: ${{ !matrix.hasCustomAuditScript }}
-        run: npm audit
+      - name: Run audit
+        env:
+          NPM_AUDIT_PACKAGE_NAME: ${{ matrix.name }}
+          NPM_AUDIT_RESULT_FILE: ${{ runner.temp }}/${{ matrix.artifactName }}/result.json
+          NPM_AUDIT_WORKING_DIRECTORY: ${{ matrix.workingDirectory }}
+        run: |
+          if [ "${{ matrix.hasCustomAuditScript }}" = "true" ]; then
+            node ./scripts/runNpmAudit.ts
+          else
+            node "$GITHUB_WORKSPACE/.github/bin/js/run-npm-audit.ts"
+          fi
         working-directory: ${{ matrix.workingDirectory }}
 
-      - name: Run audit (custom script)
-        if: ${{ matrix.hasCustomAuditScript }}
-        run: node ./scripts/runNpmAudit.ts
-        working-directory: ${{ matrix.workingDirectory }}
+      - name: Upload audit result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # 6.0.0
+        with:
+          name: ${{ matrix.artifactName }}
+          path: ${{ runner.temp }}/${{ matrix.artifactName }}/result.json
+          if-no-files-found: error
+
+  report-scheduled-audit-failures:
+    name: Report scheduled audit failures
+    if: ${{ github.event_name == 'schedule' && needs.audit-packages.result == 'failure' }}
+    needs: audit-packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 24
+
+      - name: Download audit results
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # 4
+        with:
+          path: ${{ runner.temp }}/npm-audit-results
+
+      - name: Build issue payload
+        run: |
+          node ./.github/bin/js/aggregate-npm-audit-results.ts \
+            "$RUNNER_TEMP/npm-audit-results" \
+            "$RUNNER_TEMP/npm-audit-issue-payload.json"
+
+      - name: Create or update audit issue
+        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          ISSUE_PAYLOAD_FILE: ${{ runner.temp }}/npm-audit-issue-payload.json
+        with:
+          script: |
+            const fs = require('node:fs');
+            const payload = JSON.parse(fs.readFileSync(process.env.ISSUE_PAYLOAD_FILE, 'utf8'));
+            const marker = '<!-- nightly-npm-audit-failures -->';
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const existingIssue = issues.find((issue) =>
+              issue.title === payload.issueTitle && typeof issue.body === 'string' && issue.body.includes(marker)
+            );
+
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body: payload.commentBody,
+              });
+              core.info(`Added comment to issue #${existingIssue.number}`);
+              return;
+            }
+
+            const createdIssue = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: payload.issueTitle,
+              body: payload.issueBody,
+            });
+
+            core.info(`Created issue #${createdIssue.data.number}`);

--- a/adr/2025-10-23-pin-npm-dependencies.md
+++ b/adr/2025-10-23-pin-npm-dependencies.md
@@ -27,7 +27,7 @@ Automated CI checks have been implemented to:
 - Validate that no unpinned dependencies exist
 - Block merges if unpinned dependencies are found
 
-These checks run via the `npm-audit-check.yml` workflow on every pull request and push to trunk.
+These checks run via the `npm-audit-check.yml` workflow. Pull requests and pushes to trunk run audits only for tracked packages whose `package.json`, `package-lock.json`, or `scripts/runNpmAudit.ts` changed. Scheduled and manual runs still execute the full audit matrix for all tracked packages, and scheduled audit failures create or update one GitHub issue with the latest affected packages.
 
 ## Consequences
 
@@ -53,4 +53,6 @@ When adding or updating dependencies:
 3. The CI pipeline will reject PRs with unpinned dependencies
 4. Use tools like `npm outdated` to check for available updates
 
+## Updates
 
+- 2025-11-15: PR audit run with pinned dependencies only, not on all npm packages in repository

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -38,7 +38,7 @@
         "date-fns": "2.30.0",
         "date-fns-tz": "2.0.1",
         "debug": "4.4.3",
-        "dompurify": "3.3.2",
+        "dompurify": "^3.4.0",
         "eslint-plugin-listeners": "1.5.1",
         "flatpickr": "4.6.13",
         "fs-extra": "11.3.0",
@@ -11565,9 +11565,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13891,13 +13891,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-      "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "engines": {
-        "node": ">=20"
-      },
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -80,7 +80,7 @@
     "date-fns": "2.30.0",
     "date-fns-tz": "2.0.1",
     "debug": "4.4.3",
-    "dompurify": "3.3.2",
+    "dompurify": "3.4.0",
     "eslint-plugin-listeners": "1.5.1",
     "flatpickr": "4.6.13",
     "fs-extra": "11.3.0",
@@ -253,6 +253,7 @@
       "jest": "$jest"
     },
     "tmp": "0.2.5",
+    "basic-ftp": "^5.3.0",
     "follow-redirects": "1.16.0"
   }
 }

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -449,7 +449,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -467,7 +466,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -478,7 +476,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -499,7 +496,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -855,7 +851,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -877,7 +872,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -900,7 +894,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1229,7 +1222,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1437,7 +1429,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1692,7 +1683,6 @@
     "node_modules/axe-core": {
       "version": "4.11.1",
       "license": "MPL-2.0",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -1715,7 +1705,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
       "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -1851,9 +1840,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2072,7 +2061,6 @@
     "node_modules/commander": {
       "version": "12.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2264,8 +2252,7 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1507524",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2431,7 +2418,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4642,7 +4628,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4685,7 +4670,6 @@
       "version": "1.58.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
       "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -6000,7 +5984,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -36,7 +36,7 @@
     "follow-redirects": "1.16.0",
     "minimatch": "10.2.4",
     "brace-expansion": "5.0.5",
-    "basic-ftp": "5.2.2",
+    "basic-ftp": "^5.3.0",
     "flatted": "3.4.2",
     "defu": "6.1.5",
     "lodash": "4.18.1",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->
Closes #16139 

Refines the npm audit workflow so PRs and trunk pushes only audit changed packages, while scheduled/manual runs still audit all tracked packages. 
On nightly failures, creates or updates a single GitHub issue with the affected packages and advisory links.