### PR TITLE
fix: wrap review and revocation form fields in row

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
@@ -95,17 +95,19 @@
             {% endblock %}
 
             {% block component_review_form_content %}
-                {% sw_include '@Storefront/storefront/component/form/form-textarea.html.twig' with {
-                    label: 'detail.reviewFormContentLabel'|trans|sw_sanitize,
-                    id: 'reviewContent',
-                    name: 'content',
-                    value: data.get('content'),
-                    violationPath: '/content',
-                    validationRules: 'required,minLength',
-                    minlength: '40',
-                    additionalClass: 'col-12 product-detail-review-form-content',
-                    description: 'detail.reviewTextMinLengthHint'|trans|sw_sanitize
-                } %}
+                <div class="row g-2">
+                    {% sw_include '@Storefront/storefront/component/form/form-textarea.html.twig' with {
+                        label: 'detail.reviewFormContentLabel'|trans|sw_sanitize,
+                        id: 'reviewContent',
+                        name: 'content',
+                        value: data.get('content'),
+                        violationPath: '/content',
+                        validationRules: 'required,minLength',
+                        minlength: '40',
+                        additionalClass: 'col-12 product-detail-review-form-content',
+                        description: 'detail.reviewTextMinLengthHint'|trans|sw_sanitize
+                    } %}
+                </div>
             {% endblock %}
 
             {% block component_review_form_footer %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
@@ -52,16 +52,18 @@
                 {% endblock %}
             </div>
 
-            {% block cms_form_revocation_input_contract_number %}
-                {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
-                    with {
-                    fieldName: 'contractNumber',
-                    required: true,
-                    additionalClass: 'col-md-12',
-                    label: 'revocationRequest.contractNumberLabel',
-                    placeholder: 'revocationRequest.contractNumberPlaceholder'
-                } %}
-            {% endblock %}
+            <div class="row g-2">
+                {% block cms_form_revocation_input_contract_number %}
+                    {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
+                        with {
+                        fieldName: 'contractNumber',
+                        required: true,
+                        additionalClass: 'col-md-12',
+                        label: 'revocationRequest.contractNumberLabel',
+                        placeholder: 'revocationRequest.contractNumberPlaceholder'
+                    } %}
+                {% endblock %}
+            </div>
 
             <div class="row g-2">
                 {% block cms_form_revocation_comment_textarea %}


### PR DESCRIPTION
resolves #16262

Wraps the review and revocation form fields in `<div class="row g-2">` to match the surrounding fields.