### PR TITLE
fix: Make classes final instead of internal

### DIFF
--- a/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
+++ b/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Util\Hasher;
 use Twig\Cache\FilesystemCache;
 
 /**
- * @deprecated tag:v6.8.0 - reason:becomes-internal - Will be internal in v6.8.0
+ * @deprecated tag:v6.8.0 - reason:becomes-final - Will be final in v6.8.0
  */
 #[Package('framework')]
 class ConfigurableFilesystemCache extends FilesystemCache

--- a/src/Core/Framework/Adapter/Twig/TemplateScopeDetector.php
+++ b/src/Core/Framework/Adapter/Twig/TemplateScopeDetector.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @deprecated tag:v6.8.0 - reason:becomes-internal - Will be internal in v6.8.0
+ * @deprecated tag:v6.8.0 - reason:becomes-final - Will be final in v6.8.0
  */
 #[Package('framework')]
 class TemplateScopeDetector


### PR DESCRIPTION
### 1. Why is this change necessary?

See https://github.com/shopware/shopware/pull/16109#discussion_r3240029029

### 2. What does this change do, exactly?

With 6.8 the two classes are marked as final and not internal

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
