### PR TITLE
fix: rule duplication infinite loading

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
@@ -520,11 +520,13 @@ export default {
                         return Promise.resolve();
                     }
 
-                    return this.loadEntityData(this.rule.id).then(() => {
-                        this.setTreeFinishedLoading();
-                    });
+                    return this.loadEntityData(this.rule.id);
                 })
                 .then(() => {
+                    if (reload) {
+                        this.setTreeFinishedLoading();
+                    }
+
                     if (!keepLoading) {
                         this.isLoading = false;
                     }
@@ -595,7 +597,7 @@ export default {
         onDuplicate() {
             return this.saveRuleChanges({ reload: false, keepLoading: true }).then((isSuccessful) => {
                 if (!isSuccessful) {
-                    return Promise.resolve();
+                    return Promise.resolve(false);
                 }
 
                 const behaviour = {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
@@ -69,31 +69,7 @@ export default {
         },
 
         ruleCriteria() {
-            const criteria = new Criteria();
-
-            criteria.addAssociation('tags');
-            criteria.addAssociation('flowSequences.flow');
-
-            const aggregationEntities = [
-                'personaPromotions',
-                'orderPromotions',
-                'cartPromotions',
-                'promotionDiscounts',
-                'promotionSetGroups',
-                'shippingMethodPriceCalculations',
-                'shippingMethodPrices',
-                'productPrices',
-                'shippingMethods',
-                'paymentMethods',
-            ];
-
-            aggregationEntities.forEach((entity) => {
-                criteria.addAggregation(
-                    Criteria.terms(entity, 'id', null, null, Criteria.count(entity, `rule.${entity}.id`)),
-                );
-            });
-
-            return criteria;
+            return this.createRuleCriteria();
         },
 
         appScriptConditionRepository() {
@@ -230,6 +206,34 @@ export default {
     },
 
     methods: {
+        createRuleCriteria() {
+            const criteria = new Criteria();
+
+            criteria.addAssociation('tags');
+            criteria.addAssociation('flowSequences.flow');
+
+            const aggregationEntities = [
+                'personaPromotions',
+                'orderPromotions',
+                'cartPromotions',
+                'promotionDiscounts',
+                'promotionSetGroups',
+                'shippingMethodPriceCalculations',
+                'shippingMethodPrices',
+                'productPrices',
+                'shippingMethods',
+                'paymentMethods',
+            ];
+
+            aggregationEntities.forEach((entity) => {
+                criteria.addAggregation(
+                    Criteria.terms(entity, 'id', null, null, Criteria.count(entity, `rule.${entity}.id`)),
+                );
+            });
+
+            return criteria;
+        },
+
         loadConditionData() {
             const context = {
                 ...Context.api,
@@ -254,9 +258,10 @@ export default {
             this.isLoading = true;
             this.conditions = null;
 
-            this.ruleCriteria.addFilter(Criteria.equals('id', ruleId));
+            const criteria = this.createRuleCriteria();
+            criteria.addFilter(Criteria.equals('id', ruleId));
 
-            return this.ruleRepository.search(this.ruleCriteria).then((response) => {
+            return this.ruleRepository.search(criteria).then((response) => {
                 this.entityCount = this.extractEntityCount(response.aggregations);
 
                 this.rule = response.first();
@@ -267,8 +272,12 @@ export default {
         extractEntityCount(aggregations) {
             const entityCount = {};
 
+            if (!aggregations) {
+                return entityCount;
+            }
+
             Object.keys(aggregations).forEach((key) => {
-                entityCount[key] = aggregations[key].buckets.at(0)[key].count;
+                entityCount[key] = aggregations[key]?.buckets?.at(0)?.[key]?.count ?? 0;
             });
 
             return entityCount;
@@ -336,6 +345,10 @@ export default {
         },
 
         loadConditions(conditions = null) {
+            if (!this.rule) {
+                return Promise.resolve();
+            }
+
             const context = { ...Context.api, inheritance: true };
 
             if (conditions === null) {
@@ -450,8 +463,12 @@ export default {
         },
 
         onSave() {
+            return this.saveRuleChanges();
+        },
+
+        saveRuleChanges({ reload = true, keepLoading = false } = {}) {
             if (!this.validateRuleAwareness()) {
-                return Promise.resolve();
+                return Promise.resolve(false);
             }
 
             if (!this.validateDateRange()) {
@@ -462,9 +479,10 @@ export default {
                         code: 'INVALID_DATE_RANGE',
                     }),
                 });
+
                 this.showErrorNotification();
 
-                return Promise.resolve();
+                return Promise.resolve(false);
             }
 
             this.isSaveSuccessful = false;
@@ -472,17 +490,23 @@ export default {
 
             if (this.rule.isNew()) {
                 this.rule.conditions = this.conditionTree;
+
                 return this.saveRule()
                     .then(() => {
                         this.$router.push({
-                            name: 'sw.settings.rule.detail',
+                            name: 'sw.settings.rule.detail.base',
                             params: { id: this.rule.id },
                         });
+
                         this.isSaveSuccessful = true;
                         this.conditionsTreeContainsUserChanges = false;
+
+                        return true;
                     })
                     .catch(() => {
                         this.showErrorNotification();
+
+                        return false;
                     });
             }
 
@@ -490,16 +514,28 @@ export default {
                 .then(this.syncConditions)
                 .then(() => {
                     this.isSaveSuccessful = true;
-                    this.loadEntityData(this.rule.id).then(() => {
+                    this.conditionsTreeContainsUserChanges = false;
+
+                    if (!reload) {
+                        return Promise.resolve();
+                    }
+
+                    return this.loadEntityData(this.rule.id).then(() => {
                         this.setTreeFinishedLoading();
                     });
                 })
                 .then(() => {
-                    this.isLoading = false;
+                    if (!keepLoading) {
+                        this.isLoading = false;
+                    }
+
+                    return true;
                 })
                 .catch(() => {
                     this.isLoading = false;
                     this.showErrorNotification();
+
+                    return false;
                 });
         },
 
@@ -540,6 +576,7 @@ export default {
             this.createNotificationError({
                 message: this.$t('sw-settings-rule.detail.messageSaveError', { name: this.rule.name }, 0),
             });
+
             this.isLoading = false;
         },
 
@@ -556,7 +593,11 @@ export default {
         },
 
         onDuplicate() {
-            return this.onSave().then(() => {
+            return this.saveRuleChanges({ reload: false, keepLoading: true }).then((isSuccessful) => {
+                if (!isSuccessful) {
+                    return Promise.resolve();
+                }
+
                 const behaviour = {
                     overwrites: {
                         name: `${this.rule.name} ${this.$t('global.default.copy')}`,
@@ -565,12 +606,19 @@ export default {
                     },
                 };
 
-                return this.ruleRepository.clone(this.rule.id, behaviour, Shopware.Context.api).then((duplicatedData) => {
-                    this.$router.push({
-                        name: 'sw.settings.rule.detail',
-                        params: { id: duplicatedData.id },
+                return this.ruleRepository
+                    .clone(this.rule.id, behaviour, Shopware.Context.api)
+                    .then((duplicatedData) => {
+                        return this.$router.push({
+                            name: 'sw.settings.rule.detail.base',
+                            params: { id: duplicatedData.id },
+                        });
+                    })
+                    .catch(() => {
+                        this.showErrorNotification();
+
+                        return false;
                     });
-                });
             });
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/sw-settings-rule-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/sw-settings-rule-detail.spec.js
@@ -354,6 +354,77 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         expect(call[0].aggregations.map((a) => a.name)).toEqual(aggregations);
     });
 
+    it('should skip rule awareness for incomplete aggregations without association counts', async () => {
+        global.activeAclRoles = ['rule.editor'];
+
+        const awarenessFunc = jest.fn(() => ({
+            isRestricted: false,
+        }));
+
+        ruleRepositoryMock.search.mockResolvedValueOnce(
+            getCollection('rule', [ruleMock], {
+                personaPromotions: {
+                    buckets: [{}],
+                },
+                orderPromotions: {
+                    buckets: [],
+                },
+                cartPromotions: {},
+            }),
+        );
+
+        const wrapper = await createWrapper(defaultProps, {
+            ruleConditionDataProviderService: {
+                getModuleTypes: () => [],
+                addScriptConditions: () => {},
+                getRestrictionsByAssociation: awarenessFunc,
+                getAwarenessKeysWithEqualsAnyConfig: () => [
+                    'personaPromotions',
+                    'orderPromotions',
+                    'cartPromotions',
+                ],
+            },
+        });
+        await flushPromises();
+
+        await wrapper.get('.sw-settings-rule-detail__save-action').trigger('click');
+        await flushPromises();
+
+        expect(awarenessFunc).toHaveBeenCalledTimes(0);
+    });
+
+    it('should not load conditions when the rule does not exist', async () => {
+        ruleRepositoryMock.search.mockResolvedValueOnce(getCollection('rule'));
+
+        await createWrapper();
+        await flushPromises();
+
+        expect(conditionRepositoryMock.search).toHaveBeenCalledTimes(0);
+    });
+
+    it('should search only by the current rule id when the route id changes', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        ruleRepositoryMock.search.mockClear();
+
+        await wrapper.setProps({
+            ruleId: 'duplicated-rule-id',
+        });
+        await flushPromises();
+
+        const criteria = ruleRepositoryMock.search.mock.calls[0][0];
+        const idFilters = criteria.filters.filter((filter) => filter.field === 'id');
+
+        expect(idFilters).toEqual([
+            {
+                type: 'equals',
+                field: 'id',
+                value: 'duplicated-rule-id',
+            },
+        ]);
+    });
+
     it('should create rule condition repository: $name', async () => {
         const wrapper = await createWrapper();
         await flushPromises();
@@ -459,8 +530,18 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         await wrapper.find('.sw-settings-rule-detail__save-action').trigger('click');
         await flushPromises();
 
+        const expectedCallPayload = [
+            [
+                {
+                    name: 'sw.settings.rule.detail.base',
+                    params: { id: ruleMock.id },
+                },
+            ],
+        ];
+
         expect(ruleRepositoryMock.save).toHaveBeenCalledTimes(1);
         expect(routerSpy).toHaveBeenCalledTimes(fails ? 0 : 1);
+        expect(routerSpy.mock.calls).toEqual(fails ? [] : expectedCallPayload);
         expect(wrapper.vm.createNotificationError).toHaveBeenCalledTimes(fails ? 1 : 0);
     });
 
@@ -595,13 +676,18 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-detail', () => {
         await wrapper.find('.sw-settings-rule-detail__button-context-menu').trigger('click');
         await flushPromises();
 
+        ruleRepositoryMock.search.mockClear();
+
         await wrapper.find('.sw-settings-rule-detail__save-duplicate-action').trigger('click');
         await flushPromises();
 
         expect(ruleRepositoryMock.save).toHaveBeenCalledTimes(1);
+        expect(ruleRepositoryMock.search).toHaveBeenCalledTimes(0);
         expect(ruleRepositoryMock.clone).toHaveBeenCalledTimes(1);
+
+        expect(wrapper.find('sw-skeleton-stub').exists()).toBe(true);
         expect(routerSpy).toHaveBeenNthCalledWith(1, {
-            name: 'sw.settings.rule.detail',
+            name: 'sw.settings.rule.detail.base',
             params: { id: 'duplicated-rule-id' },
         });
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/index.js
@@ -219,7 +219,7 @@ export default {
 
             this.ruleRepository.clone(referenceRule.id, behaviour, Shopware.Context.api).then((duplicatedData) => {
                 this.$router.push({
-                    name: 'sw.settings.rule.detail',
+                    name: 'sw.settings.rule.detail.base',
                     params: { id: duplicatedData.id },
                 });
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-list/sw-settings-rule-list.spec.js
@@ -170,7 +170,7 @@ describe('src/module/sw-settings-rule/page/sw-settings-rule-list', () => {
         await wrapper.vm.onDuplicate(ruleToDuplicate);
         expect(wrapper.vm.$router.push).toHaveBeenCalledTimes(1);
         expect(wrapper.vm.$router.push).toHaveBeenCalledWith({
-            name: 'sw.settings.rule.detail',
+            name: 'sw.settings.rule.detail.base',
             params: {
                 id: ruleToDuplicate.id,
             },


### PR DESCRIPTION
resolves https://github.com/shopware/shopware/issues/16541

`ruleCriteria` was a cached computed; `loadEntityData` mutated it with `addFilter(equals('id', ruleId))` on every call, so subsequent loads queried with stale, accumulated id filters.