### PR TITLE
fix: Update rule collection after creating rule (#16146)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
@@ -125,7 +125,7 @@ export default {
 
     methods: {
         onSaveRule(ruleId, rule) {
-            if (this.rules) {
+            if (this.rules && rule) {
                 const collection = EntityCollection.fromCollection(this.rules);
 
                 if (!collection.has(ruleId)) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/index.js
@@ -1,7 +1,7 @@
 import template from './sw-select-rule-create.html.twig';
 import './sw-select-rule-create.scss';
 
-const { Criteria } = Shopware.Data;
+const { Criteria, EntityCollection } = Shopware.Data;
 
 /**
  * @private
@@ -126,7 +126,13 @@ export default {
     methods: {
         onSaveRule(ruleId, rule) {
             if (this.rules) {
-                this.rules.add(rule);
+                const collection = EntityCollection.fromCollection(this.rules);
+
+                if (!collection.has(ruleId)) {
+                    collection.add(rule);
+                }
+
+                this.onUpdateCollection(collection);
             }
 
             this.$emit('save-rule', ruleId, rule);

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/sw-select-rule-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-rule-create/sw-select-rule-create.spec.js
@@ -43,7 +43,7 @@ describe('components/sw-select-rule-create', () => {
         },
     });
 
-    async function createWrapper() {
+    async function createWrapper(customProps = {}) {
         return mount(await wrapTestComponent('sw-select-rule-create', { sync: true }), {
             global: {
                 provide: {
@@ -94,6 +94,7 @@ describe('components/sw-select-rule-create', () => {
                 ruleId: 'random-rule-id',
                 restrictedRuleIds: ['restrictedId'],
                 restrictedRuleIdsTooltipLabel: 'myRestrictedLabelText',
+                ...customProps,
             },
         });
     }
@@ -148,5 +149,52 @@ describe('components/sw-select-rule-create', () => {
 
         expect(tooltipConfig.disabled).toBeFalsy();
         expect(tooltipConfig.message).toBe('ruleAwarenessRestrictionLabelText');
+    });
+
+    it('should emit updated rules collection when saving a rule from the modal', async () => {
+        const { Criteria, EntityCollection } = Shopware.Data;
+        const rules = new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25));
+        const rule = {
+            id: 'created-rule-id',
+            name: 'Created rule',
+            conditions: [],
+        };
+
+        const wrapper = await createWrapper({ rules });
+
+        wrapper.vm.onSaveRule(rule.id, rule);
+
+        const [
+            updatedRules,
+        ] = wrapper.emitted('update:rules')[0];
+
+        expect(updatedRules).not.toBe(rules);
+        expect(updatedRules.has(rule.id)).toBe(true);
+        expect(rules.has(rule.id)).toBe(false);
+        expect(wrapper.emitted('save-rule')[0]).toEqual([
+            rule.id,
+            rule,
+        ]);
+    });
+
+    it('should not duplicate an already selected rule when saving from the modal', async () => {
+        const { Criteria, EntityCollection } = Shopware.Data;
+        const rule = {
+            id: 'created-rule-id',
+            name: 'Created rule',
+            conditions: [],
+        };
+        const rules = new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25), [rule]);
+
+        const wrapper = await createWrapper({ rules });
+
+        wrapper.vm.onSaveRule(rule.id, rule);
+
+        const [
+            updatedRules,
+        ] = wrapper.emitted('update:rules')[0];
+
+        expect(updatedRules).toHaveLength(1);
+        expect(updatedRules.get(rule.id).id).toBe(rule.id);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

When creating a new rule from within a promotion, the newly created rule is not automatically assigned to that promotion.

### 2. What does this change do, exactly?

When the rule modal saves in multi-rule mode, it now shallow clones the current `EntityCollection`, adds the created rule, and emits `update:rules`. That makes the exact picker that opened the modal update its bound collection, so customer/cart/order promotion rule selects should auto-select the newly created rule.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new promotion.
2. Under Rule-based conditions, create a new rule.
3. Save the rule.

### 4. Please link to the relevant issues (if any).

fixes #16146 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
