### PR TITLE
fix: non-interactive multi plugin install in testbootstrapper

### DIFF
--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -87,7 +88,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
             $context->addState(PluginLifecycleService::STATE_SKIP_ASSET_BUILDING);
         }
 
-        $plugins = $this->parsePluginArgument($input->getArgument('plugins'), $lifecycleMethod, $io, $context);
+        $plugins = $this->parsePluginArgument($input->getArgument('plugins'), $lifecycleMethod, $io, $input, $context);
 
         if ($plugins === null) {
             return null;
@@ -143,6 +144,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
         array $arguments,
         string $lifecycleMethod,
         SymfonyStyle $io,
+        Input $input,
         Context $context
     ): ?PluginCollection {
         $plugins = array_unique($arguments);
@@ -169,7 +171,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
 
         $pluginCollection = $this->pluginRepo->search($criteria, $context)->getEntities();
 
-        if ($pluginCollection->count() <= 1) {
+        if ($pluginCollection->count() <= 1 || !$input->isInteractive()) {
             return $pluginCollection;
         }
 

--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\Input;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -144,7 +143,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
         array $arguments,
         string $lifecycleMethod,
         SymfonyStyle $io,
-        Input $input,
+        InputInterface $input,
         Context $context
     ): ?PluginCollection {
         $plugins = array_unique($arguments);

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -457,6 +457,7 @@ class TestBootstrapper
                 'command' => 'plugin:install',
                 '--activate' => true,
                 '--reinstall' => true,
+                '--no-interaction' => true,
                 'plugins' => $this->activePlugins,
             ]), $this->getOutput());
 


### PR DESCRIPTION
Follow up from https://github.com/shopware/shopware/pull/16674

### 1. Why is this change necessary?
With the changes in https://github.com/shopware/shopware/pull/16674 multiple plugins are now installed in a single command execution, however the command falls back to interaction mode by default which break the test bootstrapper

### 2. What does this change do, exactly?
Add non interaction mode to plugin install command in bootstrapper
Change abstractPuginLifecycle to assume in non-interactive mode that all passed plugins should be installed 

### 3. Describe each step to reproduce the issue or behaviour.
see https://github.com/shopware/SwagMigrationMagento/pull/48

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/SwagMigrationMagento/pull/48
https://github.com/shopware/shopware/pull/16674