### PR TITLE
fix: media thumbnail renaming with duplicate paths

### DIFF
--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -163,6 +163,10 @@ class FileSaver
             $thumbnails = $this->getNewThumbnailPaths($media, $destination);
 
             foreach ($media->getThumbnails() ?? [] as $thumbnail) {
+                if ($thumbnail->getPath() !== '' && \in_array($thumbnail->getPath(), array_keys($renamedFiles), true)) {
+                    continue;
+                }
+
                 try {
                     $thumbnailDestination = $thumbnails[$thumbnail->getUniqueIdentifier()];
 

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -582,6 +582,90 @@ class FileSaverTest extends TestCase
         static::assertTrue($this->getPublicFilesystem()->has($location));
     }
 
+    public function testRenameMediaRenamesWithMultipleThumbnailsSharingPath(): void
+    {
+        $context = Context::createDefaultContext();
+        $id = Uuid::randomHex();
+        $thumbnail1Id = Uuid::randomHex();
+        $thumbnail2Id = Uuid::randomHex();
+
+        $data = [
+            'id' => $id,
+            'fileName' => 'testRenameMediaRenamesOldFileAndThumbnails',
+            'fileExtension' => 'png',
+            'path' => 'media/test.png',
+            'thumbnails' => [
+                [
+                    'id' => $thumbnail1Id,
+                    'width' => 100,
+                    'height' => 100,
+                    'highDpi' => false,
+                    'mediaThumbnailSize' => [
+                        'width' => 100,
+                        'height' => 100,
+                    ],
+                ],
+                [
+                    'id' => $thumbnail2Id,
+                    'width' => 100,
+                    'height' => 100,
+                    'highDpi' => false,
+                    'mediaThumbnailSize' => [
+                        'width' => 111,
+                        'height' => 111,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->mediaRepository->create([$data], $context);
+
+        $png = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
+        static::assertInstanceOf(MediaEntity::class, $png);
+
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+        $dispatcher->dispatch(new UpdateMediaPathEvent([$png->getId()]));
+        $dispatcher->dispatch(new UpdateThumbnailPathEvent([$thumbnail1Id]));
+        $dispatcher->dispatch(new UpdateThumbnailPathEvent([$thumbnail2Id]));
+
+        static::getContainer()->get(MediaIndexer::class)->handle(new MediaIndexingMessage([$png->getId()]));
+
+        $png = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        static::assertInstanceOf(MediaEntity::class, $png);
+
+        static::assertNotNull($png->getThumbnails());
+        static::assertCount(2, $png->getThumbnails());
+
+        $this->getPublicFilesystem()->write($png->getPath(), 'test file content');
+
+        static::assertNotNull($png->getThumbnails()->first()?->getPath());
+        static::assertNotNull($png->getThumbnails()->last()?->getPath());
+        static::assertNotSame($png->getThumbnails()->first()->getId(), $png->getThumbnails()->last()->getId());
+        static::assertSame($png->getThumbnails()->first()->getPath(), $png->getThumbnails()->last()->getPath());
+        $oldThumbnailPath = $png->getThumbnails()->first()->getPath();
+
+        $this->getPublicFilesystem()->write($oldThumbnailPath, 'test file content');
+
+        $this->fileSaver->renameMedia($png->getId(), 'new destination', $context);
+
+        static::assertFalse($this->getPublicFilesystem()->has($oldThumbnailPath));
+
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+
+        static::assertNotNull($updatedMedia?->getThumbnails());
+        static::assertCount(2, $updatedMedia->getThumbnails());
+
+        static::assertNotNull($updatedMedia->getThumbnails()->first()?->getPath());
+        static::assertNotNull($updatedMedia->getThumbnails()->last()?->getPath());
+        static::assertNotSame($updatedMedia->getThumbnails()->first()->getId(), $updatedMedia->getThumbnails()->last()->getId());
+        static::assertSame($updatedMedia->getThumbnails()->first()->getPath(), $updatedMedia->getThumbnails()->last()->getPath());
+
+        $newThumbnailPath = $updatedMedia->getThumbnails()->first()->getPath();
+        static::assertNotSame($oldThumbnailPath, $newThumbnailPath);
+
+        static::assertTrue($this->getPublicFilesystem()->has($newThumbnailPath));
+    }
+
     public function testRenameMediaMakesRollbackOnFailure(): void
     {
         $png = $this->getPng();

--- a/tests/unit/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/unit/Core/Content/Media/File/FileSaverTest.php
@@ -51,11 +51,13 @@ class FileSaverTest extends TestCase
 
     private MockObject&AbstractMediaPathStrategy $mediaPathStrategy;
 
+    private MockObject&FilesystemOperator $filesystemPublic;
+
     protected function setUp(): void
     {
         $this->mediaRepository = new StaticEntityRepository([], new MediaDefinition());
 
-        $filesystemPublic = $this->createMock(FilesystemOperator::class);
+        $this->filesystemPublic = $this->createMock(FilesystemOperator::class);
         $thumbnailService = $this->createMock(ThumbnailService::class);
         $this->messageBus = new CollectingMessageBus();
         $metadataLoader = $this->createMock(MetadataLoader::class);
@@ -67,7 +69,7 @@ class FileSaverTest extends TestCase
 
         $this->fileSaver = new FileSaver(
             $this->mediaRepository,
-            $filesystemPublic,
+            $this->filesystemPublic,
             $filesystemPrivate,
             $thumbnailService,
             $metadataLoader,
@@ -285,7 +287,8 @@ class FileSaverTest extends TestCase
     public function testRenameMedia(): void
     {
         $mediaId = Uuid::randomHex();
-        $thumbnailId = Uuid::randomHex();
+        $thumbnail1Id = Uuid::randomHex();
+        $thumbnail2Id = Uuid::randomHex();
 
         $mediaLocation = new MediaLocationStruct(
             Uuid::randomHex(),
@@ -299,7 +302,13 @@ class FileSaverTest extends TestCase
         ]);
 
         $this->locationBuilder->method('thumbnails')->willReturn([
-            $thumbnailId => new ThumbnailLocationStruct(
+            $thumbnail1Id => new ThumbnailLocationStruct(
+                Uuid::randomHex(),
+                100,
+                100,
+                $mediaLocation
+            ),
+            $thumbnail2Id => new ThumbnailLocationStruct(
                 Uuid::randomHex(),
                 100,
                 100,
@@ -309,24 +318,47 @@ class FileSaverTest extends TestCase
 
         $this->mediaPathStrategy->method('generate')->willReturn(
             [
-                $mediaId => 'foo.png',
+                $mediaId => 'foobar.png',
             ],
             [
-                $thumbnailId => 'foo.png',
+                $thumbnail1Id => 'foobar_100x100.png',
+                $thumbnail2Id => 'foobar_100x100.png',
             ]
         );
 
-        $thumbnail = new MediaThumbnailEntity();
-        $thumbnail->setId($thumbnailId);
+        $matcher = $this->exactly(2);
+        $this->filesystemPublic->expects($matcher)
+            ->method('move')
+            ->willReturnCallback(static function (string $from, string $to) use ($matcher): void {
+                if ($matcher->numberOfInvocations() === 1) {
+                    static::assertSame('foo.png', $from);
+                    static::assertSame('foobar.png', $to);
+
+                    return;
+                }
+
+                static::assertSame('foo_100x100.png', $from);
+                static::assertSame('foobar_100x100.png', $to);
+            });
+
+        $thumbnail1 = new MediaThumbnailEntity();
+        $thumbnail1->setId($thumbnail1Id);
+        $thumbnail1->setPath('foo_100x100.png');
+
+        $thumbnail2 = new MediaThumbnailEntity();
+        $thumbnail2->setId(Uuid::randomHex());
+        $thumbnail2->setPath('foo_100x100.png');
 
         $thumbnails = new MediaThumbnailCollection();
-        $thumbnails->add($thumbnail);
+        $thumbnails->add($thumbnail1);
+        $thumbnails->add($thumbnail2);
 
         $media = new MediaEntity();
         $media->setId($mediaId);
         $media->setMimeType('image/png');
         $media->setFileName('foo');
         $media->setFileExtension('png');
+        $media->setPath('foo.png');
         $media->setPrivate(false);
         $media->setThumbnails($thumbnails);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Filesystem paths to thumbnails for different resolutions may incidentally end up being identical, e.g. when the source image is below the threshold of max width/height of one ore multiple sizes larger. Thus an image with the resolution of 100x100 may resolve to `filename_100x100.jpg` for both windows `200x200` and `300x300`. When a media file is renamed, it's thumbnails are also renamed accordingly in succession. Given the example the thumbnail for the `200x200` window would then successfully moved in the filesystem but when the same should happen for `300x300` the source file with the identical path already no longer exists. This results in an unhandled `FilesystemException`.

### 2. What does this change do, exactly?
In the iteration of thumbnails to be renamed/moved, skip those with paths that are identical to previously renamed/moved files.

### 3. Describe each step to reproduce the issue or behaviour.
* Upload an image that is below the threshold of multiple thumbnail size windows for the given folder.
* Rename the media/image

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/15545

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
