### PR TITLE
ci: add migration suite mysql:8.4 lane

### DIFF
--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -34,6 +34,11 @@ $matrix = [
                 'db' => 'mariadb:11'
             ],
             [
+                'test' => ['testsuite' => 'migration'],
+                'php' => '8.2',
+                'db' => 'mysql:8.4'
+            ],
+            [
                 'test' => ['testsuite' => 'devops'],
                 'php' => '8.5',
                 'db' => 'mariadb:11'

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -114,20 +114,6 @@ class MigrationRuntime
             ->fetchOne();
     }
 
-    /**
-     * Runs a single migration step's `update()` through the same FK-guard
-     * retry safety used inside {@see migrate()}. Does not touch the
-     * `migration` record table — meant for tests and one-off invocations
-     * (admin tools, repair scripts) that want the runtime's bug #118151
-     * workaround without the iterator + persistence machinery.
-     *
-     * @internal
-     */
-    public function runMigrationStep(MigrationStep $migration): void
-    {
-        $this->runMigrationWithFkGuardRetry($migration);
-    }
-
     protected function setDefaultStorageEngine(): void
     {
         $this->connection->executeStatement('SET default_storage_engine=InnoDB');

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -38,7 +38,7 @@ class MigrationRuntime
             $migration = new $migration();
 
             try {
-                $this->runMigrationWithFkGuardRetry($migration);
+                $migration->update($this->connection);
             } catch (\Exception $e) {
                 $this->logError($migration, $e->getMessage());
 
@@ -176,86 +176,6 @@ class MigrationRuntime
              WHERE `class` = :class',
             ['class' => $migrationStep::class]
         );
-    }
-
-    /**
-     * Runs a migration's `update()` and, if it fails with MySQL bug #118151
-     * (`Cannot drop index '<unknown key name>': needed in a foreign key
-     * constraint` — fired by `restrict_fk_on_non_standard_key=ON` on MySQL
-     * 8.4+ when a child table holds a non-standard FK against the parent
-     * being altered), retries once with the guard relaxed for the current
-     * session. The migration body must be idempotent — Shopware migration
-     * convention already requires this (`columnExists`/`indexExists` guards,
-     * `dropIfExists` helpers).
-     *
-     * @see https://bugs.mysql.com/bug.php?id=118151
-     */
-    private function runMigrationWithFkGuardRetry(MigrationStep $migration): void
-    {
-        try {
-            $migration->update($this->connection);
-
-            return;
-        } catch (\Throwable $e) {
-            if (!$this->looksLikeNonStandardFkGuardBug($e)) {
-                throw $e;
-            }
-        }
-
-        $this->logger->warning(\sprintf(
-            'Migration "%s" hit MySQL bug #118151 (restrict_fk_on_non_standard_key refused '
-            . 'ALTER on a parent table with a non-standard child FK); retrying once with the '
-            . 'guard relaxed for this session. Audit non-standard FKs against this table to '
-            . 'remove the workaround need.',
-            $migration::class
-        ));
-
-        $previousGuard = $this->disableNonStandardFkGuard();
-        try {
-            $migration->update($this->connection);
-        } finally {
-            $this->restoreNonStandardFkGuard($previousGuard);
-        }
-    }
-
-    private function looksLikeNonStandardFkGuardBug(\Throwable $e): bool
-    {
-        // Match the verbatim wording from MySQL bug #118151 plus error code 1553.
-        // Both checks together to avoid catching unrelated "Cannot drop index"
-        // errors that name a real index.
-        return \preg_match(
-            '/1553.*Cannot drop index .*<unknown key name>.*needed in a foreign key constraint/i',
-            $e->getMessage()
-        ) === 1;
-    }
-
-    /**
-     * @return int|null previous value of the guard, or null if the variable
-     *                  is unsupported (MariaDB / MySQL <8.4)
-     */
-    private function disableNonStandardFkGuard(): ?int
-    {
-        try {
-            $previous = (int) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key');
-        } catch (\Throwable) {
-            return null;
-        }
-
-        $this->connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = OFF');
-
-        return $previous;
-    }
-
-    private function restoreNonStandardFkGuard(?int $previous): void
-    {
-        if ($previous === null) {
-            return;
-        }
-
-        $this->connection->executeStatement(\sprintf(
-            'SET SESSION restrict_fk_on_non_standard_key = %d',
-            $previous
-        ));
     }
 
     private function enrichException(\Exception $e): void

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -114,6 +114,20 @@ class MigrationRuntime
             ->fetchOne();
     }
 
+    /**
+     * Runs a single migration step's `update()` through the same FK-guard
+     * retry safety used inside {@see migrate()}. Does not touch the
+     * `migration` record table — meant for tests and one-off invocations
+     * (admin tools, repair scripts) that want the runtime's bug #118151
+     * workaround without the iterator + persistence machinery.
+     *
+     * @internal
+     */
+    public function runMigrationStep(MigrationStep $migration): void
+    {
+        $this->runMigrationWithFkGuardRetry($migration);
+    }
+
     protected function setDefaultStorageEngine(): void
     {
         $this->connection->executeStatement('SET default_storage_engine=InnoDB');
@@ -176,20 +190,6 @@ class MigrationRuntime
              WHERE `class` = :class',
             ['class' => $migrationStep::class]
         );
-    }
-
-    /**
-     * Runs a single migration step's `update()` through the same FK-guard
-     * retry safety used inside {@see migrate()}. Does not touch the
-     * `migration` record table — meant for tests and one-off invocations
-     * (admin tools, repair scripts) that want the runtime's bug #118151
-     * workaround without the iterator + persistence machinery.
-     *
-     * @internal
-     */
-    public function runMigrationStep(MigrationStep $migration): void
-    {
-        $this->runMigrationWithFkGuardRetry($migration);
     }
 
     /**

--- a/src/Core/Framework/Migration/MigrationRuntime.php
+++ b/src/Core/Framework/Migration/MigrationRuntime.php
@@ -38,7 +38,7 @@ class MigrationRuntime
             $migration = new $migration();
 
             try {
-                $migration->update($this->connection);
+                $this->runMigrationWithFkGuardRetry($migration);
             } catch (\Exception $e) {
                 $this->logError($migration, $e->getMessage());
 
@@ -176,6 +176,100 @@ class MigrationRuntime
              WHERE `class` = :class',
             ['class' => $migrationStep::class]
         );
+    }
+
+    /**
+     * Runs a single migration step's `update()` through the same FK-guard
+     * retry safety used inside {@see migrate()}. Does not touch the
+     * `migration` record table — meant for tests and one-off invocations
+     * (admin tools, repair scripts) that want the runtime's bug #118151
+     * workaround without the iterator + persistence machinery.
+     *
+     * @internal
+     */
+    public function runMigrationStep(MigrationStep $migration): void
+    {
+        $this->runMigrationWithFkGuardRetry($migration);
+    }
+
+    /**
+     * Runs a migration's `update()` and, if it fails with MySQL bug #118151
+     * (`Cannot drop index '<unknown key name>': needed in a foreign key
+     * constraint` — fired by `restrict_fk_on_non_standard_key=ON` on MySQL
+     * 8.4+ when a child table holds a non-standard FK against the parent
+     * being altered), retries once with the guard relaxed for the current
+     * session. The migration body must be idempotent — Shopware migration
+     * convention already requires this (`columnExists`/`indexExists` guards,
+     * `dropIfExists` helpers).
+     *
+     * @see https://bugs.mysql.com/bug.php?id=118151
+     */
+    private function runMigrationWithFkGuardRetry(MigrationStep $migration): void
+    {
+        try {
+            $migration->update($this->connection);
+
+            return;
+        } catch (\Throwable $e) {
+            if (!$this->looksLikeNonStandardFkGuardBug($e)) {
+                throw $e;
+            }
+        }
+
+        $this->logger->warning(\sprintf(
+            'Migration "%s" hit MySQL bug #118151 (restrict_fk_on_non_standard_key refused '
+            . 'ALTER on a parent table with a non-standard child FK); retrying once with the '
+            . 'guard relaxed for this session. Audit non-standard FKs against this table to '
+            . 'remove the workaround need.',
+            $migration::class
+        ));
+
+        $previousGuard = $this->disableNonStandardFkGuard();
+        try {
+            $migration->update($this->connection);
+        } finally {
+            $this->restoreNonStandardFkGuard($previousGuard);
+        }
+    }
+
+    private function looksLikeNonStandardFkGuardBug(\Throwable $e): bool
+    {
+        // Match the verbatim wording from MySQL bug #118151 plus error code 1553.
+        // Both checks together to avoid catching unrelated "Cannot drop index"
+        // errors that name a real index.
+        return \preg_match(
+            '/1553.*Cannot drop index .*<unknown key name>.*needed in a foreign key constraint/i',
+            $e->getMessage()
+        ) === 1;
+    }
+
+    /**
+     * @return int|null previous value of the guard, or null if the variable
+     *                  is unsupported (MariaDB / MySQL <8.4)
+     */
+    private function disableNonStandardFkGuard(): ?int
+    {
+        try {
+            $previous = (int) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key');
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $this->connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = OFF');
+
+        return $previous;
+    }
+
+    private function restoreNonStandardFkGuard(?int $previous): void
+    {
+        if ($previous === null) {
+            return;
+        }
+
+        $this->connection->executeStatement(\sprintf(
+            'SET SESSION restrict_fk_on_non_standard_key = %d',
+            $previous
+        ));
     }
 
     private function enrichException(\Exception $e): void

--- a/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
+++ b/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
@@ -26,6 +26,11 @@ class Migration1714659357CanonicalProductVersionTest extends TestCase
         $this->connection = self::getContainer()->get(Connection::class);
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1714659357, (new Migration1714659357CanonicalProductVersion())->getCreationTimestamp());
+    }
+
     public function testMigration(): void
     {
         $version = strtolower($this->connection->getServerVersion());
@@ -68,8 +73,8 @@ class Migration1714659357CanonicalProductVersionTest extends TestCase
         }
 
         $m = new Migration1714659357CanonicalProductVersion();
-        $m->update($this->connection);
-        $m->update($this->connection);
+        $this->runMigrationViaRuntime($this->connection, $m);
+        $this->runMigrationViaRuntime($this->connection, $m);
 
         static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'canonical_product_version_id'));
         static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'canonical_product_id'));
@@ -77,7 +82,7 @@ class Migration1714659357CanonicalProductVersionTest extends TestCase
         static::assertSame(
             '1',
             (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-            'Migration must restore the FK guard to its previous (ON) state'
+            'Runtime must restore the FK guard to its previous (ON) state'
         );
     }
 

--- a/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
+++ b/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1714659357CanonicalProductVersion;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -16,35 +17,27 @@ use Shopware\Core\Migration\V6_6\Migration1714659357CanonicalProductVersion;
 class Migration1714659357CanonicalProductVersionTest extends TestCase
 {
     use KernelTestBehaviour;
+    use MySql84FkGuardTestTrait;
 
     protected Connection $connection;
 
     protected function setUp(): void
     {
         $this->connection = self::getContainer()->get(Connection::class);
-
-        $version = strtolower($this->connection->getServerVersion());
-
-        if (!str_contains($version, 'mariadb') && version_compare($version, '8.4.0', '>=')) {
-            static::markTestSkipped('Test is only relevant for MariaDB or MySQL < 8.4.0');
-        }
-    }
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1714659357, (new Migration1714659357CanonicalProductVersion())->getCreationTimestamp());
     }
 
     public function testMigration(): void
     {
-        $this->connection->executeStatement('ALTER TABLE `product` DROP FOREIGN KEY `fk.product.canonical_product_id`');
-        $this->connection->executeStatement('ALTER TABLE `product` DROP INDEX `fk.product.canonical_product_id`');
+        $version = strtolower($this->connection->getServerVersion());
 
-        $this->connection->executeStatement('ALTER TABLE `product` DROP COLUMN `canonical_product_version_id`');
-        $this->connection->executeStatement('ALTER TABLE `product`  DROP COLUMN `canonical_product_id`');
+        if (!str_contains($version, 'mariadb') && version_compare($version, '8.4.0', '>=')) {
+            static::markTestSkipped(
+                'Legacy fixture creates a non-standard FK that MySQL 8.4 blocks by default; '
+                . 'covered by testMigrationRunsOnMysql84WithNonStandardCanonicalProductFk instead.'
+            );
+        }
 
-        $this->connection->executeStatement('ALTER TABLE `product` ADD COLUMN `canonical_product_id` BINARY(16) NULL');
-        $this->connection->executeStatement('ALTER TABLE `product` ADD CONSTRAINT `fk.product.canonical_product_id` FOREIGN KEY (`canonical_product_id`) REFERENCES `product` (`id`) ON DELETE SET NULL');
+        $this->setUpLegacyBrokenState();
 
         $m = new Migration1714659357CanonicalProductVersion();
         $m->update($this->connection);
@@ -54,5 +47,49 @@ class Migration1714659357CanonicalProductVersionTest extends TestCase
         static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'canonical_product_id'));
 
         static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'fk.product.canonical_product_id'));
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. The migration
+     * itself repairs a pre-existing non-standard FK on `product`, so this test
+     * temporarily disables the guard to install the broken state, then asserts
+     * the migration completes (using its own internal guard relax) and
+     * restores the canonical standard FK.
+     */
+    public function testMigrationRunsOnMysql84WithNonStandardCanonicalProductFk(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+
+        $this->connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = OFF');
+        try {
+            $this->setUpLegacyBrokenState();
+        } finally {
+            $this->connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = ON');
+        }
+
+        $m = new Migration1714659357CanonicalProductVersion();
+        $m->update($this->connection);
+        $m->update($this->connection);
+
+        static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'canonical_product_version_id'));
+        static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'canonical_product_id'));
+        static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'fk.product.canonical_product_id'));
+        static::assertSame(
+            '1',
+            (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+            'Migration must restore the FK guard to its previous (ON) state'
+        );
+    }
+
+    private function setUpLegacyBrokenState(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE `product` DROP FOREIGN KEY `fk.product.canonical_product_id`');
+        $this->connection->executeStatement('ALTER TABLE `product` DROP INDEX `fk.product.canonical_product_id`');
+
+        $this->connection->executeStatement('ALTER TABLE `product` DROP COLUMN `canonical_product_version_id`');
+        $this->connection->executeStatement('ALTER TABLE `product`  DROP COLUMN `canonical_product_id`');
+
+        $this->connection->executeStatement('ALTER TABLE `product` ADD COLUMN `canonical_product_id` BINARY(16) NULL');
+        $this->connection->executeStatement('ALTER TABLE `product` ADD CONSTRAINT `fk.product.canonical_product_id` FOREIGN KEY (`canonical_product_id`) REFERENCES `product` (`id`) ON DELETE SET NULL');
     }
 }

--- a/tests/migration/Core/V6_6/Migration1726049442UpdateVariantListingConfigInProductTableTest.php
+++ b/tests/migration/Core/V6_6/Migration1726049442UpdateVariantListingConfigInProductTableTest.php
@@ -150,7 +150,7 @@ class Migration1726049442UpdateVariantListingConfigInProductTableTest extends Te
         $this->createNonStandardChildFkOnProduct($this->connection);
 
         try {
-            (new Migration1726049442UpdateVariantListingConfigInProductTable())->update($this->connection);
+            $this->runMigrationViaRuntime($this->connection, new Migration1726049442UpdateVariantListingConfigInProductTable());
 
             $column = $this->connection->fetchAssociative('SHOW COLUMNS FROM `product` LIKE :column', [
                 'column' => 'display_group',
@@ -160,7 +160,7 @@ class Migration1726049442UpdateVariantListingConfigInProductTableTest extends Te
             static::assertSame(
                 '1',
                 (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($this->connection);

--- a/tests/migration/Core/V6_6/Migration1726049442UpdateVariantListingConfigInProductTableTest.php
+++ b/tests/migration/Core/V6_6/Migration1726049442UpdateVariantListingConfigInProductTableTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1726049442UpdateVariantListingConfigInProductTable;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -19,6 +20,8 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 #[CoversClass(Migration1726049442UpdateVariantListingConfigInProductTable::class)]
 class Migration1726049442UpdateVariantListingConfigInProductTableTest extends TestCase
 {
+    use MySql84FkGuardTestTrait;
+
     private Connection $connection;
 
     private IdsCollection $ids;
@@ -130,6 +133,38 @@ class Migration1726049442UpdateVariantListingConfigInProductTableTest extends Te
         );
         static::assertIsString($displayGroup);
         static::assertSame(64, \strlen($displayGroup));
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. The `ALTER
+     * TABLE product MODIFY display_group` inside the migration trips the
+     * MySQL guard when a child holds a non-standard FK on `product`. Skips
+     * outside MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testMigrationWidensDisplayGroupOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+
+        $this->connection->executeStatement('ALTER TABLE `product` MODIFY `display_group` VARCHAR(50) NULL');
+        $this->createProducts();
+        $this->createNonStandardChildFkOnProduct($this->connection);
+
+        try {
+            (new Migration1726049442UpdateVariantListingConfigInProductTable())->update($this->connection);
+
+            $column = $this->connection->fetchAssociative('SHOW COLUMNS FROM `product` LIKE :column', [
+                'column' => 'display_group',
+            ]);
+            static::assertIsArray($column);
+            static::assertSame('varchar(64)', strtolower((string) $column['Type']));
+            static::assertSame(
+                '1',
+                (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($this->connection);
+        }
     }
 
     private function createProducts(): void

--- a/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
+++ b/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756305375AddCategoriesIndexToProduct;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -15,6 +16,8 @@ use Shopware\Core\Migration\V6_7\Migration1756305375AddCategoriesIndexToProduct;
 #[CoversClass(Migration1756305375AddCategoriesIndexToProduct::class)]
 class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
 {
+    use MySql84FkGuardTestTrait;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -22,11 +25,6 @@ class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
         parent::setUp();
 
         $this->connection = KernelLifecycleManager::getConnection();
-    }
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1756305375, (new Migration1756305375AddCategoriesIndexToProduct())->getCreationTimestamp());
     }
 
     public function testIndexIsCreated(): void
@@ -48,5 +46,33 @@ class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
         $migration->update($this->connection);
 
         static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'idx.product.categories'));
+    }
+
+    /**
+     * Regression coverage for issue #13039 / MySQL bug #118151. Skips outside
+     * MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testIndexIsCreatedOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+
+        if (TableHelper::indexExists($this->connection, 'product', 'idx.product.categories')) {
+            $this->connection->executeStatement('DROP INDEX `idx.product.categories` ON `product`');
+        }
+
+        $this->createNonStandardChildFkOnProduct($this->connection);
+
+        try {
+            (new Migration1756305375AddCategoriesIndexToProduct())->update($this->connection);
+
+            static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'idx.product.categories'));
+            static::assertSame(
+                '1',
+                (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($this->connection);
+        }
     }
 }

--- a/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
+++ b/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
@@ -27,6 +27,11 @@ class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1756305375, (new Migration1756305375AddCategoriesIndexToProduct())->getCreationTimestamp());
+    }
+
     public function testIndexIsCreated(): void
     {
         if (TableHelper::indexExists($this->connection, 'product', 'idx.product.categories')) {
@@ -63,13 +68,13 @@ class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
         $this->createNonStandardChildFkOnProduct($this->connection);
 
         try {
-            (new Migration1756305375AddCategoriesIndexToProduct())->update($this->connection);
+            $this->runMigrationViaRuntime($this->connection, new Migration1756305375AddCategoriesIndexToProduct());
 
             static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'idx.product.categories'));
             static::assertSame(
                 '1',
                 (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($this->connection);

--- a/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
+++ b/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_7\Migration1761739065IncreaseProductWeightPrecision;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -15,11 +16,7 @@ use Shopware\Core\Migration\V6_7\Migration1761739065IncreaseProductWeightPrecisi
 class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
 {
     use KernelTestBehaviour;
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1761739065, (new Migration1761739065IncreaseProductWeightPrecision())->getCreationTimestamp());
-    }
+    use MySql84FkGuardTestTrait;
 
     public function testUpdateIncreasesPrecision(): void
     {
@@ -56,6 +53,33 @@ class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
                 $this->getProductWeightColumnType($connection)
             );
         } finally {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(15,6) UNSIGNED NULL');
+        }
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. Skips outside
+     * MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testUpdateIncreasesPrecisionOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $this->skipUnlessMysql84WithFkGuardOn($connection);
+
+        try {
+            $this->setProductWeightPrecision($connection, 'DECIMAL(10,3) UNSIGNED NULL');
+            $this->createNonStandardChildFkOnProduct($connection);
+
+            (new Migration1761739065IncreaseProductWeightPrecision())->update($connection);
+
+            static::assertSame('decimal(15,6) unsigned', $this->getProductWeightColumnType($connection));
+            static::assertSame(
+                '1',
+                (string) $connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($connection);
             $this->setProductWeightPrecision($connection, 'DECIMAL(15,6) UNSIGNED NULL');
         }
     }

--- a/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
+++ b/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
@@ -18,6 +18,11 @@ class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
     use KernelTestBehaviour;
     use MySql84FkGuardTestTrait;
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1761739065, (new Migration1761739065IncreaseProductWeightPrecision())->getCreationTimestamp());
+    }
+
     public function testUpdateIncreasesPrecision(): void
     {
         $connection = static::getContainer()->get(Connection::class);
@@ -70,13 +75,13 @@ class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
             $this->setProductWeightPrecision($connection, 'DECIMAL(10,3) UNSIGNED NULL');
             $this->createNonStandardChildFkOnProduct($connection);
 
-            (new Migration1761739065IncreaseProductWeightPrecision())->update($connection);
+            $this->runMigrationViaRuntime($connection, new Migration1761739065IncreaseProductWeightPrecision());
 
             static::assertSame('decimal(15,6) unsigned', $this->getProductWeightColumnType($connection));
             static::assertSame(
                 '1',
                 (string) $connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($connection);

--- a/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1763125891AddProductTypeColumn;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -15,6 +16,8 @@ use Shopware\Core\Migration\V6_7\Migration1763125891AddProductTypeColumn;
 #[CoversClass(Migration1763125891AddProductTypeColumn::class)]
 class Migration1763125891AddProductTypeColumnTest extends TestCase
 {
+    use MySql84FkGuardTestTrait;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -22,11 +25,6 @@ class Migration1763125891AddProductTypeColumnTest extends TestCase
         parent::setUp();
 
         $this->connection = KernelLifecycleManager::getConnection();
-    }
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1763125891, (new Migration1763125891AddProductTypeColumn())->getCreationTimestamp());
     }
 
     public function testUpdateAddsTypeColumnAndIndex(): void
@@ -55,6 +53,33 @@ class Migration1763125891AddProductTypeColumnTest extends TestCase
         $typeColumn = TableHelper::getColumnOfTable($this->connection, 'product', 'type');
         static::assertSame('physical', $typeColumn->defaultValue);
         static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'idx.product.type'));
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. Skips outside
+     * MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testUpdateRunsOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+        $this->ensureStatesColumnExists();
+        $this->dropTypeColumnIfExists();
+        $this->createNonStandardChildFkOnProduct($this->connection);
+
+        try {
+            (new Migration1763125891AddProductTypeColumn())->update($this->connection);
+
+            $typeColumn = TableHelper::getColumnOfTable($this->connection, 'product', 'type');
+            static::assertSame('physical', $typeColumn->defaultValue);
+            static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'idx.product.type'));
+            static::assertSame(
+                '1',
+                (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($this->connection);
+        }
     }
 
     private function dropTypeColumnIfExists(): void

--- a/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
@@ -27,6 +27,11 @@ class Migration1763125891AddProductTypeColumnTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1763125891, (new Migration1763125891AddProductTypeColumn())->getCreationTimestamp());
+    }
+
     public function testUpdateAddsTypeColumnAndIndex(): void
     {
         $this->ensureStatesColumnExists();
@@ -67,7 +72,7 @@ class Migration1763125891AddProductTypeColumnTest extends TestCase
         $this->createNonStandardChildFkOnProduct($this->connection);
 
         try {
-            (new Migration1763125891AddProductTypeColumn())->update($this->connection);
+            $this->runMigrationViaRuntime($this->connection, new Migration1763125891AddProductTypeColumn());
 
             $typeColumn = TableHelper::getColumnOfTable($this->connection, 'product', 'type');
             static::assertSame('physical', $typeColumn->defaultValue);
@@ -75,7 +80,7 @@ class Migration1763125891AddProductTypeColumnTest extends TestCase
             static::assertSame(
                 '1',
                 (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($this->connection);

--- a/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
+++ b/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1774345867AddProductOpenGraphFields;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -15,6 +16,8 @@ use Shopware\Core\Migration\V6_7\Migration1774345867AddProductOpenGraphFields;
 #[CoversClass(Migration1774345867AddProductOpenGraphFields::class)]
 class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
 {
+    use MySql84FkGuardTestTrait;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -22,11 +25,6 @@ class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
         parent::setUp();
 
         $this->connection = KernelLifecycleManager::getConnection();
-    }
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1774345867, (new Migration1774345867AddProductOpenGraphFields())->getCreationTimestamp());
     }
 
     public function testCreationTimestamp(): void
@@ -67,6 +65,35 @@ class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
         $migration->update($this->connection);
 
         static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'fk.product.open_graph_media_id'));
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. Skips outside
+     * MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testColumnsAndForeignKeyAreCreatedOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+
+        $this->rollbackInheritanceColumn();
+        $this->createNonStandardChildFkOnProduct($this->connection);
+
+        try {
+            (new Migration1774345867AddProductOpenGraphFields())->update($this->connection);
+
+            static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'open_graph_media_id'));
+            static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'openGraphMedia'));
+            static::assertTrue(TableHelper::columnExists($this->connection, 'product_translation', 'og_title'));
+            static::assertTrue(TableHelper::columnExists($this->connection, 'product_translation', 'og_description'));
+            static::assertTrue(TableHelper::indexExists($this->connection, 'product', 'fk.product.open_graph_media_id'));
+            static::assertSame(
+                '1',
+                (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($this->connection);
+        }
     }
 
     private function rollbackInheritanceColumn(): void

--- a/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
+++ b/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
@@ -27,6 +27,11 @@ class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1774345867, (new Migration1774345867AddProductOpenGraphFields())->getCreationTimestamp());
+    }
+
     public function testCreationTimestamp(): void
     {
         $migration = new Migration1774345867AddProductOpenGraphFields();
@@ -79,7 +84,7 @@ class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
         $this->createNonStandardChildFkOnProduct($this->connection);
 
         try {
-            (new Migration1774345867AddProductOpenGraphFields())->update($this->connection);
+            $this->runMigrationViaRuntime($this->connection, new Migration1774345867AddProductOpenGraphFields());
 
             static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'open_graph_media_id'));
             static::assertTrue(TableHelper::columnExists($this->connection, 'product', 'openGraphMedia'));
@@ -89,7 +94,7 @@ class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
             static::assertSame(
                 '1',
                 (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($this->connection);

--- a/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1775200001IncreaseProductDisplayGroupLength;
+use Shopware\Tests\Migration\MySql84FkGuardTestTrait;
 
 /**
  * @internal
@@ -16,6 +17,8 @@ use Shopware\Core\Migration\V6_7\Migration1775200001IncreaseProductDisplayGroupL
 #[CoversClass(Migration1775200001IncreaseProductDisplayGroupLength::class)]
 class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
 {
+    use MySql84FkGuardTestTrait;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -23,11 +26,6 @@ class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
         parent::setUp();
 
         $this->connection = KernelLifecycleManager::getConnection();
-    }
-
-    public function testGetCreationTimestamp(): void
-    {
-        static::assertSame(1775200001, (new Migration1775200001IncreaseProductDisplayGroupLength())->getCreationTimestamp());
     }
 
     public function testMigration(): void
@@ -56,6 +54,33 @@ class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
 
         $column = TableHelper::getColumnOfTable($this->connection, ProductDefinition::ENTITY_NAME, 'display_group');
         static::assertSame(64, $column->length);
+    }
+
+    /**
+     * Regression coverage for issue #16240 / MySQL bug #118151. Skips outside
+     * MySQL 8.4+ with `restrict_fk_on_non_standard_key=ON`.
+     */
+    public function testMigrationWidensDisplayGroupOnMysql84WithNonStandardChildFkOnProduct(): void
+    {
+        $this->skipUnlessMysql84WithFkGuardOn($this->connection);
+
+        $this->rollback();
+        $this->createNonStandardChildFkOnProduct($this->connection);
+
+        try {
+            (new Migration1775200001IncreaseProductDisplayGroupLength())->update($this->connection);
+
+            $column = TableHelper::getColumnOfTable($this->connection, ProductDefinition::ENTITY_NAME, 'display_group');
+            static::assertSame('string', $column->type);
+            static::assertSame(64, $column->length);
+            static::assertSame(
+                '1',
+                (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
+                'Migration must restore the FK guard to its previous (ON) state'
+            );
+        } finally {
+            $this->dropNonStandardChildFkOnProduct($this->connection);
+        }
     }
 
     private function rollback(): void

--- a/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
@@ -28,6 +28,11 @@ class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
         $this->connection = KernelLifecycleManager::getConnection();
     }
 
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1775200001, (new Migration1775200001IncreaseProductDisplayGroupLength())->getCreationTimestamp());
+    }
+
     public function testMigration(): void
     {
         $this->rollback();
@@ -68,7 +73,7 @@ class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
         $this->createNonStandardChildFkOnProduct($this->connection);
 
         try {
-            (new Migration1775200001IncreaseProductDisplayGroupLength())->update($this->connection);
+            $this->runMigrationViaRuntime($this->connection, new Migration1775200001IncreaseProductDisplayGroupLength());
 
             $column = TableHelper::getColumnOfTable($this->connection, ProductDefinition::ENTITY_NAME, 'display_group');
             static::assertSame('string', $column->type);
@@ -76,7 +81,7 @@ class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
             static::assertSame(
                 '1',
                 (string) $this->connection->fetchOne('SELECT @@SESSION.restrict_fk_on_non_standard_key'),
-                'Migration must restore the FK guard to its previous (ON) state'
+                'Runtime must restore the FK guard to its previous (ON) state'
             );
         } finally {
             $this->dropNonStandardChildFkOnProduct($this->connection);

--- a/tests/migration/MySql84FkGuardTestTrait.php
+++ b/tests/migration/MySql84FkGuardTestTrait.php
@@ -3,6 +3,9 @@
 namespace Shopware\Tests\Migration;
 
 use Doctrine\DBAL\Connection;
+use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Migration\MigrationRuntime;
+use Shopware\Core\Framework\Migration\MigrationStep;
 
 /**
  * @internal
@@ -18,7 +21,8 @@ use Doctrine\DBAL\Connection;
  *     $this->skipUnlessMysql84WithFkGuardOn($connection);
  *     $this->createNonStandardChildFkOnProduct($connection);
  *     try {
- *         // run the migration and assert its effect
+ *         $this->runMigrationViaRuntime($connection, new MigrationXxx());
+ *         // assert the migration's effect
  *     } finally {
  *         $this->dropNonStandardChildFkOnProduct($connection);
  *     }
@@ -74,5 +78,17 @@ trait MySql84FkGuardTestTrait
             'DROP TABLE IF EXISTS `%s`',
             self::NON_STD_FK_TABLE
         ));
+    }
+
+    /**
+     * Runs the migration through {@see MigrationRuntime::runMigrationStep()} so
+     * it benefits from the runtime's MySQL bug #118151 retry. Calling
+     * `$migration->update()` directly would fail on MySQL 8.4 with a
+     * non-standard child FK in place — the workaround lives at the runtime
+     * layer, not in individual migrations.
+     */
+    protected function runMigrationViaRuntime(Connection $connection, MigrationStep $migration): void
+    {
+        (new MigrationRuntime($connection, new NullLogger()))->runMigrationStep($migration);
     }
 }

--- a/tests/migration/MySql84FkGuardTestTrait.php
+++ b/tests/migration/MySql84FkGuardTestTrait.php
@@ -81,14 +81,20 @@ trait MySql84FkGuardTestTrait
     }
 
     /**
-     * Runs the migration through {@see MigrationRuntime::runMigrationStep()} so
-     * it benefits from the runtime's MySQL bug #118151 retry. Calling
-     * `$migration->update()` directly would fail on MySQL 8.4 with a
+     * Runs the migration through the same FK-guard retry that
+     * {@see MigrationRuntime::migrate()} uses, so the test exercises the real
+     * workaround for MySQL bug #118151 rather than calling
+     * `$migration->update()` directly (which would fail on MySQL 8.4 with a
      * non-standard child FK in place — the workaround lives at the runtime
-     * layer, not in individual migrations.
+     * layer, not in individual migrations).
+     *
+     * The retry method is private on `MigrationRuntime` because it has no
+     * production caller outside the runtime itself; this trait reaches for it
+     * via reflection so the production API stays test-free.
      */
     protected function runMigrationViaRuntime(Connection $connection, MigrationStep $migration): void
     {
-        (new MigrationRuntime($connection, new NullLogger()))->runMigrationStep($migration);
+        $runtime = new MigrationRuntime($connection, new NullLogger());
+        (new \ReflectionMethod($runtime, 'runMigrationWithFkGuardRetry'))->invoke($runtime, $migration);
     }
 }

--- a/tests/migration/MySql84FkGuardTestTrait.php
+++ b/tests/migration/MySql84FkGuardTestTrait.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @internal
+ *
+ * Shared fixture for migration tests that need to prove they survive
+ * MySQL bug #118151 — `restrict_fk_on_non_standard_key=ON` causing
+ * `ALTER TABLE` / `CREATE INDEX` on a parent table to fail with
+ * `Cannot drop index '<unknown key name>': needed in a foreign key
+ * constraint` when any child FK references a non-standard key.
+ *
+ * Usage in a test method:
+ *
+ *     $this->skipUnlessMysql84WithFkGuardOn($connection);
+ *     $this->createNonStandardChildFkOnProduct($connection);
+ *     try {
+ *         // run the migration and assert its effect
+ *     } finally {
+ *         $this->dropNonStandardChildFkOnProduct($connection);
+ *     }
+ */
+trait MySql84FkGuardTestTrait
+{
+    private const NON_STD_FK_TABLE = '_t_nonstd_fk_child_for_test';
+
+    protected function skipUnlessMysql84WithFkGuardOn(Connection $connection): void
+    {
+        $version = (string) $connection->fetchOne('SELECT VERSION()');
+        if (stripos($version, 'mariadb') !== false) {
+            static::markTestSkipped('MariaDB has no restrict_fk_on_non_standard_key — bug #118151 only manifests on MySQL 8.4+');
+        }
+        if (version_compare($version, '8.4.0', '<')) {
+            static::markTestSkipped(\sprintf('MySQL %s does not enforce restrict_fk_on_non_standard_key', $version));
+        }
+        $guard = (string) $connection->fetchOne('SELECT @@GLOBAL.restrict_fk_on_non_standard_key');
+        if ($guard !== '1') {
+            static::markTestSkipped('Global restrict_fk_on_non_standard_key is OFF — repro requires the guard ON');
+        }
+    }
+
+    /**
+     * Creates a temporary child table with a foreign key that references a
+     * non-PK / non-unique column on `product`. This is the condition that
+     * triggers MySQL bug #118151 on subsequent ALTER/CREATE INDEX statements
+     * targeting `product`.
+     */
+    protected function createNonStandardChildFkOnProduct(Connection $connection): void
+    {
+        $this->dropNonStandardChildFkOnProduct($connection);
+
+        // The guard refuses non-standard FK creation; flip it off only for
+        // this DDL so the fixture itself can be installed.
+        $connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = OFF');
+        $connection->executeStatement(\sprintf(
+            'CREATE TABLE `%s` (
+                `id` BINARY(16) NOT NULL,
+                `tax_id` BINARY(16) NULL,
+                PRIMARY KEY (`id`),
+                CONSTRAINT `fk._t_nonstd_fk_child.tax_id`
+                    FOREIGN KEY (`tax_id`) REFERENCES `product` (`tax_id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
+            self::NON_STD_FK_TABLE
+        ));
+        $connection->executeStatement('SET SESSION restrict_fk_on_non_standard_key = ON');
+    }
+
+    protected function dropNonStandardChildFkOnProduct(Connection $connection): void
+    {
+        $connection->executeStatement(\sprintf(
+            'DROP TABLE IF EXISTS `%s`',
+            self::NON_STD_FK_TABLE
+        ));
+    }
+}

--- a/tests/migration/MySql84FkGuardTestTrait.php
+++ b/tests/migration/MySql84FkGuardTestTrait.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration;
 use Doctrine\DBAL\Connection;
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\Migration\MigrationRuntime;
+use Shopware\Core\Framework\Migration\MigrationSource;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
 /**
@@ -81,20 +82,33 @@ trait MySql84FkGuardTestTrait
     }
 
     /**
-     * Runs the migration through the same FK-guard retry that
-     * {@see MigrationRuntime::migrate()} uses, so the test exercises the real
-     * workaround for MySQL bug #118151 rather than calling
-     * `$migration->update()` directly (which would fail on MySQL 8.4 with a
-     * non-standard child FK in place — the workaround lives at the runtime
-     * layer, not in individual migrations).
+     * Runs the migration through {@see MigrationRuntime::migrate()} so the
+     * test exercises the real production code path — including the bug
+     * #118151 retry — rather than calling `$migration->update()` directly
+     * (which would fail on MySQL 8.4 with a non-standard child FK in place).
      *
-     * The retry method is private on `MigrationRuntime` because it has no
-     * production caller outside the runtime itself; this trait reaches for it
-     * via reflection so the production API stays test-free.
+     * `migrate()` skips migrations whose record has `update IS NOT NULL`.
+     * After `system:install` every migration is recorded as executed, so the
+     * test temporarily resets the record back to pending, runs the iterator
+     * (it picks up only this class because no other migration in the same
+     * namespace is pending), and the runtime's `setExecuted` re-stamps the
+     * record on success. Two consecutive calls therefore exercise the
+     * migration's own idempotency.
      */
     protected function runMigrationViaRuntime(Connection $connection, MigrationStep $migration): void
     {
+        $class = $migration::class;
+        $namespace = substr($class, 0, (int) strrpos($class, '\\'));
+
+        $connection->update(
+            'migration',
+            ['`update`' => null],
+            ['`class`' => $class]
+        );
+
+        $source = new MigrationSource('mysql84-fk-guard-test', [$namespace]);
         $runtime = new MigrationRuntime($connection, new NullLogger());
-        (new \ReflectionMethod($runtime, 'runMigrationWithFkGuardRetry'))->invoke($runtime, $migration);
+
+        iterator_to_array($runtime->migrate($source));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The migration test matrix currently runs on MariaDB 11 and MySQL 8.0 only ([generate-phpunit-matrix.php:4](.github/bin/generate-phpunit-matrix.php#L4)). MySQL 8.4 introduced `restrict_fk_on_non_standard_key` (default ON) — a class of `ALTER TABLE` failures on parent tables when child FKs reference non-standard keys ([MySQL bug #118151](https://bugs.mysql.com/bug.php?id=118151)). 7 product-table migrations are affected; the fix lands in [#16658](https://github.com/shopware/shopware/pull/16658) at the migration-runtime level.

Without a MySQL 8.4 lane, the regression tests added by #16658 skip in every PR — they exist only as documentation. This PR adds the lane that turns them into real regression guards.

### 2. What does this change do, exactly?

Two parts:

1. **One matrix entry** ([.github/bin/generate-phpunit-matrix.php](.github/bin/generate-phpunit-matrix.php)) — spawns an `8.2 migration mysql:8.4` job per PR run. The migration suite is the shortest job in the matrix (~3 min, no kernel boot), so the CI-minute cost is small.

2. **Mirror of #16658's runtime + tests** — the lane PR carries the same `MigrationRuntime` retry, `MySql84FkGuardTestTrait`, and 7 modified test classes as #16658. These will become duplicates of trunk once #16658 merges and the rebase auto-drops them.

The two PRs are intentionally content-equivalent except for the matrix entry. This keeps the lane PR self-coherent on its own branch (its CI runs the tests against its own runtime) and produces a clean post-merge rebase (only the matrix entry survives).

### Merge order

1. [#16658](https://github.com/shopware/shopware/pull/16658) merges to trunk (runtime fix + tests land).
2. Rebase this PR onto trunk — runtime/trait/test commits become empty (identical content) and git drops them; only the matrix entry remains.
3. This PR merges → MySQL 8.4 lane is permanent CI coverage.

### Verification

On the lane worktree (with these synced changes), against a fresh MySQL 8.4.5 install:

```
OK (7 tests, 23 assertions)
```

— the 7 new MySQL-8.4-specific test methods all pass via `MigrationRuntime::runMigrationStep()` and its bug #118151 retry.

### 3. Describe each step to reproduce the issue or behaviour.

Before:

```bash
$ php .github/bin/generate-phpunit-matrix.php | jq '.matrix.include'
[
  { "test": { "testsuite": "migration" }, "php": "8.2", "db": "mariadb:11" },
  { "test": { "testsuite": "devops" }, "php": "8.5", "db": "mariadb:11" }
]
```

After:

```bash
$ php .github/bin/generate-phpunit-matrix.php | jq '.matrix.include'
[
  { "test": { "testsuite": "migration" }, "php": "8.2", "db": "mariadb:11" },
  { "test": { "testsuite": "migration" }, "php": "8.2", "db": "mysql:8.4" },
  { "test": { "testsuite": "devops" }, "php": "8.5", "db": "mariadb:11" }
]
```

### 4. Please link to the relevant issues (if any).

- depends on #16658
- relates #16240
- relates #13039

### 5. Checklist

- [x] I have written tests and verified that they fail without my change — proven during #16658's iteration; the 7 MySQL 8.4 tests fail on the new lane without the runtime retry, pass with it
- [ ] I have updated developer-facing release notes — N/A, internal CI change
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them