### PR TITLE
feat: emit product search events from search widget

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -4,6 +4,10 @@ import Debouncer from 'src/helper/debouncer.helper';
 import HttpClient from 'src/service/http-client.service';
 import LoadingIndicatorUtil from 'src/utility/loading-indicator/loading-indicator.util';
 
+const PRODUCT_SEARCH_PERFORMED_EVENT = 'product:search-performed';
+const PRODUCT_SEARCH_SUGGESTION_SHOWN_EVENT = 'product:search-suggestion-shown';
+const PRODUCT_SEARCH_SUGGESTION_PRODUCT_VIEWED_EVENT = 'product:search-suggestion-product-viewed';
+
 export default class SearchWidgetPlugin extends Plugin {
 
     static options = {
@@ -21,6 +25,7 @@ export default class SearchWidgetPlugin extends Plugin {
 
         searchWidgetDelay: 250,
         searchWidgetMinChars: 3,
+        searchWidgetMaxChars: 100,
     };
 
     init() {
@@ -77,6 +82,13 @@ export default class SearchWidgetPlugin extends Plugin {
         if (value.length < this.options.searchWidgetMinChars) {
             event.preventDefault();
             event.stopPropagation();
+            return;
+        }
+
+        if (value.length <= this.options.searchWidgetMaxChars) {
+            document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_PERFORMED_EVENT, {
+                detail: { term: value },
+            }));
         }
     }
 
@@ -217,6 +229,12 @@ export default class SearchWidgetPlugin extends Plugin {
                     item.addEventListener('keydown', this._handleSearchItemKeyEvent.bind(this, index));
                 });
 
+                searchSuggest.addEventListener('click', this._handleSuggestResultClick.bind(this));
+
+                document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_SUGGESTION_SHOWN_EVENT, {
+                    detail: { term: value },
+                }));
+
                 this.$emitter.publish('afterSuggest');
             })
             .catch(() => {
@@ -226,6 +244,28 @@ export default class SearchWidgetPlugin extends Plugin {
                 // clear any existing results
                 this._clearSuggestResults();
             });
+    }
+
+    /**
+     * Delegated click handler on the rendered suggest dropdown. Fires a
+     * product:search-suggestion-product-viewed event when the user clicks an
+     * actual link (a product result or the "show all results" link).
+     * @param {Event} event
+     * @private
+     */
+    _handleSuggestResultClick(event) {
+        if (!event.target.closest('a[href]')) {
+            return;
+        }
+
+        const term = this._inputField.value.trim();
+        if (term.length < this.options.searchWidgetMinChars || term.length > this.options.searchWidgetMaxChars) {
+            return;
+        }
+
+        document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_SUGGESTION_PRODUCT_VIEWED_EVENT, {
+            detail: { term },
+        }));
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -25,7 +25,6 @@ export default class SearchWidgetPlugin extends Plugin {
 
         searchWidgetDelay: 250,
         searchWidgetMinChars: 3,
-        searchWidgetMaxChars: 100,
     };
 
     init() {
@@ -85,11 +84,9 @@ export default class SearchWidgetPlugin extends Plugin {
             return;
         }
 
-        if (value.length <= this.options.searchWidgetMaxChars) {
-            document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_PERFORMED_EVENT, {
-                detail: { term: value },
-            }));
-        }
+        document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_PERFORMED_EVENT, {
+            detail: { term: value },
+        }));
     }
 
     /**
@@ -248,8 +245,9 @@ export default class SearchWidgetPlugin extends Plugin {
 
     /**
      * Delegated click handler on the rendered suggest dropdown. Fires a
-     * product:search-suggestion-product-viewed event when the user clicks an
-     * actual link (a product result or the "show all results" link).
+     * product:search-performed event when the user clicks the "show all
+     * results" link, or a product:search-suggestion-product-viewed event
+     * when the user clicks a product result.
      * @param {Event} event
      * @private
      */
@@ -259,11 +257,11 @@ export default class SearchWidgetPlugin extends Plugin {
         }
 
         const term = this._inputField.value.trim();
-        if (term.length < this.options.searchWidgetMinChars || term.length > this.options.searchWidgetMaxChars) {
-            return;
-        }
+        const eventName = event.target.closest('.search-suggest-total')
+            ? PRODUCT_SEARCH_PERFORMED_EVENT
+            : PRODUCT_SEARCH_SUGGESTION_PRODUCT_VIEWED_EVENT;
 
-        document.dispatchEvent(new CustomEvent(PRODUCT_SEARCH_SUGGESTION_PRODUCT_VIEWED_EVENT, {
+        document.dispatchEvent(new CustomEvent(eventName, {
             detail: { term },
         }));
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -321,22 +321,7 @@ describe('SearchPlugin Tests', () => {
         document.removeEventListener('product:search-performed', listener);
     });
 
-    test('_handleSearchEvent does not dispatch event when term exceeds maximum length', () => {
-        const listener = jest.fn();
-        document.addEventListener('product:search-performed', listener);
-        searchPlugin._inputField.value = 'a'.repeat(101);
-
-        searchPlugin._handleSearchEvent({
-            preventDefault: jest.fn(),
-            stopPropagation: jest.fn(),
-        });
-
-        expect(listener).not.toHaveBeenCalled();
-
-        document.removeEventListener('product:search-performed', listener);
-    });
-
-    test('_handleSuggestResultClick dispatches product:search-suggestion-product-viewed when clicking a dropdown link', () => {
+    test('_handleSuggestResultClick dispatches product:search-suggestion-product-viewed when clicking a product link', () => {
         const listener = jest.fn();
         document.addEventListener('product:search-suggestion-product-viewed', listener);
         searchPlugin._inputField.value = 'shoes';
@@ -354,48 +339,42 @@ describe('SearchPlugin Tests', () => {
         document.removeEventListener('product:search-suggestion-product-viewed', listener);
     });
 
-    test('_handleSuggestResultClick ignores clicks that are not on a link', () => {
+    test('_handleSuggestResultClick dispatches product:search-performed when clicking the show-all-results link', () => {
         const listener = jest.fn();
-        document.addEventListener('product:search-suggestion-product-viewed', listener);
+        document.addEventListener('product:search-performed', listener);
+        searchPlugin._inputField.value = 'shoes';
+
+        const totalContainer = document.createElement('li');
+        totalContainer.className = 'search-suggest-total';
+        const link = document.createElement('a');
+        link.setAttribute('href', '/search?search=shoes');
+        link.className = 'search-suggest-total-link';
+        totalContainer.appendChild(link);
+
+        searchPlugin._handleSuggestResultClick({ target: link });
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0].detail).toEqual({ term: 'shoes' });
+
+        document.removeEventListener('product:search-performed', listener);
+    });
+
+    test('_handleSuggestResultClick ignores clicks that are not on a link', () => {
+        const productListener = jest.fn();
+        const performedListener = jest.fn();
+        document.addEventListener('product:search-suggestion-product-viewed', productListener);
+        document.addEventListener('product:search-performed', performedListener);
         searchPlugin._inputField.value = 'shoes';
 
         const nonLink = document.createElement('div');
 
         searchPlugin._handleSuggestResultClick({ target: nonLink });
 
-        expect(listener).not.toHaveBeenCalled();
+        expect(productListener).not.toHaveBeenCalled();
+        expect(performedListener).not.toHaveBeenCalled();
 
-        document.removeEventListener('product:search-suggestion-product-viewed', listener);
-    });
-
-    test('_handleSuggestResultClick does not dispatch event when term is below minimum length', () => {
-        const listener = jest.fn();
-        document.addEventListener('product:search-suggestion-product-viewed', listener);
-        searchPlugin._inputField.value = 'ab';
-
-        const link = document.createElement('a');
-        link.setAttribute('href', '/product/123');
-
-        searchPlugin._handleSuggestResultClick({ target: link });
-
-        expect(listener).not.toHaveBeenCalled();
-
-        document.removeEventListener('product:search-suggestion-product-viewed', listener);
-    });
-
-    test('_handleSuggestResultClick does not dispatch event when term exceeds maximum length', () => {
-        const listener = jest.fn();
-        document.addEventListener('product:search-suggestion-product-viewed', listener);
-        searchPlugin._inputField.value = 'a'.repeat(101);
-
-        const link = document.createElement('a');
-        link.setAttribute('href', '/product/123');
-
-        searchPlugin._handleSuggestResultClick({ target: link });
-
-        expect(listener).not.toHaveBeenCalled();
-
-        document.removeEventListener('product:search-suggestion-product-viewed', listener);
+        document.removeEventListener('product:search-suggestion-product-viewed', productListener);
+        document.removeEventListener('product:search-performed', performedListener);
     });
 
     test('_suggest should handle successful AJAX request', async () => {

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -290,6 +290,114 @@ describe('SearchPlugin Tests', () => {
         expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
     });
 
+    test('_handleSearchEvent dispatches product:search-performed event on form submit when term is valid', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-performed', listener);
+        searchPlugin._inputField.value = 'shoes';
+
+        searchPlugin._handleSearchEvent({
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+        });
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0].detail).toEqual({ term: 'shoes' });
+
+        document.removeEventListener('product:search-performed', listener);
+    });
+
+    test('_handleSearchEvent does not dispatch event when term is below minimum length', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-performed', listener);
+        searchPlugin._inputField.value = 'ab';
+
+        searchPlugin._handleSearchEvent({
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+        });
+
+        expect(listener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-performed', listener);
+    });
+
+    test('_handleSearchEvent does not dispatch event when term exceeds maximum length', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-performed', listener);
+        searchPlugin._inputField.value = 'a'.repeat(101);
+
+        searchPlugin._handleSearchEvent({
+            preventDefault: jest.fn(),
+            stopPropagation: jest.fn(),
+        });
+
+        expect(listener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-performed', listener);
+    });
+
+    test('_handleSuggestResultClick dispatches product:search-suggestion-product-viewed when clicking a dropdown link', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-suggestion-product-viewed', listener);
+        searchPlugin._inputField.value = 'shoes';
+
+        const link = document.createElement('a');
+        link.setAttribute('href', '/product/123');
+        const inner = document.createElement('span');
+        link.appendChild(inner);
+
+        searchPlugin._handleSuggestResultClick({ target: inner });
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener.mock.calls[0][0].detail).toEqual({ term: 'shoes' });
+
+        document.removeEventListener('product:search-suggestion-product-viewed', listener);
+    });
+
+    test('_handleSuggestResultClick ignores clicks that are not on a link', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-suggestion-product-viewed', listener);
+        searchPlugin._inputField.value = 'shoes';
+
+        const nonLink = document.createElement('div');
+
+        searchPlugin._handleSuggestResultClick({ target: nonLink });
+
+        expect(listener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-suggestion-product-viewed', listener);
+    });
+
+    test('_handleSuggestResultClick does not dispatch event when term is below minimum length', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-suggestion-product-viewed', listener);
+        searchPlugin._inputField.value = 'ab';
+
+        const link = document.createElement('a');
+        link.setAttribute('href', '/product/123');
+
+        searchPlugin._handleSuggestResultClick({ target: link });
+
+        expect(listener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-suggestion-product-viewed', listener);
+    });
+
+    test('_handleSuggestResultClick does not dispatch event when term exceeds maximum length', () => {
+        const listener = jest.fn();
+        document.addEventListener('product:search-suggestion-product-viewed', listener);
+        searchPlugin._inputField.value = 'a'.repeat(101);
+
+        const link = document.createElement('a');
+        link.setAttribute('href', '/product/123');
+
+        searchPlugin._handleSuggestResultClick({ target: link });
+
+        expect(listener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-suggestion-product-viewed', listener);
+    });
+
     test('_suggest should handle successful AJAX request', async () => {
         const mockResponse = `
             <div class="search-suggest js-search-result">
@@ -308,6 +416,9 @@ describe('SearchPlugin Tests', () => {
         searchPlugin._inputField.value = 'test';
         searchPlugin.$emitter.publish = jest.fn();
 
+        const suggestionListener = jest.fn();
+        document.addEventListener('product:search-suggestion-shown', suggestionListener);
+
         await searchPlugin._suggest('test');
 
         expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('beforeSearch');
@@ -321,6 +432,11 @@ describe('SearchPlugin Tests', () => {
         expect(searchPlugin._inputField.getAttribute('aria-controls')).toBe('search-suggest-listbox');
         expect(searchPlugin._inputField.getAttribute('aria-describedby')).toBe('search-suggest-result-info');
         expect(searchPlugin.searchSuggestLinks.length).toBe(1);
+
+        expect(suggestionListener).toHaveBeenCalledTimes(1);
+        expect(suggestionListener.mock.calls[0][0].detail).toEqual({ term: 'test' });
+
+        document.removeEventListener('product:search-suggestion-shown', suggestionListener);
     });
 
     test('_clearSuggestResults should remove dynamic accessibility references', () => {
@@ -362,6 +478,9 @@ describe('SearchPlugin Tests', () => {
         searchPlugin.$emitter.publish = jest.fn();
         searchPlugin._clearSuggestResults = jest.fn();
 
+        const suggestionListener = jest.fn();
+        document.addEventListener('product:search-suggestion-shown', suggestionListener);
+
         await searchPlugin._suggest('test');
 
         expect(global.fetch).toHaveBeenCalled();
@@ -370,6 +489,9 @@ describe('SearchPlugin Tests', () => {
         await new Promise(process.nextTick);
         expect(searchPlugin.$emitter.publish).not.toHaveBeenCalledWith('afterSuggest');
         expect(searchPlugin._clearSuggestResults).toHaveBeenCalled();
+        expect(suggestionListener).not.toHaveBeenCalled();
+
+        document.removeEventListener('product:search-suggestion-shown', suggestionListener);
     });
 
     test('_onBodyClick should clear results when clicking outside', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

The storefront search widget currently emits no analytics signal that identifies a navigation as search-driven. Page events for `/search?search=X` carry the term in the URL, but the dropdown product-click path (user types in the search box, sees the suggest dropdown, clicks a product) navigates straight to `/product/...` — the search term is gone, untraceable from page events alone.

Downstream analytics consumers (e.g. SwagAnalytics' "Top Search Terms" KPI — services-roadmap#438) need to know what users actually searched for. Rather than referencing a specific analytics plugin from core Storefront, this PR emits standard `CustomEvent`s on `document` — anyone (SwagAnalytics or otherwise) can subscribe.

### 2. What does this change do, exactly?

Adds three trigger points in `SearchWidgetPlugin` that dispatch standard DOM `CustomEvent`s on `document`. Each event carries `{ term: string }` in `event.detail`.

1. **`product:search-performed`** — fires from `_handleSearchEvent` when the user submits the search form (Enter / submit button) and the term passes the existing 3-char minimum and 100-char maximum. Maps to the `/search?search=X` navigation.
2. **`product:search-suggestion-shown`** — fires inside `_suggest` after the suggest XHR resolves and the dropdown has been rendered. Useful for partial-search analytics (typed something, saw suggestions).
3. **`product:search-suggestion-product-viewed`** — fires from `_handleSuggestResultClick` (new delegated click listener attached inside `_suggest`'s success callback) when the user clicks any `<a href>` inside the rendered suggest result block (a product link or the "show all results" link). Semantically distinct from a search submit — the user picked something from suggestions instead of running a full search.

Core Storefront stays plugin-agnostic — no reference to `_shopwareAnalytics` or any analytics integration. The previous direct `window._shopwareAnalytics?.track(...)` calls are removed.

Analytics integrations subscribe to whichever subset they care about, e.g.:

```js
document.addEventListener('product:search-performed', (e) => {
    window._shopwareAnalytics?.track('search:performed', e.detail);
});
```

Behaviour is fully backward-compatible:
- `document.dispatchEvent(new CustomEvent(...))` is a no-op when no integration subscribes.
- The existing 3-char-minimum / 250ms-debounce gating in the widget is unchanged.

No new dependencies. No public API change.

### 3. Describe each step to reproduce the issue or behaviour.

With a subscriber attached (or DevTools listening on `document`):

1. Open the storefront, focus the search input
2. Type `shoes`, press Enter → `product:search-performed` fires with `{ term: 'shoes' }`
3. Type `shoes`, wait for the suggest dropdown to render → `product:search-suggestion-shown` fires with `{ term: 'shoes' }`
4. From step 3, click any product link in the dropdown → `product:search-suggestion-product-viewed` fires with `{ term: 'shoes' }`
5. Type `sh` (under 3 chars), press Enter → no event fires (existing 3-char rule)
6. Without any subscriber → no errors, search behaviour unchanged

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/services-roadmap/issues/438

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - *Suggested:* add a short entry to `RELEASE_INFO-6.8.md` (or whichever applies) noting that the storefront search widget now emits three `product:search-*` `CustomEvent`s on `document`, so external integrations can subscribe to them.
- [x] I have written or adjusted the documentation according to my changes — no public-facing docs touched; behaviour is invisible without a consuming subscriber
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them