### PR TITLE
chore: cleanup eslint suppression comments

### DIFF
--- a/src/Administration/Resources/app/administration/eslint.config.mjs
+++ b/src/Administration/Resources/app/administration/eslint.config.mjs
@@ -363,6 +363,12 @@ export default [
             'vue/no-use-v-if-with-v-for': 'off',
         },
     },
+    {
+        files: ['src/**/sw-settings-rule-tree-item/sw-settings-rule-tree-item.html.twig'],
+        rules: {
+            'vue/no-multi-spaces': 'off',
+        },
+    },
 
     // Test files
     {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/index.ts
@@ -5,7 +5,6 @@ import { type DIVEModel, DIVEMath } from '@shopware-ag/dive';
 import { QuickView } from '@shopware-ag/dive/quickview';
 import { Toolbox } from '@shopware-ag/dive/toolbox';
 import { AssetExporter } from '@shopware-ag/dive/assetexporter';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Euler, type Vector3 } from 'three';
 import template from './sw-model-editor.html.twig';
 import './sw-model-editor.scss';

--- a/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/validation.api.service.spec.ts
@@ -1,8 +1,6 @@
 /**
  * @sw-package fundamentals@framework
  */
-
-// eslint-disable-next-line import/no-extraneous-dependencies
 import MockAdapter from 'axios-mock-adapter';
 import type { AxiosInstance } from 'axios';
 import createHTTPClient from '../../factory/http.factory';

--- a/src/Administration/Resources/app/administration/src/core/service/login.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/login.service.ts
@@ -250,7 +250,6 @@ export default function createLoginService(
                         refresh_token: token,
                     },
                     {
-                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         baseURL: context.apiPath!,
                     },
                 );

--- a/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/mixin/export-channel-filter.mixin.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-export-channel-tracking/mixin/export-channel-filter.mixin.js
@@ -5,7 +5,6 @@
 
 const { Criteria } = Shopware.Data;
 
-// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 Shopware.Mixin.register('export-channel-filter', {
     inject: [
         'repositoryFactory',

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery/index.ts
@@ -47,7 +47,6 @@ export default Component.wrapComponentConfig({
                 })
                 .catch((error: unknown) => {
                     // @ts-expect-error
-                    // eslint-disable-next-line max-len
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
                     this.displayRecoveryInfo(error.response.data);
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/agentic-product-export-templates/open-ai/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/agentic-product-export-templates/open-ai/index.js
@@ -1,8 +1,6 @@
 /**
  * @sw-package discovery
  */
-
-// eslint-disable-next-line import/no-unresolved
 import body from './body.json.twig?raw';
 
 Shopware.Service('exportTemplateService').registerProductExportTemplate({

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-tree-item/sw-settings-rule-tree-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-tree-item/sw-settings-rule-tree-item.html.twig
@@ -1,7 +1,5 @@
-<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks, vue/no-multi-spaces -->
 {% block sw_tree_item_element_actions %}
 <span v-if="hideActions"></span>
-<!-- eslint-disable-next-line vue/no-multi-spaces -->
 <span v-else>{% parent %}</span>
 {% endblock %}
 


### PR DESCRIPTION
### Changes

- removes obsolete eslint disable comments after running `eslint:admin:fix`
- adds ignore for the rule tree template where the spacing rule is still required.
