### PR TITLE
fix: footer shopware logo in safari/chrome

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_footer.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_footer.scss
@@ -57,6 +57,16 @@ Contains custom styles for the footer located at the bottom of the page.
     text-align: center;
 }
 
+.footer-copyright {
+    .icon {
+        vertical-align: middle;
+
+        > svg {
+            top: -2px;
+        }
+    }
+}
+
 .footer-service-menu-list {
     padding: $spacer 0;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Before (Chrome):
<img width="965" height="273" alt="image" src="https://github.com/user-attachments/assets/8368548c-64d5-4355-aab5-23be032daa1a" />

Before (Safari):
<img width="941" height="303" alt="image" src="https://github.com/user-attachments/assets/eae8d5b6-9dcb-4abd-9ff7-392efb2fdf35" />

### 2. What does this change do, exactly?

After (Chrome):
<img width="838" height="212" alt="image" src="https://github.com/user-attachments/assets/e45d5d73-d084-4ccf-81cf-8f94f6c1759c" />

After (Safari):
<img width="1366" height="409" alt="image" src="https://github.com/user-attachments/assets/cca057f0-29a5-4d60-b9f8-112134ba595b" />

### 3. Describe each step to reproduce the issue or behavior.

Check the storefront and have a look at the footer SVG icon.

### 4. Please link to the relevant issues (if any).
- closes: #16452

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
