### PR TITLE
fix(admin): snap sw-date-filter bounds to user timezone day

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -153,6 +153,10 @@ New Agentic Commerce sales channels types can be created.
 These sales channels have dedicated configuration options in the administration for property mapping, and usage insights.
 New entities for monitoring orders and customers for Agentic Commerce sales channels are included.
 
+### Date filter respects user timezone for day boundaries
+
+The `sw-date-filter` component (used in listing filter panels) now snaps `from`/`to` bounds to the start and end of the picked day in the current user's profile timezone. Previously the bounds were derived in UTC, so for non-UTC users the filter range did not align with the calendar day shown in list date columns. The component also no longer mutates its internal `dateValue` during emit, which prevented a duplicate `filter-update` event when a single field changed.
+
 ## Storefront
 
 ### Order cancellation only shown for open orders

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -155,7 +155,7 @@ New entities for monitoring orders and customers for Agentic Commerce sales chan
 
 ### Date filter respects user timezone for day boundaries
 
-The `sw-date-filter` component (used in listing filter panels) now snaps `from`/`to` bounds to the start and end of the picked day in the current user's profile timezone. Previously the bounds were derived in UTC, so for non-UTC users the filter range did not align with the calendar day shown in list date columns. The component also no longer mutates its internal `dateValue` during emit, which prevented a duplicate `filter-update` event when a single field changed.
+The `sw-date-filter` component (used in listing filter panels) now snaps `from`/`to` bounds to the start and end of the picked day in the current user's profile timezone, including across DST transitions where the calendar day is 23 or 25 hours long. Previously the bounds were derived in UTC, so for non-UTC users the filter range did not align with the calendar day shown in list date columns. Timeframe presets (last day, last week, last month, last quarter, last year) now resolve in the user's timezone as full calendar periods: last week is the previous Monday–Sunday, last month is the previous full calendar month, and last year is the previous full calendar year. The component also no longer mutates its internal `dateValue` during emit, which prevented a duplicate `filter-update` event when a single field changed.
 
 ## Storefront
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -162,32 +162,43 @@ export default {
 
             this.resetFilter();
 
-            let from = new Date();
-            let to = new Date();
+            const tz = this.userTimeZone();
+            const today = this.tzCalendar(tz, new Date());
 
-            from.setDate(from.getDate() + timeframe);
-            from.setHours(0, 0, 0);
+            let fromCal;
+            let toCal;
 
-            if (timeframe === 'lastQuarter') {
-                ({ startDate: from, endDate: to } = this.getPreviousQuarterDates());
+            if (timeframe === -1) {
+                fromCal = this.calendarOf(today.year, today.month, today.day - 1);
+                toCal = fromCal;
+            } else if (timeframe === -7) {
+                const daysSinceMonday = (today.weekday + 6) % 7;
+                fromCal = this.calendarOf(today.year, today.month, today.day - daysSinceMonday - 7);
+                toCal = this.calendarOf(fromCal.year, fromCal.month, fromCal.day + 6);
+            } else if (timeframe === -30) {
+                fromCal = this.calendarOf(today.year, today.month - 1, 1);
+                toCal = this.calendarOf(today.year, today.month, 0);
+            } else if (timeframe === 'lastQuarter') {
+                const firstMonthOfLastQuarter = Math.floor(today.month / 3) * 3 - 3;
+                fromCal = this.calendarOf(today.year, firstMonthOfLastQuarter, 1);
+                toCal = this.calendarOf(fromCal.year, fromCal.month + 3, 0);
+            } else {
+                fromCal = this.calendarOf(today.year - 1, 0, 1);
+                toCal = this.calendarOf(today.year - 1, 11, 31);
             }
 
             const params = {
-                gte: from.toISOString(),
-                lte: to.toISOString(),
+                gte: this.startOfDayInTz(fromCal.year, fromCal.month, fromCal.day, tz).toISOString(),
+                lte: this.endOfDayInTz(toCal.year, toCal.month, toCal.day, tz).toISOString(),
             };
-
-            const filterCriteria = [
-                Criteria.range(this.filter.property, params),
-            ];
 
             this.dateValue = {
                 from: params.gte,
                 to: params.lte,
-                timeframe: timeframe,
+                timeframe,
             };
 
-            this.$emit('filter-update', this.filter.name, filterCriteria, this.dateValue);
+            this.$emit('filter-update', this.filter.name, [Criteria.range(this.filter.property, params)], this.dateValue);
         },
 
         resetFilter() {
@@ -199,32 +210,27 @@ export default {
             this.dateValue.timeframe = 'custom';
         },
 
-        getPreviousQuarterDates() {
-            const date = new Date();
-            const quarter = Math.floor(date.getMonth() / 3);
-
-            const startDate = new Date(date.getFullYear(), quarter * 3 - 3, 1, 0, 0, 0);
-            const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 3, 0, 23, 59, 59);
-
-            return {
-                startDate: startDate,
-                endDate: endDate,
-            };
-        },
-
         userTimeZone() {
             return Shopware?.Store?.get('session')?.currentUser?.timeZone ?? 'UTC';
         },
 
-        /**
-         * mt-datepicker in date-only mode may emit an ISO instant whose wall-clock
-         * time is not midnight (e.g. it carries over the current time on the
-         * picked day). Snap to the start of the picked day in the given timezone
-         * and derive the end of that same day so filter bounds cover the full
-         * intended calendar day as the list's date formatter displays it.
-         */
-        dayBoundsInTz(iso, tz) {
-            const instant = new Date(iso);
+        tzCalendar(tz, instant) {
+            const parts = new Intl.DateTimeFormat('en-GB', {
+                timeZone: tz,
+                hour12: false,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+            }).formatToParts(instant);
+            const read = (type) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+            const year = read('year');
+            const month = read('month') - 1;
+            const day = read('day');
+            const weekday = new Date(Date.UTC(year, month, day)).getUTCDay();
+            return { year, month, day, weekday };
+        },
+
+        tzTimeOfDayMs(tz, instant) {
             const parts = new Intl.DateTimeFormat('en-GB', {
                 timeZone: tz,
                 hour12: false,
@@ -232,24 +238,47 @@ export default {
                 minute: '2-digit',
                 second: '2-digit',
             }).formatToParts(instant);
-
             const read = (type) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
-
             let hour = read('hour');
             if (hour === 24) {
                 hour = 0;
             }
-            const minute = read('minute');
-            const second = read('second');
-            const ms = instant.getUTCMilliseconds();
+            return ((hour * 60 + read('minute')) * 60 + read('second')) * 1000 + instant.getUTCMilliseconds();
+        },
 
-            const offsetIntoDayMs = ((hour * 60 + minute) * 60 + second) * 1000 + ms;
-            const startMs = instant.getTime() - offsetIntoDayMs;
-            const oneDayMs = 24 * 60 * 60 * 1000;
+        instantFromWallClockInTz(year, month, day, hour, minute, second, ms, tz) {
+            const guess = Date.UTC(year, month, day, hour, minute, second, ms);
+            const probe = new Date(guess);
+            const cal = this.tzCalendar(tz, probe);
+            const renderedAsUtc = Date.UTC(cal.year, cal.month, cal.day) + this.tzTimeOfDayMs(tz, probe);
+            return new Date(guess - (renderedAsUtc - guess));
+        },
 
+        startOfDayInTz(year, month, day, tz) {
+            return this.instantFromWallClockInTz(year, month, day, 0, 0, 0, 0, tz);
+        },
+
+        endOfDayInTz(year, month, day, tz) {
+            return this.instantFromWallClockInTz(year, month, day, 23, 59, 59, 999, tz);
+        },
+
+        calendarOf(year, month, day) {
+            const d = new Date(Date.UTC(year, month, day));
+            return { year: d.getUTCFullYear(), month: d.getUTCMonth(), day: d.getUTCDate() };
+        },
+
+        /**
+         * mt-datepicker in date-only mode may emit an ISO instant whose wall-clock
+         * time is not midnight. Snap to the start of the picked day in the given
+         * timezone and derive the end of that same day so filter bounds cover the
+         * full intended calendar day. Wall-clock-in-tz arithmetic produces correct
+         * 23h or 25h ranges across DST transitions.
+         */
+        dayBoundsInTz(iso, tz) {
+            const { year, month, day } = this.tzCalendar(tz, new Date(iso));
             return {
-                gte: new Date(startMs).toISOString(),
-                lte: new Date(startMs + oneDayMs - 1).toISOString(),
+                gte: this.startOfDayInTz(year, month, day, tz).toISOString(),
+                lte: this.endOfDayInTz(year, month, day, tz).toISOString(),
             };
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -147,12 +147,7 @@ export default {
                 ...(lte ? { to: lte } : {}),
             };
 
-            this.$emit(
-                'filter-update',
-                this.filter.name,
-                [Criteria.range(this.filter.property, rangeParams)],
-                emittedValue,
-            );
+            this.$emit('filter-update', this.filter.name, [Criteria.range(this.filter.property, rangeParams)], emittedValue);
         },
 
         onTimeframeSelect(timeframe) {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -121,7 +121,7 @@ export default {
             return label;
         },
 
-        updateFilter(params) {
+        updateFilter() {
             if (!this.dateValue.from && !this.dateValue.to) {
                 this.$emit('filter-reset', this.filter.name);
                 return;
@@ -132,19 +132,27 @@ export default {
                 return;
             }
 
-            if (this.dateValue.from) {
-                const from = new Date(this.dateValue.from);
-                from.setHours(0, 0, 0);
-                this.dateValue.from = from.toISOString();
-            }
+            const tz = this.userTimeZone();
+            const gte = this.dateValue.from ? this.dayBoundsInTz(this.dateValue.from, tz).gte : null;
+            const lte = this.dateValue.to ? this.dayBoundsInTz(this.dateValue.to, tz).lte : null;
 
-            if (this.dateValue.to) {
-                const to = new Date(this.dateValue.to);
-                to.setHours(23, 59, 59);
-                this.dateValue.to = to.toISOString();
-            }
+            const rangeParams = {
+                ...(gte ? { gte } : {}),
+                ...(lte ? { lte } : {}),
+            };
 
-            this.$emit('filter-update', this.filter.name, params, this.dateValue);
+            const emittedValue = {
+                ...this.dateValue,
+                ...(gte ? { from: gte } : {}),
+                ...(lte ? { to: lte } : {}),
+            };
+
+            this.$emit(
+                'filter-update',
+                this.filter.name,
+                [Criteria.range(this.filter.property, rangeParams)],
+                emittedValue,
+            );
         },
 
         onTimeframeSelect(timeframe) {
@@ -206,6 +214,47 @@ export default {
             return {
                 startDate: startDate,
                 endDate: endDate,
+            };
+        },
+
+        userTimeZone() {
+            return Shopware?.Store?.get('session')?.currentUser?.timeZone ?? 'UTC';
+        },
+
+        /**
+         * mt-datepicker in date-only mode may emit an ISO instant whose wall-clock
+         * time is not midnight (e.g. it carries over the current time on the
+         * picked day). Snap to the start of the picked day in the given timezone
+         * and derive the end of that same day so filter bounds cover the full
+         * intended calendar day as the list's date formatter displays it.
+         */
+        dayBoundsInTz(iso, tz) {
+            const instant = new Date(iso);
+            const parts = new Intl.DateTimeFormat('en-GB', {
+                timeZone: tz,
+                hour12: false,
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+            }).formatToParts(instant);
+
+            const read = (type) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10);
+
+            let hour = read('hour');
+            if (hour === 24) {
+                hour = 0;
+            }
+            const minute = read('minute');
+            const second = read('second');
+            const ms = instant.getUTCMilliseconds();
+
+            const offsetIntoDayMs = ((hour * 60 + minute) * 60 + second) * 1000 + ms;
+            const startMs = instant.getTime() - offsetIntoDayMs;
+            const oneDayMs = 24 * 60 * 60 * 1000;
+
+            return {
+                gte: new Date(startMs).toISOString(),
+                lte: new Date(startMs + oneDayMs - 1).toISOString(),
             };
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -65,7 +65,7 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { gte: '2021-01-22' })],
+            [Criteria.range('releaseDate', { gte: '2021-01-22T00:00:00.000Z' })],
             { from: '2021-01-22T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
     });
@@ -80,8 +80,8 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { lte: '2021-01-25' })],
-            { from: null, to: '2021-01-25T23:59:59.000Z', timeframe: 'custom' },
+            [Criteria.range('releaseDate', { lte: '2021-01-25T23:59:59.999Z' })],
+            { from: null, to: '2021-01-25T23:59:59.999Z', timeframe: 'custom' },
         ]);
     });
 
@@ -96,13 +96,6 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { gte: '2021-01-19' })],
-            { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
-        ]);
-
-        // [1] is a duplicate emission from sw-date-filter mutating dateValue.from to ISO (triggers sw-range-filter watch again)
-        expect(wrapper.emitted()['filter-update'][1]).toEqual([
-            'releaseDate',
             [Criteria.range('releaseDate', { gte: '2021-01-19T00:00:00.000Z' })],
             { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
@@ -113,20 +106,62 @@ describe('src/app/component/filter/sw-date-filter', () => {
         await toInput.trigger('input');
         await flushPromises();
 
-        expect(wrapper.emitted()['filter-update'][2]).toEqual([
+        expect(wrapper.emitted()['filter-update'][1]).toEqual([
             'releaseDate',
             [
                 Criteria.range('releaseDate', {
                     gte: '2021-01-19T00:00:00.000Z',
-                    lte: '2021-01-25',
+                    lte: '2021-01-25T23:59:59.999Z',
                 }),
             ],
             {
                 from: '2021-01-19T00:00:00.000Z',
-                to: '2021-01-25T23:59:59.000Z',
+                to: '2021-01-25T23:59:59.999Z',
                 timeframe: 'custom',
             },
         ]);
+    });
+
+    it('should snap day bounds to user timezone calendar day when picker emits non-midnight instants', async () => {
+        Shopware.Store.get('session').setCurrentUser({
+            firstName: 'John',
+            lastName: 'Doe',
+            timeZone: 'America/Los_Angeles',
+        });
+
+        try {
+            const wrapper = await createWrapper();
+
+            // 2021-01-22T15:30:00Z = 07:30 PST on Jan 22 — picker may emit any instant on the picked day
+            const fromInput = wrapper.find('.sw-date-filter__from').find('input');
+            await fromInput.setValue('2021-01-22T15:30:00.000Z');
+            await fromInput.trigger('input');
+            await flushPromises();
+
+            // 2021-01-23T03:00:00Z = 19:00 PST on Jan 22 — also lands on Jan 22 in LA
+            const toInput = wrapper.find('.sw-date-filter__to').find('input');
+            await toInput.setValue('2021-01-23T03:00:00.000Z');
+            await toInput.trigger('input');
+            await flushPromises();
+
+            const lastEmit = wrapper.emitted()['filter-update'].at(-1);
+            expect(lastEmit).toEqual([
+                'releaseDate',
+                [
+                    Criteria.range('releaseDate', {
+                        gte: '2021-01-22T08:00:00.000Z',
+                        lte: '2021-01-23T07:59:59.999Z',
+                    }),
+                ],
+                {
+                    from: '2021-01-22T08:00:00.000Z',
+                    to: '2021-01-23T07:59:59.999Z',
+                    timeframe: 'custom',
+                },
+            ]);
+        } finally {
+            Shopware.Store.get('session').removeCurrentUser();
+        }
     });
 
     it('should emit `filter-reset` event when user clicks Reset button when from value exists', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -164,6 +164,90 @@ describe('src/app/component/filter/sw-date-filter', () => {
         }
     });
 
+    it('should produce a 23h range on a DST spring-forward day', async () => {
+        Shopware.Store.get('session').setCurrentUser({
+            firstName: 'John',
+            lastName: 'Doe',
+            timeZone: 'Europe/Berlin',
+        });
+
+        try {
+            const wrapper = await createWrapper();
+
+            // 2024-03-31 in Berlin is the spring-forward day; the calendar day is only 23h long.
+            const fromInput = wrapper.find('.sw-date-filter__from').find('input');
+            await fromInput.setValue('2024-03-31T10:30:00.000Z');
+            await fromInput.trigger('input');
+            await flushPromises();
+
+            const toInput = wrapper.find('.sw-date-filter__to').find('input');
+            await toInput.setValue('2024-03-31T10:30:00.000Z');
+            await toInput.trigger('input');
+            await flushPromises();
+
+            // 00:00 Berlin (CET, UTC+1) → 2024-03-30T23:00Z; 23:59:59.999 Berlin (CEST, UTC+2) → 2024-03-31T21:59:59.999Z.
+            const lastEmit = wrapper.emitted()['filter-update'].at(-1);
+            expect(lastEmit).toEqual([
+                'releaseDate',
+                [
+                    Criteria.range('releaseDate', {
+                        gte: '2024-03-30T23:00:00.000Z',
+                        lte: '2024-03-31T21:59:59.999Z',
+                    }),
+                ],
+                {
+                    from: '2024-03-30T23:00:00.000Z',
+                    to: '2024-03-31T21:59:59.999Z',
+                    timeframe: 'custom',
+                },
+            ]);
+        } finally {
+            Shopware.Store.get('session').removeCurrentUser();
+        }
+    });
+
+    it('should produce a 25h range on a DST fall-back day', async () => {
+        Shopware.Store.get('session').setCurrentUser({
+            firstName: 'John',
+            lastName: 'Doe',
+            timeZone: 'Europe/Berlin',
+        });
+
+        try {
+            const wrapper = await createWrapper();
+
+            // 2024-10-27 in Berlin is the fall-back day; the calendar day is 25h long.
+            const fromInput = wrapper.find('.sw-date-filter__from').find('input');
+            await fromInput.setValue('2024-10-27T10:00:00.000Z');
+            await fromInput.trigger('input');
+            await flushPromises();
+
+            const toInput = wrapper.find('.sw-date-filter__to').find('input');
+            await toInput.setValue('2024-10-27T10:00:00.000Z');
+            await toInput.trigger('input');
+            await flushPromises();
+
+            // 00:00 Berlin (CEST, UTC+2) → 2024-10-26T22:00Z; 23:59:59.999 Berlin (CET, UTC+1) → 2024-10-27T22:59:59.999Z.
+            const lastEmit = wrapper.emitted()['filter-update'].at(-1);
+            expect(lastEmit).toEqual([
+                'releaseDate',
+                [
+                    Criteria.range('releaseDate', {
+                        gte: '2024-10-26T22:00:00.000Z',
+                        lte: '2024-10-27T22:59:59.999Z',
+                    }),
+                ],
+                {
+                    from: '2024-10-26T22:00:00.000Z',
+                    to: '2024-10-27T22:59:59.999Z',
+                    timeframe: 'custom',
+                },
+            ]);
+        } finally {
+            Shopware.Store.get('session').removeCurrentUser();
+        }
+    });
+
     it('should emit `filter-reset` event when user clicks Reset button when from value exists', async () => {
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -48,7 +48,7 @@ async function createWrapper() {
 describe('src/app/component/filter/sw-date-filter', () => {
     beforeAll(() => {
         jest.useFakeTimers('modern');
-        jest.setSystemTime(new Date(1337, 11, 31));
+        jest.setSystemTime(new Date(Date.UTC(2024, 11, 31)));
     });
 
     afterAll(() => {
@@ -274,28 +274,28 @@ describe('src/app/component/filter/sw-date-filter', () => {
     const cases = {
         'a year': {
             timeframe: -365,
-            expectedFrom: '1336-12-31T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedFrom: '2023-01-01T00:00:00.000Z',
+            expectedTo: '2023-12-31T23:59:59.999Z',
         },
         'a quarter': {
             timeframe: 'lastQuarter',
-            expectedFrom: '1337-07-01T00:00:00.000Z',
-            expectedTo: '1337-09-30T23:59:59.000Z',
+            expectedFrom: '2024-07-01T00:00:00.000Z',
+            expectedTo: '2024-09-30T23:59:59.999Z',
         },
         'a month': {
             timeframe: -30,
-            expectedFrom: '1337-12-01T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedFrom: '2024-11-01T00:00:00.000Z',
+            expectedTo: '2024-11-30T23:59:59.999Z',
         },
         'a week': {
             timeframe: -7,
-            expectedFrom: '1337-12-24T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedFrom: '2024-12-23T00:00:00.000Z',
+            expectedTo: '2024-12-29T23:59:59.999Z',
         },
         'a day': {
             timeframe: -1,
-            expectedFrom: '1337-12-30T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedFrom: '2024-12-30T00:00:00.000Z',
+            expectedTo: '2024-12-30T23:59:59.999Z',
         },
     };
 
@@ -350,11 +350,11 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
     describe('lastQuarter boundary when today is in Q1', () => {
         beforeEach(() => {
-            jest.setSystemTime(new Date(1337, 1, 15));
+            jest.setSystemTime(new Date(Date.UTC(2024, 1, 15)));
         });
 
         afterEach(() => {
-            jest.setSystemTime(new Date(1337, 11, 31));
+            jest.setSystemTime(new Date(Date.UTC(2024, 11, 31)));
         });
 
         it('should compute last quarter as Oct-Dec of the previous year', async () => {
@@ -376,23 +376,64 @@ describe('src/app/component/filter/sw-date-filter', () => {
                 [
                     'releaseDate',
                     [
-                        {
-                            field: 'releaseDate',
-                            parameters: {
-                                gte: '1336-10-01T00:00:00.000Z',
-                                lte: '1336-12-31T23:59:59.000Z',
-                            },
-                            type: 'range',
-                        },
+                        Criteria.range('releaseDate', {
+                            gte: '2023-10-01T00:00:00.000Z',
+                            lte: '2023-12-31T23:59:59.999Z',
+                        }),
                     ],
                     {
-                        from: '1336-10-01T00:00:00.000Z',
+                        from: '2023-10-01T00:00:00.000Z',
                         timeframe: 'lastQuarter',
-                        to: '1336-12-31T23:59:59.000Z',
+                        to: '2023-12-31T23:59:59.999Z',
                     },
                 ],
             ]);
         });
+    });
+
+    it('should snap timeframe bounds to user timezone calendar day for last day', async () => {
+        Shopware.Store.get('session').setCurrentUser({
+            firstName: 'John',
+            lastName: 'Doe',
+            timeZone: 'America/Los_Angeles',
+        });
+
+        try {
+            const wrapper = await createWrapper();
+
+            await wrapper.setProps({
+                filter: {
+                    property: 'releaseDate',
+                    name: 'releaseDate',
+                    label: 'Release Date',
+                    dateType: 'date',
+                    showTimeframe: true,
+                },
+            });
+
+            wrapper.vm.onTimeframeSelect(-1);
+
+            // 2024-12-31T00:00:00Z = 2024-12-30T16:00 PST, so today in LA is Dec 30,
+            // and "yesterday in LA" is Dec 29 spanning Dec 29 08:00Z to Dec 30 07:59:59.999Z.
+            expect(wrapper.emitted()['filter-update']).toEqual([
+                [
+                    'releaseDate',
+                    [
+                        Criteria.range('releaseDate', {
+                            gte: '2024-12-29T08:00:00.000Z',
+                            lte: '2024-12-30T07:59:59.999Z',
+                        }),
+                    ],
+                    {
+                        from: '2024-12-29T08:00:00.000Z',
+                        to: '2024-12-30T07:59:59.999Z',
+                        timeframe: -1,
+                    },
+                ],
+            ]);
+        } finally {
+            Shopware.Store.get('session').removeCurrentUser();
+        }
     });
 
     it('should console.error for invalid timeframe', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

The `sw-date-filter` component (used by listing filter panels) derived `gte`/`lte` bounds in UTC via `Date.setHours()`. For administrators whose profile `timeZone` is not UTC, the emitted range did not line up with the calendar day shown in list date columns: e.g. a user in `America/Los_Angeles` filtering "Jan 22" would query `2021-01-22T00:00:00Z` to `2021-01-22T23:59:59Z`, while the date column rendered each row's date in LA — so rows from `2021-01-21T17:00:00Z` (which display as Jan 21 in LA) were incorrectly included and rows from `2021-01-22T20:00:00Z` (which display as Jan 22 in LA) were filtered out.

A second smaller defect: `updateFilter` mutated `this.dateValue.from`/`.to` to the ISO bounds before emitting. Because `sw-range-filter` deep-watches `value`, this mutation re-fired the watcher and produced a duplicate `filter-update` event for every single field change.

### 2. What does this change do, exactly?

- Adds `dayBoundsInTz(iso, tz)` which uses `Intl.DateTimeFormat` to read the wall-clock hour/minute/second of the picked instant in the user's timezone, then derives the start (`gte`) and end (`lte`, day-start + 24h - 1ms) of that calendar day. Robust to `mt-datepicker` emitting any instant on the picked day, not just midnight.
- Pulls the timezone from `Shopware.Store.get('session').currentUser.timeZone`, falling back to `UTC`.
- Stops mutating `this.dateValue` inside `updateFilter`. The third arg of `filter-update` is now a derived `{ ...dateValue, from: gte, to: lte }` object, which keeps the consumer-visible value identical while eliminating the duplicate emission.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set the current admin user's `timeZone` to `America/Los_Angeles` (or any non-UTC zone).
2. Open any listing with a date filter (e.g. order list, release date filter).
3. Pick a single day in the `from`/`to` filter.
4. Before this change: the resulting query covers UTC midnight to UTC end-of-day; rows whose date column shows the filtered day in the user's timezone are missing or extra rows from the previous/next UTC day appear.
5. After this change: the query covers the user's calendar day for the picked date. Each user input also emits exactly one `filter-update` event instead of two.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers (added entry under Administration in `RELEASE_INFO-6.7.md` for `6.7.10.0`).
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them