### PR TITLE
fix: write product exports atomically

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
@@ -7,6 +7,7 @@ use League\Flysystem\UnableToDeleteFile;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Struct\ExportBehavior;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 #[Package('inventory')]
 class ProductExportFileHandler implements ProductExportFileHandlerInterface
@@ -37,19 +38,24 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     public function writeProductExportContent(string $content, string $filePath, bool $append = false): bool
     {
-        if ($this->fileSystem->fileExists($filePath) && !$append) {
-            $this->fileSystem->delete($filePath);
-        }
-
         $existingContent = '';
         if ($append && $this->fileSystem->fileExists($filePath)) {
             $existingContent = $this->fileSystem->read($filePath);
         }
 
+        $targetPath = $filePath;
+        if (!$append) {
+            $targetPath = $filePath . '.' . Uuid::randomHex() . '.tmp';
+        }
+
         $this->fileSystem->write(
-            $filePath,
+            $targetPath,
             $existingContent . $content
         );
+
+        if (!$append) {
+            $this->fileSystem->move($targetPath, $filePath);
+        }
 
         return true;
     }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportFileHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportFileHandlerTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ProductExport\Service;
+
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandler;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductExportFileHandler::class)]
+class ProductExportFileHandlerTest extends TestCase
+{
+    public function testWriteProductExportContentReplacesFilesViaTemporaryPath(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->expects($this->once())
+            ->method('write')
+            ->with(
+                static::callback(static function (string $path): bool {
+                    return str_starts_with($path, 'export/feed.csv.')
+                        && str_ends_with($path, '.tmp');
+                }),
+                'new-content'
+            );
+        $filesystem->expects($this->once())
+            ->method('move')
+            ->with(
+                static::callback(static function (string $path): bool {
+                    return str_starts_with($path, 'export/feed.csv.')
+                        && str_ends_with($path, '.tmp');
+                }),
+                'export/feed.csv',
+                []
+            );
+        $filesystem->expects($this->never())->method('delete');
+
+        $handler = new ProductExportFileHandler($filesystem, 'export');
+
+        static::assertTrue($handler->writeProductExportContent('new-content', 'export/feed.csv'));
+    }
+
+    public function testWriteProductExportContentAppendsExistingContent(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->expects($this->once())
+            ->method('fileExists')
+            ->with('export/feed.csv.partial')
+            ->willReturn(true);
+        $filesystem->expects($this->once())
+            ->method('read')
+            ->with('export/feed.csv.partial')
+            ->willReturn('existing-');
+        $filesystem->expects($this->once())
+            ->method('write')
+            ->with('export/feed.csv.partial', 'existing-next');
+        $filesystem->expects($this->never())->method('move');
+
+        $handler = new ProductExportFileHandler($filesystem, 'export');
+
+        static::assertTrue($handler->writeProductExportContent('next', 'export/feed.csv.partial', true));
+    }
+}


### PR DESCRIPTION
## Summary
- write regenerated product-export content into a temporary file first
- move the temporary file into place only after the new content is complete
- keep append mode unchanged apart from preserving the existing partial content

## Verification
- `php -l` on touched PHP files
- `vendor/bin/phpstan analyze --debug --memory-limit=2G` on touched files
- `vendor/bin/php-cs-fixer fix --config=/Users/tamvo/work/platform/.php-cs-fixer.dist.php --dry-run --diff --sequential` on touched files

Fixes #15099