### PR TITLE
fix: sidebar renderer z-index

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
@@ -26,7 +26,7 @@
     transition: all 0.3s ease-in-out;
     will-change: width;
     display: none;
-    z-index: 1000;
+    z-index: 1200;
 
     iframe {
         width: 100%;


### PR DESCRIPTION
### 1. Why is this change necessary?
There is a current overlapping of notifications and sidebar renderer

### 2. What does this change do, exactly?
change the z-index of sidebar renderer to avoid overlapping

### 3. Describe each step to reproduce the issue or behaviour.
Check linked ticket

### 4. Please link to the relevant issues (if any).
- closes #16108  

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
