### PR TITLE
fix: catch transport exceptions in ElasticsearchHelper::allowIndexing

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -248,6 +248,12 @@ Set the parameter to a narrower list (for example `['productNumber']`) to restor
 
 ## Critical Fixes
 
+### Transient Elasticsearch outages no longer break order placement
+
+`ElasticsearchHelper::allowIndexing()` now catches transport-level exceptions thrown from `Client::ping()` (e.g. DNS failures, connection refused, timeouts) and routes them through `logAndThrowException()`.
+
+Previously, a transient Elasticsearch / OpenSearch outage during checkout caused a `ConnectException` to bubble out of `ProductUpdater::update()` (triggered by `ProductStockAlteredEvent` after stock decrement), aborting the request after the order had already been written to the database. With `SHOPWARE_ES_THROW_EXCEPTION=0`, the indexing call is now logged at `critical` and skipped for that request; order placement completes normally. With `SHOPWARE_ES_THROW_EXCEPTION=1` (the default) behavior is unchanged — the exception is still re-thrown.
+
 # 6.7.10.1
 
 ## Critical Fixes

--- a/src/Elasticsearch/Framework/ElasticsearchHelper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchHelper.php
@@ -63,7 +63,13 @@ class ElasticsearchHelper
             return false;
         }
 
-        if (!$this->client->ping()) {
+        try {
+            $reachable = $this->client->ping();
+        } catch (\Throwable $e) {
+            return $this->logAndThrowException($e);
+        }
+
+        if (!$reachable) {
             return $this->logAndThrowException(ElasticsearchException::serverNotAvailable());
         }
 

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchHelperTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchHelperTest.php
@@ -68,6 +68,50 @@ class ElasticsearchHelperTest extends TestCase
         $helper->logAndThrowException(new \RuntimeException('test'));
     }
 
+    public function testAllowIndexingCatchesTransportFailures(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('ping')->willThrowException(new \RuntimeException('cURL error 6: Could not resolve host'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('critical');
+
+        $helper = new ElasticsearchHelper(
+            'prod',
+            true,
+            true,
+            'prefix',
+            false,
+            $client,
+            $this->createMock(ElasticsearchRegistry::class),
+            $this->createMock(CriteriaParser::class),
+            $logger
+        );
+
+        static::assertFalse($helper->allowIndexing());
+    }
+
+    public function testAllowIndexingRethrowsTransportFailuresWhenConfigured(): void
+    {
+        $client = $this->createMock(Client::class);
+        $client->method('ping')->willThrowException(new \RuntimeException('cURL error 6: Could not resolve host'));
+
+        $helper = new ElasticsearchHelper(
+            'prod',
+            true,
+            true,
+            'prefix',
+            true,
+            $client,
+            $this->createMock(ElasticsearchRegistry::class),
+            $this->createMock(CriteriaParser::class),
+            $this->createMock(LoggerInterface::class)
+        );
+
+        static::expectException(\RuntimeException::class);
+        $helper->allowIndexing();
+    }
+
     public function testGetIndexName(): void
     {
         $helper = new ElasticsearchHelper(


### PR DESCRIPTION
## Summary

- Wrap `Client::ping()` in a try/catch inside `ElasticsearchHelper::allowIndexing()` so transport-level failures (DNS errors, connection refused, timeouts) are routed through `logAndThrowException()` instead of escaping the method.
- Adds two unit tests covering the new branch (throw vs. log-and-return-false).
- Adds a `Critical Fixes` entry to `RELEASE_INFO-6.7.md`.

Refs https://github.com/shopware/shopware/issues/16897

### Why

Previously, a transient OpenSearch outage during checkout caused a `ConnectException` to bubble out of `ProductUpdater::update()` (subscribed to `ProductStockAlteredEvent`, fired after stock decrement). The order was already written to MySQL, but the storefront returned a 500 — and customers reloading the page re-submitted the order, creating duplicates.

The existing `SHOPWARE_ES_THROW_EXCEPTION=0` switch did **not** help, because the exception came from inside `Client::ping()` itself, before `logAndThrowException()` was reached. This patch makes the ping call resilient so `SHOPWARE_ES_THROW_EXCEPTION=0` actually does what its name promises in this scenario.

### Behaviour

| `SHOPWARE_ES_THROW_EXCEPTION` | Before | After |
|---|---|---|
| `1` (default) | exception bubbles up | exception bubbles up (re-thrown by `logAndThrowException`) — unchanged |
| `0` | exception bubbles up (bug) | logged at `critical`, `allowIndexing()` returns `false`, indexing is skipped for this request |

The stock decrement itself is unaffected — it runs against MySQL in the order transaction. Only the ES read-side projection is skipped on transport failure, and a follow-up `bin/console es:index` (or the next stock change) will bring the index back in sync.

## Test plan

- [x] Unit tests pass: `vendor/bin/phpunit tests/unit/Elasticsearch/Framework/ElasticsearchHelperTest.php`
- [x] phpstan clean on changed files
- [x] php-cs-fixer clean on changed files
- [x] Manual: place an order while OpenSearch is unreachable, with `SHOPWARE_ES_THROW_EXCEPTION=0` — verify no 500, order completes, `app.CRITICAL` log entry present
- [x] Manual: place an order with `SHOPWARE_ES_THROW_EXCEPTION=1` — verify previous behaviour (re-throw) is preserved