### PR TITLE
fix: redirect response to login on xhr

### DIFF
--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -17,6 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Event\MaintenanceRedirectEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -178,11 +179,10 @@ class StorefrontSubscriber implements EventSubscriberInterface
 
     public function customerNotLoggedInHandler(ExceptionEvent $event): void
     {
-        if (!$event->getRequest()->attributes->has(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST)) {
-            return;
-        }
-
-        if (!$this->shouldRedirectLoginPage($event->getThrowable())) {
+        if (
+            !$event->getRequest()->attributes->has(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST)
+            || !$this->shouldRedirectLoginPage($event->getThrowable())
+        ) {
             return;
         }
 
@@ -192,6 +192,17 @@ class StorefrontSubscriber implements EventSubscriberInterface
             'redirectTo' => $request->attributes->get('_route'),
             'redirectParameters' => json_encode($request->attributes->get('_route_params'), \JSON_THROW_ON_ERROR),
         ];
+
+        if ($request->isXmlHttpRequest()) {
+            if ($event->getResponse() instanceof JsonResponse) {
+                return;
+            }
+
+            $status = $event->getResponse()?->getStatusCode() ?? Response::HTTP_FORBIDDEN;
+            $event->setResponse(new JsonResponse($parameters, $status));
+
+            return;
+        }
 
         $redirectResponse = new RedirectResponse($this->router->generate('frontend.account.login.page', $parameters));
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -239,7 +239,7 @@ export default class ListingPlugin extends Plugin {
 
     /**
      * @private
-     * @returns {URLSearchParams} 
+     * @returns {URLSearchParams}
      */
     _getDisabledFiltersParamsFromParams(params) {
         const filterParams = Object.assign({}, {'only-aggregations': 1, 'reduce-aggregations': 1}, params);
@@ -437,10 +437,27 @@ export default class ListingPlugin extends Plugin {
         fetch(url, {
             headers: { 'X-Requested-With': 'XMLHttpRequest' },
         })
+            .then((response) => response.status >= 400 ? Promise.reject(response) : response)
             .then((response) => response.text())
             .then((response) => {
                 this.renderResponse(response);
+            })
+            .catch(async (response) => {
+                if (response?.status !== 403) {
+                    return;
+                }
 
+                const data = await response.json();
+                const parameters = new URLSearchParams(
+                    (data?.redirectTo && data.redirectParameters) ? {
+                        redirectTo: data.redirectTo,
+                        redirectParameters: data.redirectParameters,
+                    } : {},
+                );
+
+                this._navigateTo(`${window.router['frontend.account.login.page']}?${parameters.toString()}`);
+            })
+            .finally(() => {
                 if (this._filterPanelActive) {
                     this.removeLoadingIndicatorClass();
                     this._updateAriaLive();
@@ -583,5 +600,9 @@ export default class ListingPlugin extends Plugin {
         }
 
         return url.toString();
+    }
+
+    _navigateTo(url) {
+        window.location.href = url;
     }
 }

--- a/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/listing/listing.plugin.test.js
@@ -346,4 +346,22 @@ describe('ListingPlugin tests', () => {
         expect(activeFilterElements[2].textContent).toMatch('Pommes Spezial');
         expect(activeFilterElements[2].getAttribute('aria-label')).toBe('Remove filter: Pommes Spezial');
     });
+
+    test('should redirect to login on xhr request being unauthorized', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                status: 403,
+                json: () => Promise.resolve({ redirectTo: 'foo.bar', redirectParameters: '{}' }),
+            })
+        );
+        const navigateToSpy = jest.spyOn(listingPlugin, '_navigateTo')
+            .mockImplementation(() => {});
+
+        window.router['frontend.account.login.page'] = 'http://localhost/account/login';
+
+        listingPlugin._buildRequest();
+        await new Promise(process.nextTick);
+
+        expect(navigateToSpy).toHaveBeenCalledWith('http://localhost/account/login?redirectTo=foo.bar&redirectParameters=%7B%7D');
+    });
 });

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -21,6 +21,7 @@ use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Shopware\Storefront\Framework\Routing\StorefrontSubscriber;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -242,6 +243,53 @@ class StorefrontSubscriberTest extends TestCase
         ))->customerNotLoggedInHandler($event);
 
         static::assertInstanceOf(RedirectResponse::class, $event->getResponse());
+    }
+
+    #[DataProvider('dataProviderForbiddenResponseToXhrRequest')]
+    public function testRedirectLoginPageWhenCustomerNotLoggedInWithXhrRequest(Response $response): void
+    {
+        $request = new Request(attributes: [
+            SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+            '_route' => 'foo.bar',
+            '_route_params' => [],
+        ]);
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $event = new ExceptionEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new CustomerNotLoggedInException(
+                Response::HTTP_FORBIDDEN,
+                RoutingException::CUSTOMER_NOT_LOGGED_IN_CODE,
+                'Foo test'
+            )
+        );
+        $event->setResponse($response);
+
+        (new StorefrontSubscriber(
+            $this->createMock(RequestStack::class),
+            $this->createMock(RouterInterface::class),
+            $this->createMock(MaintenanceModeResolver::class),
+            new StaticSystemConfigService(),
+            new EventDispatcher(),
+        ))->customerNotLoggedInHandler($event);
+
+        static::assertInstanceOf(JsonResponse::class, $event->getResponse());
+        static::assertSame(
+            json_encode(['redirectTo' => 'foo.bar', 'redirectParameters' => '[]']),
+            $event->getResponse()->getContent()
+        );
+        static::assertSame(Response::HTTP_FORBIDDEN, $event->getResponse()->getStatusCode());
+    }
+
+    public static function dataProviderForbiddenResponseToXhrRequest(): \Generator
+    {
+        yield 'text response' => [new Response(status: Response::HTTP_FORBIDDEN)];
+        yield 'json response' => [new JsonResponse([
+            'redirectTo' => 'foo.bar',
+            'redirectParameters' => '[]',
+        ], Response::HTTP_FORBIDDEN)];
     }
 
     public function testCustomerNotLoggedInHandlerWithoutRedirect(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
When the customer session expires, Shopware redirects unauthenticated requests to the login page.
For AJAX/XHR requests from /wishlist, this causes a RoutingException because frontend.account.login.page does not allow XHR requests.

The change prevents this exception and allows the frontend to handle expired sessions correctly.

### 2. What does this change do, exactly?
The change adds special handling for AJAX requests:
* If the request is an XHR request, Shopware returns a JsonResponse instead of redirecting to the login page.
* The JSON response contains redirect information and an error status (for example 403).
* Normal browser requests still use the existing redirect behaviour.

### 3. Describe each step to reproduce the issue or behaviour.
* Enable wishlist in Shopware.
* Log in as a customer.
* Open /wishlist.
* Expire the session (delete the session cookie or wait for timeout).
* Trigger an AJAX action on the wishlist page (for example pagination).
* The request to widgets.wishlist.pagelet fails with a RoutingException.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/13688

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
