### PR TITLE
fix: preserve explicitly provided shipping address salutation on registration

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -329,7 +329,7 @@ class RegisterRoute extends AbstractRegisterRoute
             $billingAddress->set('salutationId', $data->get('salutationId'));
         }
 
-        if ($shippingAddress instanceof DataBag) {
+        if (($shippingAddress instanceof DataBag) && !$shippingAddress->get('salutationId')) {
             $shippingAddress->set('salutationId', $data->get('salutationId'));
         }
 

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -1011,6 +1011,66 @@ class RegisterRouteTest extends TestCase
         );
     }
 
+    public function testRegisterPreservesShippingAddressSalutation(): void
+    {
+        $customerEntity = new CustomerEntity();
+        $customerEntity->setDoubleOptInRegistration(false);
+        $customerEntity->setId('customer-1');
+        $customerEntity->setGuest(false);
+
+        $result = $this->createMock(EntitySearchResult::class);
+        $result->method('getEntities')->willReturn(new CustomerCollection([$customerEntity]));
+
+        $customerRepository = $this->createMock(EntityRepository::class);
+        $customerRepository->method('getDefinition')->willReturn(new CustomerDefinition());
+        $customerRepository->method('search')->willReturn($result);
+        $customerRepository
+            ->expects($this->once())
+            ->method('create')
+            ->willReturnCallback(static function (array $create) {
+                static::assertCount(1, $create);
+                static::assertCount(2, $create[0]['addresses']);
+                $billingAddress = array_values(array_filter(
+                    $create[0]['addresses'],
+                    static fn (array $address): bool => $address['firstName'] === 'John'
+                ))[0];
+                $shippingAddress = array_values(array_filter(
+                    $create[0]['addresses'],
+                    static fn (array $address): bool => $address['firstName'] === 'Jane'
+                ))[0];
+
+                static::assertSame('billing-salutation', $billingAddress['salutationId']);
+                static::assertSame('shipping-salutation', $shippingAddress['salutationId']);
+
+                return new EntityWrittenContainerEvent(Context::createDefaultContext(), new NestedEventCollection([]), []);
+            });
+
+        $dataValidator = $this->createMock(DataValidator::class);
+        $dataValidator
+            ->expects($this->once())
+            ->method('getViolations')
+            ->willReturn(new ConstraintViolationList());
+
+        $registerRoute = $this->createRegisterRoute(
+            dataValidator: $dataValidator,
+            customerRepository: $customerRepository
+        );
+
+        $registerRoute->register(
+            new RequestDataBag($this->createRegistrationData([
+                'salutationId' => 'billing-salutation',
+                'shippingAddress' => [
+                    'firstName' => 'Jane',
+                    'lastName' => 'Doe',
+                    'countryId' => Uuid::randomHex(),
+                    'salutationId' => 'shipping-salutation',
+                ],
+            ])),
+            Generator::generateSalesChannelContext(),
+            false
+        );
+    }
+
     /**
      * @return StaticEntityRepository<CustomerCollection>
      */


### PR DESCRIPTION
## Summary

- When a `shippingAddress` with an explicit `salutationId` was passed to `POST /store-api/account/register`, it was unconditionally overwritten by the top-level customer salutation in `validateRegistrationData`
- Fixed by only falling back to the customer salutation when the shipping address provides none
- Added a unit test covering the regression directly

Closes #16232