### PR TITLE
fix: handle empty batch in media:delete-unused command

### DIFF
--- a/changelog/_unreleased/2026-05-11-fix-media-delete-unused-empty-batch.md
+++ b/changelog/_unreleased/2026-05-11-fix-media-delete-unused-empty-batch.md
@@ -1,0 +1,6 @@
+---
+title: Fix media:delete-unused command crashing on empty batches
+issue: 16532
+---
+# Core
+* Changed `Shopware\Core\Content\Media\UnusedMediaPurger::filterOutNewMedia` to return early on empty id arrays, preventing the `media:delete-unused` command from throwing `Invalid ids provided in criteria` when a batch is empty (e.g. when an `UnusedMediaSearchEvent` listener marks every candidate as used or the offset is past the end of the result set) and a grace period is configured.

--- a/changelog/_unreleased/2026-05-11-fix-media-delete-unused-empty-batch.md
+++ b/changelog/_unreleased/2026-05-11-fix-media-delete-unused-empty-batch.md
@@ -1,6 +1,0 @@
----
-title: Fix media:delete-unused command crashing on empty batches
-issue: 16532
----
-# Core
-* Changed `Shopware\Core\Content\Media\UnusedMediaPurger::filterOutNewMedia` to return early on empty id arrays, preventing the `media:delete-unused` command from throwing `Invalid ids provided in criteria` when a batch is empty (e.g. when an `UnusedMediaSearchEvent` listener marks every candidate as used or the offset is past the end of the result set) and a grace period is configured.

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -130,6 +130,10 @@ class UnusedMediaPurger
      */
     public function searchMedia(array $ids, Context $context): array
     {
+        if ($ids === []) {
+            return [];
+        }
+
         $media = $this->mediaRepo->search(new Criteria($ids), $context)->getEntities()->getElements();
 
         return array_values($media);

--- a/src/Core/Content/Media/UnusedMediaPurger.php
+++ b/src/Core/Content/Media/UnusedMediaPurger.php
@@ -150,7 +150,7 @@ class UnusedMediaPurger
      */
     private function filterOutNewMedia(array $mediaIds, int $gracePeriodDays, Context $context): array
     {
-        if ($gracePeriodDays === 0) {
+        if ($gracePeriodDays === 0 || $mediaIds === []) {
             return $mediaIds;
         }
 

--- a/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -167,6 +167,53 @@ class UnusedMediaPurgerTest extends TestCase
         static::assertNotNull($stillExisting);
     }
 
+    public function testGetNotUsedMediaWithOffsetAndGracePeriodHandlesEmptyBatchFromEventListener(): void
+    {
+        $this->setFixtureContext($this->context);
+
+        $txt = $this->getTxt();
+        $this->getPublicFilesystem()->writeStream($txt->getPath(), \fopen(self::FIXTURE_FILE, 'r'));
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            UnusedMediaSearchEvent::class,
+            static function (UnusedMediaSearchEvent $event): void {
+                $event->markAsUsed($event->getUnusedIds());
+            }
+        );
+
+        $connection = static::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
+
+        $purger = new UnusedMediaPurger(
+            $this->mediaRepo,
+            $connection,
+            $eventDispatcher,
+        );
+
+        $batches = iterator_to_array($purger->getNotUsedMedia(offset: 0, gracePeriodDays: 1), false);
+
+        static::assertSame([[]], $batches);
+    }
+
+    public function testGetNotUsedMediaWithOffsetPastEndDoesNotCrash(): void
+    {
+        $this->setFixtureContext($this->context);
+
+        $connection = static::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
+
+        $purger = new UnusedMediaPurger(
+            $this->mediaRepo,
+            $connection,
+            new EventDispatcher(),
+        );
+
+        $batches = iterator_to_array($purger->getNotUsedMedia(offset: 99999, gracePeriodDays: 1), false);
+
+        static::assertSame([[]], $batches);
+    }
+
     public function testDeleteNotUsedMediaDoesNotDeleteA11yDocumentMedia(): void
     {
         $this->setFixtureContext($this->context);

--- a/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Content\Media;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Event\UnusedMediaSearchEvent;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\UnusedMediaPurger;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
@@ -129,6 +130,38 @@ class UnusedMediaPurgerTest extends TestCase
         static::assertFalse($this->getPublicFilesystem()->has($firstPath));
         static::assertFalse($this->getPublicFilesystem()->has($secondPath));
         static::assertFalse($this->getPublicFilesystem()->has($thirdPath));
+    }
+
+    public function testDeleteNotUsedMediaWithGracePeriodHandlesEmptyBatchFromEventListener(): void
+    {
+        $this->setFixtureContext($this->context);
+
+        $txt = $this->getTxt();
+        $this->getPublicFilesystem()->writeStream($txt->getPath(), \fopen(self::FIXTURE_FILE, 'r'));
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(
+            UnusedMediaSearchEvent::class,
+            static function (UnusedMediaSearchEvent $event): void {
+                $event->markAsUsed($event->getUnusedIds());
+            }
+        );
+
+        $purger = new UnusedMediaPurger(
+            $this->mediaRepo,
+            $this->createMock(Connection::class),
+            $eventDispatcher,
+        );
+
+        $deleted = $purger->deleteNotUsedMedia(gracePeriodDays: 1);
+        $this->runWorker();
+
+        static::assertSame(0, $deleted);
+
+        $stillExisting = $this->mediaRepo
+            ->search(new Criteria([$txt->getId()]), $this->context)
+            ->get($txt->getId());
+        static::assertNotNull($stillExisting);
     }
 
     public function testDeleteNotUsedMediaDoesNotDeleteA11yDocumentMedia(): void

--- a/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -147,9 +147,12 @@ class UnusedMediaPurgerTest extends TestCase
             }
         );
 
+        $connection = static::getContainer()->get(Connection::class);
+        static::assertInstanceOf(Connection::class, $connection);
+
         $purger = new UnusedMediaPurger(
             $this->mediaRepo,
-            $this->createMock(Connection::class),
+            $connection,
             $eventDispatcher,
         );
 


### PR DESCRIPTION
## Summary
- `UnusedMediaPurger::filterOutNewMedia` returns early when the input id list is empty, so `new Criteria([])` is no longer constructed.
- Fixes `media:delete-unused` crashing with `Invalid ids provided in criteria. Ids should not be empty.` when a grace period is configured and `getUnusedMediaIds` yields an empty batch (event listener marks every candidate as used, or offset is past the end of the result set).
- Adds an integration test covering the event-listener case via `UnusedMediaSearchEvent::markAsUsed`.

Fixes #16532

## Test plan
- [x] `tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php` — new test `testDeleteNotUsedMediaWithGracePeriodHandlesEmptyBatchFromEventListener` fails on `trunk`, passes with the fix.
- [x] Full `UnusedMediaPurgerTest` (integration) — 4 tests, 34 assertions, green.
- [x] `UnusedMediaPurgerTest` + `DeleteNotUsedMediaCommandTest` (unit) — 39 tests, 147 assertions, green.
- [x] PHPStan clean on touched files.
- [x] PHP-CS-Fixer clean on touched files.