### PR TITLE
fix: skip non-value snippet saves

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/index.js
@@ -237,6 +237,9 @@ export default {
                 }
 
                 if (!snippet.hasOwnProperty('value') || snippet.value === null) {
+                    if (snippet.origin === null) {
+                        return;
+                    }
                     // If you clear the input-box, reset it to its origin value
                     snippet.value = snippet.origin;
                 }
@@ -260,13 +263,9 @@ export default {
             Promise.all(responses)
                 .then(() => {
                     this.onNewKeyRedirect(true);
-                    this.prepareContent();
-                    this.isLoading = false;
                     this.isSaveSuccessful = true;
                 })
                 .catch((error) => {
-                    this.isLoading = false;
-
                     const errorSnippet = this.$t('sw-settings-snippet.detail.messageSaveError', {
                         key: this.translationKey,
                     });
@@ -279,6 +278,10 @@ export default {
                     this.createNotificationError({
                         message: errorSnippet + errorMessage,
                     });
+                })
+                .finally(() => {
+                    this.prepareContent();
+                    this.isLoading = false;
                 });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/sw-settings-snippet-detail.spec.js
@@ -92,6 +92,8 @@ function getSnippets() {
     return data;
 }
 
+const saveMock = jest.fn(() => Promise.resolve());
+
 describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
     async function createWrapper(privileges = []) {
         return mount(
@@ -123,7 +125,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
                             create: () => ({
                                 search: () => Promise.resolve(getSnippetSets()),
                                 create: () => Promise.resolve(),
-                                save: () => Promise.resolve(),
+                                save: saveMock,
                             }),
                         },
                         acl: {
@@ -276,5 +278,31 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-detail', () => {
                 page: 1,
             }),
         );
+    });
+
+    it('should skip non-saveable snippets', async () => {
+        const wrapper = await createWrapper('snippet.viewer');
+        wrapper.vm.snippets = [
+            {
+                value: 'foo',
+                origin: null,
+            },
+            {
+                value: null,
+                origin: null,
+            },
+            {
+                value: null,
+                origin: 'bar',
+            },
+            {
+                value: ' ',
+                origin: null,
+            },
+        ];
+
+        wrapper.vm.onSave();
+
+        expect(saveMock).toHaveBeenCalledTimes(3);
     });
 });


### PR DESCRIPTION
fixes: #14912

### 1. Why is this change necessary?
Snippets that can be expected to be not saveable due to missing value are tried to be saved nonetheless causing the form rendering to break

### 2. What does this change do, exactly?
* Fix form breaking on non-OK responses by calling `prepareContent` also on error responses
* Skip save persist calls for snippets that have no value and no fallback value

### 3. Describe each step to reproduce the issue or behaviour.
* Create a new snippet with two existing snippets sets
* Provide only one value for one of the snippet sets
* Save

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/14912

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
