### PR TITLE
fix: JSON-LD misses description and image on variantProduct

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/structured-data/json-ld-product.html.twig
@@ -286,6 +286,12 @@
             url: savedData.url,
             offers: savedData.offers
         } %}
+        {% if savedData.description is defined %}
+            {% set variantProduct = variantProduct|merge({description: savedData.description}) %}
+        {% endif %}
+        {% if savedData.image is defined %}
+            {% set variantProduct = variantProduct|merge({image: savedData.image}) %}
+        {% endif %}
         {% if savedData.gtin13 is defined %}
             {% set variantProduct = variantProduct|merge({gtin13: savedData.gtin13}) %}
         {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Schema requires image and description for variants, too


### 2. What does this change do, exactly?

Add image and description

### 3. Describe each step to reproduce the issue or behaviour.

1. have variant products
2. open the variant
3. inspect LD-JSON

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

####

Eventually we should also trim the description like this? Shall we add this to the MR?

```twig
    {% if page.product.translated.description %}
        {% set productData = productData|merge({
            description: page.product.translated.description|striptags|trim|u.truncate(497, '...')
        }) %}
    {% endif %}
```