### PR TITLE
fix(api): honor query params in POST search

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -19,6 +19,12 @@ These are optional and can be enabled via `shopware.api.rate_limiter` in `shopwa
 The generated Admin API and Store API `Price` schemas now include property descriptions for `percentage`, `listPrice`, `regulationPrice`, and their nested values.
 This improves the generated OpenAPI and Stoplight documentation for integrations that inspect raw price payloads and need to distinguish between the current price, list price, discount percentage, and regulation price fields.
 
+### `POST /api/search/*` now respects query pagination parameters
+
+The Admin API search endpoints now apply pagination parameters from the query string for `POST` requests, while still letting JSON body parameters take precedence.
+
+This fixes cases where integrations followed `links.next` from a search response and the next request repeated the same page because `page` from the query string was not applied to the search criteria.
+
 ## Core
 
 ### Product `display_group` values use SHA-256

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -84,7 +84,12 @@ class RequestCriteriaBuilder
             }
             $criteria = $this->fromArray($request->query->all(), $criteria, $definition, $context);
         } else {
-            $criteria = $this->fromArray($request->request->all(), $criteria, $definition, $context);
+            $criteria = $this->fromArray(
+                array_replace($request->query->all(), $request->request->all()),
+                $criteria,
+                $definition,
+                $context
+            );
         }
 
         // @deprecated tag:v6.8.0 - switch the default to 0

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchTest.php
@@ -259,6 +259,58 @@ class ApiControllerSearchTest extends TestCase
         static::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), (string) $response->getContent());
     }
 
+    public function testPostSearchUsesQueryPageForPaginationLinks(): void
+    {
+        $products = [];
+        foreach (['a', 'b', 'c'] as $suffix) {
+            $id = Uuid::randomHex();
+            $products[] = $id;
+
+            $this->getBrowser()->jsonRequest('POST', '/api/product', [
+                'id' => $id,
+                'productNumber' => 'SW-API-PAGINATION-' . $suffix,
+                'stock' => 1,
+                'name' => 'Pagination Product ' . $suffix,
+                'tax' => ['name' => 'test', 'taxRate' => 10],
+                'manufacturer' => ['name' => 'Shopware AG'],
+                'price' => [[
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 50,
+                    'net' => 25,
+                    'linked' => false,
+                ]],
+            ]);
+            static::assertSame(Response::HTTP_NO_CONTENT, $this->getBrowser()->getResponse()->getStatusCode());
+        }
+
+        $this->getBrowser()->jsonRequest('POST', '/api/search/product?page=2', [
+            'limit' => 1,
+            'total-count-mode' => Criteria::TOTAL_COUNT_MODE_EXACT,
+            'sort' => [[
+                'field' => 'product.productNumber',
+                'order' => 'asc',
+            ]],
+            'filter' => [[
+                'type' => 'equalsAny',
+                'field' => 'product.id',
+                'value' => implode('|', $products),
+            ]],
+        ]);
+
+        $content = json_decode((string) $this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        parse_str((string) parse_url($content['links']['self'], \PHP_URL_QUERY), $selfParams);
+        parse_str((string) parse_url($content['links']['next'], \PHP_URL_QUERY), $nextParams);
+        parse_str((string) parse_url($content['links']['last'], \PHP_URL_QUERY), $lastParams);
+
+        static::assertSame(3, $content['meta']['total']);
+        static::assertSame('2', $selfParams['page']);
+        static::assertSame('3', $nextParams['page']);
+        static::assertSame('1', $nextParams['limit']);
+        static::assertSame('3', $lastParams['page']);
+        static::assertSame('1', $lastParams['limit']);
+        static::assertSame('SW-API-PAGINATION-b', $content['data'][0]['attributes']['productNumber']);
+    }
+
     /**
      * Tests the API search endpoint. Asserts that an entity can be both part of the result data as well as the
      * associations when the entity is fetched as a top level entity result and through circular associations.

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilderTest.php
@@ -234,6 +234,39 @@ class RequestCriteriaBuilderTest extends TestCase
         static::assertCount(1, $nested->getSorting());
     }
 
+    public function testPostRequestUsesQueryPaginationWhenBodyDoesNotDefineIt(): void
+    {
+        $request = new Request(['limit' => 25, 'page' => 2], ['total-count-mode' => 'exact']);
+        $request->setMethod(Request::METHOD_POST);
+
+        $criteria = $this->requestCriteriaBuilder->handleRequest(
+            $request,
+            new Criteria(),
+            $this->staticDefinitionRegistry->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame(25, $criteria->getLimit());
+        static::assertSame(25, $criteria->getOffset());
+        static::assertSame(Criteria::TOTAL_COUNT_MODE_EXACT, $criteria->getTotalCountMode());
+    }
+
+    public function testPostRequestBodyParametersOverrideQueryParameters(): void
+    {
+        $request = new Request(['limit' => 10, 'page' => 2], ['limit' => 25, 'page' => 3]);
+        $request->setMethod(Request::METHOD_POST);
+
+        $criteria = $this->requestCriteriaBuilder->handleRequest(
+            $request,
+            new Criteria(),
+            $this->staticDefinitionRegistry->get(ProductDefinition::class),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame(25, $criteria->getLimit());
+        static::assertSame(50, $criteria->getOffset());
+    }
+
     public function testCriteriaToArray(): void
     {
         $criteria = (new Criteria())


### PR DESCRIPTION
### 1. Why is this change necessary?
`POST /api/search/*` pagination was inconsistent when clients followed `links.next`. The response links were built from query parameters, but the criteria builder only considered body parameters for POST requests, which could keep the internal search criteria on page 1 and cause `links.next` to repeat the current page.

### 2. What does this change do, exactly?
The change makes POST criteria handling merge query parameters with the request body, while still letting body parameters take precedence. This ensures that pagination parameters like `page` and `limit` from the query string are applied correctly for `POST /api/search/*` requests. It also adds unit and integration tests for query-based pagination and body-overrides-query behavior.

### 3. Describe each step to reproduce the issue or behaviour.
1. Send a `POST` request to `/api/search/<entity>` with a paginated body, for example `limit=1` and `total-count-mode=1`.
2. Read the `links.next` value from the response and call that URL with another `POST` request, without repeating `page` in the JSON body.
3. Observe that `links.self` shows `page=2`, but `links.next` can still point to `page=2` instead of advancing to `page=3`.
4. With this change, the query string pagination is applied to the POST search criteria and `links.next` advances correctly.

### 4. Please link to the relevant issues (if any).
N/A (internal reference: SWAG-329299)

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
