### PR TITLE
refactor: Remove leftover SCSS from the address card refactoring

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/page/account/_address.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/account/_address.scss
@@ -1,7 +1,9 @@
 .account-address {
-    .address-action-create .icon {
-        margin-top: 2px;
-        margin-right: $spacer-sm;
+    @if not feature('V6_8_0_0') {
+        .address-action-create .icon {
+            margin-top: 2px;
+            margin-right: $spacer-sm;
+        }
     }
 
     .btn > .icon {

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
@@ -63,7 +63,10 @@ https://sass-guidelin.es/#the-7-1-pattern
 
 @import 'page/account/aside';
 @import 'page/account/register';
-@import 'page/account/address';
+// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore
+@if not feature('V6_8_0_0') {
+    @import 'page/account/address';
+}
 @import 'page/account/profile';
 @import 'page/account/order';
 @import 'page/account/order-detail';

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/_base.scss
@@ -63,10 +63,8 @@ https://sass-guidelin.es/#the-7-1-pattern
 
 @import 'page/account/aside';
 @import 'page/account/register';
-// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore
-@if not feature('V6_8_0_0') {
-    @import 'page/account/address';
-}
+// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore, remove the import `page/account/address`
+@import 'page/account/address';
 @import 'page/account/profile';
 @import 'page/account/order';
 @import 'page/account/order-detail';

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_address.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_address.scss
@@ -1,3 +1,4 @@
+// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore (will not be included in the _base.scss) and the complete file will be removed
 .account-address {
     .address-action-create {
         font-size: 1.1em;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_address.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/page/account/_address.scss
@@ -1,15 +1,17 @@
-// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore (will not be included in the _base.scss) and the complete file will be removed
-.account-address {
-    .address-action-create {
-        font-size: 1.1em;
-        text-align: left;
+// @deprecated tag:v6.8.0 - The components have been removed and the SCSS is not used anymore and the complete file will be removed, also remove the import in the `_base.scss`
+@if not feature('V6_8_0_0') {
+    .account-address {
+        .address-action-create {
+            font-size: 1.1em;
+            text-align: left;
 
-        &:hover {
-            border: $border-width $border-style $border-color;
+            &:hover {
+                border: $border-width $border-style $border-color;
+            }
         }
-    }
 
-    .address-card .card-body .address:first-line {
-        font-weight: $font-weight-bold;
+        .address-card .card-body .address:first-line {
+            font-weight: $font-weight-bold;
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
In 6.6.7 the address card template has been removed, but not the SCSS related to it:
https://github.com/shopware/shopware/blob/604bcc8eb9c577c001c59c2bead59b408f1d50d3/changelog/release-6-6-7-0/2024-08-26-Deprecate-address-card-template.md?plain=1#L9

### 2. What does this change do, exactly?
Deprecate the non used SCSS.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
