### PR TITLE
fix: admin sw-data-grid cell-value letter overflow hidden under text-box

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -110,6 +110,7 @@
     .sw-data-grid__cell-value {
         overflow: hidden;
         text-overflow: ellipsis;
+        line-height: normal;
     }
 
     .sw-data-grid__cell--align-right {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
in the data grid cell-value cell every letter that has something under the text like "g", "y" box can be appeared cut off.

<img width="971" height="57" alt="image" src="https://github.com/user-attachments/assets/2523f1d4-22f5-4447-a686-9b6da1bb6345" />

### 2. What does this change do, exactly?

I add `text-box: trim-end cap text;` to the class sw-data-grid__cell-value. 
This includes the full text-box for the element sizing.
This increases the element size but not the line-height of the element, so only no misaligning between other cells.

I considered using `line-height: normal;` due to the lack of firefox support for text-box currently.
I opted for this solution instead because Firefox currently builds their implementation and it is expected to be supported in the future. The line-height would also increase the cell height and make the text compared to other types of cells unaligned.

Other Solutions but there I am unsure about side effects would be to set the line-height higher in general for the data grid. Currently, the line-height and font-size are set by the "--font-size-xs" CSS property. Or removing the class styles overflow and text-overflow entirely.

> For Information: I viewed it on Windows with Edge and the Inter font locally installed.
I checked if my browser loads it, but it appeared to load the font from Shopware/Server correctly.
Only if there are render bugs only on my side/machine. 

### 3. Describe each step to reproduce the issue or behaviour.

Visit a table where the cell-value type is used. For example, the product unit "/admin#/sw/settings/units/index", shipping times "admin#/sw/settings/delivery/time/index", etc.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
