### PR TITLE
fix: raise PHPStan memory limit to 4G

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -441,7 +441,7 @@
         "phpstan": [
             "Composer\\Config::disableProcessTimeout",
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
-            "phpstan analyze --memory-limit=2G -vv"
+            "phpstan analyze --memory-limit=4G -vv"
         ],
         "phpstan-errors-by-area": [
             "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"


### PR DESCRIPTION
## Summary

PHPStan has been crashing in shopware-private CI with `Allowed memory size of 2147483648 bytes exhausted` during analysis, causing the PHP checks workflow to fail. The codebase has grown past what the 2G limit can handle.

This PR bumps the limit from 2G to 4G in the `phpstan` composer script so CI runs through to completion.

It is used to be syned to the shopware-private repository.