### PR TITLE
fix: fall back to browser timezone when user profile timezone is not configured

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.spec.js
@@ -26,6 +26,20 @@ describe('src/core/service/utils/format.utils.js', () => {
         beforeEach(async () => {
             setLocale('en-GB');
             setTimeZone('UTC');
+            // Pin browser timezone to UTC so tests are deterministic regardless of CI environment.
+            // Our fix falls back to Intl.DateTimeFormat().resolvedOptions().timeZone when no
+            // explicit (non-UTC) timezone is stored on the user profile.
+            const originalDateTimeFormat = Intl.DateTimeFormat;
+            jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(function mockDateTimeFormat(locale, options) {
+                if (!locale && !options) {
+                    return { resolvedOptions: () => ({ timeZone: 'UTC' }) };
+                }
+                return new originalDateTimeFormat(locale, options);
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
         });
 
         it('should return empty string for null value', async () => {
@@ -97,6 +111,17 @@ describe('src/core/service/utils/format.utils.js', () => {
         beforeEach(async () => {
             setLocale('en-GB');
             setTimeZone('UTC');
+            const originalDateTimeFormat = Intl.DateTimeFormat;
+            jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(function mockDateTimeFormat(locale, options) {
+                if (!locale && !options) {
+                    return { resolvedOptions: () => ({ timeZone: 'UTC' }) };
+                }
+                return new originalDateTimeFormat(locale, options);
+            });
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
         });
 
         it('should convert the date correctly with timezone Pacific/Pago_Pago', async () => {
@@ -108,7 +133,7 @@ describe('src/core/service/utils/format.utils.js', () => {
             );
         });
 
-        it('should convert the date correctly with timezone UTC as fallback', async () => {
+        it('should use browser timezone as fallback when no timezone is stored', async () => {
             setTimeZone(null);
             const date = new Date(2000, 1, 1, 0, 13, 37);
 

--- a/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.ts
@@ -112,7 +112,9 @@ export function date(val: string, options: DateFilterOptions = {}): string {
     }
 
     const lastKnownLang = Shopware.Application.getContainer('factory').locale.getLastKnownLocale();
-    const userTimeZone = Shopware?.Store?.get('session')?.currentUser?.timeZone ?? 'UTC';
+    const storedTimeZone = Shopware?.Store?.get('session')?.currentUser?.timeZone;
+    const userTimeZone =
+        storedTimeZone && storedTimeZone !== 'UTC' ? storedTimeZone : Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     const dateTimeFormatter = new Intl.DateTimeFormat(lastKnownLang, {
         timeZone: options.skipTimezoneConversion ? undefined : userTimeZone,
@@ -135,7 +137,9 @@ export function date(val: string, options: DateFilterOptions = {}): string {
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export function dateWithUserTimezone(dateObj: Date = new Date()): Date {
-    const userTimeZone = Shopware.Store.get('session').currentUser?.timeZone ?? 'UTC';
+    const storedTimeZone = Shopware.Store.get('session').currentUser?.timeZone;
+    const userTimeZone =
+        storedTimeZone && storedTimeZone !== 'UTC' ? storedTimeZone : Intl.DateTimeFormat().resolvedOptions().timeZone;
 
     // Language and options are set in order to re-create the date object
     const localizedDate = dateObj.toLocaleDateString('en-GB', {


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware stores 'UTC' as the default timeZone for user profiles that have never been explicitly configured. The existing fallback used ?? 'UTC', which only triggers on null/undefined — so the explicit 'UTC' string was passed directly to Intl.DateTimeFormat, causing all timestamps to display in UTC regardless of the user's actual browser timezone.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- closes #15848  - closes the issue #15848 when the PR is merged
- relates #15848 - relates to the issue #15848

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
