### PR TITLE
fix: export temporary url file download missing filename

### DIFF
--- a/src/Core/Content/ImportExport/Service/DownloadService.php
+++ b/src/Core/Content/ImportExport/Service/DownloadService.php
@@ -70,7 +70,11 @@ class DownloadService
         );
 
         try {
-            $url = $this->filesystem->temporaryUrl($entity->getPath(), (new \DateTimeImmutable())->modify(self::EXPIRATION_TIME));
+            $url = $this->filesystem->temporaryUrl(
+                $entity->getPath(),
+                (new \DateTimeImmutable())->modify(self::EXPIRATION_TIME),
+                $this->getTemporaryUrlConfig($entity)
+            );
 
             return new RedirectResponse($url);
         } catch (UnableToGenerateTemporaryUrl $exception) {
@@ -132,6 +136,38 @@ class DownloadService
      */
     private function getStreamHeaders(ImportExportFileEntity $entity): array
     {
+        $downloadHeaders = $this->getDownloadHeaders($entity);
+
+        return [
+            'Content-Disposition' => $downloadHeaders['Content-Disposition'],
+            'Content-Length' => $this->filesystem->fileSize($entity->getPath()),
+            'Content-Type' => $downloadHeaders['Content-Type'],
+        ];
+    }
+
+    /**
+     * S3 temporary URLs use GetObject response overrides to preserve the download
+     * filename and content type after redirecting away from Shopware.
+     *
+     * @return array{get_object_options: array{ResponseContentDisposition: string, ResponseContentType: string}}
+     */
+    private function getTemporaryUrlConfig(ImportExportFileEntity $entity): array
+    {
+        $downloadHeaders = $this->getDownloadHeaders($entity);
+
+        return [
+            'get_object_options' => [
+                'ResponseContentDisposition' => $downloadHeaders['Content-Disposition'],
+                'ResponseContentType' => $downloadHeaders['Content-Type'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array{'Content-Disposition': string, 'Content-Type': string}
+     */
+    private function getDownloadHeaders(ImportExportFileEntity $entity): array
+    {
         $originalName = (string) preg_replace('/[\/\\\]/', '', $entity->getOriginalName());
 
         try {
@@ -147,7 +183,6 @@ class DownloadService
                 // only printable ascii
                 $filenameFallback
             ),
-            'Content-Length' => $this->filesystem->fileSize($entity->getPath()),
             'Content-Type' => $this->resolveContentType($originalName),
         ];
     }

--- a/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
@@ -173,8 +173,22 @@ class DownloadServiceTest extends TestCase
         $fileRepository = new StaticEntityRepository([new EntityCollection([$fileEntity])]);
 
         $fileSystem = $this->createMock(Filesystem::class);
-        $fileSystem->expects($this->once())->method('temporaryUrl')->willReturn('https://example.com/download');
+        $fileSystem->expects($this->once())->method('temporaryUrl')->with(
+            'export/foobar.txt',
+            static::isInstanceOf(\DateTimeImmutable::class),
+            [
+                'get_object_options' => [
+                    'ResponseContentDisposition' => HeaderUtils::makeDisposition(
+                        HeaderUtils::DISPOSITION_ATTACHMENT,
+                        'products.csv',
+                        'products.csv'
+                    ),
+                    'ResponseContentType' => 'text/csv',
+                ],
+            ]
+        )->willReturn('https://example.com/download');
         $fileSystem->expects($this->never())->method('readStream');
+        $fileSystem->expects($this->never())->method('fileSize');
 
         $downloadService = $this->createDownloadService(
             fileSystem: $fileSystem,


### PR DESCRIPTION
closes #16599

In https://github.com/shopware/shopware/pull/16061 we changed the download of import / export files to use temporary URLs when available (e.g. Amazon S3 as CDN).

With this PR these temporary URLs should also have proper `Content-Disposition` and `Content-Type` headers set, which should fix the issue that these downloads had no proper file name + extension.

File systems that didn't support `temporaryUrl` creation weren't impacted and downloaded as before with these headers set correctly. The issue was only reproduceable in SaaS / Cloud version of Shopware.