### PR TITLE
test: evaluate agentic-commerce danger warning (do not merge)

### DIFF
--- a/src/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProvider.php
+++ b/src/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProvider.php
@@ -48,8 +48,8 @@ abstract class AbstractAgenticCommerceProductExportProvider
     }
 
     /**
-     * Return provider-specific render context fields. The base class adds common fields (name, referralCode,
-     * affiliateCode, campaignCode) automatically.
+     * Return provider-specific render context fields. The base class adds common Agentic Commerce fields
+     * (name, referralCode, affiliateCode, campaignCode) automatically.
      *
      * @return array<string, mixed>
      */

--- a/src/Core/Content/ProductExport/Provider/OpenAiProductExportProvider.php
+++ b/src/Core/Content/ProductExport/Provider/OpenAiProductExportProvider.php
@@ -13,6 +13,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
+ * Agentic Commerce product-export provider for the OpenAI product feed format.
+ *
  * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
  */
 #[Package('discovery')]

--- a/src/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriber.php
+++ b/src/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriber.php
@@ -10,6 +10,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
+ * Adds the active Agentic Commerce provider's context to the product export render body event.
+ *
  * @internal
  */
 #[Package('discovery')]

--- a/src/Core/Content/ProductExport/Tracking/AgenticCommerceEvaluationEvent.php
+++ b/src/Core/Content/ProductExport/Tracking/AgenticCommerceEvaluationEvent.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\ProductExport\Tracking;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Marker event used to evaluate the Agentic Commerce Danger rule on test PRs.
+ *
+ * @codeCoverageIgnore
+ *
+ * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ */
+#[Package('discovery')]
+final class AgenticCommerceEvaluationEvent extends Event
+{
+}


### PR DESCRIPTION
## Summary
- Companion PR to #16714 — bases on that branch so the Danger run loads the new rule from base.
- Touches `AbstractAgenticCommerceProductExportProvider.php` with a doc-only edit so the new Danger rule fires its informational warning.
- Not intended to be merged. Close once the warning has been verified in the PR thread.

## Why a separate PR
The existing rule in `.danger.php` notes that changes to `.danger.php` are not reflected in the same PR (Danger reads it from the base branch). The rule introduced in #16714 therefore can only be evaluated by a PR whose base already contains it.

## Test plan
- [ ] Wait for the Danger CI job to finish.
- [ ] Verify a warning thread is opened on this PR mentioning the Agentic Commerce feature and listing `src/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProvider.php` as an affected file.
- [ ] Verify the PR is **not** blocked from merging by this warning.
- [ ] Close this PR after evaluation.