### PR TITLE
fix: add sales channel tracking customer privilege

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/acl/index.js
@@ -15,6 +15,7 @@ Shopware.Service('privileges').addPrivilegeMappingEntry({
                 'salutation:read',
                 'sales_channel:read',
                 'sales_channel_domain:read',
+                'sales_channel_tracking_customer:read',
                 'payment_method:read',
                 'country:read',
                 'country_state:read',

--- a/src/Core/Migration/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilege.php
+++ b/src/Core/Migration/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilege.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1778146739AddSalesChannelTrackingCustomerPrivilege extends MigrationStep
+{
+    final public const NEW_PRIVILEGES = [
+        'customer.viewer' => [
+            'sales_channel_tracking_customer:read',
+        ],
+    ];
+
+    public function getCreationTimestamp(): int
+    {
+        return 1778146739;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addAdditionalPrivileges($connection, self::NEW_PRIVILEGES);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest.php
+++ b/tests/migration/Core/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1778146739AddSalesChannelTrackingCustomerPrivilege;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[Package('inventory')]
+#[CoversClass(Migration1778146739AddSalesChannelTrackingCustomerPrivilege::class)]
+class Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    private Migration1778146739AddSalesChannelTrackingCustomerPrivilege $migration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->migration = new Migration1778146739AddSalesChannelTrackingCustomerPrivilege();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1778146739, $this->migration->getCreationTimestamp());
+    }
+
+    public function testUpdate(): void
+    {
+        $this->prepareTestData();
+
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        $privileges = $this->connection->fetchOne(
+            'SELECT privileges FROM acl_role WHERE name = :name',
+            ['name' => 'Customer Viewer']
+        );
+
+        static::assertNotFalse($privileges);
+        $decodedPrivileges = json_decode($privileges, true);
+
+        static::assertContains(
+            'sales_channel_tracking_customer:read',
+            $decodedPrivileges
+        );
+    }
+
+    private function prepareTestData(): void
+    {
+        $this->connection->insert('acl_role', [
+            'id' => Uuid::randomBytes(),
+            'name' => 'Customer Viewer',
+            'privileges' => json_encode(['customer.viewer']),
+            'created_at' => (new \DateTime())->format('Y-m-d H:i:s'),
+        ]);
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest.php
+++ b/tests/migration/Core/V6_7/Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest.php
@@ -14,7 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
-#[Package('inventory')]
+#[Package('discovery')]
 #[CoversClass(Migration1778146739AddSalesChannelTrackingCustomerPrivilege::class)]
 class Migration1778146739AddSalesChannelTrackingCustomerPrivilegeTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?
`sales_channel_tracking_customer:read` is missing for roles with `customer.viewer`.

### 2. What does this change do, exactly?
add `sales_channel_tracking_customer:read` privilege for roles with `customer.viewer`.

### 3. Describe each step to reproduce the issue or behaviour
add role for customer viewer.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16678

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
