### PR TITLE
fix: sso user invitation mail fallback language

### DIFF
--- a/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
+++ b/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTy
 use Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateType\MailTemplateTypeEntity;
 use Shopware\Core\Content\MailTemplate\MailTemplateCollection;
 use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Sso\SsoException;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\User\UserCollection;
 use Shopware\Core\System\User\UserEntity;
@@ -85,13 +87,17 @@ class SsoUserInvitationMailService
 
     private function getMailTemplate(string $localeId, Context $context): ?MailTemplateEntity
     {
-        $languageId = $this->getLanguageIdForLocale($localeId, $context);
-        if ($languageId) {
+        $language = $this->getLanguageForLocale($localeId, $context);
+        if ($language) {
             $newContext = new Context(
                 $context->getSource(),
                 $context->getRuleIds(),
                 $context->getCurrencyId(),
-                [$languageId],
+                array_values(array_filter([
+                    $language->getId(),
+                    $language->getParentId(),
+                    Defaults::LANGUAGE_SYSTEM,
+                ])),
                 $context->getVersionId(),
                 $context->getCurrencyFactor(),
                 $context->considerInheritance(),
@@ -150,11 +156,11 @@ class SsoUserInvitationMailService
         return $this->userRepository->search(new Criteria([$userId]), $context)->first();
     }
 
-    private function getLanguageIdForLocale(string $localeId, Context $context): ?string
+    private function getLanguageForLocale(string $localeId, Context $context): ?LanguageEntity
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('localeId', $localeId));
 
-        return $this->languageRepository->search($criteria, $context)->first()?->getId();
+        return $this->languageRepository->search($criteria, $context)->first();
     }
 }

--- a/tests/integration/Core/Framework/Sso/SsoUser/SsoUserInvitationMailServiceTest.php
+++ b/tests/integration/Core/Framework/Sso/SsoUser/SsoUserInvitationMailServiceTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Sso\SsoUser;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\Service\Event\MailBeforeSentEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Sso\SsoUser\SsoUserInvitationMailService;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleEntity;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[Group('slow')]
+class SsoUserInvitationMailServiceTest extends TestCase
+{
+    use SalesChannelFunctionalTestBehaviour;
+
+    private string $localeId;
+
+    private SsoUserInvitationMailService $ssoUserInvitationMailService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $localeRepository = static::getContainer()->get('locale.repository');
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('code', 'pl-PL'));
+        $locale = $localeRepository->search($criteria, Context::createDefaultContext())->first();
+
+        static::assertInstanceOf(LocaleEntity::class, $locale);
+
+        $this->localeId = $locale->getId();
+
+        $this->getContainer()->get('language.repository')->create(
+            [[
+                'id' => Uuid::randomHex(),
+                'name' => 'pl-PL',
+                'localeId' => $this->localeId,
+                'parentId' => Defaults::LANGUAGE_SYSTEM,
+                'active' => true,
+                'salesChannels' => [
+                    ['id' => TestDefaults::SALES_CHANNEL],
+                ],
+                'salesChannelDefaultAssignments' => [
+                    ['id' => TestDefaults::SALES_CHANNEL],
+                ],
+            ]],
+            Context::createDefaultContext()
+        );
+
+        $this->ssoUserInvitationMailService = static::getContainer()->get(SsoUserInvitationMailService::class);
+    }
+
+    public function testSendInvitationMailToUser(): void
+    {
+        $source = new AdminApiSource(null, null);
+        $context = new Context(
+            $source,
+            [],
+            Defaults::CURRENCY,
+            [Defaults::LANGUAGE_SYSTEM]
+        );
+
+        $caughtEvent = null;
+        $this->addEventListener(
+            static::getContainer()->get('event_dispatcher'),
+            MailBeforeSentEvent::class,
+            static function (MailBeforeSentEvent $event) use (&$caughtEvent): void {
+                $caughtEvent = $event;
+            }
+        );
+
+        $this->ssoUserInvitationMailService->sendInvitationMailToUser(
+            'foo@bar.baz',
+            $this->localeId,
+            $context
+        );
+
+        static::assertInstanceOf(MailBeforeSentEvent::class, $caughtEvent);
+        static::assertSame('Administrator invited you to join Demostore', $caughtEvent->getData()['subject']);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
* Fallback language is missing in`Context` for sending SSO user invitation mail. This causes validation errors when translations are missing for the given language/locale.

### 2. What does this change do, exactly?
* Add fallback language to the `Context` for sending SSO user invitation mail

### 3. Describe each step to reproduce the issue or behaviour.
* Create new language with previously unused locale
* Use new language to send SSO user invitation

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16289

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
