### PR TITLE
chore: adjust gitignore to ignore worktree and chunckhound files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ yalc.lock
 .aiderignore
 .kite/
 .codewhispererignore
+.chunkhound*
+
+# GIT worktrees
+.worktrees
 
 # Composer
 /composer.phar


### PR DESCRIPTION
### 1. Why is this change necessary?

AI tools might work in worktrees, however main checkout should stay pushable, therefore worktree content should be ignored

in the same vane tool dependend chunkhound files should be ignored
