### PR TITLE
fix: extended associations prevent the deletion of unused media

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -10,6 +10,12 @@
 
 Added and deprecated `BackwardCompatibleNumberFormatter` to temporarily allow invalid locale strings without throwing exceptions in PHP >=8.4. It will be removed in Shopware 6.8.
 
+### Technical media associations can be ignored by `media:delete-unused`
+
+Plugins can now mark technical `media` associations with the new DAL flag `IgnoreInUnusedMediaSearch`.
+This prevents `media:delete-unused` from treating metadata-only extensions as real media usage and helps avoid false negatives when removing unused files.
+Third-party developers should add this flag to media associations that store technical metadata but do not represent an actual assignment of the media file.
+
 ## Administration
 
 ### Fixed "Last Quarter" timeframe returning the wrong year in `sw-date-filter`

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\IgnoreInUnusedMediaSearch;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
@@ -241,6 +242,10 @@ class UnusedMediaPurger
             }
 
             if (!\in_array($field::class, self::VALID_ASSOCIATIONS, true)) {
+                continue;
+            }
+
+            if ($field->is(IgnoreInUnusedMediaSearch::class)) {
                 continue;
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearch.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearch.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Field\Flag;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('framework')]
+class IgnoreInUnusedMediaSearch extends Flag
+{
+    public function parse(): \Generator
+    {
+        yield 'ignore_in_unused_media_search' => true;
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearch.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearch.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field\Flag;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * Excludes a technical media association from being treated as real media usage by `media:delete-unused`.
+ */
 #[Package('framework')]
 class IgnoreInUnusedMediaSearch extends Flag
 {

--- a/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\IgnoreInUnusedMediaSearch;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
@@ -474,6 +475,48 @@ class UnusedMediaPurgerTest extends TestCase
             'Media' => $mediaDefinition = $this->getMediaDefinition([
                 new ManyToOneAssociationField('user', 'user_id', UserDefinition::class, 'id'),
             ]),
+        ]);
+
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $media1 = $this->createMedia($id1);
+        $media2 = $this->createMedia($id2);
+
+        /** @var StaticEntityRepository<MediaCollection> $repo */
+        $repo = new StaticEntityRepository(
+            [
+                static function (Criteria $criteria, Context $context) use ($id1, $id2) {
+                    $filters = $criteria->getFilters();
+
+                    self::assertCount(0, $filters);
+
+                    return [$id1, $id2];
+                },
+                static function (Criteria $criteria, Context $context) use ($id1, $id2, $media1, $media2) {
+                    static::assertSame([$id1, $id2], $criteria->getIds());
+
+                    return new MediaCollection([$media1, $media2]);
+                },
+                [],
+            ],
+            $mediaDefinition
+        );
+
+        $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
+        $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
+
+        static::assertSame([$media1, $media2], $media);
+    }
+
+    public function testGetNotUsedMediaSkipsAssociationsMarkedToIgnoreUnusedMediaSearch(): void
+    {
+        $this->configureRegistry([
+            'Media' => $mediaDefinition = $this->getMediaDefinition([
+                (new FkField('meta_id', 'metaId', 'Meta'))->addFlags(new Required()),
+                (new OneToOneAssociationField('meta', 'meta_id', 'id', 'Meta', false))->addFlags(new IgnoreInUnusedMediaSearch()),
+            ]),
+            'Meta' => $this->getMetaDefinition(),
         ]);
 
         $id1 = Uuid::randomHex();

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearchTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Field/Flag/IgnoreInUnusedMediaSearchTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Field\Flag;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\IgnoreInUnusedMediaSearch;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(IgnoreInUnusedMediaSearch::class)]
+#[Package('framework')]
+class IgnoreInUnusedMediaSearchTest extends TestCase
+{
+    public function testParse(): void
+    {
+        $flag = new IgnoreInUnusedMediaSearch();
+
+        static::assertSame(['ignore_in_unused_media_search' => true], iterator_to_array($flag->parse()));
+    }
+}


### PR DESCRIPTION
Closes #15851

### 1. Why is this change necessary?

`media:delete-unused` currently treats technical `media` extension associations as real usage references.

This becomes visible in `SwagCommercial`, where the image classification feature stores AI metadata through the `mediaAiTag` association. Once this association exists, the unused media search no longer considers the media item unused, even if the file is not actually assigned anywhere in products, CMS, categories, themes, or other entities.

The problem is not limited to `SwagCommercial`. Any plugin that adds technical associations to `media` can accidentally make unused files appear as used.

This prevents unused media with technical metadata, such as AI-generated alt text, from being deleted.

### 2. What does this change do, exactly?

This change introduces a dedicated DAL flag, `IgnoreInUnusedMediaSearch`, for media associations that should not be treated as actual usage references.

`UnusedMediaPurger` now skips associations marked with this flag when building the criteria for `media:delete-unused`.

This provides a generic core mechanism for plugins that add technical media associations.

`SwagCommercial` marks the `mediaAiTag` association with this flag, so the Commercial image classification feature keeps working as before, but AI metadata is no longer interpreted as business usage of the media file.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable the Commercial image keyword / image classification feature.
2. Upload a media file that is not assigned anywhere.
3. Wait until AI processing creates metadata for the file, for example alt text and `mediaAiTag` data.
4. Run `bin/console media:delete-unused --dry-run --grace-period-days=0`.
5. Before this change, the file is missing from the deletion candidates even though it is unused.
6. After this change, the file appears in the deletion candidates and can be removed.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
