### PR TITLE
test: rename app lifecycle asset delete test

### DIFF
--- a/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -1022,7 +1022,7 @@ class AppLifecycleTest extends TestCase
         static::assertCount(0, $apps);
     }
 
-    public function testDeleteWithCustomFields(): void
+    public function testDeleteRemovesInstalledAppAssets(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
         $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);


### PR DESCRIPTION
### 1. Why is this change necessary?

Looks to me, like the name was wrong. Even though there are custom fields in the manifest, the test does not check they are gone

### 2. What does this change do, exactly?

Rename, as it looks like its rather testing asset cleanup