### PR TITLE
fix(storefront): emit XXL breakpoint value in thumbnail sizes attribute

### DIFF
--- a/changelog/_unreleased/2026-05-13-fix-thumbnail-sizes-attribute-missing-xxl-breakpoint.md
+++ b/changelog/_unreleased/2026-05-13-fix-thumbnail-sizes-attribute-missing-xxl-breakpoint.md
@@ -1,0 +1,7 @@
+---
+title: Fix missing XXL breakpoint value in thumbnail sizes attribute
+issue: 16710
+---
+# Storefront
+* Changed `src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig` to emit a value for the XXL breakpoint in the auto-generated `sizes` attribute.
+* The `xxl` key is now used for the largest (open-ended) viewport sizing branch (boxed: `container / columns` in `px`, full-width: `100 / columns` in `vw`). The `xl` key is now treated as a closed range bounded by `breakpoint.xxl - 1` to match the pattern used by the smaller breakpoints.

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -43,7 +43,8 @@
                 xs: (theme_config('breakpoint.sm') - 1) ~'px',
                 sm: (theme_config('breakpoint.md') - 1) ~'px',
                 md: ((theme_config('breakpoint.lg') - 1) / columns)|round(0, 'ceil') ~'px',
-                lg: ((theme_config('breakpoint.xl') - 1) / columns)|round(0, 'ceil') ~'px'
+                lg: ((theme_config('breakpoint.xl') - 1) / columns)|round(0, 'ceil') ~'px',
+                xl: ((theme_config('breakpoint.xxl') - 1) / columns)|round(0, 'ceil') ~'px'
             } %}
 
             {% if sizes is not defined or sizes == null %}
@@ -53,10 +54,10 @@
             {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
             {% if layout == 'full-width' %}
                 {% set container = 100 %}
-                {% set sizes = sizes|merge({ xl: (container / columns)|round(0, 'ceil') ~'vw'}) %}
+                {% set sizes = sizes|merge({ xxl: (container / columns)|round(0, 'ceil') ~'vw'}) %}
             {% else %}
                 {% set container = 1360 %}
-                {% set sizes = sizes|merge({ xl: (container / columns)|round(0, 'ceil') ~'px'}) %}
+                {% set sizes = sizes|merge({ xxl: (container / columns)|round(0, 'ceil') ~'px'}) %}
             {% endif %}
         {% endif %}
 

--- a/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
@@ -123,6 +123,43 @@ class ThumbnailExtensionTest extends TestCase
     }
 
     /**
+     * @throws SyntaxError
+     * @throws \Throwable
+     * @throws Exception
+     * @throws RuntimeError
+     * @throws LoaderError
+     */
+    public function testSwThumbnailsRendersSizesAttrWithValueForEveryBreakpoint(): void
+    {
+        $result = $this->renderTemplate('@Storefront/storefront/thumbnail-with-columns.html.twig', [
+            'media' => $this->createExampleMediaWithThumbnails([280, 400, 800, 1920]),
+            'context' => Generator::generateSalesChannelContext(),
+        ]);
+
+        // Regression test for https://github.com/shopware/shopware/issues/16710:
+        // every breakpoint declared in the auto-generated sizes attribute must carry
+        // a non-empty size value. Before the fix the xxl entry was missing from the
+        // sizes map and produced "(min-width: ...px) ," — an empty value followed by
+        // a comma — in the rendered output.
+        static::assertMatchesRegularExpression('/\ssizes="(?P<sizes>[^"]+)"/', $result, 'sizes attribute is missing');
+        preg_match('/\ssizes="(?P<sizes>[^"]+)"/', $result, $matches);
+        $sizes = $matches['sizes'];
+
+        $entries = array_map('trim', explode(',', $sizes));
+        // 6 breakpoint entries (xs..xxl) + 1 fallback entry
+        static::assertCount(7, $entries, sprintf('Expected 7 sizes entries, got %d: %s', \count($entries), $sizes));
+
+        // The 6 breakpoint entries must each have a non-empty value after the media query.
+        for ($i = 0; $i < 6; ++$i) {
+            static::assertMatchesRegularExpression(
+                '/^\(min-width:[^)]*\)\s+\S+/',
+                $entries[$i],
+                sprintf('Sizes entry #%d has an empty value: "%s"', $i, $entries[$i])
+            );
+        }
+    }
+
+    /**
      * @param array<string, mixed> $data
      *
      * @throws SyntaxError

--- a/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/thumbnail-with-columns.html.twig
+++ b/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/thumbnail-with-columns.html.twig
@@ -1,0 +1,4 @@
+{% sw_thumbnails 'thumbnails-with-columns' with {
+    media: media,
+    columns: 2
+} %}


### PR DESCRIPTION
## Summary

Resolves the missing XXL value in the auto-generated `sizes` attribute on `thumbnail.html.twig` (issue [#16710](https://github.com/shopware/shopware/issues/16710)).

When `xxl` was added to the breakpoint map in 6.7.6.0, the corresponding entry was not added to the sizes map. The for-loop in the template iterates over all breakpoint keys and concatenates `sizes[key]`, so the missing entry produced an empty value:

```
sizes="(min-width: 1400px) , (min-width: 1200px) 680px, (min-width: 992px) 600px, (min-width: 768px) 496px, (min-width: 576px) 767px, (min-width: 0px) 575px, 50vw"
```

This PR shifts the "open-ended top" semantics to the new `xxl` key (gets `container / columns`), and turns the existing `xl` key into a closed range bounded by `breakpoint.xxl - 1`, matching the pattern already used for the smaller breakpoints.

After the fix (2-column boxed layout):

```
sizes="(min-width: 1400px) 680px, (min-width: 1200px) 700px, (min-width: 992px) 600px, (min-width: 768px) 496px, (min-width: 576px) 767px, (min-width: 0px) 575px, 50vw"
```

## Test plan

- [x] Added regression test `testSwThumbnailsRendersSizesAttrWithValueForEveryBreakpoint` to `ThumbnailExtensionTest` that verifies every breakpoint entry of the rendered `sizes` attribute carries a non-empty value.
- [ ] CI: full `tests/integration/Storefront/Framework/Twig` suite passes.

Fixes #16710