### PR TITLE
chore: Added danger notificator if agentic commerce files were touched

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -178,10 +178,9 @@ return (new Config())
         ksort($matched);
 
         $context->warning(
-            'This Pull Request touches the <strong>Agentic Commerce</strong> feature'
-            . ' (a dedicated sales channel type and product export built on top of Shopware 6 product exports).<br/>'
+            'This Pull Request touches the <strong>Agentic Commerce Sales Channel</strong> feature.<br/>'
             . 'If you added or changed functionality here, please consider porting the change to the compatibility plugin'
-            . ' [SwagAgenticCommerce](https://github.com/shopware/SwagAgenticCommerce) so it is also available to merchants on older Shopware versions.<br/><br/>'
+            . ' SwagAgenticCommerce (https://github.com/shopware/SwagAgenticCommerce) so it is also available to merchants on older Shopware versions.<br/><br/>'
             . 'Affected files:<br/>'
             . implode('<br/>', array_keys($matched))
         );

--- a/.danger.php
+++ b/.danger.php
@@ -144,6 +144,49 @@ return (new Config())
         }
     })
     ->useRule(function (Context $context): void {
+        $files = $context->platform->pullRequest->getFiles();
+
+        $agenticCommercePatterns = [
+            // PHP — product export provider, validators and tracking that back the agentic-commerce sales channel type
+            'src/Core/Content/ProductExport/Provider/*AgenticCommerce*',
+            'src/Core/Content/ProductExport/Provider/OpenAi*',
+            'src/Core/Content/ProductExport/Subscriber/*AgenticCommerce*',
+            'src/Core/Content/ProductExport/Validator/OpenAi*',
+            'src/Core/Content/ProductExport/Validator/AbstractProviderValidator.php',
+            'src/Core/Content/ProductExport/Error/JsonlValidationError.php',
+            'src/Core/Content/ProductExport/Error/ProviderValidationError.php',
+            'src/Core/Content/ProductExport/Tracking/**',
+            'src/Core/Migration/**/*AgenticCommerce*',
+            'src/Core/Migration/**/*AgenticAi*',
+            // Administration — agentic-commerce sales channel UI
+            'src/Administration/Resources/app/administration/src/module/sw-sales-channel/agentic-product-export-templates/**',
+            'src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-agentic-commerce-tracking-config/**',
+            'src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-commerce-integration/**',
+        ];
+
+        $matched = [];
+        foreach ($agenticCommercePatterns as $pattern) {
+            foreach ($files->matches($pattern) as $file) {
+                $matched[$file->name] = true;
+            }
+        }
+
+        if (count($matched) === 0) {
+            return;
+        }
+
+        ksort($matched);
+
+        $context->warning(
+            'This Pull Request touches the <strong>Agentic Commerce</strong> feature'
+            . ' (a dedicated sales channel type and product export built on top of Shopware 6 product exports).<br/>'
+            . 'If you added or changed functionality here, please consider porting the change to the compatibility plugin'
+            . ' [SwagAgenticCommerce](https://github.com/shopware/SwagAgenticCommerce) so it is also available to merchants on older Shopware versions.<br/><br/>'
+            . 'Affected files:<br/>'
+            . implode('<br/>', array_keys($matched))
+        );
+    })
+    ->useRule(function (Context $context): void {
         function checkMigrationForBundle(string $bundle, Context $context): void
         {
             $files = $context->platform->pullRequest->getFiles();


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/16223

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

  The Agentic Commerce feature in Shopware 6 — a dedicated sales-channel type plus its product-export providers, validators, tracking and admin UI — has a companion compatibility plugin
  [SwagAgenticCommerce](https://github.com/shopware/SwagAgenticCommerce) so that merchants who are still on older Shopware versions can use the feature.

  Whenever someone extends or fixes the feature in core, the change usually needs to be ported to the compatibility plugin as well — but today there is no signal that reminds contributors of this.
  The two implementations drift apart easily.

  ### 2. What does this change do, exactly?

<img width="777" height="232" alt="Bildschirmfoto 2026-05-08 um 10 50 18" src="https://github.com/user-attachments/assets/84c6e4e9-c8b0-4e8a-9d3d-5bf536a14771" />

  Adds a new, **informational** rule to `.danger.php` that watches the agentic-commerce code paths in the repository:

  - `src/Core/Content/ProductExport/Provider/*AgenticCommerce*` and `OpenAi*`
  - `src/Core/Content/ProductExport/Subscriber/*AgenticCommerce*`
  - `src/Core/Content/ProductExport/Validator/OpenAi*` and `AbstractProviderValidator.php`
  - `src/Core/Content/ProductExport/Error/{Jsonl,Provider}ValidationError.php`
  - everything under `src/Core/Content/ProductExport/Tracking/`
  - `src/Core/Migration/**/*AgenticCommerce*` and `*AgenticAi*`
  - the three `sw-sales-channel/*agentic*` admin modules (`agentic-product-export-templates`, `sw-agentic-commerce-tracking-config`, `sw-sales-channel-detail-agentic-commerce-integration`)

  If any of the PR's changed files matches one of those patterns, the rule posts a `warning` thread on the PR with a link to [SwagAgenticCommerce](https://github.com/shopware/SwagAgenticCommerce)
  and the list of affected files. The rule deliberately uses `warning`, not `failure`, so it is purely a reminder and **does not block the merge**.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Open a PR that modifies any file matching one of the agentic-commerce path patterns listed above.
  2. Wait for the Danger CI job to finish.
  3. Observe an informational warning thread on the PR pointing to the SwagAgenticCommerce plugin and listing the affected files.
  4. Verify that the PR is **not** blocked from merging by this thread.

  A live evaluation has been done in #16716 — that PR bases on this branch and modifies one matching file with a doc-only edit so the new rule fires.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
