### PR TITLE
fix: keep validation icon margin consistent across input widths

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_forms.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_forms.scss
@@ -12,7 +12,7 @@ https://getbootstrap.com/docs/5.2/forms/overview
         .was-validated &:#{$state},
         &.is-#{$state} {
             @if $enable-validation-icons {
-                background-position: 97% 50%;
+                background-position: right 0.75rem center;
             }
         }
     }


### PR DESCRIPTION
resolves https://github.com/shopware/shopware/issues/16269

### Changes

- Validation icons in forms with mixed input widths (e.g. the revocation form) had inconsistent right margins because `background-position: 97% 50%` scales with input width.
- Replaced with a fixed `right 0.75rem center`