### PR TITLE
fix: write product exports atomically

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
@@ -7,6 +7,7 @@ use League\Flysystem\UnableToDeleteFile;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Struct\ExportBehavior;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 
 #[Package('inventory')]
 class ProductExportFileHandler implements ProductExportFileHandlerInterface
@@ -37,19 +38,24 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     public function writeProductExportContent(string $content, string $filePath, bool $append = false): bool
     {
-        if ($this->fileSystem->fileExists($filePath) && !$append) {
-            $this->fileSystem->delete($filePath);
-        }
-
         $existingContent = '';
         if ($append && $this->fileSystem->fileExists($filePath)) {
             $existingContent = $this->fileSystem->read($filePath);
         }
 
+        $targetPath = $filePath;
+        if (!$append) {
+            $targetPath = $filePath . '.' . Uuid::randomHex() . '.tmp';
+        }
+
         $this->fileSystem->write(
-            $filePath,
+            $targetPath,
             $existingContent . $content
         );
+
+        if (!$append) {
+            $this->fileSystem->move($targetPath, $filePath);
+        }
 
         return true;
     }
@@ -65,10 +71,6 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     public function finalizePartialProductExport(string $partialFilePath, string $finalFilePath, string $headerContent, string $footerContent): bool
     {
-        if ($this->fileSystem->fileExists($partialFilePath) && $this->fileSystem->fileExists($finalFilePath)) {
-            $this->fileSystem->delete($finalFilePath);
-        }
-
         $content = $this->fileSystem->read($partialFilePath);
 
         try {
@@ -77,12 +79,10 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
             return false;
         }
 
-        $this->fileSystem->write(
-            $finalFilePath,
-            $headerContent . $content . $footerContent
+        return $this->writeProductExportContent(
+            $headerContent . $content . $footerContent,
+            $finalFilePath
         );
-
-        return true;
     }
 
     private function isCacheExpired(ExportBehavior $behavior, ProductExportEntity $productExport): bool

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportFileHandlerTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportFileHandlerTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ProductExport\Service;
+
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ProductExport\Service\ProductExportFileHandler;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductExportFileHandler::class)]
+class ProductExportFileHandlerTest extends TestCase
+{
+    public function testWriteProductExportContentReplacesFilesViaTemporaryPath(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $temporaryPath = null;
+
+        $filesystem->expects($this->once())
+            ->method('write')
+            ->with(
+                static::callback(static function (string $path) use (&$temporaryPath): bool {
+                    $temporaryPath = $path;
+
+                    return str_starts_with($path, 'export/feed.csv.')
+                        && str_ends_with($path, '.tmp');
+                }),
+                'new-content'
+            );
+        $filesystem->expects($this->once())
+            ->method('move')
+            ->with(
+                static::callback(static function (string $path) use (&$temporaryPath): bool {
+                    return $path === $temporaryPath;
+                }),
+                'export/feed.csv',
+                []
+            );
+        $filesystem->expects($this->never())->method('delete');
+
+        $handler = new ProductExportFileHandler($filesystem, 'export');
+
+        static::assertTrue($handler->writeProductExportContent('new-content', 'export/feed.csv'));
+    }
+
+    public function testWriteProductExportContentAppendsExistingContent(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $filesystem->expects($this->once())
+            ->method('fileExists')
+            ->with('export/feed.csv.partial')
+            ->willReturn(true);
+        $filesystem->expects($this->once())
+            ->method('read')
+            ->with('export/feed.csv.partial')
+            ->willReturn('existing-');
+        $filesystem->expects($this->once())
+            ->method('write')
+            ->with('export/feed.csv.partial', 'existing-next');
+        $filesystem->expects($this->never())->method('move');
+
+        $handler = new ProductExportFileHandler($filesystem, 'export');
+
+        static::assertTrue($handler->writeProductExportContent('next', 'export/feed.csv.partial', true));
+    }
+
+    public function testFinalizePartialProductExportReplacesFilesViaTemporaryPath(): void
+    {
+        $filesystem = $this->createMock(FilesystemOperator::class);
+        $temporaryPath = null;
+
+        $filesystem->expects($this->once())
+            ->method('read')
+            ->with('export/feed.csv.partial')
+            ->willReturn('body-content');
+        $filesystem->expects($this->once())
+            ->method('write')
+            ->with(
+                static::callback(static function (string $path) use (&$temporaryPath): bool {
+                    $temporaryPath = $path;
+
+                    return str_starts_with($path, 'export/feed.csv.')
+                        && str_ends_with($path, '.tmp');
+                }),
+                '<header>body-content<footer>'
+            );
+        $filesystem->expects($this->once())
+            ->method('delete')
+            ->with('export/feed.csv.partial');
+        $filesystem->expects($this->once())
+            ->method('move')
+            ->with(
+                static::callback(static function (string $path) use (&$temporaryPath): bool {
+                    return $path === $temporaryPath;
+                }),
+                'export/feed.csv',
+                []
+            );
+
+        $handler = new ProductExportFileHandler($filesystem, 'export');
+
+        static::assertTrue($handler->finalizePartialProductExport(
+            'export/feed.csv.partial',
+            'export/feed.csv',
+            '<header>',
+            '<footer>'
+        ));
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Accessing a product feed while it is still being generated can trigger a second live generation. The write path exposes a timing window where the target file is not yet safely in place.

### 2. What does this change do, exactly?

- write generated export content to a temporary file first
- move the temporary file into place atomically once generation is complete
- reduce the window in which concurrent requests can trigger a second live generation
- add regression coverage for the product export file handler path

### 3. Describe each step to reproduce the issue or behaviour.

1. Trigger generation of a product feed.
2. Access the same feed again before the first generation has fully written its output.
3. Observe that a second live generation can start before this change.

### 4. Please link to the relevant issues (if any).

- relates #15099

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
