### PR TITLE
fix: correct administration date filter criteria

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -2,6 +2,7 @@
  * @sw-package framework
  */
 
+import { zonedTimeToUtc } from 'date-fns-tz';
 import template from './sw-date-filter.html.twig';
 import './sw-date-filter.scss';
 
@@ -92,6 +93,10 @@ export default {
         showDivider() {
             return !this.isDateTimeType && !this.filter.showTimeframe;
         },
+
+        userTimeZone() {
+            return Shopware.Store.get('session').currentUser?.timeZone ?? 'UTC';
+        },
     },
 
     watch: {
@@ -121,30 +126,25 @@ export default {
             return label;
         },
 
-        updateFilter(params) {
+        updateFilter() {
             if (!this.dateValue.from && !this.dateValue.to) {
                 this.$emit('filter-reset', this.filter.name);
                 return;
             }
 
+            const normalizedDateValue = this.getNormalizedDateValue(this.dateValue);
+
             const { value } = this.filter;
-            if (value && value.from === this.dateValue.from && value.to === this.dateValue.to) {
+            if (value && value.from === normalizedDateValue.from && value.to === normalizedDateValue.to) {
                 return;
             }
 
-            if (this.dateValue.from) {
-                const from = new Date(this.dateValue.from);
-                from.setHours(0, 0, 0);
-                this.dateValue.from = from.toISOString();
-            }
+            const params = {
+                ...(normalizedDateValue.from ? { gte: normalizedDateValue.from } : {}),
+                ...(normalizedDateValue.to ? { lte: normalizedDateValue.to } : {}),
+            };
 
-            if (this.dateValue.to) {
-                const to = new Date(this.dateValue.to);
-                to.setHours(23, 59, 59);
-                this.dateValue.to = to.toISOString();
-            }
-
-            this.$emit('filter-update', this.filter.name, params, this.dateValue);
+            this.$emit('filter-update', this.filter.name, [Criteria.range(this.filter.property, params)], normalizedDateValue);
         },
 
         onTimeframeSelect(timeframe) {
@@ -163,26 +163,27 @@ export default {
             let to = new Date();
 
             from.setDate(from.getDate() + timeframe);
-            from.setHours(0, 0, 0);
 
             if (timeframe === 'lastQuarter') {
                 ({ startDate: from, endDate: to } = this.getPreviousQuarterDates());
             }
 
+            const normalizedDateValue = this.getNormalizedDateValue({
+                from: from.toISOString(),
+                to: to.toISOString(),
+                timeframe: timeframe,
+            });
+
             const params = {
-                gte: from.toISOString(),
-                lte: to.toISOString(),
+                gte: normalizedDateValue.from,
+                lte: normalizedDateValue.to,
             };
 
             const filterCriteria = [
                 Criteria.range(this.filter.property, params),
             ];
 
-            this.dateValue = {
-                from: params.gte,
-                to: params.lte,
-                timeframe: timeframe,
-            };
+            this.dateValue = normalizedDateValue;
 
             this.$emit('filter-update', this.filter.name, filterCriteria, this.dateValue);
         },
@@ -200,13 +201,53 @@ export default {
             const date = new Date();
             const quarter = Math.floor(date.getMonth() / 3);
 
-            const startDate = new Date(date.getFullYear(), quarter * 3 - 3, 1, 0, 0, 0);
-            const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 3, 0, 23, 59, 59);
+            const startDate = new Date(date.getFullYear(), quarter * 3 - 3, 1);
+            const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + 3, 0);
 
             return {
                 startDate: startDate,
                 endDate: endDate,
             };
+        },
+
+        getNormalizedDateValue(dateValue) {
+            return {
+                from: dateValue.from ? this.getUserTimeZoneDateBoundary(dateValue.from, '00:00:00.000') : null,
+                to: dateValue.to ? this.getUserTimeZoneDateBoundary(dateValue.to, '23:59:59.000') : null,
+                timeframe: dateValue.timeframe,
+            };
+        },
+
+        getUserTimeZoneDateBoundary(value, time) {
+            const date = new Date(value);
+
+            if (Number.isNaN(date.getTime())) {
+                return value;
+            }
+
+            const localDate = this.getUserTimeZoneDate(date, value);
+
+            return zonedTimeToUtc(`${localDate}T${time}`, this.userTimeZone).toISOString();
+        },
+
+        getUserTimeZoneDate(date, value) {
+            if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
+                return value;
+            }
+
+            const formatter = new Intl.DateTimeFormat('en-CA', {
+                timeZone: this.userTimeZone,
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+            });
+
+            const parts = formatter.formatToParts(date);
+            const year = parts.find((part) => part.type === 'year').value;
+            const month = parts.find((part) => part.type === 'month').value;
+            const day = parts.find((part) => part.type === 'day').value;
+
+            return `${year}-${month}-${day}`;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -144,7 +144,12 @@ export default {
                 ...(normalizedDateValue.to ? { lte: normalizedDateValue.to } : {}),
             };
 
-            this.$emit('filter-update', this.filter.name, [Criteria.range(this.filter.property, params)], normalizedDateValue);
+            this.$emit(
+                'filter-update',
+                this.filter.name,
+                [Criteria.range(this.filter.property, params)],
+                normalizedDateValue,
+            );
         },
 
         onTimeframeSelect(timeframe) {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -269,7 +269,7 @@ describe('src/app/component/filter/sw-date-filter', () => {
         'a year': {
             timeframe: -365,
             expectedFrom: '1336-12-31T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedTo: '1337-12-31T23:59:59.000Z',
         },
         'a quarter': {
             timeframe: 'lastQuarter',
@@ -279,17 +279,17 @@ describe('src/app/component/filter/sw-date-filter', () => {
         'a month': {
             timeframe: -30,
             expectedFrom: '1337-12-01T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedTo: '1337-12-31T23:59:59.000Z',
         },
         'a week': {
             timeframe: -7,
             expectedFrom: '1337-12-24T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedTo: '1337-12-31T23:59:59.000Z',
         },
         'a day': {
             timeframe: -1,
             expectedFrom: '1337-12-30T00:00:00.000Z',
-            expectedTo: '1337-12-31T00:00:00.000Z',
+            expectedTo: '1337-12-31T23:59:59.000Z',
         },
     };
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -51,6 +51,10 @@ describe('src/app/component/filter/sw-date-filter', () => {
         jest.setSystemTime(new Date(1337, 11, 31));
     });
 
+    beforeEach(() => {
+        Shopware.Store.get('session').setCurrentUser({ timeZone: 'UTC' });
+    });
+
     afterAll(() => {
         jest.useRealTimers();
     });
@@ -65,7 +69,7 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { gte: '2021-01-22' })],
+            [Criteria.range('releaseDate', { gte: '2021-01-22T00:00:00.000Z' })],
             { from: '2021-01-22T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
     });
@@ -80,7 +84,7 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { lte: '2021-01-25' })],
+            [Criteria.range('releaseDate', { lte: '2021-01-25T23:59:59.000Z' })],
             { from: null, to: '2021-01-25T23:59:59.000Z', timeframe: 'custom' },
         ]);
     });
@@ -96,13 +100,6 @@ describe('src/app/component/filter/sw-date-filter', () => {
 
         expect(wrapper.emitted()['filter-update'][0]).toEqual([
             'releaseDate',
-            [Criteria.range('releaseDate', { gte: '2021-01-19' })],
-            { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
-        ]);
-
-        // [1] is a duplicate emission from sw-date-filter mutating dateValue.from to ISO (triggers sw-range-filter watch again)
-        expect(wrapper.emitted()['filter-update'][1]).toEqual([
-            'releaseDate',
             [Criteria.range('releaseDate', { gte: '2021-01-19T00:00:00.000Z' })],
             { from: '2021-01-19T00:00:00.000Z', to: null, timeframe: 'custom' },
         ]);
@@ -113,17 +110,49 @@ describe('src/app/component/filter/sw-date-filter', () => {
         await toInput.trigger('input');
         await flushPromises();
 
-        expect(wrapper.emitted()['filter-update'][2]).toEqual([
+        expect(wrapper.emitted()['filter-update'][1]).toEqual([
             'releaseDate',
             [
                 Criteria.range('releaseDate', {
                     gte: '2021-01-19T00:00:00.000Z',
-                    lte: '2021-01-25',
+                    lte: '2021-01-25T23:59:59.000Z',
                 }),
             ],
             {
                 from: '2021-01-19T00:00:00.000Z',
                 to: '2021-01-25T23:59:59.000Z',
+                timeframe: 'custom',
+            },
+        ]);
+    });
+
+    it('should emit user timezone aware criteria for date ranges', async () => {
+        Shopware.Store.get('session').setCurrentUser({ timeZone: 'Europe/Berlin' });
+
+        const wrapper = await createWrapper();
+
+        const fromInput = wrapper.find('.sw-date-filter__from').find('input');
+        const toInput = wrapper.find('.sw-date-filter__to').find('input');
+
+        await fromInput.setValue('2024-04-29');
+        await fromInput.trigger('input');
+        await flushPromises();
+
+        await toInput.setValue('2024-04-29');
+        await toInput.trigger('input');
+        await flushPromises();
+
+        expect(wrapper.emitted()['filter-update'][1]).toEqual([
+            'releaseDate',
+            [
+                Criteria.range('releaseDate', {
+                    gte: '2024-04-28T22:00:00.000Z',
+                    lte: '2024-04-29T21:59:59.000Z',
+                }),
+            ],
+            {
+                from: '2024-04-28T22:00:00.000Z',
+                to: '2024-04-29T21:59:59.000Z',
                 timeframe: 'custom',
             },
         ]);


### PR DESCRIPTION
### 1. Why is this change necessary?

The order overview date filter can exclude orders from the selected "To" day and can select the wrong local-day range for users outside UTC.

### 2. What does this change do, exactly?

The Administration date filter now builds range criteria from normalized date boundaries. The selected "From" date is converted to the start of the selected day in the current admin user's timezone, and the selected "To" date is converted to the end of that day before both values are emitted as UTC ISO strings.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration order overview.
2. Set the user's timezone to Europe/Berlin.
3. Filter orders by an order date range.
4. Enter the "From" date and then the "To" date.
5. Observe that orders from the selected local "To" day or local day boundary can be missing.

### 4. Please link to the relevant issues (if any).

- closes #5331
- closes #4337

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Local verification note: The targeted Administration Jest command currently fails during setup before running tests because Meteor's CommonJS test setup loads `@shopware-ag/meteor-component-library/dist/common/index.js`, which starts with an ESM CSS import. The behavior is covered by the adjusted unit spec and should run in CI's configured environment.