### PR TITLE
feat(sso): always use system sender mail address

### DIFF
--- a/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
+++ b/src/Core/Framework/Sso/SsoUser/SsoUserInvitationMailService.php
@@ -59,14 +59,12 @@ class SsoUserInvitationMailService
 
         $user = $this->getUserById($apiSource->getUserId(), $context);
         $shopName = $this->systemConfigService->get('core.basicInformation.shopName');
-        $senderMail = $this->systemConfigService->get('core.basicInformation.email');
         $mailTemplate = $this->getMailTemplate($localeId, $context);
 
         $mailData = new DataBag();
         $mailData->set('templateId', $mailTemplate?->getId());
         $mailData->set('recipients', [$recipientEmail => $recipientEmail]);
         $mailData->set('senderName', $shopName);
-        $mailData->set('senderEmail', $user?->getEmail() ?? $senderMail);
         $mailData->set('subject', $mailTemplate?->getTranslation('subject'));
         $mailData->set('contentPlain', $mailTemplate?->getTranslation('contentPlain'));
         $mailData->set('contentHtml', $mailTemplate?->getTranslation('contentHtml'));
@@ -75,12 +73,12 @@ class SsoUserInvitationMailService
         $templateVariables->set('nameOfInviter', $this->createInviterName($user));
         $templateVariables->set('storeName', $shopName);
         $templateVariables->set('invitedEmailAddress', $recipientEmail);
-        $templateVariables->set('signupUrl', $this->createSingUpUrl());
+        $templateVariables->set('signupUrl', $this->createSignUpUrl());
 
         $this->mailService->send($mailData->all(), $context, $templateVariables->all());
     }
 
-    private function createSingUpUrl(): string
+    private function createSignUpUrl(): string
     {
         return $this->appUrl . $this->urlGenerator->generate(self::ADMIN_ROUTE_NAME);
     }

--- a/tests/integration/Core/Framework/Sso/SsoUser/SsoUserInvitationMailServiceTest.php
+++ b/tests/integration/Core/Framework/Sso/SsoUser/SsoUserInvitationMailServiceTest.php
@@ -90,5 +90,6 @@ class SsoUserInvitationMailServiceTest extends TestCase
 
         static::assertInstanceOf(MailBeforeSentEvent::class, $caughtEvent);
         static::assertSame('Administrator invited you to join Demostore', $caughtEvent->getData()['subject']);
+        static::assertNull($caughtEvent->getData()['senderEmail']);
     }
 }

--- a/tests/unit/Core/SsoUser/SsoUserInvitationMailServiceTest.php
+++ b/tests/unit/Core/SsoUser/SsoUserInvitationMailServiceTest.php
@@ -35,11 +35,18 @@ class SsoUserInvitationMailServiceTest extends TestCase
     public function testSendInvitationMailToUser(): void
     {
         $abstractMailService = $this->createMock(AbstractMailService::class);
-        $abstractMailService->expects($this->once())->method('send');
+        $abstractMailService->expects($this->once())
+            ->method('send')
+            ->with(static::callback(function (array $data) {
+                self::assertNull($data['senderEmail']);
+                self::assertSame('ShopName', $data['senderName']);
+
+                return true;
+            }));
 
         $systemConfigService = $this->createMock(SystemConfigService::class);
-        $systemConfigService->expects($this->exactly(2))->method('get')
-            ->willReturnOnConsecutiveCalls('ShopName', 'sender@name.foo');
+        $systemConfigService->expects($this->once())->method('get')
+            ->willReturn('ShopName');
 
         $mailTemplateEntity = new MailTemplateEntity();
         $mailTemplateEntity->setUniqueIdentifier(Uuid::randomHex());
@@ -59,7 +66,6 @@ class SsoUserInvitationMailServiceTest extends TestCase
 
         $userEntity = new UserEntity();
         $userEntity->setUniqueIdentifier(Uuid::randomHex());
-        $userEntity->setEmail('test@example.foo');
         $userEntity->setFirstName('FirstName');
         $userEntity->setLastName('LastName');
         $userEntity->setUsername('UserName');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When SSO is enabled and a user is invited to the Store, the `senderEmail` currently is set to the user's mail address who sent out the invite.

This can possibly be bad for mailing reputation (we observed this in our SaaS environment).

### 2. What does this change do, exactly?
The invitation email's sender address is always set to the one configured in `core.basicInformation.email` instead.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to a SaaS shop and make sure your user has an email address in their profile
2. Invite a user using their `@shopware.com` mail address.
3. The mail will land in quarantine as the sender address is mismatching with what's in `core.basicInformation.email`.

### See also
* #16862 
* #16865 