### PR TITLE
fix: preserve malformed property option values

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
@@ -171,7 +171,7 @@ abstract class AbstractFieldSerializer implements FieldSerializerInterface
         }
 
         if (!$field->is(AllowHtml::class)) {
-            return strip_tags((string) $data->getValue());
+            return preg_replace('/<\\/?[[:alpha:]][^>]*>/', '', (string) $data->getValue());
         }
 
         if ($field->getFlag(AllowHtml::class)->isSanitized()) {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/LongTextFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/LongTextFieldTest.php
@@ -99,6 +99,7 @@ class LongTextFieldTest extends TestCase
             'String values are passed through' => ['test12-B', 'test12-B', [new Required()]],
             'Null is allowed without required flag' => [null, null, []],
             'Sanitation can be turned off' => ['<test>', '<test>', [new Required(), new AllowHtml(false)]],
+            'Malformed tags are preserved' => ['<11,5', '<11,5', [new Required()]],
             'Empty string is treated as null without AllowEmpty flag' => ['', null, []],
             'Empty string is passed through with AllowEmptyFlag' => ['', '', [new AllowEmptyString()]],
             'Empty string is allowed with Required and AllowEmpty flags' => ['', '', [new Required(), new AllowEmptyString()]],

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/StringFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/StringFieldTest.php
@@ -81,6 +81,7 @@ class StringFieldTest extends TestCase
             ['assertion', 'test12-B', 'test12-B', [new Required()]],
             ['assertion', null, null, []],
             ['assertion', '<test>', '<test>', [new Required(), new AllowHtml(false)]],
+            ['assertion', '<11,5', '<11,5', [new Required()]],
             ['assertion', '', null, []],
             ['assertion', '', '', [new AllowEmptyString()]],
             ['assertion', '', '', [new Required(), new AllowEmptyString()]],


### PR DESCRIPTION
### 1. Why is this change necessary?

Property option values that begin with malformed markup-like text such as `<11,5` are currently truncated because `strip_tags` treats them as HTML. That breaks valid non-HTML data coming from imports or manual maintenance.

### 2. What does this change do, exactly?

- replace the non-HTML field sanitizer with logic that removes actual tags instead of stripping malformed text fragments
- preserve malformed values like `<11,5` for DAL string-based fields
- add regression coverage for `StringField` and `LongTextField`

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or update a property option with a value like `<11,5`.
2. Persist the entity through the DAL.
3. Observe that the stored value is truncated before this change.

### 4. Please link to the relevant issues (if any).

- fixes #11882

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
