### PR TITLE
ci: update github-script action in milestone workflow

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -22,7 +22,7 @@ jobs:
           id: versions
           uses: shopware/github-actions/versions@main
         - name: Get next minor
-          uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+          uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9
           id: next-milestone
           env:
             NEXT_MINOR: ${{ steps.versions.outputs.next-minor }}
@@ -73,7 +73,7 @@ jobs:
 
         - name: Set milestone label
           if: ${{ steps.next-milestone.outputs.result != 'skip' }}
-          uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+          uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9
           env:
             MILESTONE: ${{ steps.next-milestone.outputs.result }}
           with:
@@ -99,11 +99,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6
       - shell: bash
         run: npm ci --prefix .github/bin/js/
       - name: Set milestone
-        uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # 9
         with:
           script: |
             const { setMilestoneForPR } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')


### PR DESCRIPTION
### 1. Why is this change necessary?
The Milestone Script doesn't find the linked issue anymore. Locally everything works,  so I want to try to update the `github-script` action. That action always reports an deprecation.

### 2. What does this change do, exactly?
Update the `github-script` action to V9.

### 3. Describe each step to reproduce the issue or behaviour.
Merge an PR and check the milestone workflow.