### PR TITLE
fix: link newsletter recipient emails to detail page

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
@@ -33,14 +33,15 @@
         @keydown.enter="collapseItem"
     >
         <mt-icon
-            size="24px"
-            :name="`regular-chevron-${expandChevronDirection}-xxs`"
+            size="22px"
+            :name="`regular-chevron-${expandChevronDirection}-xs`"
             class="sw-sidebar-collapse__expand-button"
             :class="expandButtonClass"
         />
+
         <mt-icon
-            size="16px"
-            name="regular-chevron-down-xxs"
+            size="14px"
+            name="regular-chevron-down-xs"
             class="sw-sidebar-collapse__collapse-button"
             :class="collapseButtonClass"
         />

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.spec.js
@@ -24,7 +24,7 @@ describe('src/app/component/sidebar/sw-sidebar-collapse', () => {
         it('has a chevron pointing right', async () => {
             const wrapper = await createWrapper();
 
-            expect(wrapper.findComponent('.mt-icon').vm.name).toBe('regular-chevron-right-xxs');
+            expect(wrapper.findComponent('.mt-icon').vm.name).toBe('regular-chevron-right-xs');
         });
     });
 
@@ -42,7 +42,7 @@ describe('src/app/component/sidebar/sw-sidebar-collapse', () => {
                     expandChevronDirection: direction,
                 });
 
-                expect(wrapper.findComponent('.mt-icon').vm.name).toBe(`regular-chevron-${direction}-xxs`);
+                expect(wrapper.findComponent('.mt-icon').vm.name).toBe(`regular-chevron-${direction}-xs`);
             });
         });
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
@@ -78,7 +78,9 @@
             >
                 {% block sw_newsletter_recipientlist_list_grid_email %}
                 <template #column-email="{ item }">
-                    <p>{{ emailIdnFilter(item.email) }}</p>
+                    <mt-link :to="{ name: 'sw.newsletter.recipient.detail', params: { id: item.id } }">
+                        {{ emailIdnFilter(item.email) }}
+                    </mt-link>
                 </template>
                 {% endblock %}
 


### PR DESCRIPTION
Adjusts admin sidebar chevron icon sizing and updates newsletter recipient email cells to link directly to the recipient detail page.
