### PR TITLE
fix: reload customer group after save

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
@@ -314,7 +314,9 @@ export default {
             }
 
             try {
-                await this.customerGroupRepository.save(this.customerGroup);
+                await this.customerGroupRepository
+                    .save(this.customerGroup)
+                    .then((response) => (response !== undefined ? this.loadCustomerGroup() : Promise.resolve()));
 
                 this.isSaveSuccessful = true;
             } catch (_err) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.spec.js
@@ -7,6 +7,62 @@ import { mount } from '@vue/test-utils';
 const { Context } = Shopware;
 const { EntityCollection } = Shopware.Data;
 
+const customerGroupRepository = {
+    create: () => {
+        return {
+            id: '',
+            name: '',
+            displayGross: false,
+            isNew: () => true,
+        };
+    },
+
+    get: () => {
+        return Promise.resolve({
+            id: '1',
+            name: 'Net price customer group',
+            displayGross: false,
+            registrationActive: true,
+            registrationTitle: 'Foobar',
+            registrationSalesChannels: new EntityCollection(
+                '/customer-group/1/registration-sales-channels',
+                'sales_channel',
+                Context.api,
+                null,
+                [
+                    {
+                        id: '123',
+                    },
+                ],
+            ),
+            isNew: () => false,
+        });
+    },
+
+    search: () => {
+        return Promise.resolve([
+            {
+                id: '123',
+                seoPathInfo: 'Hello-world',
+                salesChannel: {
+                    translated: {
+                        name: 'Storefront',
+                    },
+                    domains: [
+                        {
+                            languageId: '1234',
+                            url: 'http://shopware.test',
+                        },
+                    ],
+                },
+                languageId: '1234',
+            },
+        ]);
+    },
+
+    save: jest.fn(() => Promise.resolve({})),
+};
+
 async function createWrapper(privileges = []) {
     return mount(
         await wrapTestComponent('sw-settings-customer-group-detail', {
@@ -91,58 +147,14 @@ async function createWrapper(privileges = []) {
 
                 provide: {
                     repositoryFactory: {
-                        create: () => ({
-                            create: () => {
-                                return {
-                                    id: '',
-                                    name: '',
-                                    displayGross: false,
-                                    isNew: () => true,
-                                };
-                            },
-
-                            get: () => {
-                                return Promise.resolve({
-                                    id: '1',
-                                    name: 'Net price customer group',
-                                    displayGross: false,
-                                    registrationActive: true,
-                                    registrationSalesChannels: new EntityCollection(
-                                        '/customer-group/1/registration-sales-channels',
-                                        'sales_channel',
-                                        Context.api,
-                                        null,
-                                        [
-                                            {
-                                                id: '123',
-                                            },
-                                        ],
-                                    ),
-                                    isNew: () => false,
-                                });
-                            },
-
-                            search: () => {
-                                return Promise.resolve([
-                                    {
-                                        id: '123',
-                                        seoPathInfo: 'Hello-world',
-                                        salesChannel: {
-                                            translated: {
-                                                name: 'Storefront',
-                                            },
-                                            domains: [
-                                                {
-                                                    languageId: '1234',
-                                                    url: 'http://shopware.test',
-                                                },
-                                            ],
-                                        },
-                                        languageId: '1234',
-                                    },
-                                ]);
-                            },
-                        }),
+                        create: (name) => {
+                            switch (name) {
+                                case 'customer_group':
+                                    return customerGroupRepository;
+                                default:
+                                    throw new Error(`No repository for ${name} configured`);
+                            }
+                        },
                     },
                     acl: {
                         can: (identifier) => {
@@ -286,6 +298,24 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
                 message: 'CTRL + S',
                 appearance: 'light',
             });
+        });
+    });
+
+    describe('should persist customer group', () => {
+        let wrapper;
+
+        beforeEach(async () => {
+            wrapper = await createWrapper();
+            await wrapper.vm.$nextTick();
+        });
+
+        it('should reload customer group on saved changes', async () => {
+            const onLoadCustomerGroupSpy = jest.spyOn(wrapper.vm, 'loadCustomerGroup');
+            const element = wrapper.find('.sw-settings-customer-group-detail__save');
+            await element.trigger('click');
+
+            expect(wrapper.vm.customerGroupRepository.save).toHaveBeenCalledTimes(1);
+            expect(onLoadCustomerGroupSpy).toHaveBeenCalled();
         });
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Editing the customer group details will detect changes only on saving initially. As it isn't refetched, changes from `true` to `false` and back to `true` won't be detected as the entity was never updated in the admin.

### 2. What does this change do, exactly?
Refetch customer group after saving.

### 3. Describe each step to reproduce the issue or behaviour.
* Go to the customer group setting
* Change type from gross to net or vice versa
* Request is dispatched to persist customer group
* Change back the type
* No request dispatched as no changes detected     

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/16506

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them