### PR TITLE
fix: integration admin save

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
@@ -29,6 +29,14 @@ class IntegrationApiService extends ApiService {
             });
     }
 
+    updateAdmin(integrationId, admin, additionalHeaders = {}) {
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        return this.httpClient.patch(this.getApiBasePath(integrationId), { admin }, { headers }).then((response) => {
+            return ApiService.handleResponse(response);
+        });
+    }
+
     generateKey(additionalParams = {}, additionalHeaders = {}, user = false) {
         const params = additionalParams;
         const headers = this.getBasicHeaders(additionalHeaders);

--- a/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.spec.js
@@ -63,4 +63,16 @@ describe('integrationApiService', () => {
 
         expect(JSON.parse(clientMock.history.post[0].data)).toEqual({ allowlist: null });
     });
+
+    it('updateAdmin sends PATCH to integration endpoint', async () => {
+        const { integrationApiService, clientMock } = getIntegrationApiService();
+        const integrationId = 'abc123';
+
+        clientMock.onPatch(`integration/${integrationId}`).reply(204, null);
+
+        await expect(integrationApiService.updateAdmin(integrationId, true)).resolves.not.toThrow();
+
+        expect(clientMock.history.patch).toHaveLength(1);
+        expect(JSON.parse(clientMock.history.patch[0].data)).toEqual({ admin: true });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/index.js
@@ -108,7 +108,7 @@ export default {
         getList() {
             this.isLoading = true;
 
-            this.integrationRepository
+            return this.integrationRepository
                 .search(this.integrationCriteria)
                 .then((integrations) => {
                     this.integrations = integrations;
@@ -134,9 +134,16 @@ export default {
 
         updateIntegration(integration) {
             this.isModalLoading = true;
+            const shouldSaveAdminFlag = this.shouldSaveAdminFlag(integration);
 
             this.integrationRepository
                 .save(integration)
+                .then(() => {
+                    return this.updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag);
+                })
+                .then(() => {
+                    return this.getList();
+                })
                 .then(() => {
                     this.createSavedSuccessNotification();
                     this.onCloseDetailModal();
@@ -154,12 +161,19 @@ export default {
             }
 
             this.isModalLoading = true;
+            const integration = this.currentIntegration;
+            const shouldSaveAdminFlag = this.shouldSaveAdminFlag(integration);
 
             this.integrationRepository
-                .save(this.currentIntegration)
+                .save(integration)
+                .then(() => {
+                    return this.updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag);
+                })
+                .then(() => {
+                    return this.getList();
+                })
                 .then(() => {
                     this.createSavedSuccessNotification();
-                    this.getList();
                 })
                 .catch(() => {
                     this.createSavedErrorNotification();
@@ -169,6 +183,24 @@ export default {
                         this.onCloseDetailModal();
                     });
                 });
+        },
+
+        shouldSaveAdminFlag(integration) {
+            if (!integration || typeof integration.getOrigin !== 'function') {
+                return false;
+            }
+
+            const origin = integration.getOrigin();
+
+            return Boolean(origin?.admin) !== Boolean(integration.admin);
+        },
+
+        updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag) {
+            if (!shouldSaveAdminFlag) {
+                return Promise.resolve();
+            }
+
+            return this.integrationService.updateAdmin(integration.id, integration.admin);
         },
 
         createSavedSuccessNotification() {

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -12,8 +12,11 @@ const appIntegration = {
     mcpAllowlist: null,
 };
 
-async function createWrapper(privileges = [], integrations = null) {
+async function createWrapper(privileges = [], integrations = null, options = {}) {
     const defaultIntegrations = integrations ?? [{ id: '44de136acf314e7184401d36406c1e90' }];
+    const saveMock = options.saveMock ?? jest.fn().mockResolvedValue();
+    const searchMock = options.searchMock ?? jest.fn().mockResolvedValue(defaultIntegrations);
+    const updateAdminMock = options.updateAdminMock ?? jest.fn().mockResolvedValue();
 
     const wrapper = mount(await wrapTestComponent('sw-integration-list', { sync: true }), {
         global: {
@@ -26,13 +29,9 @@ async function createWrapper(privileges = [], integrations = null) {
                             });
                         },
 
-                        search: () => {
-                            return Promise.resolve(defaultIntegrations);
-                        },
+                        search: searchMock,
 
-                        save: () => {
-                            return Promise.resolve();
-                        },
+                        save: saveMock,
 
                         delete: () => {
                             return Promise.resolve();
@@ -50,6 +49,7 @@ async function createWrapper(privileges = [], integrations = null) {
                     saveMcpAllowlist: () => {
                         return Promise.resolve();
                     },
+                    updateAdmin: updateAdminMock,
                 },
 
                 acl: {
@@ -230,6 +230,70 @@ describe('module/sw-integration/page/sw-integration-list', () => {
 
         const modalAfterSave = wrapper.find('.sw-modal.sw-integration-list__detail');
         expect(modalAfterSave.exists()).toBeFalsy();
+    });
+
+    it('should update the admin flag through the integration service', async () => {
+        const integration = {
+            id: '44de136acf314e7184401d36406c1e90',
+            label: 'Test integration',
+            admin: true,
+            aclRoles: [],
+            getOrigin: () => {
+                return { admin: false };
+            },
+        };
+        const saveMock = jest.fn().mockResolvedValue();
+        const updateAdminMock = jest.fn().mockResolvedValue();
+        const searchMock = jest.fn().mockResolvedValue([integration]);
+
+        const wrapper = await createWrapper(
+            [
+                'admin',
+                'integration.editor',
+            ],
+            [integration],
+            {
+                saveMock,
+                searchMock,
+                updateAdminMock,
+            },
+        );
+
+        await wrapper.vm.updateIntegration(integration);
+        await flushPromises();
+
+        expect(saveMock).toHaveBeenCalledWith(integration);
+        expect(updateAdminMock).toHaveBeenCalledWith(integration.id, true);
+        expect(searchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not update the admin flag when it was not changed', async () => {
+        const integration = {
+            id: '44de136acf314e7184401d36406c1e90',
+            label: 'Test integration',
+            admin: false,
+            aclRoles: [],
+            getOrigin: () => {
+                return { admin: false };
+            },
+        };
+        const updateAdminMock = jest.fn().mockResolvedValue();
+
+        const wrapper = await createWrapper(
+            [
+                'admin',
+                'integration.editor',
+            ],
+            [integration],
+            {
+                updateAdminMock,
+            },
+        );
+
+        await wrapper.vm.updateIntegration(integration);
+        await flushPromises();
+
+        expect(updateAdminMock).not.toHaveBeenCalled();
     });
 
     it('should be able to delete a integration', async () => {


### PR DESCRIPTION
Fixes #16979

## What changed

- Added an explicit integration API service call for updating the `admin` flag.
- The integration list page now persists the admin flag after the normal repository save when the flag changed.
- The list is reloaded after create/update so the UI reflects persisted state instead of stale local entity state.
- Added focused Jest coverage for the API service call and the integration list save flow.

## Root cause

`integration.admin` is write-protected in the DAL metadata. The Administration changeset generator skips write-protected fields before `repository.save()`, so toggling the administrator switch only changed the local entity. The save promise still resolved, and because the list was not reloaded, the UI showed `ADMINISTRATOR` even though the database did not change.

## Validation

- `npx jest --collectCoverage=false src/core/service/api/integration.api.service.spec.js src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js`
- `npx eslint src/core/service/api/integration.api.service.js src/core/service/api/integration.api.service.spec.js src/module/sw-integration/page/sw-integration-list/index.js src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js`
- `npx prettier --check src/core/service/api/integration.api.service.js src/core/service/api/integration.api.service.spec.js src/module/sw-integration/page/sw-integration-list/index.js src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js`
- `git diff --check`

Note: `composer` is not available in the local environment, so the composer wrapper commands could not be run.
