### PR TITLE
fix: use seo url from nested footer navigation

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -289,6 +289,15 @@
                                 {% if footerItem.category.cmsPageId == shippingCmsPageId and footerItem.category.seoUrl %}
                                     {% set shippingUrl = footerItem.category.seoUrl %}
                                 {% endif %}
+
+                                {# Also check for children and use the seoUrl if present. (No recursion because footer navigation supports one level) #}
+                                {% if footerItem.children|length > 0 %}
+                                    {% for child in footerItem.children %}
+                                        {% if child.category.cmsPageId == shippingCmsPageId and child.category.seoUrl %}
+                                            {% set shippingUrl = child.category.seoUrl %}
+                                        {% endif %}
+                                    {% endfor %}
+                                {% endif %}
                             {% endfor %}
                         {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If you create a nested Footer Nav Menu the SEO Url for the Shipping page can not be resolved correctly in footer VAT message. 

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- closes #16744
