### PR TITLE
ci: ignore test composer fixtures in Danger

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -450,8 +450,12 @@ return (new Config())
         }
 
         foreach ($composerFiles as $composerFile) {
+            $composerFileName = (string) $composerFile->name;
+
             if ($composerFile->status === File::STATUS_REMOVED
-                || str_contains((string) $composerFile->name, '/Test/')
+                || str_starts_with($composerFileName, 'tests/')
+                || str_contains($composerFileName, '/test/')
+                || str_contains($composerFileName, '/Test/')
             ) {
                 continue;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

Danger currently applies the composer dependency constraint rule to `composer.json` files that are only test fixtures. Those fixture files can intentionally use artificial package names or constraints to model command behavior, so they should not be treated like production package manifests.

### 2. What does this change do, exactly?

The composer version constraint rule now skips composer files in the top-level `tests/` directory and in paths containing `/test/` or `/Test/`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add or change a `composer.json` fixture below `tests/` with test-only dependency constraints.
2. Open a pull request with that fixture change.
3. Danger reports dependency constraint failures for packages from the test fixture.

### 4. Please link to the relevant issues (if any).

- Follow-up for #16674

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them