### PR TITLE
fix(captcha): restore removal of required validator from reCAPTCHA inputs

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV2.html.twig
@@ -13,7 +13,7 @@
             type="hidden"
             class="grecaptcha-v2-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV2::CAPTCHA_REQUEST_PARAMETER') }}"
-            data-validation="grecaptcha,required"
+            data-validation="grecaptcha"
             data-validate-hidden="true"
             aria-describedby="{{ feedbackId }}">
 

--- a/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/googleReCaptchaV3.html.twig
@@ -12,7 +12,7 @@
             type="hidden"
             class="grecaptcha_v3-input"
             name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\GoogleReCaptchaV3::CAPTCHA_REQUEST_PARAMETER') }}"
-            data-validation="grecaptcha,required"
+            data-validation="grecaptcha"
             data-validate-hidden="true"
             aria-describedby="{{ feedbackId }}">
 


### PR DESCRIPTION
 ### 1. Why is this change necessary?

PR #15296 accidentally re-introduced required into the data-validation attribute of the reCAPTCHA hidden inputs. This undid the intentional fix from #15212, which removed required to prevent a validation flash on form submit.

 ### 2. What does this change do, exactly?

Removes required from data-validation on the hidden captcha inputs in both googleReCaptchaV2.html.twig and googleReCaptchaV3.html.twig, restoring the state established by #15212.

 ### 3. Describe each step to reproduce the issue or behaviour.

  1. Configure reCAPTCHA v3 globally
  2. Accept cookies, navigate to the registration page
  3. Fill in all fields and submit
  4. Observe "Input should not be empty." flashing briefly before the form submits

Root cause: FormHandler validates synchronously while the reCAPTCHA plugin populates the token asynchronously — required fires before the token is set. Server-side validation already enforces token presence, so the client-side required rule is redundant.

 ### 4. Please link to the relevant issues (if any).

  - relates #15187
  - reverts the template portion of #15296 (which accidentally undid #15212)

 ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and
  how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for
  details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [ ] I have read the contribution requirements and fulfilled them