### PR TITLE
fix: respect release dates in delivery availability

### DIFF
--- a/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
@@ -18,8 +18,11 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\DatePoint;
 
 #[Package('checkout')]
 class DeliveryBuilder
@@ -143,7 +146,7 @@ class DeliveryBuilder
 
             // if the line item has a restock time, add this days to the restock date
             if ($restockTime) {
-                $restockDateCandidate = (new \DateTimeImmutable())->add(new \DateInterval('P' . $restockTime . 'D'));
+                $restockDateCandidate = Clock::get()->now()->add(new \DateInterval('P' . $restockTime . 'D'));
 
                 if ($restockDateCandidate > $restockAvailableFrom) {
                     $restockAvailableFrom = $restockDateCandidate;
@@ -172,14 +175,15 @@ class DeliveryBuilder
     private function resolveAvailableFromDate(LineItem $item): \DateTimeImmutable
     {
         $releaseDate = $item->getPayloadValue('releaseDate');
-        $now = new \DateTimeImmutable();
+        $now = Clock::get()->now();
 
         if (!\is_string($releaseDate) || trim($releaseDate) === '') {
             return $now;
         }
 
+        // the release date is stored in the payload using the storage date time format
         try {
-            $releaseDateTime = new \DateTimeImmutable($releaseDate);
+            $releaseDateTime = DatePoint::createFromFormat(Defaults::STORAGE_DATE_TIME_FORMAT, $releaseDate);
         } catch (\Exception) {
             return $now;
         }

--- a/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPosition;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPositionCollection;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryTime;
 use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
@@ -132,18 +133,25 @@ class DeliveryBuilder
                 continue;
             }
 
-            // create the estimated delivery date by detected delivery time
-            $deliveryDate = DeliveryDate::createFromDeliveryTime($deliveryTime);
+            $availableFrom = $this->resolveAvailableFromDate($item);
 
-            // create a restock date based on the detected delivery time
-            $restockDate = DeliveryDate::createFromDeliveryTime($deliveryTime);
+            // create the estimated delivery date by detected delivery time
+            $deliveryDate = DeliveryDate::createFromDeliveryTimeAt($deliveryTime, $availableFrom);
 
             $restockTime = $item->getDeliveryInformation()->getRestockTime();
+            $restockAvailableFrom = $availableFrom;
 
             // if the line item has a restock time, add this days to the restock date
             if ($restockTime) {
-                $restockDate = $restockDate->add(new \DateInterval('P' . $restockTime . 'D'));
+                $restockDateCandidate = (new \DateTimeImmutable())->add(new \DateInterval('P' . $restockTime . 'D'));
+
+                if ($restockDateCandidate > $restockAvailableFrom) {
+                    $restockAvailableFrom = $restockDateCandidate;
+                }
             }
+
+            // create a restock date based on the detected delivery time
+            $restockDate = DeliveryDate::createFromDeliveryTimeAt($deliveryTime, $restockAvailableFrom);
 
             if ($item->getPrice() === null) {
                 continue;
@@ -159,5 +167,27 @@ class DeliveryBuilder
 
             $positions->add($position);
         }
+    }
+
+    private function resolveAvailableFromDate(LineItem $item): \DateTimeImmutable
+    {
+        $releaseDate = $item->getPayloadValue('releaseDate');
+        $now = new \DateTimeImmutable();
+
+        if (!\is_string($releaseDate) || trim($releaseDate) === '') {
+            return $now;
+        }
+
+        try {
+            $releaseDateTime = new \DateTimeImmutable($releaseDate);
+        } catch (\Exception) {
+            return $now;
+        }
+
+        if ($releaseDateTime <= $now) {
+            return $now;
+        }
+
+        return $releaseDateTime;
     }
 }

--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
@@ -7,7 +7,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
-use Symfony\Component\Clock\Clock;
 
 #[Package('checkout')]
 class DeliveryDate extends Struct
@@ -29,26 +28,31 @@ class DeliveryDate extends Struct
 
     public static function createFromDeliveryTime(DeliveryTime $deliveryTime): self
     {
+        return self::createFromDeliveryTimeAt($deliveryTime, new \DateTimeImmutable());
+    }
+
+    public static function createFromDeliveryTimeAt(DeliveryTime $deliveryTime, \DateTimeInterface $base): self
+    {
         return match ($deliveryTime->getUnit()) {
             DeliveryTimeEntity::DELIVERY_TIME_HOUR => new self(
-                self::create('PT' . $deliveryTime->getMin() . 'H'),
-                self::create('PT' . $deliveryTime->getMax() . 'H')
+                self::create('PT' . $deliveryTime->getMin() . 'H', $base),
+                self::create('PT' . $deliveryTime->getMax() . 'H', $base)
             ),
             DeliveryTimeEntity::DELIVERY_TIME_DAY => new self(
-                self::create('P' . $deliveryTime->getMin() . 'D'),
-                self::create('P' . $deliveryTime->getMax() . 'D')
+                self::create('P' . $deliveryTime->getMin() . 'D', $base),
+                self::create('P' . $deliveryTime->getMax() . 'D', $base)
             ),
             DeliveryTimeEntity::DELIVERY_TIME_WEEK => new self(
-                self::create('P' . $deliveryTime->getMin() . 'W'),
-                self::create('P' . $deliveryTime->getMax() . 'W')
+                self::create('P' . $deliveryTime->getMin() . 'W', $base),
+                self::create('P' . $deliveryTime->getMax() . 'W', $base)
             ),
             DeliveryTimeEntity::DELIVERY_TIME_MONTH => new self(
-                self::create('P' . $deliveryTime->getMin() . 'M'),
-                self::create('P' . $deliveryTime->getMax() . 'M')
+                self::create('P' . $deliveryTime->getMin() . 'M', $base),
+                self::create('P' . $deliveryTime->getMax() . 'M', $base)
             ),
             DeliveryTimeEntity::DELIVERY_TIME_YEAR => new self(
-                self::create('P' . $deliveryTime->getMin() . 'Y'),
-                self::create('P' . $deliveryTime->getMax() . 'Y')
+                self::create('P' . $deliveryTime->getMin() . 'Y', $base),
+                self::create('P' . $deliveryTime->getMax() . 'Y', $base)
             ),
             default => throw CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()),
         };
@@ -77,8 +81,8 @@ class DeliveryDate extends Struct
         return 'cart_delivery_date';
     }
 
-    private static function create(string $interval): \DateTime
+    private static function create(string $interval, \DateTimeInterface $base): \DateTimeImmutable
     {
-        return \DateTime::createFromImmutable(Clock::get()->now())->add(new \DateInterval($interval));
+        return (new \DateTimeImmutable($base->format(Defaults::STORAGE_DATE_TIME_FORMAT)))->add(new \DateInterval($interval));
     }
 }

--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
@@ -7,6 +7,8 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\DatePoint;
 
 #[Package('checkout')]
 class DeliveryDate extends Struct
@@ -28,7 +30,7 @@ class DeliveryDate extends Struct
 
     public static function createFromDeliveryTime(DeliveryTime $deliveryTime): self
     {
-        return self::createFromDeliveryTimeAt($deliveryTime, new \DateTimeImmutable());
+        return self::createFromDeliveryTimeAt($deliveryTime, Clock::get()->now());
     }
 
     public static function createFromDeliveryTimeAt(DeliveryTime $deliveryTime, \DateTimeInterface $base): self
@@ -83,6 +85,6 @@ class DeliveryDate extends Struct
 
     private static function create(string $interval, \DateTimeInterface $base): \DateTimeImmutable
     {
-        return (new \DateTimeImmutable($base->format(Defaults::STORAGE_DATE_TIME_FORMAT)))->add(new \DateInterval($interval));
+        return DatePoint::createFromInterface($base)->add(new \DateInterval($interval));
     }
 }

--- a/tests/integration/Core/Checkout/Cart/Delivery/DeliveryBuilderTest.php
+++ b/tests/integration/Core/Checkout/Cart/Delivery/DeliveryBuilderTest.php
@@ -85,6 +85,29 @@ class DeliveryBuilderTest extends TestCase
         );
     }
 
+    public function testBuildDeliveryPositionUsesReleaseDateAsAvailabilityStart(): void
+    {
+        $releaseDate = new \DateTimeImmutable('2030-01-15 10:00:00');
+        $cart = $this->createCartWithReleaseDate($releaseDate);
+        $firstDelivery = $this->getDeliveries($cart)->first();
+        static::assertNotNull($firstDelivery);
+
+        $deliveryPosition = $firstDelivery->getPositions()->get('testid');
+        static::assertNotNull($deliveryPosition);
+
+        $deliveryDate = $deliveryPosition->getDeliveryDate();
+        $expectedDeliveryDate = $releaseDate->add(new \DateInterval('P2M'))->setTime(16, 0);
+
+        static::assertSame(
+            $expectedDeliveryDate->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $deliveryDate->getEarliest()->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
+        static::assertSame(
+            $expectedDeliveryDate->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $deliveryDate->getLatest()->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
+    }
+
     private function getDeliveries(Cart $cart): DeliveryCollection
     {
         $data = new CartDataCollection();
@@ -104,6 +127,17 @@ class DeliveryBuilderTest extends TestCase
 
         $lineItems = $this->createLineItems();
         $cart->addLineItems($lineItems);
+
+        return $cart;
+    }
+
+    private function createCartWithReleaseDate(\DateTimeImmutable $releaseDate): Cart
+    {
+        $cart = new Cart('test');
+        $lineItem = $this->createLineItem();
+        $lineItem->setPayloadValue('releaseDate', $releaseDate->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+
+        $cart->add($lineItem);
 
         return $cart;
     }

--- a/tests/unit/Core/Checkout/Cart/Delivery/DeliveryBuilderTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/DeliveryBuilderTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
@@ -206,6 +207,47 @@ class DeliveryBuilderTest extends TestCase
             DeliveryDate::createFromDeliveryTime(self::createDeliveryTime(4, 5)),
         ];
 
+        $releaseDate = new \DateTimeImmutable('2030-01-15 10:00:00');
+
+        yield 'It uses future release date as availability start if line item is in stock' => [
+            new LineItemCollection([
+                (new LineItem('line-item-id', LineItem::CUSTOM_LINE_ITEM_TYPE, null, 1))
+                    ->assign([
+                        'deliveryInformation' => self::createDeliveryInformation(self::createDeliveryTime(2, 3), 0),
+                        'payload' => ['releaseDate' => $releaseDate->format(Defaults::STORAGE_DATE_TIME_FORMAT)],
+                        'price' => new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        'shippingCostAware' => true,
+                    ]),
+            ]),
+            DeliveryDate::createFromDeliveryTimeAt(self::createDeliveryTime(2, 3), $releaseDate),
+        ];
+
+        yield 'It ignores invalid release date if line item is in stock' => [
+            new LineItemCollection([
+                (new LineItem('line-item-id', LineItem::CUSTOM_LINE_ITEM_TYPE, null, 1))
+                    ->assign([
+                        'deliveryInformation' => self::createDeliveryInformation(self::createDeliveryTime(2, 3), 0),
+                        'payload' => ['releaseDate' => '$invalid'],
+                        'price' => new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        'shippingCostAware' => true,
+                    ]),
+            ]),
+            DeliveryDate::createFromDeliveryTime(self::createDeliveryTime(2, 3)),
+        ];
+
+        yield 'It ignores past release date if line item is in stock' => [
+            new LineItemCollection([
+                (new LineItem('line-item-id', LineItem::CUSTOM_LINE_ITEM_TYPE, null, 1))
+                    ->assign([
+                        'deliveryInformation' => self::createDeliveryInformation(self::createDeliveryTime(2, 3), 0),
+                        'payload' => ['releaseDate' => '2020-01-15 10:00:00.000'],
+                        'price' => new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        'shippingCostAware' => true,
+                    ]),
+            ]),
+            DeliveryDate::createFromDeliveryTime(self::createDeliveryTime(2, 3)),
+        ];
+
         yield 'It adds restock time to Delivery Time if item is out of stock' => [
             new LineItemCollection([
                 (new LineItem('line-item-id', LineItem::CUSTOM_LINE_ITEM_TYPE, null, 20))
@@ -216,6 +258,19 @@ class DeliveryBuilderTest extends TestCase
                     ]),
             ]),
             DeliveryDate::createFromDeliveryTime(self::createDeliveryTime(6, 7)),
+        ];
+
+        yield 'It uses later restock availability if release date is before restock date' => [
+            new LineItemCollection([
+                (new LineItem('line-item-id', LineItem::CUSTOM_LINE_ITEM_TYPE, null, 20))
+                    ->assign([
+                        'deliveryInformation' => self::createDeliveryInformation(self::createDeliveryTime(2, 3), 10),
+                        'payload' => ['releaseDate' => (new \DateTimeImmutable('+1 day'))->format(Defaults::STORAGE_DATE_TIME_FORMAT)],
+                        'price' => new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        'shippingCostAware' => true,
+                    ]),
+            ]),
+            DeliveryDate::createFromDeliveryTime(self::createDeliveryTime(12, 13)),
         ];
 
         yield 'It takes delivery time of nested line item if parent has none' => [

--- a/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
@@ -3,11 +3,14 @@
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Delivery\Struct;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryTime;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 
 /**
  * @internal
@@ -16,6 +19,23 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(DeliveryDate::class)]
 class DeliveryDateTest extends TestCase
 {
+    #[DataProvider('deliveryTimeProvider')]
+    public function testCreateFromDeliveryTimeAtUsesProvidedBaseDate(
+        string $unit,
+        int $min,
+        int $max,
+        string $expectedEarliest,
+        string $expectedLatest
+    ): void {
+        $deliveryDate = DeliveryDate::createFromDeliveryTimeAt(
+            self::createDeliveryTime($unit, $min, $max),
+            new \DateTimeImmutable('2030-01-15 10:00:00')
+        );
+
+        static::assertSame($expectedEarliest, $deliveryDate->getEarliest()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+        static::assertSame($expectedLatest, $deliveryDate->getLatest()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
+    }
+
     public function testCreateFromDeliveryTimeThrowsExceptionWhenUnsupportedUnit(): void
     {
         $deliveryTime = new DeliveryTime();
@@ -24,5 +44,27 @@ class DeliveryDateTest extends TestCase
         static::expectExceptionObject(CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()));
 
         DeliveryDate::createFromDeliveryTime($deliveryTime);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: int, 2: int, 3: string, 4: string}>
+     */
+    public static function deliveryTimeProvider(): iterable
+    {
+        yield 'hours' => [DeliveryTimeEntity::DELIVERY_TIME_HOUR, 1, 2, '2030-01-15 16:00:00.000', '2030-01-15 16:00:00.000'];
+        yield 'days' => [DeliveryTimeEntity::DELIVERY_TIME_DAY, 2, 3, '2030-01-17 16:00:00.000', '2030-01-18 16:00:00.000'];
+        yield 'weeks' => [DeliveryTimeEntity::DELIVERY_TIME_WEEK, 1, 2, '2030-01-22 16:00:00.000', '2030-01-29 16:00:00.000'];
+        yield 'months' => [DeliveryTimeEntity::DELIVERY_TIME_MONTH, 2, 3, '2030-03-15 16:00:00.000', '2030-04-15 16:00:00.000'];
+        yield 'years' => [DeliveryTimeEntity::DELIVERY_TIME_YEAR, 1, 2, '2031-01-15 16:00:00.000', '2032-01-15 16:00:00.000'];
+    }
+
+    private static function createDeliveryTime(string $unit, int $min, int $max): DeliveryTime
+    {
+        $deliveryTime = new DeliveryTime();
+        $deliveryTime->setUnit($unit);
+        $deliveryTime->setMin($min);
+        $deliveryTime->setMax($max);
+
+        return $deliveryTime;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Delivery date calculation currently ignores a product release date and uses the current time as the availability baseline. That results in delivery and restock dates that are too early for products that are not yet released.

### 2. What does this change do, exactly?

- resolve the availability baseline from the line item `releaseDate` when it is in the future
- build both delivery and restock dates from that effective availability date
- keep the current behavior for already available products and invalid release dates
- add regression coverage for release-date-driven delivery calculation

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product with a future `releaseDate` and a delivery time.
2. Add the product to a cart and trigger delivery calculation.
3. Observe that the computed delivery date ignores the release date before this change.

### 4. Please link to the relevant issues (if any).

- fixes #12921

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
