### PR TITLE
feat: Add test plan issue automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-plan.md
+++ b/.github/ISSUE_TEMPLATE/test-plan.md
@@ -1,11 +1,120 @@
+## Summary
+
+Briefly describe what is being tested and why this test plan exists.
+
+## Related artifacts
+
+- Product concept:
+- Design concept:
+- Technical concept:
+- Discussion:
+- Related issues:
+
 ## Scope
 
-TBD
+Which areas are in scope for this test plan?
 
-## Test cases
+- [ ] Backend
+- [ ] Administration
+- [ ] Storefront
+- [ ] Store API
+- [ ] Admin API
+- [ ] CLI / scheduled task
+- [ ] Elasticsearch / indexing
+- [ ] Caching
+- [ ] Permissions / ACL
+- [ ] Performance
+- [ ] Cloud / deployment concerns
+
+## Out of scope
+
+What is explicitly not covered by this test plan?
+
+- TBD
+
+## Acceptance criteria covered
+
+Reference the parent issue's acceptance criteria that are covered by this test plan.
 
 - [ ] TBD
 
-## Notes
+## Preconditions / setup
 
-TBD
+Describe everything required before testing starts.
+
+### Environment
+
+- Environment:
+- Version / branch:
+- Feature flag(s):
+- Required data:
+- Required permissions / role:
+- License / extension requirements:
+- Browser / device requirements:
+- API client / credentials:
+
+### Preparation steps
+
+- [ ] TBD
+
+### Test data
+
+- [ ] TBD
+
+## Test scenario overview
+
+Create and link dedicated sub-issues for manual and/or automated test cases where needed.
+
+When creating dedicated scenario sub-issues from this test plan, create a blank sub-issue and copy the structure from `.github/ISSUE_TEMPLATE/test-scenario.md` into the issue body.
+
+Suggested scenario groups:
+- Happy path
+- Negative / validation scenarios
+- Edge cases
+- Regression scenarios
+
+## Area-specific checks
+
+### Administration
+- [ ] UI works as expected
+- [ ] Validation messages are correct
+- [ ] ACL restrictions are enforced
+- [ ] Listing / detail / editing flows work
+
+### Storefront
+- [ ] Feature is visible only where expected
+- [ ] Behaviour works across supported browsers/devices
+- [ ] No obvious layout or usability regressions
+
+### API
+- [ ] Endpoints behave as expected
+- [ ] Request validation works
+- [ ] Response payload is correct
+- [ ] Error cases are covered
+
+### Data / persistence
+- [ ] Data is stored correctly
+- [ ] Updates are persisted correctly
+- [ ] Deletion / cleanup works
+- [ ] Indexing / cache refresh behavior is validated
+
+### Permissions / ACL
+- [ ] Authorized users can access the feature
+- [ ] Unauthorized users are blocked
+- [ ] Permission changes are respected
+
+### Performance / reliability
+- [ ] No obvious performance degradation
+- [ ] No unnecessary reload / indexing / expensive operations observed
+- [ ] Relevant background processes behave correctly
+
+## Risks, open questions, and follow-up issues
+
+### Risks
+- TBD
+
+### Open questions
+- TBD
+
+### Follow-up issues
+- TBD

--- a/.github/ISSUE_TEMPLATE/test-plan.md
+++ b/.github/ISSUE_TEMPLATE/test-plan.md
@@ -57,10 +57,6 @@ Describe everything required before testing starts.
 
 - [ ] TBD
 
-### Test data
-
-- [ ] TBD
-
 ## Test scenario overview
 
 Create and link dedicated sub-issues for manual and/or automated test cases where needed.

--- a/.github/ISSUE_TEMPLATE/test-plan.md
+++ b/.github/ISSUE_TEMPLATE/test-plan.md
@@ -1,0 +1,11 @@
+## Scope
+
+TBD
+
+## Test cases
+
+- [ ] TBD
+
+## Notes
+
+TBD

--- a/.github/ISSUE_TEMPLATE/test-scenario.md
+++ b/.github/ISSUE_TEMPLATE/test-scenario.md
@@ -1,0 +1,30 @@
+## Scenario summary and goal
+
+Briefly describe the scenario being validated and which acceptance criteria it covers.
+
+- TBD
+
+## Test type
+
+- [ ] Manual
+- [ ] Automated
+
+## Preparation steps
+
+- [ ] TBD
+
+## Test data
+
+- [ ] TBD
+
+## Steps
+
+1. TBD
+
+## Expected result
+
+- TBD
+
+## Notes and follow-ups
+
+- TBD

--- a/.github/bin/js/test-plan-sub-issue.mjs
+++ b/.github/bin/js/test-plan-sub-issue.mjs
@@ -1,0 +1,270 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TRIGGER_LABEL = 'testing/test-plan';
+const ALLOWED_PARENT_TYPES = new Set(['Epic', 'Story']);
+
+export async function syncTestPlanSubIssue({ github, core, context }) {
+    const isManualRun = context.eventName === 'workflow_dispatch';
+    const action = isManualRun ? process.env.TEST_PLAN_ACTION : context.payload.action;
+    const parentIssue = isManualRun
+        ? (await github.rest.issues.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: Number.parseInt(process.env.TEST_PLAN_ISSUE_NUMBER, 10),
+        })).data
+        : context.payload.issue;
+
+    if (!parentIssue || parentIssue.pull_request) {
+        core.info('Skipping because the payload does not describe a plain issue.');
+        return;
+    }
+
+    if (action === 'reopened') {
+        const hasTriggerLabel = parentIssue.labels.some((label) => label.name === TRIGGER_LABEL);
+
+        if (!hasTriggerLabel) {
+            core.info(`Skipping reopened issue #${parentIssue.number} because ${TRIGGER_LABEL} is not present.`);
+            return;
+        }
+    }
+
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const parentRef = `${owner}/${repo}#${parentIssue.number}`;
+    const marker = `<!-- test-plan-for: ${parentRef} -->`;
+    const markerSearchTerm = `test-plan-for: ${parentRef}`;
+    const childTitle = `[Test Plan] ${parentIssue.title}`;
+    const templatePath = path.join(process.env.GITHUB_WORKSPACE, '.github/ISSUE_TEMPLATE/test-plan.md');
+    const templateBody = fs.readFileSync(templatePath, 'utf8').trim();
+
+    async function getIssueTypeName() {
+        const inlineTypeName = parentIssue.issue_type?.name ?? parentIssue.issueType?.name ?? null;
+
+        if (inlineTypeName) {
+            return inlineTypeName;
+        }
+
+        const result = await github.graphql(
+            `
+              query GetIssueType($id: ID!) {
+                node(id: $id) {
+                  ... on Issue {
+                    issueType {
+                      name
+                    }
+                  }
+                }
+              }
+            `,
+            { id: parentIssue.node_id },
+        );
+
+        return result?.node?.issueType?.name ?? null;
+    }
+
+    async function getLinkedSubIssues() {
+        const response = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+            owner,
+            repo,
+            issue_number: parentIssue.number,
+            per_page: 100,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        });
+
+        return response.data;
+    }
+
+    async function searchChildrenByMarker() {
+        const searchResponse = await github.rest.search.issuesAndPullRequests({
+            q: `repo:${owner}/${repo} is:issue in:body "${markerSearchTerm}"`,
+            per_page: 10,
+        });
+
+        const exactMatches = [];
+
+        for (const candidate of searchResponse.data.items) {
+            if (candidate.pull_request) {
+                continue;
+            }
+
+            const issueResponse = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: candidate.number,
+            });
+
+            if (issueResponse.data.body?.includes(marker)) {
+                exactMatches.push(issueResponse.data);
+            }
+        }
+
+        return exactMatches;
+    }
+
+    async function findMatchingChildren() {
+        const matches = new Map();
+        const linkedSubIssues = await getLinkedSubIssues();
+
+        for (const linkedSubIssue of linkedSubIssues) {
+            const issueResponse = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: linkedSubIssue.number,
+            });
+
+            if (issueResponse.data.body?.includes(marker)) {
+                matches.set(issueResponse.data.id, issueResponse.data);
+            }
+        }
+
+        const searchedIssues = await searchChildrenByMarker();
+
+        for (const searchedIssue of searchedIssues) {
+            matches.set(searchedIssue.id, searchedIssue);
+        }
+
+        return [...matches.values()];
+    }
+
+    async function reportConflict(children) {
+        const issueLinks = children
+            .map((child) => `- #${child.number}`)
+            .join('\n');
+
+        await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: parentIssue.number,
+            body: [
+                'Unable to synchronize the test-plan sub-issue automatically because multiple matching child issues were found:',
+                '',
+                issueLinks,
+                '',
+                `Marker: \`${marker}\``,
+            ].join('\n'),
+        });
+    }
+
+    async function createChildIssue() {
+        const response = await github.rest.issues.create({
+            owner,
+            repo,
+            title: childTitle,
+            body: [
+                marker,
+                '',
+                templateBody,
+            ].join('\n'),
+        });
+
+        return response.data;
+    }
+
+    async function ensureChildIsOpen(childIssue) {
+        if (childIssue.state === 'open') {
+            return childIssue;
+        }
+
+        const response = await github.rest.issues.update({
+            owner,
+            repo,
+            issue_number: childIssue.number,
+            state: 'open',
+        });
+
+        return response.data;
+    }
+
+    async function closeChildIssue(childIssue) {
+        if (childIssue.state === 'closed') {
+            core.info(`Test-plan issue #${childIssue.number} is already closed.`);
+            return;
+        }
+
+        await github.rest.issues.update({
+            owner,
+            repo,
+            issue_number: childIssue.number,
+            state: 'closed',
+            state_reason: 'not_planned',
+        });
+    }
+
+    async function getParentOfChild(childIssue) {
+        try {
+            const response = await github.request('GET /repos/{owner}/{repo}/issues/{issue_number}/parent', {
+                owner,
+                repo,
+                issue_number: childIssue.number,
+                headers: {
+                    'X-GitHub-Api-Version': '2022-11-28',
+                },
+            });
+
+            return response.data;
+        } catch (error) {
+            if (error.status === 404) {
+                return null;
+            }
+
+            throw error;
+        }
+    }
+
+    async function ensureSubIssueLink(childIssue) {
+        const currentParent = await getParentOfChild(childIssue);
+
+        if (currentParent?.number === parentIssue.number) {
+            core.info(`Test-plan issue #${childIssue.number} is already linked to parent issue #${parentIssue.number}.`);
+            return;
+        }
+
+        if (currentParent && currentParent.number !== parentIssue.number) {
+            throw new Error(`Test-plan issue #${childIssue.number} is already linked to #${currentParent.number}.`);
+        }
+
+        await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues', {
+            owner,
+            repo,
+            issue_number: parentIssue.number,
+            sub_issue_id: childIssue.id,
+            headers: {
+                'X-GitHub-Api-Version': '2022-11-28',
+            },
+        });
+    }
+
+    const matchingChildren = await findMatchingChildren();
+
+    if (matchingChildren.length > 1) {
+        await reportConflict(matchingChildren);
+        core.setFailed(`Found ${matchingChildren.length} matching test-plan issues for ${parentRef}.`);
+        return;
+    }
+
+    if (action === 'unlabeled') {
+        if (matchingChildren.length === 0) {
+            core.info(`No existing test-plan issue found for ${parentRef}.`);
+            return;
+        }
+
+        await closeChildIssue(matchingChildren[0]);
+
+        return;
+    }
+
+    const parentTypeName = await getIssueTypeName();
+
+    if (!parentTypeName || !ALLOWED_PARENT_TYPES.has(parentTypeName)) {
+        core.info(`Skipping issue #${parentIssue.number} because its type is ${parentTypeName ?? 'unknown'} instead of Epic or Story.`);
+        return;
+    }
+
+    const childIssue = matchingChildren[0] ?? await createChildIssue();
+    const openChildIssue = await ensureChildIsOpen(childIssue);
+
+    await ensureSubIssueLink(openChildIssue);
+}

--- a/.github/bin/js/test-plan-sub-issue.mjs
+++ b/.github/bin/js/test-plan-sub-issue.mjs
@@ -5,15 +5,8 @@ const TRIGGER_LABEL = 'testing/test-plan';
 const ALLOWED_PARENT_TYPES = new Set(['Epic', 'Story']);
 
 export async function syncTestPlanSubIssue({ github, core, context }) {
-    const isManualRun = context.eventName === 'workflow_dispatch';
-    const action = isManualRun ? process.env.TEST_PLAN_ACTION : context.payload.action;
-    const parentIssue = isManualRun
-        ? (await github.rest.issues.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: Number.parseInt(process.env.TEST_PLAN_ISSUE_NUMBER, 10),
-        })).data
-        : context.payload.issue;
+    const action = context.payload.action;
+    const parentIssue = context.payload.issue;
 
     if (!parentIssue || parentIssue.pull_request) {
         core.info('Skipping because the payload does not describe a plain issue.');
@@ -155,6 +148,11 @@ export async function syncTestPlanSubIssue({ github, core, context }) {
             title: childTitle,
             body: [
                 marker,
+                '',
+                '## Parent issue',
+                '',
+                `- ${parentRef}`,
+                `- ${parentIssue.html_url}`,
                 '',
                 templateBody,
             ].join('\n'),

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -4,20 +4,6 @@ on:
   pull_request:
   issues:
   workflow_dispatch:
-    inputs:
-      test_plan_issue_number:
-        description: 'Issue number to test the test-plan sync against'
-        required: false
-        type: string
-      test_plan_action:
-        description: 'Lifecycle action to simulate'
-        required: false
-        default: labeled
-        type: choice
-        options:
-          - labeled
-          - unlabeled
-          - reopened
   schedule:
     - cron: "0 1 * * *"
 
@@ -32,7 +18,7 @@ jobs:
 
   cleanup-needs-triage:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     permissions:
       contents: read
       issues: write
@@ -132,7 +118,7 @@ jobs:
 
   mark-stale-issues:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     permissions:
       contents: read
       # TODO: Set to write when Dry Run gets disabled
@@ -153,7 +139,7 @@ jobs:
 
   close-stale-issues:
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: [mark-stale-issues]
     permissions:
       contents: read
@@ -200,14 +186,11 @@ jobs:
   sync-test-plan-sub-issue:
     runs-on: ubuntu-24.04
     if: >
-      (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number != '') ||
+      github.event_name == 'issues' &&
       (
-        github.event_name == 'issues' &&
-        (
-          (github.event.action == 'labeled' && github.event.label.name == 'testing/test-plan') ||
-          (github.event.action == 'unlabeled' && github.event.label.name == 'testing/test-plan') ||
-          github.event.action == 'reopened'
-        )
+        (github.event.action == 'labeled' && github.event.label.name == 'testing/test-plan') ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'testing/test-plan') ||
+        github.event.action == 'reopened'
       )
     permissions:
       contents: read
@@ -218,9 +201,6 @@ jobs:
       - shell: bash
         run: npm ci --prefix .github/bin/js/
       - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
-        env:
-          TEST_PLAN_ISSUE_NUMBER: ${{ inputs.test_plan_issue_number }}
-          TEST_PLAN_ACTION: ${{ inputs.test_plan_action }}
         with:
           script: |
             const { syncTestPlanSubIssue } = await import('${{ github.workspace }}/.github/bin/js/test-plan-sub-issue.mjs')

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -4,6 +4,20 @@ on:
   pull_request:
   issues:
   workflow_dispatch:
+    inputs:
+      test_plan_issue_number:
+        description: 'Issue number to test the test-plan sync against'
+        required: false
+        type: string
+      test_plan_action:
+        description: 'Lifecycle action to simulate'
+        required: false
+        default: labeled
+        type: choice
+        options:
+          - labeled
+          - unlabeled
+          - reopened
   schedule:
     - cron: "0 1 * * *"
 
@@ -18,7 +32,7 @@ jobs:
 
   cleanup-needs-triage:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
     permissions:
       contents: read
       issues: write
@@ -118,7 +132,7 @@ jobs:
 
   mark-stale-issues:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
     permissions:
       contents: read
       # TODO: Set to write when Dry Run gets disabled
@@ -139,7 +153,7 @@ jobs:
 
   close-stale-issues:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number == '')
     needs: [mark-stale-issues]
     permissions:
       contents: read
@@ -182,3 +196,32 @@ jobs:
           script: |
             const { syncPriorities } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await syncPriorities({github, core, context})
+
+  sync-test-plan-sub-issue:
+    runs-on: ubuntu-24.04
+    if: >
+      (github.event_name == 'workflow_dispatch' && inputs.test_plan_issue_number != '') ||
+      (
+        github.event_name == 'issues' &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'testing/test-plan') ||
+          (github.event.action == 'unlabeled' && github.event.label.name == 'testing/test-plan') ||
+          github.event.action == 'reopened'
+        )
+      )
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 4
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          TEST_PLAN_ISSUE_NUMBER: ${{ inputs.test_plan_issue_number }}
+          TEST_PLAN_ACTION: ${{ inputs.test_plan_action }}
+        with:
+          script: |
+            const { syncTestPlanSubIssue } = await import('${{ github.workspace }}/.github/bin/js/test-plan-sub-issue.mjs')
+            await syncTestPlanSubIssue({ github, core, context })


### PR DESCRIPTION
### 1. Why is this change necessary?

We want a consistent way to create and maintain test-plan sub-issues for parent issues that are explicitly marked with the `testing/test-plan` label.

Today this work is manual and easy to do inconsistently. The automation should ensure that one dedicated test-plan issue exists per eligible parent issue and that it is reused across label changes instead of creating duplicates.

### 2. What does this change do, exactly?

This change introduces the first iteration of test-plan issue automation in `shopware/shopware`.

It adds a workflow that reacts to the `testing/test-plan` label on issues of type `Epic` and `Story` and then:
- creates a dedicated test-plan issue if none exists
- reuses and reopens the existing test-plan issue if it already exists
- keeps the child linked as a sub-issue of the parent
- closes the child when the label is removed without deleting it

The implementation uses a hidden marker in the child issue body to identify and reuse the correct test-plan issue.

This change also adds:
- a reusable parent test-plan template
- a reusable child test-scenario template for manually created scenario sub-issues
- a dedicated JS helper to keep the workflow logic out of the YAML file

Creating scenario sub-issues from the parent test-plan issue is intentionally out of scope for this iteration. The `test-scenario` template is included for manual use now and potential automation later.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or use an issue of type `Epic` or `Story`.
2. Add the `testing/test-plan` label.
3. Verify that a test-plan issue is created in the same repository and linked as a sub-issue.
4. Remove the `testing/test-plan` label.
5. Verify that the test-plan issue is closed but not deleted.
6. Add the `testing/test-plan` label again.
7. Verify that the same test-plan issue is reopened and reused instead of creating a duplicate.

Additional manual verification:
1. Open the generated test-plan issue.
2. Verify that it uses the structured `test-plan` template.
3. Create a dedicated scenario issue manually using `.github/ISSUE_TEMPLATE/test-scenario.md`.
4. Add that scenario issue as a sub-issue under the test plan.

### 4. Please link to the relevant issues (if any).

- relates #16310

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
