### PR TITLE
fix: prioritize property positions in alpha sorting

### DIFF
--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -53,22 +53,27 @@ class PropertyGroupCollection extends EntityCollection
                 continue;
             }
 
-            $columns = [];
+            $positions = [];
+            $names = [];
             $entities = [];
 
             $sortingType = $group->getSortingType();
 
             foreach ($options->getIterator() as $option) {
-                if ($sortingType === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
-                    $columns[] = (string) ($option->getTranslation('name') ?? '');
-                } else {
-                    $columns[] = (int) ($option->getTranslation('position') ?? $option->getPosition() ?? 0);
+                $names[] = (string) ($option->getTranslation('name') ?? '');
+
+                if ($sortingType !== PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
+                    $positions[] = (int) ($option->getTranslation('position') ?? $option->getPosition() ?? 0);
                 }
 
                 $entities[] = $option;
             }
 
-            array_multisort($columns, \SORT_ASC, \SORT_NATURAL, $entities);
+            if ($sortingType === PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC) {
+                array_multisort($names, \SORT_ASC, \SORT_NATURAL, $entities);
+            } else {
+                array_multisort($positions, \SORT_ASC, \SORT_NUMERIC, $names, \SORT_ASC, \SORT_NATURAL, $entities);
+            }
 
             $sortedOptions = new PropertyGroupOptionCollection();
             // Bypass expected class validation for performance optimization

--- a/tests/unit/Core/Content/Property/PropertySortTest.php
+++ b/tests/unit/Core/Content/Property/PropertySortTest.php
@@ -129,6 +129,24 @@ class PropertySortTest extends TestCase
         );
     }
 
+    public function testPositionSortingUsesNamesAsTieBreaker(): void
+    {
+        $propertyGroups = $this->getPropertyGroupPositionWithSamePositions();
+        $propertyGroups->sortByConfig();
+        $propertyGroup = $propertyGroups->first();
+        static::assertNotNull($propertyGroup);
+        $propertyOptionsArray = json_decode(json_encode($propertyGroup->getOptions(), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(
+            ['Alpha', 'Beta', 'Gamma'],
+            array_column($propertyOptionsArray, 'name')
+        );
+        static::assertSame(
+            [1, 1, 1],
+            array_column($propertyOptionsArray, 'position')
+        );
+    }
+
     private function getPropertyGroupAlphaNumericOnlyNumbers(): PropertyGroupCollection
     {
         $propertyGroup = new PropertyGroupEntity();
@@ -190,6 +208,53 @@ class PropertySortTest extends TestCase
         $propertyGroup->setDisplayType(PropertyGroupDefinition::DISPLAY_TYPE_TEXT);
         $propertyGroup->setPosition(1);
         $propertyGroup->setOptions($this->getPropertyOptionsMixed());
+
+        return new PropertyGroupCollection([$propertyGroup]);
+    }
+
+    private function getPropertyGroupPositionWithSamePositions(): PropertyGroupCollection
+    {
+        $propertyGroup = new PropertyGroupEntity();
+        $propertyGroup->setId(Uuid::randomHex());
+        $propertyGroup->setName('Position with same positions');
+        $propertyGroup->setSortingType(PropertyGroupDefinition::SORTING_TYPE_POSITION);
+        $propertyGroup->setDisplayType(PropertyGroupDefinition::DISPLAY_TYPE_TEXT);
+        $propertyGroup->setPosition(1);
+
+        $optionA = new PropertyGroupOptionEntity();
+        $optionA->setId(Uuid::randomHex());
+        $optionA->setName('Gamma');
+        $optionA->setPosition(1);
+        $optionA->setTranslated([
+            'name' => 'Gamma',
+            'description' => '',
+            'position' => 1,
+            'customFields' => [],
+        ]);
+
+        $optionB = new PropertyGroupOptionEntity();
+        $optionB->setId(Uuid::randomHex());
+        $optionB->setName('Alpha');
+        $optionB->setPosition(1);
+        $optionB->setTranslated([
+            'name' => 'Alpha',
+            'description' => '',
+            'position' => 1,
+            'customFields' => [],
+        ]);
+
+        $optionC = new PropertyGroupOptionEntity();
+        $optionC->setId(Uuid::randomHex());
+        $optionC->setName('Beta');
+        $optionC->setPosition(1);
+        $optionC->setTranslated([
+            'name' => 'Beta',
+            'description' => '',
+            'position' => 1,
+            'customFields' => [],
+        ]);
+
+        $propertyGroup->setOptions(new PropertyGroupOptionCollection([$optionA, $optionB, $optionC]));
 
         return new PropertyGroupCollection([$propertyGroup]);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Property sorting with alphanumeric configuration currently lets names override explicitly configured option positions. That breaks administrator-defined ordering whenever the names do not match the intended position order.

### 2. What does this change do, exactly?

- treat configured property option positions as the primary sort criterion
- keep alphanumeric sorting only as a tie-breaker for equal positions
- add regression coverage for the configured-position path

### 3. Describe each step to reproduce the issue or behaviour.

1. Create property options with positions that do not match alphabetical order.
2. Use the alphanumeric property sorting configuration.
3. Observe that the resulting order follows names instead of positions before this change.

### 4. Please link to the relevant issues (if any).

- relates #16318

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
