### PR TITLE
fix: pay later after-order cart context (backport: 6.6.x)

### DIFF
--- a/src/Core/Checkout/DependencyInjection/order.xml
+++ b/src/Core/Checkout/DependencyInjection/order.xml
@@ -138,6 +138,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Order\OrderConverter"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader"/>
         </service>

--- a/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
@@ -47,6 +48,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
         private readonly AbstractPaymentMethodRoute $paymentRoute,
         private readonly OrderConverter $orderConverter,
         private readonly CartRuleLoader $cartRuleLoader,
+        private readonly CartService $cartService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly InitialStateIdLoader $initialStateIdLoader
     ) {
@@ -71,7 +73,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
             [SalesChannelContextService::PAYMENT_METHOD_ID => $paymentMethodId]
         );
 
-        $this->validateRequest($context, $paymentMethodId);
+        $this->validateRequest($order, $context, $paymentMethodId);
 
         $this->validatePaymentState($order);
 
@@ -133,10 +135,16 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
         $this->eventDispatcher->dispatch($event);
     }
 
-    private function validateRequest(SalesChannelContext $salesChannelContext, string $paymentMethodId): void
+    private function validateRequest(OrderEntity $order, SalesChannelContext $salesChannelContext, string $paymentMethodId): void
     {
         $paymentRequest = new Request();
         $paymentRequest->query->set('onlyAvailable', '1');
+        $paymentRequest->attributes->set('orderId', $order->getId());
+
+        $cart = $this->orderConverter->convertToCart($order, $salesChannelContext->getContext());
+        $cart->setToken($salesChannelContext->getToken());
+
+        $this->cartService->setCart($cart);
 
         $availablePayments = $this->paymentRoute->load($paymentRequest, $salesChannelContext, new Criteria());
 

--- a/tests/unit/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Order/SalesChannel/SetPaymentOrderRouteTest.php
@@ -1,0 +1,130 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Order\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartRuleLoader;
+use Shopware\Core\Checkout\Cart\Order\OrderConverter;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Order\OrderCollection;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Order\OrderException;
+use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
+use Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
+use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
+use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(SetPaymentOrderRoute::class)]
+class SetPaymentOrderRouteTest extends TestCase
+{
+    public function testSetPaymentProvidesOrderCartToPaymentAvailability(): void
+    {
+        $orderId = Uuid::randomHex();
+        $paymentMethodId = Uuid::randomHex();
+
+        $order = new OrderEntity();
+        $order->setId($orderId);
+
+        $salesChannelContext = Generator::generateSalesChannelContext(token: 'storefront-token');
+        $orderContext = Generator::generateSalesChannelContext(token: 'restored-order-token');
+
+        $orderConverter = $this->createMock(OrderConverter::class);
+        $orderConverter
+            ->expects($this->once())
+            ->method('assembleSalesChannelContext')
+            ->with(
+                static::identicalTo($order),
+                static::identicalTo($salesChannelContext->getContext()),
+                [SalesChannelContextService::PAYMENT_METHOD_ID => $paymentMethodId]
+            )
+            ->willReturn($orderContext);
+
+        $convertedCart = new Cart('converted-order-token');
+        $orderConverter
+            ->expects($this->once())
+            ->method('convertToCart')
+            ->with(static::identicalTo($order), static::identicalTo($orderContext->getContext()))
+            ->willReturn($convertedCart);
+
+        $cartService = $this->createMock(CartService::class);
+        $cartService
+            ->expects($this->once())
+            ->method('setCart')
+            ->with(static::callback(static function (Cart $cart) use ($orderContext): bool {
+                static::assertSame($orderContext->getToken(), $cart->getToken());
+
+                return true;
+            }));
+
+        $paymentRoute = $this->createMock(AbstractPaymentMethodRoute::class);
+        $paymentRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::callback(static function (Request $request) use ($orderId): bool {
+                    static::assertSame('1', $request->query->get('onlyAvailable'));
+                    static::assertSame($orderId, $request->attributes->get('orderId'));
+
+                    return true;
+                }),
+                static::identicalTo($orderContext),
+                static::isInstanceOf(Criteria::class)
+            )
+            ->willReturn($this->createPaymentMethodRouteResponse(new PaymentMethodCollection()));
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->method('dispatch')
+            ->willReturnArgument(0);
+
+        $route = new SetPaymentOrderRoute(
+            $this->createMock(OrderService::class),
+            new StaticEntityRepository([new OrderCollection([$order])]),
+            $paymentRoute,
+            $orderConverter,
+            $this->createMock(CartRuleLoader::class),
+            $cartService,
+            $eventDispatcher,
+            $this->createMock(InitialStateIdLoader::class)
+        );
+
+        $this->expectException(OrderException::class);
+
+        $route->setPayment(new Request(request: [
+            'orderId' => $orderId,
+            'paymentMethodId' => $paymentMethodId,
+        ]), $salesChannelContext);
+    }
+
+    private function createPaymentMethodRouteResponse(PaymentMethodCollection $paymentMethods): PaymentMethodRouteResponse
+    {
+        return new PaymentMethodRouteResponse(
+            new EntitySearchResult(
+                PaymentMethodDefinition::ENTITY_NAME,
+                $paymentMethods->count(),
+                $paymentMethods,
+                null,
+                new Criteria(),
+                Generator::generateSalesChannelContext()->getContext()
+            )
+        );
+    }
+}


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/16789


---

### 1. Why is this change necessary?
After-order payment validation could use the current storefront cart instead of the existing order cart in downstream payment checks.

### 2. What does this change do, exactly?
It stores the converted order cart under the restored order context token and forwards `orderId` during payment-method validation.

### 3. Describe each step to reproduce the issue or behaviour.
1. Log in to the backend as an admin
2. Manually create an order for an existing customer account and send the customer a request to pay for the order
3. Now log in to the shop as a customer and visit the URL that was sent to the customer by email. Alternatively, go to the customer account, navigate to the orders and click on ‘Complete payment’ (e.g. https://pp6771-xxx.eu-support-1.shopdev.de/account/order/edit/{orderId})
4. During the checkout process, select PayPal PayLater if this has not already been preselected
5. Try to complete the order – an error will be displayed

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/16512

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

