### PR TITLE
fix(seo): reject invalid characters in SEO URLs

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1131,17 +1131,18 @@ To enable this feature, set the `BREADCRUMB_REWORK` feature flag to `true` and a
 
 ## API
 
-### SEO URL paths reject router-breaking characters on write
+### SEO URL paths reject characters that are not URL-allowed on write
 
-Writes to `seo_url.seoPathInfo` now reject strings containing `%`, `#`, `?`, `\`, or ASCII control characters (`\x00`–`\x1F`, `\x7F`).
-The validation runs in three places backed by a single allowlist (`ValidSeoPathInfo::containsDisallowedCharacters`):
+Writes to `seo_url.seoPathInfo` now reject strings containing sequences that are not allowed in URLs: a stray `%` that does not form a valid percent-escape (`%XX`), the fragment marker `#`, backslashes, or ASCII control characters (`\x00`–`\x1F`, `\x7F`).
+Query strings (`path?foo=bar`) and valid percent-escapes (`caf%C3%A9`) remain allowed — they are URL-valid and resolvable by the SEO resolver.
+The validation runs in three places backed by a single rule (`ValidSeoPathInfo::containsDisallowedCharacters`):
 
 * the admin `POST /api/_action/seo-url/create-custom-url` and `PATCH /api/_action/seo-url/canonical` endpoints (via `SeoUrlValidationFactory`),
 * raw `POST /api/seo-url` DAL writes (via a new `PreWriteValidationEvent` subscriber, `SeoUrlWriteValidator`),
 * and the inline admin UI form (`sw-seo-url`).
 
-API consumers that currently persist any of these characters in `seoPathInfo` will receive a `CONTENT__SEO_URL_INVALID_CHARACTERS` violation where the write previously succeeded.
-Percent-encode the value (`%25` for `%`) or sanitise it on the client side before sending.
+API consumers that currently persist any of these sequences in `seoPathInfo` will receive a `CONTENT__SEO_URL_INVALID_CHARACTERS` violation where the write previously succeeded.
+Percent-encode the value (`%25` for a literal `%`) or sanitise it on the client side before sending.
 
 ### Per-user and per-IP rate limiters for login and OAuth
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1131,6 +1131,18 @@ To enable this feature, set the `BREADCRUMB_REWORK` feature flag to `true` and a
 
 ## API
 
+### SEO URL paths reject router-breaking characters on write
+
+Writes to `seo_url.seoPathInfo` now reject strings containing `%`, `#`, `?`, `\`, or ASCII control characters (`\x00`–`\x1F`, `\x7F`).
+The validation runs in three places backed by a single allowlist (`ValidSeoPathInfo::containsDisallowedCharacters`):
+
+* the admin `POST /api/_action/seo-url/create-custom-url` and `PATCH /api/_action/seo-url/canonical` endpoints (via `SeoUrlValidationFactory`),
+* raw `POST /api/seo-url` DAL writes (via a new `PreWriteValidationEvent` subscriber, `SeoUrlWriteValidator`),
+* and the inline admin UI form (`sw-seo-url`).
+
+API consumers that currently persist any of these characters in `seoPathInfo` will receive a `CONTENT__SEO_URL_INVALID_CHARACTERS` violation where the write previously succeeded.
+Percent-encode the value (`%25` for `%`) or sanitise it on the client side before sending.
+
 ### Per-user and per-IP rate limiters for login and OAuth
 
 The login and OAuth token endpoints now support optional per user (`login_user`, `oauth_user`) and per IP (`login_client`, `oauth_client`) rate limiters, in addition to the existing combined user and IP limiter.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,6 +4,18 @@
 
 ## API
 
+### SEO URL paths reject router-breaking characters on write
+
+Writes to `seo_url.seoPathInfo` now reject strings containing `%`, `#`, `?`, `\`, or ASCII control characters (`\x00`–`\x1F`, `\x7F`).
+The validation runs in three places backed by a single allowlist (`ValidSeoPathInfo::containsDisallowedCharacters`):
+
+* the admin `POST /api/_action/seo-url/create-custom-url` and `PATCH /api/_action/seo-url/canonical` endpoints (via `SeoUrlValidationFactory`),
+* raw `POST /api/seo-url` DAL writes (via a new `PreWriteValidationEvent` subscriber, `SeoUrlWriteValidator`),
+* and the inline admin UI form (`sw-seo-url`).
+
+API consumers that currently persist any of these characters in `seoPathInfo` will receive a `CONTENT__SEO_URL_INVALID_CHARACTERS` violation where the write previously succeeded.
+Percent-encode the value (`%25` for `%`) or sanitise it on the client side before sending.
+
 ### Per-user and per-IP rate limiters for login and OAuth
 
 The login and OAuth token endpoints now support optional per user (`login_user`, `oauth_user`) and per IP (`login_client`, `oauth_client`) rate limiters, in addition to the existing combined user and IP limiter.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
@@ -9,6 +9,14 @@ import './sw-seo-url.scss';
 const Criteria = Shopware.Data.Criteria;
 const EntityCollection = Shopware.Data.EntityCollection;
 
+/**
+ * Characters that break the frontend router when present as a literal
+ * inside a SEO path. Keep this regex in sync with
+ * `Shopware\\Core\\Content\\Seo\\Validation\\Constraint\\ValidSeoPathInfo::DISALLOWED_CHARACTERS_PATTERN`.
+ */
+// eslint-disable-next-line no-control-regex
+const DISALLOWED_SEO_PATH_CHARS = /[%#?\\\x00-\x1F\x7F]/;
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     template,
@@ -110,6 +118,23 @@ export default {
 
         seoUrlHelptext() {
             return this.isHeadlessSalesChannel ? this.$t('sw-seo-url.textSeoUrlsDisallowedForHeadless') : null;
+        },
+
+        seoPathInfoError() {
+            const seoPathInfo = this.currentSeoUrl?.seoPathInfo;
+
+            if (typeof seoPathInfo !== 'string' || seoPathInfo === '') {
+                return null;
+            }
+
+            if (!DISALLOWED_SEO_PATH_CHARS.test(seoPathInfo)) {
+                return null;
+            }
+
+            return {
+                code: 'CONTENT__SEO_URL_INVALID_CHARACTERS',
+                detail: this.$t('sw-seo-url.errorInvalidCharacters'),
+            };
         },
 
         hasAdditionalSeoSlot() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
@@ -10,12 +10,14 @@ const Criteria = Shopware.Data.Criteria;
 const EntityCollection = Shopware.Data.EntityCollection;
 
 /**
- * Characters that break the frontend router when present as a literal
- * inside a SEO path. Keep this regex in sync with
+ * Sequences that are not URL-allowed inside a SEO path: a `%` that is not
+ * part of a valid percent-escape, the fragment marker `#`, backslashes and
+ * ASCII control characters. Query strings (`?`) and valid `%XX` escapes are
+ * allowed. Keep this regex in sync with
  * `Shopware\\Core\\Content\\Seo\\Validation\\Constraint\\ValidSeoPathInfo::DISALLOWED_CHARACTERS_PATTERN`.
  */
 // eslint-disable-next-line no-control-regex
-const DISALLOWED_SEO_PATH_CHARS = /[%#?\\\x00-\x1F\x7F]/;
+const DISALLOWED_SEO_PATH_CHARS = /%(?![0-9A-Fa-f]{2})|[#\\\x00-\x1F\x7F]/;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.html.twig
@@ -30,6 +30,7 @@
                         :disable-inheritance-toggle="isHeadlessSalesChannel"
                         :label="$t('sw-seo-url.labelSeoPathInfo')"
                         :help-text="seoUrlHelptext"
+                        :error="seoPathInfoError"
                         @update:model-value="props.updateCurrentValue"
                         @inheritance-restore="props.restoreInheritance"
                         @inheritance-remove="props.removeInheritance"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
@@ -164,6 +164,34 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
         });
     });
 
+    it.each([
+        ['seo/url%/1'],
+        ['foo/bar#baz'],
+        ['foo/bar?x=1'],
+        ['foo\\bar'],
+    ])('reports a validation error for disallowed character in "%s"', async (invalidPath) => {
+        Shopware.Store.get('swSeoUrl').currentSeoUrl = {
+            seoPathInfo: invalidPath,
+        };
+
+        expect(wrapper.vm.seoPathInfoError).toEqual(
+            expect.objectContaining({ code: 'CONTENT__SEO_URL_INVALID_CHARACTERS' }),
+        );
+    });
+
+    it.each([
+        ['Computers/Laptops'],
+        ['Pepper-white-ground-pearl/SW10098'],
+        [''],
+        [null],
+    ])('accepts "%s" as SEO path', async (validPath) => {
+        Shopware.Store.get('swSeoUrl').currentSeoUrl = {
+            seoPathInfo: validPath,
+        };
+
+        expect(wrapper.vm.seoPathInfoError).toBeNull();
+    });
+
     it('should update currentSeoUrl when defaultSeoUrl not empty', async () => {
         await wrapper.setProps({
             urls: [

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/sw-seo-url.spec.js
@@ -167,7 +167,6 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
     it.each([
         ['seo/url%/1'],
         ['foo/bar#baz'],
-        ['foo/bar?x=1'],
         ['foo\\bar'],
     ])('reports a validation error for disallowed character in "%s"', async (invalidPath) => {
         Shopware.Store.get('swSeoUrl').currentSeoUrl = {
@@ -182,6 +181,8 @@ describe('src/module/sw-settings-seo/component/sw-seo-url', () => {
     it.each([
         ['Computers/Laptops'],
         ['Pepper-white-ground-pearl/SW10098'],
+        ['foo/bar?x=1'],
+        ['caf%C3%A9/SW10098'],
         [''],
         [null],
     ])('accepts "%s" as SEO path', async (validPath) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/de.json
@@ -40,6 +40,7 @@
     "labelSeoPathInfo": "SEO-Pfad",
     "textEmptySeoUrls": "Es sind noch keine SEO-URLs vorhanden.",
     "textSeoUrlsDisallowedForHeadless": "Für Headless-Verkaufskanäle ist die Angabe von SEO-URLs nicht möglich.",
+    "errorInvalidCharacters": "Der SEO-Pfad enthält unzulässige Zeichen (zum Beispiel %, #, ? oder \\).",
     "labelMainCategory": "Hauptkategorie",
     "placeholderMainCategory": "Hauptkategorie wählen ..."
   }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/de.json
@@ -40,7 +40,7 @@
     "labelSeoPathInfo": "SEO-Pfad",
     "textEmptySeoUrls": "Es sind noch keine SEO-URLs vorhanden.",
     "textSeoUrlsDisallowedForHeadless": "Für Headless-Verkaufskanäle ist die Angabe von SEO-URLs nicht möglich.",
-    "errorInvalidCharacters": "Der SEO-Pfad enthält unzulässige Zeichen (zum Beispiel %, #, ? oder \\).",
+    "errorInvalidCharacters": "Der SEO-Pfad enthält Zeichen, die in URLs nicht erlaubt sind (zum Beispiel #, \\ oder ein einzelnes %).",
     "labelMainCategory": "Hauptkategorie",
     "placeholderMainCategory": "Hauptkategorie wählen ..."
   }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/en.json
@@ -40,6 +40,7 @@
     "labelSeoPathInfo": "SEO path",
     "textEmptySeoUrls": "There are no SEO URLs yet.",
     "textSeoUrlsDisallowedForHeadless": "SEO URLs cannot be assigned to a headless Sales Channel.",
+    "errorInvalidCharacters": "The SEO path contains characters that are not allowed (for example %, #, ? or \\).",
     "labelMainCategory": "Main category",
     "placeholderMainCategory": "Choose a main category..."
   }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/snippet/en.json
@@ -40,7 +40,7 @@
     "labelSeoPathInfo": "SEO path",
     "textEmptySeoUrls": "There are no SEO URLs yet.",
     "textSeoUrlsDisallowedForHeadless": "SEO URLs cannot be assigned to a headless Sales Channel.",
-    "errorInvalidCharacters": "The SEO path contains characters that are not allowed (for example %, #, ? or \\).",
+    "errorInvalidCharacters": "The SEO path contains characters that are not allowed in URLs (for example #, \\ or a stray %).",
     "labelMainCategory": "Main category",
     "placeholderMainCategory": "Choose a main category..."
   }

--- a/src/Core/Content/Seo/SeoException.php
+++ b/src/Core/Content/Seo/SeoException.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 #[Package('inventory')]
 class SeoException extends HttpException
@@ -101,5 +102,10 @@ class SeoException extends HttpException
     public static function invalidTemplate(string $message): ShopwareHttpException
     {
         return new InvalidTemplateException($message);
+    }
+
+    public static function unexpectedType(mixed $givenType, string $expectedType): UnexpectedTypeException
+    {
+        return new UnexpectedTypeException($givenType, $expectedType);
     }
 }

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -92,8 +92,10 @@ class SeoUrlPersister
             }
 
             // Generated SEO URLs bypass the DAL write validator, so filter
-            // router-breaking characters here (e.g. `%` emitted by rawurlencode
-            // for non-ASCII slug configs) rather than rejecting the batch. See #13796.
+            // sequences that are not URL-allowed here (stray `%`, `#`, `\`,
+            // control chars) rather than rejecting the batch. Valid
+            // percent-escapes emitted by rawurlencode for non-ASCII slug
+            // configs are preserved. See #13796.
             $seoPathInfo = ValidSeoPathInfo::sanitize(ltrim((string) $seoUrl['seoPathInfo'], '/'));
 
             $seoPathInfos[] = $seoPathInfo;

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -8,6 +8,7 @@ use Psr\Clock\ClockInterface;
 use Shopware\Core\Content\Seo\Event\SeoUrlUpdateEvent;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
@@ -90,7 +91,12 @@ class SeoUrlPersister
                 $obsoleted[] = $existing['id'];
             }
 
-            $seoPathInfos[] = $seoUrl['seoPathInfo'];
+            // Generated SEO URLs bypass the DAL write validator, so filter
+            // router-breaking characters here (e.g. `%` emitted by rawurlencode
+            // for non-ASCII slug configs) rather than rejecting the batch. See #13796.
+            $seoPathInfo = ValidSeoPathInfo::sanitize(ltrim((string) $seoUrl['seoPathInfo'], '/'));
+
+            $seoPathInfos[] = $seoPathInfo;
 
             $insert = [];
             $insert['id'] = Uuid::randomBytes();
@@ -102,7 +108,7 @@ class SeoUrlPersister
             $insert['foreign_key'] = Uuid::fromHexToBytes($fk);
 
             $insert['path_info'] = $seoUrl['pathInfo'];
-            $insert['seo_path_info'] = ltrim((string) $seoUrl['seoPathInfo'], '/');
+            $insert['seo_path_info'] = $seoPathInfo;
 
             $insert['route_name'] = $routeName;
             $insert['is_canonical'] = ($seoUrl['isCanonical'] ?? true) ? 1 : null;

--- a/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
+++ b/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Seo\Validation\Constraint;
 
+use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Content\Seo\Validation\SeoUrlWriteValidator;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Validator\Constraint;
@@ -12,8 +13,6 @@ use Symfony\Component\Validator\Constraint;
  * query separator `?`, backslashes and ASCII control characters).
  *
  * @internal
- *
- * @codeCoverageIgnore The class only exposes error constants and message getters; behavior lives in the validator.
  */
 #[Package('inventory')]
 class ValidSeoPathInfo extends Constraint
@@ -21,16 +20,25 @@ class ValidSeoPathInfo extends Constraint
     final public const INVALID_TYPE_MESSAGE = 'This value should be of type string.';
     final public const INVALID_CHARACTERS = 'CONTENT__SEO_URL_INVALID_CHARACTERS';
 
-    /**
-     * Characters that must never appear unescaped inside a seo path
-     * because they break Symfony routing or cause a 400 Bad Request
-     * when the URL is resolved by the frontend (e.g. `%` in "seo/url%/1").
-     */
-    public const DISALLOWED_CHARACTERS_PATTERN = '/[%#?\\\\\x00-\x1F\x7F]/';
+    public const DISALLOWED_CHARACTERS_PATTERN = '/[' . self::DISALLOWED_CHARACTERS . ']/';
 
     protected const ERROR_NAMES = [
         self::INVALID_CHARACTERS => 'CONTENT__SEO_URL_INVALID_CHARACTERS',
     ];
+
+    /**
+     * Character class (regex body, without delimiters/quantifier) of the
+     * characters that must never appear unescaped inside a seo path because
+     * they break Symfony routing or cause a 400 Bad Request when the URL is
+     * resolved by the frontend (e.g. `%` in "seo/url%/1").
+     */
+    private const DISALLOWED_CHARACTERS = '%#?\\\\\x00-\x1F\x7F';
+
+    /**
+     * Separator used when sanitising generated paths. Mirrors the default
+     * slugify separator so a collapsed run blends into the rest of the slug.
+     */
+    private const SANITIZE_SEPARATOR = '-';
 
     protected string $message = 'The SEO path "{{ path }}" contains disallowed characters.';
 
@@ -59,5 +67,25 @@ class ValidSeoPathInfo extends Constraint
     public static function containsDisallowedCharacters(string $path): bool
     {
         return \preg_match(self::DISALLOWED_CHARACTERS_PATTERN, $path) === 1;
+    }
+
+    /**
+     * Filters disallowed characters out of a generated path instead of
+     * rejecting it. Used on the write paths that produce SEO URLs internally
+     * (e.g. {@see SeoUrlPersister}), where a hard
+     * rejection would abort the whole indexing batch. Each run of disallowed
+     * characters is collapsed into a single separator.
+     *
+     * Note: replacing a whole run (rather than stripping single characters)
+     * is intentional — a `%` produced by `rawurlencode` is part of a
+     * `%XX` sequence, so dropping only the `%` would leave dangling bytes.
+     */
+    public static function sanitize(string $path): string
+    {
+        return (string) \preg_replace(
+            '/[' . self::DISALLOWED_CHARACTERS . ']+/',
+            self::SANITIZE_SEPARATOR,
+            $path
+        );
     }
 }

--- a/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
+++ b/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
@@ -8,9 +8,14 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * Validates that a SEO path does not contain characters that would break
- * the frontend router (notably the `%` URL-encoding marker, fragment `#`,
- * query separator `?`, backslashes and ASCII control characters).
+ * Validates that a SEO path only contains URL-allowed characters. Rejected
+ * are only sequences that can never reach or round-trip through the
+ * frontend router: a stray `%` that does not form a valid percent-escape
+ * (causes a 400 Bad Request), the fragment marker `#` (never sent to the
+ * server), backslashes (normalized to `/` by browsers) and ASCII control
+ * characters. Valid percent-escapes (`%C3%A9`) and query strings
+ * (`path?foo=bar`) are URL-allowed and stay valid — the SEO resolver
+ * supports query-string SEO URLs.
  *
  * @internal
  */
@@ -20,19 +25,20 @@ class ValidSeoPathInfo extends Constraint
     final public const INVALID_TYPE_MESSAGE = 'This value should be of type string.';
     final public const INVALID_CHARACTERS = 'CONTENT__SEO_URL_INVALID_CHARACTERS';
 
-    public const DISALLOWED_CHARACTERS_PATTERN = '/[' . self::DISALLOWED_CHARACTERS . ']/';
+    public const DISALLOWED_CHARACTERS_PATTERN = '/' . self::DISALLOWED_SEQUENCES . '/';
 
     protected const ERROR_NAMES = [
         self::INVALID_CHARACTERS => 'CONTENT__SEO_URL_INVALID_CHARACTERS',
     ];
 
     /**
-     * Character class (regex body, without delimiters/quantifier) of the
-     * characters that must never appear unescaped inside a seo path because
-     * they break Symfony routing or cause a 400 Bad Request when the URL is
-     * resolved by the frontend (e.g. `%` in "seo/url%/1").
+     * Regex body (without delimiters/quantifier) matching the sequences that
+     * are not URL-allowed inside a seo path: a `%` that is not part of a valid
+     * percent-escape (causes a 400 Bad Request, e.g. "seo/url%/1"), the
+     * fragment marker `#`, backslashes and ASCII control characters. `?` and
+     * valid `%XX` escapes are deliberately not matched.
      */
-    private const DISALLOWED_CHARACTERS = '%#?\\\\\x00-\x1F\x7F';
+    private const DISALLOWED_SEQUENCES = '%(?![0-9A-Fa-f]{2})|[#\\\\\x00-\x1F\x7F]';
 
     /**
      * Separator used when sanitising generated paths. Mirrors the default
@@ -40,7 +46,7 @@ class ValidSeoPathInfo extends Constraint
      */
     private const SANITIZE_SEPARATOR = '-';
 
-    protected string $message = 'The SEO path "{{ path }}" contains disallowed characters.';
+    protected string $message = 'The SEO path "{{ path }}" contains characters that are not allowed in URLs.';
 
     /**
      * @param array<string, mixed>|null $options
@@ -70,20 +76,19 @@ class ValidSeoPathInfo extends Constraint
     }
 
     /**
-     * Filters disallowed characters out of a generated path instead of
+     * Filters disallowed sequences out of a generated path instead of
      * rejecting it. Used on the write paths that produce SEO URLs internally
      * (e.g. {@see SeoUrlPersister}), where a hard
      * rejection would abort the whole indexing batch. Each run of disallowed
-     * characters is collapsed into a single separator.
+     * sequences is collapsed into a single separator.
      *
-     * Note: replacing a whole run (rather than stripping single characters)
-     * is intentional — a `%` produced by `rawurlencode` is part of a
-     * `%XX` sequence, so dropping only the `%` would leave dangling bytes.
+     * Valid percent-escapes survive untouched, so `rawurlencode(slugify(...))`
+     * output for non-ASCII slug configs (e.g. `caf%C3%A9`) is preserved.
      */
     public static function sanitize(string $path): string
     {
         return (string) \preg_replace(
-            '/[' . self::DISALLOWED_CHARACTERS . ']+/',
+            '/(?:' . self::DISALLOWED_SEQUENCES . ')+/',
             self::SANITIZE_SEPARATOR,
             $path
         );

--- a/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
+++ b/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfo.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\Validation\Constraint;
+
+use Shopware\Core\Content\Seo\Validation\SeoUrlWriteValidator;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Validates that a SEO path does not contain characters that would break
+ * the frontend router (notably the `%` URL-encoding marker, fragment `#`,
+ * query separator `?`, backslashes and ASCII control characters).
+ *
+ * @internal
+ *
+ * @codeCoverageIgnore The class only exposes error constants and message getters; behavior lives in the validator.
+ */
+#[Package('inventory')]
+class ValidSeoPathInfo extends Constraint
+{
+    final public const INVALID_TYPE_MESSAGE = 'This value should be of type string.';
+    final public const INVALID_CHARACTERS = 'CONTENT__SEO_URL_INVALID_CHARACTERS';
+
+    /**
+     * Characters that must never appear unescaped inside a seo path
+     * because they break Symfony routing or cause a 400 Bad Request
+     * when the URL is resolved by the frontend (e.g. `%` in "seo/url%/1").
+     */
+    public const DISALLOWED_CHARACTERS_PATTERN = '/[%#?\\\\\x00-\x1F\x7F]/';
+
+    protected const ERROR_NAMES = [
+        self::INVALID_CHARACTERS => 'CONTENT__SEO_URL_INVALID_CHARACTERS',
+    ];
+
+    protected string $message = 'The SEO path "{{ path }}" contains disallowed characters.';
+
+    /**
+     * @param array<string, mixed>|null $options
+     */
+    public function __construct(
+        ?array $options = null,
+        ?array $groups = null,
+        mixed $payload = null
+    ) {
+        parent::__construct($options, $groups, $payload);
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    /**
+     * Single source of truth for the allowed-character check. Reused by:
+     *  - {@see ValidSeoPathInfoValidator} (admin form / SEO action controller via `SeoUrlValidationFactory`)
+     *  - {@see SeoUrlWriteValidator} (DAL `PreWriteValidationEvent`)
+     * so the rules stay in one place regardless of which write path is used.
+     */
+    public static function containsDisallowedCharacters(string $path): bool
+    {
+        return \preg_match(self::DISALLOWED_CHARACTERS_PATTERN, $path) === 1;
+    }
+}

--- a/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidator.php
+++ b/src/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidator.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\Validation\Constraint;
+
+use Shopware\Core\Content\Seo\SeoException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class ValidSeoPathInfoValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidSeoPathInfo) {
+            throw SeoException::unexpectedType($constraint, ValidSeoPathInfo::class);
+        }
+
+        if ($value === null || $value === '') {
+            return;
+        }
+
+        if (!\is_string($value)) {
+            $this->context->buildViolation(ValidSeoPathInfo::INVALID_TYPE_MESSAGE)
+                ->addViolation();
+
+            return;
+        }
+
+        if (!ValidSeoPathInfo::containsDisallowedCharacters($value)) {
+            return;
+        }
+
+        $this->context->buildViolation($constraint->getMessage())
+            ->setParameter('{{ path }}', $this->formatValue($value))
+            ->setCode(ValidSeoPathInfo::INVALID_CHARACTERS)
+            ->addViolation();
+    }
+}

--- a/src/Core/Content/Seo/Validation/SeoUrlValidationFactory.php
+++ b/src/Core/Content/Seo/Validation/SeoUrlValidationFactory.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Seo\Validation;
 
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Log\Package;
@@ -42,7 +43,7 @@ class SeoUrlValidationFactory implements SeoUrlDataValidationFactoryInterface
             ->add('foreignKey', ...$fkConstraints)
             ->add('routeName', new NotBlank(), new Type('string'))
             ->add('pathInfo', new NotBlank(), new Type('string'))
-            ->add('seoPathInfo', new NotBlank(), new Type('string'), new RouteNotBlocked())
+            ->add('seoPathInfo', new NotBlank(), new Type('string'), new ValidSeoPathInfo(), new RouteNotBlocked())
             ->add('salesChannelId', new NotBlank(), new EntityExists(
                 entity: SalesChannelDefinition::ENTITY_NAME,
                 context: $context,

--- a/src/Core/Content/Seo/Validation/SeoUrlWriteValidator.php
+++ b/src/Core/Content/Seo/Validation/SeoUrlWriteValidator.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\Validation;
+
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Ensures that SEO paths written through the DAL (e.g. via the Admin API)
+ * pass the same character-allowlist that the admin form and SEO controller
+ * already enforce, so that values such as "seo/url%/1" cannot be persisted.
+ *
+ * @internal
+ */
+#[Package('inventory')]
+class SeoUrlWriteValidator implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'preValidate',
+        ];
+    }
+
+    public function preValidate(PreWriteValidationEvent $event): void
+    {
+        $constraint = new ValidSeoPathInfo();
+
+        foreach ($event->getCommands() as $command) {
+            if (!$command instanceof InsertCommand && !$command instanceof UpdateCommand) {
+                continue;
+            }
+
+            if ($command->getEntityName() !== SeoUrlDefinition::ENTITY_NAME) {
+                continue;
+            }
+
+            $payload = $command->getPayload();
+
+            if (!\array_key_exists('seo_path_info', $payload)) {
+                continue;
+            }
+
+            $seoPathInfo = $payload['seo_path_info'];
+
+            if ($seoPathInfo === null || $seoPathInfo === '') {
+                continue;
+            }
+
+            $violationList = new ConstraintViolationList();
+
+            if (!\is_string($seoPathInfo)) {
+                $violationList->add($this->buildViolation(
+                    ValidSeoPathInfo::INVALID_TYPE_MESSAGE,
+                    ['{{ path }}' => null],
+                    '/seoPathInfo',
+                    (string) $seoPathInfo,
+                    ValidSeoPathInfo::INVALID_CHARACTERS
+                ));
+
+                $event->getExceptions()->add(new WriteConstraintViolationException($violationList, $command->getPath()));
+
+                continue;
+            }
+
+            if (!ValidSeoPathInfo::containsDisallowedCharacters($seoPathInfo)) {
+                continue;
+            }
+
+            $violationList->add($this->buildViolation(
+                $constraint->getMessage(),
+                ['{{ path }}' => \sprintf('"%s"', $seoPathInfo)],
+                '/seoPathInfo',
+                $seoPathInfo,
+                ValidSeoPathInfo::INVALID_CHARACTERS
+            ));
+
+            $event->getExceptions()->add(new WriteConstraintViolationException($violationList, $command->getPath()));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function buildViolation(
+        string $messageTemplate,
+        array $parameters,
+        string $propertyPath,
+        string $invalidValue,
+        string $code
+    ): ConstraintViolationInterface {
+        return new ConstraintViolation(
+            \str_replace(\array_keys($parameters), \array_map(static fn ($value) => (string) $value, \array_values($parameters)), $messageTemplate),
+            $messageTemplate,
+            $parameters,
+            null,
+            $propertyPath,
+            $invalidValue,
+            null,
+            $code
+        );
+    }
+}

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -93,6 +93,14 @@
 
         <service id="Shopware\Core\Content\Seo\Validation\SeoUrlValidationFactory"/>
 
+        <service id="Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfoValidator">
+            <tag name="validator.constraint_validator"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Seo\Validation\SeoUrlWriteValidator">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Adapter\Twig\Extension\SeoUrlFunctionExtension">
             <argument type="service" id="twig.extension.routing"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" />

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -70,6 +70,14 @@
 
         <service id="Shopware\Core\Content\Seo\Validation\SeoUrlValidationFactory"/>
 
+        <service id="Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfoValidator">
+            <tag name="validator.constraint_validator"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Seo\Validation\SeoUrlWriteValidator">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Adapter\Twig\Extension\SeoUrlFunctionExtension">
             <argument type="service" id="twig.extension.routing"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" />

--- a/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
@@ -2,16 +2,20 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Seo\SeoUrl;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -132,6 +136,50 @@ class SeoUrlRepositoryTest extends TestCase
 
         $registry = new SeoUrlRouteRegistry([]);
         static::assertSame([], (array) $registry->getSeoUrlRoutes());
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function invalidSeoPathInfoProvider(): iterable
+    {
+        yield 'percent (issue #13796)' => ['seo/url%/1'];
+        yield 'fragment' => ['foo/bar#baz'];
+        yield 'query separator' => ['foo/bar?x=1'];
+        yield 'backslash' => ['foo\\bar'];
+    }
+
+    #[DataProvider('invalidSeoPathInfoProvider')]
+    public function testWritingInvalidSeoPathInfoIsRejected(string $invalidSeoPathInfo): void
+    {
+        $id = Uuid::randomHex();
+        $fk = Uuid::randomHex();
+        $url = [
+            'id' => $id,
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'foreignKey' => $fk,
+
+            'routeName' => 'testRoute',
+            'pathInfo' => '/ugly/path',
+            'seoPathInfo' => $invalidSeoPathInfo,
+
+            'isCanonical' => true,
+            'isModified' => false,
+        ];
+
+        $context = Context::createDefaultContext();
+
+        try {
+            $this->seoUrlRepository->create([$url], $context);
+            static::fail(\sprintf('Expected WriteException for invalid SEO path "%s"', $invalidSeoPathInfo));
+        } catch (WriteException $exception) {
+            $violationException = $exception->getExceptions()[0] ?? null;
+            static::assertInstanceOf(WriteConstraintViolationException::class, $violationException);
+
+            $violation = $violationException->getViolations()->get(0);
+            static::assertSame(ValidSeoPathInfo::INVALID_CHARACTERS, $violation->getCode());
+            static::assertSame('/seoPathInfo', $violation->getPropertyPath());
+        }
     }
 
     /**

--- a/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
@@ -145,8 +145,31 @@ class SeoUrlRepositoryTest extends TestCase
     {
         yield 'percent (issue #13796)' => ['seo/url%/1'];
         yield 'fragment' => ['foo/bar#baz'];
-        yield 'query separator' => ['foo/bar?x=1'];
         yield 'backslash' => ['foo\\bar'];
+    }
+
+    /**
+     * Query strings and valid percent-escapes are URL-allowed and resolvable
+     * by the SEO resolver, so writing them must stay possible.
+     */
+    public function testWritingUrlAllowedSeoPathInfoSucceeds(): void
+    {
+        $urls = array_map(static fn (string $seoPathInfo) => [
+            'id' => Uuid::randomHex(),
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'foreignKey' => Uuid::randomHex(),
+
+            'routeName' => 'testRoute',
+            'pathInfo' => '/ugly/path',
+            'seoPathInfo' => $seoPathInfo,
+
+            'isCanonical' => true,
+            'isModified' => false,
+        ], ['foo/bar?x=1', 'caf%C3%A9/SW10098']);
+
+        $written = $this->seoUrlRepository->create($urls, Context::createDefaultContext());
+
+        static::assertCount(2, $written->getPrimaryKeys(SeoUrlDefinition::ENTITY_NAME));
     }
 
     #[DataProvider('invalidSeoPathInfoProvider')]

--- a/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlGenerator;
 use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Content\Test\TestNavigationSeoUrlRoute;
 use Shopware\Core\Defaults;
@@ -135,6 +136,38 @@ class SeoUrlPersisterTest extends TestCase
         $first = $obsoletedSeoUrls->first();
         static::assertInstanceOf(SeoUrlEntity::class, $first);
         static::assertSame('fancy-path', $first->getSeoPathInfo());
+    }
+
+    public function testGeneratedSeoUrlsWithDisallowedCharactersAreSanitised(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $fk = Uuid::randomHex();
+        // Mimics what `rawurlencode(slugify(...))` can emit for non-ASCII slug
+        // configs; these characters break the storefront router (see #13796).
+        $seoUrlUpdates = [
+            [
+                'foreignKey' => $fk,
+                'pathInfo' => 'normal/path',
+                'seoPathInfo' => 'caf%C3%A9/with#frag?q=1',
+            ],
+        ];
+
+        $this->seoUrlPersister->updateSeoUrls($context, 'foo.route', array_column($seoUrlUpdates, 'foreignKey'), $seoUrlUpdates, $this->salesChannel);
+
+        $seoUrls = $this->seoUrlRepository->search(new Criteria(), Context::createDefaultContext())->getEntities();
+        static::assertCount(1, $seoUrls);
+
+        $first = $seoUrls->first();
+        static::assertInstanceOf(SeoUrlEntity::class, $first);
+
+        $stored = $first->getSeoPathInfo();
+        static::assertDoesNotMatchRegularExpression(
+            ValidSeoPathInfo::DISALLOWED_CHARACTERS_PATTERN,
+            $stored,
+            'Persisted SEO path must not contain router-breaking characters'
+        );
+        static::assertSame('caf-C3-A9/with-frag-q=1', $stored);
     }
 
     public function testDuplicatesSameSalesChannel(): void

--- a/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
@@ -143,13 +143,15 @@ class SeoUrlPersisterTest extends TestCase
         $context = Context::createDefaultContext();
 
         $fk = Uuid::randomHex();
-        // Mimics what `rawurlencode(slugify(...))` can emit for non-ASCII slug
-        // configs; these characters break the storefront router (see #13796).
+        // Valid percent-escapes (`rawurlencode(slugify(...))` output for
+        // non-ASCII slug configs) and query strings are URL-allowed and must
+        // survive; only sequences that break the storefront router are
+        // filtered (here the `#` and the stray `%`, see #13796).
         $seoUrlUpdates = [
             [
                 'foreignKey' => $fk,
                 'pathInfo' => 'normal/path',
-                'seoPathInfo' => 'caf%C3%A9/with#frag?q=1',
+                'seoPathInfo' => 'caf%C3%A9/with#frag%/url?q=1',
             ],
         ];
 
@@ -167,7 +169,7 @@ class SeoUrlPersisterTest extends TestCase
             $stored,
             'Persisted SEO path must not contain router-breaking characters'
         );
-        static::assertSame('caf-C3-A9/with-frag-q=1', $stored);
+        static::assertSame('caf%C3%A9/with-frag-/url?q=1', $stored);
     }
 
     public function testDuplicatesSameSalesChannel(): void

--- a/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
@@ -22,9 +22,12 @@ class ValidSeoPathInfoTest extends TestCase
     {
         yield 'plain path' => ['Computers/Laptops', false];
         yield 'dot and tilde' => ['a.b~c', false];
+        yield 'query string' => ['foo/bar?x=1', false];
+        yield 'valid percent-escape' => ['caf%C3%A9', false];
         yield 'percent (#13796)' => ['seo/url%/1', true];
+        yield 'incomplete percent-escape' => ['seo/url%4/1', true];
+        yield 'percent at end' => ['seo/url%', true];
         yield 'fragment' => ['foo/bar#baz', true];
-        yield 'query' => ['foo/bar?x=1', true];
         yield 'backslash' => ['foo\\bar', true];
         yield 'control char' => ["foo\0bar", true];
     }
@@ -41,14 +44,14 @@ class ValidSeoPathInfoTest extends TestCase
     public static function sanitizeProvider(): iterable
     {
         yield 'untouched when clean' => ['Computers/Laptops', 'Computers/Laptops'];
-        yield 'percent collapsed' => ['seo/url%/1', 'seo/url-/1'];
+        yield 'stray percent collapsed' => ['seo/url%/1', 'seo/url-/1'];
         yield 'fragment collapsed' => ['foo/bar#baz', 'foo/bar-baz'];
-        yield 'query collapsed' => ['foo/bar?x=1', 'foo/bar-x=1'];
         yield 'backslash collapsed' => ['foo\\bar', 'foo-bar'];
-        // Only the disallowed characters are replaced; the surrounding
-        // alphanumerics survive. The result is router-safe, not a faithful
-        // decode of the original `%XX` sequence.
-        yield 'percent markers in encoded sequence replaced' => ['caf%C3%A9', 'caf-C3-A9'];
+        // Query strings are URL-allowed and resolvable, so they survive.
+        yield 'query string untouched' => ['foo/bar?x=1', 'foo/bar?x=1'];
+        // Valid percent-escapes (rawurlencode output for non-ASCII slug
+        // configs) are URL-allowed and must survive untouched.
+        yield 'valid percent-escapes untouched' => ['caf%C3%A9', 'caf%C3%A9'];
         // A consecutive run of disallowed characters collapses to one separator.
         yield 'control characters collapsed' => ["foo\0\nbar", 'foo-bar'];
     }

--- a/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\Validation\Constraint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ValidSeoPathInfo::class)]
+class ValidSeoPathInfoTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function detectionProvider(): iterable
+    {
+        yield 'plain path' => ['Computers/Laptops', false];
+        yield 'dot and tilde' => ['a.b~c', false];
+        yield 'percent (#13796)' => ['seo/url%/1', true];
+        yield 'fragment' => ['foo/bar#baz', true];
+        yield 'query' => ['foo/bar?x=1', true];
+        yield 'backslash' => ['foo\\bar', true];
+        yield 'control char' => ["foo\0bar", true];
+    }
+
+    #[DataProvider('detectionProvider')]
+    public function testContainsDisallowedCharacters(string $path, bool $expected): void
+    {
+        static::assertSame($expected, ValidSeoPathInfo::containsDisallowedCharacters($path));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function sanitizeProvider(): iterable
+    {
+        yield 'untouched when clean' => ['Computers/Laptops', 'Computers/Laptops'];
+        yield 'percent collapsed' => ['seo/url%/1', 'seo/url-/1'];
+        yield 'fragment collapsed' => ['foo/bar#baz', 'foo/bar-baz'];
+        yield 'query collapsed' => ['foo/bar?x=1', 'foo/bar-x=1'];
+        yield 'backslash collapsed' => ['foo\\bar', 'foo-bar'];
+        // Only the disallowed characters are replaced; the surrounding
+        // alphanumerics survive. The result is router-safe, not a faithful
+        // decode of the original `%XX` sequence.
+        yield 'percent markers in encoded sequence replaced' => ['caf%C3%A9', 'caf-C3-A9'];
+        // A consecutive run of disallowed characters collapses to one separator.
+        yield 'control characters collapsed' => ["foo\0\nbar", 'foo-bar'];
+    }
+
+    #[DataProvider('sanitizeProvider')]
+    public function testSanitize(string $path, string $expected): void
+    {
+        $sanitized = ValidSeoPathInfo::sanitize($path);
+
+        static::assertSame($expected, $sanitized);
+        static::assertFalse(
+            ValidSeoPathInfo::containsDisallowedCharacters($sanitized),
+            'Sanitised path must no longer contain disallowed characters'
+        );
+    }
+}

--- a/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidatorTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidatorTest.php
@@ -32,6 +32,9 @@ class ValidSeoPathInfoValidatorTest extends TestCase
         yield 'with hyphen and digits' => ['Pepper-white-ground-pearl/SW10098'];
         yield 'with unicode letters' => ['café/über'];
         yield 'with dot and tilde' => ['a.b~c'];
+        yield 'with query string' => ['seo/url?foo=bar'];
+        yield 'with valid percent-escape' => ['seo/%20/foo'];
+        yield 'with encoded unicode' => ['caf%C3%A9/SW10098'];
     }
 
     /**
@@ -39,10 +42,9 @@ class ValidSeoPathInfoValidatorTest extends TestCase
      */
     public static function invalidValues(): iterable
     {
-        yield 'percent' => ['seo/url%/1'];
-        yield 'url-encoded hint' => ['seo/%20/foo'];
+        yield 'stray percent' => ['seo/url%/1'];
+        yield 'incomplete percent-escape' => ['seo/url%4/1'];
         yield 'fragment' => ['seo/url#anchor'];
-        yield 'query' => ['seo/url?foo=bar'];
         yield 'backslash' => ['seo\\url'];
         yield 'control character NUL' => ["seo\0url"];
         yield 'control character newline' => ["seo\nurl"];

--- a/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidatorTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/Constraint/ValidSeoPathInfoValidatorTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\Validation\Constraint;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoException;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfoValidator;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(ValidSeoPathInfoValidator::class)]
+class ValidSeoPathInfoValidatorTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function validValues(): iterable
+    {
+        yield 'simple path' => ['Computers/Laptops'];
+        yield 'with hyphen and digits' => ['Pepper-white-ground-pearl/SW10098'];
+        yield 'with unicode letters' => ['café/über'];
+        yield 'with dot and tilde' => ['a.b~c'];
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function invalidValues(): iterable
+    {
+        yield 'percent' => ['seo/url%/1'];
+        yield 'url-encoded hint' => ['seo/%20/foo'];
+        yield 'fragment' => ['seo/url#anchor'];
+        yield 'query' => ['seo/url?foo=bar'];
+        yield 'backslash' => ['seo\\url'];
+        yield 'control character NUL' => ["seo\0url"];
+        yield 'control character newline' => ["seo\nurl"];
+    }
+
+    #[DataProvider('validValues')]
+    public function testValidValuesPass(string $value): void
+    {
+        $violations = $this->buildValidator()
+            ->validate($value, new ValidSeoPathInfo());
+
+        static::assertCount(0, $violations);
+    }
+
+    #[DataProvider('invalidValues')]
+    public function testInvalidValuesAreRejected(string $value): void
+    {
+        $violations = $this->buildValidator()
+            ->validate($value, new ValidSeoPathInfo());
+
+        static::assertCount(1, $violations);
+
+        $violation = $violations->get(0);
+        static::assertInstanceOf(ConstraintViolation::class, $violation);
+        static::assertSame(ValidSeoPathInfo::INVALID_CHARACTERS, $violation->getCode());
+    }
+
+    public function testEmptyStringIsIgnored(): void
+    {
+        $violations = $this->buildValidator()
+            ->validate('', new ValidSeoPathInfo());
+
+        static::assertCount(0, $violations);
+    }
+
+    public function testNullIsIgnored(): void
+    {
+        $violations = $this->buildValidator()
+            ->validate(null, new ValidSeoPathInfo());
+
+        static::assertCount(0, $violations);
+    }
+
+    public function testNonStringValueReportsTypeViolation(): void
+    {
+        $violations = $this->buildValidator()
+            ->validate(123, new ValidSeoPathInfo());
+
+        static::assertCount(1, $violations);
+        static::assertSame(ValidSeoPathInfo::INVALID_TYPE_MESSAGE, $violations->get(0)->getMessageTemplate());
+    }
+
+    private function buildValidator(): ValidatorInterface
+    {
+        return Validation::createValidatorBuilder()
+            ->setConstraintValidatorFactory(new class implements ConstraintValidatorFactoryInterface {
+                public function getInstance(Constraint $constraint): ConstraintValidatorInterface
+                {
+                    if ($constraint instanceof ValidSeoPathInfo) {
+                        return new ValidSeoPathInfoValidator();
+                    }
+
+                    throw SeoException::unexpectedType($constraint, ValidSeoPathInfo::class);
+                }
+            })
+            ->getValidator();
+    }
+}

--- a/tests/unit/Core/Content/Seo/Validation/SeoUrlValidationFactoryTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/SeoUrlValidationFactoryTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
 use Shopware\Core\Content\Seo\Validation\SeoUrlValidationFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
@@ -77,10 +78,11 @@ class SeoUrlValidationFactoryTest extends TestCase
         static::assertInstanceOf(Type::class, $properties['pathInfo'][1]);
 
         static::assertArrayHasKey('seoPathInfo', $properties);
-        static::assertCount(3, $properties['seoPathInfo']);
+        static::assertCount(4, $properties['seoPathInfo']);
         static::assertInstanceOf(NotBlank::class, $properties['seoPathInfo'][0]);
         static::assertInstanceOf(Type::class, $properties['seoPathInfo'][1]);
-        static::assertInstanceOf(RouteNotBlocked::class, $properties['seoPathInfo'][2]);
+        static::assertInstanceOf(ValidSeoPathInfo::class, $properties['seoPathInfo'][2]);
+        static::assertInstanceOf(RouteNotBlocked::class, $properties['seoPathInfo'][3]);
 
         static::assertArrayHasKey('salesChannelId', $properties);
         static::assertCount(2, $properties['salesChannelId']);

--- a/tests/unit/Core/Content/Seo/Validation/SeoUrlWriteValidatorTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/SeoUrlWriteValidatorTest.php
@@ -102,6 +102,8 @@ class SeoUrlWriteValidatorTest extends TestCase
     {
         yield 'simple path' => ['Computers/Laptops'];
         yield 'hyphen and digits' => ['Pepper-white-ground-pearl/SW10098'];
+        yield 'query string' => ['foo/bar?x=1'];
+        yield 'valid percent-escape' => ['caf%C3%A9/SW10098'];
     }
 
     /**
@@ -111,7 +113,6 @@ class SeoUrlWriteValidatorTest extends TestCase
     {
         yield 'percent reported in #13796' => ['seo/url%/1'];
         yield 'fragment' => ['foo/bar#baz'];
-        yield 'query' => ['foo/bar?x=1'];
         yield 'backslash' => ['foo\\bar'];
     }
 

--- a/tests/unit/Core/Content/Seo/Validation/SeoUrlWriteValidatorTest.php
+++ b/tests/unit/Core/Content/Seo/Validation/SeoUrlWriteValidatorTest.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\Validation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlDefinition;
+use Shopware\Core\Content\Seo\Validation\Constraint\ValidSeoPathInfo;
+use Shopware\Core\Content\Seo\Validation\SeoUrlWriteValidator;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(SeoUrlWriteValidator::class)]
+class SeoUrlWriteValidatorTest extends TestCase
+{
+    private WriteContext $context;
+
+    private SeoUrlDefinition $seoUrlDefinition;
+
+    private SalesChannelDefinition $salesChannelDefinition;
+
+    protected function setUp(): void
+    {
+        $this->context = WriteContext::createFromContext(Context::createDefaultContext());
+
+        $registry = new StaticDefinitionInstanceRegistry(
+            [SeoUrlDefinition::class, SalesChannelDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+
+        $seoUrlDefinition = $registry->get(SeoUrlDefinition::class);
+        static::assertInstanceOf(SeoUrlDefinition::class, $seoUrlDefinition);
+        $this->seoUrlDefinition = $seoUrlDefinition;
+
+        $salesChannelDefinition = $registry->get(SalesChannelDefinition::class);
+        static::assertInstanceOf(SalesChannelDefinition::class, $salesChannelDefinition);
+        $this->salesChannelDefinition = $salesChannelDefinition;
+    }
+
+    public function testSubscribedEvents(): void
+    {
+        $events = SeoUrlWriteValidator::getSubscribedEvents();
+
+        static::assertSame(['preValidate'], array_values($events));
+        static::assertArrayHasKey(PreWriteValidationEvent::class, $events);
+    }
+
+    public function testIgnoresOtherEntities(): void
+    {
+        $command = new InsertCommand(
+            $this->salesChannelDefinition,
+            ['name' => 'channel'],
+            ['id' => Uuid::randomBytes()],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+
+        $event = new PreWriteValidationEvent($this->context, [$command]);
+        (new SeoUrlWriteValidator())->preValidate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testPayloadWithoutSeoPathInfoPasses(): void
+    {
+        $command = new UpdateCommand(
+            $this->seoUrlDefinition,
+            ['is_canonical' => 1],
+            ['id' => Uuid::randomBytes()],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+
+        $event = new PreWriteValidationEvent($this->context, [$command]);
+        (new SeoUrlWriteValidator())->preValidate($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function validSeoPaths(): iterable
+    {
+        yield 'simple path' => ['Computers/Laptops'];
+        yield 'hyphen and digits' => ['Pepper-white-ground-pearl/SW10098'];
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function invalidSeoPaths(): iterable
+    {
+        yield 'percent reported in #13796' => ['seo/url%/1'];
+        yield 'fragment' => ['foo/bar#baz'];
+        yield 'query' => ['foo/bar?x=1'];
+        yield 'backslash' => ['foo\\bar'];
+    }
+
+    #[DataProvider('validSeoPaths')]
+    public function testValidSeoPathPasses(string $path): void
+    {
+        $event = $this->dispatch($path);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    #[DataProvider('invalidSeoPaths')]
+    public function testInvalidSeoPathIsRejected(string $path): void
+    {
+        $event = $this->dispatch($path);
+
+        $thrown = null;
+
+        try {
+            $event->getExceptions()->tryToThrow();
+        } catch (WriteException $e) {
+            $thrown = $e;
+        }
+
+        static::assertNotNull($thrown, \sprintf('Expected WriteException for path "%s"', $path));
+
+        $violationException = $thrown->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $violationException);
+
+        $violation = $violationException->getViolations()->get(0);
+        static::assertSame(ValidSeoPathInfo::INVALID_CHARACTERS, $violation->getCode());
+        static::assertSame('/seoPathInfo', $violation->getPropertyPath());
+    }
+
+    private function dispatch(string $seoPathInfo): PreWriteValidationEvent
+    {
+        $command = new InsertCommand(
+            $this->seoUrlDefinition,
+            [
+                'seo_path_info' => $seoPathInfo,
+                'path_info' => '/detail/' . Uuid::randomHex(),
+                'route_name' => 'frontend.detail.page',
+                'foreign_key' => Uuid::randomBytes(),
+                'language_id' => Uuid::randomBytes(),
+            ],
+            ['id' => Uuid::randomBytes()],
+            $this->createMock(EntityExistence::class),
+            '/0/'
+        );
+
+        $event = new PreWriteValidationEvent($this->context, [$command]);
+        (new SeoUrlWriteValidator())->preValidate($event);
+
+        return $event;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

A SEO URL containing sequences that are not URL-allowed — a stray `%` that does not form a valid percent-escape, the fragment marker `#`, backslashes, or ASCII control characters — could be persisted unchanged through both the admin UI and the Admin API. When the storefront later tried to resolve a product detail page for one of those URLs, the frontend router rejected the request with a `400 Bad Request` (or the URL could simply never match, since `#` fragments are not sent to the server and browsers normalize `\` to `/`), with no user-facing indication at save time.

The validation is deliberately based on **URL-allowed characters** rather than a blanket character denylist:

* `?` stays allowed — the SEO resolver supports query-string SEO URLs (#15638), so rejecting the query separator would forbid exactly the values that PR makes resolvable.
* Valid percent-escapes (`%XX`, e.g. `caf%C3%A9`) stay allowed — the storefront matches the raw, still-encoded path info, and the SEO escaper `rawurlencode(slugify(...))` legitimately emits `%XX` for non-ASCII slug configs.

### 2. What does this change do, exactly?

- Adds a new `ValidSeoPathInfo` constraint + `ValidSeoPathInfoValidator` that rejects paths containing sequences that are not URL-allowed: a stray `%` (no valid `%XX` escape), `#`, `\`, or ASCII control characters. The rule is exposed as a shared regex so the admin UI mirrors the backend rule.
- Wires the constraint into the request validation used by the admin SEO action controller via `SeoUrlValidationFactory`, so admin form saves surface a clear violation before persistence.
- Adds a new `PreWriteValidationEvent` subscriber `SeoUrlWriteValidator` that applies the same rule to every `InsertCommand` / `UpdateCommand` targeting the `seo_url` entity. This covers generic Admin API writes to `/api/seo-url` (including raw DAL writes), which bypass `SeoUrlValidationFactory`.
- Sanitises *generated* SEO URLs in `SeoUrlPersister::updateSeoUrls()` (which persists via raw SQL and bypasses the DAL validator) with the same rule, collapsing disallowed runs to a separator instead of rejecting, so an indexing batch never aborts. Valid percent-escapes and query strings survive untouched.
- Surfaces the same validation inline in the `sw-seo-url` administration component so merchants see the error before submitting.
- Adds an `unexpectedType` static factory to `SeoException` so the new validator can follow the domain-exception pattern.

### 3. Describe each step to reproduce the issue or behaviour.

Before the fix:
1. In the Administration, edit a product and set its SEO URL to e.g. `seo/url%/1`.
2. Save. The value persists without validation.
3. Open the product detail page in the storefront. You get a `400 Bad Request` instead of the product page.

After the fix:
1. Same edit is rejected inline in the admin with a clear "invalid characters" error.
2. A direct `POST /api/seo-url` with the same `seoPathInfo` is rejected with a `CONTENT__SEO_URL_INVALID_CHARACTERS` violation on `/seoPathInfo`.
3. URL-valid values such as `Main-product/SWDEMO10001?test=123` (cf. #15638) or `caf%C3%A9/SW10098` are still accepted.

### 4. Please link to the relevant issues (if any).

- closes #13796
- related: #15638 (query-string SEO URL resolution — the reason `?` is allowed)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes (changelog entry added)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
