### PR TITLE
fix(admin): restore text-editor toolbar contrast and disabled/active …

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.scss
@@ -9,15 +9,6 @@
     align-items: center;
     justify-content: center;
 
-    &.is--active {
-        color: var(--color-icon-brand-default);
-    }
-
-    &.is--disabled {
-        color: var(--color-icon-secondary-default);
-        cursor: initial;
-    }
-
     .sw-text-editor-toolbar-button__icon {
         display: flex;
         align-items: center;
@@ -25,7 +16,16 @@
         width: 100%;
         cursor: pointer;
 
-        &:hover {
+        &.is--active {
+            color: var(--color-icon-brand-default);
+        }
+
+        &.is--disabled {
+            color: var(--color-icon-secondary-disabled);
+            cursor: initial;
+        }
+
+        &:not(.is--disabled):hover {
             color: var(--color-icon-brand-default);
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
@@ -4,7 +4,7 @@ $sw-text-editor-toolbar-item-color-boxed: var(--color-icon-secondary-default);
     padding: 0 6px;
     background: var(--color-elevation-floating-default);
     border-radius: 4px;
-    color: var(--color-icon-primary-default);
+    color: var(--color-icon-inverse-default);
     display: grid;
     grid-auto-flow: column dense;
     grid-auto-columns: min-content;


### PR DESCRIPTION



### 1. Why is this change necessary?

- After the token migration, the floating text-editor toolbar became unreadable: dark icons on near-black bg (light mode), white icons on white bg (dark mode).
- Found a long-standing latent bug: `is--active`/`is--disabled` rules targeted the outer wrapper, but the classes are applied on the inner icon — both states were silently broken.

### 2. What does this change do, exactly?

- Floating toolbar uses `--color-icon-inverse-default` to pair with the inverse `--color-elevation-floating-default` surface.
- Moved `is--active`/`is--disabled` selectors onto the inner `.sw-text-editor-toolbar-button__icon` element.
- Disabled state now uses `--color-icon-secondary-disabled` so disabled buttons are visually distinct from enabled ones.
- Hover excludes disabled buttons (`&:not(.is--disabled):hover`).

### 3. Describe each step to reproduce the issue or behaviour.

### before
<img width="1352" height="900" alt="image" src="https://github.com/user-attachments/assets/10fa87ee-a72d-4bf9-a494-1be4e76286bb" />


### after
<img width="1120" height="249" alt="image" src="https://github.com/user-attachments/assets/24ac1dbf-00a5-46d1-8e3d-08a2ddab38c8" />


**Floating toolbar contrast:**
1. CMS → open layout → edit a text block.
2. Select any text → floating toolbar appears.
3. Before: icons barely visible (light) / invisible (dark). After: readable in both.

**Disabled state:**
1. Open any category → Description editor.
2. Click `</>` (switch edit modes) → code-edit mode.
3. Before: other buttons still look enabled. After: clearly greyed out.

### 4. Please link to the relevant issues (if any).

- Follow-up fix for #16749

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change — *SCSS-only, visually verified in Chrome*
- [ ] I have updated developer-facing release notes — *not relevant, internal style fix*
- [ ] I have written or adjusted the documentation — *no doc changes needed*
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
