### PR TITLE
fix: prevent the upsert of negative restockTime

### DIFF
--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -161,7 +161,7 @@ class ProductDefinition extends EntityDefinition
 
             (new PriceField('price', 'price'))->addFlags(new Inherited(), new Required(), new ApiCriteriaAware())->setDescription('Price of the product.'),
             (new NumberRangeField('product_number', 'productNumber'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING, false), new Required())->setDescription('Unique number assigned to individual products. Define rules for automatic assignment of every product creation as per your number range.'),
-            (new IntField('restock_time', 'restockTime'))->addFlags(new ApiAware(), new Inherited())->setDescription('The restock time in days indicates how long it will take until a sold out item is back in stock.'),
+            (new IntField('restock_time', 'restockTime', minValue: 0))->addFlags(new ApiAware(), new Inherited())->setDescription('The restock time in days indicates how long it will take until a sold out item is back in stock.'),
             new AutoIncrementField(),
             (new BoolField('active', 'active'))->addFlags(new ApiAware(), new Inherited())->setDescription('When boolean value is `true`, the products are available for selection in the storefront for purchase.'),
             (new BoolField('available', 'available'))->addFlags(new ApiAware(), new WriteProtected())->setDescription('Indicates weather the product is available or not.'),


### PR DESCRIPTION
### 1. Why is this change necessary?
Hello ! This change is necessary because it prevents the upsert of negative restockTime.
A negative restockTime will trigger an error when the item is added to the cart, as we use it in a DateInterval in core/Checkout/Cart/Delivery/DeliveryBuilder.

### 2. What does this change do, exactly?
It adds a minValue to the restockTime, preventing errors at the source

### 3. Describe each step to reproduce the issue or behaviour.
Upsert a product with a negative restockTime
Add the product to the cart

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
