### PR TITLE
feat: Allow merge into non live version

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -274,7 +274,7 @@ export default {
                 this.hasNewVersionId = false;
 
                 // clean up recently created version
-                await this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId, oldVersionContext);
+                await this.orderRepository.deleteVersion(this.orderId, oldVersionContext.versionId);
             }
 
             window.removeEventListener('beforeunload', this.beforeDestroyComponent);
@@ -343,7 +343,7 @@ export default {
                     this.hasOrderDeepEdit = false;
                     this.promotionsToDelete = [];
                     this.deliveryDiscountsToDelete = [];
-                    return this.orderRepository.mergeVersion(this.order.versionId, this.versionContext);
+                    return this.orderRepository.mergeVersion(this.order.versionId);
                 })
                 .then(() => this.createNewVersionId())
                 .then(() => {
@@ -407,7 +407,7 @@ export default {
             this.hasNewVersionId = false;
 
             return this.orderRepository
-                .deleteVersion(this.orderId, oldVersionContext.versionId, oldVersionContext)
+                .deleteVersion(this.orderId, oldVersionContext.versionId)
                 .then(() => {
                     this.hasOrderDeepEdit = false;
                 })
@@ -543,7 +543,7 @@ export default {
             this.hasNewVersionId = false;
 
             return this.orderRepository
-                .createVersion(this.orderId, this.versionContext)
+                .createVersion(this.orderId)
                 .then((newContext) => {
                     this.hasNewVersionId = true;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -99,7 +99,6 @@ describe('src/module/sw-order/page/sw-order-detail', () => {
         expect(wrapper.vm.orderRepository.deleteVersion).toHaveBeenCalledWith(
             wrapper.vm.orderId,
             oldVersionContext.versionId,
-            oldVersionContext,
         );
         expect(wrapper.vm.versionContext).toBe(Shopware.Context.api);
         expect(wrapper.vm.hasNewVersionId).toBe(false);

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -51,6 +51,7 @@ class DataAbstractionLayerException extends HttpException
     public const INVALID_API_CRITERIA_IDS = 'FRAMEWORK__INVALID_API_CRITERIA_IDS';
     public const CANNOT_CREATE_NEW_VERSION = 'FRAMEWORK__CANNOT_CREATE_NEW_VERSION';
     public const VERSION_MERGE_ALREADY_LOCKED = 'FRAMEWORK__VERSION_MERGE_ALREADY_LOCKED';
+    public const VERSION_MERGE_SAME_VERSION = 'FRAMEWORK__VERSION_MERGE_SAME_VERSION';
     public const INVALID_LANGUAGE_ID = 'FRAMEWORK__INVALID_LANGUAGE_ID';
     public const VERSION_NO_COMMITS_FOUND = 'FRAMEWORK__VERSION_NO_COMMITS_FOUND';
     public const VERSION_NOT_EXISTS = 'FRAMEWORK__VERSION_NOT_EXISTS';
@@ -299,6 +300,16 @@ class DataAbstractionLayerException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::VERSION_MERGE_ALREADY_LOCKED,
             'Merging of version {{ versionId }} is locked, as the merge is already running by another process.',
+            ['versionId' => $versionId]
+        );
+    }
+
+    public static function versionMergeSameVersion(string $versionId): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::VERSION_MERGE_SAME_VERSION,
+            'Cannot merge version {{ versionId }} into itself.',
             ['versionId' => $versionId]
         );
     }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -159,6 +159,11 @@ class VersionManager
 
     public function merge(string $versionId, WriteContext $writeContext): void
     {
+        $targetVersionId = $writeContext->getContext()->getVersionId();
+        if ($targetVersionId === $versionId) {
+            throw DataAbstractionLayerException::versionMergeSameVersion($versionId);
+        }
+
         // acquire a lock to prevent multiple merges of the same version
         $lock = $this->lockFactory->createLock('sw-merge-version-' . $versionId);
 
@@ -172,8 +177,6 @@ class VersionManager
 
         // load all commits of the provided version
         $commits = $this->getCommits($versionId, $writeContext);
-
-        $targetVersionId = $writeContext->getContext()->getVersionId();
 
         // create context for source and target versions
         $versionContext = $writeContext->createWithVersionId($versionId);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -173,15 +173,17 @@ class VersionManager
         // load all commits of the provided version
         $commits = $this->getCommits($versionId, $writeContext);
 
-        // create context for live and version
+        $targetVersionId = $writeContext->getContext()->getVersionId();
+
+        // create context for source and target versions
         $versionContext = $writeContext->createWithVersionId($versionId);
-        $liveContext = $writeContext->createWithVersionId(Defaults::LIVE_VERSION);
+        $targetContext = $writeContext->createWithVersionId($targetVersionId);
 
         $versionContext->addState(self::MERGE_SCOPE);
-        $liveContext->addState(self::MERGE_SCOPE);
+        $targetContext->addState(self::MERGE_SCOPE);
 
         // group all payloads by their action (insert, update, delete) and by their entity name
-        $writes = $this->buildWrites($commits);
+        $writes = $this->buildWrites($commits, $versionId, $targetVersionId);
 
         $this->eventDispatcher->dispatch($event = new BeforeVersionMergeEvent($writes));
         $writes = $event->filterWrites(static function ($operation) {
@@ -189,10 +191,10 @@ class VersionManager
         });
 
         // execute writes and get access to the write result to dispatch events later on
-        $result = $this->executeWrites($writes, $liveContext);
+        $result = $this->executeWrites($writes, $targetContext);
 
-        // remove commits which reference the version and create a "merge commit" for the live version with all payloads
-        $this->updateVersionData($commits, $writeContext, $versionId);
+        // remove commits which reference the version and create a "merge commit" for the target version with all payloads
+        $this->updateVersionData($commits, $writeContext, $versionId, $targetVersionId);
 
         // delete all versioned records
         $this->deleteClones($commits, $versionContext, $versionId);
@@ -201,9 +203,9 @@ class VersionManager
         $lock->release();
 
         // dispatch events to trigger indexer and other subscribers
-        $writes = EntityWrittenContainerEvent::createWithWrittenEvents($result->getWritten(), $liveContext->getContext(), []);
+        $writes = EntityWrittenContainerEvent::createWithWrittenEvents($result->getWritten(), $targetContext->getContext(), []);
 
-        $deletes = EntityWrittenContainerEvent::createWithDeletedEvents($result->getDeleted(), $liveContext->getContext(), []);
+        $deletes = EntityWrittenContainerEvent::createWithDeletedEvents($result->getDeleted(), $targetContext->getContext(), []);
 
         if ($deletes->getEvents() !== null) {
             $writes->addEvent(...$deletes->getEvents()->getElements());
@@ -211,7 +213,7 @@ class VersionManager
         $this->eventDispatcher->dispatch($writes);
 
         $versionContext->removeState(self::MERGE_SCOPE);
-        $liveContext->addState(self::MERGE_SCOPE);
+        $targetContext->removeState(self::MERGE_SCOPE);
     }
 
     /**
@@ -531,11 +533,15 @@ class VersionManager
      *
      * @return array<string, mixed>
      */
-    private function addVersionToPayload(array $payload, EntityDefinition $definition, string $versionId): array
+    private function addVersionToPayload(array $payload, EntityDefinition $definition, string $versionId, ?string $sourceVersionId = null): array
     {
         $fields = $definition->getFields()->filter(static fn (Field $field) => $field instanceof VersionField || $field instanceof ReferenceVersionField);
 
         foreach ($fields as $field) {
+            if ($field instanceof ReferenceVersionField && $sourceVersionId !== null && ($payload[$field->getPropertyName()] ?? null) !== $sourceVersionId) {
+                continue;
+            }
+
             $payload[$field->getPropertyName()] = $versionId;
         }
 
@@ -669,8 +675,14 @@ class VersionManager
      *
      * @return array<string, mixed>
      */
-    private function addTranslationToPayload(array $entityId, array $payload, EntityDefinition $definition, VersionCommitEntity $commit): array
-    {
+    private function addTranslationToPayload(
+        array $entityId,
+        array $payload,
+        EntityDefinition $definition,
+        VersionCommitEntity $commit,
+        string $sourceVersionId,
+        string $targetVersionId
+    ): array {
         $translationDefinition = $definition->getTranslationDefinition();
 
         if (!$translationDefinition) {
@@ -700,7 +712,7 @@ class VersionManager
                 continue;
             }
 
-            $translations[] = $this->addVersionToPayload($translation, $translationDefinition, Defaults::LIVE_VERSION);
+            $translations[] = $this->addVersionToPayload($translation, $translationDefinition, $targetVersionId, $sourceVersionId);
         }
 
         $payload['translations'] = $translations;
@@ -743,7 +755,7 @@ class VersionManager
     /**
      * @return array{insert:array<string, list<array<string, mixed>>>, update:array<string, list<array<string, mixed>>>, delete:array<string, list<array<string, mixed>>>}
      */
-    private function buildWrites(VersionCommitCollection $commits): array
+    private function buildWrites(VersionCommitCollection $commits, string $sourceVersionId, string $targetVersionId): array
     {
         $writes = [
             'insert' => [],
@@ -766,14 +778,21 @@ class VersionManager
                         if ($payload === null || $payload === []) {
                             break;
                         }
-                        $payload = $this->addVersionToPayload($payload, $definition, Defaults::LIVE_VERSION);
-                        $payload = $this->addTranslationToPayload($data->getEntityId(), $payload, $definition, $commit);
+                        $payload = $this->addVersionToPayload($payload, $definition, $targetVersionId, $sourceVersionId);
+                        $payload = $this->addTranslationToPayload(
+                            $data->getEntityId(),
+                            $payload,
+                            $definition,
+                            $commit,
+                            $sourceVersionId,
+                            $targetVersionId
+                        );
                         $writes[$data->getAction()][$definition->getEntityName()][] = $payload;
 
                         break;
                     case 'delete':
                         $id = $data->getEntityId();
-                        $id = $this->addVersionToPayload($id, $definition, Defaults::LIVE_VERSION);
+                        $id = $this->addVersionToPayload($id, $definition, $targetVersionId, $sourceVersionId);
                         $writes['delete'][$definition->getEntityName()][] = $id;
 
                         break;
@@ -788,7 +807,7 @@ class VersionManager
     /**
      * @param array{insert:array<string, list<array<string, mixed>>>, update:array<string, list<array<string, mixed>>>, delete:array<string, list<array<string, mixed>>>} $writes
      */
-    private function executeWrites(array $writes, WriteContext $liveContext): WriteResult
+    private function executeWrites(array $writes, WriteContext $targetContext): WriteResult
     {
         $operations = [];
 
@@ -808,10 +827,10 @@ class VersionManager
             return new WriteResult([], [], []);
         }
 
-        return $this->entityWriter->sync($operations, $liveContext);
+        return $this->entityWriter->sync($operations, $targetContext);
     }
 
-    private function updateVersionData(VersionCommitCollection $commits, WriteContext $writeContext, string $versionId): void
+    private function updateVersionData(VersionCommitCollection $commits, WriteContext $writeContext, string $versionId, string $targetVersionId): void
     {
         $new = [];
 
@@ -824,9 +843,9 @@ class VersionManager
                 $definition = $this->registry->getByEntityName($data->getEntityName());
 
                 $id = $data->getEntityId();
-                $id = $this->addVersionToPayload($id, $definition, Defaults::LIVE_VERSION);
+                $id = $this->addVersionToPayload($id, $definition, $targetVersionId, $versionId);
 
-                $payload = $this->addVersionToPayload($data->getPayload(), $definition, Defaults::LIVE_VERSION);
+                $payload = $this->addVersionToPayload($data->getPayload(), $definition, $targetVersionId, $versionId);
 
                 $new[] = [
                     'entityId' => $id,
@@ -841,7 +860,7 @@ class VersionManager
         }
 
         $commit = [
-            'versionId' => Defaults::LIVE_VERSION,
+            'versionId' => $targetVersionId,
             'data' => $new,
             'userId' => $writeContext->getContext()->getSource() instanceof AdminApiSource ? $writeContext->getContext()->getSource()->getUserId() : null,
             'isMerge' => true,

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -538,8 +538,16 @@ class VersionManager
         $fields = $definition->getFields()->filter(static fn (Field $field) => $field instanceof VersionField || $field instanceof ReferenceVersionField);
 
         foreach ($fields as $field) {
-            if ($field instanceof ReferenceVersionField && $sourceVersionId !== null && ($payload[$field->getPropertyName()] ?? null) !== $sourceVersionId) {
-                continue;
+            if ($field instanceof ReferenceVersionField && $sourceVersionId !== null) {
+                $propertyName = $field->getPropertyName();
+
+                if (\array_key_exists($propertyName, $payload)) {
+                    if ($payload[$propertyName] !== $sourceVersionId) {
+                        continue;
+                    }
+                } elseif ($field->getVersionReferenceDefinition() !== $definition->getParentDefinition()) {
+                    continue;
+                }
             }
 
             $payload[$field->getPropertyName()] = $versionId;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
@@ -861,6 +861,8 @@ class VersioningTest extends TestCase
     public function testICanMergeIntoNonLiveVersion(): void
     {
         $id = Uuid::randomHex();
+        $priceId = Uuid::randomHex();
+        $ruleId = Uuid::randomHex();
         $data = [
             'id' => $id,
             'productNumber' => Uuid::randomHex(),
@@ -870,33 +872,72 @@ class VersioningTest extends TestCase
             'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 100, 'net' => 10, 'linked' => false]],
             'manufacturer' => ['name' => 'create'],
             'tax' => ['name' => 'create', 'taxRate' => 1],
+            'prices' => [
+                [
+                    'id' => $priceId,
+                    'quantityStart' => 1,
+                    'ruleId' => $ruleId,
+                    'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 50, 'net' => 40, 'linked' => false]],
+                ],
+            ],
         ];
 
         $context = Context::createDefaultContext();
+        static::getContainer()->get('rule.repository')->create([
+            ['id' => $ruleId, 'name' => 'test', 'priority' => 1],
+        ], $context);
+
         $this->productRepository->create([$data], $context);
 
+        // Target version is the merge destination.
         $targetVersionId = $this->productRepository->createVersion($id, $context);
         $targetVersionContext = $context->createWithVersionId($targetVersionId);
 
+        // Source starts from the changed target state.
         $this->productRepository->update([['id' => $id, 'stock' => 5]], $targetVersionContext);
 
         $sourceVersionId = $this->productRepository->createVersion($id, $targetVersionContext);
         $sourceVersionContext = $targetVersionContext->createWithVersionId($sourceVersionId);
-        $this->productRepository->update([['id' => $id, 'ean' => 'source-version']], $sourceVersionContext);
+        $this->productRepository->update([[
+            'id' => $id,
+            'ean' => 'source-version',
+            'prices' => [
+                [
+                    'id' => $priceId,
+                    'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 80, 'net' => 70, 'linked' => false]],
+                ],
+            ],
+        ]], $sourceVersionContext);
 
         $this->productRepository->merge($sourceVersionId, $targetVersionContext);
 
-        $product = $this->productRepository->search(new Criteria([$id]), $context)->first();
+        $criteria = new Criteria([$id]);
+        $criteria->addAssociation('prices');
+
+        // Live stays unchanged.
+        $product = $this->productRepository->search($criteria, $context)->first();
         static::assertInstanceOf(ProductEntity::class, $product);
         static::assertSame('EAN', $product->getEan());
         static::assertSame(1, $product->getStock());
+        static::assertInstanceOf(ProductPriceCollection::class, $product->getPrices());
+        static::assertInstanceOf(ProductPriceEntity::class, $product->getPrices()->get($priceId));
+        $price = $product->getPrices()->get($priceId)->getPrice()->get(Defaults::CURRENCY);
+        static::assertInstanceOf(Price::class, $price);
+        static::assertSame(50.0, $price->getGross());
 
-        $product = $this->productRepository->search(new Criteria([$id]), $targetVersionContext)->first();
+        // Target gets source changes and keeps its own stock.
+        $product = $this->productRepository->search($criteria, $targetVersionContext)->first();
         static::assertInstanceOf(ProductEntity::class, $product);
         static::assertSame('source-version', $product->getEan());
         static::assertSame(5, $product->getStock());
+        static::assertInstanceOf(ProductPriceCollection::class, $product->getPrices());
+        static::assertInstanceOf(ProductPriceEntity::class, $product->getPrices()->get($priceId));
+        $price = $product->getPrices()->get($priceId)->getPrice()->get(Defaults::CURRENCY);
+        static::assertInstanceOf(Price::class, $price);
+        static::assertSame(80.0, $price->getGross());
 
         $changelog = $this->getVersionData('product', $id, $targetVersionId);
+        // Merge changelog belongs to the target version.
         $mergeChangelog = array_values(array_filter(
             $changelog,
             static fn (array $row) => ($row['payload']['ean'] ?? null) === 'source-version'

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
@@ -858,6 +858,54 @@ class VersioningTest extends TestCase
         static::assertSame('updated', $product->getEan());
     }
 
+    public function testICanMergeIntoNonLiveVersion(): void
+    {
+        $id = Uuid::randomHex();
+        $data = [
+            'id' => $id,
+            'productNumber' => Uuid::randomHex(),
+            'stock' => 1,
+            'name' => 'test',
+            'ean' => 'EAN',
+            'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 100, 'net' => 10, 'linked' => false]],
+            'manufacturer' => ['name' => 'create'],
+            'tax' => ['name' => 'create', 'taxRate' => 1],
+        ];
+
+        $context = Context::createDefaultContext();
+        $this->productRepository->create([$data], $context);
+
+        $targetVersionId = $this->productRepository->createVersion($id, $context);
+        $targetVersionContext = $context->createWithVersionId($targetVersionId);
+
+        $this->productRepository->update([['id' => $id, 'stock' => 5]], $targetVersionContext);
+
+        $sourceVersionId = $this->productRepository->createVersion($id, $targetVersionContext);
+        $sourceVersionContext = $targetVersionContext->createWithVersionId($sourceVersionId);
+        $this->productRepository->update([['id' => $id, 'ean' => 'source-version']], $sourceVersionContext);
+
+        $this->productRepository->merge($sourceVersionId, $targetVersionContext);
+
+        $product = $this->productRepository->search(new Criteria([$id]), $context)->first();
+        static::assertInstanceOf(ProductEntity::class, $product);
+        static::assertSame('EAN', $product->getEan());
+        static::assertSame(1, $product->getStock());
+
+        $product = $this->productRepository->search(new Criteria([$id]), $targetVersionContext)->first();
+        static::assertInstanceOf(ProductEntity::class, $product);
+        static::assertSame('source-version', $product->getEan());
+        static::assertSame(5, $product->getStock());
+
+        $changelog = $this->getVersionData('product', $id, $targetVersionId);
+        $mergeChangelog = array_values(array_filter(
+            $changelog,
+            static fn (array $row) => ($row['payload']['ean'] ?? null) === 'source-version'
+        ));
+
+        static::assertCount(1, $mergeChangelog);
+        static::assertSame($targetVersionId, $mergeChangelog[0]['entity_id']['versionId']);
+    }
+
     public function testICanReadOneToManyInASpecifyVersion(): void
     {
         $productId = Uuid::randomHex();

--- a/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -173,6 +173,36 @@ class VersionManagerTest extends TestCase
         );
     }
 
+    public function testMergeFailsWhenSourceAndTargetVersionAreIdentical(): void
+    {
+        $versionId = Uuid::randomHex();
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory->expects($this->never())->method('createLock');
+
+        $versionManager = new VersionManager(
+            $this->createMock(EntityWriterInterface::class),
+            $this->createMock(EntityReaderInterface::class),
+            $this->createMock(EntitySearcherInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(SerializerInterface::class),
+            $this->createMock(DefinitionInstanceRegistry::class),
+            $this->createMock(VersionCommitDefinition::class),
+            $this->createMock(VersionCommitDataDefinition::class),
+            $this->createMock(VersionDefinition::class),
+            $lockFactory
+        );
+
+        static::expectException(DataAbstractionLayerException::class);
+        static::expectExceptionMessage(DataAbstractionLayerException::versionMergeSameVersion($versionId)->getMessage());
+
+        $versionManager->merge(
+            $versionId,
+            WriteContext::createFromContext(Context::createDefaultContext()->createWithVersionId($versionId))
+        );
+    }
+
     public function testMergeFailsForNonExistentVersion(): void
     {
         $lockFactory = $this->createMock(LockFactory::class);

--- a/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -173,36 +173,6 @@ class VersionManagerTest extends TestCase
         );
     }
 
-    public function testMergeFailsWhenSourceAndTargetVersionAreIdentical(): void
-    {
-        $versionId = Uuid::randomHex();
-
-        $lockFactory = $this->createMock(LockFactory::class);
-        $lockFactory->expects($this->never())->method('createLock');
-
-        $versionManager = new VersionManager(
-            $this->createMock(EntityWriterInterface::class),
-            $this->createMock(EntityReaderInterface::class),
-            $this->createMock(EntitySearcherInterface::class),
-            $this->createMock(EntityWriteGatewayInterface::class),
-            $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(SerializerInterface::class),
-            $this->createMock(DefinitionInstanceRegistry::class),
-            $this->createMock(VersionCommitDefinition::class),
-            $this->createMock(VersionCommitDataDefinition::class),
-            $this->createMock(VersionDefinition::class),
-            $lockFactory
-        );
-
-        static::expectException(DataAbstractionLayerException::class);
-        static::expectExceptionMessage(DataAbstractionLayerException::versionMergeSameVersion($versionId)->getMessage());
-
-        $versionManager->merge(
-            $versionId,
-            WriteContext::createFromContext(Context::createDefaultContext()->createWithVersionId($versionId))
-        );
-    }
-
     public function testMergeFailsForNonExistentVersion(): void
     {
         $lockFactory = $this->createMock(LockFactory::class);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

This PR updates DAL version merging so a version can be merged into the version from the provided write context, instead of always merging into the live version.

### 1. Why is this change necessary?

VersionManager::merge() always used Defaults::LIVE_VERSION as the merge target. This prevents nested version workflows such as:

1. Create version 1 from live.
2. Create version 2 from version 1.
3. Apply changes in version 2.
4. Merge version 2 back into version 1.

The previous implementation also rewrote all VersionField and ReferenceVersionField values to the target version. That is unsafe because not every ReferenceVersionField belongs to the entity being merged.

For example, a product may reference a manufacturer that still exists only in live. Rewriting productManufacturerVersionId from live to the target draft version creates an invalid FK reference if that manufacturer was never cloned into the target version.

At the same time, some reference version fields do need to be written when merging, especially child/translation parent references such as product_translation.productVersionId. Those fields identify the parent version of the child record and must follow the merge target.

### 2. What does this change do, exactly?

- Use the WriteContext version as the merge target in VersionManager::merge().
- Execute merge writes and dispatch write/delete events with the target version context.
- Store merge commit data under the target version instead of always under live.
- Rewrite an entity’s own VersionField to the target version during merge.
- Rewrite ReferenceVersionField values only when:
        + the current reference points to the source version being merged, or
        + the reference field is missing and points to the entity’s parent definition, e.g. translation/sub-entity parent version fields.
- Preserve external references that point to live or another version, preventing invalid FK rewrites.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
