### PR TITLE
fix: non interactive installs in test bootstrapper

### DIFF
--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -453,13 +453,15 @@ class TestBootstrapper
 
         if ($this->activePlugins !== []) {
             $application = new Application($kernel);
-            $returnCode = $application->doRun(new ArrayInput([
+
+            $input = new ArrayInput([
                 'command' => 'plugin:install',
                 '--activate' => true,
                 '--reinstall' => true,
-                '--no-interaction' => true,
                 'plugins' => $this->activePlugins,
-            ]), $this->getOutput());
+            ]);
+            $input->setInteractive(false);
+            $returnCode = $application->doRun($input, $this->getOutput());
 
             if ($returnCode !== Command::SUCCESS) {
                 throw new \RuntimeException('system:install failed');


### PR DESCRIPTION
Follow up from https://github.com/shopware/shopware/pull/16765


--no-interaction flag does not work because symfony resolves that earlier in the stack, we can set interaction=false directly on the input object