### PR TITLE
fix: Remove obsolete func_get_arg handling

### DIFF
--- a/src/Core/Checkout/Cart/LineItem/LineItem.php
+++ b/src/Core/Checkout/Cart/LineItem/LineItem.php
@@ -258,11 +258,6 @@ class LineItem extends Struct
      */
     public function setPayloadValue(string $key, $value, ?bool $protected = null): self
     {
-        $protected = false;
-        if (\func_num_args() === 3) {
-            $protected = func_get_arg(2);
-        }
-
         if ($value !== null && !\is_scalar($value) && !\is_array($value)) {
             throw CartException::invalidPayload($key, $this->getId());
         }

--- a/tests/unit/Core/Checkout/Cart/LineItem/LineItemTest.php
+++ b/tests/unit/Core/Checkout/Cart/LineItem/LineItemTest.php
@@ -245,6 +245,49 @@ class LineItemTest extends TestCase
         static::assertSame(2, $lineItem->getPayloadValue('test'));
     }
 
+    public function testSetPayloadValueCanProtectPayloadValue(): void
+    {
+        $lineItem = new LineItem('abc', 'type', null, 5);
+        $lineItem->setPayloadValue('visible', 'test', false);
+        $lineItem->setPayloadValue('protected', 'test', true);
+
+        static::assertSame('test', $lineItem->getPayloadValue('protected'));
+
+        $payload = self::getSerializedPayload($lineItem);
+
+        static::assertArrayHasKey('visible', $payload);
+        static::assertArrayNotHasKey('protected', $payload);
+    }
+
+    public function testSetPayloadValueCanRemovePayloadProtection(): void
+    {
+        $lineItem = new LineItem('abc', 'type', null, 5);
+        $lineItem->setPayloadValue('test', 'protected', true);
+
+        $payload = self::getSerializedPayload($lineItem);
+
+        static::assertArrayNotHasKey('test', $payload);
+
+        $lineItem->setPayloadValue('test', 'visible', false);
+
+        $payload = self::getSerializedPayload($lineItem);
+
+        static::assertSame('visible', $payload['test']);
+    }
+
+    public function testSetPayloadValueKeepsProtectionWithoutThirdArgument(): void
+    {
+        $lineItem = new LineItem('abc', 'type', null, 5);
+        $lineItem->setPayloadValue('test', 'protected', true);
+        $lineItem->setPayloadValue('test', 'updated');
+
+        static::assertSame('updated', $lineItem->getPayloadValue('test'));
+
+        $payload = self::getSerializedPayload($lineItem);
+
+        static::assertArrayNotHasKey('test', $payload);
+    }
+
     public function testReplacePayloadNonRecursively(): void
     {
         $lineItem = new LineItem('abc', 'type', null, 5);
@@ -379,5 +422,18 @@ class LineItemTest extends TestCase
         ];
 
         static::assertSame($expectedArray, $parent->getHashContent());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function getSerializedPayload(LineItem $lineItem): array
+    {
+        $data = $lineItem->jsonSerialize();
+
+        static::assertArrayHasKey('payload', $data);
+        static::assertIsArray($data['payload']);
+
+        return $data['payload'];
     }
 }


### PR DESCRIPTION
This removes leftover `func_get_arg()` handling in `LineItem::setPayloadValue()` that was missed during the major update.

Added unit coverage for the third argument behavior.