### PR TITLE
fix: use parent custom field values in grouped sorting

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
@@ -140,6 +140,36 @@ class CriteriaQueryBuilder
                 continue;
             }
 
+            if ($this->isDisplayParentCustomFieldGrouping($definition, $criteria, $sorting, $context)) {
+                $considerInheritance = $context->considerInheritance();
+                $context->setConsiderInheritance(false);
+
+                try {
+                    $displayParentAccessor = $this->helper->getFieldAccessor(
+                        'parent.variantListingConfig.displayParent',
+                        $definition,
+                        $definition->getEntityName(),
+                        $context
+                    );
+                    $parentAccessor = $this->helper->getFieldAccessor(
+                        'parent.' . $this->normalizeSortingField($sorting->getField()),
+                        $definition,
+                        $definition->getEntityName(),
+                        $context
+                    );
+                } finally {
+                    $context->setConsiderInheritance($considerInheritance);
+                }
+
+                $accessor = \sprintf(
+                    'IF(%s = "1", COALESCE(%s, %s), %s)',
+                    $displayParentAccessor,
+                    $parentAccessor,
+                    $accessor,
+                    $accessor
+                );
+            }
+
             if (!\in_array($sorting->getField(), ['product.cheapestPrice', 'cheapestPrice'], true)) {
                 if ($sorting->getDirection() === FieldSorting::ASCENDING) {
                     $accessor = 'MIN(' . $accessor . ')';
@@ -265,6 +295,32 @@ class CriteriaQueryBuilder
         return $query->hasState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN) || $criteria->getGroupFields() !== [];
     }
 
+    private function isDisplayParentCustomFieldGrouping(EntityDefinition $definition, Criteria $criteria, FieldSorting $sorting, Context $context): bool
+    {
+        if (!$context->considerInheritance() || !$definition->isInheritanceAware()) {
+            return false;
+        }
+
+        if (!$definition->getFields()->has('displayGroup') || !$definition->getFields()->has('parent') || !$definition->getFields()->has('variantListingConfig')) {
+            return false;
+        }
+
+        $field = $this->normalizeSortingField($sorting->getField());
+        if (!str_starts_with($field, 'customFields.')) {
+            return false;
+        }
+
+        foreach ($criteria->getGroupFields() as $grouping) {
+            if ($this->normalizeSortingField($grouping->getField()) !== 'displayGroup') {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * @param list<string> $additionalFields
      *
@@ -301,6 +357,11 @@ class CriteriaQueryBuilder
     private function hasQueriesOrTerm(Criteria $criteria): bool
     {
         return $criteria->getQueries() !== [] || $criteria->getTerm();
+    }
+
+    private function normalizeSortingField(string $field): string
+    {
+        return preg_replace('/^product\./', '', $field) ?? $field;
     }
 
     private function validateSortingDirection(string $direction): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -71,6 +72,54 @@ class CriteriaQueryBuilderTest extends TestCase
         );
     }
 
+    public function testSortingByCustomFieldUsesDisplayedParentValue(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->createCustomFieldSortingProducts();
+        $this->createProductCustomFieldSorting('custom-field-asc', 'asc');
+        $this->createProductCustomFieldSorting('custom-field-desc', 'desc');
+
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            'anytokenstring',
+            TestDefaults::SALES_CHANNEL
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('custom-a'),
+                $this->ids->get('custom-b'),
+                $this->ids->get('custom-c'),
+                $this->ids->get('custom-d'),
+            ],
+            array_values($this->orderListing('custom-field-asc', $context))
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('custom-d'),
+                $this->ids->get('custom-c'),
+                $this->ids->get('custom-b'),
+                $this->ids->get('custom-a'),
+            ],
+            array_values($this->orderListing('custom-field-desc', $context))
+        );
+    }
+
+    public function testSortingByCustomFieldDoesNotRequireParentJoinWithoutInheritance(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->createCustomFieldSortingProducts();
+        $this->createProductCustomFieldSorting('custom-field-asc', 'asc');
+
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            'anytokenstring',
+            TestDefaults::SALES_CHANNEL
+        );
+        $context->getContext()->setConsiderInheritance(false);
+
+        static::assertIsArray($this->orderListing('custom-field-asc', $context));
+    }
+
     private function createExampleProducts(): void
     {
         $this->ids->set('s1', '0198bd43b1c37964a5c1ecbd2d89fd6e');
@@ -114,6 +163,117 @@ class CriteriaQueryBuilderTest extends TestCase
             ->build();
 
         static::getContainer()->get('product.repository')->create([$s1, $p1], Context::createDefaultContext());
+    }
+
+    private function createCustomFieldSortingProducts(): void
+    {
+        static::getContainer()->get('custom_field_set.repository')->create([
+            [
+                'id' => $this->ids->create('custom-field-set'),
+                'name' => 'listing_sort_custom_field_set',
+                'relations' => [
+                    ['entityName' => 'product'],
+                ],
+                'customFields' => [
+                    [
+                        'name' => 'listing_sort_weight',
+                        'type' => CustomFieldTypes::FLOAT,
+                    ],
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $products = [
+            $this->buildDisplayParentCustomFieldProduct(
+                key: 'custom-a',
+                name: 'Custom A',
+                parentValue: 100.0,
+                variants: [
+                    ['key' => 'custom-a.1', 'name' => 'Variant A 1', 'price' => 110.0, 'value' => null],
+                    ['key' => 'custom-a.2', 'name' => 'Variant A 2', 'price' => 120.0, 'value' => null],
+                ]
+            ),
+            $this->buildDisplayParentCustomFieldProduct(
+                key: 'custom-b',
+                name: 'Custom B',
+                parentValue: 200.0,
+                variants: [
+                    ['key' => 'custom-b.1', 'name' => 'Variant B 1', 'price' => 210.0, 'value' => 999.0],
+                    ['key' => 'custom-b.2', 'name' => 'Variant B 2', 'price' => 220.0, 'value' => null],
+                ]
+            ),
+            $this->buildDisplayParentCustomFieldProduct(
+                key: 'custom-c',
+                name: 'Custom C',
+                parentValue: 250.0,
+                variants: [
+                    ['key' => 'custom-c.1', 'name' => 'Variant C 1', 'price' => 260.0, 'value' => 10.0],
+                    ['key' => 'custom-c.2', 'name' => 'Variant C 2', 'price' => 270.0, 'value' => null],
+                ]
+            ),
+            $this->buildDisplayParentCustomFieldProduct(
+                key: 'custom-d',
+                name: 'Custom D',
+                parentValue: 300.0,
+                variants: [
+                    ['key' => 'custom-d.1', 'name' => 'Variant D 1', 'price' => 310.0, 'value' => null],
+                    ['key' => 'custom-d.2', 'name' => 'Variant D 2', 'price' => 320.0, 'value' => null],
+                ]
+            ),
+        ];
+
+        static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
+    }
+
+    private function createProductCustomFieldSorting(string $key, string $direction): void
+    {
+        static::getContainer()->get('product_sorting.repository')->create([
+            [
+                'id' => $this->ids->create('sorting-' . $key),
+                'key' => $key,
+                'priority' => 1,
+                'active' => true,
+                'fields' => [
+                    [
+                        'field' => 'customFields.listing_sort_weight',
+                        'order' => $direction,
+                        'priority' => 1,
+                        'naturalSorting' => false,
+                    ],
+                ],
+                'label' => 'Sort by listing_sort_weight ' . $direction,
+            ],
+        ], Context::createDefaultContext());
+    }
+
+    /**
+     * @param list<array{key: string, name: string, price: float, value: float|null}> $variants
+     *
+     * @return array<mixed>
+     */
+    private function buildDisplayParentCustomFieldProduct(string $key, string $name, float $parentValue, array $variants): array
+    {
+        $product = (new ProductBuilder($this->ids, $key))
+            ->name($name)
+            ->price($parentValue)
+            ->customField('listing_sort_weight', $parentValue)
+            ->category('test-category')
+            ->variantListingConfig(['displayParent' => true])
+            ->visibility();
+
+        foreach ($variants as $variant) {
+            $builder = (new ProductBuilder($this->ids, $variant['key']))
+                ->name($variant['name'])
+                ->price($variant['price']);
+
+            if ($variant['value'] !== null) {
+                $builder->customField('listing_sort_weight', $variant['value']);
+            }
+
+            $product->variant($builder->build());
+        }
+
+        return $product->build();
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Grouped listings with `displayParent` enabled can currently be sorted by hidden child custom-field values instead of the displayed parent value. That makes the storefront order unstable and inconsistent with the visible parent data.

### 2. What does this change do, exactly?

- use the displayed parent value when building grouped custom-field sorting expressions
- keep the existing grouped sorting flow in `CriteriaQueryBuilder`
- prevent hidden child overrides from changing parent ordering
- add regression coverage for ascending and descending grouped custom-field sorting

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a variant listing that displays parent products.
2. Configure custom-field sort values on the parent products.
3. Override a hidden child variant with a different custom-field value.
4. Sort the listing by that custom field.
5. Observe that the hidden child value influences the parent order before this change.

### 4. Please link to the relevant issues (if any).

- relates #9805

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
