### PR TITLE
fix: Handle unknown scheduled class names gracefully, to improve blue…

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -25,6 +25,11 @@ Plugins can now mark technical `media` associations with the new DAL flag `Ignor
 This prevents `media:delete-unused` from treating metadata-only extensions as real media usage and helps avoid false negatives when removing unused files.
 Third-party developers should add this flag to media associations that store technical metadata but do not represent an actual assignment of the media file.
 
+### Deprecation of RegisterScheduleTaskMessage
+
+The `RegisterScheduleTaskMessage` class and the accompanying message handler `RegisterScheduledTaskHandler` is deprecated and will be removed in Shopware 6.8.0.0, as the message wasn't dispatched anymore.
+If you dispatched that message manually, you should call the `TaskScheduler::registerTask()` method directly instead.
+
 ## Administration
 
 ### Fixed "Last Quarter" timeframe returning the wrong year in `sw-date-filter`

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -311,6 +311,11 @@ The default value for the `serializer` parameter in the `#[Serialized]` field at
 You need to explicitly set the serializer to use for your field.
 Additionally, the `SerializedField` class is now internal, as you should not use it directly in classic `EntityDefinitions`. It's only intended use case is in combination with the `#[Serialized]` attribute in attribute entities.
 
+## Removal of `RegisterScheduledTaskMessage`
+
+The class `\Shopware\Core\Framework\MessageQueue\ScheduledTask\MessageQueue\RegisterScheduledTaskMessage` and it's accompanying handler `\Shopware\Core\Framework\MessageQueue\ScheduledTask\MessageQueue\RegisterScheduledTaskHandler` were removed, as the message was no longer dispatched.
+If you dispatched that message manually, you should call the `TaskScheduler::registerTask()` method directly instead.
+
 ## Removal of `EntityDefinition` constructor
 
 The constructor of the `EntityDefinition` has been removed, therefore the call of child classes to it need to be removed as well, i.e:

--- a/src/Core/Framework/DependencyInjection/scheduled-task.xml
+++ b/src/Core/Framework/DependencyInjection/scheduled-task.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="messenger.default_bus"/>
             <argument type="service" id="parameter_bag"/>
+            <argument type="service" id="logger"/>
             <argument>%shopware.messenger.scheduled_task.requeue_timeout%</argument>
         </service>
 

--- a/src/Core/Framework/MessageQueue/ScheduledTask/MessageQueue/RegisterScheduledTaskHandler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/MessageQueue/RegisterScheduledTaskHandler.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\MessageQueue\ScheduledTask\MessageQueue;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -10,6 +11,8 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * @final
  *
  * @internal
+ *
+ * @deprecated tag:v6.8.0 - Will be removed as the message was not dispatched anymore, call TaskRegistry synchronously
  */
 #[AsMessageHandler]
 #[Package('framework')]
@@ -24,6 +27,11 @@ class RegisterScheduledTaskHandler
 
     public function __invoke(RegisterScheduledTaskMessage $message): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'Dispatching RegisterScheduledTaskMessage is deprecated and will be removed in v6.8.0.0, call TaskRegistry synchronously instead.'
+        );
+
         $this->registry->registerTasks();
     }
 }

--- a/src/Core/Framework/MessageQueue/ScheduledTask/MessageQueue/RegisterScheduledTaskMessage.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/MessageQueue/RegisterScheduledTaskMessage.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
 
 #[Package('framework')]
+/**
+ * @deprecated tag:v6.8.0 - Will be removed as it was not dispatched anymore, call TaskRegistry synchronously
+ */
 class RegisterScheduledTaskMessage implements AsyncMessageInterface
 {
 }

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
@@ -13,6 +13,9 @@ class ScheduledTaskEntity extends Entity
 
     protected string $name;
 
+    /**
+     * @var class-string<ScheduledTask>
+     */
     protected string $scheduledTaskClass;
 
     protected int $runInterval;
@@ -35,11 +38,17 @@ class ScheduledTaskEntity extends Entity
         $this->name = $name;
     }
 
+    /**
+     * @return class-string<ScheduledTask>
+     */
     public function getScheduledTaskClass(): string
     {
         return $this->scheduledTaskClass;
     }
 
+    /**
+     * @param class-string<ScheduledTask> $scheduledTaskClass
+     */
     public function setScheduledTaskClass(string $scheduledTaskClass): void
     {
         $this->scheduledTaskClass = $scheduledTaskClass;

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -157,9 +157,10 @@ readonly class TaskScheduler
         $taskClass = $taskEntity->getScheduledTaskClass();
 
         if (!class_exists($taskClass)) {
-            $this->logger->warning(sprintf(
+            $this->logger->warning(\sprintf(
                 'Scheduled task class "%s" does not exist, this might be due to version mismatch during deployments when a new scheduled task is already registered, but the worker still running on an older version where that task does not exist yet.',
-                $taskClass));
+                $taskClass
+            ));
 
             return;
         }

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -29,7 +30,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  * @final
  */
 #[Package('framework')]
-class TaskScheduler
+readonly class TaskScheduler
 {
     /**
      * @internal
@@ -37,10 +38,11 @@ class TaskScheduler
      * @param EntityRepository<ScheduledTaskCollection> $scheduledTaskRepository
      */
     public function __construct(
-        private readonly EntityRepository $scheduledTaskRepository,
-        private readonly MessageBusInterface $bus,
-        private readonly ParameterBagInterface $parameterBag,
-        private readonly int $requeueTimeout,
+        private EntityRepository $scheduledTaskRepository,
+        private MessageBusInterface $bus,
+        private ParameterBagInterface $parameterBag,
+        private LoggerInterface $logger,
+        private int $requeueTimeout,
     ) {
     }
 
@@ -153,6 +155,14 @@ class TaskScheduler
     private function queueTask(ScheduledTaskEntity $taskEntity, Context $context): void
     {
         $taskClass = $taskEntity->getScheduledTaskClass();
+
+        if (!class_exists($taskClass)) {
+            $this->logger->warning(sprintf(
+                'Scheduled task class "%s" does not exist, this might be due to version mismatch during deployments when a new scheduled task is already registered, but the worker still running on an older version where that task does not exist yet.',
+                $taskClass));
+
+            return;
+        }
 
         if (!\is_a($taskClass, ScheduledTask::class, true)) {
             throw MessageQueueException::scheduledTaskDoesNotImplementInterface($taskClass);

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -72,9 +72,9 @@ class ScheduledTaskHandlerTest extends TestCase
 
         static::assertTrue($handler->wasCalled());
 
-        /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
 
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
         $newOriginalNextExecution = clone $originalNextExecution;
         $newOriginalNextExecution->modify(\sprintf('+%d seconds', $interval));
         $newOriginalNextExecutionString = $newOriginalNextExecution->format(Defaults::STORAGE_DATE_TIME_FORMAT);
@@ -126,11 +126,11 @@ class ScheduledTaskHandlerTest extends TestCase
 
         static::assertTrue($handler->wasCalled());
 
-        /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
 
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
         static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
-        static::assertGreaterThan(
+        static::assertGreaterThanOrEqual(
             $task->getNextExecutionTime()->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             $nowTime->format(Defaults::STORAGE_DATE_TIME_FORMAT)
         );
@@ -172,8 +172,8 @@ class ScheduledTaskHandlerTest extends TestCase
 
         static::assertTrue($handler->wasCalled());
 
-        /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
         static::assertSame(ScheduledTaskDefinition::STATUS_FAILED, $task->getStatus());
     }
 
@@ -202,8 +202,6 @@ class ScheduledTaskHandlerTest extends TestCase
 
         $handler = new DummyScheduledTaskHandler($this->scheduledTaskRepo, $this->logger, $taskId, true);
 
-        $exception = null;
-
         try {
             $handler($task);
         } catch (\Exception $exception) {
@@ -211,8 +209,8 @@ class ScheduledTaskHandlerTest extends TestCase
 
         static::assertTrue($handler->wasCalled());
 
-        /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
         static::assertSame(ScheduledTaskDefinition::STATUS_SCHEDULED, $task->getStatus());
     }
 
@@ -256,8 +254,8 @@ class ScheduledTaskHandlerTest extends TestCase
 
         static::assertFalse($handler->wasCalled());
 
-        /** @var ScheduledTaskEntity $task */
         $task = $this->scheduledTaskRepo->search(new Criteria([$taskId]), Context::createDefaultContext())->get($taskId);
+        static::assertInstanceOf(ScheduledTaskEntity::class, $task);
         static::assertSame($status, $task->getStatus());
     }
 

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\MessageQueue\ScheduledTask\Scheduler;
 
 use Doctrine\DBAL\Connection;
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -45,7 +46,13 @@ class TaskSchedulerTest extends TestCase
         $this->scheduledTaskRepo = static::getContainer()->get('scheduled_task.repository');
         $this->messageBus = $this->createMock(MessageBusInterface::class);
 
-        $this->scheduler = new TaskScheduler($this->scheduledTaskRepo, $this->messageBus, new ParameterBag(), 12);
+        $this->scheduler = new TaskScheduler(
+            $this->scheduledTaskRepo,
+            $this->messageBus,
+            new ParameterBag(),
+            new Logger('test'),
+            12
+        );
 
         $this->connection = static::getContainer()->get(Connection::class);
     }

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistryTest.php
@@ -100,6 +100,7 @@ class TaskRegistryTest extends TestCase
         $registeredTask->setDefaultRunInterval(CleanupCartTask::getDefaultInterval());
         $registeredTask->setStatus(ScheduledTaskDefinition::STATUS_SCHEDULED);
         $registeredTask->setNextExecutionTime(new \DateTimeImmutable());
+        /** @phpstan-ignore argument.type (wrong class string is needed for test case) */
         $registeredTask->setScheduledTaskClass('InvalidClass');
         $result = $this->createMock(EntitySearchResult::class);
         $result->method('getEntities')->willReturn(new ScheduledTaskCollection([$registeredTask]));

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\ScheduledTask\Scheduler;
 
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Constraint\StringStartsWith;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -14,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\MinResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\MessageQueue\MessageQueueException;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
@@ -45,6 +48,7 @@ class TaskSchedulerTest extends TestCase
             $scheduledTaskRepository,
             $this->createMock(MessageBusInterface::class),
             new ParameterBag(),
+            new Logger('test'),
             12
         );
 
@@ -93,6 +97,7 @@ class TaskSchedulerTest extends TestCase
             $scheduledTaskRepository,
             $this->createMock(MessageBusInterface::class),
             new ParameterBag(),
+            new Logger('test'),
             12
         );
 
@@ -139,6 +144,7 @@ class TaskSchedulerTest extends TestCase
             $scheduledTaskRepository,
             $bus,
             new ParameterBag(),
+            new Logger('test'),
             12
         );
 
@@ -181,6 +187,7 @@ class TaskSchedulerTest extends TestCase
             new ParameterBag([
                 'shopware.test.active' => false,
             ]),
+            new Logger('test'),
             12
         );
 
@@ -230,6 +237,7 @@ class TaskSchedulerTest extends TestCase
             $scheduledTaskRepository,
             $bus,
             new ParameterBag(['shopware.test.active' => $shouldSchedule]),
+            new Logger('test'),
             12
         );
 
@@ -249,7 +257,8 @@ class TaskSchedulerTest extends TestCase
     {
         $scheduledTask = new ScheduledTaskEntity();
         $scheduledTask->setId('1');
-        $scheduledTask->setScheduledTaskClass('foo');
+        /** @phpstan-ignore argument.type (wrong class string is needed for test case) */
+        $scheduledTask->setScheduledTaskClass(ScheduledTaskEntity::class);
 
         $result = $this->createMock(EntitySearchResult::class);
         $result->method('getEntities')->willReturn(new ScheduledTaskCollection([$scheduledTask]));
@@ -263,11 +272,41 @@ class TaskSchedulerTest extends TestCase
             $scheduledTaskRepository,
             $this->createMock(MessageBusInterface::class),
             new ParameterBag(),
+            new Logger('test'),
             12
         );
 
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Tried to schedule "foo", but class does not extend ScheduledTask');
+        static::expectExceptionObject(MessageQueueException::scheduledTaskDoesNotImplementInterface(ScheduledTaskEntity::class));
+        $scheduler->queueScheduledTasks();
+    }
+
+    public function testScheduleWithUnknownClassIsHandledGracefully(): void
+    {
+        $scheduledTask = new ScheduledTaskEntity();
+        $scheduledTask->setId('1');
+        /** @phpstan-ignore argument.type (wrong class string is needed for test case) */
+        $scheduledTask->setScheduledTaskClass('foo');
+
+        $result = $this->createMock(EntitySearchResult::class);
+        $result->method('getEntities')->willReturn(new ScheduledTaskCollection([$scheduledTask]));
+
+        $scheduledTaskRepository = $this->createMock(EntityRepository::class);
+        $scheduledTaskRepository
+            ->method('search')
+            ->willReturn($result);
+
+        $logger = $this->createMock(Logger::class);
+        $logger->expects($this->once())->method('warning')
+            ->with(new StringStartsWith('Scheduled task class "foo" does not exist'));
+
+        $scheduler = new TaskScheduler(
+            $scheduledTaskRepository,
+            $this->createMock(MessageBusInterface::class),
+            new ParameterBag(),
+            $logger,
+            12
+        );
+
         $scheduler->queueScheduledTasks();
     }
 }


### PR DESCRIPTION
…/green compatibility

### 1. Why is this change necessary?
In blue/green deployment cases new scheduled tasks might already be registered in a new versio of the application, but the scheduler task might still run on the old application version. 
currently this leads to erros as the old application does not know the classes of the tasks added in the new version.

### 2. What does this change do, exactly?
Only throw a warning when the class from the DB is unknown, so cases like described above are handled gracefully and do not lead to the scheduled tasks failing, unknown scheduled task will simply be ignored. 
as soon as the scheduler is running on the new application version the new scheduled tasks will automatically be picked up as expected.

**Note** this assumes `\Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry::registerTasks` won't be called on an old application, after scheduled tasks of a new version are registered, as that would delete the definition of any unknown scheduled task again, which is still the expected behaviour

### 3. Describe each step to reproduce the issue or behaviour.
see https://shopware-ag.slack.com/archives/C080HM3C85R/p1776347345628099
