### PR TITLE
fix: add PRODUCT_COMPARISON type to SalesChannelValidator

### DIFF
--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -120,7 +120,8 @@ class SalesChannelValidator implements EventSubscriberInterface
         $typeId = Uuid::fromBytesToHex($command->getPayload()['type_id']);
 
         return $typeId === Defaults::SALES_CHANNEL_TYPE_STOREFRONT
-            || $typeId === Defaults::SALES_CHANNEL_TYPE_API;
+            || $typeId === Defaults::SALES_CHANNEL_TYPE_API
+            || $typeId === Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON;
     }
 
     private function handleSalesChannelLanguageMapping(Mapping $mapping, WriteCommand $command): void

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -315,12 +315,22 @@ class SalesChannelValidatorTest extends TestCase
         static::assertCount(0, $result);
     }
 
-    public function testOnlyStorefrontAndHeadlessSalesChannelsWillBeSupported(): void
+    public function testProductComparisonSalesChannelValidationFailsWithoutLanguageEntry(): void
     {
         $id = Uuid::randomHex();
-        $languageId = Defaults::LANGUAGE_SYSTEM;
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM);
+        $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON;
 
-        $data = $this->getSalesChannelData($id, $languageId);
+        $this->expectException(WriteException::class);
+        $this->expectExceptionMessage(\sprintf(self::INSERT_VALIDATION_MESSAGE, $id));
+
+        $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
+    }
+
+    public function testProductComparisonSalesChannelValidationSucceedsWithLanguageEntry(): void
+    {
+        $id = Uuid::randomHex();
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
         $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON;
 
         $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
@@ -328,11 +338,9 @@ class SalesChannelValidatorTest extends TestCase
         $count = (int) static::getContainer()->get(Connection::class)
             ->fetchOne('SELECT COUNT(*) FROM sales_channel_language WHERE sales_channel_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
 
-        static::assertSame(0, $count);
+        static::assertSame(1, $count);
 
-        $this->getSalesChannelRepository()->delete([[
-            'id' => $id,
-        ]], Context::createDefaultContext());
+        $this->getSalesChannelRepository()->delete([['id' => $id]], Context::createDefaultContext());
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

When a sales channel of type `SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` is created, the `SalesChannelValidator` skipped validation because `isSupportedSalesChannelType()` did not include this type.
As a result, creation could succeed even when the default `language_id` was not included in the `sales_channel_language` association. The sales channel then existed with a default language on the entity itself, but with an empty list of available sales channel languages.

This causes `BaseContextFactory::buildLanguageChain()` to throw a `SYSTEM__SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION` (HTTP 412) whenever Shopware tries to build a context for that sales channel for example, during the Admin live search preview, which iterates over all sales channels.

The bug affects Shopware 6.6 and 6.7.

### 2. What does this change do, exactly?

Adds `SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` to the `isSupportedSalesChannelType()` check in `SalesChannelValidator`. This ensures that when a product comparison sales channel is created, the validator enforces that the default `language_id` is also present in the `sales_channel_language` association inserts, consistent with the existing behaviour for `STOREFRONT` and `API` channels.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a sales channel of type "Product Comparison" (e.g. via Admin → Sales Channels → Add sales channel → Product Comparison).
2. Check the `sales_channel_language` table: no entry exists for the newly created channel.
3. Open Admin → Settings → Search → Live Search preview.
4. Result: HTTP 412 `SYSTEM__SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION` "Provided language X is not in list of available languages: []"

### 4. Please link to the relevant issues (if any).

No existing issue found. This bug was discovered in a production environment where multiple product comparison sales channels (e.g. product feeds) existed without `sales_channel_language` entries.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them