### PR TITLE
chore: account register form action twig block

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -47,7 +47,7 @@ Previously, the switch field itself was disabled as expected, but its inheritanc
 
 ### New block in account registration form for easier form action overrides
 
-New extensible Twig block `component_account_register_form_action` to allow easy manipulation of the form action from extended templates in `src/Storefront/Resources/views/storefront/component/account/register.html.twig`.
+New extensible Twig block `component_account_register_form_action_url` to allow easy manipulation of the form action from extended templates in `src/Storefront/Resources/views/storefront/component/account/register.html.twig`.
 
 ## App System
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -45,10 +45,6 @@ Previously, the switch field itself was disabled as expected, but its inheritanc
 
 ## Storefront
 
-### New block in account registration form for easier form action overrides
-
-New extensible Twig block `component_account_register_form_action_url` to allow easy manipulation of the form action from extended templates in `src/Storefront/Resources/views/storefront/component/account/register.html.twig`.
-
 ## App System
 
 ## Hosting & Configuration

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -45,6 +45,10 @@ Previously, the switch field itself was disabled as expected, but its inheritanc
 
 ## Storefront
 
+### New block in account registration form for easier form action overrides
+
+New extensible Twig block `component_account_register_form_action` to allow easy manipulation of the form action from extended templates in `src/Storefront/Resources/views/storefront/component/account/register.html.twig`.
+
 ## App System
 
 ## Hosting & Configuration

--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -1,3 +1,7 @@
+{% if formAction is not defined %}
+    {% set formAction = path('frontend.account.register.save') %}
+{% endif %}
+
 {% block component_account_register %}
     <div class="card register-card">
         <div class="card-body">
@@ -10,7 +14,7 @@
             {% endblock %}
 
             {% block component_account_register_form %}
-                <form action="{% block component_account_register_form_action_url %}{{ path('frontend.account.register.save') }}{% endblock %}"
+                <form action="{{ formAction }}"
                       class="register-form"
                       method="post"
                       data-form-handler="true">

--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -10,7 +10,7 @@
             {% endblock %}
 
             {% block component_account_register_form %}
-                <form action="{{ path('frontend.account.register.save') }}"
+                <form action="{% block component_account_register_form_action %}{{ path('frontend.account.register.save') }}{% endblock %}"
                       class="register-form"
                       method="post"
                       data-form-handler="true">

--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -10,7 +10,7 @@
             {% endblock %}
 
             {% block component_account_register_form %}
-                <form action="{% block component_account_register_form_action %}{{ path('frontend.account.register.save') }}{% endblock %}"
+                <form action="{% block component_account_register_form_action_url %}{{ path('frontend.account.register.save') }}{% endblock %}"
                       class="register-form"
                       method="post"
                       data-form-handler="true">


### PR DESCRIPTION
### 1. Why is this change necessary?
Account register form action can not be manipulated properly from child templates.

### 2. What does this change do, exactly?
Add block for this.

### 4. Please link to the relevant issues (if any).
Needed for https://github.com/shopware/SwagCommercial/pull/2560