### PR TITLE
fix: use sku as ga item id

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-cart.event.js
@@ -52,7 +52,7 @@ export default class AddToCartEvent extends EventAwareAnalyticsEvent
             'currency': productData.currency || ProductPageHelper.getCurrency(),
             'value': productData.value,
             'items': [{
-                'id': productId,
+                'id': productData.id ?? productId,
                 'name': formData.get('product-name') || productData.name,
                 'quantity': formData.get(`lineItems[${productId}][quantity]`),
                 'brand': formData.get('brand-name') || productData.brand,

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-wishlist.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/add-to-wishlist.event.js
@@ -45,7 +45,7 @@ export default class AddToWishlistEvent extends EventAwareAnalyticsEvent
             'currency': productData.currency,
             'value': productData.value,
             'items': [{
-                'id': productId,
+                'id': productData.id ?? productId,
                 'name': productData.name,
                 'brand': productData.brand,
                 ...categories,

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-cart.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-cart.event.js
@@ -50,13 +50,14 @@ export default class RemoveFromCart extends AnalyticsEvent
         const categories = LineItemHelper.getCategoriesFromElement(hiddenLineItem);
         const price = hiddenLineItem.getAttribute('data-price');
         const quantity = hiddenLineItem.getAttribute('data-quantity');
+        const sku = hiddenLineItem.getAttribute('data-sku');
         const value = (parseFloat(price) || 0) * (parseInt(quantity, 10) || 1);
 
         gtag('event', 'remove_from_cart', {
             'currency': additionalProperties.currency,
             'value': value.toFixed(2),
             'items': [{
-                'id': productId,
+                'id': sku ?? productId,
                 'name': hiddenLineItem.getAttribute('data-name'),
                 'quantity': quantity,
                 'price': price,

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-wishlist.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/remove-from-wishlist.event.js
@@ -95,7 +95,7 @@ export default class RemoveFromWishlistEvent extends AnalyticsEvent
             'currency': productData.currency,
             'value': productData.value,
             'items': [{
-                'id': productId,
+                'id': productData.id ?? productId,
                 'name': productData.name,
                 'brand': productData.brand,
                 ...categories,

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
@@ -70,8 +70,10 @@ export default class ViewItemListEvent extends EventAwareAnalyticsEvent
         productBoxes.forEach(item => {
             if (item.dataset.productInformation) {
                 const productData = JSON.parse(item.dataset.productInformation);
+                const { sku, id, ...properties } = productData;
                 lineItems.push({
-                    ...productData,
+                    ...properties,
+                    id: sku ?? id,
                     ...categories,
                 });
             }

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -24,14 +24,14 @@ export default class ViewItemEvent extends AnalyticsEvent
             return;
         }
 
-        const productIdElement = productItemElement.querySelector('meta[itemprop="productID"]');
+        const productIdElement = productItemElement.querySelector('[itemprop="sku"]');
         const productNameElement = productItemElement.querySelector('[itemprop="name"]');
         if (!productIdElement || !productNameElement) {
-            console.warn('[Google Analytics Plugin] Product ID (meta[itemprop="productID"]) or product name ([itemprop="name"]) could not be found within product scope.');
+            console.warn('[Google Analytics Plugin] Product ID ([itemprop="sku"]) or product name ([itemprop="name"]) could not be found within product scope.');
             return;
         }
 
-        const productId = productIdElement.content;
+        const productId = productIdElement.textContent.trim();
         const productName = productNameElement.textContent.trim();
         if (!productId || !productName) {
             console.warn('[Google Analytics Plugin] Product ID or product name is empty, do not track page view.');

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/line-item.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/line-item.helper.js
@@ -24,16 +24,21 @@ export default class LineItemHelper
     }
 
     /**
+     * @param {string|null} productId
      * @returns { Object[] }
      */
-    static getLineItems() {
+    static getLineItems(productId = null) {
         const lineItemsContainer = document.querySelector('.hidden-line-items-information');
-        const lineItemDataElements = lineItemsContainer.querySelectorAll('.hidden-line-item');
+        const lineItemDataElements = lineItemsContainer?.querySelectorAll('.hidden-line-item') ?? [];
         const lineItems = [];
 
         lineItemDataElements.forEach(itemEl => {
+            if (productId && itemEl.getAttribute('data-id') !== productId) {
+                return;
+            }
+
             const itemData = {
-                id: itemEl.getAttribute('data-id'),
+                id: itemEl.getAttribute('data-sku') ?? itemEl.getAttribute('data-id'),
                 name: itemEl.getAttribute('data-name'),
                 quantity: itemEl.getAttribute('data-quantity'),
                 price: itemEl.getAttribute('data-price'),
@@ -73,8 +78,8 @@ export default class LineItemHelper
             return null;
         }
 
-        const lineItems = LineItemHelper.getLineItems();
-        const lineItem = lineItems.find(item => item.id === productId);
+        const lineItems = LineItemHelper.getLineItems(productId);
+        const lineItem = lineItems.find(() => true);
         if (!lineItem) {
             return null;
         }
@@ -90,6 +95,7 @@ export default class LineItemHelper
         }
 
         return {
+            id: lineItem.id,
             name: lineItem.name,
             brand: lineItem.brand,
             value: lineItem.price,

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/product-page.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/product-page.helper.js
@@ -7,7 +7,7 @@ export default class ProductPageHelper {
      * Gets product data from available sources (detail page or product card)
      * @param {string} productId
      * @param {HTMLElement|null} fallbackElement - Optional element to search for product card (e.g., form)
-     * @returns {{name: string|undefined, brand: string|undefined, currency: string|undefined, value: string|undefined}}
+     * @returns {{id: string|undefined, name: string|undefined, brand: string|undefined, currency: string|undefined, value: string|undefined}}
      */
     static getProductData(productId, fallbackElement = null) {
         const detailData = ProductPageHelper.getProductDetailData();
@@ -18,6 +18,7 @@ export default class ProductPageHelper {
 
         const cardData = ProductPageHelper.getProductCardData(productId, fallbackElement);
         return {
+            id: cardData.id,
             name: cardData.name,
             brand: cardData.brand,
             currency: detailData.currency,
@@ -27,10 +28,11 @@ export default class ProductPageHelper {
 
     /**
      * Gets product data from product detail page
-     * @returns {{name: string|undefined, brand: string|undefined, currency: string|undefined, value: string|undefined}}
+     * @returns {{id: string|undefined, name: string|undefined, brand: string|undefined, currency: string|undefined, value: string|undefined}}
      */
     static getProductDetailData() {
         return {
+            id: ProductPageHelper.getSku(),
             name: document.querySelector('.product-detail-name')?.textContent.trim(),
             brand: ProductPageHelper.getBrand(),
             currency: ProductPageHelper.getCurrency(),
@@ -42,7 +44,7 @@ export default class ProductPageHelper {
      * Gets product data from product card (listing page)
      * @param {string} productId
      * @param {HTMLElement|null} fallbackElement - Optional element to search for product card
-     * @returns {{name: string|undefined, brand: string|undefined, value: string|undefined}}
+     * @returns {{id: string|undefined, name: string|undefined, brand: string|undefined, value: string|undefined}}
      */
     static getProductCardData(productId, fallbackElement = null) {
         let productCard = document.querySelector(`.product-wishlist-${productId}`)?.closest('.product-box');
@@ -59,6 +61,7 @@ export default class ProductPageHelper {
         try {
             const info = JSON.parse(productCard.dataset.productInformation);
             return {
+                id: info.sku ?? productId,
                 name: info.name,
                 brand: info.brand,
                 value: info.price,
@@ -66,6 +69,14 @@ export default class ProductPageHelper {
         } catch {
             return {};
         }
+    }
+
+    /**
+     * Gets SKU from product detail page
+     * @returns {string|undefined}
+     */
+    static getSku() {
+        return document.querySelector('[itemprop="sku"]')?.textContent.trim();
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/add-payment-info.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/add-payment-info.event.test.js
@@ -25,6 +25,7 @@ describe('plugin/google-analytics/events/add-payment-info.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="2"
                     data-price="99.99"
@@ -80,6 +81,7 @@ describe('plugin/google-analytics/events/add-payment-info.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="49.99">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="1"
                     data-price="49.99">

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/add-shipping-info.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/add-shipping-info.event.test.js
@@ -25,6 +25,7 @@ describe('plugin/google-analytics/events/add-shipping-info.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="2"
                     data-price="99.99"

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/begin-checkout-on-cart.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/begin-checkout-on-cart.event.test.js
@@ -25,6 +25,7 @@ describe('plugin/google-analytics/events/begin-checkout-on-cart.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="2"
                     data-price="99.99">

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/purchase.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/purchase.event.test.js
@@ -32,6 +32,7 @@ describe('plugin/google-analytics/events/purchase.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98" data-tax="31.93" data-shipping="4.99">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="2"
                     data-price="99.99">

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-cart.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-cart.event.test.js
@@ -38,6 +38,7 @@ describe('plugin/google-analytics/events/view-cart.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                 <span class="hidden-line-item"
                     data-id="product-123"
+                    data-sku="product-123"
                     data-name="Test Product"
                     data-quantity="2"
                     data-price="99.99">
@@ -79,6 +80,7 @@ describe('plugin/google-analytics/events/view-cart.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="99.99">
                 <span class="hidden-line-item"
                     data-id="product-456"
+                    data-sku="product-456"
                     data-name="Another Product"
                     data-quantity="1"
                     data-price="99.99">
@@ -206,6 +208,7 @@ describe('plugin/google-analytics/events/view-cart.event', () => {
             <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                 <span class="hidden-line-item"
                     data-id="product-456"
+                    data-sku="product-456"
                     data-name="Another Product"
                     data-quantity="2"
                     data-price="99.99">

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-item-list.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-item-list.event.test.js
@@ -32,8 +32,8 @@ describe('plugin/google-analytics/events/view-item-list.event', () => {
                 <span class="breadcrumb-title">Computers</span>
             </nav>
             <div class="cms-element-product-listing-wrapper">
-                <div class="product-box" data-product-information='{ "id": "product-1", "name": "Laptop", "price": 999.99 }'></div>
-                <div class="product-box" data-product-information='{ "id": "product-2", "name": "Desktop", "price": 1499.99 }'></div>
+                <div class="product-box" data-product-information='{ "id": "1", "name": "Laptop", "price": 999.99, "sku": "product-1" }'></div>
+                <div class="product-box" data-product-information='{ "id": "2", "name": "Desktop", "price": 1499.99, "sku": "product-2" }'></div>
             </div>
         `;
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-item.event.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/event/view-item.event.test.js
@@ -22,7 +22,9 @@ describe('plugin/google-analytics/events/view-item.event', () => {
     test('fires view_item event with product data', () => {
         document.body.innerHTML = `
             <div itemtype="https://schema.org/Product">
-                <meta itemprop="productID" content="product-123">
+                <span itemprop="sku">
+                    product-123
+                </span>
                 <span itemprop="name">Test Product</span>
                 <div itemprop="brand">
                     <meta itemprop="name" content="Test Brand">

--- a/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/line-item.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/google-analytics/line-item.helper.test.js
@@ -11,6 +11,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
                 <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                     <span class="hidden-line-item"
                         data-id="product-123"
+                        data-sku="product-123"
                         data-name="Test Product"
                         data-quantity="2"
                         data-price="99.99"
@@ -61,12 +62,14 @@ describe('plugin/google-analytics/line-item.helper', () => {
                 <div class="hidden-line-items-information" data-currency="EUR" data-value="150.00">
                     <span class="hidden-line-item"
                         data-id="product-1"
+                        data-sku="product-1"
                         data-name="Product 1"
                         data-quantity="1"
                         data-price="50.00">
                     </span>
                     <span class="hidden-line-item"
                         data-id="product-2"
+                        data-sku="product-2"
                         data-name="Product 2"
                         data-quantity="2"
                         data-price="50.00">
@@ -133,6 +136,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
                 <div class="hidden-line-items-information" data-currency="EUR" data-value="199.98">
                     <span class="hidden-line-item"
                         data-id="product-123"
+                        data-sku="product-123"
                         data-name="Test Product"
                         data-quantity="2"
                         data-price="99.99"
@@ -144,6 +148,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
             const productData = LineItemHelper.getProductData('product-123');
 
             expect(productData).toEqual({
+                id: 'product-123',
                 name: 'Test Product',
                 brand: 'Test Brand',
                 value: '99.99',
@@ -157,6 +162,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
                 <div class="hidden-line-items-information" data-currency="USD" data-value="75.00">
                     <span class="hidden-line-item"
                         data-id="product-456"
+                        data-sku="product-456"
                         data-name="Categorized Product"
                         data-price="25.00"
                         data-brand="Brand"
@@ -169,6 +175,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
             const productData = LineItemHelper.getProductData('product-456');
 
             expect(productData).toEqual({
+                id: 'product-456',
                 name: 'Categorized Product',
                 brand: 'Brand',
                 value: '25.00',
@@ -185,11 +192,13 @@ describe('plugin/google-analytics/line-item.helper', () => {
                 <div class="hidden-line-items-information" data-currency="EUR" data-value="150.00">
                     <span class="hidden-line-item"
                         data-id="product-1"
+                        data-sku="product-1"
                         data-name="First Product"
                         data-price="50.00">
                     </span>
                     <span class="hidden-line-item"
                         data-id="product-2"
+                        data-sku="product-2"
                         data-name="Second Product"
                         data-price="100.00"
                         data-brand="Second Brand">
@@ -200,6 +209,7 @@ describe('plugin/google-analytics/line-item.helper', () => {
             const productData = LineItemHelper.getProductData('product-2');
 
             expect(productData).toEqual({
+                id: 'product-2',
                 name: 'Second Product',
                 brand: 'Second Brand',
                 value: '100.00',

--- a/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/hidden-line-items-information.html.twig
@@ -18,8 +18,10 @@
                 {% for name in categories %}
                     {% set categoryAttributes = categoryAttributes ~ ' data-category-' ~ loop.index ~ '="' ~ name ~ '"' %}
                 {% endfor %}
+                {% set productId = lineItem.productId ?? lineItem.referencedId ?? lineItem.id %}
                 <span class="hidden-line-item"
-                      data-id="{{ lineItem.productId ?? lineItem.referencedId ?? lineItem.id }}"
+                      data-id="{{ productId }}"
+                      data-sku="{{ lineItem.payload.productNumber ?? productId }}"
                       data-name="{{ lineItem.label }}"
                       data-quantity="{{ lineItem.quantity }}"
                       data-price="{{ gaPrice }}"

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -4,6 +4,7 @@
         {% set name = product.translated.name %}
         {% set brand = product.manufacturer.translated.name|default('') %}
         {% set price = product.calculatedPrice.unitPrice %}
+        {% set sku = product.productNumber %}
 
         {% set cover = product.cover.media %}
         {% set variation = product.variation %}
@@ -19,7 +20,7 @@
             {% set routeArguments = routeArguments|merge({ referrerCategoryId: referrerCategoryId }) %}
         {% endif %}
 
-        <div class="card product-box box-{{ layout }}" data-product-information="{{ {id, name, brand, price}|json_encode }}">
+        <div class="card product-box box-{{ layout }}" data-product-information="{{ {id, name, brand, price, sku}|json_encode }}">
             {% block component_product_box_content %}
                 <div class="card-body">
                     {% block component_product_box_badges %}


### PR DESCRIPTION
fixes: #13875

### 1. Why is this change necessary?

Google Analytics currently sends the Shopware internal product ID as `item_id` in storefront ecommerce events. This is inconsistent with the schema.org markup and the default Google Shopping / Merchant Center integration, which use the product number (SKU) as the product identifier.

Because Merchant Center and storefront structured data already rely on the SKU, using a different identifier in Google Analytics makes it harder to compare and reconcile tracking data across Google services.

### 2. What does this change do, exactly?

This change updates the Google Analytics storefront event payloads to use the SKU as the item ID where possible instead of the internal Shopware product ID.

Specifically, it:
- uses the SKU in `view_item` tracking by reading `meta[itemprop="sku"]`
- passes the SKU in product card analytics data
- exposes the product number in hidden line item data for cart-related tracking
- ensures add-to-cart, remove-from-cart, wishlist, and similar events use the SKU-based identifier if available
- adjusts tests for the updated tracking behavior

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a sales channel using the default Google Shopping template.
2. Export or sync products to Google Merchant Center.
3. Open a product detail page in the storefront.
4. Trigger a Google Analytics ecommerce event such as `view_item`.
5. Inspect the transmitted `item_id`.
6. Compare that value with the product identifier used in the Merchant feed / structured data.

### 4. Please link to the relevant issues (if any).

- closes #13875

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them