### PR TITLE
fix: superseded ADR link

### DIFF
--- a/adr/2024-10-02-vue-2-options-api-to-vue-3-composition-api-conversion-codemod.md
+++ b/adr/2024-10-02-vue-2-options-api-to-vue-3-composition-api-conversion-codemod.md
@@ -7,7 +7,7 @@ tags: [vue, migration, codemod, eslint, composition-api]
 
 ## Context
 
-Our Vue.js application currently uses the Options API, which is the traditional way of writing Vue components in Vue 2. With the release of Vue 3, the Composition API was introduced, offering improved code organization, better TypeScript support, and enhanced reusability of component logic. For more detailed information about the reasons for migrating to the Composition API, see the [documentation entry](https://developer.shopware.com/docs/guides/plugins/plugins/administration/system-updates/vue-native.html).
+Our Vue.js application currently uses the Options API, which is the traditional way of writing Vue components in Vue 2. With the release of Vue 3, the Composition API was introduced, offering improved code organization, better TypeScript support, and enhanced reusability of component logic. For more detailed information about the reasons for migrating to the Composition API, see the [documentation entry](https://developer.shopware.com/docs/guides/upgrades-migrations/administration/vue-native.html).
 
 To modernize our codebase and take advantage of these benefits, we need to migrate our existing Vue 2 Options API components to use the Vue 3 Composition API. Manual conversion of numerous components would be time-consuming and error-prone. Therefore, we need an automated solution to assist in this migration process.
 

--- a/coding-guidelines/core/6.5-new-php-language-features.md
+++ b/coding-guidelines/core/6.5-new-php-language-features.md
@@ -556,7 +556,7 @@ Further to that, we can decorate services with attributes: https://symfony.com/b
 
 #### Backwards Compatibility / Migration Strategy
 
-See the [Symfony Dependency Management](../../adr/2023-05-16-symfony-dependency-management.md) ADR for the decision and migration strategy.
+See the [Symfony Dependency Management](../../adr/_superseded/2023-05-16-symfony-dependency-management.md) ADR for the decision and migration strategy.
 
 ### Improved console autocompletion
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This PR fixes a few broken links so we can fully activate the deadlink check in the Dev Docs pipeline.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.

Check the workflow log:
https://github.com/shopware/developer-portal/actions/runs/26213065727/job/77128480300#step:8:544 


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [X] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
