### PR TITLE
fix(seo): allow editing and clearing of write-protected SEO URLs

### DIFF
--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -176,12 +176,12 @@ class SeoActionController extends AbstractController
             return new Response('', Response::HTTP_NO_CONTENT);
         }
 
-        $this->seoUrlPersister->updateSeoUrls(
+        $this->seoUrlPersister->forceUpdateSeoUrls(
             $context,
             $seoUrlData['routeName'],
             [$seoUrlData['foreignKey']],
             [$seoUrlData],
-            $salesChannel
+            $salesChannel,
         );
 
         return new Response('', Response::HTTP_NO_CONTENT);
@@ -232,12 +232,12 @@ class SeoActionController extends AbstractController
                 continue;
             }
 
-            $this->seoUrlPersister->updateSeoUrls(
+            $this->seoUrlPersister->forceUpdateSeoUrls(
                 $context,
                 $writeRows[0]['routeName'],
                 array_column($writeRows, 'foreignKey'),
                 $writeRows,
-                $salesChannelEntity
+                $salesChannelEntity,
             );
         }
 

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -175,12 +175,12 @@ class SeoActionController extends AbstractController
             return new Response('', Response::HTTP_NO_CONTENT);
         }
 
-        $this->seoUrlPersister->updateSeoUrls(
+        $this->seoUrlPersister->forceUpdateSeoUrls(
             $context,
             $seoUrlData['routeName'],
             [$seoUrlData['foreignKey']],
             [$seoUrlData],
-            $salesChannel
+            $salesChannel,
         );
 
         return new Response('', Response::HTTP_NO_CONTENT);
@@ -231,12 +231,12 @@ class SeoActionController extends AbstractController
                 continue;
             }
 
-            $this->seoUrlPersister->updateSeoUrls(
+            $this->seoUrlPersister->forceUpdateSeoUrls(
                 $context,
                 $writeRows[0]['routeName'],
                 array_column($writeRows, 'foreignKey'),
                 $writeRows,
-                $salesChannelEntity
+                $salesChannelEntity,
             );
         }
 

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -42,6 +42,32 @@ class SeoUrlPersister
      */
     public function updateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel): void
     {
+        $this->doUpdateSeoUrls($context, $routeName, $foreignKeys, $seoUrls, $salesChannel, false);
+    }
+
+    /**
+     * Like {@see self::updateSeoUrls()} but bypasses the write-protection guard
+     * that normally keeps automatic template regeneration from overwriting
+     * manually modified (`isModified = true`) SEO URLs.
+     *
+     * Intended for explicit admin/API updates where the user wants to edit or
+     * reset a manually modified SEO URL; must not be used for automatic
+     * template regeneration pipelines (indexers, subscribers on other entities).
+     *
+     * @param array<string> $foreignKeys
+     * @param iterable<array<string, mixed>|SeoUrlEntity> $seoUrls
+     */
+    public function forceUpdateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel): void
+    {
+        $this->doUpdateSeoUrls($context, $routeName, $foreignKeys, $seoUrls, $salesChannel, true);
+    }
+
+    /**
+     * @param array<string> $foreignKeys
+     * @param iterable<array<string, mixed>|SeoUrlEntity> $seoUrls
+     */
+    private function doUpdateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel, bool $overwrite): void
+    {
         $languageId = $context->getLanguageId();
         $canonicals = $this->findCanonicalPaths($routeName, $languageId, $foreignKeys);
         $dateTime = $this->clock->now()->format(Defaults::STORAGE_DATE_TIME_FORMAT);
@@ -85,7 +111,7 @@ class SeoUrlPersister
             if ($existing) {
                 // entity has override or does not change
                 /** @phpstan-ignore-next-line PHPStan could not recognize the array generated from the jsonSerialize method of the SeoUrlEntity */
-                if ($this->skipUpdate($existing, $seoUrl)) {
+                if ($this->skipUpdate($existing, $seoUrl, $overwrite)) {
                     continue;
                 }
                 $obsoleted[] = $existing['id'];
@@ -148,9 +174,23 @@ class SeoUrlPersister
      * @param array{isModified: bool, seoPathInfo: string, salesChannelId: string} $existing
      * @param array{isModified?: bool, seoPathInfo: string, salesChannelId: string} $seoUrl
      */
-    private function skipUpdate(array $existing, array $seoUrl): bool
+    private function skipUpdate(array $existing, array $seoUrl, bool $overwrite = false): bool
     {
-        if ($existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
+        // When the caller (e.g. admin/API action) explicitly requests an overwrite,
+        // skip the "write protection" guard that normally preserves manually modified
+        // (isModified=1) SEO URLs against automatic template regeneration. The path
+        // equality guard below is still honoured to avoid creating superfluous
+        // duplicate rows when nothing actually changes.
+        //
+        // Edge case: clearing the write-protection flag with the *same* path
+        // (existing.isModified=true, payload.isModified=false, identical
+        // seoPathInfo) still short-circuits via the equality guard, so the
+        // `is_modified` flag will not actually be reset until the path also
+        // changes. Admin flows handle this naturally (clearing the SEO URL
+        // field resubmits the template-generated path, which differs from the
+        // manual value); a bare "drop protection" without a path change needs
+        // to be done via DAL write.
+        if (!$overwrite && $existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
             return true;
         }
 

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -176,26 +176,26 @@ class SeoUrlPersister
      */
     private function skipUpdate(array $existing, array $seoUrl, bool $overwrite = false): bool
     {
-        // When the caller (e.g. admin/API action) explicitly requests an overwrite,
-        // skip the "write protection" guard that normally preserves manually modified
-        // (isModified=1) SEO URLs against automatic template regeneration. The path
-        // equality guard below is still honoured to avoid creating superfluous
-        // duplicate rows when nothing actually changes.
-        //
-        // Edge case: clearing the write-protection flag with the *same* path
-        // (existing.isModified=true, payload.isModified=false, identical
-        // seoPathInfo) still short-circuits via the equality guard, so the
-        // `is_modified` flag will not actually be reset until the path also
-        // changes. Admin flows handle this naturally (clearing the SEO URL
-        // field resubmits the template-generated path, which differs from the
-        // manual value); a bare "drop protection" without a path change needs
-        // to be done via DAL write.
+        // Write-protection guard: automatic template regeneration (overwrite=false)
+        // must never replace a manually modified (isModified=1) SEO URL that still
+        // has a non-empty path.
         if (!$overwrite && $existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
             return true;
         }
 
-        return $seoUrl['seoPathInfo'] === $existing['seoPathInfo']
-            && $seoUrl['salesChannelId'] === $existing['salesChannelId'];
+        // A different path or sales channel is always a real change, so never skip.
+        if ($seoUrl['seoPathInfo'] !== $existing['seoPathInfo']
+            || $seoUrl['salesChannelId'] !== $existing['salesChannelId']) {
+            return false;
+        }
+
+        // Path and sales channel are identical. Normally we skip to avoid creating a
+        // duplicate row. For an explicit overwrite, however, we must still proceed when
+        // only the isModified flag differs, so that an admin "reset to template" can drop
+        // the write-protection flag even when the manual value already equals the template
+        // output (shopware/shopware#4413). When the flag matches too, nothing changed -> skip.
+        return !$overwrite
+            || ($seoUrl['isModified'] ?? false) === $existing['isModified'];
     }
 
     /**

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -39,6 +39,32 @@ class SeoUrlPersister
      */
     public function updateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel): void
     {
+        $this->doUpdateSeoUrls($context, $routeName, $foreignKeys, $seoUrls, $salesChannel, false);
+    }
+
+    /**
+     * Like {@see self::updateSeoUrls()} but bypasses the write-protection guard
+     * that normally keeps automatic template regeneration from overwriting
+     * manually modified (`isModified = true`) SEO URLs.
+     *
+     * Intended for explicit admin/API updates where the user wants to edit or
+     * reset a manually modified SEO URL; must not be used for automatic
+     * template regeneration pipelines (indexers, subscribers on other entities).
+     *
+     * @param array<string> $foreignKeys
+     * @param iterable<array<string, mixed>|SeoUrlEntity> $seoUrls
+     */
+    public function forceUpdateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel): void
+    {
+        $this->doUpdateSeoUrls($context, $routeName, $foreignKeys, $seoUrls, $salesChannel, true);
+    }
+
+    /**
+     * @param array<string> $foreignKeys
+     * @param iterable<array<string, mixed>|SeoUrlEntity> $seoUrls
+     */
+    private function doUpdateSeoUrls(Context $context, string $routeName, array $foreignKeys, iterable $seoUrls, SalesChannelEntity $salesChannel, bool $overwrite): void
+    {
         $languageId = $context->getLanguageId();
         $canonicals = $this->findCanonicalPaths($routeName, $languageId, $foreignKeys);
         $dateTime = (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
@@ -82,7 +108,7 @@ class SeoUrlPersister
             if ($existing) {
                 // entity has override or does not change
                 /** @phpstan-ignore-next-line PHPStan could not recognize the array generated from the jsonSerialize method of the SeoUrlEntity */
-                if ($this->skipUpdate($existing, $seoUrl)) {
+                if ($this->skipUpdate($existing, $seoUrl, $overwrite)) {
                     continue;
                 }
                 $obsoleted[] = $existing['id'];
@@ -138,9 +164,23 @@ class SeoUrlPersister
      * @param array{isModified: bool, seoPathInfo: string, salesChannelId: string} $existing
      * @param array{isModified?: bool, seoPathInfo: string, salesChannelId: string} $seoUrl
      */
-    private function skipUpdate(array $existing, array $seoUrl): bool
+    private function skipUpdate(array $existing, array $seoUrl, bool $overwrite = false): bool
     {
-        if ($existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
+        // When the caller (e.g. admin/API action) explicitly requests an overwrite,
+        // skip the "write protection" guard that normally preserves manually modified
+        // (isModified=1) SEO URLs against automatic template regeneration. The path
+        // equality guard below is still honoured to avoid creating superfluous
+        // duplicate rows when nothing actually changes.
+        //
+        // Edge case: clearing the write-protection flag with the *same* path
+        // (existing.isModified=true, payload.isModified=false, identical
+        // seoPathInfo) still short-circuits via the equality guard, so the
+        // `is_modified` flag will not actually be reset until the path also
+        // changes. Admin flows handle this naturally (clearing the SEO URL
+        // field resubmits the template-generated path, which differs from the
+        // manual value); a bare "drop protection" without a path change needs
+        // to be done via DAL write.
+        if (!$overwrite && $existing['isModified'] && !($seoUrl['isModified'] ?? false) && trim($seoUrl['seoPathInfo']) !== '') {
             return true;
         }
 

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -9,17 +9,14 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\Exception\SeoUrlRouteNotFoundException;
 use Shopware\Core\Content\Seo\SeoException;
-use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Content\Seo\SeoUrlTemplate\SeoUrlTemplateEntity;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
@@ -374,26 +371,32 @@ class SeoActionControllerTest extends TestCase
 
     /**
      * Regression for shopware/shopware#4413 (same-path reset): a write-protected canonical whose
-     * path already equals the template output must still be resettable. Clearing the flag without
-     * changing the path must actually drop isModified instead of silently keeping it write-protected.
+     * path already equals the template output must still be resettable through the admin endpoint.
+     * Clearing the flag without changing the path must actually drop isModified instead of silently
+     * keeping it write-protected.
      *
-     * This drives SeoUrlPersister::forceUpdateSeoUrls() directly - the exact code path the admin
-     * `seo-url/canonical` endpoint uses - against a real database. That exercises the obsolete +
-     * useReplace + updateCanonicalSeoUrls interaction (which the unit tests mock away) and proves
-     * the canonical is not re-protected afterwards, without depending on storefront product SEO
-     * indexing.
+     * The write-protected canonical is seeded directly so the test does not depend on storefront
+     * product SEO indexing, but the reset itself goes through the real `/api/_action/seo-url/canonical`
+     * endpoint (validation + SeoUrlPersister + DB).
      */
-    public function testForceUpdateClearsWriteProtectionOnUnchangedPath(): void
+    public function testResetWriteProtectedCanonicalWithUnchangedPath(): void
     {
         $connection = static::getContainer()->get(Connection::class);
-        $persister = static::getContainer()->get(SeoUrlPersister::class);
 
         $salesChannelId = Uuid::randomHex();
         $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+        $productId = $this->createTestProduct($salesChannelId);
 
-        $foreignKey = Uuid::randomHex();
         $route = ProductPageSeoUrlRoute::ROUTE_NAME;
         $path = 'red-shoe';
+
+        // Normalise: drop any auto-generated SEO URLs for the product so the seeded
+        // write-protected canonical is the only row, regardless of whether the environment
+        // generated one on product creation.
+        $connection->executeStatement(
+            'DELETE FROM seo_url WHERE foreign_key = :fk',
+            ['fk' => Uuid::fromHexToBytes($productId)]
+        );
 
         // Seed a write-protected canonical whose path already equals the template output
         // (mimics a migrated/manually created SEO URL).
@@ -401,9 +404,9 @@ class SeoActionControllerTest extends TestCase
             'id' => Uuid::randomBytes(),
             'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
             'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
-            'foreign_key' => Uuid::fromHexToBytes($foreignKey),
+            'foreign_key' => Uuid::fromHexToBytes($productId),
             'route_name' => $route,
-            'path_info' => '/detail/' . $foreignKey,
+            'path_info' => '/detail/' . $productId,
             'seo_path_info' => $path,
             'is_canonical' => 1,
             'is_modified' => 1,
@@ -411,31 +414,22 @@ class SeoActionControllerTest extends TestCase
             'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
 
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId($salesChannelId);
-        $salesChannel->setUniqueIdentifier($salesChannelId);
+        // Reset through the admin endpoint: same path, isModified=false.
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', [
+            'foreignKey' => $productId,
+            'routeName' => $route,
+            'pathInfo' => '/detail/' . $productId,
+            'seoPathInfo' => $path,
+            'salesChannelId' => $salesChannelId,
+            'isModified' => false,
+        ]);
 
-        // Reset using the overwrite path the admin endpoint uses: same path, isModified=false.
-        $persister->forceUpdateSeoUrls(
-            Context::createDefaultContext(),
-            $route,
-            [$foreignKey],
-            [[
-                'foreignKey' => $foreignKey,
-                'salesChannelId' => $salesChannelId,
-                'routeName' => $route,
-                'pathInfo' => '/detail/' . $foreignKey,
-                'seoPathInfo' => $path,
-                'isCanonical' => true,
-                'isModified' => false,
-                'isDeleted' => false,
-            ]],
-            $salesChannel
-        );
+        $response = $this->getBrowser()->getResponse();
+        static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
 
         $canonicals = $connection->fetchAllAssociative(
             'SELECT seo_path_info, is_modified FROM seo_url WHERE foreign_key = :fk AND is_canonical = 1',
-            ['fk' => Uuid::fromHexToBytes($foreignKey)]
+            ['fk' => Uuid::fromHexToBytes($productId)]
         );
 
         static::assertCount(1, $canonicals, 'Exactly one canonical SEO URL must remain');

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -369,6 +369,53 @@ class SeoActionControllerTest extends TestCase
         );
     }
 
+    /**
+     * Regression for shopware/shopware#4413 (same-path reset): a write-protected canonical whose
+     * path already equals the template output must still be resettable. Clearing the flag without
+     * changing the path must actually drop isModified, not silently keep the URL write-protected.
+     */
+    public function testResetWriteProtectedCanonicalWithUnchangedPath(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $id = $this->createTestProduct($salesChannelId);
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        $templatePath = $seoUrls[0]['attributes']['seoPathInfo'];
+
+        // Write-protect the URL while keeping the template path (mimics a migrated/manual URL
+        // whose value happens to equal the current template output).
+        $protectPayload = $seoUrls[0]['attributes'];
+        $protectPayload['seoPathInfo'] = $templatePath;
+        $protectPayload['isModified'] = true;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $protectPayload);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertTrue($seoUrls[0]['attributes']['isModified']);
+        static::assertSame($templatePath, $seoUrls[0]['attributes']['seoPathInfo']);
+
+        // Reset: clear the write-protection flag without changing the path.
+        $resetPayload = $seoUrls[0]['attributes'];
+        $resetPayload['seoPathInfo'] = $templatePath;
+        $resetPayload['isModified'] = false;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $resetPayload);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertFalse(
+            $seoUrls[0]['attributes']['isModified'],
+            'Write-protection flag must be cleared even when the path did not change'
+        );
+        static::assertSame($templatePath, $seoUrls[0]['attributes']['seoPathInfo']);
+    }
+
     public function testUpdateCanonicalWithCustomSalesChannel(): void
     {
         $salesChannelId = Uuid::randomHex();

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -293,6 +293,82 @@ class SeoActionControllerTest extends TestCase
         static::assertSame($newSeoPathInfo, $seoUrl['seoPathInfo']);
     }
 
+    /**
+     * Regression for shopware/shopware#4413: a write-protected (isModified=true) canonical
+     * SEO URL must be editable again and resettable to the template-generated path.
+     */
+    public function testUpdateWriteProtectedCanonicalCanBeEditedAndReset(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
+
+        $id = $this->createTestProduct($salesChannelId);
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        $initialPathInfo = $seoUrls[0]['attributes']['seoPathInfo'];
+
+        // Initial manual modification – writes a write-protected URL.
+        $manualPath = 'manual-path';
+        $firstPayload = $seoUrls[0]['attributes'];
+        $firstPayload['seoPathInfo'] = $manualPath;
+        $firstPayload['isModified'] = true;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $firstPayload);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertTrue($seoUrls[0]['attributes']['isModified']);
+        static::assertSame($manualPath, $seoUrls[0]['attributes']['seoPathInfo']);
+
+        // (a) Manual edit of the already write-protected SEO URL must persist.
+        $editedPath = 'manual-path-edited';
+        $editPayload = $seoUrls[0]['attributes'];
+        $editPayload['seoPathInfo'] = $editedPath;
+        $editPayload['isModified'] = true;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $editPayload);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        static::assertCount(1, $seoUrls);
+        static::assertTrue($seoUrls[0]['attributes']['isModified']);
+        static::assertSame($editedPath, $seoUrls[0]['attributes']['seoPathInfo']);
+
+        // (b) Clearing the write-protection flag must also actually clear it on the
+        // persisted canonical (previously the overwrite check silently kept isModified=true).
+        $clearPayload = $seoUrls[0]['attributes'];
+        $clearPayload['seoPathInfo'] = 'manual-path-final';
+        $clearPayload['isModified'] = false;
+
+        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $clearPayload);
+        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
+        $canonical = null;
+        foreach ($seoUrls as $url) {
+            if ($url['attributes']['isCanonical'] ?? true) {
+                $canonical = $url['attributes'];
+                break;
+            }
+        }
+
+        static::assertNotNull($canonical, 'A canonical SEO URL must still exist after clearing the write-protection flag');
+        static::assertFalse($canonical['isModified'], 'Canonical SEO URL must be cleared of the write-protection flag');
+        static::assertSame('manual-path-final', $canonical['seoPathInfo']);
+
+        // The original template-generated path is still reachable (kept as a
+        // redirecting non-canonical entry so old links keep working).
+        static::assertNotEmpty(
+            array_filter(
+                $this->getSeoUrls($id, null, $salesChannelId),
+                static fn (array $url): bool => $url['attributes']['seoPathInfo'] === $initialPathInfo
+            ),
+            'Original template path must be retained as a non-canonical redirect'
+        );
+    }
+
     public function testUpdateCanonicalWithCustomSalesChannel(): void
     {
         $salesChannelId = Uuid::randomHex();

--- a/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/Api/SeoActionControllerTest.php
@@ -9,14 +9,17 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\Exception\SeoUrlRouteNotFoundException;
 use Shopware\Core\Content\Seo\SeoException;
+use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Content\Seo\SeoUrlTemplate\SeoUrlTemplateEntity;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
@@ -372,48 +375,76 @@ class SeoActionControllerTest extends TestCase
     /**
      * Regression for shopware/shopware#4413 (same-path reset): a write-protected canonical whose
      * path already equals the template output must still be resettable. Clearing the flag without
-     * changing the path must actually drop isModified, not silently keep the URL write-protected.
+     * changing the path must actually drop isModified instead of silently keeping it write-protected.
+     *
+     * This drives SeoUrlPersister::forceUpdateSeoUrls() directly - the exact code path the admin
+     * `seo-url/canonical` endpoint uses - against a real database. That exercises the obsolete +
+     * useReplace + updateCanonicalSeoUrls interaction (which the unit tests mock away) and proves
+     * the canonical is not re-protected afterwards, without depending on storefront product SEO
+     * indexing.
      */
-    public function testResetWriteProtectedCanonicalWithUnchangedPath(): void
+    public function testForceUpdateClearsWriteProtectionOnUnchangedPath(): void
     {
+        $connection = static::getContainer()->get(Connection::class);
+        $persister = static::getContainer()->get(SeoUrlPersister::class);
+
         $salesChannelId = Uuid::randomHex();
         $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
 
-        $id = $this->createTestProduct($salesChannelId);
+        $foreignKey = Uuid::randomHex();
+        $route = ProductPageSeoUrlRoute::ROUTE_NAME;
+        $path = 'red-shoe';
 
-        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
-        static::assertCount(1, $seoUrls);
-        $templatePath = $seoUrls[0]['attributes']['seoPathInfo'];
+        // Seed a write-protected canonical whose path already equals the template output
+        // (mimics a migrated/manually created SEO URL).
+        $connection->insert('seo_url', [
+            'id' => Uuid::randomBytes(),
+            'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+            'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+            'foreign_key' => Uuid::fromHexToBytes($foreignKey),
+            'route_name' => $route,
+            'path_info' => '/detail/' . $foreignKey,
+            'seo_path_info' => $path,
+            'is_canonical' => 1,
+            'is_modified' => 1,
+            'is_deleted' => 0,
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
 
-        // Write-protect the URL while keeping the template path (mimics a migrated/manual URL
-        // whose value happens to equal the current template output).
-        $protectPayload = $seoUrls[0]['attributes'];
-        $protectPayload['seoPathInfo'] = $templatePath;
-        $protectPayload['isModified'] = true;
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setUniqueIdentifier($salesChannelId);
 
-        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $protectPayload);
-        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
+        // Reset using the overwrite path the admin endpoint uses: same path, isModified=false.
+        $persister->forceUpdateSeoUrls(
+            Context::createDefaultContext(),
+            $route,
+            [$foreignKey],
+            [[
+                'foreignKey' => $foreignKey,
+                'salesChannelId' => $salesChannelId,
+                'routeName' => $route,
+                'pathInfo' => '/detail/' . $foreignKey,
+                'seoPathInfo' => $path,
+                'isCanonical' => true,
+                'isModified' => false,
+                'isDeleted' => false,
+            ]],
+            $salesChannel
+        );
 
-        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
-        static::assertCount(1, $seoUrls);
-        static::assertTrue($seoUrls[0]['attributes']['isModified']);
-        static::assertSame($templatePath, $seoUrls[0]['attributes']['seoPathInfo']);
+        $canonicals = $connection->fetchAllAssociative(
+            'SELECT seo_path_info, is_modified FROM seo_url WHERE foreign_key = :fk AND is_canonical = 1',
+            ['fk' => Uuid::fromHexToBytes($foreignKey)]
+        );
 
-        // Reset: clear the write-protection flag without changing the path.
-        $resetPayload = $seoUrls[0]['attributes'];
-        $resetPayload['seoPathInfo'] = $templatePath;
-        $resetPayload['isModified'] = false;
-
-        $this->getBrowser()->jsonRequest('PATCH', '/api/_action/seo-url/canonical', $resetPayload);
-        static::assertSame(204, $this->getBrowser()->getResponse()->getStatusCode());
-
-        $seoUrls = $this->getSeoUrls($id, true, $salesChannelId);
-        static::assertCount(1, $seoUrls);
-        static::assertFalse(
-            $seoUrls[0]['attributes']['isModified'],
+        static::assertCount(1, $canonicals, 'Exactly one canonical SEO URL must remain');
+        static::assertSame($path, $canonicals[0]['seo_path_info']);
+        static::assertSame(
+            0,
+            (int) $canonicals[0]['is_modified'],
             'Write-protection flag must be cleared even when the path did not change'
         );
-        static::assertSame($templatePath, $seoUrls[0]['attributes']['seoPathInfo']);
     }
 
     public function testUpdateCanonicalWithCustomSalesChannel(): void

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -84,6 +84,100 @@ class SeoUrlPersisterTest extends TestCase
         );
     }
 
+    /**
+     * Regression for shopware/shopware#4413: when a SEO URL is write-protected (is_modified=1),
+     * the legacy guard in skipUpdate() should still protect it against automatic template
+     * regeneration (default overwrite=false).
+     */
+    public function testSkipUpdateProtectsWriteProtectedSeoUrlByDefault(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'template-path',
+            'isModified' => false,
+        ];
+
+        static::assertTrue($this->invokeSkipUpdate($existing, $payload, false));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: when the admin/API explicitly requests an overwrite,
+     * the skipUpdate() guard must no longer protect write-protected SEO URLs from being
+     * replaced with the template-generated path.
+     */
+    public function testSkipUpdateAllowsResetWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'template-path',
+            'isModified' => false,
+        ];
+
+        static::assertFalse($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: the admin must be able to persist an edit that
+     * replaces the write-protected path with a new manual path.
+     */
+    public function testSkipUpdateAllowsManualEditWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'manual-path-edited',
+            'isModified' => true,
+        ];
+
+        static::assertFalse($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: even with overwrite=true the path-equality guard
+     * must still short-circuit, so re-saving the exact same SEO URL does not create a duplicate.
+     */
+    public function testSkipUpdateStillSkipsIdenticalPayloadWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'manual-path',
+            'isModified' => true,
+        ];
+
+        static::assertTrue($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
     public function testUpdateSeoUrlsWithInuseSeoPaths(): void
     {
         $seoUrls = [
@@ -152,5 +246,17 @@ class SeoUrlPersisterTest extends TestCase
             $seoUrls,
             $seoChannel
         );
+    }
+
+    /**
+     * @param array{isModified: bool, seoPathInfo: string, salesChannelId: string} $existing
+     * @param array{isModified?: bool, seoPathInfo: string, salesChannelId: string} $seoUrl
+     */
+    private function invokeSkipUpdate(array $existing, array $seoUrl, bool $overwrite): bool
+    {
+        $reflection = new \ReflectionMethod(SeoUrlPersister::class, 'skipUpdate');
+        $reflection->setAccessible(true);
+
+        return (bool) $reflection->invoke($this->seoUrlPersister, $existing, $seoUrl, $overwrite);
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -178,6 +178,90 @@ class SeoUrlPersisterTest extends TestCase
         static::assertTrue($this->invokeSkipUpdate($existing, $payload, true));
     }
 
+    /**
+     * Regression for shopware/shopware#4413 (same-path reset): when a write-protected URL
+     * already equals the template output, an explicit overwrite that only flips isModified
+     * to false must NOT be skipped, so the write-protection flag is actually dropped.
+     */
+    public function testSkipUpdateClearsProtectionOnIdenticalPathWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'red-shoe',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'red-shoe',
+            'isModified' => false,
+        ];
+
+        static::assertFalse($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
+    /**
+     * Without overwrite the same-path automatic regeneration must keep skipping, regardless of
+     * the requested isModified state, so it never creates duplicate rows.
+     */
+    public function testSkipUpdateKeepsSkippingIdenticalPathWithoutOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'red-shoe',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'red-shoe',
+            'isModified' => false,
+        ];
+
+        static::assertTrue($this->invokeSkipUpdate($existing, $payload, false));
+    }
+
+    public function testForceUpdateSeoUrlsPersistsNewSeoPaths(): void
+    {
+        $seoUrls = [
+            [
+                'languageId' => Uuid::randomHex(),
+                'foreignKey' => Uuid::randomHex(),
+                'salesChannelId' => Uuid::randomHex(),
+                'routeName' => 'test-route',
+                'pathInfo' => 'path1',
+                'seoPathInfo' => 'path1',
+            ],
+        ];
+
+        $this->connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $this->connection->expects($this->never())
+            ->method('fetchOne');
+
+        $this->connection->expects($this->never())
+            ->method('executeStatement');
+
+        $seoChannel = new SalesChannelEntity();
+        $seoChannel->setId(Uuid::randomHex());
+
+        $this->seoUrlPersister->forceUpdateSeoUrls(
+            Context::createDefaultContext(),
+            'test-route',
+            [
+                'foreignKey' => Uuid::randomHex(),
+            ],
+            $seoUrls,
+            $seoChannel
+        );
+    }
+
     public function testUpdateSeoUrlsWithInuseSeoPaths(): void
     {
         $seoUrls = [

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Core\Content\Seo;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoUrlPersister;
 use Shopware\Core\Framework\Context;
@@ -23,23 +22,18 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(SeoUrlPersister::class)]
 class SeoUrlPersisterTest extends TestCase
 {
-    private Connection&MockObject $connection;
-
     private SeoUrlPersister $seoUrlPersister;
 
     protected function setUp(): void
     {
-        $this->connection = $this->createMock(Connection::class);
-        $this->seoUrlPersister = new SeoUrlPersister(
-            $this->connection,
-            static::createStub(EntityRepository::class),
-            static::createStub(EventDispatcherInterface::class),
-            new NativeClock()
-        );
+        $this->seoUrlPersister = $this->createSeoUrlPersister(static::createStub(Connection::class));
     }
 
     public function testUpdateSeoUrlsWithNewSeoPaths(): void
     {
+        $connection = $this->createMock(Connection::class);
+        $seoUrlPersister = $this->createSeoUrlPersister($connection);
+
         $seoUrls = [
             [
                 'languageId' => Uuid::randomHex(),
@@ -59,21 +53,21 @@ class SeoUrlPersisterTest extends TestCase
             ],
         ];
 
-        $this->connection->expects($this->once())
+        $connection->expects($this->once())
             ->method('fetchAllAssociative')
             ->willReturn([]);
 
-        $this->connection->expects($this->never())
+        $connection->expects($this->never())
             ->method('fetchOne')
             ->willReturn([]);
 
-        $this->connection->expects($this->never())
+        $connection->expects($this->never())
             ->method('executeStatement');
 
         $seoChannel = new SalesChannelEntity();
         $seoChannel->setId(Uuid::randomHex());
 
-        $this->seoUrlPersister->updateSeoUrls(
+        $seoUrlPersister->updateSeoUrls(
             Context::createDefaultContext(),
             'test-route',
             [
@@ -227,6 +221,9 @@ class SeoUrlPersisterTest extends TestCase
 
     public function testForceUpdateSeoUrlsPersistsNewSeoPaths(): void
     {
+        $connection = $this->createMock(Connection::class);
+        $seoUrlPersister = $this->createSeoUrlPersister($connection);
+
         $seoUrls = [
             [
                 'languageId' => Uuid::randomHex(),
@@ -238,20 +235,20 @@ class SeoUrlPersisterTest extends TestCase
             ],
         ];
 
-        $this->connection->expects($this->once())
+        $connection->expects($this->once())
             ->method('fetchAllAssociative')
             ->willReturn([]);
 
-        $this->connection->expects($this->never())
+        $connection->expects($this->never())
             ->method('fetchOne');
 
-        $this->connection->expects($this->never())
+        $connection->expects($this->never())
             ->method('executeStatement');
 
         $seoChannel = new SalesChannelEntity();
         $seoChannel->setId(Uuid::randomHex());
 
-        $this->seoUrlPersister->forceUpdateSeoUrls(
+        $seoUrlPersister->forceUpdateSeoUrls(
             Context::createDefaultContext(),
             'test-route',
             [
@@ -264,6 +261,9 @@ class SeoUrlPersisterTest extends TestCase
 
     public function testUpdateSeoUrlsWithInuseSeoPaths(): void
     {
+        $connection = $this->createMock(Connection::class);
+        $seoUrlPersister = $this->createSeoUrlPersister($connection);
+
         $seoUrls = [
             [
                 'languageId' => Uuid::randomHex(),
@@ -287,7 +287,7 @@ class SeoUrlPersisterTest extends TestCase
         $id2 = Uuid::randomBytes();
         $expectedIds = [$id1, $id2];
 
-        $this->connection->expects($this->once())
+        $connection->expects($this->once())
             ->method('fetchAllAssociative')
             ->willReturn([
                 [
@@ -306,11 +306,11 @@ class SeoUrlPersisterTest extends TestCase
                 ],
             ]);
 
-        $this->connection->expects($this->exactly(2))
+        $connection->expects($this->exactly(2))
             ->method('fetchOne')
             ->willReturnOnConsecutiveCalls($id1, $id2);
 
-        $this->connection->expects($this->once())
+        $connection->expects($this->once())
             ->method('executeStatement')
             ->with(
                 'UPDATE seo_url SET is_canonical = 1, is_modified = 1 WHERE id IN (:ids)',
@@ -321,7 +321,7 @@ class SeoUrlPersisterTest extends TestCase
         $seoChannel = new SalesChannelEntity();
         $seoChannel->setId(Uuid::randomHex());
 
-        $this->seoUrlPersister->updateSeoUrls(
+        $seoUrlPersister->updateSeoUrls(
             Context::createDefaultContext(),
             'test-route',
             [
@@ -342,5 +342,15 @@ class SeoUrlPersisterTest extends TestCase
         $reflection->setAccessible(true);
 
         return (bool) $reflection->invoke($this->seoUrlPersister, $existing, $seoUrl, $overwrite);
+    }
+
+    private function createSeoUrlPersister(Connection $connection): SeoUrlPersister
+    {
+        return new SeoUrlPersister(
+            $connection,
+            static::createStub(EntityRepository::class),
+            static::createStub(EventDispatcherInterface::class),
+            new NativeClock()
+        );
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlPersisterTest.php
@@ -82,6 +82,100 @@ class SeoUrlPersisterTest extends TestCase
         );
     }
 
+    /**
+     * Regression for shopware/shopware#4413: when a SEO URL is write-protected (is_modified=1),
+     * the legacy guard in skipUpdate() should still protect it against automatic template
+     * regeneration (default overwrite=false).
+     */
+    public function testSkipUpdateProtectsWriteProtectedSeoUrlByDefault(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'template-path',
+            'isModified' => false,
+        ];
+
+        static::assertTrue($this->invokeSkipUpdate($existing, $payload, false));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: when the admin/API explicitly requests an overwrite,
+     * the skipUpdate() guard must no longer protect write-protected SEO URLs from being
+     * replaced with the template-generated path.
+     */
+    public function testSkipUpdateAllowsResetWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'template-path',
+            'isModified' => false,
+        ];
+
+        static::assertFalse($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: the admin must be able to persist an edit that
+     * replaces the write-protected path with a new manual path.
+     */
+    public function testSkipUpdateAllowsManualEditWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'manual-path-edited',
+            'isModified' => true,
+        ];
+
+        static::assertFalse($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
+    /**
+     * Regression for shopware/shopware#4413: even with overwrite=true the path-equality guard
+     * must still short-circuit, so re-saving the exact same SEO URL does not create a duplicate.
+     */
+    public function testSkipUpdateStillSkipsIdenticalPayloadWithOverwrite(): void
+    {
+        $existing = [
+            'id' => 'id-1',
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'isModified' => true,
+            'seoPathInfo' => 'manual-path',
+        ];
+        $payload = [
+            'foreignKey' => 'fk-1',
+            'salesChannelId' => 'sc-1',
+            'seoPathInfo' => 'manual-path',
+            'isModified' => true,
+        ];
+
+        static::assertTrue($this->invokeSkipUpdate($existing, $payload, true));
+    }
+
     public function testUpdateSeoUrlsWithInuseSeoPaths(): void
     {
         $seoUrls = [
@@ -150,5 +244,17 @@ class SeoUrlPersisterTest extends TestCase
             $seoUrls,
             $seoChannel
         );
+    }
+
+    /**
+     * @param array{isModified: bool, seoPathInfo: string, salesChannelId: string} $existing
+     * @param array{isModified?: bool, seoPathInfo: string, salesChannelId: string} $seoUrl
+     */
+    private function invokeSkipUpdate(array $existing, array $seoUrl, bool $overwrite): bool
+    {
+        $reflection = new \ReflectionMethod(SeoUrlPersister::class, 'skipUpdate');
+        $reflection->setAccessible(true);
+
+        return (bool) $reflection->invoke($this->seoUrlPersister, $existing, $seoUrl, $overwrite);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Manually-created or migrated SEO URLs are flagged `is_modified=1` and were write-protected: admin edits and "clear + regenerate from template" attempts both fell through silently because the persister's `skipUpdate()` refused to touch them. Merchants had no way to unmanage a SEO URL without flipping the flag directly in the database.

### 2. What does this change do, exactly?

- `SeoUrlPersister::updateSeoUrls()` / `skipUpdate()`: new optional `$overwrite` parameter. When true, the write-protection guard is bypassed. Default behavior unchanged for all other callers — automatic template regeneration still respects `is_modified=1`.
- `SeoActionController::updateCanonicalUrl()` and `createCustomSeoUrls()` (both explicit admin/API entry points driven by user input) now pass `overwrite=true`.
- Path-equality guard is preserved on both branches, so repeat saves with the same path still short-circuit.

### 3. Describe each step to reproduce the issue or behaviour.

Before the fix:
1. Migrate or manually create a product with `is_modified=1` SEO URL.
2. Edit the SEO URL in admin or clear the field to regenerate from template.
3. Save — the value appears to save, but reopening the product shows the original URL unchanged.

After the fix:
1. Edit persists.
2. Clearing the field saves as empty, which the admin flow then re-submits as the template path with `isModified=false`, replacing the canonical and dropping the write-protection flag.

### 4. Please link to the relevant issues (if any).

- closes #4413

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them