### PR TITLE
test: TestBootStrapper has Kernel leakage

### DIFF
--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -75,6 +75,8 @@ class TestBootstrapper
             $this->installPlugins();
         }
 
+        KernelLifecycleManager::ensureKernelShutdown();
+
         return $this;
     }
 

--- a/tests/unit/Core/TestBootstrapperTest.php
+++ b/tests/unit/Core/TestBootstrapperTest.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Core;
 
+use Composer\Autoload\ClassLoader;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Kernel;
 use Shopware\Core\TestBootstrapper;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @internal
@@ -57,5 +63,54 @@ class TestBootstrapperTest extends TestCase
         $activePlugins = (new \ReflectionProperty($testBootstrapper, 'activePlugins'))->getValue($testBootstrapper);
 
         static::assertSame(['Test'], $activePlugins);
+    }
+
+    public function testBootstrapShutsDownKernelBeforeReturning(): void
+    {
+        $previousKernel = KernelLifecycleAccessor::currentKernel();
+
+        $result = static::createStub(Result::class);
+        $result->method('fetchAllAssociative')->willReturn([]);
+
+        $connection = static::createStub(Connection::class);
+        $connection->method('executeQuery')->willReturn($result);
+
+        $container = static::createStub(ContainerInterface::class);
+        $container->method('get')->willReturn($connection);
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->method('getContainer')->willReturn($container);
+        $kernel->expects($this->once())->method('shutdown');
+
+        KernelLifecycleAccessor::setKernel($kernel);
+
+        try {
+            $bootstrapper = (new TestBootstrapper())
+                ->setClassLoader(static::createStub(ClassLoader::class))
+                ->setDatabaseUrl('mysql://irrelevant')
+                ->setLoadEnvFile(false);
+
+            $bootstrapper->bootstrap();
+
+            static::assertNull(KernelLifecycleAccessor::currentKernel(), 'bootstrap() must leave no residual kernel');
+        } finally {
+            KernelLifecycleAccessor::setKernel($previousKernel);
+        }
+    }
+}
+
+/**
+ * @internal
+ */
+class KernelLifecycleAccessor extends KernelLifecycleManager
+{
+    public static function setKernel(?Kernel $kernel): void
+    {
+        static::$kernel = $kernel;
+    }
+
+    public static function currentKernel(): ?Kernel
+    {
+        return static::$kernel;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Follow up of https://github.com/shopware/shopware/pull/16442/changes#r3138552868

While investigating that TestBootstrapper is booting a Kernel before any tests, we have discovered potential leaks in Kernel state.

### 2. What does this change do, exactly?
- Shut down Kernel once the check is done, to start with a clean state
- Write Unit test

### 3. Describe each step to reproduce the issue or behaviour.
Write an integration test and dump kernel at setupBeforeClass, surprise surprise it's already there

Run the new unit test from this PR

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/16444

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
