### PR TITLE
feat: provide imitated flag in context response for customer session initialized in admin

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -37,6 +37,27 @@ To partly comply with old behaviour, primary deliveries are ordered first and pr
 
 <details>
 
+## Deprecated `imitatingUserId` on Store API `sales_channel_context` response
+
+The `imitatingUserId` field on the Store API `sales_channel_context` response is deprecated and will be removed in v6.8.0.
+The field is now always serialized as `null` over the API surface and no longer leaks the admin UUID to API consumers.
+
+A new boolean field `imitated` has been added at the root of the response. Use it to detect whether the current customer
+session is being impersonated by an admin user. The flag is now also persisted to the `sales_channel_api_context` payload,
+which means headless clients (those that only carry `sw-context-token` and no Symfony session cookie) can detect
+imitation reliably across requests.
+
+```diff
+- if (response.imitatingUserId !== null) { /* impersonated */ }
++ if (response.imitated) { /* impersonated */ }
+```
+
+`imitatingUserId` is now persisted into the context payload exclusively by the imitation login. The regular login,
+registration and double-opt-in confirmation routes explicitly clear the value on the new customer's context, so a
+context token previously used for imitation can no longer leak `imitated: true` into a subsequent unrelated login.
+A `SalesChannelContext::isImitated(): bool` helper is available for server-side code that needs to branch on the
+current state.
+
 ## Changed returned status code for `/store-api/document/download/` when no documents are found
 
 The Store API route `/store-api/document/download` returns now a standard Shopware domain exception with status code `404` and the code `DOCUMENT_FILETYPE_UNAVAILABLE` when the document has no generated document with the requested mime type, instead of returning a `204` status code.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -39,24 +39,13 @@ To partly comply with old behaviour, primary deliveries are ordered first and pr
 
 ## Deprecated `imitatingUserId` on Store API `sales_channel_context` response
 
-The `imitatingUserId` field on the Store API `sales_channel_context` response is deprecated and will be removed in v6.8.0.
-The field is now always serialized as `null` over the API surface and no longer leaks the admin UUID to API consumers.
-
-A new boolean field `imitated` has been added at the root of the response. Use it to detect whether the current customer
-session is being impersonated by an admin user. The flag is now also persisted to the `sales_channel_api_context` payload,
-which means headless clients (those that only carry `sw-context-token` and no Symfony session cookie) can detect
-imitation reliably across requests.
+The `imitatingUserId` field is deprecated and will be removed in v6.8.0; it is now always serialized as `null`.
+Use the new `imitated: boolean` field at the root of the response instead.
 
 ```diff
 - if (response.imitatingUserId !== null) { /* impersonated */ }
 + if (response.imitated) { /* impersonated */ }
 ```
-
-`imitatingUserId` is now persisted into the context payload exclusively by the imitation login. The regular login,
-registration and double-opt-in confirmation routes explicitly clear the value on the new customer's context, so a
-context token previously used for imitation can no longer leak `imitated: true` into a subsequent unrelated login.
-A `SalesChannelContext::isImitated(): bool` helper is available for server-side code that needs to branch on the
-current state.
 
 ## Changed returned status code for `/store-api/document/download/` when no documents are found
 

--- a/src/Core/Checkout/Customer/SalesChannel/AccountService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AccountService.php
@@ -107,10 +107,7 @@ class AccountService
 
         $customer = $this->getCustomerByLogin($email, $password, $context);
 
-        // A regular credentials login is by definition not an admin imitation.
-        // Drop any imitating-user-id propagated by a previous session attached
-        // to the same context token before handing off to loginByCustomer, so
-        // CartRestorer's current → customer sync does not carry it forward.
+        // Credentials login is never an imitation; drop any stale value before CartRestorer syncs it forward.
         $context->setImitatingUserId(null);
 
         return $this->loginByCustomer($customer, $context);
@@ -188,11 +185,7 @@ class AccountService
         $context = $this->restorer->restore($customer->getId(), $context);
         $newToken = $context->getToken();
 
-        // Persist the imitating-user-id on the new customer's context payload so
-        // headless clients carrying only `sw-context-token` can detect imitation
-        // (or its absence) on subsequent /store-api/context calls. Writing the
-        // current value, including null, also clears any stale value left in the
-        // DB row from a prior imitation that shared this token.
+        // Persist imitating state to the new token so headless clients can detect it on later requests.
         $this->contextPersister->save(
             $newToken,
             [SalesChannelContextService::IMITATING_USER_ID => $context->getImitatingUserId()],

--- a/src/Core/Checkout/Customer/SalesChannel/AccountService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AccountService.php
@@ -24,6 +24,8 @@ use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\System\SalesChannel\Context\CartRestorer;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\PasswordHasher\Hasher\CheckPasswordLengthTrait;
@@ -44,7 +46,8 @@ class AccountService
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly LegacyPasswordVerifier $legacyPasswordVerifier,
         private readonly AbstractSwitchDefaultAddressRoute $switchDefaultAddressRoute,
-        private readonly CartRestorer $restorer
+        private readonly CartRestorer $restorer,
+        private readonly SalesChannelContextPersister $contextPersister
     ) {
     }
 
@@ -103,6 +106,12 @@ class AccountService
         $this->eventDispatcher->dispatch($event);
 
         $customer = $this->getCustomerByLogin($email, $password, $context);
+
+        // A regular credentials login is by definition not an admin imitation.
+        // Drop any imitating-user-id propagated by a previous session attached
+        // to the same context token before handing off to loginByCustomer, so
+        // CartRestorer's current → customer sync does not carry it forward.
+        $context->setImitatingUserId(null);
 
         return $this->loginByCustomer($customer, $context);
     }
@@ -178,6 +187,18 @@ class AccountService
 
         $context = $this->restorer->restore($customer->getId(), $context);
         $newToken = $context->getToken();
+
+        // Persist the imitating-user-id on the new customer's context payload so
+        // headless clients carrying only `sw-context-token` can detect imitation
+        // (or its absence) on subsequent /store-api/context calls. Writing the
+        // current value, including null, also clears any stale value left in the
+        // DB row from a prior imitation that shared this token.
+        $this->contextPersister->save(
+            $newToken,
+            [SalesChannelContextService::IMITATING_USER_ID => $context->getImitatingUserId()],
+            $context->getSalesChannelId(),
+            $customer->getId(),
+        );
 
         $event = new CustomerLoginEvent($context, $customer, $newToken);
         $this->eventDispatcher->dispatch($event);

--- a/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
@@ -106,9 +106,6 @@ class ImitateCustomerRoute extends AbstractImitateCustomerRoute
 
         $context->setImitatingUserId($token->iss);
 
-        // AccountService::loginByCustomer persists imitatingUserId into the
-        // sales_channel_api_context payload after the customer is logged in,
-        // so the value is reachable by headless clients on subsequent requests.
         $newToken = $this->accountService->loginById($token->customerId, $context);
 
         return new ContextTokenResponse($newToken);

--- a/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ImitateCustomerRoute.php
@@ -106,6 +106,9 @@ class ImitateCustomerRoute extends AbstractImitateCustomerRoute
 
         $context->setImitatingUserId($token->iss);
 
+        // AccountService::loginByCustomer persists imitatingUserId into the
+        // sales_channel_api_context payload after the customer is logged in,
+        // so the value is reachable by headless clients on subsequent requests.
         $newToken = $this->accountService->loginById($token->customerId, $context);
 
         return new ContextTokenResponse($newToken);

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -93,6 +94,9 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
                 'customerId' => $customer->getId(),
                 'billingAddressId' => null,
                 'shippingAddressId' => null,
+                // Double-opt-in confirmation is not an admin imitation: drop any
+                // stale value carried over from a prior session sharing this token.
+                SalesChannelContextService::IMITATING_USER_ID => null,
             ],
             $context->getSalesChannelId(),
             $customer->getId()

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -94,8 +94,6 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
                 'customerId' => $customer->getId(),
                 'billingAddressId' => null,
                 'shippingAddressId' => null,
-                // Double-opt-in confirmation is not an admin imitation: drop any
-                // stale value carried over from a prior session sharing this token.
                 SalesChannelContextService::IMITATING_USER_ID => null,
             ],
             $context->getSalesChannelId(),

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -46,6 +46,7 @@ use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInt
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
@@ -230,6 +231,9 @@ class RegisterRoute extends AbstractRegisterRoute
                 'billingAddressId' => null,
                 'shippingAddressId' => null,
                 'domainId' => $context->getDomainId(),
+                // Registration is not an admin imitation: drop any stale value
+                // carried over from a prior session sharing this context token.
+                SalesChannelContextService::IMITATING_USER_ID => null,
             ],
             $context->getSalesChannelId(),
             $customerEntity->getId()

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -231,8 +231,6 @@ class RegisterRoute extends AbstractRegisterRoute
                 'billingAddressId' => null,
                 'shippingAddressId' => null,
                 'domainId' => $context->getDomainId(),
-                // Registration is not an admin imitation: drop any stale value
-                // carried over from a prior session sharing this context token.
                 SalesChannelContextService::IMITATING_USER_ID => null,
             ],
             $context->getSalesChannelId(),

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -48,6 +48,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\Password\LegacyPasswordVerifier"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\SwitchDefaultAddressRoute"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\CartRestorer"/>
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\Validation\AddressValidationFactory">

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SalesChannelContext.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SalesChannelContext.json
@@ -222,6 +222,10 @@
                         "enum": [
                             "sales_channel_context"
                         ]
+                    },
+                    "imitated": {
+                        "type": "boolean",
+                        "description": "Indicates whether the current customer session is being impersonated by an admin user."
                     }
                 },
                 "required": [
@@ -229,7 +233,8 @@
                     "apiAlias",
                     "itemRounding",
                     "totalRounding",
-                    "languageInfo"
+                    "languageInfo",
+                    "imitated"
                 ]
             }
         }

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -128,10 +128,7 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
             $requestSession = $currentRequest?->hasSession() ? $currentRequest->getSession() : null;
 
-            // Remove imitating user id when there is no customer logged in.
-            // Clearing the persister payload as well ensures headless clients
-            // (which never had a Symfony session entry) do not keep reporting
-            // `imitated: true` after the imitated customer has logged out.
+            // Stale imitating value without a logged-in customer: clear from session and persister payload.
             if ($context->getImitatingUserId() && !$context->getCustomerId()) {
                 $requestSession?->remove(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID);
                 $this->contextPersister->save(

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -128,9 +128,17 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
             $requestSession = $currentRequest?->hasSession() ? $currentRequest->getSession() : null;
 
-            // Remove imitating user id from session, if there is no customer
-            if ($requestSession && $context->getImitatingUserId() && !$context->getCustomerId()) {
-                $requestSession->remove(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID);
+            // Remove imitating user id when there is no customer logged in.
+            // Clearing the persister payload as well ensures headless clients
+            // (which never had a Symfony session entry) do not keep reporting
+            // `imitated: true` after the imitated customer has logged out.
+            if ($context->getImitatingUserId() && !$context->getCustomerId()) {
+                $requestSession?->remove(PlatformRequest::ATTRIBUTE_IMITATING_USER_ID);
+                $this->contextPersister->save(
+                    $token,
+                    [self::IMITATING_USER_ID => null],
+                    $parameters->getSalesChannelId(),
+                );
                 $context->setImitatingUserId(null);
             }
 

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -41,6 +41,9 @@ class SalesChannelContext extends Struct
 
     protected bool $permissionsLocked = false;
 
+    /**
+     * @deprecated tag:v6.8.0 - reason:visibility-change - Will become private. The UUID of the imitating admin user is no longer exposed via the Store API JSON response; consumers should use the `imitated` boolean instead.
+     */
     protected ?string $imitatingUserId = null;
 
     protected MeasurementUnits $measurementSystem;
@@ -405,6 +408,27 @@ class SalesChannelContext extends Struct
     public function setImitatingUserId(?string $imitatingUserId): void
     {
         $this->imitatingUserId = $imitatingUserId;
+    }
+
+    public function isImitated(): bool
+    {
+        return $this->imitatingUserId !== null;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = parent::jsonSerialize();
+
+        $data['imitated'] = $this->isImitated();
+
+        // Never expose the imitating admin UUID over the API surface.
+        // @deprecated tag:v6.8.0 - The `imitatingUserId` field will be removed; use `imitated` instead.
+        $data['imitatingUserId'] = null;
+
+        return $data;
     }
 
     /**

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -42,7 +42,7 @@ class SalesChannelContext extends Struct
     protected bool $permissionsLocked = false;
 
     /**
-     * @deprecated tag:v6.8.0 - reason:visibility-change - Will become private. The UUID of the imitating admin user is no longer exposed via the Store API JSON response; consumers should use the `imitated` boolean instead.
+     * @deprecated tag:v6.8.0 - reason:visibility-change - Will become private; consumers should use the `imitated` flag from the JSON response.
      */
     protected ?string $imitatingUserId = null;
 
@@ -424,8 +424,7 @@ class SalesChannelContext extends Struct
 
         $data['imitated'] = $this->isImitated();
 
-        // Never expose the imitating admin UUID over the API surface.
-        // @deprecated tag:v6.8.0 - The `imitatingUserId` field will be removed; use `imitated` instead.
+        // @deprecated tag:v6.8.0 - field will be removed; use `imitated` instead.
         $data['imitatingUserId'] = null;
 
         return $data;

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ImitateCustomerRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ImitateCustomerRouteTest.php
@@ -1,0 +1,242 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Customer\SalesChannel;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Customer\ImitateCustomerTokenGenerator;
+use Shopware\Core\Checkout\Customer\SalesChannel\ImitateCustomerRoute;
+use Shopware\Core\Checkout\Customer\Struct\ImitateCustomerToken;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\User\UserCollection;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[Group('store-api')]
+class ImitateCustomerRouteTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    private KernelBrowser $browser;
+
+    private IdsCollection $ids;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->create('sales-channel'),
+        ]);
+    }
+
+    public function testHeadlessClientDetectsImitationViaImitatedFlag(): void
+    {
+        $customerEmail = Uuid::randomHex() . '@example.com';
+        $customerId = $this->createCustomerForBrowser($customerEmail);
+        $userId = $this->createAdminUser();
+
+        $tokenGenerator = static::getContainer()->get(ImitateCustomerTokenGenerator::class);
+
+        if (Feature::isActive('v6.8.0.0')) {
+            $tokenStruct = new ImitateCustomerToken();
+            $tokenStruct->salesChannelId = $this->ids->get('sales-channel');
+            $tokenStruct->customerId = $customerId;
+            $tokenStruct->iss = $userId;
+
+            $imitateToken = $tokenGenerator->encode($tokenStruct);
+
+            $payload = [ImitateCustomerRoute::TOKEN => $imitateToken];
+        } else {
+            $imitateToken = Feature::silent(
+                'v6.8.0.0',
+                fn (): string => $tokenGenerator->generate($this->ids->get('sales-channel'), $customerId, $userId)
+            );
+
+            $payload = [
+                ImitateCustomerRoute::TOKEN => $imitateToken,
+                ImitateCustomerRoute::CUSTOMER_ID => $customerId,
+                ImitateCustomerRoute::USER_ID => $userId,
+            ];
+        }
+
+        $this->browser->request(
+            'POST',
+            '/store-api/account/login/imitate-customer',
+            $payload
+        );
+
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode(), (string) $this->browser->getResponse()->getContent());
+
+        $imitatedContextToken = $this->browser->getResponse()->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN) ?? '';
+        static::assertNotSame('', $imitatedContextToken, 'imitate-customer login must return a sw-context-token header');
+
+        // Drop any Symfony session cookie set during the imitation login so the next
+        // call mimics a purely headless client carrying only `sw-context-token`.
+        $this->browser->getCookieJar()->clear();
+        $this->browser->setServerParameter('HTTP_' . PlatformRequest::HEADER_CONTEXT_TOKEN, $imitatedContextToken);
+
+        $this->browser->request('GET', '/store-api/context');
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode(), (string) $this->browser->getResponse()->getContent());
+
+        $context = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertArrayHasKey('imitated', $context);
+        static::assertTrue($context['imitated'], 'Headless context token must report `imitated: true` after imitation login');
+        static::assertArrayHasKey('imitatingUserId', $context);
+        static::assertNull($context['imitatingUserId'], 'imitatingUserId must remain masked over the Store API surface');
+
+        $this->browser->request('POST', '/store-api/account/logout');
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode(), (string) $this->browser->getResponse()->getContent());
+
+        $postLogoutToken = $this->browser->getResponse()->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN) ?? '';
+        static::assertNotSame('', $postLogoutToken, 'logout must return a sw-context-token header');
+
+        $this->browser->getCookieJar()->clear();
+        $this->browser->setServerParameter('HTTP_' . PlatformRequest::HEADER_CONTEXT_TOKEN, $postLogoutToken);
+
+        $this->browser->request('GET', '/store-api/context');
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
+
+        $context = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertFalse($context['imitated'], 'After logout, headless context token must no longer report imitation');
+    }
+
+    public function testRegularCredentialsLoginAfterImitationClearsImitatedFlag(): void
+    {
+        $imitatedEmail = Uuid::randomHex() . '@example.com';
+        $imitatedCustomerId = $this->createCustomerForBrowser($imitatedEmail);
+        $userId = $this->createAdminUser();
+
+        $regularLoginEmail = Uuid::randomHex() . '@example.com';
+        $this->createCustomerForBrowser($regularLoginEmail);
+
+        $tokenGenerator = static::getContainer()->get(ImitateCustomerTokenGenerator::class);
+
+        if (Feature::isActive('v6.8.0.0')) {
+            $tokenStruct = new ImitateCustomerToken();
+            $tokenStruct->salesChannelId = $this->ids->get('sales-channel');
+            $tokenStruct->customerId = $imitatedCustomerId;
+            $tokenStruct->iss = $userId;
+
+            $imitateToken = $tokenGenerator->encode($tokenStruct);
+            $imitatePayload = [ImitateCustomerRoute::TOKEN => $imitateToken];
+        } else {
+            $imitateToken = Feature::silent(
+                'v6.8.0.0',
+                fn (): string => $tokenGenerator->generate($this->ids->get('sales-channel'), $imitatedCustomerId, $userId)
+            );
+            $imitatePayload = [
+                ImitateCustomerRoute::TOKEN => $imitateToken,
+                ImitateCustomerRoute::CUSTOMER_ID => $imitatedCustomerId,
+                ImitateCustomerRoute::USER_ID => $userId,
+            ];
+        }
+
+        $this->browser->request('POST', '/store-api/account/login/imitate-customer', $imitatePayload);
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode(), (string) $this->browser->getResponse()->getContent());
+
+        $imitatedContextToken = $this->browser->getResponse()->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN) ?? '';
+        static::assertNotSame('', $imitatedContextToken);
+
+        // Headless: drop session cookies and reuse the imitation context token
+        // to log in with a regular customer's credentials.
+        $this->browser->getCookieJar()->clear();
+        $this->browser->setServerParameter('HTTP_' . PlatformRequest::HEADER_CONTEXT_TOKEN, $imitatedContextToken);
+
+        $this->browser->request(
+            'POST',
+            '/store-api/account/login',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            (string) json_encode(['email' => $regularLoginEmail, 'password' => 'shopware'])
+        );
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode(), (string) $this->browser->getResponse()->getContent());
+
+        $regularContextToken = $this->browser->getResponse()->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN) ?? '';
+        static::assertNotSame('', $regularContextToken);
+
+        $this->browser->getCookieJar()->clear();
+        $this->browser->setServerParameter('HTTP_' . PlatformRequest::HEADER_CONTEXT_TOKEN, $regularContextToken);
+
+        $this->browser->request('GET', '/store-api/context');
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
+
+        $context = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertFalse(
+            $context['imitated'],
+            'Regular credentials login on a context token previously used for imitation must clear the imitated flag'
+        );
+        static::assertSame($regularLoginEmail, $context['customer']['email']);
+    }
+
+    private function createCustomerForBrowser(string $email): string
+    {
+        $customerId = Uuid::randomHex();
+        $addressId = Uuid::randomHex();
+
+        /** @var EntityRepository<CustomerCollection> $customerRepository */
+        $customerRepository = static::getContainer()->get('customer.repository');
+        $customerRepository->create([
+            [
+                'id' => $customerId,
+                'salesChannelId' => $this->ids->get('sales-channel'),
+                'defaultShippingAddress' => [
+                    'id' => $addressId,
+                    'firstName' => 'Max',
+                    'lastName' => 'Mustermann',
+                    'street' => 'Musterstraße 1',
+                    'city' => 'Schöppingen',
+                    'zipcode' => '12345',
+                    'salutationId' => $this->getValidSalutationId(),
+                    'countryId' => $this->getValidCountryId(),
+                ],
+                'defaultBillingAddressId' => $addressId,
+                'defaultPaymentMethodId' => $this->getValidPaymentMethodId(),
+                'groupId' => 'cfbd5018d38d41d8adca10d94fc8bdd6',
+                'email' => $email,
+                'password' => 'shopware',
+                'firstName' => 'Max',
+                'lastName' => 'Mustermann',
+                'salutationId' => $this->getValidSalutationId(),
+                'customerNumber' => '12345',
+            ],
+        ], Context::createDefaultContext());
+
+        return $customerId;
+    }
+
+    private function createAdminUser(): string
+    {
+        $userId = Uuid::randomHex();
+
+        /** @var EntityRepository<UserCollection> $userRepository */
+        $userRepository = static::getContainer()->get('user.repository');
+        $userRepository->create([
+            [
+                'id' => $userId,
+                'username' => 'imitator-' . Uuid::randomHex(),
+                'firstName' => 'Imitator',
+                'lastName' => 'Admin',
+                'email' => Uuid::randomHex() . '@example.com',
+                'password' => 'shopware-admin-pw',
+                'localeId' => $this->getLocaleIdOfSystemLanguage(),
+            ],
+        ], Context::createDefaultContext());
+
+        return $userId;
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Shopware\Core\System\SalesChannel\Context\CartRestorer;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\TestDefaults;
@@ -98,6 +99,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $cartRestorer,
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $token = $accountService->loginByCredentials('foo@bar.de', 'shopware', $salesChannelContext);
@@ -145,6 +147,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $cartRestorer,
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(BadCredentialsException::class);
@@ -173,6 +176,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(BadCredentialsException::class);
@@ -227,6 +231,7 @@ class AccountServiceTest extends TestCase
             $legacyPasswordVerifier,
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(PasswordPoliciesUpdatedException::class);
@@ -282,6 +287,7 @@ class AccountServiceTest extends TestCase
             $legacyPasswordVerifier,
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(WriteException::class);
@@ -307,6 +313,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $switcher,
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $accountService->setDefaultBillingAddress('billing-address-id', $context, $customer);
@@ -331,6 +338,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $switcher,
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $accountService->setDefaultShippingAddress('shipping-address-id', $context, $customer);
@@ -386,6 +394,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $accountService->loginById($customer->getId(), $context);
@@ -401,6 +410,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(BadCredentialsException::class);
@@ -431,6 +441,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         $this->expectException(CustomerNotFoundByIdException::class);
@@ -447,6 +458,7 @@ class AccountServiceTest extends TestCase
             $this->createMock(LegacyPasswordVerifier::class),
             $this->createMock(AbstractSwitchDefaultAddressRoute::class),
             $this->createMock(CartRestorer::class),
+            $this->createMock(SalesChannelContextPersister::class),
         );
 
         static::expectException(BadCredentialsException::class);

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/ImitateCustomerRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/ImitateCustomerRouteTest.php
@@ -110,6 +110,11 @@ class ImitateCustomerRouteTest extends TestCase
         $response = $route->imitateCustomerLogin($dataBag, $salesChannelContext);
 
         static::assertSame('newToken', $response->getToken());
+        static::assertSame(
+            $tokenStruct->iss,
+            $salesChannelContext->getImitatingUserId(),
+            'imitate route must set imitatingUserId on the context before delegating to AccountService::loginById; AccountService is then responsible for persisting it'
+        );
     }
 
     public function testImitateCustomerWithLoggedInUser(): void

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -159,4 +159,35 @@ class SalesChannelContextTest extends TestCase
         $this->expectExceptionObject(SalesChannelException::contextTokenNotAccessible());
         $salesChannelContext->getToken();
     }
+
+    public function testIsImitatedReflectsImitatingUserId(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        static::assertFalse($salesChannelContext->isImitated());
+
+        $salesChannelContext->setImitatingUserId(Uuid::randomHex());
+        static::assertTrue($salesChannelContext->isImitated());
+
+        $salesChannelContext->setImitatingUserId(null);
+        static::assertFalse($salesChannelContext->isImitated());
+    }
+
+    public function testJsonSerializeExposesImitatedFlagAndMasksUuid(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+
+        $serialized = $salesChannelContext->jsonSerialize();
+        static::assertArrayHasKey('imitated', $serialized);
+        static::assertFalse($serialized['imitated']);
+        static::assertArrayHasKey('imitatingUserId', $serialized);
+        static::assertNull($serialized['imitatingUserId']);
+
+        $salesChannelContext->setImitatingUserId(Uuid::randomHex());
+
+        $serialized = $salesChannelContext->jsonSerialize();
+        static::assertTrue($serialized['imitated']);
+        // the UUID must never reach the API surface, even when set internally
+        static::assertNull($serialized['imitatingUserId']);
+    }
 }


### PR DESCRIPTION
closes: #16419 

### TL;DR

Headless Store API clients can't detect that the current session is being imitated
by an admin — `imitatingUserId` on `/store-api/context` is always `null`. This PR
adds an `imitated: boolean` flag to the response. Closes #16419.

### Behaviour

Before: `{ "imitatingUserId": null }` — even during an active imitation session.
After:  `{ "imitated": true, "imitatingUserId": null }` during imitation,
        `{ "imitated": false, "imitatingUserId": null }` otherwise.

`imitatingUserId` is preserved in the wire shape (always `null`) and marked
`@deprecated tag:v6.8.0`. The admin UUID is never exposed over the API.

OpenAPI schema and `UPGRADE-6.8.md` updated.

### Checklist

- [x] Tests
- [x] UPGRADE note
- [x] Docs / comments
- [x] Contribution requirements