### PR TITLE
fix: remove empty directories on media delete

### DIFF
--- a/src/Core/Content/Media/Message/DeleteFileHandler.php
+++ b/src/Core/Content/Media/Message/DeleteFileHandler.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media\Message;
 
+use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\UnableToDeleteFile;
 use League\Flysystem\Visibility;
@@ -27,13 +28,54 @@ final readonly class DeleteFileHandler
 
     public function __invoke(DeleteFileMessage $message): void
     {
+        $filesystem = $this->getFileSystem($message->getVisibility());
+
         foreach ($message->getFiles() as $file) {
             try {
-                $this->getFileSystem($message->getVisibility())->delete($file);
+                $filesystem->delete($file);
             } catch (UnableToDeleteFile) {
                 // ignore file is already deleted
             }
         }
+
+        if (!$message->isDeleteEmptyDirectories()) {
+            return;
+        }
+
+        foreach ($message->getFiles() as $file) {
+            try {
+                $this->deleteEmptyDirectories($filesystem, $file);
+            } catch (FilesystemException) {
+                // ignore already deleted directories
+            }
+        }
+    }
+
+    private function deleteEmptyDirectories(FilesystemOperator $filesystem, string $path): void
+    {
+        $directory = \dirname($path);
+
+        if (
+            $directory === ''
+            || \dirname($directory) === '.'
+            || \dirname($directory) === '/'
+            || !$this->isDirectoryEmpty($filesystem, $directory)
+        ) {
+            return;
+        }
+
+        $filesystem->deleteDirectory($directory);
+
+        $this->deleteEmptyDirectories($filesystem, $directory);
+    }
+
+    private function isDirectoryEmpty(FilesystemOperator $filesystem, string $path): bool
+    {
+        foreach ($filesystem->listContents($path) as $ignored) {
+            return false;
+        }
+
+        return true;
     }
 
     private function getFileSystem(string $visibility): FilesystemOperator

--- a/src/Core/Content/Media/Message/DeleteFileMessage.php
+++ b/src/Core/Content/Media/Message/DeleteFileMessage.php
@@ -14,7 +14,8 @@ class DeleteFileMessage implements AsyncMessageInterface
      */
     public function __construct(
         private array $files = [],
-        private string $visibility = Visibility::PUBLIC
+        private string $visibility = Visibility::PUBLIC,
+        private bool $deleteEmptyDirectories = false,
     ) {
     }
 
@@ -42,5 +43,15 @@ class DeleteFileMessage implements AsyncMessageInterface
     public function setVisibility(string $visibility): void
     {
         $this->visibility = $visibility;
+    }
+
+    public function isDeleteEmptyDirectories(): bool
+    {
+        return $this->deleteEmptyDirectories;
+    }
+
+    public function setDeleteEmptyDirectories(bool $deleteEmptyDirectories): void
+    {
+        $this->deleteEmptyDirectories = $deleteEmptyDirectories;
     }
 }

--- a/src/Core/Content/Media/Subscriber/MediaDeletionSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/MediaDeletionSubscriber.php
@@ -228,11 +228,11 @@ class MediaDeletionSubscriber implements EventSubscriberInterface
         }
 
         if ($context->hasState(self::SYNCHRONE_FILE_DELETE)) {
-            $this->deleteFileHandler->__invoke(new DeleteFileMessage($paths, $visibility));
+            $this->deleteFileHandler->__invoke(new DeleteFileMessage($paths, $visibility, true));
 
             return;
         }
 
-        $this->messageBus->dispatch(new DeleteFileMessage($paths, $visibility));
+        $this->messageBus->dispatch(new DeleteFileMessage($paths, $visibility, true));
     }
 }

--- a/tests/unit/Core/Content/Media/Message/DeleteFileHandlerTest.php
+++ b/tests/unit/Core/Content/Media/Message/DeleteFileHandlerTest.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Message;
+
+use League\Flysystem\DirectoryListing;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Message\DeleteFileHandler;
+use Shopware\Core\Content\Media\Message\DeleteFileMessage;
+
+/**
+ * @internal
+ */
+#[CoversClass(DeleteFileHandler::class)]
+class DeleteFileHandlerTest extends TestCase
+{
+    private MockObject&FilesystemOperator $filesystem;
+
+    private DeleteFileHandler $deleteFileHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = $this->createMock(FilesystemOperator::class);
+
+        $this->deleteFileHandler = new DeleteFileHandler($this->filesystem, $this->filesystem);
+    }
+
+    public function testItDeletesFilesOnly(): void
+    {
+        $paths = [
+            'media/12/34/56/foo.bar',
+            'media/12/34/56/bar.baz',
+            'media/23/45/65/foo.bar',
+            'media/23/56/78/bar.baz',
+        ];
+
+        $matcher = $this->exactly(4);
+        $this->filesystem->expects($matcher)->method('delete')->willReturnCallback(
+            static function (string $path) use ($paths, $matcher): void {
+                static::assertSame($paths[$matcher->numberOfInvocations() - 1], $path);
+            }
+        );
+
+        $this->filesystem->expects($this->never())->method('listContents');
+
+        $message = new DeleteFileMessage($paths);
+        $this->deleteFileHandler->__invoke($message);
+    }
+
+    public function testItDeletesFilesAndEmptyDirectories(): void
+    {
+        $paths = [
+            'media/12/34/56/foo.bar',
+            'media/12/34/56/bar.baz',
+            'media/23/45/65/foo.bar',
+            'media/23/56/78/bar.baz',
+        ];
+
+        $this->filesystem->expects($this->exactly(10))
+            ->method('listContents')
+            ->willReturnOnConsecutiveCalls(
+                new DirectoryListing(['bar.baz']),
+                new DirectoryListing([]),
+                new DirectoryListing([]),
+                new DirectoryListing([]),
+                new DirectoryListing([]),
+                new DirectoryListing([]),
+                new DirectoryListing(['56']),
+                new DirectoryListing([]),
+                new DirectoryListing([]),
+                new DirectoryListing([])
+            );
+
+        $directories = [
+            'media/12/34/56',
+            'media/12/34',
+            'media/12',
+            'media/23/45/65',
+            'media/23/45',
+            'media/23/56/78',
+            'media/23/56',
+            'media/23',
+        ];
+
+        $matcher = $this->exactly(8);
+        $this->filesystem->expects($matcher)->method('deleteDirectory')->willReturnCallback(
+            static function (string $path) use ($directories, $matcher): void {
+                static::assertSame($directories[$matcher->numberOfInvocations() - 1], $path);
+            }
+        );
+
+        $message = new DeleteFileMessage($paths, deleteEmptyDirectories: true);
+        $this->deleteFileHandler->__invoke($message);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
* Empty directories may remain after media was deleted

### 2. What does this change do, exactly?
* Check directories recursively from deletes file paths whether they are empty or not and remove them if they are

### 3. Describe each step to reproduce the issue or behaviour.
* Upload media
* Note file path to uploaded media file
* Delete media
* Check file path is still existing without content

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/7027

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
