### PR TITLE
fix: order ui filters race condition

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/service/filter.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/filter.service.js
@@ -73,15 +73,21 @@ export default class FilterService {
             }
         });
 
-        this._filterEntity.value = filterValues;
+        const filterEntity = this._filterEntity;
+
+        filterEntity.value = filterValues;
         this._storedFilters[storeKey] = savedCriteria;
 
         this._pushFiltersToUrl();
-        this._userConfigRepository.save(this._filterEntity, Shopware.Context.api).then(() => {
-            this.getStoredFilters(storeKey);
-        });
 
-        return Promise.resolve(this._filterEntity.value);
+        return this._userConfigRepository
+            .save(filterEntity, Shopware.Context.api)
+            .then(() => {
+                return this.getStoredFilters(storeKey);
+            })
+            .catch(() => {
+                return filterEntity.value;
+            });
     }
 
     async mergeWithStoredFilters(storeKey, listCriteria) {

--- a/src/Administration/Resources/app/administration/src/app/service/filter.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/filter.service.spec.js
@@ -10,6 +10,7 @@ import { createRouter, createWebHashHistory } from 'vue-router';
 describe('app/service/filter.service.js', () => {
     let filterService;
     let filterData;
+    let userConfigRepository;
 
     beforeEach(async () => {
         const router = createRouter({
@@ -62,19 +63,24 @@ describe('app/service/filter.service.js', () => {
             },
         });
 
-        filterService = new FilterService({
-            userConfigRepository: {
-                create: () =>
-                    Promise.resolve({
-                        key: 'test',
-                        userId: '123',
-                    }),
-                search: () => Promise.resolve(filterData),
-                save: (criteria) => {
-                    filterData = criteria;
-                    return Promise.resolve();
-                },
+        userConfigRepository = {
+            create: () =>
+                Promise.resolve({
+                    key: 'test',
+                    userId: '123',
+                }),
+            search: () => Promise.resolve(filterData),
+            save: (entity) => {
+                filterData = new EntityCollection(null, null, null, new Criteria(1, 25), [
+                    entity,
+                ]);
+
+                return Promise.resolve();
             },
+        };
+
+        filterService = new FilterService({
+            userConfigRepository,
         });
     });
 
@@ -198,6 +204,74 @@ describe('app/service/filter.service.js', () => {
             { type: 'equalsAny', field: 'salutation.id', value: 'filter1' },
             { type: 'equalsAny', field: 'salutation.id', value: 'filter2' },
         ]);
+    });
+
+    it('saveFilters should resolve after the user config save finished', async () => {
+        await filterService.getStoredFilters('test');
+
+        const filters = {
+            filter1: {
+                value: 'filter1',
+                criteria: [
+                    {
+                        type: 'equalsAny',
+                        field: 'salutation.id',
+                        value: 'filter1',
+                    },
+                ],
+            },
+        };
+
+        let resolveSave;
+        const savePromise = new Promise((resolve) => {
+            resolveSave = resolve;
+        });
+
+        userConfigRepository.save = jest.fn((entity) => {
+            filterData = new EntityCollection(null, null, null, new Criteria(1, 25), [
+                entity,
+            ]);
+
+            return savePromise;
+        });
+
+        const saveFiltersPromise = filterService.saveFilters('test', filters);
+        let resolved = false;
+        const resolutionMarker = saveFiltersPromise.then(() => {
+            resolved = true;
+        });
+
+        await flushPromises();
+
+        expect(resolved).toBe(false);
+
+        resolveSave();
+
+        await resolutionMarker;
+        await expect(saveFiltersPromise).resolves.toEqual(filters);
+    });
+
+    it('saveFilters should resolve with current filters when the user config save fails', async () => {
+        await filterService.getStoredFilters('test');
+
+        const filters = {
+            filter1: {
+                value: 'filter1',
+                criteria: [
+                    {
+                        type: 'equalsAny',
+                        field: 'salutation.id',
+                        value: 'filter1',
+                    },
+                ],
+            },
+        };
+
+        userConfigRepository.save = jest.fn(() => {
+            return Promise.reject(new Error('Save failed'));
+        });
+
+        await expect(filterService.saveFilters('test', filters)).resolves.toEqual(filters);
     });
 
     it('mergeWithStoredFilters when there is no cache data', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
When selecting certain filters in the order UI, the selection is not applied on the first click. Instead, the filter is immediately deselected again. Only after a second click does the filter remain selected and behave as expected.

The reason is a race condition in the filter.service.js between saving and reloading user filters.

### 2. What does this change do, exactly?
Wait for the "save" call of the user filters before refreshing them from store.

### 3. Describe each step to reproduce the issue or behaviour.
Open the orders section in the admin panel and select a sales channel in the filter e.g. “Sales Channels”.
The issue was also reproducable with other filters.

Correct behaviour should be, that all filters are applied correctly and do not "disappear" after selecting them in the admin.

### 4. Please link to the relevant issues (if any).
fixes https://github.com/shopware/shopware/issues/15965