### PR TITLE
fix: keep variant surcharges on inherited advanced prices

### DIFF
--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -285,6 +285,7 @@
             <argument type="service" id="unit.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="kernel.reset" method="reset"/>
         </service>

--- a/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
+++ b/src/Core/Content/Product/SalesChannel/Price/ProductPriceCalculator.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Price;
 
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceCollection as CalculatedPriceCollection;
@@ -22,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Unit\UnitCollection;
 
@@ -39,6 +42,7 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
         private readonly EntityRepository $unitRepository,
         private readonly QuantityPriceCalculator $calculator,
         private readonly ExtensionDispatcher $extensions,
+        private readonly Connection $connection,
     ) {
     }
 
@@ -70,11 +74,13 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
      */
     private function _calculate(iterable $products, SalesChannelContext $context): void
     {
+        $products = \is_array($products) ? $products : iterator_to_array($products, false);
         $units = $this->getUnits($context);
+        $inheritedAdvancedPriceBases = $this->loadInheritedAdvancedPriceBases($products, $context);
 
         foreach ($products as $product) {
             $this->calculatePrice($product, $context, $units);
-            $this->calculateAdvancePrices($product, $context, $units);
+            $this->calculateAdvancePrices($product, $context, $units, $inheritedAdvancedPriceBases);
             $this->calculateCheapestPrice($product, $context, $units);
         }
     }
@@ -98,7 +104,10 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
         ]);
     }
 
-    private function calculateAdvancePrices(Entity $product, SalesChannelContext $context, UnitCollection $units): void
+    /**
+     * @param array<string, PriceCollection> $inheritedAdvancedPriceBases
+     */
+    private function calculateAdvancePrices(Entity $product, SalesChannelContext $context, UnitCollection $units, array $inheritedAdvancedPriceBases): void
     {
         $prices = $product->get('prices');
 
@@ -131,7 +140,14 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
 
             $quantity = \is_int($quantityEnd) ? $quantityEnd : $quantityStart;
 
-            $definition = $this->buildDefinition($product, $priceObj, $context, $units, $reference, $quantity);
+            $definition = $this->buildDefinition(
+                $product,
+                $this->resolveInheritedAdvancedPrice($product, $price, $priceObj, $inheritedAdvancedPriceBases, $context),
+                $context,
+                $units,
+                $reference,
+                $quantity
+            );
 
             $calculated->add($this->calculator->calculate($definition, $context));
         }
@@ -271,6 +287,209 @@ class ProductPriceCalculator extends AbstractProductPriceCalculator
         }
 
         return $value;
+    }
+
+    /**
+     * @param array<Entity> $products
+     *
+     * @return array<string, PriceCollection>
+     */
+    private function loadInheritedAdvancedPriceBases(array $products, SalesChannelContext $context): array
+    {
+        $ownerIds = [];
+
+        foreach ($products as $product) {
+            $prices = $product->get('prices');
+
+            if (!$prices instanceof EntityCollection) {
+                continue;
+            }
+
+            $productId = $product->getUniqueIdentifier();
+
+            foreach ($prices as $price) {
+                $ownerId = $price->getVars()['productId'] ?? null;
+
+                if (!\is_string($ownerId) || $ownerId === $productId) {
+                    continue;
+                }
+
+                $ownerIds[$ownerId] = true;
+            }
+        }
+
+        if ($ownerIds === []) {
+            return [];
+        }
+
+        $rows = $this->connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(id)) as id, price
+             FROM product
+             WHERE id IN (:ids)
+             AND version_id = :version',
+            [
+                'ids' => Uuid::fromHexToBytesList(array_keys($ownerIds)),
+                'version' => Uuid::fromHexToBytes($context->getContext()->getVersionId()),
+            ],
+            [
+                'ids' => ArrayParameterType::BINARY,
+            ]
+        );
+
+        $basePrices = [];
+        foreach ($rows as $ownerId => $price) {
+            if (!\is_string($ownerId) || !\is_string($price)) {
+                continue;
+            }
+
+            $basePrices[$ownerId] = $this->decodePriceCollection($price);
+        }
+
+        return $basePrices;
+    }
+
+    /**
+     * @param array<string, PriceCollection> $inheritedAdvancedPriceBases
+     */
+    private function resolveInheritedAdvancedPrice(Entity $product, Entity $advancedPrice, PriceCollection $price, array $inheritedAdvancedPriceBases, SalesChannelContext $context): PriceCollection
+    {
+        $ownerId = $advancedPrice->getVars()['productId'] ?? null;
+        if (!\is_string($ownerId) || $ownerId === $product->getUniqueIdentifier()) {
+            return $price;
+        }
+
+        $productPrice = $product->get('price');
+        $ownerBasePrice = $inheritedAdvancedPriceBases[$ownerId] ?? null;
+
+        if (!$productPrice instanceof PriceCollection || !$ownerBasePrice instanceof PriceCollection) {
+            return $price;
+        }
+
+        return $this->applyPriceDelta($price, $productPrice, $ownerBasePrice, $context);
+    }
+
+    private function applyPriceDelta(PriceCollection $advancedPrice, PriceCollection $productPrice, PriceCollection $ownerBasePrice, SalesChannelContext $context): PriceCollection
+    {
+        $adjusted = [];
+        $hasDelta = false;
+
+        foreach ($advancedPrice as $price) {
+            $delta = $this->resolvePriceDelta($price->getCurrencyId(), $productPrice, $ownerBasePrice, $context);
+
+            if ($delta === null) {
+                $adjusted[] = $this->clonePrice($price);
+
+                continue;
+            }
+
+            if ($delta->getNet() !== 0.0 || $delta->getGross() !== 0.0) {
+                $hasDelta = true;
+            }
+
+            $adjusted[] = $this->clonePrice($price, $delta);
+        }
+
+        if (!$hasDelta) {
+            return $advancedPrice;
+        }
+
+        return new PriceCollection($adjusted);
+    }
+
+    private function resolvePriceDelta(string $currencyId, PriceCollection $productPrice, PriceCollection $ownerBasePrice, SalesChannelContext $context): ?Price
+    {
+        $productCurrencyPrice = $productPrice->getCurrencyPrice($currencyId);
+        $ownerCurrencyPrice = $ownerBasePrice->getCurrencyPrice($currencyId);
+
+        if (!$productCurrencyPrice instanceof Price || !$ownerCurrencyPrice instanceof Price) {
+            return null;
+        }
+
+        $productValues = $this->convertPriceValues($productCurrencyPrice, $currencyId, $context);
+        $ownerValues = $this->convertPriceValues($ownerCurrencyPrice, $currencyId, $context);
+
+        if ($productValues === null || $ownerValues === null) {
+            return null;
+        }
+
+        return new Price(
+            $currencyId,
+            $productValues['net'] - $ownerValues['net'],
+            $productValues['gross'] - $ownerValues['gross'],
+            $productCurrencyPrice->getLinked()
+        );
+    }
+
+    /**
+     * @return array{net: float, gross: float}|null
+     */
+    private function convertPriceValues(Price $price, string $currencyId, SalesChannelContext $context): ?array
+    {
+        if ($price->getCurrencyId() === $currencyId) {
+            return [
+                'net' => $price->getNet(),
+                'gross' => $price->getGross(),
+            ];
+        }
+
+        if ($currencyId !== $context->getCurrencyId()) {
+            return null;
+        }
+
+        $factor = $context->getContext()->getCurrencyFactor();
+
+        return [
+            'net' => $price->getNet() * $factor,
+            'gross' => $price->getGross() * $factor,
+        ];
+    }
+
+    private function decodePriceCollection(string $value): PriceCollection
+    {
+        $decoded = json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+
+        $prices = [];
+        foreach ($decoded as $price) {
+            if (!\is_array($price)) {
+                continue;
+            }
+
+            $prices[] = $this->decodePrice($price);
+        }
+
+        return new PriceCollection($prices);
+    }
+
+    /**
+     * @param array<string, mixed> $price
+     */
+    private function decodePrice(array $price, ?string $currencyId = null, ?bool $linked = null): Price
+    {
+        $currencyId ??= (string) $price['currencyId'];
+        $linked ??= (bool) ($price['linked'] ?? false);
+
+        return new Price(
+            $currencyId,
+            (float) $price['net'],
+            (float) $price['gross'],
+            $linked,
+            isset($price['listPrice']) && \is_array($price['listPrice']) ? $this->decodePrice($price['listPrice'], $currencyId, $linked) : null,
+            isset($price['percentage']) && \is_array($price['percentage']) ? $price['percentage'] : null,
+            isset($price['regulationPrice']) && \is_array($price['regulationPrice']) ? $this->decodePrice($price['regulationPrice'], $currencyId, $linked) : null
+        );
+    }
+
+    private function clonePrice(Price $price, ?Price $delta = null): Price
+    {
+        return new Price(
+            $price->getCurrencyId(),
+            $price->getNet() + ($delta?->getNet() ?? 0.0),
+            $price->getGross() + ($delta?->getGross() ?? 0.0),
+            $price->getLinked(),
+            $price->getListPrice() ? $this->clonePrice($price->getListPrice(), $delta) : null,
+            $price->getPercentage(),
+            $price->getRegulationPrice() ? $this->clonePrice($price->getRegulationPrice(), $delta) : null
+        );
     }
 
     private function buildReferencePriceDefinition(ReferencePriceDto $definition, UnitCollection $units): ?ReferencePriceDefinition

--- a/src/Core/Content/Product/SalesChannel/SalesChannelProductDefinition.php
+++ b/src/Core/Content/Product/SalesChannel/SalesChannelProductDefinition.php
@@ -82,7 +82,7 @@ class SalesChannelProductDefinition extends ProductDefinition implements SalesCh
             (new JsonField('calculated_price', 'calculatedPrice'))->addFlags(new ApiAware(), new Runtime(\array_merge(self::PRICE_BASELINE, ['price', 'prices'])))
         );
         $fields->add(
-            (new ListField('calculated_prices', 'calculatedPrices'))->addFlags(new ApiAware(), new Runtime(\array_merge(self::PRICE_BASELINE, ['prices'])))
+            (new ListField('calculated_prices', 'calculatedPrices'))->addFlags(new ApiAware(), new Runtime(\array_merge(self::PRICE_BASELINE, ['price', 'prices'])))
         );
         $fields->add(
             (new IntField('calculated_max_purchase', 'calculatedMaxPurchase'))->addFlags(new ApiAware(), new Runtime(['maxPurchase']))

--- a/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Price/ProductPriceCalculatorTest.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Price;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Price\CashRounding;
 use Shopware\Core\Checkout\Cart\Price\GrossPriceCalculator;
@@ -22,6 +24,7 @@ use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPri
 use Shopware\Core\Content\Product\Extension\ProductPriceCalculationExtension;
 use Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceCalculator;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
@@ -48,11 +51,14 @@ class ProductPriceCalculatorTest extends TestCase
 {
     private ProductPriceCalculator $calculator;
 
+    private Connection&MockObject $connection;
+
     private EventDispatcher $eventDispatcher;
 
     protected function setUp(): void
     {
         $this->eventDispatcher = new EventDispatcher();
+        $this->connection = $this->createMock(Connection::class);
 
         /** @var StaticEntityRepository<UnitCollection> $unitRepository */
         $unitRepository = new StaticEntityRepository([
@@ -67,6 +73,7 @@ class ProductPriceCalculatorTest extends TestCase
                 new NetPriceCalculator(new TaxCalculator(), new CashRounding())
             ),
             new ExtensionDispatcher($this->eventDispatcher),
+            $this->connection,
         );
     }
 
@@ -174,7 +181,8 @@ class ProductPriceCalculatorTest extends TestCase
                 new GrossPriceCalculator(new TaxCalculator(), new CashRounding()),
                 new NetPriceCalculator(new TaxCalculator(), new CashRounding())
             ),
-            new ExtensionDispatcher($this->eventDispatcher)
+            new ExtensionDispatcher($this->eventDispatcher),
+            $this->createMock(Connection::class)
         ))->getDecorated();
     }
 
@@ -365,6 +373,126 @@ class ProductPriceCalculatorTest extends TestCase
             ]),
             [1.0],
         ];
+    }
+
+    public function testInheritedAdvancedPricesKeepVariantSurcharge(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+
+        $this->connection->expects($this->once())
+            ->method('fetchAllKeyValue')
+            ->willReturn([
+                $parentId => json_encode([
+                    [
+                        'currencyId' => Defaults::CURRENCY,
+                        'gross' => 100.0,
+                        'net' => 100.0,
+                        'linked' => false,
+                    ],
+                ], \JSON_THROW_ON_ERROR),
+            ]);
+
+        $product = (new PartialEntity())->assign([
+            'id' => $variantId,
+            '_uniqueIdentifier' => $variantId,
+            'parentId' => $parentId,
+            'taxId' => Uuid::randomHex(),
+            'price' => new PriceCollection([
+                new Price(Defaults::CURRENCY, 110.0, 110.0, false),
+            ]),
+            'prices' => new ProductPriceCollection([
+                (new ProductPriceEntity())->assign([
+                    'id' => Uuid::randomHex(),
+                    '_uniqueIdentifier' => Uuid::randomHex(),
+                    'productId' => $parentId,
+                    'ruleId' => Defaults::CURRENCY,
+                    'price' => new PriceCollection([
+                        new Price(Defaults::CURRENCY, 80.0, 80.0, false),
+                    ]),
+                    'quantityStart' => 1,
+                    'quantityEnd' => null,
+                ]),
+            ]),
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCurrencyId')->willReturn(Defaults::CURRENCY);
+        $context->method('getContext')->willReturn(Context::createDefaultContext());
+        $context->method('getRuleIds')->willReturn([Defaults::CURRENCY]);
+        $context->method('buildTaxRules')->willReturn(new TaxRuleCollection([new TaxRule(0)]));
+
+        $this->calculator->calculate([$product], $context);
+
+        $prices = $product->get('calculatedPrices');
+
+        static::assertInstanceOf(CalculatedPriceCollection::class, $prices);
+        static::assertCount(1, $prices);
+        static::assertSame(90.0, $prices->first()?->getTotalPrice());
+    }
+
+    public function testInheritedAdvancedPricesKeepVariantSurchargeWithCurrencyFallback(): void
+    {
+        $parentId = Uuid::randomHex();
+        $variantId = Uuid::randomHex();
+        $currencyId = Uuid::randomHex();
+
+        $this->connection->expects($this->once())
+            ->method('fetchAllKeyValue')
+            ->willReturn([
+                $parentId => json_encode([
+                    [
+                        'currencyId' => Defaults::CURRENCY,
+                        'gross' => 100.0,
+                        'net' => 100.0,
+                        'linked' => false,
+                    ],
+                ], \JSON_THROW_ON_ERROR),
+            ]);
+
+        $product = (new PartialEntity())->assign([
+            'id' => $variantId,
+            '_uniqueIdentifier' => $variantId,
+            'parentId' => $parentId,
+            'taxId' => Uuid::randomHex(),
+            'price' => new PriceCollection([
+                new Price(Defaults::CURRENCY, 110.0, 110.0, false),
+            ]),
+            'prices' => new ProductPriceCollection([
+                (new ProductPriceEntity())->assign([
+                    'id' => Uuid::randomHex(),
+                    '_uniqueIdentifier' => Uuid::randomHex(),
+                    'productId' => $parentId,
+                    'ruleId' => Defaults::CURRENCY,
+                    'price' => new PriceCollection([
+                        new Price($currencyId, 160.0, 160.0, false),
+                    ]),
+                    'quantityStart' => 1,
+                    'quantityEnd' => null,
+                ]),
+            ]),
+        ]);
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCurrencyId')->willReturn($currencyId);
+        $context->method('getContext')->willReturn(new Context(
+            new SystemSource(),
+            [],
+            $currencyId,
+            [Defaults::LANGUAGE_SYSTEM],
+            Defaults::LIVE_VERSION,
+            2.0
+        ));
+        $context->method('getRuleIds')->willReturn([Defaults::CURRENCY]);
+        $context->method('buildTaxRules')->willReturn(new TaxRuleCollection([new TaxRule(0)]));
+
+        $this->calculator->calculate([$product], $context);
+
+        $prices = $product->get('calculatedPrices');
+
+        static::assertInstanceOf(CalculatedPriceCollection::class, $prices);
+        static::assertCount(1, $prices);
+        static::assertSame(180.0, $prices->first()?->getTotalPrice());
     }
 
     #[DataProvider('cheapestPriceWillBeCalculatedProvider')]


### PR DESCRIPTION
### 1. Why is this change necessary?

When a variant inherits advanced prices from its parent, the sales-channel price calculation currently applies the inherited advanced price directly and drops the variant surcharge. That produces a final variant price that is lower than the configured storefront price logic.

### 2. What does this change do, exactly?

- detect inherited advanced-price rows during sales-channel price calculation
- load the parent base prices needed to determine the variant delta
- re-apply the variant surcharge delta on top of the inherited advanced price
- add focused regression coverage for the inherited advanced-price path

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a parent product with advanced prices.
2. Create a variant that inherits pricing from the parent and adds a surcharge.
3. Load the variant price in the sales channel.
4. Observe that the advanced price overwrites the variant surcharge before this change.

### 4. Please link to the relevant issues (if any).

- relates #16014

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
