### PR TITLE
fix: allow selecting more promotion exclusions

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/index.js
@@ -92,7 +92,9 @@ export default {
             }
 
             const promotionRepository = this.repositoryFactory.create('promotion');
-            const criteria = new Criteria(1, 25).addFilter(Criteria.equalsAny('id', this.promotion.exclusionIds));
+            const criteria = new Criteria(1, this.promotion.exclusionIds.length).addFilter(
+                Criteria.equalsAny('id', this.promotion.exclusionIds),
+            );
 
             promotionRepository.search(criteria).then((excluded) => {
                 this.excludedPromotions = excluded;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js
@@ -3,7 +3,72 @@
  */
 import { mount } from '@vue/test-utils';
 
-async function createWrapper() {
+const { Criteria, EntityCollection } = Shopware.Data;
+
+function createPromotion(overrides = {}) {
+    return {
+        name: 'Test Promotion',
+        active: true,
+        validFrom: '2020-07-28T12:00:00.000+00:00',
+        validUntil: '2020-08-11T12:00:00.000+00:00',
+        maxRedemptionsGlobal: 45,
+        maxRedemptionsPerCustomer: 12,
+        exclusive: false,
+        code: null,
+        useCodes: true,
+        useIndividualCodes: false,
+        individualCodePattern: 'code-%d',
+        useSetGroups: false,
+        customerRestriction: true,
+        orderCount: 0,
+        ordersPerCustomerCount: null,
+        exclusionIds: ['d671d6d3efc74d2a8b977e3be3cd69c7'],
+        translated: {
+            name: 'Test Promotion',
+        },
+        apiAlias: null,
+        id: 'promotionId',
+        setgroups: [],
+        salesChannels: [
+            {
+                promotionId: 'promotionId',
+                salesChannelId: 'salesChannelId',
+                priority: 1,
+                createdAt: '2020-08-17T13:24:52.692+00:00',
+                id: 'promotionSalesChannelId',
+            },
+        ],
+        discounts: [],
+        individualCodes: [],
+        personaRules: [],
+        personaCustomers: [],
+        orderRules: [],
+        cartRules: [],
+        translations: [],
+        hasOrders: false,
+        isNew() {
+            return true;
+        },
+        ...overrides,
+    };
+}
+
+function createPromotionCollection(promotions = []) {
+    return new EntityCollection(
+        '/promotion',
+        'promotion',
+        Shopware.Context.api,
+        new Criteria(1, 25),
+        promotions,
+        promotions.length,
+    );
+}
+
+function defaultRepositorySearch() {
+    return Promise.resolve(createPromotionCollection([{ id: 'promotionId1' }]));
+}
+
+async function createWrapper({ promotion = {}, repositorySearch } = {}) {
     return mount(await wrapTestComponent('sw-promotion-v2-conditions', { sync: true }), {
         global: {
             stubs: {
@@ -53,7 +118,7 @@ async function createWrapper() {
             provide: {
                 repositoryFactory: {
                     create: () => ({
-                        search: () => Promise.resolve([{ id: 'promotionId1' }]),
+                        search: repositorySearch ?? defaultRepositorySearch,
                     }),
                 },
                 ruleConditionDataProviderService: {
@@ -66,50 +131,7 @@ async function createWrapper() {
             },
         },
         props: {
-            promotion: {
-                name: 'Test Promotion',
-                active: true,
-                validFrom: '2020-07-28T12:00:00.000+00:00',
-                validUntil: '2020-08-11T12:00:00.000+00:00',
-                maxRedemptionsGlobal: 45,
-                maxRedemptionsPerCustomer: 12,
-                exclusive: false,
-                code: null,
-                useCodes: true,
-                useIndividualCodes: false,
-                individualCodePattern: 'code-%d',
-                useSetGroups: false,
-                customerRestriction: true,
-                orderCount: 0,
-                ordersPerCustomerCount: null,
-                exclusionIds: ['d671d6d3efc74d2a8b977e3be3cd69c7'],
-                translated: {
-                    name: 'Test Promotion',
-                },
-                apiAlias: null,
-                id: 'promotionId',
-                setgroups: [],
-                salesChannels: [
-                    {
-                        promotionId: 'promotionId',
-                        salesChannelId: 'salesChannelId',
-                        priority: 1,
-                        createdAt: '2020-08-17T13:24:52.692+00:00',
-                        id: 'promotionSalesChannelId',
-                    },
-                ],
-                discounts: [],
-                individualCodes: [],
-                personaRules: [],
-                personaCustomers: [],
-                orderRules: [],
-                cartRules: [],
-                translations: [],
-                hasOrders: false,
-                isNew() {
-                    return true;
-                },
-            },
+            promotion: createPromotion(promotion),
         },
     });
 }
@@ -133,5 +155,32 @@ describe('src/module/sw-promotion-v2/component/sw-promotion-v2-conditions', () =
         wrapper.findAllComponents('.sw-field').forEach((field) => {
             expect(field.props('disabled')).toBeFalsy();
         });
+    });
+
+    it('should load all selected promotion exclusions', async () => {
+        const selectedPromotions = Array.from({ length: 26 }, (_, index) => {
+            return {
+                id: `promotion-id-${index}`,
+                name: `Promotion ${index}`,
+            };
+        });
+        const repositorySearch = jest.fn((criteria) => {
+            return Promise.resolve(createPromotionCollection(selectedPromotions.slice(0, criteria.limit)));
+        });
+        const wrapper = await createWrapper({
+            promotion: {
+                exclusionIds: [],
+            },
+            repositorySearch,
+        });
+
+        wrapper.vm.onChangeExclusions(createPromotionCollection(selectedPromotions));
+
+        await flushPromises();
+
+        expect(wrapper.vm.promotion.exclusionIds).toHaveLength(26);
+        expect(repositorySearch).toHaveBeenCalledTimes(1);
+        expect(repositorySearch.mock.calls[0][0].limit).toBe(26);
+        expect(wrapper.vm.excludedPromotions).toHaveLength(26);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Promotion exclusions in the Administration can be selected through the "Do not combine with" multi-select. The selected exclusions are reloaded with a fixed `Criteria(1, 25)`, so selections above 25 can be truncated from the selected entity collection.

### 2. What does this change do, exactly?

- Loads selected promotion exclusions with a criteria limit matching `promotion.exclusionIds.length`.
- Keeps the dropdown search result paging unchanged at `new Criteria(1, 25)`.
- Adds regression coverage for selecting 26 promotion exclusions.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create more than 25 valid promotions.
2. Open another promotion in the Administration.
3. Go to the conditions tab and use "Do not combine with" to select more than 25 promotions.
4. Save or reload the selection.
5. The selected exclusions above the first 25 are not retained in the selected entity collection.

### 4. Please link to the relevant issues (if any).

Fixes #5493

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them

Validation notes:

- `git diff --check -- src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/index.js src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js`
- `./node_modules/.bin/prettier --check src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/index.js src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js`

Blocked locally:

- `npx jest --collectCoverage=false src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js --runInBand` failed because `npx` is not available in this shell.
- `./node_modules/.bin/jest --collectCoverage=false src/module/sw-promotion-v2/view/sw-promotion-v2-conditions/sw-promotion-v2-conditions.spec.js --runInBand` failed before running tests because Jest could not validate `test/_helper_/jest-resolver.js` in the local node_modules layout.
- `composer eslint:admin` and `composer format:admin` failed because `npm` is not available in this shell.
