### PR TITLE
feat: make order deep link expiry days configurable via shopware.yaml

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -58,6 +58,15 @@ Product exports now support `ProductExportEntity::FILE_FORMAT_JSONL` as a third 
 
 The new `AbstractAgenticCommerceProductExportProvider` can be used to implement custom Agentic Commerce export providers.
 
+### Configurable order deep link expiry
+
+The number of days an order can be accessed via deep link is now configurable via `shopware.yaml`:
+
+    shopware:
+      order:
+        deep_link:
+          expire_days: 30
+
 ## Administration
 
 ### [Internal] Twig to Native Block Runtime Adapter

--- a/config-schema.json
+++ b/config-schema.json
@@ -75,6 +75,9 @@
                 "cart": {
                     "$ref": "#/definitions/cart"
                 },
+                "order": {
+                    "$ref": "#/definitions/order"
+                },
                 "number_range": {
                     "$ref": "#/definitions/number_range"
                 },
@@ -811,6 +814,25 @@
                 }
             },
             "title": "Cart"
+        },
+        "order": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "deep_link": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "expire_days": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 30,
+                            "description": "Specifies the number of days an order can be accessed via the deep link."
+                        }
+                    }
+                }
+            },
+            "title": "Order"
         },
         "number_range": {
             "type": "object",

--- a/src/Core/Checkout/DependencyInjection/order.xml
+++ b/src/Core/Checkout/DependencyInjection/order.xml
@@ -129,6 +129,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\Service\GuestAuthenticator"/>
+            <argument>%shopware.order.deep_link.expire_days%</argument>
         </service>
 
         <service id="Shopware\Core\Checkout\Order\SalesChannel\CancelOrderRoute" public="true">

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -44,13 +44,13 @@ class OrderRoute extends AbstractOrderRoute
      * @param EntityRepository<PromotionCollection> $promotionRepository
      */
     public function __construct(
-        private readonly EntityRepository         $orderRepository,
-        private readonly EntityRepository         $promotionRepository,
-        private readonly RateLimiter              $rateLimiter,
+        private readonly EntityRepository $orderRepository,
+        private readonly EntityRepository $promotionRepository,
+        private readonly RateLimiter $rateLimiter,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly AccountService           $accountService,
-        private readonly GuestAuthenticator       $guestAuthenticator,
-        private readonly int                      $deepLinkExpireDays = 30,
+        private readonly AccountService $accountService,
+        private readonly GuestAuthenticator $guestAuthenticator,
+        private readonly int $deepLinkExpireDays = 30,
     ) {
     }
 

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -44,12 +44,13 @@ class OrderRoute extends AbstractOrderRoute
      * @param EntityRepository<PromotionCollection> $promotionRepository
      */
     public function __construct(
-        private readonly EntityRepository $orderRepository,
-        private readonly EntityRepository $promotionRepository,
-        private readonly RateLimiter $rateLimiter,
+        private readonly EntityRepository         $orderRepository,
+        private readonly EntityRepository         $promotionRepository,
+        private readonly RateLimiter              $rateLimiter,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly AccountService $accountService,
-        private readonly GuestAuthenticator $guestAuthenticator,
+        private readonly AccountService           $accountService,
+        private readonly GuestAuthenticator       $guestAuthenticator,
+        private readonly int                      $deepLinkExpireDays = 30,
     ) {
     }
 
@@ -229,7 +230,7 @@ class OrderRoute extends AbstractOrderRoute
     private function filterOldOrders(OrderCollection $orders): OrderCollection
     {
         // Search with deepLinkCode needs updatedAt Filter
-        $latestOrderDate = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'))->modify(-abs(30) . ' Day');
+        $latestOrderDate = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'))->modify(-abs($this->deepLinkExpireDays) . ' Day');
 
         return $orders->filter(static fn (OrderEntity $order) => $order->getCreatedAt() > $latestOrderDate || $order->getUpdatedAt() > $latestOrderDate);
     }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -30,6 +30,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->createApiSection())
                 ->append($this->createStoreSection())
                 ->append($this->createCartSection())
+                ->append($this->createOrderSection())
                 ->append($this->createSalesChannelContextSection())
                 ->append($this->createAdminWorkerSection())
                 ->append($this->createAutoUpdateSection())
@@ -592,6 +593,24 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('connection')->defaultValue(null)->end()
                             ->end()
+                    ->end()
+            ->end();
+
+        return $rootNode;
+    }
+
+    private function createOrderSection(): ArrayNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('order');
+
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+                ->arrayNode('deep_link')
+                    ->children()
+                        ->integerNode('expire_days')
+                            ->min(1)
+                            ->defaultValue(30)
                     ->end()
             ->end();
 

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -410,6 +410,10 @@ shopware:
             # for redis also the shopware.cart.storage.config.connection is required to point to a valid redis connection
             type: "mysql"
 
+    order:
+        deep_link:
+            expire_days: 30
+
     number_range:
         # supported types: mysql, redis
         # for redis also the shopware.number_range.config.connection is required to point to a valid redis connection

--- a/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -327,7 +327,7 @@ class OrderRouteTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, array{int, int, bool}>
      */
     public static function deeplinkExpireDaysProvider(): array
     {

--- a/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/OrderRouteTest.php
@@ -255,4 +255,87 @@ class OrderRouteTest extends TestCase
             'deeplink prefix' => [new PrefixFilter('deepLinkCode', 'deep')],
         ];
     }
+
+    #[DataProvider('deeplinkExpireDaysProvider')]
+    public function testDeeplinkFilterExpireDays(int $createdDaysAgo, int $expireDays, bool $expectedFiltered): void
+    {
+        $orderCustomer = new OrderCustomerEntity();
+        $orderCustomer->setId(Uuid::randomHex());
+        $orderCustomer->setEmail('test@example.com');
+        $orderCustomer->setCustomerId(Uuid::randomHex());
+
+        $guestCustomer = new CustomerEntity();
+        $guestCustomer->setId($orderCustomer->getId());
+        $guestCustomer->setGuest(true);
+        $orderCustomer->setCustomer($guestCustomer);
+
+        $billingAddress = new OrderAddressEntity();
+        $billingAddress->setZipcode('AA-345');
+
+        $order = new OrderEntity();
+        $order->setId(Uuid::randomHex());
+        $order->setCreatedAt(new \DateTime("-{$createdDaysAgo} days"));
+        $order->setUpdatedAt(new \DateTime("-{$createdDaysAgo} days"));
+        $order->setOrderCustomer($orderCustomer);
+        $order->setBillingAddress($billingAddress);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context
+            ->method('getCustomer')
+            ->willReturn(null);
+
+        $searchResult = new EntitySearchResult(
+            OrderDefinition::ENTITY_NAME,
+            1,
+            new OrderCollection([$order]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $orderRepository = $this->createMock(EntityRepository::class);
+        $orderRepository
+            ->method('search')
+            ->willReturn($searchResult);
+
+        $route = new OrderRoute(
+            $orderRepository,
+            $this->createMock(EntityRepository::class),
+            $this->createMock(RateLimiter::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(AccountService::class),
+            new GuestAuthenticator(),
+            $expireDays
+        );
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('deepLinkCode', 'someDeepLinkCode'));
+
+        $request = new Request();
+        $request->request->set('email', 'test@example.com');
+        $request->request->set('zipcode', 'AA-345');
+
+        if ($expectedFiltered) {
+            $this->expectException(OrderException::class);
+        }
+
+        $response = $route->load($request, $context, $criteria);
+
+        if (!$expectedFiltered) {
+            static::assertSame($order->getId(), $response->getOrders()->first()?->getId());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public static function deeplinkExpireDaysProvider(): array
+    {
+        return [
+            'order within limit' => [10, 30, false],
+            'order beyond limit' => [31, 30, true],
+            'order beyond default, within custom limit' => [40, 60, false],
+            'order beyond custom limit' => [61, 60, true],
+        ];
+    }
 }


### PR DESCRIPTION
### Why is this change necessary?
The number of days an order is accessible via deep link was hardcoded to 30 days in `OrderRoute::filterOldOrders()`.
Feedback hub: https://feedback.shopware.com/forums/942607-shopware-6-product-feedback-ideas/suggestions/50846258-make-the-validity-of-the-guest-order-link-deep-li

### What does this change do, exactly?
This change makes the value configurable via `shopware.yaml`:

    shopware:
      order:
        deep_link:
          expire_days: 30

The default value remains 30 to ensure backwards compatibility.

### Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

~There isn't a unit test available yet, as I haven't had much experience with them. I'd be happy to add one later, though.~ A manual test was successful, however. If this PR is okay, I'd be happy to add a note to the documentation.