### PR TITLE
feat: system check invalid locales

### DIFF
--- a/src/Core/System/DependencyInjection/locale.xml
+++ b/src/Core/System/DependencyInjection/locale.xml
@@ -22,5 +22,11 @@
         <service id="Shopware\Core\System\Locale\Subscriber\LocaleValidator">
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Shopware\Core\System\Locale\SystemCheck\LocalesReadinessCheck">
+            <argument type="service" id="locale.repository"/>
+
+            <tag name="shopware.system_check"/>
+        </service>
     </services>
 </container>

--- a/src/Core/System/Locale/SystemCheck/LocalesReadinessCheck.php
+++ b/src/Core/System/Locale/SystemCheck/LocalesReadinessCheck.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Locale\SystemCheck;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\SystemCheck\BaseCheck;
+use Shopware\Core\Framework\SystemCheck\Check\Category;
+use Shopware\Core\Framework\SystemCheck\Check\Result;
+use Shopware\Core\Framework\SystemCheck\Check\Status;
+use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+use Shopware\Core\System\Locale\LocaleCollection;
+use Shopware\Core\System\Locale\LocaleEntity;
+use Shopware\Core\System\Locale\Util\LocaleHelper;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class LocalesReadinessCheck extends BaseCheck
+{
+    /**
+     * @param EntityRepository<LocaleCollection> $localeRepository
+     */
+    public function __construct(private readonly EntityRepository $localeRepository)
+    {
+    }
+
+    public function run(): Result
+    {
+        $locales = $this->localeRepository
+            ->search(new Criteria(), Context::createDefaultContext())
+            ->map(static fn (LocaleEntity $locale) => $locale->getCode());
+
+        $invalidLocales = array_filter(
+            $locales,
+            static fn (string $locale) => !LocaleHelper::isLocale($locale)
+        );
+
+        $status = \count($invalidLocales) === 0 ? Status::OK : Status::WARNING;
+
+        return new Result(
+            $this->name(),
+            $status,
+            $status === Status::OK ? 'All locales are OK' : 'Some locales are invalid',
+            $status === Status::OK,
+            $invalidLocales
+        );
+    }
+
+    public function category(): Category
+    {
+        return Category::SYSTEM;
+    }
+
+    public function name(): string
+    {
+        return 'LocalesReadiness';
+    }
+
+    protected function allowedSystemCheckExecutionContexts(): array
+    {
+        return SystemCheckExecutionContext::longRunning();
+    }
+}

--- a/tests/unit/Core/System/Locale/SystemCheck/LocalesReadinessCheckTest.php
+++ b/tests/unit/Core/System/Locale/SystemCheck/LocalesReadinessCheckTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Locale\SystemCheck;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\SystemCheck\Check\Category;
+use Shopware\Core\Framework\SystemCheck\Check\Status;
+use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+use Shopware\Core\System\Locale\LocaleCollection;
+use Shopware\Core\System\Locale\LocaleDefinition;
+use Shopware\Core\System\Locale\LocaleEntity;
+use Shopware\Core\System\Locale\SystemCheck\LocalesReadinessCheck;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LocalesReadinessCheck::class)]
+class LocalesReadinessCheckTest extends TestCase
+{
+    public function testItChecksLocales(): void
+    {
+        /** @var StaticEntityRepository<LocaleCollection> $localeRepository */
+        $localeRepository = new StaticEntityRepository(
+            [
+                new LocaleCollection([
+                    (new LocaleEntity())->assign([
+                        'id' => 'locale-1',
+                        'code' => 'de-DE',
+                    ]),
+                    (new LocaleEntity())->assign([
+                        'id' => 'locale-2',
+                        'code' => 'foo-BAR',
+                    ]),
+                ]),
+            ],
+            new LocaleDefinition()
+        );
+
+        $localesReadninessCheck = new LocalesReadinessCheck($localeRepository);
+
+        static::assertSame(Category::SYSTEM, $localesReadninessCheck->category());
+        static::assertTrue($localesReadninessCheck->allowedToRunIn(SystemCheckExecutionContext::CLI));
+        $result = $localesReadninessCheck->run();
+        static::assertSame(Status::WARNING, $result->status);
+        static::assertSame('Some locales are invalid', $result->message);
+        static::assertFalse($result->healthy);
+        static::assertSame(['locale-2' => 'foo-BAR'], $result->extra);
+    }
+}


### PR DESCRIPTION
This pull request introduces stricter validation for locale codes throughout the system, ensuring that only valid PHP locales are accepted. It does so by adding a new `LocaleValidator` for validation logic, updating currency and number formatting to use this validator, and providing system checks and exceptions for invalid locales. The test suite is also updated to use valid locale codes, reflecting the new validation rules.

**System health checks:**

* Added a new `LocalesReadinessCheck` system check to report any invalid locales present in the system, aiding administrators in identifying and correcting issues. (`src/Core/System/Locale/SystemCheck/LocalesReadinessCheck.php`, `src/Core/System/DependencyInjection/locale.xml`) [[1]](diffhunk://#diff-6b5e43cab1901cd0a044a9607ecb2b81ba42dfb9c2db8b4e1e77c41aa410f5abR1-R67) [[2]](diffhunk://#diff-81d0afc9066f22fa289448e58d1428784c56f8080d44934cb8500d1deb47ab54R21-R30)
