### PR TITLE
fix: make administration search filter dropdown scrollable

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
@@ -321,6 +321,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         top: 73px;
         z-index: $sw-search-bar-types-z-index;
         padding: 25px;
+        max-height: calc(100vh - 100px);
         overflow-x: hidden;
         overflow-y: auto;
         background-color: $sw-search-bar-results-background-color;


### PR DESCRIPTION
Fixes shopware/shopware#16064 by constraining the Administration search module filter dropdown to the visible viewport. The `#` module filter list already had vertical overflow enabled, but no max height, so long filter lists could extend past the screen instead of becoming scrollable.

https://github.com/user-attachments/assets/1633c8cd-c192-4134-9e40-07959f55febe

