### PR TITLE
fix: Add max-width to text element

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
@@ -50,4 +50,9 @@
     .sw-text-editor.is--disabled .sw-text-editor__content {
         background-color: var(--color-elevation-surface-raised);
     }
+
+    img {
+        max-width: 100%;
+        height: auto;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a user inserts an image into the CMS Text element (via the editor's source/HTML view, paste, or media link) whose natural width is larger than the slot, the image overflows the slot's right edge.

### 2. What does this change do, exactly?
Adds max-width: 100%; to cms text element to force it to stay inside slot

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
