### PR TITLE
fix: twig variable parser improvements

### DIFF
--- a/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParser.php
@@ -5,12 +5,14 @@ namespace Shopware\Core\Framework\Adapter\Twig;
 use Shopware\Core\Framework\Log\Package;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
+use Twig\Node\Expression\ArrowFunctionExpression;
 use Twig\Node\Expression\AssignNameExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\GetAttrExpression;
 use Twig\Node\Expression\NameExpression;
 use Twig\Node\ForNode;
 use Twig\Node\Node;
+use Twig\Node\SetNode;
 
 /**
  * @deprecated tag:v6.8.0 - reason:becomes-internal - Will be internal in v6.8.0
@@ -51,7 +53,7 @@ class TwigVariableParser
     {
         $variables = [];
         foreach ($nodes as $node) {
-            if ($node instanceof AssignNameExpression) {
+            if ($node instanceof AssignNameExpression || $node instanceof ArrowFunctionExpression) {
                 continue;
             }
 
@@ -89,7 +91,26 @@ class TwigVariableParser
                 $target = implode('.', $this->getVariables($node->getNode('seq'), $aliases));
                 $source = $node->getNode('value_target')->getAttribute('name');
 
+                if ($target === '' && $node->getNode('seq')->hasAttribute('name')) {
+                    $in = $node->getNode('seq')->getAttribute('name');
+                    if (\is_string($in) && isset($aliases[$in])) {
+                        $target = $aliases[$in];
+                    }
+                }
+
                 $aliases[$source] = $target;
+            }
+
+            if ($node instanceof SetNode) {
+                $names = $node->getNode('names');
+                $values = $node->getNode('values');
+
+                $resolvedValue = implode('.', $this->getVariables($values, $aliases));
+
+                foreach ($names as $nameNode) {
+                    $varName = $nameNode->getAttribute('name');
+                    $aliases[$varName] = $resolvedValue;
+                }
             }
 
             if ($node instanceof Node) {

--- a/tests/unit/Core/Framework/Adapter/Twig/TwigVariableParserTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TwigVariableParserTest.php
@@ -71,6 +71,16 @@ TWIG;
     {{ foo.group.name }}
 {% endfor %}
 
+{% for foo in product.foo|sort((a, b) => a.position <=> b.position) %}
+    {{ foo.bar.baz }}
+{% endfor %}
+
+{% set foo = product.test %}
+{% for bar in foo %}
+    {% set baz = bar.shop %}
+    {{ baz.ware }}
+{% endfor %}
+
 TWIG;
 
         $parser = new TwigVariableParser(new Environment(new ArrayLoader([])));
@@ -83,6 +93,11 @@ TWIG;
             'product.options',
             'product.options.group.name',
             'product.stock',
+            'product.foo',
+            'product.foo.bar.baz',
+            'product.test',
+            'product.test.shop',
+            'product.test.shop.ware',
         ];
 
         sort($expected);


### PR DESCRIPTION
### 1. Why is this change necessary?
The `TwigVariableParser` doesn't handle variables used in arrow function such as `|sort((a, b) => a.position <=> b.position)` correctly and variables used within those will pollute the array of associations used by the DAL.  
Furthermore variables stored by `set` which are in turn used in `for` loops aren't resolved correctly e.g.
```twig
{% set test = product.media %}
{% for media in test %}
    {{ media.media.url }}
{% endfor %}
```

### 2. What does this change do, exactly?
* Change `TwigVariableParser` to ignore variables within arrow functions.
* Change `TwigVariableParser` to store names of variables set in the template as aliases for the original value.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a product with multiple media associations in the admin.
* Set up a dynamic product group where this product is part of.
* In a product feed (could be Google Shopping, Idealo etc.) try sorting media associations with the following snippet
```twig
{% for media in product.media|sort((a, b) => a.position <=> b.position) %}
    {{ media.media.url }}
{% endfor %}
```
* Click "Generate preview" afterwards

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/13381

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
