### PR TITLE
fix: lookup sales channels with punycode host

### DIFF
--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -121,6 +121,14 @@ class RequestTransformer implements RequestTransformerInterface
          */
         $absoluteBaseUrl = $this->getSchemeAndHttpHost($request) . $request->getBasePath();
         $baseUrl = str_replace($absoluteBaseUrl, '', $salesChannel['url']);
+        // if no replacement occurred, consider punycode urls
+        if ($baseUrl === $salesChannel['url']) {
+            $baseUrl = str_replace(
+                $this->getSchemeAndAsciiHttpHost($request) . $request->getBasePath(),
+                '',
+                $salesChannel['url']
+            );
+        }
 
         $resolved = $this->resolveSeoUrl(
             $request,
@@ -273,18 +281,27 @@ class RequestTransformer implements RequestTransformerInterface
         }
 
         // domain urls and request uri should be in same format, all with trailing slash
-        $requestUrl = rtrim($this->getSchemeAndHttpHost($request) . $request->getBasePath() . $request->getPathInfo(), '/') . '/';
+        $requestUrl = $this->getNormalizedRequestUrl($request);
+
+        if ($this->isHttpHostPunycode($request)) {
+            $asciiRequestUrl = $this->getNormalizedRequestUrl($request, false);
+            $domain = $domains[$requestUrl] ?? $domains[$asciiRequestUrl] ?? null;
+            $filter = static fn ($baseUrl): bool => str_starts_with($requestUrl, $baseUrl)
+                || str_starts_with($asciiRequestUrl, $baseUrl);
+        } else {
+            $domain = $domains[$requestUrl] ?? null;
+            $filter = static fn ($baseUrl): bool => str_starts_with($requestUrl, $baseUrl);
+        }
 
         // direct hit
-        if (\array_key_exists($requestUrl, $domains)) {
-            $domain = $domains[$requestUrl];
+        if ($domain !== null) {
             $domain['url'] = rtrim($domain['url'], '/');
 
             return $domain;
         }
 
         // reduce shops to which base url is the beginning of the request
-        $domains = array_filter($domains, static fn ($baseUrl): bool => str_starts_with($requestUrl, $baseUrl), \ARRAY_FILTER_USE_KEY);
+        $domains = array_filter($domains, $filter, \ARRAY_FILTER_USE_KEY);
 
         if ($domains === []) {
             return null;
@@ -334,6 +351,28 @@ class RequestTransformer implements RequestTransformerInterface
     private function getSchemeAndHttpHost(Request $request): string
     {
         return $request->getScheme() . '://' . idn_to_utf8($request->getHttpHost());
+    }
+
+    private function getSchemeAndAsciiHttpHost(Request $request): string
+    {
+        return $request->getScheme() . '://' . $request->getHttpHost();
+    }
+
+    private function isHttpHostPunycode(Request $request): bool
+    {
+        return $request->getHttpHost() !== idn_to_utf8($request->getHttpHost());
+    }
+
+    /**
+     * domain urls and request uri should be in same format, all with trailing slash
+     */
+    private function getNormalizedRequestUrl(Request $request, bool $unicode = true): string
+    {
+        $schemeAndHost = $unicode === true
+            ? $this->getSchemeAndHttpHost($request)
+            : $this->getSchemeAndAsciiHttpHost($request);
+
+        return rtrim($schemeAndHost . $request->getBasePath() . $request->getPathInfo(), '/') . '/';
     }
 
     /**

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -249,11 +249,15 @@ class RequestTransformerTest extends TestCase
         yield 'punycode' => [
             [
                 self::getGermanSalesChannel($germanId, $gerDomainId, 'http://würmer.test'),
+                self::getEnglishSalesChannel($englishId, $ukDomainId, 'http://xn--shpwre-eua5l.test'),
             ],
             [
                 new ExpectedRequest('http://xn--wrmer-kva.test', '', '/', $gerDomainId, $germanId, true, self::LOCALE_DE_DE_ISO, Defaults::CURRENCY, 'de-DE', self::LOCALE_DE_DE_ISO),
                 new ExpectedRequest('http://xn--wrmer-kva.test/', '', '/', $gerDomainId, $germanId, true, self::LOCALE_DE_DE_ISO, Defaults::CURRENCY, 'de-DE', self::LOCALE_DE_DE_ISO),
                 new ExpectedRequest('http://xn--wrmer-kva.test/foobar', '', '/foobar', $gerDomainId, $germanId, true, self::LOCALE_DE_DE_ISO, Defaults::CURRENCY, 'de-DE', self::LOCALE_DE_DE_ISO),
+                new ExpectedRequest('http://xn--shpwre-eua5l.test', '', '/', $ukDomainId, $englishId, true, self::LOCALE_EN_GB_ISO, Defaults::CURRENCY, Defaults::LANGUAGE_SYSTEM, self::LOCALE_EN_GB_ISO),
+                new ExpectedRequest('http://xn--shpwre-eua5l.test/', '', '/', $ukDomainId, $englishId, true, self::LOCALE_EN_GB_ISO, Defaults::CURRENCY, Defaults::LANGUAGE_SYSTEM, self::LOCALE_EN_GB_ISO),
+                new ExpectedRequest('http://xn--shpwre-eua5l.test/foobar', '', '/foobar', $ukDomainId, $englishId, true, self::LOCALE_EN_GB_ISO, Defaults::CURRENCY, Defaults::LANGUAGE_SYSTEM, self::LOCALE_EN_GB_ISO),
             ],
         ];
     }

--- a/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/unit/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -183,6 +183,46 @@ class RequestTransformerTest extends TestCase
             'expectedStorefrontUrl' => 'http://shopware.com/de',
             'expectedResolvedUri' => '/outdoor',
         ];
+
+        yield 'punycode to punycode direct hit' => [
+            'requestUrl' => 'http://xn--shpwre-eua5l.com',
+            'serverVars' => [],
+            'domainUrl' => 'http://xn--shpwre-eua5l.com',
+            'expectedBaseUrl' => '',
+            'expectedAbsoluteBaseUrl' => 'http://shöpwäre.com',
+            'expectedStorefrontUrl' => 'http://shöpwäre.com',
+            'expectedResolvedUri' => '/',
+        ];
+
+        yield 'punycode to unicode direct hit' => [
+            'requestUrl' => 'http://xn--shpwre-eua5l.com',
+            'serverVars' => [],
+            'domainUrl' => 'http://shöpwäre.com',
+            'expectedBaseUrl' => '',
+            'expectedAbsoluteBaseUrl' => 'http://shöpwäre.com',
+            'expectedStorefrontUrl' => 'http://shöpwäre.com',
+            'expectedResolvedUri' => '/',
+        ];
+
+        yield 'punycode to punycode filter hit' => [
+            'requestUrl' => 'http://xn--shpwre-eua5l.com/de/outdoor',
+            'serverVars' => [],
+            'domainUrl' => 'http://xn--shpwre-eua5l.com/de',
+            'expectedBaseUrl' => '/de',
+            'expectedAbsoluteBaseUrl' => 'http://shöpwäre.com',
+            'expectedStorefrontUrl' => 'http://shöpwäre.com/de',
+            'expectedResolvedUri' => '/outdoor',
+        ];
+
+        yield 'punycode to unicode filter hit' => [
+            'requestUrl' => 'http://xn--shpwre-eua5l.com/de/outdoor',
+            'serverVars' => [],
+            'domainUrl' => 'http://shöpwäre.com/de',
+            'expectedBaseUrl' => '/de',
+            'expectedAbsoluteBaseUrl' => 'http://shöpwäre.com',
+            'expectedStorefrontUrl' => 'http://shöpwäre.com/de',
+            'expectedResolvedUri' => '/outdoor',
+        ];
     }
 
     /**


### PR DESCRIPTION
fixes: #14008

### 1. Why is this change necessary?
This pull request improves the handling of internationalized domain names (IDNs), specifically punycode and unicode URLs, in the `RequestTransformer` logic. The changes ensure that both punycode and unicode representations of domain names are correctly matched and resolved, which is essential for supporting multilingual and international storefronts. Additionally, the test coverage has been expanded to verify these scenarios.

### 2. What does this change do, exactly?
* Added logic in `RequestTransformer.php` to check and handle both punycode and unicode representations when transforming requests and finding sales channels, ensuring correct base URL resolution for IDNs. [[1]](diffhunk://#diff-1f3982bcc6e8c6f7c0a40178567f81556b03e371613421f9678007eac11a64bfR124-R131) [[2]](diffhunk://#diff-1f3982bcc6e8c6f7c0a40178567f81556b03e371613421f9678007eac11a64bfL276-R304)
* Introduced new helper methods: `getSchemeAndAsciiHttpHost`, `isHttpHostPunycode`, and `getNormalizedRequestUrl` to facilitate accurate comparison and normalization of punycode and unicode URLs.

### 3. Describe each step to reproduce the issue or behaviour.
* In the admin create a new sales channel domain or edit an existing one
* Use non-ascii characters and it will convert the domain to punycode client-side before saving
* Save the sales channel domain and request it's storefront
* The lookup of the sales channel will fail because the host is converted back to unicode but the lookup table contains the host as punycode

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/14008

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
