### PR TITLE
fix: restore TestBootstrapper plugin path fallback

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -69,6 +69,8 @@ The old `pluginTranslationExists(Plugin $plugin)` is deprecated and will be remo
 
 `TestBootstrapper::addActivePlugins()` can now be used with Composer-managed plugins installed below `vendor/`.
 Plugins no longer need to be copied into `custom/plugins` or `custom/static-plugins` just to be installed and activated during test bootstrap.
+When `TestBootstrapper::getPluginPath()` or `getClassLoader()` is used without bootstrapping the full application, local plugins below `custom/plugins` and `custom/static-plugins` are still resolved from the filesystem.
+This keeps static analysis and other tooling that only needs plugin paths or `autoload-dev` registration working without a database-backed kernel.
 
 ### Requirement-aware plugin installation order
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Finder\Finder;
 
 #[Package('framework')]
 class TestBootstrapper
@@ -300,6 +301,18 @@ class TestBootstrapper
 
     public function getPluginPath(string $pluginName): ?string
     {
+        // Prefer the kernel plugin loader as it knows Composer-managed plugin paths once Shopware can access the kernel/database.
+        // Some tooling calls getPluginPath()/getClassLoader() without bootstrapping the application, so keep the legacy filesystem fallback for local plugins.
+        $pluginPath = $this->getPluginPathFromKernelPluginLoader($pluginName);
+        if ($pluginPath !== null) {
+            return $pluginPath;
+        }
+
+        return $this->getPluginPathFromFilesystem($pluginName);
+    }
+
+    private function getPluginPathFromKernelPluginLoader(string $pluginName): ?string
+    {
         try {
             $pluginInfos = $this->getKernel()->getPluginLoader()->getPluginInfos();
         } catch (\Throwable) {
@@ -312,6 +325,36 @@ class TestBootstrapper
             }
 
             return $this->getAbsolutePluginPath($pluginInfo['path']);
+        }
+
+        return null;
+    }
+
+    private function getPluginPathFromFilesystem(string $pluginName): ?string
+    {
+        $pluginDirectories = [
+            $this->getProjectDir() . '/custom/plugins',
+            $this->getProjectDir() . '/custom/static-plugins',
+        ];
+
+        $pluginDirectories = array_filter($pluginDirectories, \is_dir(...));
+        if ($pluginDirectories === []) {
+            return null;
+        }
+
+        $finder = (new Finder())->directories()->in($pluginDirectories)->depth('== 0')->sortByName();
+        foreach ($finder as $pluginDir) {
+            $pluginPath = $pluginDir->getPathname();
+
+            if (!is_file($pluginPath . '/composer.json')) {
+                continue;
+            }
+
+            if (!is_file($pluginPath . '/src/' . $pluginName . '.php')) {
+                continue;
+            }
+
+            return $pluginPath;
         }
 
         return null;

--- a/tests/unit/Core/TestBootstrapperTest.php
+++ b/tests/unit/Core/TestBootstrapperTest.php
@@ -66,7 +66,7 @@ class TestBootstrapperTest extends TestCase
         static::assertSame(['Test'], $activePlugins);
     }
 
-    public function testGetClassLoaderRegistersActivePluginAutoloadDev(): void
+    public function testGetClassLoaderRegistersActivePluginAutoloadDevFromKernelPluginLoader(): void
     {
         $previousKernel = KernelLifecycleAccessor::currentKernel();
         $projectDir = __DIR__ . '/_fixtures/TestBootstrapper/project';
@@ -129,6 +129,47 @@ class TestBootstrapperTest extends TestCase
 
         try {
             static::assertSame($projectDir . '/' . $vendorPluginPath, (new TestBootstrapper())->setProjectDir($projectDir)->getPluginPath('SwagCmsElements'));
+        } finally {
+            KernelLifecycleAccessor::setKernel($previousKernel);
+        }
+    }
+
+    public function testGetPluginPathFallsBackToFilesystemForLocalPlugins(): void
+    {
+        $previousKernel = KernelLifecycleAccessor::currentKernel();
+        $projectDir = __DIR__ . '/_fixtures/TestBootstrapper/project';
+        $pluginPath = $projectDir . '/custom/static-plugins/SwagStaticAnalysis';
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->method('getPluginLoader')->willThrowException(new \RuntimeException('Kernel plugin loader is not available.'));
+
+        KernelLifecycleAccessor::setKernel($kernel);
+
+        try {
+            static::assertSame($pluginPath, (new TestBootstrapper())->setProjectDir($projectDir)->getPluginPath('SwagStaticAnalysis'));
+        } finally {
+            KernelLifecycleAccessor::setKernel($previousKernel);
+        }
+    }
+
+    public function testGetClassLoaderRegistersActivePluginAutoloadDevFromFilesystemFallback(): void
+    {
+        $previousKernel = KernelLifecycleAccessor::currentKernel();
+        $projectDir = __DIR__ . '/_fixtures/TestBootstrapper/project';
+        $pluginPath = $projectDir . '/custom/static-plugins/SwagStaticAnalysis';
+
+        $kernel = $this->createMock(Kernel::class);
+        $kernel->method('getPluginLoader')->willThrowException(new \RuntimeException('Kernel plugin loader is not available.'));
+
+        KernelLifecycleAccessor::setKernel($kernel);
+
+        try {
+            $classLoader = (new TestBootstrapper())
+                ->setProjectDir($projectDir)
+                ->addActivePlugins('SwagStaticAnalysis')
+                ->getClassLoader();
+
+            static::assertSame([$pluginPath . '/tests/'], $classLoader->getPrefixesPsr4()['SwagStaticAnalysis\\Tests\\']);
         } finally {
             KernelLifecycleAccessor::setKernel($previousKernel);
         }

--- a/tests/unit/Core/_fixtures/TestBootstrapper/project/custom/static-plugins/SwagStaticAnalysis/composer.json
+++ b/tests/unit/Core/_fixtures/TestBootstrapper/project/custom/static-plugins/SwagStaticAnalysis/composer.json
@@ -1,0 +1,7 @@
+{
+    "autoload-dev": {
+        "psr-4": {
+            "SwagStaticAnalysis\\Tests\\": "tests/"
+        }
+    }
+}

--- a/tests/unit/Core/_fixtures/TestBootstrapper/project/custom/static-plugins/SwagStaticAnalysis/src/SwagStaticAnalysis.php
+++ b/tests/unit/Core/_fixtures/TestBootstrapper/project/custom/static-plugins/SwagStaticAnalysis/src/SwagStaticAnalysis.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+class SwagStaticAnalysis
+{
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`TestBootstrapper::getPluginPath()` and `getClassLoader()` are also used by tooling such as static analysis without bootstrapping the full application. After switching plugin path lookup to the kernel plugin loader, local plugins below `custom/plugins` and `custom/static-plugins` could no longer be resolved in those no-bootstrap paths.

### 2. What does this change do, exactly?

It keeps the kernel plugin loader as the preferred path for Composer-managed plugins, and restores a Finder-based filesystem fallback for local plugins when the kernel loader is unavailable. It also updates unit fixtures, tests, and release info.

### 3. Describe each step to reproduce the issue or behaviour.

Use `TestBootstrapper::addActivePlugins()` and `getClassLoader()` for a local plugin from `custom/static-plugins` in a static-analysis setup without bootstrapping the application. The bootstrapper cannot resolve the plugin path because there is no usable kernel plugin loader.

### 4. Please link to the relevant issues (if any).

Follow-up to #16674 and #16765.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them