### PR TITLE
fix: Manufacturer's page cannot be accessed.

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
@@ -59,7 +59,10 @@
 
                         {% block component_product_quickview_minimal_product_manufacturer %}
                             {% if manufacturer %}
-                                <a href="{{ manufacturer.translated.link }}"
+                                {% set manufacturerLink = manufacturer.translated.link %}
+                                {% set manufacturerLinkHasScheme = manufacturerLink matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturerLink starts with '//' %}
+                                {% set manufacturerLinkHref = manufacturerLink ? (manufacturerLinkHasScheme ? manufacturerLink : 'https://' ~ manufacturerLink) : '' %}
+                                <a href="{{ manufacturerLinkHref }}"
                                    target="_blank"
                                    rel="noopener"
                                    title="{{ manufacturer.translated.name }}"

--- a/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
@@ -25,7 +25,9 @@
 
             {% block element_manufacturer_logo_link %}
                 {% if manufacturer.link %}
-                    <a href="{{ manufacturer.link }}"
+                    {% set manufacturerLinkHasScheme = manufacturer.link matches '/^[a-zA-Z][a-zA-Z0-9+.-]*:/' or manufacturer.link starts with '//' %}
+                    {% set manufacturerLinkHref = manufacturerLinkHasScheme ? manufacturer.link : 'https://' ~ manufacturer.link %}
+                    <a href="{{ manufacturerLinkHref }}"
                         class="cms-image-link product-detail-manufacturer-link"
                         {% if config.newTab.value %}target="_blank" rel="noreferrer noopener"{% endif %}
                         title="{{ manufacturer.name }}">


### PR DESCRIPTION
## Summary

Fixes #6345

- Manufacturer URLs stored without a scheme (e.g. `www.shopware.com`) were rendered verbatim into anchor `href` attributes. Browsers resolve scheme-less hrefs as relative references (RFC 3986 §5), so clicking the manufacturer link from `/main-product` navigated to `/main-product/www.shopware.com` (404).
- Normalize the link at render time: if the stored value matches an RFC 3986 URI scheme (`^[a-zA-Z][a-zA-Z0-9+.-]*:`) or starts with `//` (protocol-relative), render as-is; otherwise prepend `https://`.
- The DAL field for the manufacturer link is `LongTextField` (no URL validation), so render-time normalization protects existing data without a migration and avoids BC risk for extension consumers of the LongTextField.

## Changes

- 2 files changed (+9/-2)

### Changed files
- `src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig`
- `src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig`

## Behavior summary

| Stored value | Before | After |
|---|---|---|
| `www.shopware.com` | `<current-page>/www.shopware.com` (404) | `https://www.shopware.com` |
| `https://example.com` | `https://example.com` | `https://example.com` |
| `HTTP://EXAMPLE.COM` | `<current-page>/HTTP://EXAMPLE.COM` (404) | `HTTP://EXAMPLE.COM` |
| `//cdn.example.com` | `//cdn.example.com` | `//cdn.example.com` |
| `mailto:foo@bar.com` | `mailto:foo@bar.com` | `mailto:foo@bar.com` |
| `tel:+49123` | `tel:+49123` | `tel:+49123` |
| empty (quickview only) | `href=""` | `href=""` (no stray `https://`) |

## Environment needs

- [ ] Admin build needed
- [ ] Storefront build needed
- [ ] DB reset / migration
- [x] Cache clear (Twig template cache)

## Test plan

- [x] Unit tests pass — `phpunit tests/unit/Core/Content/Product/Cms/ManufacturerLogoCmsElementResolverTest.php` → 10/10 (36 assertions)
- [x] Integration tests pass — `phpunit tests/integration/Core/Content/Product/Cms/Type/ManufacturerLogoTypeCmsResolverTest.php` → 5/5 (12 assertions)
- [x] Twig syntax — `bin/console lint:twig <files>` → OK
- [x] Static analysis clean — `composer phpstan -- <files>` → no errors
- [x] Live render smoke test — Twig render against 11 input variants behaves correctly (`http`, `https`, uppercase, `mailto`, `tel`, `ftp`, `javascript`, protocol-relative, scheme-less, empty)
- [ ] Manual storefront verification: configure a manufacturer with link `www.shopware.com`, open a product detail page that displays the manufacturer logo, click the link → navigates to `https://www.shopware.com`

## Review

- Independent review agent verdict: **PASS**
- Flow Builder impact: **none** (render-only change on storefront templates; no events, actions, rules, entities, or state machines touched)