### PR TITLE
feat(elasticsearch): tighten fuzziness policy for precision

### DIFF
--- a/src/Elasticsearch/FieldQueryBuilder.php
+++ b/src/Elasticsearch/FieldQueryBuilder.php
@@ -122,11 +122,11 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
     {
         if ($tokenCount === 1) {
             if ($config->useExactSubfield()) {
-                return new TermQuery($config->getField() . '.exact', $token, ['boost' => 1]);
+                return new TermQuery($config->getField() . '.exact', $token, ['boost' => 2]);
             }
 
             $matchQueryParams = [
-                'boost' => 1,
+                'boost' => 2,
                 'fuzziness' => 0,
                 'operator' => 'and',
             ];
@@ -145,23 +145,23 @@ class FieldQueryBuilder extends AbstractFieldQueryBuilder
                 $exactMatchQuery->add(new TermQuery($config->getField(), $tokenPart), BoolQuery::MUST);
             }
 
-            $exactMatchQuery->addParameter('boost', 1);
+            $exactMatchQuery->addParameter('boost', 2);
 
             return $exactMatchQuery;
         }
 
-        return new TermsQuery($config->getField(), $tokens, ['boost' => 1]);
+        return new TermsQuery($config->getField(), $tokens, ['boost' => 2]);
     }
 
     private function buildFuzzyMatchQuery(string $searchField, string $token, SearchFieldConfig $config, int $maxExpansions): MatchQuery
     {
         $matchQueryParams = [
-            'boost' => 0.8,
+            'boost' => 0.4,
             'fuzziness' => $config->getFuzziness($token),
             'operator' => $config->isAndLogic() ? 'and' : 'or',
             'fuzzy_transpositions' => true,
             'max_expansions' => $maxExpansions,
-            'prefix_length' => 1,
+            'prefix_length' => $config->getPrefixLength($token),
         ];
 
         if (!$this->useLanguageAnalyzer) {

--- a/src/Elasticsearch/Product/SearchFieldConfig.php
+++ b/src/Elasticsearch/Product/SearchFieldConfig.php
@@ -69,7 +69,17 @@ class SearchFieldConfig
             return 0;
         }
 
-        // Let AUTO:3,8 handle length thresholds (0 for ≤3, 1 for 4–8, 2 for ≥9)
-        return 'AUTO:3,8';
+        // Let AUTO:5,10 handle length thresholds (0 for <5, 1 for 5–9, 2 for ≥10)
+        return 'AUTO:5,10';
+    }
+
+    /**
+     * Lock a longer exact prefix on longer tokens so fuzzy expansion stays proportional:
+     * short tokens already allow few edits (AUTO:5,10) so lock 2 chars; long tokens carry
+     * more signal and can afford a 3-char lock without losing useful matches.
+     */
+    public function getPrefixLength(string $token): int
+    {
+        return mb_strlen($token) >= 10 ? 3 : 2;
     }
 }

--- a/tests/unit/Elasticsearch/FieldQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/FieldQueryBuilderTest.php
@@ -135,7 +135,7 @@ class FieldQueryBuilderTest extends TestCase
         static::assertNotNull($exactMatch);
         static::assertArrayHasKey('match', $exactMatch);
         static::assertArrayHasKey('name.search', $exactMatch['match']);
-        static::assertEquals(1.0, $exactMatch['match']['name.search']['boost']);
+        static::assertEquals(2.0, $exactMatch['match']['name.search']['boost']);
         static::assertSame(0, $exactMatch['match']['name.search']['fuzziness']);
         static::assertSame('and', $exactMatch['match']['name.search']['operator']);
     }

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -166,18 +166,18 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::exactAnalyzed('tags.name.search', 'foo', 1),
-                    self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('tags.name.search', 'foo', 2),
+                    self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
                 self::nested('parent', self::disMax([
-                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 800)),
             ]),
@@ -204,69 +204,69 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::bool([
                         self::disMax([
-                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::exactAnalyzed('ean.search', 'foo', 1),
-                            self::match('ean.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('ean.search', 'foo', 2),
+                            self::match('ean.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('ean.search', 'foo', 0.4),
                         ], 2000),
                         self::nested('tags', self::disMax([
-                            self::exactAnalyzed('tags.name.search', 'foo', 1),
-                            self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('tags.name.search', 'foo', 2),
+                            self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('tags.name.search', 'foo', 0.4),
                         ], 500)),
                         self::nested('parent', self::disMax([
-                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 800)),
                     ]),
                     self::bool([
                         self::disMax([
-                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
-                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 2),
+                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::exactAnalyzed('ean.search', '2023', 1),
-                            self::match('ean.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('ean.search', '2023', 2),
+                            self::match('ean.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('ean.search', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
-                            self::exactAnalyzed('tags.name.search', '2023', 1),
-                            self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('tags.name.search', '2023', 2),
+                            self::match('tags.name.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('tags.name.search', '2023', 0.4),
                         ], 500)),
                         self::nested('parent', self::disMax([
-                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
-                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 2),
+                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 800)),
                     ]),
                 ], BoolQuery::MUST),
                 self::bool([
                     self::disMax([
-                        self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                        self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                        self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                     ], 1000),
                     self::disMax([
-                        self::must('ean', ['foo', '2023'], 1),
-                        self::match('ean.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('ean', ['foo', '2023'], 2),
+                        self::match('ean.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                     ], 2000),
                     self::nested('tags', self::disMax([
-                        self::must('tags.name', ['foo', '2023'], 1),
-                        self::match('tags.name.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('tags.name', ['foo', '2023'], 2),
+                        self::match('tags.name.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                     ], 500)),
                     self::nested('parent', self::disMax([
-                        self::must('parent.name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                        self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('parent.name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                        self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                     ], 800)),
                 ]),
@@ -302,14 +302,14 @@ class ProductSearchQueryBuilderTest extends TestCase
             'expected' => self::disMax([
                 self::bool([
                     self::disMax([
-                        self::exactAnalyzed($prefix . 'evolvesText.search', 'foo', 1),
-                        self::match($prefix . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                        self::exactAnalyzed($prefix . 'evolvesText.search', 'foo', 2),
+                        self::match($prefix . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                         self::prefix($prefix . 'evolvesText.search', 'foo', 0.4),
                     ], 500),
                     self::bool([
                         self::disMax([
-                            self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 1),
-                            self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 2),
+                            self::match($prefix . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix($prefix . 'evolvesText.search', '2023', 0.4),
                         ], 500),
                         self::term($prefix . 'evolvesInt', 2023, 400),
@@ -318,8 +318,8 @@ class ProductSearchQueryBuilderTest extends TestCase
                     ]),
                 ], BoolQuery::MUST),
                 self::disMax([
-                    self::must($prefix . 'evolvesText', ['foo', '2023'], 1),
-                    self::match($prefix . 'evolvesText.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must($prefix . 'evolvesText', ['foo', '2023'], 2),
+                    self::match($prefix . 'evolvesText.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix($prefix . 'evolvesText.search', 'foo 2023', 0.6, 3, 10),
                 ], 500),
             ]),
@@ -343,30 +343,30 @@ class ProductSearchQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::exactAnalyzed('tags.name.search', 'foo', 1),
-                    self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('tags.name.search', 'foo', 2),
+                    self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
                 self::nested('categories', self::disMax([
                     self::disMax([
-                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                        self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                        self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                         self::prefix('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                     ], 200),
                     self::disMax([
-                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 1),
-                        self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 2),
+                        self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                         self::prefix('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4),
                     ], 160),
                 ])),
                 self::nested('parent', self::disMax([
-                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 800)),
             ]),
@@ -385,69 +385,69 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::bool([
                         self::disMax([
-                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::exactAnalyzed('ean.search', 'foo', 1),
-                            self::match('ean.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('ean.search', 'foo', 2),
+                            self::match('ean.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('ean.search', 'foo', 0.4),
                         ], 2000),
                         self::nested('tags', self::disMax([
-                            self::exactAnalyzed('tags.name.search', 'foo', 1),
-                            self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('tags.name.search', 'foo', 2),
+                            self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('tags.name.search', 'foo', 0.4),
                         ], 500)),
                         self::nested('parent', self::disMax([
-                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                         ], 800)),
                     ]),
                     self::bool([
                         self::disMax([
-                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
-                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 2),
+                            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 1000),
                         self::disMax([
-                            self::exactAnalyzed('ean.search', '2023', 1),
-                            self::match('ean.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('ean.search', '2023', 2),
+                            self::match('ean.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('ean.search', '2023', 0.4),
                         ], 2000),
                         self::term('restockTime', 2023, 1500),
                         self::nested('tags', self::disMax([
-                            self::exactAnalyzed('tags.name.search', '2023', 1),
-                            self::match('tags.name.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('tags.name.search', '2023', 2),
+                            self::match('tags.name.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('tags.name.search', '2023', 0.4),
                         ], 500)),
                         self::nested('parent', self::disMax([
-                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 1),
-                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.8, 0, 'and', 10),
+                            self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 2),
+                            self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4, 0, 'and', 10),
                             self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', '2023', 0.4),
                         ], 800)),
                     ]),
                 ], BoolQuery::MUST),
                 self::bool([
                     self::disMax([
-                        self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                        self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                        self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                     ], 1000),
                     self::disMax([
-                        self::must('ean', ['foo', '2023'], 1),
-                        self::match('ean.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('ean', ['foo', '2023'], 2),
+                        self::match('ean.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                     ], 2000),
                     self::nested('tags', self::disMax([
-                        self::must('tags.name', ['foo', '2023'], 1),
-                        self::match('tags.name.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('tags.name', ['foo', '2023'], 2),
+                        self::match('tags.name.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                     ], 500)),
                     self::nested('parent', self::disMax([
-                        self::must('parent.name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                        self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must('parent.name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                        self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                     ], 800)),
                 ]),
@@ -466,26 +466,26 @@ class ProductSearchQueryBuilderTest extends TestCase
                 self::bool([
                     self::disMax([
                         self::disMax([
-                            self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
-                            self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 2),
+                            self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                         ], 500),
                         self::disMax([
-                            self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
-                            self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                            self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 2),
+                            self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                             self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                         ], 400),
                     ]),
                     self::bool([
                         self::disMax([
                             self::disMax([
-                                self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 1),
-                                self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                                self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 2),
+                                self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                                 self::prefix($prefixCfLang1 . 'evolvesText.search', '2023', 0.4),
                             ], 500),
                             self::disMax([
-                                self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 1),
-                                self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                                self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 2),
+                                self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                                 self::prefix($prefixCfLang2 . 'evolvesText.search', '2023', 0.4),
                             ], 400),
                         ]),
@@ -502,13 +502,13 @@ class ProductSearchQueryBuilderTest extends TestCase
                 ], BoolQuery::MUST),
                 self::disMax([
                     self::disMax([
-                        self::must($prefixCfLang1 . 'evolvesText', ['foo', '2023'], 1),
-                        self::match($prefixCfLang1 . 'evolvesText.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must($prefixCfLang1 . 'evolvesText', ['foo', '2023'], 2),
+                        self::match($prefixCfLang1 . 'evolvesText.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix($prefixCfLang1 . 'evolvesText.search', 'foo 2023', 0.6, 3, 10),
                     ], 500),
                     self::disMax([
-                        self::must($prefixCfLang2 . 'evolvesText', ['foo', '2023'], 1),
-                        self::match($prefixCfLang2 . 'evolvesText.search', 'foo 2023', 0.8, 0, 'and', 10),
+                        self::must($prefixCfLang2 . 'evolvesText', ['foo', '2023'], 2),
+                        self::match($prefixCfLang2 . 'evolvesText.search', 'foo 2023', 0.4, 0, 'and', 10),
                         self::matchPhrasePrefix($prefixCfLang2 . 'evolvesText.search', 'foo 2023', 0.6, 3, 10),
                     ], 400),
                 ]),
@@ -618,13 +618,13 @@ class ProductSearchQueryBuilderTest extends TestCase
         static::assertEquals(
             self::bool([
                 self::disMax([
-                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('parent', self::disMax([
-                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('parent.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 800)),
             ]),
@@ -751,7 +751,7 @@ class ProductSearchQueryBuilderTest extends TestCase
             'operator' => $operator,
             'fuzzy_transpositions' => true,
             'max_expansions' => $maxExpansions,
-            'prefix_length' => 1,
+            'prefix_length' => mb_strlen((string) $query) >= 10 ? 3 : 2,
         ];
 
         return [
@@ -804,7 +804,7 @@ class ProductSearchQueryBuilderTest extends TestCase
      *
      * @return array{bool: array{must: array<array{term: array<string, string>}>, boost: float|int}}
      */
-    private static function must(string $field, array $tokens, int|float $boost = 1): array
+    private static function must(string $field, array $tokens, int|float $boost = 2): array
     {
         $queries = array_map(static fn (string $token) => ['term' => [$field => $token]], $tokens);
 

--- a/tests/unit/Elasticsearch/Product/SearchFieldConfigTest.php
+++ b/tests/unit/Elasticsearch/Product/SearchFieldConfigTest.php
@@ -35,18 +35,28 @@ class SearchFieldConfigTest extends TestCase
     {
         $searchConfig = new SearchFieldConfig('fooField', 1000.0, true);
 
-        static::assertSame('AUTO:3,8', $searchConfig->getFuzziness('foo'));
-        static::assertSame('AUTO:3,8', $searchConfig->getFuzziness('f'));
+        static::assertSame('AUTO:5,10', $searchConfig->getFuzziness('foo'));
+        static::assertSame('AUTO:5,10', $searchConfig->getFuzziness('f'));
         static::assertSame(0, $searchConfig->getFuzziness('123'));
         static::assertSame(0, $searchConfig->getFuzziness('1234'));
         static::assertSame(0, $searchConfig->getFuzziness('1234.5'));
 
         $searchConfig = new SearchFieldConfig('fooField', 1000.0, false);
 
-        static::assertSame('AUTO:3,8', $searchConfig->getFuzziness('foo'));
-        static::assertSame('AUTO:3,8', $searchConfig->getFuzziness('f'));
+        static::assertSame('AUTO:5,10', $searchConfig->getFuzziness('foo'));
+        static::assertSame('AUTO:5,10', $searchConfig->getFuzziness('f'));
         static::assertSame(0, $searchConfig->getFuzziness('123'));
         static::assertSame(0, $searchConfig->getFuzziness('1234'));
         static::assertSame(0, $searchConfig->getFuzziness('1234.5'));
+    }
+
+    public function testGetPrefixLength(): void
+    {
+        $searchConfig = new SearchFieldConfig('fooField', 1000.0, true);
+
+        static::assertSame(2, $searchConfig->getPrefixLength('foo'));
+        static::assertSame(2, $searchConfig->getPrefixLength('bohrcraft'));
+        static::assertSame(3, $searchConfig->getPrefixLength('bohrcraftX'));
+        static::assertSame(3, $searchConfig->getPrefixLength('Tellerkopfschraube'));
     }
 }

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -107,12 +107,12 @@ class TokenQueryBuilderTest extends TestCase
 
         static::assertNotNull($query);
 
-        $expectedFuzziness = 'AUTO:3,8';
+        $expectedFuzziness = 'AUTO:5,10';
         $expectedMaxExpansions = 5;
 
         $nameQuery = self::disMax([
-            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
+            self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+            self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, $expectedFuzziness, 'or', $expectedMaxExpansions),
             self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
         ], 1000);
 
@@ -123,8 +123,8 @@ class TokenQueryBuilderTest extends TestCase
         ]);
 
         $tagQuery = self::disMax([
-            self::exactAnalyzed('tags.name.search', 'foo', 1),
-            self::match('tags.name.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
+            self::exactAnalyzed('tags.name.search', 'foo', 2),
+            self::match('tags.name.search', 'foo', 0.4, $expectedFuzziness, 'or', $expectedMaxExpansions),
             self::prefix('tags.name.search', 'foo', 0.4),
         ], 500);
 
@@ -170,22 +170,22 @@ class TokenQueryBuilderTest extends TestCase
 
         static::assertNotNull($query);
 
-        $expectedFuzziness = 'AUTO:3,8';
+        $expectedFuzziness = 'AUTO:5,10';
         $expectedMaxExpansions = 5;
 
         $expected = self::bool([
             self::disMax([
-                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, $expectedFuzziness, 'or', $expectedMaxExpansions),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
             ], 1000),
             self::disMax([
-                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, $expectedFuzziness, 'and', $expectedMaxExpansions),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, $expectedFuzziness, 'and', $expectedMaxExpansions),
             ], 800),
             self::nested('tags', self::disMax([
-                self::exactAnalyzed('tags.name.search', 'foo', 1),
-                self::match('tags.name.search', 'foo', 0.8, $expectedFuzziness, 'or', $expectedMaxExpansions),
+                self::exactAnalyzed('tags.name.search', 'foo', 2),
+                self::match('tags.name.search', 'foo', 0.4, $expectedFuzziness, 'or', $expectedMaxExpansions),
                 self::prefix('tags.name.search', 'foo', 0.4),
             ], 500)),
         ]);
@@ -250,13 +250,13 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::exactAnalyzed('tags.name.search', 'foo', 1),
-                    self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('tags.name.search', 'foo', 2),
+                    self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
             ]),
@@ -268,8 +268,8 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => ' FoO ',
             'expected' => self::disMax([
-                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
             ], 1000),
         ];
@@ -280,8 +280,8 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => ' FoO     BaR    Baz    ',
             'expected' => self::disMax([
-                self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', 'bar', 'baz'], 1),
-                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.8, 'AUTO:3,8', 'or', 5),
+                self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', 'bar', 'baz'], 2),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.4, 'AUTO:5,10', 'or', 5),
                 self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo bar baz', 0.6, 3, 5),
             ], 1000),
         ];
@@ -292,8 +292,8 @@ class TokenQueryBuilderTest extends TestCase
             ],
             'term' => 'foooooooooo',
             'expected' => self::disMax([
-                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 1),
-                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.8, 'AUTO:3,8', 'or', 20),
+                self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 2),
+                self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.4, 'AUTO:5,10', 'or', 20),
                 self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foooooooooo', 0.4),
                 self::matchSimple('name.' . Defaults::LANGUAGE_SYSTEM . '.ngram', 'foooooooooo', 0.4),
             ], 1000),
@@ -309,18 +309,18 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                 ], 1000),
                 self::disMax([
-                    self::terms('ean', ['foo', '2023'], 1),
-                    self::match('ean.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('ean', ['foo', '2023'], 2),
+                    self::match('ean.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                 ], 2000),
                 self::nested('tags', self::disMax([
-                    self::terms('tags.name', ['foo', '2023'], 1),
-                    self::match('tags.name.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('tags.name', ['foo', '2023'], 2),
+                    self::match('tags.name.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                 ], 500)),
             ]),
@@ -336,18 +336,18 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                 ], 1000),
                 self::disMax([
-                    self::must('ean', ['foo', '2023'], 1),
-                    self::match('ean.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('ean', ['foo', '2023'], 2),
+                    self::match('ean.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                 ], 2000),
                 self::nested('tags', self::disMax([
-                    self::must('tags.name', ['foo', '2023'], 1),
-                    self::match('tags.name.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('tags.name', ['foo', '2023'], 2),
+                    self::match('tags.name.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                 ], 500)),
             ]),
@@ -363,8 +363,8 @@ class TokenQueryBuilderTest extends TestCase
             'term' => '2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 1),
-                    self::match($prefix . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                    self::exactAnalyzed($prefix . 'evolvesText.search', '2023', 2),
+                    self::match($prefix . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                     self::prefix($prefix . 'evolvesText.search', '2023', 0.4),
                 ], 500),
                 self::term($prefix . 'evolvesInt', 2023, 400),
@@ -391,24 +391,24 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::bool([
                 self::disMax([
-                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                 ], 1000),
                 self::nested('tags', self::disMax([
-                    self::exactAnalyzed('tags.name.search', 'foo', 1),
-                    self::match('tags.name.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                    self::exactAnalyzed('tags.name.search', 'foo', 2),
+                    self::match('tags.name.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                     self::prefix('tags.name.search', 'foo', 0.4),
                 ], 500)),
                 self::nested('categories', self::disMax([
                     self::disMax([
-                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 1),
-                        self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                        self::exactAnalyzed('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 2),
+                        self::match('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                         self::prefix('categories.name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo', 0.4),
                     ], 200),
                     self::disMax([
-                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 1),
-                        self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.8, 'AUTO:3,8', 'or', 5),
+                        self::exactAnalyzed('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 2),
+                        self::match('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4, 'AUTO:5,10', 'or', 5),
                         self::prefix('categories.name.' . self::SECOND_LANGUAGE_ID . '.search', 'foo', 0.4),
                     ], 160),
                 ])),
@@ -425,18 +425,18 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                 ], 1000),
                 self::disMax([
-                    self::terms('ean', ['foo', '2023'], 1),
-                    self::match('ean.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('ean', ['foo', '2023'], 2),
+                    self::match('ean.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                 ], 2000),
                 self::nested('tags', self::disMax([
-                    self::terms('tags.name', ['foo', '2023'], 1),
-                    self::match('tags.name.search', 'foo 2023', 0.8, 0, 'or', 10),
+                    self::terms('tags.name', ['foo', '2023'], 2),
+                    self::match('tags.name.search', 'foo 2023', 0.4, 0, 'or', 10),
                     self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                 ], 500)),
             ]),
@@ -452,18 +452,18 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo 2023',
             'expected' => self::bool([
                 self::disMax([
-                    self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 1),
-                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('name.' . Defaults::LANGUAGE_SYSTEM, ['foo', '2023'], 2),
+                    self::match('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('name.' . Defaults::LANGUAGE_SYSTEM . '.search', 'foo 2023', 0.6, 3, 10),
                 ], 1000),
                 self::disMax([
-                    self::must('ean', ['foo', '2023'], 1),
-                    self::match('ean.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('ean', ['foo', '2023'], 2),
+                    self::match('ean.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('ean.search', 'foo 2023', 0.6, 3, 10),
                 ], 2000),
                 self::nested('tags', self::disMax([
-                    self::must('tags.name', ['foo', '2023'], 1),
-                    self::match('tags.name.search', 'foo 2023', 0.8, 0, 'and', 10),
+                    self::must('tags.name', ['foo', '2023'], 2),
+                    self::match('tags.name.search', 'foo 2023', 0.4, 0, 'and', 10),
                     self::matchPhrasePrefix('tags.name.search', 'foo 2023', 0.6, 3, 10),
                 ], 500)),
             ]),
@@ -480,13 +480,13 @@ class TokenQueryBuilderTest extends TestCase
             'expected' => self::bool([
                 self::disMax([
                     self::disMax([
-                        self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 1),
-                        self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                        self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', '2023', 2),
+                        self::match($prefixCfLang1 . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                         self::prefix($prefixCfLang1 . 'evolvesText.search', '2023', 0.4),
                     ], 500),
                     self::disMax([
-                        self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 1),
-                        self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.8, 0, 'and', 10),
+                        self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', '2023', 2),
+                        self::match($prefixCfLang2 . 'evolvesText.search', '2023', 0.4, 0, 'and', 10),
                         self::prefix($prefixCfLang2 . 'evolvesText.search', '2023', 0.4),
                     ], 400),
                 ]),
@@ -512,13 +512,13 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::disMax([
                 self::disMax([
-                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
-                    self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 2),
+                    self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                     self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                 ], 500),
                 self::disMax([
-                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
-                    self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 2),
+                    self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                     self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                 ], 400),
             ]),
@@ -586,13 +586,13 @@ class TokenQueryBuilderTest extends TestCase
             'term' => 'foo',
             'expected' => self::disMax([
                 self::disMax([
-                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 1),
-                    self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                    self::exactAnalyzed($prefixCfLang1 . 'evolvesText.search', 'foo', 2),
+                    self::match($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                     self::prefix($prefixCfLang1 . 'evolvesText.search', 'foo', 0.4),
                 ], 500),
                 self::disMax([
-                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 1),
-                    self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.8, 'AUTO:3,8', 'and', 5),
+                    self::exactAnalyzed($prefixCfLang2 . 'evolvesText.search', 'foo', 2),
+                    self::match($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4, 'AUTO:5,10', 'and', 5),
                     self::prefix($prefixCfLang2 . 'evolvesText.search', 'foo', 0.4),
                 ], 400),
             ]),
@@ -881,7 +881,7 @@ class TokenQueryBuilderTest extends TestCase
             'operator' => $operator,
             'fuzzy_transpositions' => true,
             'max_expansions' => $maxExpansions,
-            'prefix_length' => 1,
+            'prefix_length' => mb_strlen((string) $query) >= 10 ? 3 : 2,
             'analyzer' => $analyzer,
         ];
 
@@ -950,7 +950,7 @@ class TokenQueryBuilderTest extends TestCase
      *
      * @return array{bool: array{must: array<array{term: array<string, string>}>, boost: float|int}}
      */
-    private static function must(string $field, array $tokens, int|float $boost = 1): array
+    private static function must(string $field, array $tokens, int|float $boost = 2): array
     {
         $queries = array_map(static fn (string $token) => ['term' => [$field => $token]], $tokens);
 
@@ -967,7 +967,7 @@ class TokenQueryBuilderTest extends TestCase
      *
      * @return array{terms: non-empty-array<string, array<string>|float|int>}
      */
-    private static function terms(string $field, array $tokens, int|float $boost = 1): array
+    private static function terms(string $field, array $tokens, int|float $boost = 2): array
     {
         return [
             'terms' => [


### PR DESCRIPTION
## Summary
- Raises the fuzziness threshold from `AUTO:3,8` to `AUTO:5,10` — short tokens now require an exact match instead of allowing 1 edit at length 3.
- Boosts exact matches to `2.0` (was `1.0`) and demotes fuzzy matches to `0.4` (was `0.8`), so an exact hit cleanly outranks a 1-edit hit.
- Adds a token-length-aware `prefix_length`: tokens ≥ 10 chars require 3-char prefix anchor (was 2 globally).

## Why
B2B catalogs are full of similar SKUs (`BC1010` vs `BC1011`, `M8x20` vs `M8x25`) where 1-edit fuzziness on a 4-char token blew up precision. Customer reports surfaced cases where typing `BC1010` returned `BC1011` ranked equal-or-higher.

## Example
Search `BC1010`:
- Before: matches `BC1010` (exact, boost 1.0) and `BC1011` (1 edit, boost 0.8) — near-tie.
- After: matches `BC1010` (exact, boost 2.0) and `BC1011` (1 edit, boost 0.4) — clear winner.

Search `abc` (3 chars):
- Before: fuzzy matched `abd`, `abe` etc.
- After: must match exactly. Reduces noise on short queries.