### PR TITLE
feat(component): Enforce default override priorities to not conflict with offical modules

### DIFF
--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/index.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/index.js
@@ -16,6 +16,7 @@ module.exports = {
         'replace-top-level-blocks-to-extends': require(path.resolve(__dirname, 'replace-top-level-blocks-to-extends.js')),
         'enforce-async-component-registers': require(path.resolve(__dirname, 'enforce-async-component-registers.js')),
         'no-tc-translation': require(path.resolve(__dirname, 'no-tc-translation.js')),
+        'require-override-priority': require(path.resolve(__dirname, 'require-override-priority.js')),
         /* eslint-enable global-require,import/no-dynamic-require */
     },
 };

--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-override-priority.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-override-priority.js
@@ -1,0 +1,115 @@
+/**
+ * @sw-package framework
+ */
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const utils = require('eslint-plugin-vue/lib/utils');
+
+function getOverrideCalleePrefix(callee) {
+    if (callee.type !== 'MemberExpression' || callee.property.name !== 'override') {
+        return null;
+    }
+
+    const obj = callee.object;
+
+    // Component.override(...)
+    if (obj.type === 'Identifier' && obj.name === 'Component') {
+        return 'Component';
+    }
+
+    // Shopware.Component.override(...)
+    if (
+        obj.type === 'MemberExpression' &&
+        obj.property.name === 'Component' &&
+        obj.object.type === 'Identifier' &&
+        obj.object.name === 'Shopware'
+    ) {
+        return 'Shopware.Component';
+    }
+
+    return null;
+}
+
+module.exports = {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Require an explicit overrideIndex priority on Component.override calls',
+            category: 'Best Practices',
+            recommended: true,
+        },
+        hasSuggestions: true,
+        schema: [],
+        messages: {
+            missingPriority:
+                '{{prefix}}.override() must specify a priority as the third argument. ' +
+                'Use {{prefix}}.CONST.OVERRIDE_PRIORITY.{CORE,STOREFRONT_ADMIN_MODULES,COMMERCIAL,DEFAULT}.',
+            suggestCore: 'Use {{prefix}}.CONST.OVERRIDE_PRIORITY.CORE (Administration bundle override)',
+            suggestStorefront:
+                'Use {{prefix}}.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES (Storefront-bundle admin module override)',
+        },
+    },
+
+    create(context) {
+        const filename = (context.getFilename && context.getFilename()) || '';
+        const isStorefrontAdmin = filename.includes('/Storefront/Resources/app/administration/');
+
+        function checkCallExpression(node) {
+            const prefix = getOverrideCalleePrefix(node.callee);
+            if (!prefix) return;
+            if (node.arguments.length >= 3) return;
+
+            // Only offer auto-fix suggestions when the call has the canonical 2 args
+            // (component name + config). Other arities are reported without fixes.
+            const canSuggest = node.arguments.length === 2;
+            const lastArg = canSuggest ? node.arguments[1] : null;
+
+            const coreSuggestion = {
+                messageId: 'suggestCore',
+                data: { prefix },
+                fix(fixer) {
+                    return fixer.insertTextAfter(
+                        lastArg,
+                        `, ${prefix}.CONST.OVERRIDE_PRIORITY.CORE`,
+                    );
+                },
+            };
+
+            const storefrontSuggestion = {
+                messageId: 'suggestStorefront',
+                data: { prefix },
+                fix(fixer) {
+                    return fixer.insertTextAfter(
+                        lastArg,
+                        `, ${prefix}.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES`,
+                    );
+                },
+            };
+
+            // Surface the suggestion that matches this file's bundle first; the other stays
+            // available so non-canonical layouts can still pick the alternative.
+            const suggest = canSuggest
+                ? isStorefrontAdmin
+                    ? [storefrontSuggestion, coreSuggestion]
+                    : [coreSuggestion, storefrontSuggestion]
+                : [];
+
+            context.report({
+                node,
+                messageId: 'missingPriority',
+                data: { prefix },
+                suggest,
+            });
+        }
+
+        const visitors = {
+            CallExpression: checkCallExpression,
+        };
+
+        if (context.parserServices && context.parserServices.defineTemplateBodyVisitor) {
+            return utils.defineTemplateBodyVisitor(context, visitors, visitors);
+        }
+
+        return visitors;
+    },
+};

--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-override-priority.spec.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-override-priority.spec.js
@@ -1,0 +1,123 @@
+const RuleTester = require('eslint').RuleTester;
+const rule = require('./require-override-priority');
+
+const tester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+    },
+});
+
+tester.run('require-override-priority', rule, {
+    valid: [
+        {
+            name: 'Component.override with explicit priority',
+            code: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.CORE);`,
+        },
+        {
+            name: 'Shopware.Component.override with explicit priority',
+            code: `Shopware.Component.override('foo', {}, Shopware.Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);`,
+        },
+        {
+            name: 'Component.override with numeric priority',
+            code: `Component.override('foo', {}, -100);`,
+        },
+        {
+            name: 'unrelated method call is ignored',
+            code: `this.someMethod('foo', {});`,
+        },
+        {
+            name: 'Component.register is ignored',
+            code: `Component.register('foo', {});`,
+        },
+        {
+            name: 'override called on different object',
+            code: `something.override('foo', {});`,
+        },
+    ],
+    invalid: [
+        {
+            name: 'Component.override without priority',
+            code: `Component.override('foo', {});`,
+            errors: [
+                {
+                    messageId: 'missingPriority',
+                    suggestions: [
+                        {
+                            messageId: 'suggestCore',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.CORE);`,
+                        },
+                        {
+                            messageId: 'suggestStorefront',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Shopware.Component.override without priority',
+            code: `Shopware.Component.override('foo', {});`,
+            errors: [
+                {
+                    messageId: 'missingPriority',
+                    suggestions: [
+                        {
+                            messageId: 'suggestCore',
+                            output: `Shopware.Component.override('foo', {}, Shopware.Component.CONST.OVERRIDE_PRIORITY.CORE);`,
+                        },
+                        {
+                            messageId: 'suggestStorefront',
+                            output: `Shopware.Component.override('foo', {}, Shopware.Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Component.override with single argument',
+            code: `Component.override('foo');`,
+            errors: [{ messageId: 'missingPriority' }],
+        },
+        {
+            name: 'Storefront-admin path surfaces STOREFRONT_ADMIN_MODULES suggestion first',
+            filename: '/repo/src/Storefront/Resources/app/administration/src/extension/foo/index.js',
+            code: `Component.override('foo', {});`,
+            errors: [
+                {
+                    messageId: 'missingPriority',
+                    suggestions: [
+                        {
+                            messageId: 'suggestStorefront',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);`,
+                        },
+                        {
+                            messageId: 'suggestCore',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.CORE);`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'Core-admin path surfaces CORE suggestion first',
+            filename: '/repo/src/Administration/Resources/app/administration/src/module/foo/index.js',
+            code: `Component.override('foo', {});`,
+            errors: [
+                {
+                    messageId: 'missingPriority',
+                    suggestions: [
+                        {
+                            messageId: 'suggestCore',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.CORE);`,
+                        },
+                        {
+                            messageId: 'suggestStorefront',
+                            output: `Component.override('foo', {}, Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);`,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+});

--- a/src/Administration/Resources/app/administration/eslint.config.mjs
+++ b/src/Administration/Resources/app/administration/eslint.config.mjs
@@ -72,6 +72,7 @@ const baseRules = {
     }],
     'sw-core-rules/require-package-annotation': ['error'],
     'sw-core-rules/no-tc-translation': 'error',
+    'sw-core-rules/require-override-priority': 'error',
     'sw-deprecation-rules/private-feature-declarations': 'error',
     'no-restricted-exports': 'off',
     'filename-rules/match': [2, /^.*(?:\.js|\.ts|\.html|\.html\.twig)$/],

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
@@ -37,6 +37,28 @@ import { defineComponent } from 'vue';
 
 const wrapComponentConfig = defineComponent;
 
+
+/**
+ * Public constants for `Component.override` priorities — overrides merge from lowest to highest.
+ *
+ * @public
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export const CONST = {
+    OVERRIDE_PRIORITY: {
+        CORE: -300,
+        STOREFRONT_ADMIN_MODULES: -200,
+        COMMERCIAL: -100,
+        DEFAULT: 0,
+    },
+} as const;
+
+/**
+ * @public
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export type ComponentOverridePriority = (typeof CONST.OVERRIDE_PRIORITY)[keyof typeof CONST.OVERRIDE_PRIORITY];
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     register,
@@ -54,6 +76,7 @@ export default {
     markComponentTemplatesAsNotResolved,
     isSyncComponent,
     markComponentAsSync,
+    CONST,
 };
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/core/shopware.ts
+++ b/src/Administration/Resources/app/administration/src/core/shopware.ts
@@ -141,6 +141,7 @@ class ShopwareClass implements CustomShopwareProperties {
         getOverrideRegistry: AsyncComponentFactory.getOverrideRegistry,
         createExtendableSetup: createExtendableSetup,
         overrideComponentSetup: overrideComponentSetup,
+        CONST: AsyncComponentFactory.CONST,
 
         /**
          * @experimental stableVersion:v6.8.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM

--- a/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/extension/sw-customer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/extension/sw-customer-list/index.js
@@ -51,4 +51,4 @@ Component.override('sw-customer-list', {
             return columns;
         },
     },
-});
+}, Component.CONST.OVERRIDE_PRIORITY.CORE);

--- a/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/extension/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/extension/sw-order-list/index.js
@@ -51,4 +51,4 @@ Component.override('sw-order-list', {
             return columns;
         },
     },
-});
+}, Component.CONST.OVERRIDE_PRIORITY.CORE);

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/extension/sw-admin-menu/index.js
@@ -8,4 +8,4 @@ const { Component } = Shopware;
 Component.override('sw-admin-menu', {
     template,
     inject: ['acl'],
-});
+}, Component.CONST.OVERRIDE_PRIORITY.CORE);

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-admin-menu-extension/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-admin-menu-extension/index.js
@@ -16,4 +16,4 @@ Component.override('sw-admin-menu', {
             return this.acl.can('sales_channel.viewer');
         },
     },
-});
+}, Component.CONST.OVERRIDE_PRIORITY.CORE);

--- a/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/extension/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -44,4 +44,4 @@ Component.override('sw-sales-channel-detail', {
             }
         },
     },
-});
+}, Component.CONST.OVERRIDE_PRIORITY.STOREFRONT_ADMIN_MODULES);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Override priority is not a widely known feature, so by default people could override features and the order can be "random". While this is a known risk among Plugin developers themselves, it also can conflict only with the core. For example `sw-sales-channel-default` will be overridden by the core itself, but its storefront admin-modules.

### 2. What does this change do, exactly?
Add a priority constant to `Shopware.Component`and enforces them to everything to be found in our core itself, so external contributer's can make sure that the Core does not override their plugins by default.

### 3. Describe each step to reproduce the issue or behaviour.
- Create/Take a plugin which overrides `sw-sales-channel-default`
- Do not uninstall the Storefront admin bundle
- Use a build and the admin watcher, you will notice random override orders from time to time

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
