### PR TITLE
fix: backwards compatible invalid locale

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -58,6 +58,10 @@ Product exports now support `ProductExportEntity::FILE_FORMAT_JSONL` as a third 
 
 The new `AbstractAgenticCommerceProductExportProvider` can be used to implement custom Agentic Commerce export providers.
 
+### Backward compatible invalid locales
+
+Added and deprecated `BackwardCompatibleNumberFormatter` to temporarily allow invalid locale strings without throwing exceptions in PHP >=8.4. It will be removed in Shopware 6.8.
+
 ## Administration
 
 ### [Internal] Twig to Native Block Runtime Adapter

--- a/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
+++ b/src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter\Twig;
 
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Locale\Util\LocaleHelper;
 use Twig\Extension\AbstractExtension;
 use Twig\Extra\Intl\IntlExtension;
 use Twig\TwigFilter;
@@ -43,10 +44,7 @@ class BackwardCompatibleIntlExtension extends AbstractExtension
             return $this->intlExtension->formatCurrency($amount, $currency, $attrs, $locale);
         }
 
-        try {
-            /** @phpstan-ignore new.resultUnused (just called to "validate" the locale) */
-            new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
-        } catch (\ValueError) {
+        if (!LocaleHelper::isLocale($locale)) {
             Feature::triggerDeprecationOrThrow(
                 'v6.8.0.0',
                 'The locale "' . $locale . '" passed to "format_currency" twig filter is no valid PHP locale. Please use a valid locale.'
@@ -67,10 +65,7 @@ class BackwardCompatibleIntlExtension extends AbstractExtension
             return $this->intlExtension->formatNumber($number, $attrs, $style, $type, $locale);
         }
 
-        try {
-            /** @phpstan-ignore new.resultUnused (just called to "validate" the locale) */
-            new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
-        } catch (\ValueError) {
+        if (!LocaleHelper::isLocale($locale)) {
             Feature::triggerDeprecationOrThrow(
                 'v6.8.0.0',
                 'The locale "' . $locale . '" passed to "format_number" twig filter is no valid PHP locale. Please use a valid locale.'

--- a/src/Core/System/Currency/CurrencyFormatter.php
+++ b/src/Core/System/Currency/CurrencyFormatter.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
+use Shopware\Core\System\Locale\Util\BackwardCompatibleNumberFormatter;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('fundamentals@framework')]
@@ -49,6 +50,6 @@ class CurrencyFormatter implements ResetInterface
             return $this->formatter[$locale];
         }
 
-        return $this->formatter[$locale] = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
+        return $this->formatter[$locale] = new BackwardCompatibleNumberFormatter($locale, \NumberFormatter::CURRENCY);
     }
 }

--- a/src/Core/System/Locale/Util/BackwardCompatibleNumberFormatter.php
+++ b/src/Core/System/Locale/Util/BackwardCompatibleNumberFormatter.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Locale\Util;
+
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.8.0 - reason:behavior-change - will be removed in 6.8.0, invalid locales won't be supported anymore
+ *
+ * We extend NumberFormatter to make sure that invalid locales are still supported
+ * Since php 8.4.0 invalid locales will throw an exception, which leads to a breaking change
+ */
+#[Package('discovery')]
+final class BackwardCompatibleNumberFormatter extends \NumberFormatter
+{
+    public function __construct(
+        string $locale,
+        int $style,
+        ?string $pattern = null,
+    ) {
+        if ($locale === '' || LocaleHelper::isLocale($locale)) {
+            parent::__construct($locale, $style, $pattern);
+
+            return;
+        }
+
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The locale "' . $locale . '" is no valid PHP locale. Please use a valid locale.'
+        );
+
+        parent::__construct('', $style, $pattern);
+    }
+}

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -19,8 +19,6 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
 {
     use KernelTestBehaviour;
 
-    private ?string $locale;
-
     private Environment $twig;
 
     private IntlExtension $intlExtension;
@@ -30,11 +28,6 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
         if (Feature::isActive('v6.8.0.0')) {
             static::markTestSkipped('This test is only relevant for versions before v6.8.0');
         }
-
-        // Set locale based on PHP version
-        // PHP 8.4+ throws exceptions for invalid locales, so we use null to fallback to default
-        // PHP < 8.4 allows invalid locales, so we keep 'zzz'
-        $this->locale = \PHP_VERSION_ID >= 80400 ? null : 'zzz';
 
         // Create a fresh Twig environment with IntlExtension and BackwardCompatibleIntlExtension
         $loader = new ArrayLoader();
@@ -52,7 +45,7 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
         $output = $template->render(['value' => 1234567.891]);
 
         // Create expected value using IntlExtension with same settings as template (fraction_digit: 1)
-        $expected = $this->intlExtension->formatNumber(1234567.891, ['fraction_digit' => 1], 'decimal', 'default', $this->locale);
+        $expected = $this->intlExtension->formatNumber(1234567.891, ['fraction_digit' => 1], 'decimal', 'default');
         static::assertSame($expected, $output);
     }
 
@@ -63,7 +56,7 @@ class BackwardCompatibleIntlExtensionTest extends TestCase
         $output = $template->render(['value' => 1234567.891]);
 
         // Create expected value using IntlExtension with same settings as template
-        $expected = $this->intlExtension->formatCurrency(1234567.891, 'USD', [], $this->locale);
+        $expected = $this->intlExtension->formatCurrency(1234567.891, 'USD', []);
         static::assertSame($expected, $output);
     }
 }

--- a/tests/unit/Core/System/Locale/Util/BackwardCompatibleNumberFormatterTest.php
+++ b/tests/unit/Core/System/Locale/Util/BackwardCompatibleNumberFormatterTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Locale\Util;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Locale\Util\BackwardCompatibleNumberFormatter;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(BackwardCompatibleNumberFormatter::class)]
+class BackwardCompatibleNumberFormatterTest extends TestCase
+{
+    public function testItGetsNumberFormatterWithValidLocale(): void
+    {
+        $numberFormatter = new BackwardCompatibleNumberFormatter('en-GB', \NumberFormatter::DECIMAL);
+        static::assertSame('en_GB', $numberFormatter->getLocale());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testItFallsBackToDefaultLocaleIfGivenLocaleIsInvalid(): void
+    {
+        $numberFormatter = new BackwardCompatibleNumberFormatter('us', \NumberFormatter::DECIMAL);
+        static::assertSame(\Locale::canonicalize(\Locale::getDefault()), $numberFormatter->getLocale());
+    }
+
+    public function testItThrowsExceptionIfGivenLocaleIsInvalid(): void
+    {
+        static::expectException(FeatureException::class);
+        static::expectExceptionMessage('Tried to access deprecated functionality: The locale "us" is no valid PHP locale. Please use a valid locale.');
+
+        new BackwardCompatibleNumberFormatter('us', \NumberFormatter::DECIMAL);
+    }
+}


### PR DESCRIPTION
This pull request introduces a temporary backward compatibility layer to handle invalid locale strings for number and currency formatting, ensuring smoother transitions for users upgrading to PHP 8.4 and preparing for stricter locale validation in Shopware 6.8. The main changes include the addition of a deprecated `BackwardCompatibleNumberFormatter` class, updates to use this class in currency formatting, improved locale validation logic, and comprehensive tests for the new behavior.

**Backward compatibility for invalid locales:**

* Added the `BackwardCompatibleNumberFormatter` class, which extends `\NumberFormatter` to allow invalid locales without throwing exceptions in PHP >=8.4, but triggers a deprecation warning. This class will be removed in Shopware 6.8. (`src/Core/System/Locale/Util/BackwardCompatibleNumberFormatter.php`)
* Updated `CurrencyFormatter` to use `BackwardCompatibleNumberFormatter` instead of `\NumberFormatter` directly, ensuring backward compatibility when formatting currencies with potentially invalid locales. (`src/Core/System/Currency/CurrencyFormatter.php`) [[1]](diffhunk://#diff-468417e4f65eb6c324bbc70a7b9d70216c247938b87940c92fc1198e70184b06R9) [[2]](diffhunk://#diff-468417e4f65eb6c324bbc70a7b9d70216c247938b87940c92fc1198e70184b06L52-R53)

**Improved locale validation:**

* Modified `BackwardCompatibleIntlExtension` to use `LocaleHelper::isLocale()` for locale validation in both `formatCurrency` and `formatNumber` methods, providing consistent checks and triggering deprecation warnings for invalid locales. (`src/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtension.php`) [[1]](diffhunk://#diff-a74b09268bffda8f354b3735235319222d4c565543ee9d405e75979ec69776e3R7) [[2]](diffhunk://#diff-a74b09268bffda8f354b3735235319222d4c565543ee9d405e75979ec69776e3L46-R47) [[3]](diffhunk://#diff-a74b09268bffda8f354b3735235319222d4c565543ee9d405e75979ec69776e3L70-R68)

**Testing and documentation:**

* Added a new unit test for `BackwardCompatibleNumberFormatter`, verifying correct handling of valid and invalid locales, and proper triggering of deprecation exceptions. (`tests/unit/Core/System/Locale/Util/BackwardCompatibleNumberFormatterTest.php`)
* Updated integration tests for `BackwardCompatibleIntlExtension` to align with the new locale handling logic. (`tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php`) [[1]](diffhunk://#diff-9318f0abe8812fe659ad3a5d5dabd8310db58aba5a62c8460772426bf178f7a8L22-L23) [[2]](diffhunk://#diff-9318f0abe8812fe659ad3a5d5dabd8310db58aba5a62c8460772426bf178f7a8L34-L38) [[3]](diffhunk://#diff-9318f0abe8812fe659ad3a5d5dabd8310db58aba5a62c8460772426bf178f7a8L55-R48) [[4]](diffhunk://#diff-9318f0abe8812fe659ad3a5d5dabd8310db58aba5a62c8460772426bf178f7a8L66-R59)
* Added release notes documenting the new backward compatibility layer and its deprecation timeline. (`RELEASE_INFO-6.7.md`)