### PR TITLE
feat: add exact match subfield

### DIFF
--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
@@ -46,6 +46,7 @@ class ProductSearchConfigFieldDefinition extends EntityDefinition
         return [
             'tokenize' => false,
             'searchable' => false,
+            'useExactSubfield' => false,
             'ranking' => 0,
         ];
     }
@@ -69,6 +70,7 @@ class ProductSearchConfigFieldDefinition extends EntityDefinition
             (new StringField('field', 'field'))->addFlags(new Required())->setDescription('Configuration of search field.'),
             (new BoolField('tokenize', 'tokenize'))->addFlags(new Required())->setDescription('To decide whether the text within the field should undergo tokenization, which involves splitting it into smaller chunks.'),
             (new BoolField('searchable', 'searchable'))->addFlags(new Required())->setDescription('To configure whether the field can be used for searching.'),
+            (new BoolField('use_exact_subfield', 'useExactSubfield'))->addFlags(new Required())->setDescription('To configure whether exact match queries should target the analyzed exact subfield.'),
             (new IntField('ranking', 'ranking'))->addFlags(new Required())->setDescription('Search ranking.'),
             new ManyToOneAssociationField('searchConfig', 'product_search_config_id', ProductSearchConfigDefinition::class, 'id', false),
             new ManyToOneAssociationField('customField', 'custom_field_id', CustomFieldDefinition::class, 'id', false),

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldDefinition.php
@@ -70,7 +70,7 @@ class ProductSearchConfigFieldDefinition extends EntityDefinition
             (new StringField('field', 'field'))->addFlags(new Required())->setDescription('Configuration of search field.'),
             (new BoolField('tokenize', 'tokenize'))->addFlags(new Required())->setDescription('To decide whether the text within the field should undergo tokenization, which involves splitting it into smaller chunks.'),
             (new BoolField('searchable', 'searchable'))->addFlags(new Required())->setDescription('To configure whether the field can be used for searching.'),
-            (new BoolField('use_exact_subfield', 'useExactSubfield'))->addFlags(new Required())->setDescription('To configure whether exact match queries should target the analyzed exact subfield.'),
+            (new BoolField('use_exact_subfield', 'useExactSubfield'))->addFlags(new Required())->setDescription('To configure whether exact match queries should target the exact subfield, which uses the whitespace analyzer (lowercased, whitespace-tokenised) and bypasses the language analyzer (no stemming, no stop-word removal, no compound decomposition).'),
             (new IntField('ranking', 'ranking'))->addFlags(new Required())->setDescription('Search ranking.'),
             new ManyToOneAssociationField('searchConfig', 'product_search_config_id', ProductSearchConfigDefinition::class, 'id', false),
             new ManyToOneAssociationField('customField', 'custom_field_id', CustomFieldDefinition::class, 'id', false),

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldEntity.php
@@ -23,6 +23,8 @@ class ProductSearchConfigFieldEntity extends Entity
 
     protected bool $searchable;
 
+    protected bool $useExactSubfield;
+
     protected int $ranking;
 
     protected ?ProductSearchConfigEntity $searchConfig = null;
@@ -77,6 +79,16 @@ class ProductSearchConfigFieldEntity extends Entity
     public function setSearchable(bool $searchable): void
     {
         $this->searchable = $searchable;
+    }
+
+    public function getUseExactSubfield(): bool
+    {
+        return $this->useExactSubfield;
+    }
+
+    public function setUseExactSubfield(bool $useExactSubfield): void
+    {
+        $this->useExactSubfield = $useExactSubfield;
     }
 
     public function getRanking(): int

--- a/src/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoader.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * @phpstan-type SearchConfig array{and_logic: string, excluded_terms: array<string>, min_search_length: int, field: string, tokenize: int, ranking: float}
+ * @phpstan-type SearchConfig array{and_logic: string, excluded_terms: array<string>, min_search_length: int, field: string, tokenize: int, ranking: float, use_exact_subfield: int}
  */
 #[Package('framework')]
 class SearchConfigLoader
@@ -40,7 +40,8 @@ LOWER(product_search_config.excluded_terms) as `excluded_terms`,
 product_search_config.`min_search_length`,
 product_search_config_field.field,
 product_search_config_field.tokenize,
-product_search_config_field.ranking
+product_search_config_field.ranking,
+product_search_config_field.use_exact_subfield
 
 FROM product_search_config
 INNER JOIN product_search_config_field ON(product_search_config_field.product_search_config_id = product_search_config.id)
@@ -63,6 +64,7 @@ WHERE product_search_config.language_id = :languageId AND product_search_config_
                         'field' => $item['field'],
                         'tokenize' => (int) $item['tokenize'],
                         'ranking' => (float) $item['ranking'],
+                        'use_exact_subfield' => (int) $item['use_exact_subfield'],
                     ];
                 }, $config);
             }

--- a/src/Core/Migration/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigField.php
+++ b/src/Core/Migration/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigField.php
@@ -23,15 +23,22 @@ class Migration1776827954AddExactSubfieldFlagToProductSearchConfigField extends 
         if (!$this->columnExists($connection, 'product_search_config_field', 'use_exact_subfield')) {
             $connection->executeStatement('
                 ALTER TABLE `product_search_config_field`
-                ADD COLUMN `use_exact_subfield` TINYINT(1) NOT NULL DEFAULT 0 AFTER `searchable`
+                ADD COLUMN `use_exact_subfield` TINYINT(1) NOT NULL DEFAULT 0
             ');
         }
 
+        // Identifier fields (productNumber, ean, manufacturerNumber) opt in alongside the
+        // long-form text fields. Without the exact subfield, a query like `5,5` is expanded
+        // by `word_delimiter_graph`'s `catenate_all` into `5,5 OR 55` and then matches every
+        // productNumber whose tokens happen to include `55` (UUIDs, supplier SKUs, etc.).
+        // The exact subfield is keyword-style — only the literal lowercased token matches —
+        // so the high-boost path correctly drops phantom matches and keeps the legitimate
+        // `5,5`-in-name hit on top.
         $connection->executeStatement(
             'UPDATE `product_search_config_field`
                 SET `use_exact_subfield` = 1
               WHERE `field` IN (:fields)',
-            ['fields' => ['name', 'customSearchKeywords']],
+            ['fields' => ['name', 'customSearchKeywords', 'productNumber', 'ean', 'manufacturerNumber']],
             ['fields' => ArrayParameterType::STRING]
         );
     }

--- a/src/Core/Migration/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigField.php
+++ b/src/Core/Migration/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigField.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+class Migration1776827954AddExactSubfieldFlagToProductSearchConfigField extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1776827954;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if (!$this->columnExists($connection, 'product_search_config_field', 'use_exact_subfield')) {
+            $connection->executeStatement('
+                ALTER TABLE `product_search_config_field`
+                ADD COLUMN `use_exact_subfield` TINYINT(1) NOT NULL DEFAULT 0 AFTER `searchable`
+            ');
+        }
+
+        $connection->executeStatement(
+            'UPDATE `product_search_config_field`
+                SET `use_exact_subfield` = 1
+              WHERE `field` IN (:fields)',
+            ['fields' => ['name', 'customSearchKeywords']],
+            ['fields' => ArrayParameterType::STRING]
+        );
+    }
+}

--- a/src/Elasticsearch/FieldQueryBuilder.php
+++ b/src/Elasticsearch/FieldQueryBuilder.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder;
 use Shopware\Elasticsearch\Product\SearchFieldConfig;
 use Shopware\Elasticsearch\Query\MatchBoolPrefixQuery;
 
@@ -131,7 +132,7 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
             ];
 
             if (!$this->useLanguageAnalyzer) {
-                $matchQueryParams['analyzer'] = 'sw_whitespace_analyzer';
+                $matchQueryParams['analyzer'] = ElasticsearchFieldBuilder::ANALYZER_WHITESPACE;
             }
 
             return new MatchQuery($config->getField() . '.search', $token, $matchQueryParams);
@@ -164,7 +165,7 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
         ];
 
         if (!$this->useLanguageAnalyzer) {
-            $matchQueryParams['analyzer'] = 'sw_whitespace_analyzer';
+            $matchQueryParams['analyzer'] = ElasticsearchFieldBuilder::ANALYZER_WHITESPACE;
         }
 
         return new MatchQuery($searchField, $token, $matchQueryParams);
@@ -189,7 +190,7 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
             ];
 
             if (!$this->useLanguageAnalyzer) {
-                $matchPhrasePrefixParams['analyzer'] = 'sw_whitespace_analyzer';
+                $matchPhrasePrefixParams['analyzer'] = ElasticsearchFieldBuilder::ANALYZER_WHITESPACE;
             }
 
             return new MatchPhrasePrefixQuery($searchField, $token, $matchPhrasePrefixParams);
@@ -198,7 +199,7 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
         $matchBoolPrefixParams = ['boost' => 0.4];
 
         if (!$this->useLanguageAnalyzer) {
-            $matchBoolPrefixParams['analyzer'] = 'sw_whitespace_analyzer';
+            $matchBoolPrefixParams['analyzer'] = ElasticsearchFieldBuilder::ANALYZER_WHITESPACE;
         }
 
         return new MatchBoolPrefixQuery($searchField, $token, $matchBoolPrefixParams);

--- a/src/Elasticsearch/FieldQueryBuilder.php
+++ b/src/Elasticsearch/FieldQueryBuilder.php
@@ -120,7 +120,21 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
     private function buildExactMatchQuery(SearchFieldConfig $config, array $tokens, string $token, int $tokenCount): BuilderInterface
     {
         if ($tokenCount === 1) {
-            return new TermQuery($config->getField(), $token, ['boost' => 1]);
+            if ($config->useExactSubfield()) {
+                return new TermQuery($config->getField() . '.exact', $token, ['boost' => 1]);
+            }
+
+            $matchQueryParams = [
+                'boost' => 1,
+                'fuzziness' => 0,
+                'operator' => 'and',
+            ];
+
+            if (!$this->useLanguageAnalyzer) {
+                $matchQueryParams['analyzer'] = 'sw_whitespace_analyzer';
+            }
+
+            return new MatchQuery($config->getField() . '.search', $token, $matchQueryParams);
         }
 
         if ($config->isAndLogic()) {

--- a/src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
+++ b/src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
@@ -31,6 +31,19 @@ abstract class AbstractElasticsearchDefinition
         ],
     ];
 
+    final public const SEARCH_FIELD_WITH_EXACT = [
+        'fields' => [
+            'exact' => [
+                'type' => 'text',
+                'analyzer' => 'sw_whitespace_analyzer',
+                'search_analyzer' => 'sw_whitespace_analyzer',
+                'norms' => false,
+            ],
+            'search' => ['type' => 'text', 'analyzer' => 'sw_whitespace_analyzer'],
+            'ngram' => ['type' => 'text', 'analyzer' => 'sw_ngram_analyzer'],
+        ],
+    ];
+
     final public const SEARCH_FIELD_WITH_LENGTH_NORM = [
         'fields' => [
             'search' => ['type' => 'text', 'analyzer' => 'sw_whitespace_analyzer', 'similarity' => 'sw_length_norm'],
@@ -68,9 +81,9 @@ abstract class AbstractElasticsearchDefinition
     /**
      * @return array<string, mixed>
      */
-    protected static function getTextFieldConfig(): array
+    protected static function getTextFieldConfig(bool $withExact = false): array
     {
-        return self::KEYWORD_FIELD + self::SEARCH_FIELD;
+        return self::KEYWORD_FIELD + ($withExact ? self::SEARCH_FIELD_WITH_EXACT : self::SEARCH_FIELD);
     }
 
     /**

--- a/src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
+++ b/src/Elasticsearch/Framework/AbstractElasticsearchDefinition.php
@@ -15,7 +15,7 @@ abstract class AbstractElasticsearchDefinition
     final public const KEYWORD_FIELD = [
         'type' => 'keyword',
         'ignore_above' => 10000,
-        'normalizer' => 'sw_lowercase_normalizer',
+        'normalizer' => ElasticsearchFieldBuilder::NORMALIZER_LOWERCASE,
     ];
 
     final public const BOOLEAN_FIELD = ['type' => 'boolean'];
@@ -26,8 +26,8 @@ abstract class AbstractElasticsearchDefinition
 
     final public const SEARCH_FIELD = [
         'fields' => [
-            'search' => ['type' => 'text', 'analyzer' => 'sw_whitespace_analyzer'],
-            'ngram' => ['type' => 'text', 'analyzer' => 'sw_ngram_analyzer'],
+            'search' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE],
+            'ngram' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_NGRAM],
         ],
     ];
 
@@ -35,19 +35,34 @@ abstract class AbstractElasticsearchDefinition
         'fields' => [
             'exact' => [
                 'type' => 'text',
-                'analyzer' => 'sw_whitespace_analyzer',
-                'search_analyzer' => 'sw_whitespace_analyzer',
+                'analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE,
+                'search_analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE,
                 'norms' => false,
             ],
-            'search' => ['type' => 'text', 'analyzer' => 'sw_whitespace_analyzer'],
-            'ngram' => ['type' => 'text', 'analyzer' => 'sw_ngram_analyzer'],
+            'search' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE],
+            'ngram' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_NGRAM],
         ],
     ];
 
     final public const SEARCH_FIELD_WITH_LENGTH_NORM = [
         'fields' => [
-            'search' => ['type' => 'text', 'analyzer' => 'sw_whitespace_analyzer', 'similarity' => 'sw_length_norm'],
-            'ngram' => ['type' => 'text', 'analyzer' => 'sw_ngram_analyzer'],
+            'search' => [
+                'type' => 'text',
+                'analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE,
+                'similarity' => ElasticsearchFieldBuilder::SIMILARITY_LENGTH_NORM,
+            ],
+            'ngram' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_NGRAM],
+        ],
+    ];
+
+    final public const TECHNICAL_TERM_SEARCH_FIELD = [
+        'fields' => [
+            'search' => [
+                'type' => 'text',
+                'analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_INDEX,
+                'search_analyzer' => ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_SEARCH,
+            ],
+            'ngram' => ['type' => 'text', 'analyzer' => ElasticsearchFieldBuilder::ANALYZER_NGRAM],
         ],
     ];
 
@@ -79,11 +94,40 @@ abstract class AbstractElasticsearchDefinition
     abstract public function buildTermQuery(Context $context, Criteria $criteria): BuilderInterface;
 
     /**
+     * @deprecated tag:v6.8.0 - reason:becomes-internal - Use {@see self::buildTextFieldConfig()} instead.
+     *
      * @return array<string, mixed>
      */
-    protected static function getTextFieldConfig(bool $withExact = false): array
+    protected static function getTextFieldConfig(): array
     {
-        return self::KEYWORD_FIELD + ($withExact ? self::SEARCH_FIELD_WITH_EXACT : self::SEARCH_FIELD);
+        return self::KEYWORD_FIELD + self::SEARCH_FIELD;
+    }
+
+    /**
+     * Returns text field config. Flags:
+     * - `$withExact`: add an unanalyzed `exact` subfield for high-boost exact-token matching.
+     * - `$technicalTerms`: route the `search` subfield through the `word_delimiter_graph`
+     *   analyzer pair so SKUs, manufacturer numbers, and EANs keep their letter+digit
+     *   boundaries and survive `,` / `-` / `.` separators.
+     * - `$lengthNorm`: apply BM25 length normalization (`sw_length_norm`, b=0.75) on the
+     *   `search` subfield, for long merchant-curated fields like `customSearchKeywords`
+     *   where document length is a relevance signal.
+     *
+     * @return array<string, mixed>
+     */
+    protected static function buildTextFieldConfig(bool $withExact = false, bool $technicalTerms = false, bool $lengthNorm = false): array
+    {
+        $fieldConfig = $technicalTerms ? self::TECHNICAL_TERM_SEARCH_FIELD : self::SEARCH_FIELD;
+
+        if ($lengthNorm) {
+            $fieldConfig['fields']['search']['similarity'] = 'sw_length_norm';
+        }
+
+        if ($withExact) {
+            $fieldConfig['fields'] = ['exact' => self::SEARCH_FIELD_WITH_EXACT['fields']['exact']] + $fieldConfig['fields'];
+        }
+
+        return self::KEYWORD_FIELD + $fieldConfig;
     }
 
     /**

--- a/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
+++ b/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
@@ -11,6 +11,52 @@ use Shopware\Elasticsearch\Product\ElasticsearchCustomFieldsMappingHelper;
 class ElasticsearchFieldBuilder
 {
     /**
+     * Lowercase normalizer applied to every keyword field so case folding is
+     * consistent across the index.
+     */
+    public const NORMALIZER_LOWERCASE = 'sw_lowercase_normalizer';
+
+    /**
+     * BM25 similarity profile with length normalisation enabled (`b=0.75`).
+     * Applied to the `.search` subfield of long-form text fields where document
+     * length should temper TF.
+     */
+    public const SIMILARITY_LENGTH_NORM = 'sw_length_norm';
+
+    /**
+     * Whitespace-only analyzer (whitespace tokenize + lowercase). The default
+     * for `.exact` subfields and for the language-agnostic `.search` subfield.
+     */
+    public const ANALYZER_WHITESPACE = 'sw_whitespace_analyzer';
+
+    /**
+     * N-gram analyzer for the `.ngram` subfield. Substring matching for prefix
+     * and partial-token queries. Min/max grams configured via
+     * `SHOPWARE_ES_NGRAM_MIN_GRAM` / `SHOPWARE_ES_NGRAM_MAX_GRAM`.
+     */
+    public const ANALYZER_NGRAM = 'sw_ngram_analyzer';
+
+    /**
+     * Index-side technical-term analyzer (`word_delimiter_graph` chain) for
+     * SKU-style fields where letter↔digit boundaries and `,` / `-` / `.`
+     * separators must survive into the inverted index.
+     */
+    public const ANALYZER_WHITESPACE_TECHNICAL_INDEX = 'sw_whitespace_word_delimiter_index_analyzer';
+
+    /**
+     * Search-side counterpart of {@see self::ANALYZER_WHITESPACE_TECHNICAL_INDEX}
+     * with the cross-position deduplication filter appended.
+     */
+    public const ANALYZER_WHITESPACE_TECHNICAL_SEARCH = 'sw_whitespace_word_delimiter_search_analyzer';
+
+    /**
+     * Common prefix of every language-agnostic analyzer this bundle ships.
+     * Used by {@see self::translated()} to derive language-specific analyzer
+     * names by string substitution (`sw_whitespace_…` → `sw_<lang>_…`).
+     */
+    public const ANALYZER_WHITESPACE_PREFIX = 'sw_whitespace_';
+
+    /**
      * @internal
      *
      * @param array<string, string> $languageAnalyzerMapping

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -53,8 +53,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
      */
     public function getMapping(Context $context): array
     {
-        $languageFields = $this->fieldBuilder->translated(self::getTextFieldConfig());
-        $languageFieldsWithExact = $this->fieldBuilder->translated(self::getTextFieldConfig(withExact: true));
+        $languageFields = $this->fieldBuilder->translated(self::buildTextFieldConfig());
+        $languageFieldsWithExact = $this->fieldBuilder->translated(self::buildTextFieldConfig(withExact: true));
         $languageFieldsWithLengthNorm = $this->fieldBuilder->translated(self::getTextFieldWithLengthNormConfig());
         $salesChannelByLanguage = $this->salesChannelLanguageLoader->loadLanguages();
         $allSalesChannels = array_values(array_unique(array_merge(...array_values($salesChannelByLanguage))));
@@ -108,14 +108,14 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
             'streamIds' => self::KEYWORD_FIELD,
             'autoIncrement' => self::INT_FIELD,
             'manufacturerId' => self::KEYWORD_FIELD,
-            'manufacturerNumber' => self::getTextFieldConfig(),
+            'manufacturerNumber' => self::buildTextFieldConfig(withExact: true),
             'deliveryTimeId' => self::KEYWORD_FIELD,
             'displayGroup' => self::KEYWORD_FIELD,
-            'ean' => self::getTextFieldConfig(),
+            'ean' => self::buildTextFieldConfig(withExact: true),
             'height' => self::FLOAT_FIELD,
             'length' => self::FLOAT_FIELD,
             'markAsTopseller' => self::BOOLEAN_FIELD,
-            'productNumber' => self::getTextFieldConfig(),
+            'productNumber' => self::buildTextFieldConfig(withExact: true),
             'ratingAverage' => self::FLOAT_FIELD,
             'releaseDate' => ElasticsearchFieldBuilder::datetime(),
             'createdAt' => ElasticsearchFieldBuilder::datetime(),
@@ -124,7 +124,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
             'availableStock' => self::INT_FIELD,
             'shippingFree' => self::BOOLEAN_FIELD,
             'taxId' => self::KEYWORD_FIELD,
-            'tags' => ElasticsearchFieldBuilder::nested(['name' => self::getTextFieldConfig()]),
+            'tags' => ElasticsearchFieldBuilder::nested(['name' => self::buildTextFieldConfig()]),
             'visibilities' => ElasticsearchFieldBuilder::nested([
                 'id' => null,
                 'salesChannelId' => self::KEYWORD_FIELD,

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -54,6 +54,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
     public function getMapping(Context $context): array
     {
         $languageFields = $this->fieldBuilder->translated(self::getTextFieldConfig());
+        $languageFieldsWithExact = $this->fieldBuilder->translated(self::getTextFieldConfig(withExact: true));
         $languageFieldsWithLengthNorm = $this->fieldBuilder->translated(self::getTextFieldWithLengthNormConfig());
         $salesChannelByLanguage = $this->salesChannelLanguageLoader->loadLanguages();
         $allSalesChannels = array_values(array_unique(array_merge(...array_values($salesChannelByLanguage))));
@@ -70,11 +71,11 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 
         $properties = [
             'id' => self::KEYWORD_FIELD,
-            'name' => $languageFields,
+            'name' => $languageFieldsWithExact,
             'description' => $languageFieldsWithLengthNorm,
             'metaTitle' => $languageFields,
             'metaDescription' => $languageFieldsWithLengthNorm,
-            'customSearchKeywords' => $languageFields,
+            'customSearchKeywords' => $languageFieldsWithExact,
             'categories' => ElasticsearchFieldBuilder::nested([
                 'name' => $languageFields,
             ]),

--- a/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
+++ b/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
@@ -17,7 +17,7 @@ use Shopware\Elasticsearch\AbstractTokenQueryBuilder;
 use Shopware\Elasticsearch\ElasticsearchException;
 
 /**
- * @phpstan-type SearchConfig array{and_logic: string, field: string, tokenize: int, ranking: int}
+ * @phpstan-type SearchConfig array{and_logic: string, field: string, tokenize: int, ranking: int, use_exact_subfield?: int}
  */
 #[Package('framework')]
 class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
@@ -60,6 +60,8 @@ class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
                 $item['ranking'],
                 (bool) $item['tokenize'],
                 (bool) $item['and_logic'],
+                true,
+                (bool) ($item['use_exact_subfield'] ?? 0),
             );
         }, $searchConfig);
 

--- a/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
+++ b/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
@@ -61,7 +61,7 @@ class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
                 (bool) $item['tokenize'],
                 (bool) $item['and_logic'],
                 true,
-                (bool) ($item['use_exact_subfield'] ?? 0),
+                (bool) $item['use_exact_subfield'],
             );
         }, $searchConfig);
 

--- a/src/Elasticsearch/Product/SearchFieldConfig.php
+++ b/src/Elasticsearch/Product/SearchFieldConfig.php
@@ -12,7 +12,8 @@ class SearchFieldConfig
         private float $ranking,
         private readonly bool $tokenize,
         private readonly bool $andLogic = false,
-        private readonly bool $prefixMatch = true
+        private readonly bool $prefixMatch = true,
+        private readonly bool $useExactSubfield = false,
     ) {
     }
 
@@ -49,6 +50,11 @@ class SearchFieldConfig
     public function usePrefixMatch(): bool
     {
         return $this->prefixMatch;
+    }
+
+    public function useExactSubfield(): bool
+    {
+        return $this->useExactSubfield;
     }
 
     public function getFuzziness(string $token): string|int

--- a/src/Elasticsearch/TranslatedFieldQueryBuilder.php
+++ b/src/Elasticsearch/TranslatedFieldQueryBuilder.php
@@ -56,6 +56,7 @@ class TranslatedFieldQueryBuilder extends AbstractFieldQueryBuilder
                 $config->tokenize(),
                 $config->isAndLogic(),
                 $config->usePrefixMatch(),
+                $config->useExactSubfield(),
             );
 
             $languageQuery = $this->getDecorated()->build(

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -32,13 +32,11 @@ class SearchCasesTest extends TestCase
     use SalesChannelApiTestBehaviour;
     use SessionTestBehaviour;
 
-    private static IdsCollection $ids;
-
     /**
      * @param array<mixed> $products
      */
     #[DataProvider('numbersProvider')]
-    public function testSearch(array $products, string $term, string $best): void
+    public function testSearch(IdsCollection $ids, array $products, string $term, string $best): void
     {
         $this->clearElasticsearch();
 
@@ -63,21 +61,19 @@ class SearchCasesTest extends TestCase
 
         $scores = [];
         foreach ($result->getData() as $item) {
-            $key = self::$ids->getKey((string) $item['id']);
+            $key = $ids->getKey((string) $item['id']);
             static::assertNotNull($key);
             $scores[$key] = $item['_score'];
         }
 
-        static::assertSame(
-            $best,
-            self::$ids->getKey((string) $result->firstId()),
-            print_r($scores, true)
-        );
+        $firstId = $result->firstId();
+        static::assertNotNull($firstId, print_r($scores, true));
+        static::assertSame($best, $ids->getKey($firstId), print_r($scores, true));
     }
 
     public static function numbersProvider(): \Generator
     {
-        self::$ids = $ids = new IdsCollection();
+        $ids = new IdsCollection();
 
         $products = [
             'p1' => self::product($ids, 'p1', 'DE-031668-B', 'HP LaserJet Enterprise M608x Inkl. Stapelfach und Papierfach'),
@@ -92,7 +88,7 @@ class SearchCasesTest extends TestCase
             'p10' => self::product($ids, 'p10', 'DE-17.447-N', 'SOLID DDR3 Desktop Speicher - DIMM 240-PIN - DDR3 - 1600 MHz - CL 11'),
         ];
 
-        yield 'Exact number match' => [$products, 'DE-031668-B', 'p1'];
+        yield 'Exact number match' => [$ids, $products, 'DE-031668-B', 'p1'];
     }
 
     public function testExactNameTokenMatchRanksAheadOfPrefixOnlyMatch(): void
@@ -101,7 +97,7 @@ class SearchCasesTest extends TestCase
 
         static::getContainer()->get(Connection::class)->executeStatement('DELETE FROM product');
 
-        self::$ids = $ids = new IdsCollection();
+        $ids = new IdsCollection();
 
         static::getContainer()->get('product.repository')->create([
             self::product($ids, 'exact', 'DE-EXACT-1', 'Leather Jacket'),
@@ -123,11 +119,9 @@ class SearchCasesTest extends TestCase
 
         $result = $searcher->search($definition, $criteria, Context::createDefaultContext());
 
-        static::assertSame(
-            'exact',
-            self::$ids->getKey((string) $result->firstId()),
-            print_r($result->getData(), true)
-        );
+        $firstId = $result->firstId();
+        static::assertNotNull($firstId, print_r($result->getData(), true));
+        static::assertSame('exact', $ids->getKey($firstId), print_r($result->getData(), true));
     }
 
     protected function getDiContainer(): ContainerInterface

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -95,6 +95,41 @@ class SearchCasesTest extends TestCase
         yield 'Exact number match' => [$products, 'DE-031668-B', 'p1'];
     }
 
+    public function testExactNameTokenMatchRanksAheadOfPrefixOnlyMatch(): void
+    {
+        $this->clearElasticsearch();
+
+        static::getContainer()->get(Connection::class)->executeStatement('DELETE FROM product');
+
+        self::$ids = $ids = new IdsCollection();
+
+        static::getContainer()->get('product.repository')->create([
+            self::product($ids, 'exact', 'DE-EXACT-1', 'Leather Jacket'),
+            self::product($ids, 'prefix', 'DE-PREFIX-1', 'Leathery Jacket'),
+        ], Context::createDefaultContext());
+
+        $this->setSearchConfiguration(true, ['name']);
+        $this->setSearchScores(['name' => 700]);
+
+        $this->indexElasticSearch();
+
+        $searcher = $this->createEntitySearcher();
+
+        $criteria = new Criteria();
+        $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
+        $criteria->setTerm('Leather');
+
+        $definition = static::getContainer()->get(ProductDefinition::class);
+
+        $result = $searcher->search($definition, $criteria, Context::createDefaultContext());
+
+        static::assertSame(
+            'exact',
+            self::$ids->getKey((string) $result->firstId()),
+            print_r($result->getData(), true)
+        );
+    }
+
     protected function getDiContainer(): ContainerInterface
     {
         return static::getContainer();

--- a/tests/migration/Core/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest.php
+++ b/tests/migration/Core/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Database\TableHelper;
+use Shopware\Core\Migration\V6_7\Migration1776827954AddExactSubfieldFlagToProductSearchConfigField;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1776827954AddExactSubfieldFlagToProductSearchConfigField::class)]
+class Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigration(): void
+    {
+        $this->rollback();
+
+        $migration = new Migration1776827954AddExactSubfieldFlagToProductSearchConfigField();
+        static::assertSame(1776827954, $migration->getCreationTimestamp());
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertTrue(TableHelper::columnExists($this->connection, 'product_search_config_field', 'use_exact_subfield'));
+
+        $column = TableHelper::getColumnOfTable($this->connection, 'product_search_config_field', 'use_exact_subfield');
+        static::assertSame('boolean', $column->type);
+        static::assertTrue($column->isNotNull);
+        static::assertSame('0', (string) $column->defaultValue);
+
+        $expectedFields = ['name', 'customSearchKeywords', 'productNumber', 'ean', 'manufacturerNumber'];
+
+        $enabled = $this->connection->fetchAllKeyValue('
+            SELECT `field`, `use_exact_subfield`
+            FROM `product_search_config_field`
+            WHERE `field` IN (:fields)
+        ', ['fields' => $expectedFields], ['fields' => ArrayParameterType::STRING]);
+
+        foreach ($enabled as $field => $value) {
+            static::assertSame(1, (int) $value, \sprintf('use_exact_subfield should be enabled for "%s"', $field));
+        }
+    }
+
+    private function rollback(): void
+    {
+        if (TableHelper::columnExists($this->connection, 'product_search_config_field', 'use_exact_subfield')) {
+            $this->connection->executeStatement('ALTER TABLE `product_search_config_field` DROP COLUMN `use_exact_subfield`');
+        }
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoaderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/SearchConfigLoaderTest.php
@@ -22,8 +22,8 @@ use Shopware\Core\Framework\Uuid\Uuid;
 class SearchConfigLoaderTest extends TestCase
 {
     /**
-     * @param array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float}>> $configKeyedByLanguageId
-     * @param array<array{and_logic: string, field: string, tokenize: int, ranking: float}> $expectedResult
+     * @param array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float, use_exact_subfield?: int}>> $configKeyedByLanguageId
+     * @param array<array{and_logic: string, field: string, tokenize: int, ranking: float, excluded_terms: array<string>, min_search_length: int, use_exact_subfield: int}> $expectedResult
      */
     #[DataProvider('loadDataProvider')]
     public function testLoad(array $configKeyedByLanguageId, array $expectedResult): void
@@ -75,7 +75,7 @@ class SearchConfigLoaderTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{configKeyedByLanguageId: array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float}>>, expectedResult: array<array{and_logic: string, field: string, tokenize: int, ranking: float}>}>
+     * @return iterable<string, array{configKeyedByLanguageId: array<string, list<array{and_logic: string, excluded_terms: string, min_search_length: int, field: string, tokenize: int, ranking: float, use_exact_subfield?: int}>>, expectedResult: array<array{and_logic: string, field: string, tokenize: int, ranking: float, excluded_terms: array<string>, min_search_length: int, use_exact_subfield: int}>}>
      */
     public static function loadDataProvider(): iterable
     {
@@ -88,6 +88,7 @@ class SearchConfigLoaderTest extends TestCase
                     'field' => 'name',
                     'tokenize' => 1,
                     'ranking' => 2.0,
+                    'use_exact_subfield' => 1,
                 ]],
             ],
             'expectedResult' => [
@@ -98,6 +99,7 @@ class SearchConfigLoaderTest extends TestCase
                     'field' => 'name',
                     'tokenize' => 1,
                     'ranking' => 2.0,
+                    'use_exact_subfield' => 1,
                 ],
             ],
         ];
@@ -111,6 +113,7 @@ class SearchConfigLoaderTest extends TestCase
                     'ranking' => 100.0,
                     'excluded_terms' => json_encode(['term1', 'term2'], \JSON_THROW_ON_ERROR),
                     'min_search_length' => 5,
+                    'use_exact_subfield' => 0,
                 ]],
                 Uuid::randomHex() => [[
                     'and_logic' => 'and',
@@ -119,6 +122,7 @@ class SearchConfigLoaderTest extends TestCase
                     'field' => 'name',
                     'tokenize' => 0,
                     'ranking' => 50.0,
+                    'use_exact_subfield' => 1,
                 ]],
             ],
             'expectedResult' => [
@@ -129,6 +133,7 @@ class SearchConfigLoaderTest extends TestCase
                     'field' => 'name',
                     'tokenize' => 1,
                     'ranking' => 100.0,
+                    'use_exact_subfield' => 0,
                 ],
             ],
         ];

--- a/tests/unit/Elasticsearch/FieldQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/FieldQueryBuilderTest.php
@@ -103,6 +103,65 @@ class FieldQueryBuilderTest extends TestCase
         static::assertArrayHasKey('terms', $exactMatch);
     }
 
+    public function testSingleTokenExactMatchUsesExactSubfieldWhenConfigured(): void
+    {
+        $builder = new FieldQueryBuilder();
+        $field = new ResolvedField(new StringField('name', 'name'));
+        $config = new SearchFieldConfig('name', 500, false, true, true, true);
+
+        $query = $builder->build($field, 'foo', $config, Context::createDefaultContext());
+
+        static::assertNotNull($query);
+        $array = $query->toArray();
+        $exactMatch = $array['dis_max']['queries'][0] ?? null;
+        static::assertNotNull($exactMatch);
+        static::assertStringContainsString(
+            '"name.exact"',
+            json_encode($exactMatch, \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function testSingleTokenWithoutExactSubfieldUsesSearchMatchQuery(): void
+    {
+        $builder = new FieldQueryBuilder();
+        $field = new ResolvedField(new StringField('name', 'name'));
+        $config = new SearchFieldConfig('name', 500, false, true, true);
+
+        $query = $builder->build($field, 'foo', $config, Context::createDefaultContext());
+
+        static::assertNotNull($query);
+        $array = $query->toArray();
+        $exactMatch = $array['dis_max']['queries'][0] ?? null;
+        static::assertNotNull($exactMatch);
+        static::assertArrayHasKey('match', $exactMatch);
+        static::assertArrayHasKey('name.search', $exactMatch['match']);
+        static::assertEquals(1.0, $exactMatch['match']['name.search']['boost']);
+        static::assertSame(0, $exactMatch['match']['name.search']['fuzziness']);
+        static::assertSame('and', $exactMatch['match']['name.search']['operator']);
+    }
+
+    public function testMultiTokenExactMatchDoesNotUseExactSubfieldWhenConfigured(): void
+    {
+        $builder = new FieldQueryBuilder();
+        $field = new ResolvedField(new StringField('name', 'name'));
+        $config = new SearchFieldConfig('name', 500, false, true, true, true);
+
+        $query = $builder->build($field, 'foo bar', $config, Context::createDefaultContext());
+
+        static::assertNotNull($query);
+        $array = $query->toArray();
+        $exactMatch = $array['dis_max']['queries'][0] ?? null;
+        static::assertNotNull($exactMatch);
+        static::assertStringNotContainsString(
+            '"name.exact"',
+            json_encode($exactMatch, \JSON_THROW_ON_ERROR),
+        );
+        static::assertStringContainsString(
+            '"name"',
+            json_encode($exactMatch, \JSON_THROW_ON_ERROR),
+        );
+    }
+
     public function testNgramQueryIncludedForLongTokenizedTerm(): void
     {
         $builder = new FieldQueryBuilder(4);
@@ -167,16 +226,8 @@ class FieldQueryBuilderTest extends TestCase
 
         static::assertNotNull($query);
         $array = $query->toArray();
-        $matchQuery = null;
-        foreach ($array['dis_max']['queries'] as $q) {
-            if (isset($q['match'])) {
-                $matchQuery = $q;
-
-                break;
-            }
-        }
-        static::assertNotNull($matchQuery);
-        $matchValues = reset($matchQuery['match']);
+        static::assertArrayHasKey('match', $array['dis_max']['queries'][0]);
+        $matchValues = reset($array['dis_max']['queries'][0]['match']);
         static::assertSame('sw_whitespace_analyzer', $matchValues['analyzer'] ?? null);
     }
 

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -176,6 +176,28 @@ class ElasticsearchProductDefinitionTest extends TestCase
         ],
     ];
 
+    private const EXACT_SEARCHABLE_MAPPING = [
+        'type' => 'keyword',
+        'ignore_above' => 10000,
+        'normalizer' => 'sw_lowercase_normalizer',
+        'fields' => [
+            'exact' => [
+                'type' => 'text',
+                'analyzer' => 'sw_whitespace_analyzer',
+                'search_analyzer' => 'sw_whitespace_analyzer',
+                'norms' => false,
+            ],
+            'search' => [
+                'type' => 'text',
+                'analyzer' => 'sw_whitespace_analyzer',
+            ],
+            'ngram' => [
+                'type' => 'text',
+                'analyzer' => 'sw_ngram_analyzer',
+            ],
+        ],
+    ];
+
     private readonly IdsCollection $ids;
 
     protected function setUp(): void
@@ -275,12 +297,12 @@ class ElasticsearchProductDefinitionTest extends TestCase
                 'autoIncrement' => [
                     'type' => 'long',
                 ],
-                'manufacturerNumber' => self::SEARCHABLE_MAPPING,
+                'manufacturerNumber' => self::EXACT_SEARCHABLE_MAPPING,
                 'description' => self::TRANSLATABLE_SEARCHABLE_LENGTH_NORM_MAPPING,
                 'metaTitle' => self::TRANSLATABLE_SEARCHABLE_MAPPING,
                 'metaDescription' => self::TRANSLATABLE_SEARCHABLE_LENGTH_NORM_MAPPING,
                 'displayGroup' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
-                'ean' => self::SEARCHABLE_MAPPING,
+                'ean' => self::EXACT_SEARCHABLE_MAPPING,
                 'height' => [
                     'type' => 'double',
                 ],
@@ -312,7 +334,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
                         ],
                     ],
                 ],
-                'productNumber' => self::SEARCHABLE_MAPPING,
+                'productNumber' => self::EXACT_SEARCHABLE_MAPPING,
                 'properties' => [
                     'type' => 'nested',
                     'properties' => [

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -76,6 +76,53 @@ class ElasticsearchProductDefinitionTest extends TestCase
         ],
     ];
 
+    private const TRANSLATABLE_EXACT_SEARCHABLE_MAPPING = [
+        'properties' => [
+            'lang_en' => [
+                'type' => 'keyword',
+                'ignore_above' => 10000,
+                'normalizer' => 'sw_lowercase_normalizer',
+                'fields' => [
+                    'exact' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_whitespace_analyzer',
+                        'search_analyzer' => 'sw_whitespace_analyzer',
+                        'norms' => false,
+                    ],
+                    'search' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_english_analyzer',
+                    ],
+                    'ngram' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_ngram_analyzer',
+                    ],
+                ],
+            ],
+            'lang_de' => [
+                'type' => 'keyword',
+                'ignore_above' => 10000,
+                'normalizer' => 'sw_lowercase_normalizer',
+                'fields' => [
+                    'exact' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_whitespace_analyzer',
+                        'search_analyzer' => 'sw_whitespace_analyzer',
+                        'norms' => false,
+                    ],
+                    'search' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_german_analyzer',
+                    ],
+                    'ngram' => [
+                        'type' => 'text',
+                        'analyzer' => 'sw_ngram_analyzer',
+                    ],
+                ],
+            ],
+        ],
+    ];
+
     private const TRANSLATABLE_SEARCHABLE_LENGTH_NORM_MAPPING = [
         'properties' => [
             'lang_en' => [
@@ -253,7 +300,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
                 'markAsTopseller' => [
                     'type' => 'boolean',
                 ],
-                'name' => self::TRANSLATABLE_SEARCHABLE_MAPPING,
+                'name' => self::TRANSLATABLE_EXACT_SEARCHABLE_MAPPING,
                 'options' => [
                     'type' => 'nested',
                     'properties' => [
@@ -353,7 +400,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
                         ],
                     ],
                 ],
-                'customSearchKeywords' => self::TRANSLATABLE_SEARCHABLE_MAPPING,
+                'customSearchKeywords' => self::TRANSLATABLE_EXACT_SEARCHABLE_MAPPING,
                 'type' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
                 'states' => AbstractElasticsearchDefinition::KEYWORD_FIELD,
                 'manufacturerId' => AbstractElasticsearchDefinition::KEYWORD_FIELD,

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -167,12 +167,12 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                     self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::term('tags.name', 'foo', 1),
+                    self::exactAnalyzed('tags.name.search', 'foo', 1),
                     self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
@@ -199,35 +199,35 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::bool([
                         self::disMax([
-                            self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::term('ean', 'foo', 1),
+                            self::exactAnalyzed('ean.search', 'foo', 1),
                             self::match('ean.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('ean.search', 'foo', 0.4),
                         ], 2000),
                         self::nested('tags', self::disMax([
-                            self::term('tags.name', 'foo', 1),
+                            self::exactAnalyzed('tags.name.search', 'foo', 1),
                             self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('tags.name.search', 'foo', 0.4),
                         ], 500)),
                     ]),
                     self::bool([
                         self::disMax([
-                            self::term('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 1),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::term('ean', '2023', 1),
+                            self::exactAnalyzed('ean.search', '2023', 1),
                             self::match('ean.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('ean.search', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
-                            self::term('tags.name', '2023', 1),
+                            self::exactAnalyzed('tags.name.search', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('tags.name.search', '2023', 0.4),
                         ], 500)),
@@ -282,13 +282,13 @@ class ProductSearchQueryBuilderTest extends TestCase
             'expected' => self::disMax([
                 self::bool([
                     self::disMax([
-                        self::term($prefix . 'evolvesText', 'foo', 1),
+                        self::exactAnalyzed($prefix . 'evolvesText.search', 'foo', 1),
                         self::match($prefix . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                         self::prefix($prefix . 'evolvesText.search', 'foo', 0.4),
                     ], 500),
                     self::bool([
                         self::disMax([
-                            self::term($prefix . 'evolvesText', '2023', 1),
+                            self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 1),
                             self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix($prefix . 'evolvesText.search', '2023', 0.4),
                         ], 500),
@@ -322,23 +322,23 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                     self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::term('tags.name', 'foo', 1),
+                    self::exactAnalyzed('tags.name.search', 'foo', 1),
                     self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
                 self::nested('categories', self::disMax([
                     self::disMax([
-                        self::term('categories.name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                         self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                         self::prefix('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                     ], 200),
                     self::disMax([
-                        self::term('categories.name.' . self::SECOND_LANGUAGE_ID, 'foo', 1),
+                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 1),
                         self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                         self::prefix('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4),
                     ], 160),
@@ -358,35 +358,35 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::bool([
                         self::disMax([
-                            self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::term('ean', 'foo', 1),
+                            self::exactAnalyzed('ean.search', 'foo', 1),
                             self::match('ean.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('ean.search', 'foo', 0.4),
                         ], 2000),
                         self::nested('tags', self::disMax([
-                            self::term('tags.name', 'foo', 1),
+                            self::exactAnalyzed('tags.name.search', 'foo', 1),
                             self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix('tags.name.search', 'foo', 0.4),
                         ], 500)),
                     ]),
                     self::bool([
                         self::disMax([
-                            self::term('name.' . Defaults::LANGUAGE_SYSTEM, '2023', 1),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
                             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::term('ean', '2023', 1),
+                            self::exactAnalyzed('ean.search', '2023', 1),
                             self::match('ean.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('ean.search', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
-                            self::term('tags.name', '2023', 1),
+                            self::exactAnalyzed('tags.name.search', '2023', 1),
                             self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
                             self::prefix('tags.name.search', '2023', 0.4),
                         ], 500)),
@@ -424,12 +424,12 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::disMax([
                         self::disMax([
-                            self::term($prefixCfLang1 . 'evolvesText', 'foo', 1),
+                            self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
                             self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                         ], 500),
                         self::disMax([
-                            self::term($prefixCfLang2 . 'evolvesText', 'foo', 1),
+                            self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
                             self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                             self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                         ], 400),
@@ -437,12 +437,12 @@ class ProductSearchQueryBuilderTest extends TestCase
                     self::bool([
                         self::disMax([
                             self::disMax([
-                                self::term($prefixCfLang1 . 'evolvesText', '2023', 1),
+                                self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 1),
                                 self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                                 self::prefix($prefixCfLang1 . 'evolvesText.search', '2023', 0.4),
                             ], 500),
                             self::disMax([
-                                self::term($prefixCfLang2 . 'evolvesText', '2023', 1),
+                                self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 1),
                                 self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                                 self::prefix($prefixCfLang2 . 'evolvesText.search', '2023', 0.4),
                             ], 400),
@@ -503,6 +503,48 @@ class ProductSearchQueryBuilderTest extends TestCase
             static::assertNotNull($disMax);
             static::assertSame(0.2, $disMax['tie_breaker']);
         }
+    }
+
+    public function testTranslatedSingleTokenExactMatchUsesExactSubfieldWhenConfigured(): void
+    {
+        $builder = $this->getBuilder([
+            self::config(field: 'name', ranking: 1000, useExactSubfield: true),
+        ]);
+
+        $criteria = new Criteria();
+        $criteria->setTerm('foo');
+
+        $parsed = $builder->build($criteria, Context::createDefaultContext());
+
+        static::assertStringContainsString(
+            '"name.' . Defaults::LANGUAGE_SYSTEM . '.exact"',
+            json_encode($parsed->toArray(), \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function testTranslatedMultiTokenExactMatchUsesKeywordFieldWhenConfigured(): void
+    {
+        $builder = $this->getBuilder([
+            self::config(field: 'name', ranking: 1000, useExactSubfield: true),
+        ]);
+
+        $criteria = new Criteria();
+        $criteria->setTerm('foo bar');
+
+        $parsed = $builder->build($criteria, Context::createDefaultContext());
+
+        $queryArray = $parsed->toArray();
+        $originalTermQuery = $queryArray['dis_max']['queries'][1] ?? null;
+
+        static::assertNotNull($originalTermQuery);
+        static::assertStringContainsString(
+            '"name.' . Defaults::LANGUAGE_SYSTEM . '"',
+            json_encode($originalTermQuery, \JSON_THROW_ON_ERROR),
+        );
+        static::assertStringNotContainsString(
+            '"name.' . Defaults::LANGUAGE_SYSTEM . '.exact"',
+            json_encode($originalTermQuery, \JSON_THROW_ON_ERROR),
+        );
     }
 
     public function testDecoration(): void
@@ -566,15 +608,16 @@ class ProductSearchQueryBuilderTest extends TestCase
     }
 
     /**
-     * @return array{and_logic: string, field: string, tokenize: int, ranking: float}
+     * @return array{and_logic: string, field: string, tokenize: int, ranking: float, use_exact_subfield: int}
      */
-    private static function config(string $field, float $ranking, bool $tokenize = false, bool $and = true): array
+    private static function config(string $field, float $ranking, bool $tokenize = false, bool $and = true, bool $useExactSubfield = false): array
     {
         return [
             'and_logic' => $and ? '1' : '0',
             'field' => $field,
             'tokenize' => $tokenize ? 1 : 0,
             'ranking' => $ranking,
+            'use_exact_subfield' => $useExactSubfield ? 1 : 0,
         ];
     }
 
@@ -588,6 +631,23 @@ class ProductSearchQueryBuilderTest extends TestCase
                 $field => [
                     'boost' => $boost,
                     'value' => $query,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array{match: array<string, array{query: string|int|float, boost: float, fuzziness: int, operator: string}>}
+     */
+    private static function exactAnalyzed(string $field, string|int|float $query, float $boost): array
+    {
+        return [
+            'match' => [
+                $field => [
+                    'query' => $query,
+                    'boost' => $boost,
+                    'fuzziness' => 0,
+                    'operator' => 'and',
                 ],
             ],
         ];

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -111,7 +111,7 @@ class TokenQueryBuilderTest extends TestCase
         $expectedMaxExpansions = 5;
 
         $nameQuery = self::disMax([
-            self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
             self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
         ], 1000);
@@ -123,7 +123,7 @@ class TokenQueryBuilderTest extends TestCase
         ]);
 
         $tagQuery = self::disMax([
-            self::term('tags.name', 'foo', 1),
+            self::exactAnalyzed('tags.name.search', 'foo', 1),
             self::match('tags.name.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
             self::prefix('tags.name.search', 'foo', 0.4),
         ], 500);
@@ -175,16 +175,16 @@ class TokenQueryBuilderTest extends TestCase
 
         $expected = self::bool([
             self::disMax([
-                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
             ], 1000),
             self::disMax([
-                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'and', $expectedMaxExpansions),
             ], 800),
             self::nested('tags', self::disMax([
-                self::term('tags.name', 'foo', 1),
+                self::exactAnalyzed('tags.name.search', 'foo', 1),
                 self::match('tags.name.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
                 self::prefix('tags.name.search', 'foo', 0.4),
             ], 500)),
@@ -250,12 +250,12 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                     self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::term('tags.name', 'foo', 1),
+                    self::exactAnalyzed('tags.name.search', 'foo', 1),
                     self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
@@ -268,7 +268,7 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => ' FoO ',
             'expected' => self::disMax([
-                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
             ], 1000),
@@ -292,7 +292,7 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => 'foooooooooo',
             'expected' => self::disMax([
-                self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foooooooooo', 1),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 1),
                 self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.8, 'AUTO:3,8', 'or', 20),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.4),
                 self::matchSimple('name.' . Defaults::LANGUAGE_SYSTEM . '.ngram', 'foooooooooo', 0.4),
@@ -363,7 +363,7 @@ class TokenQueryBuilderTest extends TestCase
             'term' => '2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::term($prefix . 'evolvesText', '2023', 1),
+                    self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 1),
                     self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                     self::prefix($prefix . 'evolvesText.search', '2023', 0.4),
                 ], 500),
@@ -391,23 +391,23 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::term('name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                     self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::term('tags.name', 'foo', 1),
+                    self::exactAnalyzed('tags.name.search', 'foo', 1),
                     self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
                 self::nested('categories', self::disMax([
                     self::disMax([
-                        self::term('categories.name.' . Defaults::LANGUAGE_SYSTEM, 'foo', 1),
+                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
                         self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                         self::prefix('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                     ], 200),
                     self::disMax([
-                        self::term('categories.name.' . self::SECOND_LANGUAGE_ID, 'foo', 1),
+                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 1),
                         self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
                         self::prefix('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4),
                     ], 160),
@@ -480,12 +480,12 @@ class TokenQueryBuilderTest extends TestCase
             'expected' => self::bool([
                 self::disMax([
                     self::disMax([
-                        self::term($prefixCfLang1 . 'evolvesText', '2023', 1),
+                        self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 1),
                         self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                         self::prefix($prefixCfLang1 . 'evolvesText.search', '2023', 0.4),
                     ], 500),
                     self::disMax([
-                        self::term($prefixCfLang2 . 'evolvesText', '2023', 1),
+                        self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 1),
                         self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
                         self::prefix($prefixCfLang2 . 'evolvesText.search', '2023', 0.4),
                     ], 400),
@@ -512,12 +512,12 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::disMax([
                 self::disMax([
-                    self::term($prefixCfLang1 . 'evolvesText', 'foo', 1),
+                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
                     self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                     self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                 ], 500),
                 self::disMax([
-                    self::term($prefixCfLang2 . 'evolvesText', 'foo', 1),
+                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
                     self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                     self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                 ], 400),
@@ -586,12 +586,12 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::disMax([
                 self::disMax([
-                    self::term($prefixCfLang1 . 'evolvesText', 'foo', 1),
+                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
                     self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                     self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                 ], 500),
                 self::disMax([
-                    self::term($prefixCfLang2 . 'evolvesText', 'foo', 1),
+                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
                     self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
                     self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                 ], 400),
@@ -676,7 +676,7 @@ class TokenQueryBuilderTest extends TestCase
         static::assertSame(0.2, $queryArray['dis_max']['tie_breaker']);
         static::assertCount(4, $queryArray['dis_max']['queries']);
 
-        static::assertArrayHasKey('term', $queryArray['dis_max']['queries'][0]);
+        static::assertArrayHasKey('match', $queryArray['dis_max']['queries'][0]);
         static::assertArrayHasKey('match', $queryArray['dis_max']['queries'][1]);
         static::assertArrayHasKey('match_bool_prefix', $queryArray['dis_max']['queries'][2]);
         static::assertArrayHasKey('match', $queryArray['dis_max']['queries'][3]);
@@ -825,6 +825,23 @@ class TokenQueryBuilderTest extends TestCase
                 $field => [
                     'boost' => $normalizedBoost,
                     'value' => $query,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array{match: array<string, array{query: string|int|float, boost: int|float, fuzziness: int, operator: string}>}
+     */
+    private static function exactAnalyzed(string $field, string|int|float $query, int|float $boost): array
+    {
+        return [
+            'match' => [
+                $field => [
+                    'query' => $query,
+                    'boost' => $boost,
+                    'fuzziness' => 0,
+                    'operator' => 'and',
                 ],
             ],
         ];


### PR DESCRIPTION
## Summary
- Adds an `exact` keyword subfield to product search-config fields, enabling exact-token boosts alongside fuzzy matches.
- New flag column on `product_search_config_field` (migration `Migration1776827954AddExactSubfieldFlagToProductSearchConfigField`) so merchants can opt fields into exact-subfield ranking.
- `FieldQueryBuilder` and `SearchFieldConfig` learn to emit a high-boost term clause on the `.exact` subfield when the flag is set.

## Why
Pure fuzzy/full-text scoring underweights merchants' high-signal exact tokens (SKUs, manufacturer numbers, EANs). The exact subfield pushes whole-token matches above prefix/fuzzy hits.

## Example
With `manufacturerNumber.useExactSubfield = true`:

- Search `BC1010` → product with `manufacturerNumber = "BC1010"` ranks above products containing `BC10101` or `BC1010-XL` as a prefix.
- Fuzzy fallback still applies: `BC101O` (typo) still matches via the parent analyzer.