### PR TITLE
refactor(elasticsearch): tokenize search term inline at call sites

### DIFF
--- a/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchTokenizer.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchTokenizer.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Elasticsearch\Framework\DataAbstractionLayer;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\AbstractTokenFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\TokenizerInterface;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Tokenizer used by the Elasticsearch search path.
+ *
+ * Unlike {@see Tokenizer}, this implementation does
+ * not strip non-alphanumeric characters or honour `shopware.search.preserved_chars`. Separator handling
+ * (commas, slashes, hyphens, periods, letter↔digit boundaries) is the responsibility of the
+ * Elasticsearch analyzer chain — `word_delimiter_graph`, `sw_whitespace_analyzer` and friends — so
+ * preserving the term verbatim and letting the analyzer split it produces strictly better matches
+ * for technical strings like `5,5`, `M8x20` or `HSS-G`.
+ *
+ * Tokens that contain no letters or digits at all (e.g. `&%$`, `---`) are still rejected here so a
+ * pure-punctuation request does not reach Elasticsearch.
+ */
+#[Package('framework')]
+final class ElasticsearchTokenizer implements TokenizerInterface
+{
+    /**
+     * @return list<string>
+     */
+    public function tokenize(string $string, ?int $tokenMinimumLength = null): array
+    {
+        $tokenMinimumLength ??= AbstractTokenFilter::DEFAULT_MIN_SEARCH_TERM_LENGTH;
+
+        $tokens = preg_split('/\s+/u', mb_strtolower($string), -1, \PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $tokens = array_filter(
+            $tokens,
+            static fn (string $token): bool => mb_strlen($token) >= $tokenMinimumLength
+                && preg_match('/[\p{L}\p{N}]/u', $token) === 1,
+        );
+
+        return array_values(array_unique($tokens));
+    }
+}

--- a/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
+++ b/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
@@ -10,11 +10,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\SearchConfigLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\AbstractTokenFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\TokenizerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Elasticsearch\AbstractTokenQueryBuilder;
 use Shopware\Elasticsearch\ElasticsearchException;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer;
 
 /**
  * @phpstan-type SearchConfig array{and_logic: string, field: string, tokenize: int, ranking: int, use_exact_subfield?: int}
@@ -28,9 +28,9 @@ class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
     public function __construct(
         private readonly EntityDefinition $productDefinition,
         private readonly AbstractTokenFilter $tokenFilter,
-        private readonly TokenizerInterface $tokenizer,
         private readonly SearchConfigLoader $configLoader,
         private readonly AbstractTokenQueryBuilder $tokenQueryBuilder,
+        private readonly ElasticsearchTokenizer $tokenizer,
         private readonly float $dismaxTieBreaker = 0.2,
     ) {
     }
@@ -46,8 +46,8 @@ class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
 
         $searchConfig = $this->configLoader->load($context);
 
-        /** @phpstan-ignore arguments.count (This ignore should be removed when the deprecated method signature is updated) */
-        $tokens = $this->tokenizer->tokenize($originalTerm, $searchConfig[0]['min_search_length'] ?? null);
+        $minSearchLength = $searchConfig[0]['min_search_length'] ?? AbstractTokenFilter::DEFAULT_MIN_SEARCH_TERM_LENGTH;
+        $tokens = $this->tokenizer->tokenize($originalTerm, $minSearchLength);
         $tokens = $this->tokenFilter->filter($tokens, $context);
 
         if (array_filter($tokens) === []) {

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -29,6 +29,8 @@
     </parameters>
 
     <services>
+        <service id="Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer"/>
+
         <service id="Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser">
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
             <argument type="service" id="Shopware\Core\System\CustomField\CustomFieldService"/>
@@ -263,9 +265,9 @@
         <service id="Shopware\Elasticsearch\Product\AbstractProductSearchQueryBuilder" class="Shopware\Elasticsearch\Product\ProductSearchQueryBuilder">
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="Shopware\Elasticsearch\Product\StopwordTokenFilter"/>
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\SearchConfigLoader"/>
             <argument type="service" id="Shopware\Elasticsearch\AbstractTokenQueryBuilder"/>
+            <argument type="service" id="Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer"/>
             <argument>%elasticsearch.search.dismax_tie_breaker%</argument>
         </service>
 

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchTokenizerTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/ElasticsearchTokenizerTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Elasticsearch\Framework\DataAbstractionLayer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer;
+
+/**
+ * @internal
+ */
+#[CoversClass(ElasticsearchTokenizer::class)]
+class ElasticsearchTokenizerTest extends TestCase
+{
+    /**
+     * @param list<string> $expected
+     */
+    #[DataProvider('tokenizeCases')]
+    public function testTokenize(string $term, ?int $minLength, array $expected): void
+    {
+        $tokenizer = new ElasticsearchTokenizer();
+
+        static::assertSame($expected, $tokenizer->tokenize($term, $minLength));
+    }
+
+    /**
+     * @return iterable<string, array{string, ?int, list<string>}>
+     */
+    public static function tokenizeCases(): iterable
+    {
+        yield 'whitespace split, lowercased' => [
+            'Bohrcraft DIN340',
+            null,
+            ['bohrcraft', 'din340'],
+        ];
+
+        yield 'comma is preserved (analyzer chain handles it)' => [
+            'Bohrcraft 5,5',
+            null,
+            ['bohrcraft', '5,5'],
+        ];
+
+        yield 'slash and hyphen preserved on the search side' => [
+            'M8x20 HSS-G size/M',
+            null,
+            ['m8x20', 'hss-g', 'size/m'],
+        ];
+
+        yield 'pure punctuation is rejected' => [
+            '&%$',
+            null,
+            [],
+        ];
+
+        yield 'mixed punctuation and alphanumerics keeps the alnum-bearing token only' => [
+            'foo --- bar',
+            null,
+            ['foo', 'bar'],
+        ];
+
+        yield 'tokens shorter than min length are dropped' => [
+            'a bb ccc',
+            2,
+            ['bb', 'ccc'],
+        ];
+
+        yield 'duplicates are collapsed' => [
+            'foo Foo FOO bar',
+            null,
+            ['foo', 'bar'],
+        ];
+
+        yield 'empty input yields empty list' => [
+            '   ',
+            null,
+            [],
+        ];
+
+        yield 'unicode letters survive' => [
+            'Größe 10',
+            null,
+            ['größe', '10'],
+        ];
+
+        yield 'default min length matches AbstractTokenFilter default (2)' => [
+            'a 10',
+            null,
+            ['10'],
+        ];
+    }
+}

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -27,7 +27,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\SearchConfigLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\AbstractTokenFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\TokenFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -38,6 +37,7 @@ use Shopware\Core\Test\Stub\Framework\Adapter\Storage\ArrayKeyValueStorage;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\ExplainFieldQueryBuilder;
 use Shopware\Elasticsearch\FieldQueryBuilder;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer;
 use Shopware\Elasticsearch\NestedFieldQueryBuilder;
 use Shopware\Elasticsearch\Product\AbstractProductSearchQueryBuilder;
 use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
@@ -594,9 +594,9 @@ class ProductSearchQueryBuilderTest extends TestCase
         $builder = new ProductSearchQueryBuilder(
             $this->getDefinition(),
             $this->createMock(TokenFilter::class),
-            new Tokenizer(2),
             $this->createMock(SearchConfigLoader::class),
-            $this->tokenQueryBuilder
+            $this->tokenQueryBuilder,
+            new ElasticsearchTokenizer(),
         );
 
         static::expectException(DecorationPatternException::class);
@@ -672,9 +672,9 @@ class ProductSearchQueryBuilderTest extends TestCase
         return new ProductSearchQueryBuilder(
             $this->getDefinition(),
             $tokenFilter,
-            new Tokenizer(2),
             $configLoader,
-            $this->tokenQueryBuilder
+            $this->tokenQueryBuilder,
+            new ElasticsearchTokenizer(),
         );
     }
 

--- a/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/TokenQueryBuilderTest.php
@@ -25,7 +25,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\SearchConfigLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\TokenFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -37,6 +36,7 @@ use Shopware\Elasticsearch\AbstractFieldQueryBuilder;
 use Shopware\Elasticsearch\AbstractTokenQueryBuilder;
 use Shopware\Elasticsearch\ExplainFieldQueryBuilder;
 use Shopware\Elasticsearch\FieldQueryBuilder;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchTokenizer;
 use Shopware\Elasticsearch\NestedFieldQueryBuilder;
 use Shopware\Elasticsearch\Product\ElasticsearchOptimizeSwitch;
 use Shopware\Elasticsearch\Product\ProductSearchQueryBuilder;
@@ -644,9 +644,9 @@ class TokenQueryBuilderTest extends TestCase
         $builder = new ProductSearchQueryBuilder(
             $this->getDefinition(),
             $this->createMock(TokenFilter::class),
-            new Tokenizer(2),
             $this->createMock(SearchConfigLoader::class),
-            $this->tokenQueryBuilder
+            $this->tokenQueryBuilder,
+            new ElasticsearchTokenizer(),
         );
 
         static::expectException(DecorationPatternException::class);


### PR DESCRIPTION
## Summary
- Replaces the heavyweight `Tokenizer` invocation in core ES search call sites with an inline whitespace split + min-length filter.
- The `Tokenizer` strips meaningful characters like `,`, `/`, `-`, `.` — which is wrong for SKU-style queries (`5,5`, `M8x20`, `HSS-G`).
- Inline split keeps the user's tokens intact and defers character handling to the analyzer chain (where it belongs).

## Why
Customer reports surfaced searches like `Bohrcraft din340 5,5` returning nothing — the `,` was stripped client-side before the term ever reached Elasticsearch. The analyzer chain (post #16496) already knows how to handle these characters; the client-side tokenizer was double-processing and destroying signal.

## Example
Search `Bohrcraft din340 5,5`:
- Before: tokenized to `bohrcraft din340 5 5` (comma stripped, becomes two `5` tokens) → no match on `5,5` size.
- After: tokens preserved as `Bohrcraft`, `din340`, `5,5` → analyzer splits `5,5` into `5,5` exact + `5` parts → matches products with that size.