### PR TITLE
fix: Fix cannot download media after renaming media

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -92,6 +92,9 @@ The Administration sidebar off-canvas now closes reliably on very small viewport
 Switch and checkbox fields in theme configuration now render and handle inheritance consistently. Before they wouldn't have shown the inheritance switch.
 Also the checkbox field is now positionally aligned with the other components.
 
+### Resolving download errors by renaming media
+When merchants rename a media file, its URL automatically updates so they can download it without issues.
+
 ## Storefront
 
 ## App System

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/index.js
@@ -106,6 +106,10 @@ export default {
                 );
             });
         },
+
+        mediaRepository() {
+            return Shopware.Service('repositoryFactory').create('media');
+        },
     },
 
     methods: {
@@ -119,7 +123,10 @@ export default {
 
             try {
                 await this.mediaService.renameMedia(item.id, updatedName);
-                item.fileName = updatedName;
+                await this.mediaRepository.get(item.id).then((response) => {
+                    Object.assign(item, response);
+                });
+
                 item.isLoading = false;
                 this.createNotificationSuccess({
                     message: this.$t('global.sw-media-media-item.notification.renamingSuccess.message'),

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.spec.js
@@ -78,6 +78,32 @@ describe('components/media/sw-media-media-item', () => {
         Shopware.Store.get('actionButtons').buttons = [];
     });
 
+    it('should update item with repository data after successful rename', async () => {
+        global.activeAclRoles = ['media.editor'];
+
+        const updatedItem = {
+            id: 'media-id',
+            fileName: 'new file name',
+            url: 'https://example.com/new-file-name.png',
+        };
+
+        const getMock = jest.fn().mockResolvedValue(updatedItem);
+        jest.spyOn(Shopware.Service('repositoryFactory'), 'create').mockReturnValue({ get: getMock });
+
+        const wrapper = await createWrapper();
+        wrapper.vm.createNotificationSuccess = jest.fn();
+
+        const item = { id: 'media-id', isLoading: false };
+        await wrapper.vm.onChangeName('new file name', item, () => {});
+
+        expect(getMock).toHaveBeenCalledWith('media-id');
+        expect(item.fileName).toBe('new file name');
+        expect(item.url).toBe('https://example.com/new-file-name.png');
+        expect(wrapper.vm.createNotificationSuccess).toHaveBeenCalledWith({
+            message: 'global.sw-media-media-item.notification.renamingSuccess.message',
+        });
+    });
+
     it('should throw error if new file name is too long', async () => {
         global.activeAclRoles = ['media.editor'];
         const error = {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To fix error that media cannot download after renaming

### 2. What does this change do, exactly?
Updating new URL for media after its name is changed

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
