### PR TITLE
fix(admin): set initial pagination limit for customer addresses association

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/index.js
@@ -102,7 +102,10 @@ export default {
                 .addAssociation('requestedGroup')
                 .addAssociation('boundSalesChannel');
 
-            criteria.getAssociation('addresses').addSorting(Criteria.sort('firstName'), 'ASC', false);
+            criteria
+                .getAssociation('addresses')
+                .addSorting(Criteria.sort('firstName'), 'ASC', false)
+                .setLimit(criteria.limit);
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.spec.js
@@ -221,4 +221,14 @@ describe('module/sw-customer/page/sw-customer-detail', () => {
 
         expect(wrapper.vm.customer.salutationId).toBe('1');
     });
+
+    it('should set the initial limit on the addresses association criteria', async () => {
+        await flushPromises();
+
+        const criteria = wrapper.vm.defaultCriteria;
+        const addressesAssociation = criteria.getAssociation('addresses');
+
+        expect(addressesAssociation.limit).toBe(criteria.limit);
+        expect(addressesAssociation.limit).toBe(25);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

In the Shopware 6 administration under Customer > Addresses, pagination behaves inconsistently when a customer has more than 25 addresses.

Although the pagination control allows defining the number of items per page (default: 25), this setting is not respected on the initial load.

Instead, more than the configured number of addresses (sometimes all) are displayed on the first page. The correct number is only applied after manually re-selecting the “Items per Page” value.

### 2. What does this change do, exactly?

Previously, the customer detail page fetched the `addresses` association without an explicit limit, causing the API to fall back to `shopware.api.max_limit` (e.g., 500). This adds `.setLimit(criteria.limit)` to the addresses association criteria so that the initial payload perfectly mirrors the root criteria's default pagination limit.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make sure to have a customer with more than 25 addresses (use "duplicate" for testing purposes)
2. Navigate to Customer > Addresses for a customer with >25 addresses
3. Observe the number of displayed addresses on initial load.

### 4. Please link to the relevant issues (if any).

- fixes #15722 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
