### PR TITLE
fix(webhook): narrow claimNext lock scope to webhook_stream

### DIFF
--- a/src/Core/Framework/Webhook/Outbox/StreamLockService.php
+++ b/src/Core/Framework/Webhook/Outbox/StreamLockService.php
@@ -61,7 +61,7 @@ class StreamLockService
                   )
                 ORDER BY s.last_claimed_at ASC, s.partition_key ASC
                 LIMIT 1
-                FOR UPDATE SKIP LOCKED
+                FOR UPDATE OF s SKIP LOCKED
                 SQL;
 
             $row = $this->connection->fetchAssociative(


### PR DESCRIPTION
## Summary
- `FOR UPDATE` on the claim `SELECT` was locking every `webhook_delivery` and `webhook_event_log` row touched by the `EXISTS` subquery, placing row locks on the producer's hot path.
- Only the stream row needs exclusive ownership — switch to `FOR UPDATE OF s SKIP LOCKED` (MySQL 8.0.1+) so the claimability probe stays lock-free.

## Test plan
- [ ] Existing `StreamLockService` integration tests pass
- [ ] Verify under concurrent producer load that `webhook_delivery` / `webhook_event_log` rows are no longer locked during claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)