### PR TITLE
fix: decouple storefront routing from core

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -138,6 +138,13 @@ A new `translation:list` console command prints every locale configured for `tra
 The new `SnippetPatterns::ALLOWED_PSEUDO_LOCALES` and `SnippetPatterns::PSEUDO_LOCALE_TERRITORY` constants register Crowdin pseudo-languages (e.g. `ach-UG`) as valid translation targets for in-context proofreading and translatability audits.
 Pseudo-locales bypass Symfony Intl validation in `Language::validateLocale` and `TranslationLoader::getLocalePath`, and a missing `locale` entity is auto-created on install with a display name from the constant map and a fixed `Pseudo Language` territory.
 
+### URL provider abstraction for SEO URL handling and routing independent of Storefront package
+The new `UrlProviderInterface` abstraction is used for SEO URL generation and route resolution instead of depending on hard-coded Storefront routes.
+
+This abstraction is used by features such as sitemap generation, category URL generation, category breadcrumbs, and hreflang handling. The default implementation is only registered when the Storefront package is installed.
+
+In setups without the Storefront package, no `UrlProviderInterface` service is available by default. Integrations can provide their own implementation to supply custom SEO URLs and route mappings, for example for composable frontends or other custom sales channel implementations.
+
 ## Administration
 
 ### Block renaming

--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -2,8 +2,6 @@
 
 namespace Shopware\Core\Content\Category\Service;
 
-use Doctrine\DBAL\ArrayParameterType;
-use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Breadcrumb\BreadcrumbException;
 use Shopware\Core\Content\Breadcrumb\Struct\Breadcrumb;
 use Shopware\Core\Content\Breadcrumb\Struct\BreadcrumbCollection;
@@ -13,7 +11,10 @@ use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -25,7 +26,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -42,7 +42,7 @@ class CategoryBreadcrumbBuilder
     public function __construct(
         private readonly EntityRepository $categoryRepository,
         private readonly SalesChannelRepository $productRepository,
-        private readonly Connection $connection
+        private readonly ?UrlProviderInterface $urlProvider,
     ) {
     }
 
@@ -281,34 +281,20 @@ class CategoryBreadcrumbBuilder
     /**
      * @param array<string> $categoryIds
      *
-     * @return list<array<string, string|mixed>>
+     * @return list<SeoUrl>
      */
     private function loadSeoUrls(array $categoryIds, Context $context, SalesChannelEntity $salesChannel): array
     {
-        $query = $this->connection->createQueryBuilder();
-        $query->select(
-            'LOWER(HEX(id)) as id',
-            'LOWER(HEX(foreign_key)) as categoryId',
-            'path_info as pathInfo',
-            'seo_path_info as seoPathInfo',
-        );
-        $query->from('seo_url');
-        $query->where('seo_url.is_canonical = 1');
-        $query->andWhere('seo_url.route_name = :routeName');
-        $query->andWhere('seo_url.language_id = :languageId');
-        $query->andWhere('seo_url.sales_channel_id = :salesChannelId');
-        $query->andWhere('seo_url.foreign_key IN (:categoryIds)');
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $query->setParameter('routeName', 'frontend.navigation.page');
-        $query->setParameter('languageId', Uuid::fromHexToBytes($context->getLanguageId()));
-        $query->setParameter('salesChannelId', Uuid::fromHexToBytes($salesChannel->getId()));
-        $query->setParameter('categoryIds', Uuid::fromHexToBytesList($categoryIds), ArrayParameterType::BINARY);
-
-        return $query->executeQuery()->fetchAllAssociative();
+        return $this->urlProvider?->getSeoUrls(
+            array_values($categoryIds),
+            UrlType::CATEGORY,
+            $context->getLanguageId(),
+            $salesChannel->getId()
+        ) ?? [];
     }
 
     /**
-     * @param list<array<string, string|mixed>> $seoUrls
+     * @param list<SeoUrl> $seoUrls
      */
     private function convertCategoriesToBreadcrumbUrls(CategoryCollection $categories, array $seoUrls): BreadcrumbCollection
     {
@@ -332,13 +318,15 @@ class CategoryBreadcrumbBuilder
 
             foreach ($categorySeoUrls as $categorySeoUrl) {
                 if ($categoryBreadcrumb->path === '') {
-                    $categoryBreadcrumb->path = (isset($categorySeoUrl['seoPathInfo']) && $categorySeoUrl['seoPathInfo'] !== '')
-                        ? $categorySeoUrl['seoPathInfo'] : $categorySeoUrl['pathInfo'];
+                    $categoryBreadcrumb->path = $categorySeoUrl->seoPathInfo !== ''
+                        ? $categorySeoUrl->seoPathInfo
+                        : $categorySeoUrl->pathInfo;
                 }
-                if ($categoryId === $categorySeoUrl['categoryId']) {
-                    unset($categorySeoUrl['categoryId']); // remove redundant data
-                }
-                $categoryBreadcrumb->seoUrls[] = $categorySeoUrl;
+                $categoryBreadcrumb->seoUrls[] = [
+                    'seoPathInfo' => $categorySeoUrl->seoPathInfo,
+                    'pathInfo' => $categorySeoUrl->pathInfo,
+                    'id' => $categorySeoUrl->id ?? '',
+                ];
             }
 
             $seoBreadcrumbCollection[$categoryId] = $categoryBreadcrumb;
@@ -348,14 +336,16 @@ class CategoryBreadcrumbBuilder
     }
 
     /**
-     * @param array<int, array<string, string|mixed>> $seoUrls
+     * @param list<SeoUrl> $seoUrls
      *
-     * @return array<int, array<string, string|mixed>>
+     * @return list<SeoUrl>
      */
     private function filterCategorySeoUrls(array $seoUrls, string $categoryId): array
     {
-        return array_filter($seoUrls, static function (array $seoUrl) use ($categoryId): bool {
-            return $seoUrl['categoryId'] === $categoryId;
-        });
+        return array_values(
+            array_filter($seoUrls, static function (SeoUrl $seoUrl) use ($categoryId): bool {
+                return $seoUrl->foreignKey === $categoryId;
+            })
+        );
     }
 }

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -4,7 +4,8 @@ namespace Shopware\Core\Content\Category\Service;
 
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -15,7 +16,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
     /**
      * @internal
      */
-    public function __construct(private readonly SeoUrlPlaceholderHandlerInterface $seoUrlReplacer)
+    public function __construct(private readonly ?UrlProviderInterface $urlProvider)
     {
     }
 
@@ -31,8 +32,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
         }
 
         if ($category->getType() !== CategoryDefinition::TYPE_LINK) {
-            /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-            return $this->seoUrlReplacer->generate('frontend.navigation.page', ['navigationId' => $category->getId()]);
+            return $this->urlProvider?->generateWithPlaceholder(UrlType::CATEGORY, ['navigationId' => $category->getId()]);
         }
 
         $linkType = $category->getTranslation('linkType');
@@ -44,21 +44,17 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
 
         switch ($linkType) {
             case CategoryDefinition::LINK_TYPE_PRODUCT:
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.detail.page', ['productId' => $internalLink]);
+                return $this->urlProvider?->generateWithPlaceholder(UrlType::PRODUCT, ['productId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
                 if ($salesChannel !== null && $internalLink === $salesChannel->getNavigationCategoryId()) {
-                    /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                    return $this->seoUrlReplacer->generate('frontend.home.page');
+                    return $this->urlProvider?->generateWithPlaceholder(UrlType::HOME);
                 }
 
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.navigation.page', ['navigationId' => $internalLink]);
+                return $this->urlProvider?->generateWithPlaceholder(UrlType::CATEGORY, ['navigationId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.landing.page', ['landingPageId' => $internalLink]);
+                return $this->urlProvider?->generateWithPlaceholder(UrlType::LANDING_PAGE, ['landingPageId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_EXTERNAL:
             default:

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -91,11 +91,11 @@
         <service id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder">
             <argument type="service" id="category.repository"/>
             <argument type="service" id="sales_channel.product.repository"/>
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator">
-            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" />
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Validation\EntryPointValidator">

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -46,11 +46,10 @@
 
         <service id="Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\ConfigHandler"/>
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
-            <argument type="service" id="router"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>
@@ -63,12 +62,11 @@
 
         <service id="Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\ConfigHandler"/>
-            <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
-            <argument type="service" id="router"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>
@@ -76,8 +74,8 @@
         <service id="Shopware\Core\Content\Sitemap\Provider\LandingPageUrlProvider">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\ConfigHandler"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="router"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>

--- a/src/Core/Content/Seo/DTO/SeoUrl.php
+++ b/src/Core/Content/Seo/DTO/SeoUrl.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\DTO;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('discovery')]
+final readonly class SeoUrl
+{
+    /**
+     * @param string $foreignKey the category, product or landing page id
+     * @param string $seoPathInfo the actual seo url
+     * @param string $pathInfo fallback url
+     * @param string|null $id the id of seo_url table
+     */
+    public function __construct(
+        public string $foreignKey,
+        public string $seoPathInfo,
+        public string $pathInfo,
+        public ?string $id = null,
+    ) {
+    }
+}

--- a/src/Core/Content/Seo/HreflangLoader.php
+++ b/src/Core/Content/Seo/HreflangLoader.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Seo\Hreflang\HreflangCollection;
 use Shopware\Core\Content\Seo\Hreflang\HreflangStruct;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Routing\RouterInterface;
@@ -18,7 +20,8 @@ class HreflangLoader implements HreflangLoaderInterface
      */
     public function __construct(
         private readonly RouterInterface $router,
-        private readonly Connection $connection
+        private readonly Connection $connection,
+        private readonly ?UrlProviderInterface $urlProvider,
     ) {
     }
 
@@ -32,8 +35,7 @@ class HreflangLoader implements HreflangLoaderInterface
 
         $domains = $this->fetchSalesChannelDomains($salesChannelContext->getSalesChannelId());
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        if ($parameter->getRoute() === 'frontend.home.page') {
+        if ($this->urlProvider?->getUrlTypeByRouteName($parameter->getRoute()) === UrlType::HOME) {
             return $this->getHreflangForHomepage($domains, $salesChannelContext->getSalesChannel()->getHreflangDefaultDomainId());
         }
 

--- a/src/Core/Content/Seo/UrlProvider/UrlProviderInterface.php
+++ b/src/Core/Content/Seo/UrlProvider/UrlProviderInterface.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\UrlProvider;
+
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+interface UrlProviderInterface
+{
+    /**
+     * @param list<string> $ids
+     *
+     * @return list<SeoUrl>
+     */
+    public function getSeoUrls(array $ids, UrlType $urlType, string $languageId, string $salesChannelId): array;
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function generate(UrlType $urlType, array $parameters = []): string;
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function generateWithPlaceholder(UrlType $urlType, array $parameters = []): string;
+
+    public function getRouteNameByUrlType(UrlType $urlType): string;
+
+    public function getUrlTypeByRouteName(string $routeName): ?UrlType;
+}

--- a/src/Core/Content/Seo/UrlProvider/UrlType.php
+++ b/src/Core/Content/Seo/UrlProvider/UrlType.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\UrlProvider;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('discovery')]
+enum UrlType
+{
+    case HOME;
+    case CATEGORY;
+    case LANDING_PAGE;
+    case PRODUCT;
+}

--- a/src/Core/Content/Sitemap/Provider/AbstractUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/AbstractUrlProvider.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -26,9 +27,16 @@ abstract class AbstractUrlProvider
      * @param list<string> $ids
      *
      * @return list<array{foreign_key: string, seo_path_info: string}>
+     *
+     * @deprecated tag:v6.8.0 - Will be removed without replacement
      */
     protected function getSeoUrls(array $ids, string $routeName, SalesChannelContext $context, Connection $connection): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, 'getSeoUrls', 'v6.8.0.0'),
+        );
+
         $sql = 'SELECT LOWER(HEX(foreign_key)) as foreign_key, seo_path_info
                     FROM seo_url WHERE foreign_key IN (:ids)
                      AND `seo_url`.`route_name` =:routeName

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -3,10 +3,12 @@
 namespace Shopware\Core\Content\Sitemap\Provider;
 
 use Doctrine\DBAL\ArrayParameterType;
-use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -19,7 +21,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class CategoryUrlProvider extends AbstractUrlProvider
@@ -33,11 +34,10 @@ class CategoryUrlProvider extends AbstractUrlProvider
      */
     public function __construct(
         private readonly ConfigHandler $configHandler,
-        private readonly Connection $connection,
         private readonly CategoryDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?UrlProviderInterface $urlProvider,
     ) {
     }
 
@@ -53,6 +53,10 @@ class CategoryUrlProvider extends AbstractUrlProvider
 
     public function getUrls(SalesChannelContext $context, int $limit, ?int $offset = null): UrlResult
     {
+        if ($this->urlProvider === null) {
+            return new UrlResult([], null);
+        }
+
         $categories = $this->getCategories($context, $limit, $offset);
 
         if ($categories === []) {
@@ -80,11 +84,16 @@ class CategoryUrlProvider extends AbstractUrlProvider
             static fn (array $category) => $categoryIdsFetchedEvent->hasId($category['id'])
         );
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls($categoryIdsFetchedEvent->getIds(), 'frontend.navigation.page', $context, $this->connection);
-
-        /** @var array<string, array{seo_path_info: string}> $seoUrls */
-        $seoUrls = FetchModeHelper::groupUnique($seoUrls);
+        /** @var array<string, SeoUrl> $seoUrls */
+        $seoUrls = array_merge(...array_map(
+            static fn (SeoUrl $seoUrl) => [$seoUrl->foreignKey => $seoUrl],
+            $this->urlProvider->getSeoUrls(
+                $categoryIdsFetchedEvent->getIds(),
+                UrlType::CATEGORY,
+                $context->getContext()->getLanguageId(),
+                $context->getSalesChannelId()
+            )
+        ));
 
         $urls = [];
         $url = new Url();
@@ -97,10 +106,9 @@ class CategoryUrlProvider extends AbstractUrlProvider
             $newUrl = clone $url;
 
             if (isset($seoUrls[$category['id']])) {
-                $newUrl->setLoc($seoUrls[$category['id']]['seo_path_info']);
+                $newUrl->setLoc($seoUrls[$category['id']]->seoPathInfo);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $newUrl->setLoc($this->router->generate('frontend.navigation.page', ['navigationId' => $category['id']]));
+                $newUrl->setLoc($this->urlProvider->generate(UrlType::CATEGORY, ['navigationId' => $category['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -5,18 +5,19 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class LandingPageUrlProvider extends AbstractUrlProvider
@@ -31,8 +32,8 @@ class LandingPageUrlProvider extends AbstractUrlProvider
     public function __construct(
         private readonly ConfigHandler $configHandler,
         private readonly Connection $connection,
-        private readonly RouterInterface $router,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?UrlProviderInterface $urlProvider,
     ) {
     }
 
@@ -53,6 +54,10 @@ class LandingPageUrlProvider extends AbstractUrlProvider
      */
     public function getUrls(SalesChannelContext $context, int $limit, ?int $offset = null): UrlResult
     {
+        if ($this->urlProvider === null) {
+            return new UrlResult([], null);
+        }
+
         $landingPages = $this->getLandingPages($context, $limit, $offset);
 
         if ($landingPages === []) {
@@ -61,21 +66,25 @@ class LandingPageUrlProvider extends AbstractUrlProvider
 
         $ids = array_column($landingPages, 'id');
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls($ids, 'frontend.landing.page', $context, $this->connection);
-
-        /** @var array<string, array{seo_path_info: string}> $seoUrls */
-        $seoUrls = FetchModeHelper::groupUnique($seoUrls);
+        /** @var array<string, SeoUrl> $seoUrls */
+        $seoUrls = array_merge(...array_map(
+            static fn (SeoUrl $seoUrl) => [$seoUrl->foreignKey => $seoUrl],
+            $this->urlProvider->getSeoUrls(
+                $ids,
+                UrlType::LANDING_PAGE,
+                $context->getContext()->getLanguageId(),
+                $context->getSalesChannelId()
+            )
+        ));
 
         $urls = [];
         foreach ($landingPages as $landingPage) {
             $url = new Url();
 
             if (isset($seoUrls[$landingPage['id']])) {
-                $url->setLoc($seoUrls[$landingPage['id']]['seo_path_info']);
+                $url->setLoc($seoUrls[$landingPage['id']]->seoPathInfo);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $url->setLoc($this->router->generate('frontend.landing.page', ['landingPageId' => $landingPage['id']]));
+                $url->setLoc($this->urlProvider->generate(UrlType::LANDING_PAGE, ['landingPageId' => $landingPage['id']]));
             }
 
             $lastMod = $landingPage['updated_at'] ?: $landingPage['created_at'];

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -3,10 +3,12 @@
 namespace Shopware\Core\Content\Sitemap\Provider;
 
 use Doctrine\DBAL\ArrayParameterType;
-use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -20,7 +22,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class ProductUrlProvider extends AbstractUrlProvider
@@ -38,12 +39,11 @@ class ProductUrlProvider extends AbstractUrlProvider
      */
     public function __construct(
         private readonly ConfigHandler $configHandler,
-        private readonly Connection $connection,
         private readonly ProductDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router,
         private readonly SystemConfigService $systemConfigService,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?UrlProviderInterface $urlProvider,
     ) {
     }
 
@@ -64,6 +64,10 @@ class ProductUrlProvider extends AbstractUrlProvider
      */
     public function getUrls(SalesChannelContext $context, int $limit, ?int $offset = null): UrlResult
     {
+        if ($this->urlProvider === null) {
+            return new UrlResult([], null);
+        }
+
         $products = $this->getProducts($context, $limit, $offset);
 
         if ($products === []) {
@@ -72,11 +76,16 @@ class ProductUrlProvider extends AbstractUrlProvider
 
         $keys = FetchModeHelper::keyPair($products);
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls(array_values($keys), 'frontend.detail.page', $context, $this->connection);
-
-        /** @var array<string, array{seo_path_info: string}> $seoUrls */
-        $seoUrls = FetchModeHelper::groupUnique($seoUrls);
+        /** @var array<string, SeoUrl> $seoUrls */
+        $seoUrls = array_merge(...array_map(
+            static fn (SeoUrl $seoUrl) => [$seoUrl->foreignKey => $seoUrl],
+            $this->urlProvider->getSeoUrls(
+                array_values($keys),
+                UrlType::PRODUCT,
+                $context->getContext()->getLanguageId(),
+                $context->getSalesChannelId()
+            )
+        ));
 
         $urls = [];
         $url = new Url();
@@ -89,10 +98,9 @@ class ProductUrlProvider extends AbstractUrlProvider
             $newUrl = clone $url;
 
             if (isset($seoUrls[$product['id']])) {
-                $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
+                $newUrl->setLoc($seoUrls[$product['id']]->seoPathInfo);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $newUrl->setLoc($this->router->generate('frontend.detail.page', ['productId' => $product['id']]));
+                $newUrl->setLoc($this->urlProvider->generate(UrlType::PRODUCT, ['productId' => $product['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -113,6 +113,7 @@
         <service id="Shopware\Core\Content\Seo\HreflangLoaderInterface" class="Shopware\Core\Content\Seo\HreflangLoader">
             <argument type="service" id="router.default"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface" on-invalid="null"/>
         </service>
 
         <service id="Shopware\Core\Content\Seo\SalesChannel\SeoUrlRoute" public="true">

--- a/src/Storefront/DependencyInjection/seo.xml
+++ b/src/Storefront/DependencyInjection/seo.xml
@@ -33,5 +33,12 @@
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry"/>
             <tag name="shopware.api.enum_provider" />
         </service>
+
+        <service id="Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface"
+                 class="Shopware\Storefront\Framework\Seo\UrlProvider\StorefrontUrlProvider">
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" />
+            <argument type="service" id="router"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
     </services>
 </container>

--- a/src/Storefront/Framework/Seo/UrlProvider/StorefrontUrlProvider.php
+++ b/src/Storefront/Framework/Seo/UrlProvider/StorefrontUrlProvider.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Seo\UrlProvider;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
+use Symfony\Component\Routing\RouterInterface;
+
+#[Package('discovery')]
+class StorefrontUrlProvider implements UrlProviderInterface
+{
+    private const HOME_PAGE_ROUTE = 'frontend.home.page';
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly SeoUrlPlaceholderHandlerInterface $seoUrlReplacer,
+        private readonly RouterInterface $router,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSeoUrls(array $ids, UrlType $urlType, string $languageId, string $salesChannelId): array
+    {
+        $sql = 'SELECT LOWER(HEX(`seo_url`.`foreign_key`)) as foreignKey,
+                    `seo_url`.`seo_path_info` as seoPathInfo,
+                    `seo_url`.`path_info` as pathInfo,
+                    LOWER(HEX(`seo_url`.`id`)) as id
+                FROM `seo_url`
+                WHERE `seo_url`.`foreign_key` IN (:ids)
+                AND `seo_url`.`route_name` = :routeName
+                AND `seo_url`.`is_canonical` = 1
+                AND `seo_url`.`is_deleted` = 0
+                AND `seo_url`.`language_id` = :languageId
+                AND (`seo_url`.`sales_channel_id` = :salesChannelId OR `seo_url`.`sales_channel_id` IS NULL)';
+
+        /** @var list<array{foreignKey: string, seoPathInfo: string, pathInfo: string, id: string}> $result */
+        $result = $this->connection->fetchAllAssociative(
+            $sql,
+            [
+                'routeName' => $this->getRouteNameByUrlType($urlType),
+                'languageId' => Uuid::fromHexToBytes($languageId),
+                'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
+                'ids' => Uuid::fromHexToBytesList(array_values($ids)),
+            ],
+            [
+                'ids' => ArrayParameterType::BINARY,
+            ]
+        );
+
+        return array_map(
+            static fn (array $row) => new SeoUrl(...$row),
+            $result
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(UrlType $urlType, array $parameters = []): string
+    {
+        return $this->router->generate($this->getRouteNameByUrlType($urlType), $parameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generateWithPlaceholder(UrlType $urlType, array $parameters = []): string
+    {
+        return $this->seoUrlReplacer->generate($this->getRouteNameByUrlType($urlType), $parameters);
+    }
+
+    public function getRouteNameByUrlType(UrlType $urlType): string
+    {
+        return match ($urlType) {
+            UrlType::HOME => self::HOME_PAGE_ROUTE,
+            UrlType::PRODUCT => ProductPageSeoUrlRoute::ROUTE_NAME,
+            UrlType::CATEGORY => NavigationPageSeoUrlRoute::ROUTE_NAME,
+            UrlType::LANDING_PAGE => LandingPageSeoUrlRoute::ROUTE_NAME,
+        };
+    }
+
+    public function getUrlTypeByRouteName(string $routeName): ?UrlType
+    {
+        return match ($routeName) {
+            self::HOME_PAGE_ROUTE => UrlType::HOME,
+            ProductPageSeoUrlRoute::ROUTE_NAME => UrlType::PRODUCT,
+            NavigationPageSeoUrlRoute::ROUTE_NAME => UrlType::CATEGORY,
+            LandingPageSeoUrlRoute::ROUTE_NAME => UrlType::LANDING_PAGE,
+            default => null,
+        };
+    }
+}

--- a/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
+++ b/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Seo\HreflangLoaderInterface;
 use Shopware\Core\Content\Seo\HreflangLoaderParameter;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -346,6 +347,10 @@ class HreflangLoaderTest extends TestCase
 
     public function testHomePageWithTwoDomains(): void
     {
+        if (!static::getContainer()->has(UrlProviderInterface::class)) {
+            static::markTestSkipped('This test needs storefront to be installed.');
+        }
+
         $this->salesChannelContext->getSalesChannel()->setHreflangActive(true);
 
         list($first, $last) = $this->getFirstAndLastLanguages();
@@ -396,6 +401,10 @@ class HreflangLoaderTest extends TestCase
 
     public function testHomePageWithTwoDomainsAndDefault(): void
     {
+        if (!static::getContainer()->has(UrlProviderInterface::class)) {
+            static::markTestSkipped('This test needs storefront to be installed.');
+        }
+
         $this->salesChannelContext->getSalesChannel()->setHreflangActive(true);
 
         list($first, $last) = $this->getFirstAndLastLanguages();

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Sitemap\Provider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -13,7 +14,6 @@ use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 
 /**
  * @internal
@@ -28,8 +28,8 @@ class CategoryUrlProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!static::getContainer()->has(ProductPageSeoUrlRoute::class)) {
-            static::markTestSkipped('NEXT-16799: Sitemap module has a dependency on storefront routes');
+        if (!static::getContainer()->has(UrlProviderInterface::class)) {
+            static::markTestSkipped('This test needs storefront to be installed.');
         }
 
         $navigationCategoryId = $this->createRootCategoryData();

--- a/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Content\Sitemap\Provider\LandingPageUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -21,8 +22,6 @@ use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -44,8 +43,8 @@ class LandingPageUrlProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!static::getContainer()->has(ProductPageSeoUrlRoute::class)) {
-            static::markTestSkipped('NEXT-16799: Sitemap module has a dependency on storefront routes');
+        if (!static::getContainer()->has(UrlProviderInterface::class)) {
+            static::markTestSkipped('This test needs storefront to be installed.');
         }
 
         $this->landingPageRepository = static::getContainer()->get('landing_page.repository');
@@ -122,8 +121,8 @@ class LandingPageUrlProviderTest extends TestCase
         $landingPageUrlProvider = new LandingPageUrlProvider(
             $configHandler,
             static::getContainer()->get(Connection::class),
-            static::getContainer()->get(RouterInterface::class),
             static::getContainer()->get('event_dispatcher'),
+            static::getContainer()->get(UrlProviderInterface::class)
         );
 
         $urlResult = $landingPageUrlProvider->getUrls($this->salesChannelContext, 20);

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -19,7 +20,6 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelD
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\Tax\TaxEntity;
-use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 
 /**
  * @internal
@@ -48,8 +48,8 @@ class ProductUrlProviderTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!static::getContainer()->has(ProductPageSeoUrlRoute::class)) {
-            static::markTestSkipped('NEXT-16799: Sitemap module has a dependency on storefront routes');
+        if (!static::getContainer()->has(UrlProviderInterface::class)) {
+            static::markTestSkipped('This test needs storefront to be installed.');
         }
 
         $this->productRepository = static::getContainer()->get('product.repository');

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -2,9 +2,6 @@
 
 namespace Shopware\Tests\Unit\Core\Content\Category\Service;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +12,9 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -54,7 +53,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -75,7 +74,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -90,7 +89,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -111,7 +110,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -131,7 +130,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
         $product = $this->getProductEntity($streamIds, []);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -151,7 +150,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $categoryRepositoryMock,
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
         $product = $this->getProductEntity([], $categoryIds);
 
@@ -208,7 +207,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c01', $this->salesChannelContext->getContext());
@@ -242,7 +241,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c02', $this->salesChannelContext->getContext());
@@ -256,6 +255,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertSame('Home sweet home', $firstBreadcrumb->name);
         static::assertSame('pathInfo/1', $firstBreadcrumb->path);
         static::assertCount(1, $firstBreadcrumb->seoUrls);
+        static::assertSame(['seoPathInfo' => '', 'pathInfo' => 'pathInfo/1', 'id' => '019192b9cd82711482744d7b456b6c12'], $firstBreadcrumb->seoUrls[0]);
     }
 
     public function testConvertCategoriesToBreadcrumbUrlsWithNoSeoUrls(): void
@@ -276,7 +276,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c03', $this->salesChannelContext->getContext());
@@ -311,7 +311,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([$product], [$product]),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
 
         $result = $categoryBreadcrumbBuilder->getProductBreadcrumbUrls($product->getId(), '', $this->salesChannelContext)->getElements();
@@ -335,44 +335,41 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getUrlProviderMock()
         );
         $result = $categoryBreadcrumbBuilder->getProductSeoCategory($productEntity, $this->salesChannelContext);
 
         static::assertNull($result);
     }
 
-    private function getConnectionMock(): Connection
+    private function getUrlProviderMock(): UrlProviderInterface
     {
-        $connection = $this->createMock(Connection::class);
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn(
+        $urlProvider = $this->createMock(UrlProviderInterface::class);
+
+        $urlProvider->method('getSeoUrls')->willReturn(
             [
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c01',
-                    'pathInfo' => 'pathInfo/1',
-                    'seoPathInfo' => 'seoPathInfo/1',
-                ],
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c02',
-                    'pathInfo' => 'pathInfo/1',
-                    'seoPathInfo' => '',
-                ],
-                [
-                    'categoryId' => '019192b9cd82711482744d7b456b6c03',
-                    'pathInfo' => 'navigation/1',
-                    'seoPathInfo' => '',
-                ],
+                '019192b9cd82711482744d7b456b6c01' => new SeoUrl(
+                    '019192b9cd82711482744d7b456b6c01',
+                    'seoPathInfo/1',
+                    'pathInfo/1',
+                    '019192b9cd82711482744d7b456b6c11',
+                ),
+                '019192b9cd82711482744d7b456b6c02' => new SeoUrl(
+                    '019192b9cd82711482744d7b456b6c02',
+                    '',
+                    'pathInfo/1',
+                    '019192b9cd82711482744d7b456b6c12',
+                ),
+                '019192b9cd82711482744d7b456b6c03' => new SeoUrl(
+                    '019192b9cd82711482744d7b456b6c03',
+                    '',
+                    'navigation/1',
+                    '019192b9cd82711482744d7b456b6c13',
+                ),
             ]
         );
 
-        $queryBuilder->method('select')->willReturnSelf();
-        $queryBuilder->method('executeQuery')->willReturn($result);
-
-        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
-
-        return $connection;
+        return $urlProvider;
     }
 
     /**

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -9,7 +9,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
@@ -23,15 +24,15 @@ class CategoryUrlGeneratorTest extends TestCase
 
     private CategoryUrlGenerator $urlGenerator;
 
-    private MockObject&SeoUrlPlaceholderHandlerInterface $replacer;
+    private MockObject&UrlProviderInterface $provider;
 
     private SalesChannelEntity $salesChannel;
 
     protected function setUp(): void
     {
-        $this->replacer = $this->getMockBuilder(SeoUrlPlaceholderHandlerInterface::class)->getMock();
-        $this->urlGenerator = new CategoryUrlGenerator($this->replacer);
-        $this->replacer->method('generate')->willReturnArgument(0);
+        $this->provider = $this->createMock(UrlProviderInterface::class);
+        $this->urlGenerator = new CategoryUrlGenerator($this->provider);
+        $this->provider->method('generateWithPlaceholder')->willReturnCallback(static fn (UrlType $urlType) => $urlType->name);
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
     }
@@ -42,7 +43,7 @@ class CategoryUrlGeneratorTest extends TestCase
         $category->setId(Uuid::randomHex());
         $category->setType(CategoryDefinition::TYPE_PAGE);
 
-        static::assertSame('frontend.navigation.page', $this->urlGenerator->generate($category, $this->salesChannel));
+        static::assertSame(UrlType::CATEGORY->name, $this->urlGenerator->generate($category, $this->salesChannel));
     }
 
     public function testFolder(): void
@@ -66,7 +67,7 @@ class CategoryUrlGeneratorTest extends TestCase
         $category->addTranslated('internalLink', $internalLink);
         $this->salesChannel->setNavigationCategoryId($internalLink);
 
-        static::assertSame('frontend.home.page', $this->urlGenerator->generate($category, $this->salesChannel));
+        static::assertSame(UrlType::HOME->name, $this->urlGenerator->generate($category, $this->salesChannel));
     }
 
     #[DataProvider('dataProviderLinkTypes')]
@@ -93,9 +94,9 @@ class CategoryUrlGeneratorTest extends TestCase
     public static function dataProviderLinkTypes(): array
     {
         return [
-            [CategoryDefinition::LINK_TYPE_PRODUCT, 'frontend.detail.page'],
-            [CategoryDefinition::LINK_TYPE_CATEGORY, 'frontend.navigation.page'],
-            [CategoryDefinition::LINK_TYPE_LANDING_PAGE, 'frontend.landing.page'],
+            [CategoryDefinition::LINK_TYPE_PRODUCT, UrlType::PRODUCT->name],
+            [CategoryDefinition::LINK_TYPE_CATEGORY, UrlType::CATEGORY->name],
+            [CategoryDefinition::LINK_TYPE_LANDING_PAGE, UrlType::LANDING_PAGE->name],
             [CategoryDefinition::LINK_TYPE_EXTERNAL, self::EXTERNAL_URL],
             [null, self::EXTERNAL_URL],
         ];

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -12,6 +12,8 @@ use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\DTO\SeoUrl;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
 use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -26,7 +28,6 @@ use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -37,13 +38,11 @@ class CategoryUrlProviderTest extends TestCase
 {
     private readonly ConfigHandler&MockObject $configHandler;
 
-    private readonly Connection&MockObject $connection;
+    private readonly UrlProviderInterface&MockObject $provider;
 
     private readonly CategoryDefinition&MockObject $definition;
 
     private readonly IteratorFactory&MockObject $iteratorFactory;
-
-    private readonly RouterInterface&MockObject $router;
 
     private readonly EventDispatcher&MockObject $dispatcher;
 
@@ -56,10 +55,9 @@ class CategoryUrlProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->configHandler = $this->createMock(ConfigHandler::class);
-        $this->connection = $this->createMock(Connection::class);
+        $this->provider = $this->createMock(UrlProviderInterface::class);
         $this->definition = $this->createMock(CategoryDefinition::class);
         $this->iteratorFactory = $this->createMock(IteratorFactory::class);
-        $this->router = $this->createMock(RouterInterface::class);
         $this->ids = new IdsCollection();
         $this->dispatcher = $this->createMock(EventDispatcher::class);
         $this->categoryResultIncrement = 0;
@@ -89,7 +87,7 @@ class CategoryUrlProviderTest extends TestCase
                     array_values($categoryResult2),
                 ]
             ),
-            $this->connection
+            $this->createMock(Connection::class)
         );
         $this->initServices($queryResult);
         static::assertNotNull($this->queryBuilder);
@@ -128,7 +126,7 @@ class CategoryUrlProviderTest extends TestCase
         $categoryRowNames = array_keys($this->createCategoryResult());
         $queryResult = new Result(
             new ArrayResult($categoryRowNames, []),
-            $this->connection
+            $this->createMock(Connection::class)
         );
         $this->initServices($queryResult);
         static::assertNotNull($this->queryBuilder);
@@ -146,7 +144,7 @@ class CategoryUrlProviderTest extends TestCase
         $categoryRowNames = array_keys($this->createCategoryResult());
         $queryResult = new Result(
             new ArrayResult($categoryRowNames, []),
-            $this->connection
+            $this->createMock(Connection::class)
         );
         $this->initServices($queryResult, []);
         static::assertNotNull($this->queryBuilder);
@@ -182,7 +180,7 @@ class CategoryUrlProviderTest extends TestCase
                     array_values($categoryResult2),
                 ]
             ),
-            $this->connection
+            $this->createMock(Connection::class)
         );
         $this->initServices($queryResult);
         static::assertNotNull($this->queryBuilder);
@@ -224,7 +222,7 @@ class CategoryUrlProviderTest extends TestCase
                     array_values($categoryResult2),
                 ]
             ),
-            $this->connection
+            $this->createMock(Connection::class)
         );
         $this->initServices($queryResult);
         static::assertNotNull($this->queryBuilder);
@@ -247,6 +245,33 @@ class CategoryUrlProviderTest extends TestCase
         static::assertSame(2, $urlResult->getNextOffset());
     }
 
+    public function testGetEmptyResultWithoutUrlProviderImplementation(): void
+    {
+        $categoryResult1 = $this->createCategoryResult();
+        $queryResult = new Result(
+            new ArrayResult(
+                array_keys($categoryResult1),
+                [
+                    array_values($categoryResult1),
+                ]
+            ),
+            $this->createMock(Connection::class)
+        );
+        $this->initServices($queryResult);
+        static::assertNotNull($this->queryBuilder);
+        $context = Generator::generateSalesChannelContext();
+
+        $this->dispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $provider = $this->getCategoryUrlProvider(false);
+        $urlResult = $provider->getUrls($context, 100, 50);
+
+        $urls = $urlResult->getUrls();
+        static::assertCount(0, $urls);
+    }
+
     /**
      * @param array<array{resource: class-string, salesChannelId: string, identifier: string}>|null $excludedUrls
      */
@@ -254,14 +279,11 @@ class CategoryUrlProviderTest extends TestCase
         Result $categoryQueryResult,
         ?array $excludedUrls = null,
     ): void {
-        $this->connection->method('fetchAllAssociative')->willReturn([
-            [
-                'foreign_key' => $this->ids->get('category-1'),
-                'seo_path_info' => 'category/1/detail',
-            ],
+        $this->provider->method('getSeoUrls')->willReturn([
+            new SeoUrl($this->ids->get('category-1'), 'category/1/detail', '', ''),
         ]);
 
-        $this->router->method('generate')->willReturn('category/2/detail');
+        $this->provider->method('generate')->willReturn('category/2/detail');
 
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->queryBuilder->method('executeQuery')->willReturn($categoryQueryResult);
@@ -274,15 +296,14 @@ class CategoryUrlProviderTest extends TestCase
             ->willReturn($excludedUrls ?? $this->getDefaultExcludedUrls());
     }
 
-    private function getCategoryUrlProvider(): CategoryUrlProvider
+    private function getCategoryUrlProvider(bool $isUrlProviderImplemented = true): CategoryUrlProvider
     {
         return new CategoryUrlProvider(
             $this->configHandler,
-            $this->connection,
             $this->definition,
             $this->iteratorFactory,
-            $this->router,
-            $this->dispatcher
+            $this->dispatcher,
+            $isUrlProviderImplemented ? $this->provider : null
         );
     }
 

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -16,6 +16,8 @@ use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
 use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlProviderInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -64,16 +66,18 @@ class NavigationControllerTest extends TestCase
         $this->seoUrlReplacer = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
         $this->seoUrlReplacer->method('replace')
             ->willReturnCallback(static fn (string $url) => $url);
-        $this->seoUrlReplacer->method('generate')
-            ->willReturnCallback(static function (string $route, array $parameters) {
-                return match ($route) {
-                    'frontend.detail.page' => '/product/' . $parameters['productId'],
-                    'frontend.navigation.page' => '/navigation/' . $parameters['navigationId'],
-                    'frontend.home.page' => '/',
-                    default => '/' . $route,
+
+        $urlProvider = $this->createMock(UrlProviderInterface::class);
+        $urlProvider->method('generateWithPlaceholder')
+            ->willReturnCallback(static function (UrlType $urlType, array $parameters) {
+                return match ($urlType) {
+                    UrlType::PRODUCT => '/product/' . $parameters['productId'],
+                    UrlType::CATEGORY => '/navigation/' . $parameters['navigationId'],
+                    UrlType::HOME => '/',
+                    default => '/' . $urlType->name,
                 };
             });
-        $this->categoryUrlGenerator = new CategoryUrlGenerator($this->seoUrlReplacer);
+        $this->categoryUrlGenerator = new CategoryUrlGenerator($urlProvider);
 
         $this->controller = new NavigationControllerTestClass(
             $this->pageLoader,

--- a/tests/unit/Storefront/Framework/Seo/UrlProvider/StorefrontUrlProviderTest.php
+++ b/tests/unit/Storefront/Framework/Seo/UrlProvider/StorefrontUrlProviderTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Seo\UrlProvider;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\UrlProvider\UrlType;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
+use Shopware\Storefront\Framework\Seo\UrlProvider\StorefrontUrlProvider;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(StorefrontUrlProvider::class)]
+class StorefrontUrlProviderTest extends TestCase
+{
+    private MockObject&SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler;
+
+    private MockObject&RouterInterface $router;
+
+    private MockObject&Connection $connection;
+
+    private StorefrontUrlProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->provider = new StorefrontUrlProvider(
+            $this->seoUrlPlaceholderHandler,
+            $this->router,
+            $this->connection,
+        );
+    }
+
+    public function testItGetsSeoUrls(): void
+    {
+        $id = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+        $salesChannelId = Uuid::randomHex();
+
+        $this->connection->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->with(
+                static::anything(),
+                [
+                    'routeName' => ProductPageSeoUrlRoute::ROUTE_NAME,
+                    'languageId' => Uuid::fromHexToBytes($languageId),
+                    'salesChannelId' => Uuid::fromHexToBytes($salesChannelId),
+                    'ids' => Uuid::fromHexToBytesList([$id]),
+                ],
+                [
+                    'ids' => ArrayParameterType::BINARY,
+                ]
+            );
+
+        $this->provider->getSeoUrls(
+            [$id],
+            UrlType::PRODUCT,
+            $languageId,
+            $salesChannelId
+        );
+    }
+
+    public function testItGeneratesUrl(): void
+    {
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(ProductPageSeoUrlRoute::ROUTE_NAME, ['productId' => 'foobar']);
+
+        $this->provider->generate(UrlType::PRODUCT, ['productId' => 'foobar']);
+    }
+
+    public function testItGeneratesUrlWithPlaceholder(): void
+    {
+        $this->seoUrlPlaceholderHandler->expects($this->once())
+            ->method('generate')
+            ->with(ProductPageSeoUrlRoute::ROUTE_NAME, ['productId' => 'foobar']);
+
+        $this->provider->generateWithPlaceholder(UrlType::PRODUCT, ['productId' => 'foobar']);
+    }
+
+    #[DataProvider('urlTypeProvider')]
+    public function testItGetsRouteNameByUrlType(UrlType $urlType, string $expectedRouteName): void
+    {
+        $routeName = $this->provider->getRouteNameByUrlType($urlType);
+
+        static::assertSame($expectedRouteName, $routeName);
+    }
+
+    public static function urlTypeProvider(): \Generator
+    {
+        yield UrlType::PRODUCT->name => [UrlType::PRODUCT, ProductPageSeoUrlRoute::ROUTE_NAME];
+        yield UrlType::CATEGORY->name => [UrlType::CATEGORY, NavigationPageSeoUrlRoute::ROUTE_NAME];
+        yield UrlType::LANDING_PAGE->name => [UrlType::LANDING_PAGE, LandingPageSeoUrlRoute::ROUTE_NAME];
+        yield UrlType::HOME->name => [UrlType::HOME, 'frontend.home.page'];
+    }
+
+    #[DataProvider('routeNameProvider')]
+    public function testItGetsUrlTypeByRouteName(string $routeName, UrlType $expectedUrlType): void
+    {
+        $urlType = $this->provider->getUrlTypeByRouteName($routeName);
+
+        static::assertSame($expectedUrlType, $urlType);
+    }
+
+    public static function routeNameProvider(): \Generator
+    {
+        yield ProductPageSeoUrlRoute::ROUTE_NAME => [ProductPageSeoUrlRoute::ROUTE_NAME, UrlType::PRODUCT];
+        yield NavigationPageSeoUrlRoute::ROUTE_NAME => [NavigationPageSeoUrlRoute::ROUTE_NAME, UrlType::CATEGORY];
+        yield LandingPageSeoUrlRoute::ROUTE_NAME => [LandingPageSeoUrlRoute::ROUTE_NAME, UrlType::LANDING_PAGE];
+        yield 'frontend.home.page' => ['frontend.home.page', UrlType::HOME];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Core currently still depends on hard-coded Storefront route names and Storefront-specific URL generation in several places such as sitemap generation, category URL generation, breadcrumbs, and hreflang handling.

This makes these core features implicitly depend on the Storefront package, which is a problem for setups that do not use Storefront at all, for example composable frontends or other custom sales channel implementations.

### 2. What does this change do, exactly?

This change introduces a new `UrlProviderInterface` plus a `UrlType` enum to abstract SEO URL lookup and route generation away from concrete Storefront routes.

The affected core services now depend on this abstraction instead of directly using Storefront route names, router generation, or SEO placeholder generation:
- `CategoryBreadcrumbBuilder`
- `CategoryUrlGenerator`
- `HreflangLoader`
- sitemap URL providers for categories, products, and landing pages

The default implementation, `StorefrontUrlProvider`, is registered only when the Storefront package is installed and maps the abstract URL types to the existing Storefront routes.

Additionally:
- core service definitions now inject the URL provider optionally (`on-invalid="null"`) so they can operate without Storefront being installed
- sitemap and category-related tests were updated accordingly
- a dedicated unit test for `StorefrontUrlProvider` was added
- `AbstractUrlProvider::getSeoUrls()` was marked as deprecated in favor of the new abstraction
- developer-facing release notes were added to document the new extension point and behavior in Storefront-less setups

### 3. Describe each step to reproduce the issue or behaviour.

1. Use Shopware without the Storefront package installed.
2. Trigger functionality in core that still assumes Storefront routes exist, for example sitemap generation, category URL generation, breadcrumb URL resolution, or hreflang loading.
3. Observe that these components rely on hard-coded Storefront route names or Storefront-specific URL generation behavior.
4. With this change, those core components no longer depend directly on Storefront. If Storefront is installed, the default `StorefrontUrlProvider` keeps the current behavior. If it is not installed, integrations can provide their own `UrlProviderInterface` implementation.

### 4. Please link to the relevant issues (if any).

- closes #12970

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them