### PR TITLE
fix: use translated page name in category/product layout card

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -66,6 +66,14 @@ export default {
             const pageType = this.cmsPageTypeService.getType(this.cmsPage.type);
             return pageType ? this.$t(this.cmsPageTypeService.getType(this.cmsPage.type).title) : fallback;
         },
+
+        pageName() {
+            if (!this.cmsPage) {
+                return this.$t('sw-category.base.cms.defaultTitle');
+            }
+
+            return this.cmsPage.translated?.name ?? this.cmsPage.name;
+        },
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
@@ -45,7 +45,7 @@
                     class="sw-category-layout-card__desc-headline"
                     :class="{ 'is--empty': !cmsPage }"
                 >
-                    {{ cmsPage ? cmsPage.name : $t('sw-category.base.cms.defaultTitle') }}
+                    {{ pageName }}
                 </div>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/index.js
@@ -31,6 +31,16 @@ export default {
         },
     },
 
+    computed: {
+        pageName() {
+            if (!this.cmsPage) {
+                return this.$t('sw-product.layoutAssignment.title');
+            }
+
+            return this.cmsPage.translated?.name ?? this.cmsPage.name;
+        },
+    },
+
     methods: {
         openLayoutModal() {
             this.$emit('modal-layout-open');

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/sw-product-layout-assignment.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/sw-product-layout-assignment.html.twig
@@ -27,7 +27,7 @@
         >
             {% block sw_product_layout_assignment_heading_title %}
             <p class="sw-product-layout-assignment__title">
-                {{ cmsPage ? cmsPage.name : $t('sw-product.layoutAssignment.title') }}
+                {{ pageName }}
             </p>
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If the name of a CMS layout is not given for the selected language, the fallback in the default language isn't showing in the category/product layout card

### 2. What does this change do, exactly?
Use the translated name for the CMS layout so it falls back on the default language if no name in the current language is given.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a CMS layout but don't provide a name in the secondary language.
* Go to the product/category layout assignment and assign the new layout
* Change the language from default language to secondary language.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16184

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
