### PR TITLE
feat: expose service requirements in service list

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.spec.js
@@ -29,14 +29,17 @@ describe('src/module/sw-settings-services/service/shopware-services-service.ts',
             const shopwareServicesService = new ShopwareServicesService(client, loginService, systemConfigService);
 
             clientMock.onGet('service/list').reply(200, [
-                { name: 'Service1', active: true },
-                { name: 'Service2', active: false },
-                { name: 'Service3', active: true },
+                { name: 'Service1', active: true, requirements: ['service_consent'] },
+                { name: 'Service2', active: false, requirements: ['shopware_account'] },
+                { name: 'Service3', active: true, requirements: [] },
             ]);
 
             const installedServices = await shopwareServicesService.getInstalledServices();
 
             expect(installedServices).toHaveLength(3);
+            expect(installedServices[0].requirements).toEqual(['service_consent']);
+            expect(installedServices[1].requirements).toEqual(['shopware_account']);
+            expect(installedServices[2].requirements).toEqual([]);
             expect(clientMock.history.get).toHaveLength(1);
             expect(clientMock.history.get[0].headers['sw-language-id']).toBe(expectedLanguage);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.ts
@@ -23,6 +23,7 @@ export type ServiceDescription = {
     requested_privileges: string[];
     privileges: string[];
     domains: string[];
+    requirements: string[];
 };
 
 type ServiceConfigurationConfigValues = {

--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -27,6 +27,22 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
+ * @phpstan-type ServiceListItem array{
+ *     id: string,
+ *     name: string,
+ *     label: string,
+ *     active: bool,
+ *     icon: string|null,
+ *     description: string|null,
+ *     updated_at: string|null,
+ *     version: string,
+ *     requested_privileges: list<string>,
+ *     privileges: list<string>|null,
+ *     state: string,
+ *     domains: list<string>|null,
+ *     requirements: list<string>,
+ * }
+ *
  * @internal only for use by the service-system
  */
 #[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [ApiRouteScope::ID]])]
@@ -225,7 +241,7 @@ class ServiceController
     }
 
     /**
-     * @return array<array{id: string, name: string, active: bool}>
+     * @return list<ServiceListItem>
      */
     private function loadAllServices(Context $context): array
     {
@@ -244,9 +260,21 @@ class ServiceController
             'version' => $app->getVersion(),
             'requested_privileges' => $app->getRequestedPrivileges(),
             'privileges' => $app->getAclRole()?->getPrivileges(),
-            'state' => State::state($app),
+            'state' => State::state($app)->value,
             'domains' => $app->getAllowedHosts(),
+            'requirements' => self::getRequirements($app),
         ]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function getRequirements(AppEntity $app): array
+    {
+        /** @var list<string> $requirements */
+        $requirements = $app->getSourceConfig()['requirements'] ?? [];
+
+        return $requirements;
     }
 
     private function loadService(Context $context): ?AppEntity

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -60,6 +60,13 @@ class ServiceControllerTest extends TestCase
             'description' => 'A cool service',
             'createdAt' => new \DateTimeImmutable(),
             'updatedAt' => new \DateTimeImmutable(),
+            'sourceConfig' => [
+                'version' => '1.0.0',
+                'hash' => 'service-hash',
+                'revision' => '2025-05-18',
+                'zip-url' => 'https://example.com/service.zip',
+                'requirements' => ['service_consent'],
+            ],
         ]);
 
         $this->appRepo = new StaticEntityRepository([[$this->app]]);
@@ -265,6 +272,7 @@ class ServiceControllerTest extends TestCase
         static::assertTrue($service['active']);
         static::assertSame('1.0.0', $service['version']);
         static::assertSame('active', $service['state']);
+        static::assertSame(['service_consent'], $service['requirements']);
     }
 
     public function testDisableServices(): void


### PR DESCRIPTION
## Summary

- add `requirements` to `/api/service/list` responses from each service app's source config
- update the Administration service response type

Roadmap: shopware/services-roadmap#483

Stacked on: #16843 (will be merged in to feature branch `feat/gmv-service-protection`
