### PR TITLE
fix: allow merge theme config with null values

### DIFF
--- a/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseConfigLoader.php
@@ -232,7 +232,7 @@ class DatabaseConfigLoader extends AbstractConfigLoader
         }
 
         foreach ($theme->getConfigValues() as $fieldName => $configValue) {
-            if (isset($configValue['value'])) {
+            if (\array_key_exists('value', $configValue)) {
                 $configuredTheme['fields'][$fieldName]['value'] = $configValue['value'];
             }
         }

--- a/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme\ConfigLoader;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+use Shopware\Storefront\Theme\StorefrontPluginRegistry;
+use Shopware\Storefront\Theme\ThemeCollection;
+use Shopware\Storefront\Theme\ThemeDefinition;
+use Shopware\Storefront\Theme\ThemeEntity;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DatabaseConfigLoader::class)]
+class DatabaseConfigLoaderTest extends TestCase
+{
+    /**
+     * @var StaticEntityRepository<ThemeCollection>
+     */
+    private StaticEntityRepository $themeRepository;
+
+    private MockObject&StorefrontPluginRegistry $storefrontPluginRegistry;
+
+    /**
+     * @var StaticEntityRepository<MediaCollection>
+     */
+    private StaticEntityRepository $mediaRepository;
+
+    private DatabaseConfigLoader $databaseConfigLoader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->themeRepository = new StaticEntityRepository([], new ThemeDefinition());
+        $this->storefrontPluginRegistry = $this->createMock(StorefrontPluginRegistry::class);
+        $this->mediaRepository = new StaticEntityRepository([new MediaCollection([])], new MediaDefinition());
+
+        $this->databaseConfigLoader = new DatabaseConfigLoader(
+            $this->themeRepository,
+            $this->storefrontPluginRegistry,
+            $this->mediaRepository
+        );
+    }
+
+    public function testItLoadsStorefrontPluginConfiguration(): void
+    {
+        $themeId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $theme = new ThemeEntity();
+        $theme->setId($themeId);
+        $theme->setName('FooBar');
+        $theme->setTechnicalName('FooBar');
+        $theme->setActive(true);
+        $theme->setBaseConfig([
+            'foo' => [
+                'type' => 'media',
+                'value' => 'bar',
+            ],
+            'bar' => [
+                'type' => 'media',
+                'value' => 'foo',
+            ],
+        ]);
+        $theme->setConfigValues([
+            'foo' => [
+                'type' => 'media',
+                'value' => null,
+            ],
+        ]);
+
+        $baseTheme = new ThemeEntity();
+        $baseTheme->setId(Uuid::randomHex());
+        $baseTheme->setTechnicalName(StorefrontPluginRegistry::BASE_THEME_NAME);
+
+        $this->themeRepository->searches = [new ThemeCollection([$theme]), new ThemeCollection([$theme, $baseTheme])];
+
+        $configuration = new StorefrontPluginConfiguration('FooBar');
+        $configuration->setThemeConfig($theme->getBaseConfig());
+
+        $this->storefrontPluginRegistry
+            ->expects($this->exactly(3))
+            ->method('getConfigurations')
+            ->willReturn(new StorefrontPluginConfigurationCollection([$configuration]));
+
+        $config = $this->databaseConfigLoader->load($themeId, $context);
+
+        static::assertNotNull($config->getThemeConfig());
+        static::assertArrayHasKey('foo', $config->getThemeConfig());
+        static::assertNull($config->getThemeConfig()['foo']['value']);
+        static::assertArrayHasKey('bar', $config->getThemeConfig());
+        static::assertSame('foo', $config->getThemeConfig()['bar']['value']);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When the theme is compiled the merging of theme configs ignores overwritten values that are `null`. E.g. the base config of the theme has a default value, but the user configuration changes that value to be `null`. The user setting is ignored in favor of the default/base value.

### 2. What does this change do, exactly?
Allow values to be overwritten to be `null`.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a theme with media config field and a default value.
* Use the config field value as a variable in scss.
* Compile the theme with the default value
* Set the config value to be `null`
* Recompile the theme

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16672

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
