### PR TITLE
fix: prevent Maximum call stack size exceeded in extension-api deep clone

### DIFF
--- a/changelog/_unreleased/2026-04-24-fix-extension-api-deep-clone-cycle.md
+++ b/changelog/_unreleased/2026-04-24-fix-extension-api-deep-clone-cycle.md
@@ -1,0 +1,9 @@
+---
+title: Fix Maximum call stack size exceeded in extension-api-data deep clone on circular entity references
+issue: NEXT-00000
+author: Y Tran
+author_email: nguyenytran06@gmail.com
+author_github: nguyenytran
+---
+# Administration
+* Changed `Resources/app/administration/src/core/service/extension-api-data.service.ts` so `deepCloneWithEntity` tracks entities currently being cloned via a shared `WeakSet`. When a cycle is detected (e.g. `order.lineItems[i].order === order`) the original reference is returned instead of recursing, preventing the `Maximum call stack size exceeded` crash on order detail pages containing line items with back-references to their parent.

--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.spec.js
@@ -513,6 +513,29 @@ describe('core/service/extension-api-data.service.ts', () => {
         expect(clonedValue.mediaCollection.context.auth).toBeUndefined();
     });
 
+    it('should deepClone entities with circular references without blowing the stack', () => {
+        // Repro for shopware/shopware#14317 — order.lineItems[i].order points back to order.
+        const order = new Entity('order1', 'order', {
+            orderNumber: '10001',
+            lineItems: new EntityCollection('/order/order1/line-items', 'order_line_item', {}, null, []),
+        });
+
+        const lineItem = new Entity('li1', 'order_line_item', {
+            label: 'Custom T-Shirt',
+            order,
+            children: new EntityCollection('/order/order1/line-items/li1/children', 'order_line_item', {}, null, []),
+        });
+        order.lineItems.push(lineItem);
+
+        expect(() => deepCloneWithEntity(order)).not.toThrow();
+
+        const cloned = deepCloneWithEntity(order);
+        expect(cloned).not.toBe(order);
+        expect(cloned.lineItems[0]).not.toBe(lineItem);
+        // The back-reference is preserved (shared with original) to break the cycle.
+        expect(cloned.lineItems[0].order).toBe(order);
+    });
+
     it('should not update value after component gets unmounted', async () => {
         const wrapper = mount({
             template: '<h1>jest</h1>',

--- a/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/extension-api-data.service.ts
@@ -55,10 +55,16 @@ let unregisterPublishDataIds: string[] = [];
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Deep clone with custom handling for entities and entity collections
+ * Deep clone with custom handling for entities and entity collections.
+ * Tracks entities currently being cloned so back-references (e.g. orderLineItem.order → order)
+ * break the recursion instead of blowing the call stack.
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export function deepCloneWithEntity(data: any): any {
+    return cloneWithEntity(data, new WeakSet<object>());
+}
+
+function cloneWithEntity(data: any, inProgress: WeakSet<object>): any {
     return cloneDeepWith(
         data,
         (value: {
@@ -75,40 +81,58 @@ export function deepCloneWithEntity(data: any): any {
             _isDirty?: boolean;
             _isNew?: boolean;
         }) => {
+            if (value === null || typeof value !== 'object') {
+                return undefined;
+            }
+
+            if (inProgress.has(value)) {
+                return value;
+            }
+
             // If value is a entity collection, we need to clone it custom
             if (
                 value?.__identifier__ &&
                 typeof value.__identifier__ === 'function' &&
                 value.__identifier__() === 'EntityCollection'
             ) {
-                return new EntityCollection(
-                    value.source!,
-                    value.entity!,
-                    // @ts-expect-error - we don't want to provide a context
-                    {},
-                    value.criteria === null ? value.criteria : Criteria.fromCriteria(value.criteria!),
-                    // @ts-expect-error - value is an array inside a entity collection
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    deepCloneWithEntity(Array.from(value)),
-                    value.total,
-                    value.aggregations,
-                );
+                inProgress.add(value);
+                try {
+                    return new EntityCollection(
+                        value.source!,
+                        value.entity!,
+                        // @ts-expect-error - we don't want to provide a context
+                        {},
+                        value.criteria === null ? value.criteria : Criteria.fromCriteria(value.criteria!),
+                        // @ts-expect-error - value is an array inside a entity collection
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        cloneWithEntity(Array.from(value), inProgress),
+                        value.total,
+                        value.aggregations,
+                    );
+                } finally {
+                    inProgress.delete(value);
+                }
             }
 
             // If value is a entity, we need to clone it custom
             if (value?.__identifier__ && typeof value.__identifier__ === 'function' && value.__identifier__() === 'Entity') {
-                return new Entity(
-                    value.id!,
-                    value._entityName!,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    deepCloneWithEntity(value._draft),
-                    {
-                        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                        originData: deepCloneWithEntity(value._origin),
-                        isDirty: value._isDirty,
-                        isNew: value._isNew,
-                    },
-                );
+                inProgress.add(value);
+                try {
+                    return new Entity(
+                        value.id!,
+                        value._entityName!,
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        cloneWithEntity(value._draft, inProgress),
+                        {
+                            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                            originData: cloneWithEntity(value._origin, inProgress),
+                            isDirty: value._isDirty,
+                            isNew: value._isNew,
+                        },
+                    );
+                } finally {
+                    inProgress.delete(value);
+                }
             }
 
             return undefined;


### PR DESCRIPTION
### 1. Why is this change necessary?

Opening an order detail page in the administration crashes with `Uncaught RangeError: Maximum call stack size exceeded` when the order contains a custom product line item (issue #14317).

The stack trace points at `extension-api-data.service.ts` lines 62/89/92/104 recursing indefinitely:
```
(anonymous) @ extension-api-data.service.ts:92    (EntityCollection branch)
(anonymous) @ extension-api-data.service.ts:62    (cloneDeepWith entry)
(anonymous) @ extension-api-data.service.ts:104   (Entity _draft branch)
(anonymous) @ extension-api-data.service.ts:62
...
```

Custom products load `lineItems.children.children`, and order line items hold an `order` back-reference to the parent order entity. `deepCloneWithEntity` starts a fresh `cloneDeepWith` for every nested entity, so lodash's internal cycle tracking is lost between calls and the `order → lineItems[i] → order` cycle recurses forever.

Core-side PR #190 (criteria sorting) did not fix the crash because the recursion is in the admin clone path, not the DAL query.

### 2. What does this change do, exactly?

Threads a single `WeakSet` of in-progress entities through all recursive calls in `deepCloneWithEntity`. When the customizer encounters an entity that is currently being cloned higher up the stack, it returns the original reference — breaking the cycle while preserving the object graph shape. The set is scoped per top-level call and cleaned up via `try { ... } finally { inProgress.delete(value) }` so repeated appearances in non-cyclic positions are still deep-cloned normally.

Added regression test `should deepClone entities with circular references without blowing the stack` that constructs the exact `order ↔ orderLineItem.order` cycle and asserts `deepCloneWithEntity` does not throw.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install the `SwagCustomizedProducts` plugin.
2. Create a customized product template with at least one option (e.g. checkbox).
3. Assign the template to a product and place an order for it via the storefront.
4. Open the resulting order in the administration order detail.

Before this change: the page renders with `Uncaught RangeError: Maximum call stack size exceeded` in the console and blank extension slots.
After this change: no error; the order detail renders normally.

### 4. Please link to the relevant issues (if any).

- closes #14317

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them