### PR TITLE
fix: keep shipping tax when promotion zeroes the cart total

### DIFF
--- a/src/Core/Checkout/Cart/Tax/PercentageTaxRuleBuilder.php
+++ b/src/Core/Checkout/Cart/Tax/PercentageTaxRuleBuilder.php
@@ -20,13 +20,15 @@ class PercentageTaxRuleBuilder
     {
         $rules = new TaxRuleCollection([]);
 
+        if ($taxes->count() === 0) {
+            return $rules;
+        }
+
+        $equalShare = $totalPrice !== 0.0 ? null : 100.0 / $taxes->count();
+
         foreach ($taxes as $tax) {
-            $rules->add(
-                new TaxRule(
-                    $tax->getTaxRate(),
-                    $totalPrice !== 0.0 ? $tax->getPrice() / $totalPrice * 100 : 0
-                )
-            );
+            $percentage = $equalShare ?? ($tax->getPrice() / $totalPrice * 100);
+            $rules->add(new TaxRule($tax->getTaxRate(), $percentage));
         }
 
         return $rules;

--- a/tests/unit/Core/Checkout/Cart/Tax/PercentageTaxRuleBuilderTest.php
+++ b/tests/unit/Core/Checkout/Cart/Tax/PercentageTaxRuleBuilderTest.php
@@ -39,6 +39,28 @@ class PercentageTaxRuleBuilderTest extends TestCase
         static::assertSame($percentNineteen, $nineteen->getPercentage());
     }
 
+    public function testBuildCollectionRulesFallsBackToFullAllocationWhenSingleRateNetsToZero(): void
+    {
+        $collection = new CalculatedTaxCollection([
+            new CalculatedTax(0, 19, 0),
+        ]);
+
+        $rules = (new PercentageTaxRuleBuilder())->buildCollectionRules($collection, 0);
+
+        $rule = $rules->get('19');
+
+        static::assertNotNull($rule);
+        static::assertSame(19.0, $rule->getTaxRate());
+        static::assertSame(100.0, $rule->getPercentage());
+    }
+
+    public function testBuildCollectionRulesReturnsEmptyCollectionWhenNoTaxes(): void
+    {
+        $rules = (new PercentageTaxRuleBuilder())->buildCollectionRules(new CalculatedTaxCollection(), 0);
+
+        static::assertCount(0, $rules);
+    }
+
     /**
      * @return array<string, array<float>>
      */
@@ -46,7 +68,7 @@ class PercentageTaxRuleBuilderTest extends TestCase
     {
         return [
             'with total' => [200, 25.0, 75.0],
-            'without total' => [0, 0.0, 0.0],
+            'without total falls back to equal share' => [0, 50.0, 50.0],
         ];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a promotion fully discounts a cart to €0, the shipping cost still shows the correct tax rate (e.g. 19%) but the tax amount drops to €0.00. So, the cart looks like gross silently turned into net. This makes invoices and totals wrong for any order where a code makes the products free. Reproduces with: product + shipping method with cost + voucher larger than the product price

### 2. What does this change do, exactly?
`TaxRule` has two numbers: `taxRate` (e.g. 19%) and `percentage` which are the share of a price that is taxed at that rate. For shipping, `PercentageTaxRuleBuilder::buildCollectionRules` computes that share as `tax->price / totalPrice * 100`

When the cart total is `0`, the divide-by-zero guard returns `percentage = 0`. Downstream, `TaxCalculator::calculateTaxFromGrossPrice` multiplies the shipping price by that 0, so the tax becomes 0 even though the rate is still rendered

The way to fix: when `totalPrice = 0` but tax buckets are present, split the share evenly across them: 1 rate → `100%`, 2 rates → `50/50`. Shipping €5 with a single 19% rate now correctly resolves to `€5 × 100% × 19%`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- relates #15769
### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
