### PR TITLE
chore: add AGENTS.override.md to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,7 +115,10 @@ app/config/parameters.yml
 .env.dev
 
 # Local AI/LLM overrides
+# Claude.local.md
 *.local.md
+# AGENTS.override.md
+*.override.md
 *.cursorignore.local
 *.cursorindexingignore.local
 *.tabnineignore.local


### PR DESCRIPTION
### 1. Why is this change necessary?
Codex uses agents.override.md for custom instructions, while local claude files where already ignored, that was not the case for codex files: https://developers.openai.com/codex/guides/agents-md

### 2. What does this change do, exactly?
Ignore Agents.override.md files, so custom instructions are not part of the repo
