### PR TITLE
fix: filter active categories in product export

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\SalesChannelRepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
@@ -116,6 +117,11 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
 
         foreach ($associations as $association) {
             $criteria->addAssociation($association);
+        }
+
+        if ($criteria->hasAssociation('categories')) {
+            $criteria->getAssociation('categories')
+                ->addFilter(new EqualsFilter('active', true));
         }
 
         $this->eventDispatcher->dispatch(

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -336,8 +336,8 @@ class ProductExportGeneratorTest extends TestCase
                 'encoding' => ProductExportEntity::ENCODING_UTF8,
                 'fileFormat' => ProductExportEntity::FILE_FORMAT_CSV,
                 'interval' => 0,
-                'headerTemplate' => 'name,stock',
-                'bodyTemplate' => '{{ product.name }},{{ product.stock }}',
+                'headerTemplate' => 'name,stock,category',
+                'bodyTemplate' => '{{ product.name }},{{ product.stock }},{%- if product.categories.count > 0 -%}{{ product.categories.first.name }}{%- endif -%}',
                 'productStreamId' => '137b079935714281ba80b40f83f8d7eb',
                 'storefrontSalesChannelId' => $this->getSalesChannelDomain()->getSalesChannelId(),
                 'salesChannelId' => $this->getSalesChannelId(),
@@ -430,6 +430,9 @@ class ProductExportGeneratorTest extends TestCase
                             ],
                         ],
                     ],
+                ],
+                'categories' => [
+                    ['id' => Uuid::randomHex(), 'name' => 'Foobar', 'active' => $i % 2 === 0],
                 ],
             ];
         }

--- a/tests/integration/Core/Content/ProductExport/Service/fixtures/test-export.csv
+++ b/tests/integration/Core/Content/ProductExport/Service/fixtures/test-export.csv
@@ -1,3 +1,3 @@
-name,stock
-Test,1
-Test,1
+name,stock,category
+Test,1,Foobar
+Test,1,

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
@@ -23,7 +25,9 @@ use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
@@ -33,7 +37,9 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Twig\Environment;
 
 /**
@@ -76,6 +82,14 @@ class ProductExportGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
+        $registry = new StaticDefinitionInstanceRegistry(
+            [CategoryDefinition::class, ProductCategoryDefinition::class, ProductDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+        $productDefinition = $registry->get(ProductDefinition::class);
+        static::assertInstanceOf(ProductDefinition::class, $productDefinition);
+
         $this->productStreamBuilder = $this->createMock(ProductStreamBuilderInterface::class);
         $this->productRepository = $this->createMock(SalesChannelRepository::class);
         $this->productExportRender = $this->createMock(ProductExportRendererInterface::class);
@@ -87,7 +101,7 @@ class ProductExportGeneratorTest extends TestCase
         $this->connection = $this->createMock(Connection::class);
         $this->seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
         $this->twig = $this->createMock(Environment::class);
-        $this->productDefinition = new ProductDefinition();
+        $this->productDefinition = $productDefinition;
         $this->languageLocaleProvider = $this->createMock(LanguageLocaleCodeProvider::class);
         $this->parserFactory = $this->createMock(TwigVariableParserFactory::class);
     }
@@ -168,7 +182,7 @@ class ProductExportGeneratorTest extends TestCase
         $productExport = $this->getProductExportEntity();
         $productExport->setEncoding(ProductExportEntity::ENCODING_UTF8);
         $productExport->setFileFormat(ProductExportEntity::FILE_FORMAT_JSONL);
-        $productExport->setBodyTemplate('{{ product.id }}');
+        $productExport->setBodyTemplate('{{ product.id }}{{ product.categories.count }}');
         $productExport->setIncludeVariants(false);
 
         $context = $this->createSalesChannelContext();
@@ -182,7 +196,7 @@ class ProductExportGeneratorTest extends TestCase
         $this->productStreamBuilder->expects($this->once())->method('buildFilters')->with('productStreamId', $context->getContext())->willReturn([]);
 
         $twigVariableParser = $this->createMock(TwigVariableParser::class);
-        $twigVariableParser->expects($this->once())->method('parse')->with('{{ product.id }}')->willReturn([]);
+        $twigVariableParser->expects($this->once())->method('parse')->with('{{ product.id }}{{ product.categories.count }}')->willReturn(['product.categories.count']);
         $this->parserFactory->expects($this->once())->method('getParser')->willReturn($twigVariableParser);
 
         $this->productRepository->expects($this->exactly(2))
@@ -190,6 +204,9 @@ class ProductExportGeneratorTest extends TestCase
             ->willReturnCallback(static function (Criteria $criteria, SalesChannelContext $salesChannelContext) use ($context): IdSearchResult {
                 static::assertSame(Criteria::TOTAL_COUNT_MODE_EXACT, $criteria->getTotalCountMode());
                 static::assertSame($context, $salesChannelContext);
+                static::assertTrue($criteria->hasAssociation('categories'));
+                static::assertCount(1, $criteria->getAssociation('categories')->getFilters());
+                static::assertEquals(new EqualsFilter('active', true), $criteria->getAssociation('categories')->getFilters()[0]);
 
                 return IdSearchResult::fromIds(['product-id'], $criteria, $context->getContext());
             });


### PR DESCRIPTION
### 1. Why is this change necessary?
The product export includes inactive categories, e.g. when getting the first associated category for the breadcrumb, it could be an inactive one

### 2. What does this change do, exactly?
Filters associated categories to have to be active

### 3. Describe each step to reproduce the issue or behaviour.
* Assign a single inactive category to a product
* Include the product in a feed/export
* See that the breadcrumb of the inactive category is included in the export

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16670

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
