### PR TITLE
fix: validate product comparison sales channel language

### DIFF
--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -120,7 +120,9 @@ class SalesChannelValidator implements EventSubscriberInterface
         $typeId = Uuid::fromBytesToHex($command->getPayload()['type_id']);
 
         return $typeId === Defaults::SALES_CHANNEL_TYPE_STOREFRONT
-            || $typeId === Defaults::SALES_CHANNEL_TYPE_API;
+            || $typeId === Defaults::SALES_CHANNEL_TYPE_API
+            || $typeId === Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON
+            || $typeId === Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE;
     }
 
     private function handleSalesChannelLanguageMapping(Mapping $mapping, WriteCommand $command): void

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -315,12 +315,48 @@ class SalesChannelValidatorTest extends TestCase
         static::assertCount(0, $result);
     }
 
-    public function testOnlyStorefrontAndHeadlessSalesChannelsWillBeSupported(): void
+    public function testAgenticCommerceSalesChannelValidationFailsWithoutLanguageEntry(): void
     {
         $id = Uuid::randomHex();
-        $languageId = Defaults::LANGUAGE_SYSTEM;
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM);
+        $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE;
 
-        $data = $this->getSalesChannelData($id, $languageId);
+        $this->expectException(WriteException::class);
+        $this->expectExceptionMessage(\sprintf(self::INSERT_VALIDATION_MESSAGE, $id));
+
+        $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
+    }
+
+    public function testAgenticCommerceSalesChannelValidationSucceedsWithLanguageEntry(): void
+    {
+        $id = Uuid::randomHex();
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
+        $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE;
+
+        $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
+
+        $count = (int) static::getContainer()->get(Connection::class)
+            ->fetchOne('SELECT COUNT(*) FROM sales_channel_language WHERE sales_channel_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
+
+        static::assertSame(1, $count);
+    }
+
+    public function testProductComparisonSalesChannelValidationFailsWithoutLanguageEntry(): void
+    {
+        $id = Uuid::randomHex();
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM);
+        $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON;
+
+        $this->expectException(WriteException::class);
+        $this->expectExceptionMessage(\sprintf(self::INSERT_VALIDATION_MESSAGE, $id));
+
+        $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
+    }
+
+    public function testProductComparisonSalesChannelValidationSucceedsWithLanguageEntry(): void
+    {
+        $id = Uuid::randomHex();
+        $data = $this->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
         $data['typeId'] = Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON;
 
         $this->getSalesChannelRepository()->create([$data], Context::createDefaultContext());
@@ -328,11 +364,7 @@ class SalesChannelValidatorTest extends TestCase
         $count = (int) static::getContainer()->get(Connection::class)
             ->fetchOne('SELECT COUNT(*) FROM sales_channel_language WHERE sales_channel_id = :id', ['id' => Uuid::fromHexToBytes($id)]);
 
-        static::assertSame(0, $count);
-
-        $this->getSalesChannelRepository()->delete([[
-            'id' => $id,
-        ]], Context::createDefaultContext());
+        static::assertSame(1, $count);
     }
 
     /**

--- a/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/unit/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\SalesChannel\Validation;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelLanguage\SalesChannelLanguageDefinition;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+use Shopware\Core\System\SalesChannel\Validation\SalesChannelValidator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SalesChannelValidator::class)]
+class SalesChannelValidatorTest extends TestCase
+{
+    private StaticDefinitionInstanceRegistry $definitionRegistry;
+
+    protected function setUp(): void
+    {
+        $this->definitionRegistry = new StaticDefinitionInstanceRegistry(
+            [SalesChannelDefinition::class, SalesChannelLanguageDefinition::class],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+    }
+
+    #[DataProvider('supportedSalesChannelTypeProvider')]
+    public function testSupportedSalesChannelTypesRequireDefaultLanguageInLanguageList(string $typeId): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->with(
+                static::isString(),
+                ['ids' => [Uuid::fromHexToBytes($salesChannelId)]],
+                ['ids' => ArrayParameterType::BINARY]
+            )
+            ->willReturn([]);
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new InsertCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelDefinition::ENTITY_NAME),
+                    [
+                        'type_id' => Uuid::fromHexToBytes($typeId),
+                        'language_id' => Uuid::fromHexToBytes($languageId),
+                    ],
+                    ['id' => Uuid::fromHexToBytes($salesChannelId)],
+                    $this->createMock(EntityExistence::class),
+                    '/0'
+                ),
+            ]
+        );
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(1, $event->getExceptions()->getExceptions());
+        $exception = $event->getExceptions()->getExceptions()[0];
+        static::assertInstanceOf(WriteConstraintViolationException::class, $exception);
+        static::assertSame('SYSTEM__NO_GIVEN_DEFAULT_LANGUAGE_ID', $exception->getViolations()->get(0)->getCode());
+    }
+
+    public function testUnsupportedSalesChannelTypeDoesNotRequireDefaultLanguageInLanguageList(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new InsertCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelDefinition::ENTITY_NAME),
+                    [
+                        'type_id' => Uuid::randomBytes(),
+                        'language_id' => Uuid::randomBytes(),
+                    ],
+                    ['id' => Uuid::randomBytes()],
+                    $this->createMock(EntityExistence::class),
+                    '/0'
+                ),
+            ]
+        );
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    public function testProductComparisonSalesChannelSucceedsWithDefaultLanguageInLanguageList(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([]);
+
+        $event = new PreWriteValidationEvent(
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            [
+                new InsertCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelDefinition::ENTITY_NAME),
+                    [
+                        'type_id' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON),
+                        'language_id' => Uuid::fromHexToBytes($languageId),
+                    ],
+                    ['id' => Uuid::fromHexToBytes($salesChannelId)],
+                    $this->createMock(EntityExistence::class),
+                    '/0'
+                ),
+                new InsertCommand(
+                    $this->definitionRegistry->getByEntityName(SalesChannelLanguageDefinition::ENTITY_NAME),
+                    [],
+                    [
+                        'sales_channel_id' => Uuid::fromHexToBytes($salesChannelId),
+                        'language_id' => Uuid::fromHexToBytes($languageId),
+                    ],
+                    $this->createMock(EntityExistence::class),
+                    '/0/languages/0'
+                ),
+            ]
+        );
+
+        (new SalesChannelValidator($connection))->handleSalesChannelLanguageIds($event);
+
+        static::assertCount(0, $event->getExceptions()->getExceptions());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function supportedSalesChannelTypeProvider(): iterable
+    {
+        yield 'storefront' => [Defaults::SALES_CHANNEL_TYPE_STOREFRONT];
+        yield 'api' => [Defaults::SALES_CHANNEL_TYPE_API];
+        yield 'product comparison' => [Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON];
+        yield 'agentic commerce' => [Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When a sales channel of type `SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` is written without a matching entry in the `sales_channel_language` association, the write can currently succeed because `SalesChannelValidator::isSupportedSalesChannelType()` only validates Storefront and API sales channels.

Product comparison sales channels also store a default `language_id` on the sales channel entity. The default language should therefore be part of the sales channel language list, consistent with the existing validation for Storefront and API sales channels.

Without this validation, invalid product comparison sales channels can exist with a default language on the entity itself, but without the corresponding available sales channel language mapping. This can later break context creation with `SYSTEM__SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION` when Shopware tries to build a context for that sales channel.

### 2. What does this change do, exactly?

Adds `SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` to the supported type check in `SalesChannelValidator`.

This makes product comparison sales channels follow the same default-language validation as Storefront and API sales channels. On create, the validator now enforces that the default `language_id` is also present in the `sales_channel_language` association inserts.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product comparison sales channel through a write path that sets `language_id` but does not include the same language in the `languages` association.
2. The write currently succeeds because product comparison sales channels are skipped by `SalesChannelValidator`.
3. The sales channel then has a default language, but no matching entry in `sales_channel_language`.
4. When Shopware later builds a context for that sales channel, context creation can fail with `SYSTEM__SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION`.

### 4. Please link to the relevant issues (if any).

No existing issue found. This inconsistency was found while investigating product comparison sales channels without `sales_channel_language` entries.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them