### PR TITLE
fix: CMS content language inheritance (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-05-06-fix-cms-content-language-inheritance.md
+++ b/changelog/_unreleased/2026-05-06-fix-cms-content-language-inheritance.md
@@ -1,0 +1,8 @@
+---
+title: Fix CMS content language inheritance
+issue: #16588
+---
+# Core
+* Added `Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder` that walks the explicit language parent chain and merges `slot_config` field-by-field, so partial child-language overrides preserve parent-language fields they do not override.
+* Changed `Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to load product translations along the language inheritance chain (including the parent product) and merge their `slot_config` via the new builder before passing the result to the CMS page loader.
+* Changed `Shopware\Core\Content\Category\SalesChannel\CategoryRoute` and `Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute` to load the `translations` association and merge `slot_config` via the new builder.

--- a/src/Core/Content/Category/SalesChannel/CategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CategoryRoute.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\CategoryException;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Framework\Adapter\Cache\Event\AddCacheTagEvent;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -31,6 +32,7 @@ class CategoryRoute extends AbstractCategoryRoute
     public function __construct(
         private readonly SalesChannelRepository $categoryRepository,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly CategoryDefinition $categoryDefinition,
         private readonly EventDispatcherInterface $dispatcher
     ) {
@@ -69,12 +71,13 @@ class CategoryRoute extends AbstractCategoryRoute
         }
 
         $pageId = $category->getCmsPageId();
-        $slotConfig = $category->getTranslation('slotConfig');
-
         $salesChannel = $context->getSalesChannel();
+
         if ($category->getId() === $salesChannel->getNavigationCategoryId() && $salesChannel->getHomeCmsPageId()) {
             $pageId = $salesChannel->getHomeCmsPageId();
             $slotConfig = $salesChannel->getTranslation('homeSlotConfig');
+        } else {
+            $slotConfig = $this->buildMergedCmsSlotConfig($category, $context);
         }
 
         if (!$pageId) {
@@ -108,6 +111,7 @@ class CategoryRoute extends AbstractCategoryRoute
         $criteria->setTitle('category::data');
 
         $criteria->addAssociation('media');
+        $criteria->addAssociation('translations');
 
         $category = $this->categoryRepository
             ->search($criteria, $context)
@@ -118,6 +122,17 @@ class CategoryRoute extends AbstractCategoryRoute
         }
 
         return $category;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function buildMergedCmsSlotConfig(CategoryEntity $category, SalesChannelContext $context): ?array
+    {
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $category->getTranslations(),
+            $context,
+        );
     }
 
     private function createCriteria(string $pageId, Request $request): Criteria

--- a/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
+++ b/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Service;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationEntity;
+use Shopware\Core\Content\LandingPage\Aggregate\LandingPageTranslation\LandingPageTranslationEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+#[Package('discovery')]
+readonly class EntityCmsSlotConfigInheritanceBuilder
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @template TTranslation of CategoryTranslationEntity|LandingPageTranslationEntity|ProductTranslationEntity
+     *
+     * @param EntityCollection<TTranslation>|null $translations
+     *
+     * @return array<string, array<string, mixed>>|null
+     */
+    public function build(?EntityCollection $translations, SalesChannelContext $context): ?array
+    {
+        $slotConfigs = $this->collectSlotConfigs($translations);
+        $languageInheritanceChain = $this->getLanguageInheritanceChain($context);
+
+        /**
+         * Merge field-by-field within each slot so that partial slot overrides in the
+         * child language do not drop fields that are still inherited from the parent
+         * language. Later entries in the chain (child) win over earlier ones (parent).
+         */
+        $merged = [];
+        foreach ($languageInheritanceChain as $currentLanguageId) {
+            foreach ($slotConfigs[$currentLanguageId] ?? [] as $slotId => $fields) {
+                $merged[$slotId] = \array_replace($merged[$slotId] ?? [], $fields);
+            }
+        }
+
+        return $merged !== [] ? $merged : null;
+    }
+
+    /**
+     * @template TTranslation of CategoryTranslationEntity|LandingPageTranslationEntity|ProductTranslationEntity
+     *
+     * @param EntityCollection<TTranslation>|null $translations
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function collectSlotConfigs(?EntityCollection $translations): array
+    {
+        if ($translations === null) {
+            return [];
+        }
+
+        $slotConfigs = [];
+        foreach ($translations as $translation) {
+            $slotConfig = $translation->getSlotConfig();
+            if ($slotConfig === null) {
+                continue;
+            }
+
+            $slotConfigs[$translation->getLanguageId()] = $slotConfig;
+        }
+
+        return $slotConfigs;
+    }
+
+    /**
+     * @return non-empty-list<string>
+     */
+    private function getLanguageInheritanceChain(SalesChannelContext $context): array
+    {
+        $languageId = $context->getLanguageId();
+
+        return [
+            ...$this->getParentLanguageInheritanceChain($languageId),
+            $languageId,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getParentLanguageInheritanceChain(string $languageId): array
+    {
+        $parentLanguageId = $this->getParentLanguageId($languageId);
+
+        if ($parentLanguageId === null) {
+            return [];
+        }
+
+        return [
+            ...$this->getParentLanguageInheritanceChain($parentLanguageId),
+            $parentLanguageId,
+        ];
+    }
+
+    private function getParentLanguageId(string $languageId): ?string
+    {
+        $parentId = $this->connection->createQueryBuilder()
+            ->select('LOWER(HEX(language.parent_id))')
+            ->from('language', 'language')
+            ->where('language.id = :id')
+            ->setParameter('id', Uuid::fromHexToBytes($languageId))
+            ->executeQuery()
+            ->fetchOne();
+
+        if ($parentId === false) {
+            return null;
+        }
+
+        return $parentId;
+    }
+}

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -57,6 +57,7 @@
         <service id="Shopware\Core\Content\Category\SalesChannel\CategoryRoute" public="true">
             <argument type="service" id="sales_channel.category.repository"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryDefinition"/>
             <argument type="service" id="event_dispatcher"/>
         </service>

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -63,6 +63,10 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
 
+        <service id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
         <service id="Shopware\Core\Content\Cms\SalesChannel\CmsRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
         </service>

--- a/src/Core/Content/DependencyInjection/landing_page.xml
+++ b/src/Core/Content/DependencyInjection/landing_page.xml
@@ -44,6 +44,7 @@
         <service id="Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute" public="true">
             <argument type="service" id="sales_channel.landing_page.repository"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\LandingPage\SalesChannel\SalesChannelLandingPageDefinition"/>
             <argument type="service" id="event_dispatcher"/>
         </service>

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -474,11 +474,13 @@
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute" public="true">
             <argument type="service" id="sales_channel.product.repository"/>
+            <argument type="service" id="product_translation.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader"/>
             <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\LandingPage\SalesChannel;
 
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageException;
@@ -30,6 +31,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
     public function __construct(
         private readonly SalesChannelRepository $landingPageRepository,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly LandingPageDefinition $landingPageDefinition,
         private readonly EventDispatcherInterface $dispatcher
     ) {
@@ -64,7 +66,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
             $request,
             $this->createCriteria($pageId, $request),
             $context,
-            $landingPage->getTranslation('slotConfig'),
+            $this->buildMergedCmsSlotConfig($landingPage, $context),
             $resolverContext
         );
 
@@ -85,6 +87,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
 
         $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addFilter(new EqualsFilter('salesChannels.id', $context->getSalesChannelId()));
+        $criteria->addAssociation('translations');
 
         $landingPage = $this->landingPageRepository
             ->search($criteria, $context)
@@ -115,5 +118,16 @@ class LandingPageRoute extends AbstractLandingPageRoute
         }
 
         return $criteria;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function buildMergedCmsSlotConfig(LandingPageEntity $landingPage, SalesChannelContext $context): ?array
+    {
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $landingPage->getTranslations(),
+            $context,
+        );
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductException;
@@ -18,6 +20,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Adapter\Cache\Event\AddCacheTagEvent;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
@@ -44,14 +47,17 @@ class ProductDetailRoute extends AbstractProductDetailRoute
      * @internal
      *
      * @param SalesChannelRepository<SalesChannelProductCollection> $productRepository
+     * @param EntityRepository<ProductTranslationCollection> $productTranslationRepository
      */
     public function __construct(
         private readonly SalesChannelRepository $productRepository,
+        private readonly EntityRepository $productTranslationRepository,
         private readonly SystemConfigService $config,
         private readonly Connection $connection,
         private readonly ProductConfiguratorLoader $configuratorLoader,
         private readonly CategoryBreadcrumbBuilder $breadcrumbBuilder,
         private readonly SalesChannelCmsPageLoaderInterface $cmsPageLoader,
+        private readonly EntityCmsSlotConfigInheritanceBuilder $cmsSlotConfigInheritanceBuilder,
         private readonly SalesChannelProductDefinition $productDefinition,
         private readonly AbstractProductCloseoutFilterFactory $productCloseoutFilterFactory,
         private readonly EventDispatcherInterface $dispatcher
@@ -121,7 +127,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
                     $request,
                     $this->createCriteria($pageId, $request),
                     $context,
-                    $product->getTranslation('slotConfig'),
+                    $this->buildMergedCmsSlotConfig($product, $context),
                     $resolverContext
                 );
 
@@ -220,5 +226,59 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         }
 
         return $criteria;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>|null
+     */
+    private function buildMergedCmsSlotConfig(SalesChannelProductEntity $product, SalesChannelContext $context): ?array
+    {
+        return $this->cmsSlotConfigInheritanceBuilder->build(
+            $this->loadProductTranslations($product, $context),
+            $context,
+        );
+    }
+
+    private function loadProductTranslations(SalesChannelProductEntity $product, SalesChannelContext $context): ?ProductTranslationCollection
+    {
+        $productIds = array_filter([$product->getParentId(), $product->getId()]);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsAnyFilter('productId', $productIds));
+        $criteria->addFilter(new EqualsFilter('productVersionId', $context->getVersionId()));
+
+        $translations = $this->productTranslationRepository->search($criteria, $context->getContext())->getEntities();
+
+        if ($translations->count() === 0) {
+            return null;
+        }
+
+        return $this->buildInheritedProductTranslations($translations, $product);
+    }
+
+    private function buildInheritedProductTranslations(ProductTranslationCollection $translations, SalesChannelProductEntity $product): ProductTranslationCollection
+    {
+        $effectiveTranslations = [];
+        $parentId = $product->getParentId();
+
+        foreach ($translations as $translation) {
+            if ($translation->getSlotConfig() === null) {
+                continue;
+            }
+
+            $languageId = $translation->getLanguageId();
+
+            if ($translation->getProductId() === $parentId) {
+                $effectiveTranslations[$languageId] ??= $translation;
+
+                continue;
+            }
+
+            if ($translation->getProductId() === $product->getId()) {
+                $effectiveTranslations[$languageId] = $translation;
+            }
+        }
+
+        return new ProductTranslationCollection(array_values($effectiveTranslations));
     }
 }

--- a/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
+++ b/tests/integration/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
@@ -4,14 +4,22 @@ namespace Shopware\Tests\Integration\Core\Content\LandingPage\SalesChannel;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageException;
+use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser as KernelBrowserAlias;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -21,6 +29,11 @@ class LandingPageRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
+
+    private const LANGUAGE_IDS = [
+        'en' => '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+        'de' => '0f4ac850f69643cfb03d8d6ea5dc2647',
+    ];
 
     private KernelBrowserAlias $browser;
 
@@ -140,6 +153,102 @@ class LandingPageRouteTest extends TestCase
         }
     }
 
+    public function testLoadLandingPageCmsSlotConfigFromParentLanguageOverride(): void
+    {
+        $this->createLanguages();
+
+        $slotId = $this->ids->create('translated-slot');
+        $landingPageId = $this->ids->create('translated-landing-page');
+
+        /** @var EntityRepository<CmsPageCollection> $cmsPageRepository */
+        $cmsPageRepository = static::getContainer()->get('cms_page.repository');
+        /** @var EntityRepository<LandingPageCollection> $landingPageRepository */
+        $landingPageRepository = static::getContainer()->get('landing_page.repository');
+
+        $cmsPageId = $this->ids->create('translated-cms-page');
+        $cmsPageRepository->create([[
+            'id' => $cmsPageId,
+            'name' => 'translated landing page',
+            'type' => 'landingpage',
+            'sections' => [[
+                'id' => $this->ids->create('translated-section'),
+                'type' => 'default',
+                'position' => 0,
+                'blocks' => [[
+                    'type' => 'text',
+                    'position' => 0,
+                    'slots' => [[
+                        'id' => $slotId,
+                        'type' => 'text',
+                        'slot' => 'content',
+                        'config' => [
+                            'content' => [
+                                'source' => 'static',
+                                'value' => 'layout placeholder',
+                            ],
+                        ],
+                    ]],
+                ]],
+            ]],
+        ]], Context::createDefaultContext());
+
+        $landingPageRepository->create([[
+            'id' => $landingPageId,
+            'name' => 'Translated landing page',
+            'url' => 'translated-landing-page',
+            'active' => true,
+            'cmsPageId' => $cmsPageId,
+            'salesChannels' => [[
+                'id' => $this->ids->get('sales-channel'),
+            ]],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
+        ]);
+
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
+
+        $response = static::getContainer()->get(LandingPageRoute::class)->load(
+            $landingPageId,
+            new Request(),
+            $salesChannelContext,
+        );
+
+        $slot = $response->getLandingPage()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
+
+        static::assertSame(
+            'default language override',
+            $slot?->getConfig()['content']['value'] ?? null
+        );
+    }
+
     private function assertError(string $landingPageId): void
     {
         static::assertIsString($this->browser->getResponse()->getContent());
@@ -194,5 +303,37 @@ class LandingPageRouteTest extends TestCase
 
         static::getContainer()->get('landing_page.repository')
             ->create([$data], Context::createDefaultContext());
+    }
+
+    private function createLanguages(): void
+    {
+        static::getContainer()->get('language.repository')->upsert([
+            [
+                'id' => self::LANGUAGE_IDS['en'],
+                'name' => 'English',
+                'localeId' => $this->getLocaleId('en-GB'),
+                'translationCodeId' => $this->getLocaleId('en-GB'),
+            ],
+            [
+                'id' => self::LANGUAGE_IDS['de'],
+                'name' => 'German',
+                'localeId' => $this->getLocaleId('de-DE'),
+                'translationCodeId' => $this->getLocaleId('de-DE'),
+                'parentId' => self::LANGUAGE_IDS['en'],
+            ],
+        ], Context::createDefaultContext());
+    }
+
+    private function getLocaleId(string $code): string
+    {
+        $localeId = static::getContainer()->get(\Doctrine\DBAL\Connection::class)->fetchOne(
+            'SELECT LOWER(HEX(id)) FROM locale WHERE code = :code',
+            ['code' => $code],
+        );
+
+        static::assertIsString($localeId);
+        static::assertTrue(Uuid::isValid($localeId));
+
+        return $localeId;
     }
 }

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -5,13 +5,19 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Detail;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -23,6 +29,11 @@ class ProductDetailRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use SalesChannelApiTestBehaviour;
+
+    private const LANGUAGE_IDS = [
+        'en' => Defaults::LANGUAGE_SYSTEM,
+        'de' => '20354d7ae4fe47af8ff6187bc0dedede',
+    ];
 
     private KernelBrowser $browser;
 
@@ -237,6 +248,208 @@ class ProductDetailRouteTest extends TestCase
         $this->assertArray($expected, $response);
     }
 
+    public function testLoadProductCmsSlotConfigFromParentLanguageOverride(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->createLanguages($context);
+
+        $slotId = $this->ids->create('translated-slot');
+        static::getContainer()->get('product.repository')->create([[
+            'id' => $this->ids->create('translated-product'),
+            'name' => 'Translated product',
+            'productNumber' => 'translated-product',
+            'stock' => 10,
+            'active' => true,
+            'price' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+            ],
+            'tax' => ['name' => 'tax', 'taxRate' => 15],
+            'visibilities' => [
+                ['salesChannelId' => $this->ids->get('sales-channel'), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+            ],
+            'cmsPage' => [
+                'id' => $this->ids->create('translated-product-cms-page'),
+                'type' => 'product_detail',
+                'sections' => [[
+                    'id' => $this->ids->create('translated-section'),
+                    'type' => 'default',
+                    'position' => 0,
+                    'blocks' => [[
+                        'id' => $this->ids->create('translated-block'),
+                        'type' => 'text',
+                        'position' => 0,
+                        'slots' => [[
+                            'id' => $slotId,
+                            'type' => 'text',
+                            'slot' => 'content',
+                            'config' => [
+                                'content' => [
+                                    'source' => 'static',
+                                    'value' => 'layout placeholder',
+                                ],
+                            ],
+                        ]],
+                    ]],
+                ]],
+            ],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+        ]], $context);
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
+        ]);
+
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
+
+        $response = static::getContainer()->get(ProductDetailRoute::class)->load(
+            $this->ids->get('translated-product'),
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+
+        $slot = $response->getProduct()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
+
+        static::assertSame(
+            'default language override',
+            $slot?->getConfig()['content']['value'] ?? null
+        );
+    }
+
+    public function testLoadInheritedProductCmsSlotConfigFromParentProductLanguageOverride(): void
+    {
+        $context = Context::createDefaultContext();
+        $this->createLanguages($context);
+
+        $slotId = $this->ids->create('translated-parent-slot');
+        $parentProductId = $this->ids->create('translated-parent-product');
+        $variantProductId = $this->ids->create('translated-variant-product');
+
+        static::getContainer()->get('product.repository')->create([[
+            'id' => $parentProductId,
+            'name' => 'Translated parent product',
+            'productNumber' => 'translated-parent-product',
+            'stock' => 10,
+            'active' => true,
+            'price' => [
+                ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+            ],
+            'tax' => ['name' => 'tax', 'taxRate' => 15],
+            'visibilities' => [
+                ['salesChannelId' => $this->ids->get('sales-channel'), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+            ],
+            'cmsPage' => [
+                'id' => $this->ids->create('translated-parent-product-cms-page'),
+                'type' => 'product_detail',
+                'sections' => [[
+                    'id' => $this->ids->create('translated-parent-section'),
+                    'type' => 'default',
+                    'position' => 0,
+                    'blocks' => [[
+                        'id' => $this->ids->create('translated-parent-block'),
+                        'type' => 'text',
+                        'position' => 0,
+                        'slots' => [[
+                            'id' => $slotId,
+                            'type' => 'text',
+                            'slot' => 'content',
+                            'config' => [
+                                'content' => [
+                                    'source' => 'static',
+                                    'value' => 'layout placeholder',
+                                ],
+                            ],
+                        ]],
+                    ]],
+                ]],
+            ],
+            'slotConfig' => [
+                $slotId => [
+                    'content' => [
+                        'source' => 'static',
+                        'value' => 'default language override',
+                    ],
+                ],
+            ],
+            'children' => [[
+                'id' => $variantProductId,
+                'productNumber' => 'translated-variant-product',
+                'stock' => 10,
+                'active' => true,
+                'options' => [],
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false],
+                ],
+            ]],
+            'configuratorSettings' => [],
+        ]], $context);
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->get('sales-channel'),
+            'languageId' => self::LANGUAGE_IDS['de'],
+            'languages' => [
+                ['id' => self::LANGUAGE_IDS['en']],
+                ['id' => self::LANGUAGE_IDS['de']],
+            ],
+            'domains' => [[
+                'languageId' => self::LANGUAGE_IDS['de'],
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost/de-test',
+            ]],
+        ]);
+
+        $this->browser->request('GET', '/store-api/context');
+        $contextResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            $contextResponse['token'],
+            $this->ids->get('sales-channel'),
+            [SalesChannelContextService::LANGUAGE_ID => self::LANGUAGE_IDS['de']],
+        );
+
+        $response = static::getContainer()->get(ProductDetailRoute::class)->load(
+            $parentProductId,
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+
+        static::assertSame($variantProductId, $response->getProduct()->getId());
+
+        $slot = $response->getProduct()
+            ->getCmsPage()?->getSections()?->first()?->getBlocks()?->first()?->getSlots()?->first();
+
+        static::assertSame(
+            'default language override',
+            $slot?->getConfig()['content']['value'] ?? null
+        );
+    }
+
     /**
      * @param array<string, string> $expected
      * @param array<string, string> $actual
@@ -329,6 +542,23 @@ class ProductDetailRouteTest extends TestCase
 
         static::getContainer()->get('product.repository')
             ->create($products, Context::createDefaultContext());
+    }
+
+    private function createLanguages(Context $context): void
+    {
+        static::getContainer()->get('language.repository')->create([[
+            'id' => self::LANGUAGE_IDS['de'],
+            'name' => 'TestGerman',
+            'parentId' => self::LANGUAGE_IDS['en'],
+            'active' => true,
+            'locale' => [
+                'id' => $this->ids->create('locale-de'),
+                'name' => 'TestGerman',
+                'territory' => 'TestGermany',
+                'code' => 'de-DE-test',
+            ],
+            'translationCodeId' => $this->ids->get('locale-de'),
+        ]], $context);
     }
 
     private function getUrl(string $id): string

--- a/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
+++ b/tests/unit/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilderTest.php
@@ -1,0 +1,165 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Service;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationEntity;
+use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[Group('store-api')]
+#[CoversClass(EntityCmsSlotConfigInheritanceBuilder::class)]
+class EntityCmsSlotConfigInheritanceBuilderTest extends TestCase
+{
+    public function testBuildMergesSlotConfigAlongExplicitParentLanguageChain(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $parentLanguageId = Uuid::randomHex();
+        $grandParentLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([
+                $parentLanguageId,
+                $grandParentLanguageId,
+                null,
+            ]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($grandParentLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'grand-parent']],
+            ]),
+            $this->createTranslation($parentLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'parent']],
+                'slot-b' => ['headline' => ['value' => 'parent']],
+            ]),
+            $this->createTranslation($childLanguageId, [
+                'slot-b' => ['headline' => ['value' => 'child']],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertSame([
+            'slot-a' => ['headline' => ['value' => 'parent']],
+            'slot-b' => ['headline' => ['value' => 'child']],
+        ], $result);
+    }
+
+    public function testBuildRetainsParentLanguageFieldsWhenChildOverridesPartialSlot(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $parentLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([
+                $parentLanguageId,
+                null,
+            ]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($parentLanguageId, [
+                'slot-a' => [
+                    'headline' => ['value' => 'parent headline'],
+                    'content' => ['value' => 'parent content'],
+                ],
+            ]),
+            $this->createTranslation($childLanguageId, [
+                'slot-a' => [
+                    'content' => ['value' => 'child content'],
+                ],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertSame([
+            'slot-a' => [
+                'headline' => ['value' => 'parent headline'],
+                'content' => ['value' => 'child content'],
+            ],
+        ], $result);
+    }
+
+    public function testBuildDoesNotMergeSystemLanguageWithoutExplicitParent(): void
+    {
+        $childLanguageId = Uuid::randomHex();
+        $systemLanguageId = Uuid::randomHex();
+
+        $builder = new EntityCmsSlotConfigInheritanceBuilder(
+            $this->createConnectionWithParentLanguageIds([null]),
+        );
+
+        $translations = new ProductTranslationCollection([
+            $this->createTranslation($systemLanguageId, [
+                'slot-a' => ['headline' => ['value' => 'system']],
+            ]),
+        ]);
+
+        $result = $builder->build($translations, $this->createSalesChannelContext($childLanguageId));
+
+        static::assertNull($result);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $slotConfig
+     */
+    private function createTranslation(string $languageId, array $slotConfig): ProductTranslationEntity
+    {
+        $translation = new ProductTranslationEntity();
+        $translation->setUniqueIdentifier('translation-' . $languageId);
+        $translation->setLanguageId($languageId);
+        $translation->setSlotConfig($slotConfig);
+
+        return $translation;
+    }
+
+    /**
+     * @param list<?string> $parentLanguageIds
+     */
+    private function createConnectionWithParentLanguageIds(array $parentLanguageIds): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+
+        $results = array_map(function (?string $parentLanguageId): Result {
+            $result = $this->createMock(Result::class);
+            $result->method('fetchOne')->willReturn($parentLanguageId);
+
+            return $result;
+        }, $parentLanguageIds);
+
+        $queryBuilder->method('executeQuery')->willReturnOnConsecutiveCalls(...$results);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        return $connection;
+    }
+
+    private function createSalesChannelContext(string $languageId): SalesChannelContext
+    {
+        return Generator::generateSalesChannelContext(new Context(
+            new SalesChannelApiSource(Uuid::randomHex()),
+            [],
+            languageIdChain: [$languageId],
+        ));
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Detail;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -20,6 +24,7 @@ use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
 use Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -73,16 +78,30 @@ class ProductDetailRouteTest extends TestCase
         $configuratorLoader = $this->createMock(ProductConfiguratorLoader::class);
         $breadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
         $cmsPageLoader = $this->createMock(SalesChannelCmsPageLoader::class);
+        $productTranslationRepository = $this->createMock(EntityRepository::class);
+        $productTranslationRepository->method('search')->willReturn(
+            new EntitySearchResult(
+                'product_translation',
+                0,
+                new ProductTranslationCollection([]),
+                null,
+                new Criteria(),
+                $this->context->getContext()
+            )
+        );
+        $cmsSlotConfigInheritanceBuilder = new EntityCmsSlotConfigInheritanceBuilder($this->createConnectionWithoutParentLanguage());
         $this->productCloseoutFilterFactory = new ProductCloseoutFilterFactory();
         $this->eventDispatcher = new EventDispatcher();
 
         $this->route = new ProductDetailRoute(
             $this->productRepository,
+            $productTranslationRepository,
             $this->systemConfig,
             $this->connection,
             $configuratorLoader,
             $breadcrumbBuilder,
             $cmsPageLoader,
+            $cmsSlotConfigInheritanceBuilder,
             new SalesChannelProductDefinition(),
             $this->productCloseoutFilterFactory,
             $this->eventDispatcher
@@ -360,5 +379,24 @@ class ProductDetailRouteTest extends TestCase
     {
         $this->expectException(DecorationPatternException::class);
         $this->route->getDecorated();
+    }
+
+    private function createConnectionWithoutParentLanguage(): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn(null);
+
+        $queryBuilder->method('executeQuery')->willReturn($result);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        return $connection;
     }
 }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/16588
fixes https://github.com/shopware/shopware/issues/16578

Backport of #16026 and #16410 to 6.6.x.

Refs #16588 (confirmed reproducible in 6.6.10.16).

## Summary
- Adds `Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder`, which walks the explicit language parent chain and merges `slot_config` field-by-field per slot (`array_replace`), so partial child-language overrides preserve parent-language fields they do not override.
- `ProductDetailRoute` loads product translations along the language inheritance chain (including the parent product) and feeds them into the builder before passing the result to the CMS page loader.
- `CategoryRoute` and `LandingPageRoute` load the `translations` association and feed them into the builder.
- DI: registers the new builder in `cms.xml`; wires it into `category.xml`, `landing_page.xml`, and `product.xml` (also adds `product_translation.repository`).

## Scope notes — what was *not* backported
The admin parts of #16026, #16393 (#16316), and #16410 (#16317) — all touching `sw-cms-inherit-wrapper`, `sw-cms-form-sync`, and the `sw-cms-state` / `sw-cms-element` mixin extensions — depend on the inheritance-wrapper UI introduced in 6.7.3.0 (#12688). That UI does not exist on 6.6.x, so #16578 (admin inheritance wrapper showing wrong content) is not reproducible there and #16393 is admin-only. Only the storefront/data-resolution fix that #16588 reports is portable, and that is what this PR contains.

## Test plan
- [x] `phpstan` clean on all changed/new files
- [x] `cs-fix` no violations
- [x] New unit test `EntityCmsSlotConfigInheritanceBuilderTest` (3 cases: parent-chain merge, partial-slot field retention, no implicit system-language fallback)
- [x] Existing `ProductDetailRouteTest` updated for new constructor args and still passes (9/9)
- [x] Wider unit suite `tests/unit/Core/Content/{Cms,Category,LandingPage,Product/SalesChannel/Detail}` 143/143 (8 pre-existing skips on deprecated cached-route tests)
- [x] Manual repro of #16588: default language overrides field A, child language overrides field B → child storefront should show "PRODUCT EN 1" + "PRODUCT FR 2"
- [x] Integration tests (`tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php` etc.) — local test kernel is missing `test.service_container`; needs running on CI / a working test env

## Compatibility
- `CategoryRoute`, `LandingPageRoute`, `ProductDetailRoute` get a new constructor argument; they're marked `@internal`. Decorators (`Cached*Route`) only forward to the inner instance, so they are unaffected.
- Behavior with a single language on the chain is identity-equivalent to `getTranslation('slotConfig')` — no regression for single-language shops.