### PR TITLE
fix: sales channel specific static system config

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Telemetry\Metrics\Metric\Type;
 use Shopware\Core\Framework\Util\MemorySizeCalculator;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\WebhookFailureStrategy;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -967,8 +968,18 @@ class Configuration implements ConfigurationInterface
 
         $rootNode = $treeBuilder->getRootNode();
         $rootNode
-            ->children()
-                ->arrayNode('default')->scalarPrototype()->end()
+            ->arrayPrototype()->scalarPrototype()->end()
+            ->end()
+            ->validate()
+            ->ifFalse(
+                static fn (array $v) => \count(
+                    array_filter(
+                        array_keys($v),
+                        static fn (string $key) => $key !== 'default' && !Uuid::isValid($key)
+                    )
+                ) === 0
+            )
+            ->thenInvalid('Key must be "default" or a valid UUID')
             ->end();
 
         return $rootNode;

--- a/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/ConfigurationTest.php
@@ -5,10 +5,13 @@ namespace Shopware\Tests\Unit\Core\Framework\DependencyInjection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DependencyInjection\Configuration;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @internal
@@ -164,8 +167,8 @@ class ConfigurationTest extends TestCase
 
         $nodes = $nodes['system_config']->getChildNodeDefinitions();
 
-        static::assertArrayHasKey('default', $nodes);
-        static::assertInstanceOf(ArrayNodeDefinition::class, $nodes['default']);
+        static::assertArrayHasKey('', $nodes);
+        static::assertInstanceOf(ArrayNodeDefinition::class, $nodes['']);
     }
 
     public function testUsageDataSection(): void
@@ -214,5 +217,48 @@ class ConfigurationTest extends TestCase
 
         static::assertArrayHasKey('allowed_types', $nodes);
         static::assertInstanceOf(ArrayNodeDefinition::class, $nodes['allowed_types']);
+    }
+
+    public function testValidSystemConfigKeys(): void
+    {
+        $configuration = new Configuration();
+        $salesChannelId = Uuid::randomHex();
+
+        $systemConfigs = (new Processor())->processConfiguration($configuration, [
+            'shopware' => [
+                'system_config' => [
+                    'default' => [
+                        'core.listing.allowBuyInListing' => true,
+                    ],
+                    $salesChannelId => [
+                        'core.listing.allowBuyInListing' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        static::assertTrue($systemConfigs['system_config']['default']['core.listing.allowBuyInListing']);
+        static::assertFalse($systemConfigs['system_config'][$salesChannelId]['core.listing.allowBuyInListing']);
+    }
+
+    public function testInvalidSystemConfigKeys(): void
+    {
+        static::expectException(InvalidConfigurationException::class);
+        static::expectExceptionMessage('Invalid configuration for path "shopware.system_config": Key must be "default" or a valid UUID');
+
+        $configuration = new Configuration();
+
+        (new Processor())->processConfiguration($configuration, [
+            'shopware' => [
+                'system_config' => [
+                    'default' => [
+                        'core.listing.allowBuyInListing' => true,
+                    ],
+                    'foobar' => [
+                        'core.listing.allowBuyInListing' => false,
+                    ],
+                ],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
https://developer.shopware.com/docs/guides/hosting/configurations/shopware/static-system-config.html#usage states that for the static system config using *.yaml files, the sales channel ID can be used to set system config specifically for the given sales channel. In fact only the `default` key can be used.

### 2. What does this change do, exactly?
Allows either the use of `default` or a valid UUID as key for the collection of system config values.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a `*.yaml` file at `config/packages` with the content
```yaml
shopware:
    system_config:
        default:
            core.listing.allowBuyInListing: true
        # Disable it for the specific sales channel
        {{salesChannelId}}:
            core.listing.allowBuyInListing: false
```
* Replace {{salesChannelId}} with an actual id of a sales channel

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/13792

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
