### PR TITLE
fix: pay later after-order cart context

### DIFF
--- a/src/Core/Checkout/DependencyInjection/order.xml
+++ b/src/Core/Checkout/DependencyInjection/order.xml
@@ -143,6 +143,7 @@
             <argument type="service" id="order.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Order\OrderConverter"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader"/>
             <argument type="service" id="Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute"/>

--- a/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\Event\OrderPaymentMethodChangedCriteriaEvent;
@@ -49,6 +50,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
         private readonly EntityRepository $orderRepository,
         private readonly OrderConverter $orderConverter,
         private readonly CartRuleLoader $cartRuleLoader,
+        private readonly CartService $cartService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly InitialStateIdLoader $initialStateIdLoader,
         private readonly AbstractCheckoutGatewayRoute $checkoutGatewayRoute
@@ -156,6 +158,11 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
     {
         $paymentMethodId = $request->request->getAlnum('paymentMethodId');
         $cart = $this->orderConverter->convertToCart($order, $salesChannelContext->getContext());
+        $cart->setToken($salesChannelContext->getToken());
+
+        $this->cartService->setCart($cart);
+        $request->attributes->set('orderId', $order->getId());
+
         $response = $this->checkoutGatewayRoute->load($request, $cart, $salesChannelContext);
 
         if ($response->getPaymentMethods()->get($paymentMethodId) === null) {

--- a/tests/unit/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
@@ -5,11 +5,14 @@ namespace Shopware\Tests\Unit\Core\Checkout\Order\SalesChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\RuleLoaderResult;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -26,6 +29,7 @@ use Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
@@ -59,6 +63,7 @@ class SetPaymentOrderRouteTest extends TestCase
             $this->createMock(EntityRepository::class),
             $this->createMock(OrderConverter::class),
             $this->createMock(CartRuleLoader::class),
+            $this->createMock(CartService::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $this->createMock(AbstractCheckoutGatewayRoute::class)
@@ -76,6 +81,7 @@ class SetPaymentOrderRouteTest extends TestCase
             $this->createMock(EntityRepository::class),
             $this->createMock(OrderConverter::class),
             $this->createMock(CartRuleLoader::class),
+            $this->createMock(CartService::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $this->createMock(AbstractCheckoutGatewayRoute::class)
@@ -116,6 +122,7 @@ class SetPaymentOrderRouteTest extends TestCase
             $staticRepository,
             $this->createMock(OrderConverter::class),
             $this->createMock(CartRuleLoader::class),
+            $this->createMock(CartService::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $gatewayRoute
@@ -165,6 +172,7 @@ class SetPaymentOrderRouteTest extends TestCase
             $staticRepository,
             $this->createMock(OrderConverter::class),
             $this->createMock(CartRuleLoader::class),
+            $this->createMock(CartService::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $gatewayRoute
@@ -247,6 +255,7 @@ class SetPaymentOrderRouteTest extends TestCase
             $staticRepository,
             $orderConverter,
             $this->createMock(CartRuleLoader::class),
+            $this->createMock(CartService::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $gatewayRoute
@@ -336,10 +345,6 @@ class SetPaymentOrderRouteTest extends TestCase
         );
 
         $gatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
-        $gatewayRoute
-            ->expects($this->once())
-            ->method('load')
-            ->willReturn($response);
 
         $orderService = $this->createMock(OrderService::class);
         $orderService
@@ -351,17 +356,46 @@ class SetPaymentOrderRouteTest extends TestCase
         $customer->setId(Uuid::randomHex());
         $context = Generator::generateSalesChannelContext(customer: $customer);
 
+        $gatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::callback(static fn (Request $request): bool => $request->attributes->getAlnum('orderId') === $order->getId()),
+                static::callback(static fn (Cart $cart): bool => $cart->getToken() === $context->getToken()),
+                $context
+            )
+            ->willReturn($response);
+
         $orderConverter = $this->createMock(OrderConverter::class);
         $orderConverter
             ->expects($this->once())
             ->method('assembleSalesChannelContext')
             ->willReturn($context);
+        $orderConverter
+            ->expects($this->exactly(2))
+            ->method('convertToCart')
+            ->willReturnOnConsecutiveCalls(
+                new Cart('converted-order-token'),
+                new Cart('converted-order-token')
+            );
+
+        $cartService = $this->createMock(CartService::class);
+        $cartService
+            ->expects($this->once())
+            ->method('setCart')
+            ->with(static::callback(static fn (Cart $cart): bool => $cart->getToken() === $context->getToken()));
+
+        $cartRuleLoader = $this->createMock(CartRuleLoader::class);
+        $cartRuleLoader
+            ->method('loadByCart')
+            ->willReturnCallback(static fn (SalesChannelContext $context, Cart $cart): RuleLoaderResult => new RuleLoaderResult($cart, new RuleCollection()));
 
         $paymentOrderRoute = new SetPaymentOrderRoute(
             $orderService,
             $orderRepository,
             $orderConverter,
-            $this->createMock(CartRuleLoader::class),
+            $cartRuleLoader,
+            $cartService,
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(InitialStateIdLoader::class),
             $gatewayRoute


### PR DESCRIPTION
### 1. Why is this change necessary?
After-order payment validation could use the current storefront cart instead of the existing order cart in downstream payment checks.

### 2. What does this change do, exactly?
It stores the converted order cart under the restored order context token and forwards `orderId` during payment-method validation.

### 3. Describe each step to reproduce the issue or behaviour.
1. Log in to the backend as an admin
2. Manually create an order for an existing customer account and send the customer a request to pay for the order
3. Now log in to the shop as a customer and visit the URL that was sent to the customer by email. Alternatively, go to the customer account, navigate to the orders and click on ‘Complete payment’ (e.g. https://pp6771-xxx.eu-support-1.shopdev.de/account/order/edit/{orderId})
4. During the checkout process, select PayPal PayLater if this has not already been preselected
5. Try to complete the order – an error will be displayed

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/16512

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
