### PR TITLE
fix: Add pointer events property to overlay

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-code-editor/sw-code-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-code-editor/sw-code-editor.scss
@@ -79,6 +79,7 @@
                 right: 0;
                 bottom: 0;
                 left: 0;
+                pointer-events: none;
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In the Shopping Experience editor, admins were unable to replace an existing CMS element with the HTML element. Clicking the HTML option in the change-element modal had no effect because the action handler (onSelectElement) was never invoked.

### 2. What does this change do, exactly?
Adds the pointer-events: none to the is--disabled ::after overlay in sw-code-editor.scss.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
