### PR TITLE
fix: re-index variants and configurator settings after variant generation

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
@@ -344,6 +344,9 @@ export default {
                     );
                 })
                 .then(() => {
+                    this.variantsGenerator.indexProducts(this.variantsGenerator.productIds);
+                })
+                .then(() => {
                     this.$emit('variations-finish-generate');
                     this.$emit('modal-close');
                     this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
@@ -672,8 +672,10 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
             },
             variantsGenerator: {
                 ...wrapper.vm.variantsGenerator,
+                productIds: [],
                 saveVariants: () => Promise.resolve(),
                 saveConfiguratorSettings: () => Promise.resolve(),
+                indexProducts: () => {},
             },
         });
 
@@ -712,9 +714,11 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
                 ],
             },
             variantsGenerator: {
+                productIds: [],
                 generateVariants: () => Promise.resolve(),
                 saveVariants: () => Promise.resolve(),
                 saveConfiguratorSettings: () => Promise.resolve(),
+                indexProducts: () => {},
             },
         });
         await wrapper.vm.$nextTick();
@@ -723,6 +727,58 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
         await flushPromises();
 
         expect(wrapper.emitted('variations-finish-generate')).toHaveLength(1);
+    });
+
+    it('should index products after saving configurator settings', async () => {
+        const wrapper = await createWrapper();
+        const calls = [];
+
+        await wrapper.setData({
+            variantGenerationQueue: {
+                createQueue: [
+                    {
+                        id: 'random-id',
+                        downloads: [],
+                        productStates: [],
+                        type: 'physical',
+                        options: [],
+                    },
+                ],
+                deleteQueue: [],
+            },
+            variantsGenerator: {
+                productIds: [
+                    'variant-id',
+                    'parent-id',
+                ],
+                saveVariants: jest.fn(() => {
+                    calls.push('saveVariants');
+
+                    return Promise.resolve();
+                }),
+                saveConfiguratorSettings: jest.fn(() => {
+                    calls.push('saveConfiguratorSettings');
+
+                    return Promise.resolve();
+                }),
+                indexProducts: jest.fn(() => {
+                    calls.push('indexProducts');
+                }),
+            },
+        });
+
+        wrapper.vm.generateVariants();
+        await flushPromises();
+
+        expect(calls).toEqual([
+            'saveVariants',
+            'saveConfiguratorSettings',
+            'indexProducts',
+        ]);
+        expect(wrapper.vm.variantsGenerator.indexProducts).toHaveBeenCalledWith([
+            'variant-id',
+            'parent-id',
+        ]);
     });
 
     it('should show variant generation step', async () => {
@@ -1081,8 +1137,10 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
                 deleteQueue: [],
             },
             variantsGenerator: {
+                productIds: [],
                 saveVariants: () => Promise.resolve(),
                 saveConfiguratorSettings: () => Promise.resolve(),
+                indexProducts: () => {},
             },
         });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.js
@@ -40,6 +40,8 @@ export default class VariantsGenerator extends EventEmitter {
             return Promise.resolve();
         }
 
+        const configuratorSettingPositions = this.getConfiguratorSettingPositions(configuratorSettings);
+
         const newOptionIds = new Set();
         createQueue.forEach((variant) => {
             if (variant.options) {
@@ -60,6 +62,7 @@ export default class VariantsGenerator extends EventEmitter {
             .map((setting) => {
                 const settingData = deepCopyObject(setting);
                 settingData.productId = this.product.id;
+                settingData.position = configuratorSettingPositions.get(setting.optionId) ?? setting.position;
                 return settingData;
             });
 
@@ -80,10 +83,37 @@ export default class VariantsGenerator extends EventEmitter {
         );
     }
 
+    getConfiguratorSettingPositions(configuratorSettings) {
+        const positions = new Map();
+        const settingsByGroup = new Map();
+
+        configuratorSettings.forEach((setting) => {
+            if (setting.isDeleted || !setting.option?.groupId) {
+                return;
+            }
+
+            if (!settingsByGroup.has(setting.option.groupId)) {
+                settingsByGroup.set(setting.option.groupId, []);
+            }
+
+            settingsByGroup.get(setting.option.groupId).push(setting);
+        });
+
+        settingsByGroup.forEach((settings) => {
+            settings.forEach((setting, index) => {
+                positions.set(setting.optionId, index + 1);
+            });
+        });
+
+        return positions;
+    }
+
     /**
      * Saves the variants to the database via sync api.
      */
     saveVariants(queues) {
+        this.productIds = [];
+
         return new Promise((resolveDelete) => {
             // notify view to refresh progress
             this.emit('progress-max', {
@@ -112,7 +142,9 @@ export default class VariantsGenerator extends EventEmitter {
                 });
             })
             .then(() => {
-                this.indexProducts(this.productIds);
+                if (this.product?.id) {
+                    this.productIds.push(this.product.id);
+                }
             });
     }
 
@@ -499,16 +531,20 @@ export default class VariantsGenerator extends EventEmitter {
         RetryHelper.retry(() => {
             return this.syncService.sync(payload, { 'indexing-behavior': 'disable-indexing' }, header);
         }).then((response) => {
-            this.productIds.concat(response.data?.product ?? []).concat(response.data?.deleted?.product ?? []);
+            this.productIds = this.productIds
+                .concat(response.data?.product ?? [])
+                .concat(response.data?.deleted?.product ?? []);
             this.processQueue(type, queue, offset + limit, limit, resolve);
         });
     }
 
     indexProducts(productIds) {
-        if (productIds.length <= 0) {
+        const ids = Array.from(new Set(productIds));
+
+        if (ids.length <= 0) {
             return;
         }
 
-        this.cacheService.indexProducts(productIds);
+        this.cacheService.indexProducts(ids);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.spec.js
@@ -378,6 +378,66 @@ describe('/src/module/sw-product/helper/sw-products-variants-generator.spec.js',
         });
     });
 
+    describe('saveVariants', () => {
+        it('should collect synced product ids and the parent id without indexing immediately', async () => {
+            variantsGenerator.product = {
+                id: 'parent-product-id',
+            };
+            variantsGenerator.productIds = [];
+
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync').mockResolvedValue({
+                data: {
+                    product: ['variant-product-id'],
+                    deleted: {
+                        product: ['deleted-product-id'],
+                    },
+                },
+            });
+            const indexProductsSpy = jest.spyOn(variantsGenerator, 'indexProducts');
+
+            await variantsGenerator.saveVariants({
+                createQueue: [
+                    {
+                        parentId: 'parent-product-id',
+                        options: [],
+                        stock: 0,
+                        productNumber: 'SW10000.1',
+                    },
+                ],
+                deleteQueue: [],
+            });
+
+            expect(variantsGenerator.productIds).toEqual([
+                'variant-product-id',
+                'deleted-product-id',
+                'parent-product-id',
+            ]);
+            expect(indexProductsSpy).not.toHaveBeenCalled();
+
+            syncSpy.mockRestore();
+            indexProductsSpy.mockRestore();
+        });
+
+        it('should deduplicate product ids before indexing', () => {
+            const indexProductsSpy = jest
+                .spyOn(variantsGenerator.cacheService, 'indexProducts')
+                .mockImplementation(() => {});
+
+            variantsGenerator.indexProducts([
+                'variant-product-id',
+                'variant-product-id',
+                'parent-product-id',
+            ]);
+
+            expect(indexProductsSpy).toHaveBeenCalledWith([
+                'variant-product-id',
+                'parent-product-id',
+            ]);
+
+            indexProductsSpy.mockRestore();
+        });
+    });
+
     describe('saveConfiguratorSettings', () => {
         it('should resolve immediately when configuratorSettings is null', async () => {
             const result = await variantsGenerator.saveConfiguratorSettings(null);
@@ -484,6 +544,65 @@ describe('/src/module/sw-product/helper/sw-products-variants-generator.spec.js',
             await variantsGenerator.saveConfiguratorSettings(originalSettings);
 
             expect(originalSettings[0].productId).toBe('original-product-id');
+
+            syncSpy.mockRestore();
+        });
+
+        it('should persist configurator setting positions in current administration order', async () => {
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync').mockResolvedValue({});
+
+            variantsGenerator.product = {
+                id: 'product-123',
+            };
+
+            const mockSettings = [
+                {
+                    id: 'setting-a',
+                    optionId: 'option-a',
+                    position: 0,
+                    option: { groupId: 'group-1' },
+                    isNew: () => false,
+                },
+                {
+                    id: 'setting-b',
+                    optionId: 'option-b',
+                    position: 0,
+                    option: { groupId: 'group-1' },
+                    isNew: () => false,
+                },
+                {
+                    id: 'setting-c',
+                    optionId: 'option-c',
+                    position: 0,
+                    option: { groupId: 'group-1' },
+                    isNew: () => false,
+                },
+                {
+                    id: 'setting-zero',
+                    optionId: 'option-zero',
+                    position: 0,
+                    option: { groupId: 'group-1' },
+                    isNew: () => false,
+                },
+            ];
+
+            await variantsGenerator.saveConfiguratorSettings(mockSettings);
+
+            const calledPayload = syncSpy.mock.calls[0][0][0].payload;
+
+            expect(calledPayload.map(({ optionId, position }) => ({ optionId, position }))).toEqual([
+                { optionId: 'option-a', position: 1 },
+                { optionId: 'option-b', position: 2 },
+                { optionId: 'option-c', position: 3 },
+                { optionId: 'option-zero', position: 4 },
+            ]);
+
+            expect(mockSettings.map((setting) => setting.position)).toEqual([
+                0,
+                0,
+                0,
+                0,
+            ]);
 
             syncSpy.mockRestore();
         });


### PR DESCRIPTION
### 1. Why is this change necessary?

After generating variants, the Storefront Presentation Display Sequence was not applied correctly. Options appeared sorted alphabetically instead of using the configured order. The correct order only became visible after manually saving the Display Sequence again in the Administration.

Two bugs caused this:

**Missing positions:** `saveConfiguratorSettings` upserts configurator settings via the sync API without setting the `position` field. As a result, positions were missing or reset to zero in the database.

**Broken re-indexing:** The sync API call uses `disable-indexing`, so the search index is not updated during the upsert. Therefore, `indexProducts` must be called afterwards. However, `VariantsGenerator.processQueue` contained a bug: `this.productIds.concat(...)` was called without assigning the result back. Since `Array.prototype.concat()` returns a new array, all collected variant IDs were silently discarded, and `indexProducts` was always called with an empty list, resulting in a no-op.

Even if positions had been stored correctly, the storefront would still have read stale index data because re-indexing never actually ran.

### 2. What does this change do, exactly?

- Adds `getConfiguratorSettingPositions` to `VariantsGenerator`, which assigns sequential positions per group to configurator settings before the upsert
- Fixes `processQueue` to correctly accumulate variant IDs by assigning the result of `concat` back to `this.productIds`
- Resets `productIds` at the start of `saveVariants` and collects the parent product ID at the end, so all affected products are available for indexing
- Moves the `indexProducts` call from inside `saveVariants` to after the full save chain in the component, ensuring variants and configurator settings are fully persisted before re-indexing
- Deduplicates product IDs before indexing via `Array.from(new Set(...))`

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product in the Administration and navigate to the variant generation tab
2. Configure a Storefront Presentation Display Sequence for the property group options that differs from alphabetical order
3. Click "Generate variants"
4. Open the product detail page in the storefront
5. **Before the fix:** The variant options appear sorted alphabetically instead of using the configured display order. The correct order is only applied after manually saving the Display Sequence again in the Administration.
6. **After the fix:** The configured Storefront Presentation Display Sequence is applied correctly immediately after variant generation

### 4. Please link to the relevant issues (if any).

- https://github.com/shopware/shopware/issues/16900

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
