### PR TITLE
fix: missing order primary refs

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -188,6 +188,8 @@ If only one, the "primary", order delivery and order transaction is displayed an
 There is now an easy way to make use of this by using the `primaryOrderDelivery` and `primaryOrderTransaction` properties.
 All existing orders will be updated with a migration so that they also have the primary values.
 From now on, the `OrderTransactionStatusRule::match` will always use the `primaryOrderTransaction` instead of the most recently successful transaction.
+Starting with 6.8, integrations and API users that write orders through the Admin API, Sync API, or DAL must set `primaryOrderDeliveryId` and `primaryOrderTransactionId` when they write deliveries or transactions.
+Otherwise, the delivery address, delivery state, or payment state will be missing for those orders in the Administration.
 
 ### Use `primaryOrderDelivery`
 
@@ -195,7 +197,7 @@ Get the first order delivery with `order.primaryOrderDelivery` so you should rep
 
 ### Use `primaryOrderTransaction`
 
-Get the latest order transaction with `order.primaryOrderDelivery` so you should replace methods like `order.transactions.last()` or `order.transactions[length - 1]`.
+Get the latest order transaction with `order.primaryOrderTransaction` so you should replace methods like `order.transactions.last()` or `order.transactions[length - 1]`.
 
 ## Removal of helper methods in `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper`
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -493,34 +493,13 @@ export default {
         },
 
         getVariantFromPaymentState(order) {
-            let technicalName = order.primaryOrderTransaction?.stateMachineState.technicalName;
-
-            if (!Shopware.Feature.isActive('v6.8.0.0')) {
-                technicalName = order.transactions.last().stateMachineState.technicalName;
-
-                // set the payment status to the first transaction that is not cancelled
-                for (let i = 0; i < order.transactions.length; i += 1) {
-                    if (
-                        ![
-                            'cancelled',
-                            'failed',
-                        ].includes(order.transactions[i].stateMachineState.technicalName)
-                    ) {
-                        technicalName = order.transactions[i].stateMachineState.technicalName;
-                        break;
-                    }
-                }
-            }
+            const technicalName = this.getTransactionState(order)?.technicalName;
 
             return this.stateStyleDataProviderService.getStyle('order_transaction.state', technicalName).colorCode;
         },
 
         getVariantFromDeliveryState(order) {
-            let technicalName = order.primaryOrderDelivery?.stateMachineState.technicalName;
-
-            if (!Shopware.Feature.isActive('v6.8.0.0')) {
-                technicalName = this.getDelivery(order).stateMachineState.technicalName;
-            }
+            const technicalName = this.getDeliveryState(order)?.technicalName;
 
             return this.stateStyleDataProviderService.getStyle('order_delivery.state', technicalName).colorCode;
         },
@@ -581,22 +560,27 @@ export default {
          * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderTransaction instead
          */
         transaction(order) {
-            if (Shopware.Feature.isActive('v6.8.0.0')) {
-                return order.primaryOrderTransaction;
-            }
-
-            for (let i = 0; i < order.transactions.length; i += 1) {
-                if (
-                    ![
-                        'cancelled',
-                        'failed',
-                    ].includes(order.transactions[i].stateMachineState.technicalName)
-                ) {
-                    return order.transactions[i];
+            if (!Shopware.Feature.isActive('v6.8.0.0')) {
+                if (order.primaryOrderTransaction) {
+                    return order.primaryOrderTransaction;
                 }
+
+                const transactions = order.transactions ?? [];
+                for (let i = 0; i < transactions.length; i += 1) {
+                    if (
+                        ![
+                            'cancelled',
+                            'failed',
+                        ].includes(transactions[i].stateMachineState?.technicalName)
+                    ) {
+                        return transactions[i];
+                    }
+                }
+
+                return transactions.last?.() ?? transactions[transactions.length - 1] ?? null;
             }
 
-            return order.transactions.last();
+            return order.primaryOrderTransaction ?? null;
         },
 
         /**
@@ -604,10 +588,31 @@ export default {
          */
         getDelivery(order) {
             if (!Shopware.Feature.isActive('v6.8.0.0')) {
-                return order.deliveries[0];
+                return order.primaryOrderDelivery ?? order.deliveries?.[0] ?? null;
             }
 
-            return order.primaryOrderDelivery;
+            return order.primaryOrderDelivery ?? null;
+        },
+
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderDelivery.shippingOrderAddress instead
+         */
+        getDeliveryAddress(order) {
+            return this.getDelivery(order)?.shippingOrderAddress ?? null;
+        },
+
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderDelivery.stateMachineState instead
+         */
+        getDeliveryState(order) {
+            return this.getDelivery(order)?.stateMachineState ?? null;
+        },
+
+        /**
+         * @deprecated tag:v6.8.0 - will be removed, use order.primaryOrderTransaction.stateMachineState instead
+         */
+        getTransactionState(order) {
+            return this.transaction(order)?.stateMachineState ?? null;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -175,11 +175,11 @@
 
                 {% block sw_order_list_grid_columns_delivery_address %}
                 <template #column-primaryOrderDelivery.shippingOrderAddress.street="{ item }">
-                    <template v-if="item.primaryOrderDelivery?.shippingOrderAddress">
-                        <span v-if="item.primaryOrderDelivery.shippingOrderAddress.company">{{ item.primaryOrderDelivery.shippingOrderAddress.company }}<span v-if="item.primaryOrderDelivery.shippingOrderAddress.department"> - {{ item.primaryOrderDelivery.shippingOrderAddress.department }}</span>,</span>
-                        {{ item.primaryOrderDelivery.shippingOrderAddress.street }},
-                        {{ item.primaryOrderDelivery.shippingOrderAddress.zipcode }}
-                        {{ item.primaryOrderDelivery.shippingOrderAddress.city }}
+                    <template v-if="getDeliveryAddress(item)">
+                        <span v-if="getDeliveryAddress(item).company">{{ getDeliveryAddress(item).company }}<span v-if="getDeliveryAddress(item).department"> - {{ getDeliveryAddress(item).department }}</span>,</span>
+                        {{ getDeliveryAddress(item).street }},
+                        {{ getDeliveryAddress(item).zipcode }}
+                        {{ getDeliveryAddress(item).city }}
                     </template>
 
                 </template>
@@ -209,7 +209,7 @@
                 {% block sw_order_list_grid_columns_transaction_state %}
                 <template #column-primaryOrderTransaction.stateMachineState.name="{ item }">
                     <div
-                        v-if="item.primaryOrderTransaction?.stateMachineState"
+                        v-if="getTransactionState(item)"
                         class="sw-order-list__state"
                     >
                         <sw-color-badge
@@ -217,7 +217,7 @@
                             rounded
                         />
 
-                        {{ item.primaryOrderTransaction.stateMachineState.translated.name }}
+                        {{ getTransactionState(item).translated.name }}
                     </div>
                 </template>
                 {% endblock %}
@@ -225,7 +225,7 @@
                 {% block sw_order_list_grid_columns_delivery_state %}
                 <template #column-primaryOrderDelivery.stateMachineState.name="{ item }">
                     <div
-                        v-if="item.primaryOrderDelivery?.stateMachineState"
+                        v-if="getDeliveryState(item)"
                         class="sw-order-list__state"
                     >
                         <sw-color-badge
@@ -233,7 +233,7 @@
                             rounded
                         />
 
-                        {{ item.primaryOrderDelivery.stateMachineState.translated.name }}
+                        {{ getDeliveryState(item).translated.name }}
                     </div>
                 </template>
                 {% endblock %}
@@ -421,11 +421,11 @@
                         {% block sw_order_list_bulk_edit_grid_columns_transaction_state %}
                         <template #column-primaryOrderTransaction.stateMachineState.name="{ item }">
                             <sw-label
-                                v-if="item.primaryOrderTransaction?.stateMachineState"
+                                v-if="getTransactionState(item)"
                                 :variant="getVariantFromPaymentState(item)"
                                 appearance="pill"
                             >
-                                {{ item.primaryOrderTransaction.stateMachineState.translated.name }}
+                                {{ getTransactionState(item).translated.name }}
                             </sw-label>
                         </template>
                         {% endblock %}
@@ -433,11 +433,11 @@
                         {% block sw_order_list_bulk_edit_grid_columns_delivery_state %}
                         <template #column-primaryOrderDelivery.stateMachineState.name="{ item }">
                             <sw-label
-                                v-if="item.primaryOrderDelivery?.stateMachineState"
+                                v-if="getDeliveryState(item)"
                                 :variant="getVariantFromDeliveryState(item)"
                                 appearance="pill"
                             >
-                                {{ item.primaryOrderDelivery.stateMachineState.translated.name }}
+                                {{ getDeliveryState(item).translated.name }}
                             </sw-label>
                         </template>
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -150,6 +150,10 @@ async function createWrapper() {
     });
 }
 
+function createTransactionCollection(transactions) {
+    return new EntityCollection(null, null, null, new Criteria(1, 25), transactions);
+}
+
 Shopware.Service().register('filterService', () => {
     return {
         mergeWithStoredFilters: (storeKey, criteria) => criteria,
@@ -439,6 +443,24 @@ describe('src/module/sw-order/page/sw-order-list', () => {
         expect(criteria.getAssociation('primaryOrderTransaction').hasAssociation('stateMachineState')).toBe(true);
     });
 
+    it('should only load primary order associations when v6.8.0.0 is active', async () => {
+        global.activeAclRoles = [];
+        global.activeFeatureFlags = ['v6.8.0.0'];
+
+        try {
+            wrapper = await createWrapper();
+            const criteria = wrapper.vm.orderCriteria;
+
+            expect(criteria.hasAssociation('primaryOrderDelivery')).toBe(true);
+            expect(criteria.hasAssociation('primaryOrderTransaction')).toBe(true);
+            expect(criteria.hasAssociation('deliveries')).toBe(false);
+            expect(criteria.hasAssociation('transactions')).toBe(false);
+            expect(criteria.hasAssociation('addresses')).toBe(false);
+        } finally {
+            global.activeFeatureFlags = [];
+        }
+    });
+
     it('should contain a computed property, called: listFilterOptions', async () => {
         global.activeAclRoles = [];
         wrapper = await createWrapper();
@@ -519,4 +541,360 @@ describe('src/module/sw-order/page/sw-order-list', () => {
 
         expect(wrapper.vm.filterCriteria).toContainEqual(filter);
     });
+
+    it('should render the delivery address from primaryOrderDelivery', async () => {
+        global.activeAclRoles = [];
+        wrapper = await createWrapper();
+
+        await wrapper.setData({
+            orders: [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: {
+                        stateMachineState: {
+                            technicalName: 'open',
+                            translated: { name: 'Open' },
+                        },
+                        shippingOrderAddress: {
+                            street: '742 Evergreen Terrace',
+                            zipcode: '99999',
+                            city: 'Springfield',
+                        },
+                    },
+                },
+            ],
+            total: 1,
+        });
+
+        const html = wrapper.html();
+        expect(html).toContain('742 Evergreen Terrace');
+        expect(html).toContain('Springfield');
+        expect(html).toContain('99999');
+    });
+
+    it('should render the delivery state from primaryOrderDelivery', async () => {
+        global.activeAclRoles = [];
+        wrapper = await createWrapper();
+
+        await wrapper.setData({
+            orders: [
+                {
+                    ...mockItem,
+                    primaryOrderDelivery: {
+                        stateMachineState: {
+                            technicalName: 'shipped',
+                            translated: { name: 'Shipped' },
+                        },
+                        shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
+                    },
+                },
+            ],
+            total: 1,
+        });
+
+        const stateCells = wrapper.findAll('.sw-order-list__state');
+        const stateTexts = stateCells.map((cell) => cell.text());
+        expect(stateTexts).toContain('Shipped');
+    });
+
+    it('should render the transaction state from primaryOrderTransaction', async () => {
+        global.activeAclRoles = [];
+        wrapper = await createWrapper();
+
+        await wrapper.setData({
+            orders: [
+                {
+                    ...mockItem,
+                    primaryOrderTransaction: {
+                        stateMachineState: {
+                            technicalName: 'paid',
+                            translated: { name: 'Paid' },
+                        },
+                    },
+                },
+            ],
+            total: 1,
+        });
+
+        const stateCells = wrapper.findAll('.sw-order-list__state');
+        const stateTexts = stateCells.map((cell) => cell.text());
+        expect(stateTexts).toContain('Paid');
+    });
+
+    it('should not fall back to deliveries and transactions when v6.8.0.0 is active', async () => {
+        global.activeAclRoles = [];
+        global.activeFeatureFlags = ['v6.8.0.0'];
+
+        try {
+            wrapper = await createWrapper();
+
+            const order = {
+                primaryOrderDelivery: null,
+                primaryOrderTransaction: null,
+                deliveries: [
+                    {
+                        stateMachineState: {
+                            technicalName: 'shipped',
+                            translated: { name: 'Fallback Shipped' },
+                        },
+                    },
+                ],
+                transactions: new EntityCollection(null, null, null, new Criteria(1, 25), [
+                    {
+                        stateMachineState: {
+                            technicalName: 'paid',
+                            translated: { name: 'Fallback Paid' },
+                        },
+                    },
+                ]),
+            };
+
+            expect(wrapper.vm.getDelivery(order)).toBeNull();
+            expect(wrapper.vm.transaction(order)).toBeNull();
+        } finally {
+            global.activeFeatureFlags = [];
+        }
+    });
+
+    /**
+     * @deprecated tag:v6.8.0 - test will be removed when the 6.7 fallback is dropped
+     */
+    if (!Shopware.Feature.isActive('v6.8.0.0')) {
+        it('should fall back to deliveries[0] address when primaryOrderDelivery is null (DAL writes without primaryOrderDeliveryId)', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderDelivery: null,
+                        deliveries: [
+                            {
+                                stateMachineState: {
+                                    technicalName: 'open',
+                                    translated: { name: 'Open' },
+                                },
+                                shippingOrderAddress: {
+                                    street: 'Fallback Street 1',
+                                    zipcode: '54321',
+                                    city: 'Fallback City',
+                                },
+                            },
+                        ],
+                    },
+                ],
+                total: 1,
+            });
+
+            const html = wrapper.html();
+            expect(html).toContain('Fallback Street 1');
+            expect(html).toContain('Fallback City');
+            expect(html).toContain('54321');
+        });
+
+        it('should fall back to the first delivery when multiple deliveries exist without primaryOrderDelivery', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderDelivery: null,
+                        deliveries: [
+                            {
+                                stateMachineState: {
+                                    technicalName: 'open',
+                                    translated: { name: 'Open' },
+                                },
+                                shippingOrderAddress: {
+                                    street: 'First Fallback Street',
+                                    zipcode: '11111',
+                                    city: 'First City',
+                                },
+                            },
+                            {
+                                stateMachineState: {
+                                    technicalName: 'shipped',
+                                    translated: { name: 'Shipped' },
+                                },
+                                shippingOrderAddress: {
+                                    street: 'Second Fallback Street',
+                                    zipcode: '22222',
+                                    city: 'Second City',
+                                },
+                            },
+                        ],
+                    },
+                ],
+                total: 1,
+            });
+
+            const html = wrapper.html();
+            expect(html).toContain('First Fallback Street');
+            expect(html).not.toContain('Second Fallback Street');
+        });
+
+        it('should fall back to deliveries[0] state when primaryOrderDelivery is null', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderDelivery: null,
+                        deliveries: [
+                            {
+                                stateMachineState: {
+                                    technicalName: 'shipped',
+                                    translated: { name: 'Fallback Shipped' },
+                                },
+                                shippingOrderAddress: mockItem.primaryOrderDelivery.shippingOrderAddress,
+                            },
+                        ],
+                    },
+                ],
+                total: 1,
+            });
+
+            const stateCells = wrapper.findAll('.sw-order-list__state');
+            const stateTexts = stateCells.map((cell) => cell.text());
+            expect(stateTexts).toContain('Fallback Shipped');
+        });
+
+        it('should fall back to transactions[0] state when primaryOrderTransaction is null', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderTransaction: null,
+                        transactions: new EntityCollection(null, null, null, new Criteria(1, 25), [
+                            {
+                                stateMachineState: {
+                                    technicalName: 'paid',
+                                    translated: { name: 'Fallback Paid' },
+                                },
+                            },
+                        ]),
+                    },
+                ],
+                total: 1,
+            });
+
+            const stateCells = wrapper.findAll('.sw-order-list__state');
+            const stateTexts = stateCells.map((cell) => cell.text());
+            expect(stateTexts).toContain('Fallback Paid');
+        });
+
+        it('should fall back to the first transaction that is not cancelled or failed', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderTransaction: null,
+                        transactions: createTransactionCollection([
+                            {
+                                stateMachineState: {
+                                    technicalName: 'cancelled',
+                                    translated: { name: 'Fallback Cancelled' },
+                                },
+                            },
+                            {
+                                stateMachineState: {
+                                    technicalName: 'paid',
+                                    translated: { name: 'Fallback Paid' },
+                                },
+                            },
+                            {
+                                stateMachineState: {
+                                    technicalName: 'open',
+                                    translated: { name: 'Fallback Open' },
+                                },
+                            },
+                        ]),
+                    },
+                ],
+                total: 1,
+            });
+
+            const stateCells = wrapper.findAll('.sw-order-list__state');
+            const stateTexts = stateCells.map((cell) => cell.text());
+            expect(stateTexts).toContain('Fallback Paid');
+            expect(stateTexts).not.toContain('Fallback Cancelled');
+        });
+
+        it('should fall back to the last transaction when all transactions are cancelled or failed', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderTransaction: null,
+                        transactions: createTransactionCollection([
+                            {
+                                stateMachineState: {
+                                    technicalName: 'cancelled',
+                                    translated: { name: 'Fallback Cancelled' },
+                                },
+                            },
+                            {
+                                stateMachineState: {
+                                    technicalName: 'failed',
+                                    translated: { name: 'Fallback Failed' },
+                                },
+                            },
+                        ]),
+                    },
+                ],
+                total: 1,
+            });
+
+            const stateCells = wrapper.findAll('.sw-order-list__state');
+            const stateTexts = stateCells.map((cell) => cell.text());
+            expect(stateTexts).toContain('Fallback Failed');
+        });
+
+        it('should render no transaction state when both primaryOrderTransaction and transactions are missing', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            const order = {
+                ...mockItem,
+                primaryOrderTransaction: null,
+                transactions: [],
+            };
+
+            expect(wrapper.vm.transaction(order)).toBeNull();
+            expect(wrapper.vm.getTransactionState(order)).toBeNull();
+        });
+
+        it('should render no delivery address when both primaryOrderDelivery and deliveries are missing', async () => {
+            global.activeAclRoles = [];
+            wrapper = await createWrapper();
+
+            await wrapper.setData({
+                orders: [
+                    {
+                        ...mockItem,
+                        primaryOrderDelivery: null,
+                        deliveries: [],
+                    },
+                ],
+                total: 1,
+            });
+
+            const html = wrapper.html();
+            expect(html).not.toContain('123 Random street');
+        });
+    }
 });

--- a/src/Core/Migration/V6_8/Migration1777952600BackfillPrimaryOrderDelivery.php
+++ b/src/Core/Migration/V6_8/Migration1777952600BackfillPrimaryOrderDelivery.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_8;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1777952600BackfillPrimaryOrderDelivery extends MigrationStep
+{
+    private const UPDATE_LIMIT = 1000;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1777952600;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // Re-runs the backfill from \Shopware\Core\Migration\V6_7\Migration1728040169AddPrimaryOrderDelivery
+        // to cover orders created during the 6.7 lifecycle via direct DAL writes that did not set
+        // primary_order_delivery_id.
+        do {
+            $ids = $connection->fetchFirstColumn(
+                'SELECT `order`.`id`
+                 FROM `order`
+                 WHERE `order`.`primary_order_delivery_id` IS NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM `order_delivery`
+                       WHERE `order_delivery`.`order_id` = `order`.`id`
+                         AND `order_delivery`.`order_version_id` = `order`.`version_id`
+                   )
+                 LIMIT :limit',
+                ['limit' => self::UPDATE_LIMIT],
+                ['limit' => ParameterType::INTEGER]
+            );
+
+            if ($ids === []) {
+                break;
+            }
+
+            $connection->executeStatement(
+                'UPDATE `order` AS `o`
+                 INNER JOIN (
+                     SELECT `order_id`, `order_version_id`, `id`, `version_id`
+                     FROM (
+                         SELECT
+                             `order_id`,
+                             `order_version_id`,
+                             `id`,
+                             `version_id`,
+                             ROW_NUMBER() OVER (
+                                 PARTITION BY `order_id`, `order_version_id`
+                                 ORDER BY CAST(JSON_UNQUOTE(JSON_EXTRACT(`shipping_costs`, \'$.unitPrice\')) AS DECIMAL(20, 6)) DESC, `id` ASC
+                             ) AS `rn`
+                         FROM `order_delivery`
+                         WHERE `order_id` IN (:ids)
+                     ) AS `ranked`
+                     WHERE `ranked`.`rn` = 1
+                 ) AS `primary_delivery`
+                     ON `primary_delivery`.`order_id` = `o`.`id`
+                     AND `primary_delivery`.`order_version_id` = `o`.`version_id`
+                 SET `o`.`primary_order_delivery_id` = `primary_delivery`.`id`,
+                     `o`.`primary_order_delivery_version_id` = `primary_delivery`.`version_id`
+                 WHERE `o`.`id` IN (:ids)
+                   AND `o`.`primary_order_delivery_id` IS NULL',
+                ['ids' => $ids],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+        } while (\count($ids) === self::UPDATE_LIMIT);
+    }
+}

--- a/src/Core/Migration/V6_8/Migration1777952601BackfillPrimaryOrderTransaction.php
+++ b/src/Core/Migration/V6_8/Migration1777952601BackfillPrimaryOrderTransaction.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_8;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1777952601BackfillPrimaryOrderTransaction extends MigrationStep
+{
+    private const UPDATE_LIMIT = 1000;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1777952601;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // Re-runs the backfill from \Shopware\Core\Migration\V6_7\Migration1728040170AddPrimaryOrderTransaction
+        // to cover orders created during the 6.7 lifecycle via direct DAL writes that did not set
+        // primary_order_transaction_id.
+        do {
+            $ids = $connection->fetchFirstColumn(
+                'SELECT `order`.`id`
+                 FROM `order`
+                 WHERE `order`.`primary_order_transaction_id` IS NULL
+                   AND EXISTS (
+                       SELECT 1
+                       FROM `order_transaction`
+                       WHERE `order_transaction`.`order_id` = `order`.`id`
+                         AND `order_transaction`.`order_version_id` = `order`.`version_id`
+                   )
+                 LIMIT :limit',
+                ['limit' => self::UPDATE_LIMIT],
+                ['limit' => ParameterType::INTEGER]
+            );
+
+            if ($ids === []) {
+                break;
+            }
+
+            $connection->executeStatement(
+                'UPDATE `order` AS `o`
+                 INNER JOIN (
+                     SELECT `order_id`, `order_version_id`, `id`, `version_id`
+                     FROM (
+                         SELECT
+                             `order_id`,
+                             `order_version_id`,
+                             `id`,
+                             `version_id`,
+                             ROW_NUMBER() OVER (
+                                 PARTITION BY `order_id`, `order_version_id`
+                                 ORDER BY `created_at` DESC, `id` ASC
+                             ) AS `rn`
+                         FROM `order_transaction`
+                         WHERE `order_id` IN (:ids)
+                     ) AS `ranked`
+                     WHERE `ranked`.`rn` = 1
+                 ) AS `primary_transaction`
+                     ON `primary_transaction`.`order_id` = `o`.`id`
+                     AND `primary_transaction`.`order_version_id` = `o`.`version_id`
+                 SET `o`.`primary_order_transaction_id` = `primary_transaction`.`id`,
+                     `o`.`primary_order_transaction_version_id` = `primary_transaction`.`version_id`
+                 WHERE `o`.`id` IN (:ids)
+                   AND `o`.`primary_order_transaction_id` IS NULL',
+                ['ids' => $ids],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+        } while (\count($ids) === self::UPDATE_LIMIT);
+    }
+}

--- a/tests/migration/Core/V6_8/Migration1777952600BackfillPrimaryOrderDeliveryTest.php
+++ b/tests/migration/Core/V6_8/Migration1777952600BackfillPrimaryOrderDeliveryTest.php
@@ -1,0 +1,237 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_8;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
+use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_8\Migration1777952600BackfillPrimaryOrderDelivery;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1777952600BackfillPrimaryOrderDelivery::class)]
+class Migration1777952600BackfillPrimaryOrderDeliveryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->delete('`order`');
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1777952600, (new Migration1777952600BackfillPrimaryOrderDelivery())->getCreationTimestamp());
+    }
+
+    public function testMigrationBackfillsOrderWithNullPrimaryDelivery(): void
+    {
+        $orderId = $this->prepareOrderWithNullPrimaryDelivery();
+
+        $this->migrate();
+        $this->migrate();
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT primary_order_delivery_id, primary_order_delivery_version_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertIsArray($row);
+        static::assertNotNull($row['primary_order_delivery_id']);
+        static::assertNotNull($row['primary_order_delivery_version_id']);
+    }
+
+    public function testMigrationLeavesOrdersWithoutDeliveryUntouched(): void
+    {
+        $orderId = $this->prepareOrder(false);
+
+        $this->migrate();
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT primary_order_delivery_id, primary_order_delivery_version_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertIsArray($row);
+        static::assertNull($row['primary_order_delivery_id']);
+        static::assertNull($row['primary_order_delivery_version_id']);
+    }
+
+    public function testMigrationPicksDeliveryWithHighestShippingCost(): void
+    {
+        $orderId = $this->prepareOrder(false);
+        $cheapDeliveryId = $this->insertDelivery($orderId, 5.0);
+        $expensiveDeliveryId = $this->insertDelivery($orderId, 25.0);
+        $midDeliveryId = $this->insertDelivery($orderId, 15.0);
+
+        $this->migrate();
+
+        $primaryId = $this->connection->fetchOne(
+            'SELECT primary_order_delivery_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertSame($expensiveDeliveryId, $primaryId);
+        static::assertNotSame($cheapDeliveryId, $primaryId);
+        static::assertNotSame($midDeliveryId, $primaryId);
+    }
+
+    public function testMigrationDoesNotOverwriteAlreadySetPrimary(): void
+    {
+        $orderId = $this->prepareOrder(false);
+        $deliveryAId = $this->insertDelivery($orderId, 50.0);
+        $deliveryBId = $this->insertDelivery($orderId, 10.0);
+
+        $this->connection->executeStatement(
+            'UPDATE `order` SET primary_order_delivery_id = :delivery, primary_order_delivery_version_id = :version WHERE id = :id',
+            [
+                'delivery' => $deliveryBId,
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'id' => $orderId,
+            ]
+        );
+
+        $this->migrate();
+
+        $primaryId = $this->connection->fetchOne(
+            'SELECT primary_order_delivery_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertSame($deliveryBId, $primaryId);
+        static::assertNotSame($deliveryAId, $primaryId);
+    }
+
+    public function testMigrationProcessesMultipleOrders(): void
+    {
+        $orderIds = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $orderId = $this->prepareOrder(true);
+            $this->connection->executeStatement(
+                'UPDATE `order` SET primary_order_delivery_id = NULL, primary_order_delivery_version_id = NULL WHERE id = :id',
+                ['id' => $orderId]
+            );
+            $orderIds[] = $orderId;
+        }
+
+        $this->migrate();
+
+        foreach ($orderIds as $orderId) {
+            $row = $this->connection->fetchAssociative(
+                'SELECT primary_order_delivery_id, primary_order_delivery_version_id FROM `order` WHERE id = :id',
+                ['id' => $orderId]
+            );
+            static::assertIsArray($row);
+            static::assertNotNull($row['primary_order_delivery_id']);
+            static::assertNotNull($row['primary_order_delivery_version_id']);
+        }
+    }
+
+    private function prepareOrderWithNullPrimaryDelivery(): string
+    {
+        $orderId = $this->prepareOrder(true);
+
+        $this->connection->executeStatement(
+            'UPDATE `order` SET primary_order_delivery_id = NULL, primary_order_delivery_version_id = NULL WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        return $orderId;
+    }
+
+    private function prepareOrder(bool $withDelivery): string
+    {
+        $orderId = Uuid::fromHexToBytes(Uuid::randomHex());
+
+        $this->connection->insert(
+            '`order`',
+            [
+                'id' => $orderId,
+                'currency_factor' => 1.0,
+                'order_date_time' => '2020-01-01',
+                'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'price' => json_encode([
+                    'netPrice' => 100,
+                    'taxStatus' => 'gross',
+                    'totalPrice' => 100,
+                    'positionPrice' => 1,
+                ], \JSON_THROW_ON_ERROR),
+                'currency_id' => Uuid::fromHexToBytes(Defaults::CURRENCY),
+                'state_id' => $this->fetchStateId(OrderStates::STATE_MACHINE),
+                'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+                'sales_channel_id' => Uuid::fromHexToBytes(TestDefaults::SALES_CHANNEL),
+                'billing_address_id' => Uuid::randomBytes(),
+                'billing_address_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'shipping_costs' => '{}',
+                'created_at' => '2020-01-01',
+            ]
+        );
+
+        if ($withDelivery) {
+            $this->insertDelivery($orderId, 0.0);
+        }
+
+        return $orderId;
+    }
+
+    private function insertDelivery(string $orderId, float $unitPrice): string
+    {
+        $deliveryId = Uuid::fromHexToBytes(Uuid::randomHex());
+
+        $shippingMethodId = $this->connection->executeQuery('SELECT id FROM shipping_method WHERE active = 1')->fetchOne();
+        static::assertIsString($shippingMethodId);
+
+        $this->connection->insert(
+            '`order_delivery`',
+            [
+                'id' => $deliveryId,
+                'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'order_id' => $orderId,
+                'order_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'state_id' => $this->fetchStateId(OrderDeliveryStates::STATE_MACHINE),
+                'shipping_method_id' => $shippingMethodId,
+                'tracking_codes' => '["code"]',
+                'shipping_date_earliest' => '2020-01-01',
+                'shipping_date_latest' => '2025-01-01',
+                'shipping_costs' => json_encode(['unitPrice' => $unitPrice], \JSON_THROW_ON_ERROR),
+                'created_at' => '2020-01-01',
+            ]
+        );
+
+        return $deliveryId;
+    }
+
+    private function fetchStateId(string $stateMachine): string
+    {
+        $machineId = $this->connection
+            ->fetchOne('SELECT id FROM state_machine WHERE technical_name = :state', ['state' => $stateMachine]);
+        static::assertIsString($machineId);
+
+        $stateId = $this->connection
+            ->fetchOne('SELECT id FROM state_machine_state WHERE technical_name = :state AND state_machine_id = :machineId', ['state' => 'open', 'machineId' => $machineId]);
+        static::assertIsString($stateId);
+
+        return $stateId;
+    }
+
+    private function migrate(): void
+    {
+        (new Migration1777952600BackfillPrimaryOrderDelivery())->update($this->connection);
+    }
+}

--- a/tests/migration/Core/V6_8/Migration1777952601BackfillPrimaryOrderTransactionTest.php
+++ b/tests/migration/Core/V6_8/Migration1777952601BackfillPrimaryOrderTransactionTest.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_8;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
+use Shopware\Core\Checkout\Order\OrderStates;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_8\Migration1777952601BackfillPrimaryOrderTransaction;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1777952601BackfillPrimaryOrderTransaction::class)]
+class Migration1777952601BackfillPrimaryOrderTransactionTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->delete('`order`');
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1777952601, (new Migration1777952601BackfillPrimaryOrderTransaction())->getCreationTimestamp());
+    }
+
+    public function testMigrationBackfillsOrderWithNullPrimaryTransaction(): void
+    {
+        $orderId = $this->prepareOrderWithNullPrimaryTransaction();
+
+        $this->migrate();
+        $this->migrate();
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT primary_order_transaction_id, primary_order_transaction_version_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertIsArray($row);
+        static::assertNotNull($row['primary_order_transaction_id']);
+        static::assertNotNull($row['primary_order_transaction_version_id']);
+    }
+
+    public function testMigrationLeavesOrdersWithoutTransactionUntouched(): void
+    {
+        $orderId = $this->prepareOrder(false);
+
+        $this->migrate();
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT primary_order_transaction_id, primary_order_transaction_version_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertIsArray($row);
+        static::assertNull($row['primary_order_transaction_id']);
+        static::assertNull($row['primary_order_transaction_version_id']);
+    }
+
+    public function testMigrationPicksLatestCreatedTransaction(): void
+    {
+        $orderId = $this->prepareOrder(false);
+        $oldestId = $this->insertTransaction($orderId, '2020-01-01 00:00:00');
+        $latestId = $this->insertTransaction($orderId, '2024-06-01 00:00:00');
+        $midId = $this->insertTransaction($orderId, '2022-03-15 00:00:00');
+
+        $this->migrate();
+
+        $primaryId = $this->connection->fetchOne(
+            'SELECT primary_order_transaction_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertSame($latestId, $primaryId);
+        static::assertNotSame($oldestId, $primaryId);
+        static::assertNotSame($midId, $primaryId);
+    }
+
+    public function testMigrationDoesNotOverwriteAlreadySetPrimary(): void
+    {
+        $orderId = $this->prepareOrder(false);
+        $transactionAId = $this->insertTransaction($orderId, '2024-06-01 00:00:00');
+        $transactionBId = $this->insertTransaction($orderId, '2020-01-01 00:00:00');
+
+        $this->connection->executeStatement(
+            'UPDATE `order` SET primary_order_transaction_id = :transaction, primary_order_transaction_version_id = :version WHERE id = :id',
+            [
+                'transaction' => $transactionBId,
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'id' => $orderId,
+            ]
+        );
+
+        $this->migrate();
+
+        $primaryId = $this->connection->fetchOne(
+            'SELECT primary_order_transaction_id FROM `order` WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        static::assertSame($transactionBId, $primaryId);
+        static::assertNotSame($transactionAId, $primaryId);
+    }
+
+    public function testMigrationProcessesMultipleOrders(): void
+    {
+        $orderIds = [];
+        for ($i = 0; $i < 5; ++$i) {
+            $orderId = $this->prepareOrder(true);
+            $this->connection->executeStatement(
+                'UPDATE `order` SET primary_order_transaction_id = NULL, primary_order_transaction_version_id = NULL WHERE id = :id',
+                ['id' => $orderId]
+            );
+            $orderIds[] = $orderId;
+        }
+
+        $this->migrate();
+
+        foreach ($orderIds as $orderId) {
+            $row = $this->connection->fetchAssociative(
+                'SELECT primary_order_transaction_id, primary_order_transaction_version_id FROM `order` WHERE id = :id',
+                ['id' => $orderId]
+            );
+            static::assertIsArray($row);
+            static::assertNotNull($row['primary_order_transaction_id']);
+            static::assertNotNull($row['primary_order_transaction_version_id']);
+        }
+    }
+
+    private function prepareOrderWithNullPrimaryTransaction(): string
+    {
+        $orderId = $this->prepareOrder(true);
+
+        $this->connection->executeStatement(
+            'UPDATE `order` SET primary_order_transaction_id = NULL, primary_order_transaction_version_id = NULL WHERE id = :id',
+            ['id' => $orderId]
+        );
+
+        return $orderId;
+    }
+
+    private function prepareOrder(bool $withTransaction): string
+    {
+        $orderId = Uuid::fromHexToBytes(Uuid::randomHex());
+
+        $this->connection->insert(
+            '`order`',
+            [
+                'id' => $orderId,
+                'currency_factor' => 1.0,
+                'order_date_time' => '2020-01-01',
+                'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'price' => json_encode([
+                    'netPrice' => 100,
+                    'taxStatus' => 'gross',
+                    'totalPrice' => 100,
+                    'positionPrice' => 1,
+                ], \JSON_THROW_ON_ERROR),
+                'currency_id' => Uuid::fromHexToBytes(Defaults::CURRENCY),
+                'state_id' => $this->fetchStateId(OrderStates::STATE_MACHINE),
+                'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+                'sales_channel_id' => Uuid::fromHexToBytes(TestDefaults::SALES_CHANNEL),
+                'billing_address_id' => Uuid::randomBytes(),
+                'billing_address_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'shipping_costs' => '{}',
+                'created_at' => '2020-01-01',
+            ]
+        );
+
+        if ($withTransaction) {
+            $this->insertTransaction($orderId, '2020-01-01');
+        }
+
+        return $orderId;
+    }
+
+    private function insertTransaction(string $orderId, string $createdAt): string
+    {
+        $transactionId = Uuid::fromHexToBytes(Uuid::randomHex());
+
+        $paymentMethodId = $this->connection->executeQuery('SELECT id FROM payment_method WHERE active = 1 ORDER BY `position`')->fetchOne();
+        static::assertIsString($paymentMethodId);
+
+        $this->connection->insert(
+            '`order_transaction`',
+            [
+                'id' => $transactionId,
+                'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'order_id' => $orderId,
+                'order_version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+                'state_id' => $this->fetchStateId(OrderTransactionStates::STATE_MACHINE),
+                'payment_method_id' => $paymentMethodId,
+                'amount' => 100,
+                'created_at' => $createdAt,
+            ]
+        );
+
+        return $transactionId;
+    }
+
+    private function fetchStateId(string $stateMachine): string
+    {
+        $machineId = $this->connection
+            ->fetchOne('SELECT id FROM state_machine WHERE technical_name = :state', ['state' => $stateMachine]);
+        static::assertIsString($machineId);
+
+        $stateId = $this->connection
+            ->fetchOne('SELECT id FROM state_machine_state WHERE technical_name = :state AND state_machine_id = :machineId', ['state' => 'open', 'machineId' => $machineId]);
+        static::assertIsString($stateId);
+
+        return $stateId;
+    }
+
+    private function migrate(): void
+    {
+        (new Migration1777952601BackfillPrimaryOrderTransaction())->update($this->connection);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Direct DAL order writes can create deliveries and transactions without filling `primary_order_delivery_id` and `primary_order_transaction_id`. This leaves Admin/API consumers without primary delivery, shipping address, and payment state information for imported orders

### 2. What does this change do, exactly?

This fix association error on administration and also adds 6.7 Admin fallbacks, keeps 6.8 on primary references only, and adds 6.8 migrations to backfill missing primary references


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- relates #16517
### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
