### PR TITLE
fix: sort displayed parents by parent values

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
@@ -140,6 +140,22 @@ class CriteriaQueryBuilder
                 continue;
             }
 
+            if ($this->isDisplayParentGrouping($definition, $criteria, $sorting)) {
+                $displayParentAccessors = $this->getDisplayParentAccessors($definition, $sorting, $query, $context);
+
+                if ($displayParentAccessors !== null) {
+                    [$displayParentAccessor, $parentAccessor] = $displayParentAccessors;
+
+                    $accessor = \sprintf(
+                        'IF(%s, COALESCE(%s, %s), %s)',
+                        $displayParentAccessor,
+                        $parentAccessor,
+                        $accessor,
+                        $accessor
+                    );
+                }
+            }
+
             if (!\in_array($sorting->getField(), ['product.cheapestPrice', 'cheapestPrice'], true)) {
                 if ($sorting->getDirection() === FieldSorting::ASCENDING) {
                     $accessor = 'MIN(' . $accessor . ')';
@@ -265,6 +281,72 @@ class CriteriaQueryBuilder
         return $query->hasState(EntityDefinitionQueryHelper::HAS_TO_MANY_JOIN) || $criteria->getGroupFields() !== [];
     }
 
+    private function isDisplayParentGrouping(EntityDefinition $definition, Criteria $criteria, FieldSorting $sorting): bool
+    {
+        if (!$definition->getFields()->has('displayGroup') || !$definition->getFields()->has('parent') || !$definition->getFields()->has('variantListingConfig')) {
+            return false;
+        }
+
+        foreach ($criteria->getGroupFields() as $grouping) {
+            if ($this->normalizeSortingField($grouping->getField()) !== 'displayGroup') {
+                continue;
+            }
+
+            $field = $this->normalizeSortingField($sorting->getField());
+
+            return $field !== 'id' && $field !== 'displayGroup' && !str_starts_with($field, 'parent.');
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{string, string}|null
+     */
+    private function getDisplayParentAccessors(EntityDefinition $definition, FieldSorting $sorting, QueryBuilder $query, Context $context): ?array
+    {
+        $sortingField = $this->normalizeSortingField($sorting->getField());
+        if ($sortingField === 'cheapestPrice') {
+            $sortingField = 'price';
+        }
+
+        return $context->disableInheritance(function (Context $context) use ($definition, $query, $sortingField): ?array {
+            try {
+                $this->helper->resolveAccessor(
+                    'parent.variantListingConfig.displayParent',
+                    $definition,
+                    $definition->getEntityName(),
+                    $query,
+                    $context
+                );
+                $this->helper->resolveAccessor(
+                    'parent.' . $sortingField,
+                    $definition,
+                    $definition->getEntityName(),
+                    $query,
+                    $context
+                );
+
+                return [
+                    $this->helper->getFieldAccessor(
+                        'parent.variantListingConfig.displayParent',
+                        $definition,
+                        $definition->getEntityName(),
+                        $context
+                    ),
+                    $this->helper->getFieldAccessor(
+                        'parent.' . $sortingField,
+                        $definition,
+                        $definition->getEntityName(),
+                        $context
+                    ),
+                ];
+            } catch (DataAbstractionLayerException) {
+                return null;
+            }
+        });
+    }
+
     /**
      * @param list<string> $additionalFields
      *
@@ -301,6 +383,11 @@ class CriteriaQueryBuilder
     private function hasQueriesOrTerm(Criteria $criteria): bool
     {
         return $criteria->getQueries() !== [] || $criteria->getTerm();
+    }
+
+    private function normalizeSortingField(string $field): string
+    {
+        return preg_replace('/^product\./', '', $field) ?? $field;
     }
 
     private function validateSortingDirection(string $direction): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
@@ -71,6 +71,64 @@ class CriteriaQueryBuilderTest extends TestCase
         );
     }
 
+    public function testSortingByPriceUsesDisplayedParentPrice(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->createPriceSortingProducts();
+
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            'anytokenstring',
+            TestDefaults::SALES_CHANNEL
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('product-a'),
+                $this->ids->get('product-b'),
+                $this->ids->get('product-c'),
+            ],
+            array_values($this->orderListing('price-asc', $context))
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('product-c'),
+                $this->ids->get('product-b'),
+                $this->ids->get('product-a'),
+            ],
+            array_values($this->orderListing('price-desc', $context))
+        );
+    }
+
+    public function testSortingByNameUsesDisplayedParentName(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->createNameSortingProducts();
+
+        $context = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            'anytokenstring',
+            TestDefaults::SALES_CHANNEL
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('name-a'),
+                $this->ids->get('name-b'),
+                $this->ids->get('name-c'),
+            ],
+            array_values($this->orderListing('name-asc', $context))
+        );
+
+        static::assertSame(
+            [
+                $this->ids->get('name-c'),
+                $this->ids->get('name-b'),
+                $this->ids->get('name-a'),
+            ],
+            array_values($this->orderListing('name-desc', $context))
+        );
+    }
+
     private function createExampleProducts(): void
     {
         $this->ids->set('s1', '0198bd43b1c37964a5c1ecbd2d89fd6e');
@@ -81,7 +139,7 @@ class CriteriaQueryBuilderTest extends TestCase
         $this->ids->set('p1.2', '0198bd446e077084984f95175b2bea27');
 
         $s1 = (new ProductBuilder($this->ids, 's1'))
-            ->price(100)
+            ->price(200)
             ->category('test-category')
             ->variantListingConfig(['displayParent' => true])
             ->visibility()
@@ -114,6 +172,100 @@ class CriteriaQueryBuilderTest extends TestCase
             ->build();
 
         static::getContainer()->get('product.repository')->create([$s1, $p1], Context::createDefaultContext());
+    }
+
+    private function createPriceSortingProducts(): void
+    {
+        $products = [
+            $this->buildDisplayParentProduct(
+                key: 'product-a',
+                name: 'Product A',
+                price: 100.0,
+                variants: [
+                    ['key' => 'product-a.1', 'name' => 'Variant Z Product A', 'price' => 110.0],
+                    ['key' => 'product-a.2', 'name' => 'Variant ZZ Product A', 'price' => 120.0],
+                ]
+            ),
+            $this->buildDisplayParentProduct(
+                key: 'product-b',
+                name: 'Product B',
+                price: 200.0,
+                variants: [
+                    ['key' => 'product-b.1', 'name' => 'Cheap Variant Product B', 'price' => 50.0],
+                    ['key' => 'product-b.2', 'name' => 'Premium Variant Product B', 'price' => 500.0],
+                ]
+            ),
+            $this->buildDisplayParentProduct(
+                key: 'product-c',
+                name: 'Product C',
+                price: 300.0,
+                variants: [
+                    ['key' => 'product-c.1', 'name' => 'Variant Z Product C', 'price' => 310.0],
+                    ['key' => 'product-c.2', 'name' => 'Variant ZZ Product C', 'price' => 320.0],
+                ]
+            ),
+        ];
+
+        static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
+    }
+
+    private function createNameSortingProducts(): void
+    {
+        $products = [
+            $this->buildDisplayParentProduct(
+                key: 'name-a',
+                name: 'A',
+                price: 100.0,
+                variants: [
+                    ['key' => 'name-a.1', 'name' => 'ZZZ A', 'price' => 110.0],
+                    ['key' => 'name-a.2', 'name' => 'YYY A', 'price' => 120.0],
+                ]
+            ),
+            $this->buildDisplayParentProduct(
+                key: 'name-b',
+                name: 'B',
+                price: 200.0,
+                variants: [
+                    ['key' => 'name-b.1', 'name' => 'ZZZ B', 'price' => 210.0],
+                    ['key' => 'name-b.2', 'name' => 'YYY B', 'price' => 220.0],
+                ]
+            ),
+            $this->buildDisplayParentProduct(
+                key: 'name-c',
+                name: 'C',
+                price: 300.0,
+                variants: [
+                    ['key' => 'name-c.1', 'name' => '100 C', 'price' => 310.0],
+                    ['key' => 'name-c.2', 'name' => 'ZZZ C', 'price' => 320.0],
+                ]
+            ),
+        ];
+
+        static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
+    }
+
+    /**
+     * @param list<array{key: string, name: string, price: float}> $variants
+     */
+    private function buildDisplayParentProduct(string $key, string $name, float $price, array $variants): array
+    {
+        $product = (new ProductBuilder($this->ids, $key))
+            ->name($name)
+            ->price($price)
+            ->category('test-category')
+            ->variantListingConfig(['displayParent' => true])
+            ->visibility();
+
+        foreach ($variants as $variant) {
+            $product->variant(
+                (new ProductBuilder($this->ids, $variant['key']))
+                    ->name($variant['name'])
+                    ->price($variant['price'])
+                    ->build()
+            );
+        }
+
+        return $product->build();
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Grouped listings with `displayParent` enabled can currently derive built-in sorting from hidden child values instead of the displayed parent values. That causes parent products to move in the listing based on data the storefront does not show.

### 2. What does this change do, exactly?

- use parent values for grouped `displayParent` sorting in the existing DAL query builder path
- keep the current grouped `MIN` and `MAX` behavior for non-parent-display cases
- prevent hidden child names and prices from changing visible parent ordering
- add regression coverage for grouped name and price sorting

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a variant listing that displays parent products.
2. Give child variants names or prices that differ from the parent values.
3. Sort the listing by a built-in sort such as name or price.
4. Observe that hidden child data changes the parent order before this change.

### 4. Please link to the relevant issues (if any).

- relates #11648

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
