### PR TITLE
refactor: introduce app manager

### DIFF
--- a/src/Core/Framework/App/AppStateService.php
+++ b/src/Core/Framework/App/AppStateService.php
@@ -2,17 +2,11 @@
 
 namespace Shopware\Core\Framework\App;
 
-use Shopware\Core\Framework\App\Event\AppActivatedEvent;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
-use Shopware\Core\Framework\App\Event\Hooks\AppActivatedHook;
-use Shopware\Core\Framework\App\Event\Hooks\AppDeactivatedHook;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal only for use by the app-system
@@ -21,69 +15,31 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class AppStateService
 {
     /**
-     * @param EntityRepository<AppCollection> $appRepo
-     * @param iterable<PersisterInterface> $persisters
+     * @param EntityRepository<AppCollection> $appRepository
      */
     public function __construct(
-        private readonly EntityRepository $appRepo,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly ActiveAppsLoader $activeAppsLoader,
-        private readonly ScriptExecutor $scriptExecutor,
-        private readonly iterable $persisters
+        private readonly AppManager $appManager,
+        private readonly EntityRepository $appRepository,
     ) {
     }
 
     public function activateApp(string $appId, Context $context): void
     {
-        $app = $this->appRepo->search(new Criteria([$appId]), $context)->getEntities()->first();
-
-        if ($app === null) {
-            throw AppException::notFound($appId);
-        }
-        if ($app->isActive()) {
-            return;
-        }
-
-        $this->appRepo->update([['id' => $appId, 'active' => true]], $context);
-        // manually set active flag to true, so we don't need to re-fetch the app from DB
-        $app->setActive(true);
-        foreach ($this->persisters as $persister) {
-            $persister->activate($app, $context);
-        }
-
-        $this->activeAppsLoader->reset();
-
-        $event = new AppActivatedEvent($app, $context);
-        $this->eventDispatcher->dispatch($event);
-        $this->scriptExecutor->execute(new AppActivatedHook($event));
+        $this->appManager->activate($this->loadApp($appId, $context), $context);
     }
 
     public function deactivateApp(string $appId, Context $context, bool $deactivateForDeletion = false): void
     {
-        $app = $this->appRepo->search(new Criteria([$appId]), $context)->getEntities()->first();
+        $this->appManager->deactivate($this->loadApp($appId, $context), $context, $deactivateForDeletion);
+    }
 
-        if ($app === null) {
+    private function loadApp(string $appId, Context $context): AppEntity
+    {
+        $app = $this->appRepository->search(new Criteria([$appId]), $context)->getEntities()->first();
+        if (!$app instanceof AppEntity) {
             throw AppException::notFound($appId);
         }
-        if (!$app->isActive()) {
-            return;
-        }
-        if (!$deactivateForDeletion && !$app->getAllowDisable()) {
-            throw AppException::restrictDeletePreventsDeactivation($app->getName());
-        }
 
-        // throw event before deactivating app in db as theme configs from the app need to be removed beforehand
-        $event = new AppDeactivatedEvent($app, $context);
-        $this->eventDispatcher->dispatch($event);
-        $this->scriptExecutor->execute(new AppDeactivatedHook($event));
-
-        $this->appRepo->update([['id' => $appId, 'active' => false]], $context);
-        $app->setActive(false);
-        foreach ($this->persisters as $persister) {
-            $persister->deactivate($app, $context);
-        }
-
-        // reset only after new state is in the DB
-        $this->activeAppsLoader->reset();
+        return $app;
     }
 }

--- a/src/Core/Framework/App/Lifecycle/AppLifecycle.php
+++ b/src/Core/Framework/App/Lifecycle/AppLifecycle.php
@@ -2,48 +2,17 @@
 
 namespace Shopware\Core\Framework\App\Lifecycle;
 
-use Composer\Semver\VersionParser;
-use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
-use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
-use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
-use Shopware\Core\Framework\App\Event\AppDeletedEvent;
-use Shopware\Core\Framework\App\Event\AppInstalledEvent;
-use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
-use Shopware\Core\Framework\App\Event\Hooks\AppDeletedHook;
-use Shopware\Core\Framework\App\Event\Hooks\AppInstalledHook;
-use Shopware\Core\Framework\App\Event\Hooks\AppUpdatedHook;
-use Shopware\Core\Framework\App\Event\PostAppDeletedEvent;
-use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
-use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
 use Shopware\Core\Framework\App\Manifest\Manifest;
-use Shopware\Core\Framework\App\Source\SourceResolver;
-use Shopware\Core\Framework\App\Validation\AppRequirementsValidator;
-use Shopware\Core\Framework\App\Validation\ConfigValidator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Plugin\Util\AssetService;
-use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
-use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\CustomEntity\CustomEntityLifecycleService;
-use Shopware\Core\System\Integration\IntegrationCollection;
-use Shopware\Core\System\Language\LanguageCollection;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Core\System\SystemConfig\Util\ConfigReader;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -53,33 +22,10 @@ class AppLifecycle extends AbstractAppLifecycle
 {
     /**
      * @param EntityRepository<AppCollection> $appRepository
-     * @param EntityRepository<LanguageCollection> $languageRepository
-     * @param EntityRepository<IntegrationCollection> $integrationRepository
-     * @param EntityRepository<AclRoleCollection> $aclRoleRepository
-     * @param iterable<PersisterInterface> $persisters
      */
     public function __construct(
-        private readonly iterable $persisters,
+        private readonly AppManager $appManager,
         private readonly EntityRepository $appRepository,
-        private readonly PermissionLifecycleService $permissionLifecycle,
-        private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly AppRegistrationService $registrationService,
-        private readonly AppStateService $appStateService,
-        private readonly EntityRepository $languageRepository,
-        private readonly SystemConfigService $systemConfigService,
-        private readonly ConfigValidator $configValidator,
-        private readonly EntityRepository $integrationRepository,
-        private readonly EntityRepository $aclRoleRepository,
-        private readonly AssetService $assetService,
-        private readonly ScriptExecutor $scriptExecutor,
-        private readonly string $projectDir,
-        private readonly CustomEntityLifecycleService $customEntityLifecycleService,
-        private readonly string $shopwareVersion,
-        private readonly AppFeatureValidator $appFeatureValidator,
-        private readonly SourceResolver $sourceResolver,
-        private readonly ConfigReader $configReader,
-        private readonly DeletedAppsGateway $deletedAppsGateway,
-        private readonly AppRequirementsValidator $requirementsValidator,
     ) {
     }
 
@@ -90,417 +36,26 @@ class AppLifecycle extends AbstractAppLifecycle
 
     public function install(Manifest $manifest, AppInstallParameters $parameters, Context $context): void
     {
-        $this->ensureIsCompatible($manifest);
-        $this->ensureMeetsRequirements($manifest);
-
-        $app = $this->loadAppByName($manifest->getMetadata()->getName(), $context);
-        if ($app) {
-            throw AppException::alreadyInstalled($manifest->getMetadata()->getName());
-        }
-
-        $defaultLocale = $this->getDefaultLocale($context);
-        $metadata = $manifest->getMetadata()->toArray($defaultLocale);
-        $appId = Uuid::randomHex();
-        $roleId = Uuid::randomHex();
-        $metadata = $this->enrichInstallMetadata($manifest, $metadata, $roleId);
-
-        $app = $this->updateApp(
-            $manifest,
-            new AppUpdateParameters(acceptPermissions: $parameters->acceptPermissions),
-            $metadata,
-            $appId,
-            $roleId,
-            $defaultLocale,
-            $context,
-            true
-        );
-
-        $event = new AppInstalledEvent($app, $manifest, $context);
-        $this->eventDispatcher->dispatch($event);
-        $this->scriptExecutor->execute(new AppInstalledHook($event));
-
-        if ($parameters->activate) {
-            $this->appStateService->activateApp($appId, $context);
-        }
-
-        $this->updateAclRole($app->getName(), $context);
+        $this->appManager->install($manifest, $parameters, $context);
     }
 
     public function update(Manifest $manifest, AppUpdateParameters $parameters, array $app, Context $context): void
     {
-        $this->ensureIsCompatible($manifest);
-        $this->ensureMeetsRequirements($manifest);
-
-        $defaultLocale = $this->getDefaultLocale($context);
-        $metadata = $manifest->getMetadata()->toArray($defaultLocale);
-        $appEntity = $this->updateApp(
-            $manifest,
-            $parameters,
-            $metadata,
-            $app['id'],
-            $app['roleId'],
-            $defaultLocale,
-            $context,
-            false
-        );
-
-        $event = new AppUpdatedEvent($appEntity, $manifest, $context);
-        $this->eventDispatcher->dispatch($event);
-        $this->scriptExecutor->execute(new AppUpdatedHook($event));
+        $this->appManager->update($manifest, $parameters, $this->loadApp($app['id'], $context), $context);
     }
 
     public function delete(string $appName, array $app, Context $context, bool $keepUserData = false): void
     {
-        $appEntity = $this->loadApp($app['id'], $context);
-
-        // if we do not keep user data, or the app has no restrict delete data with rows,
-        // we can safely delete the app as no references in the DB will be left over
-        $isSafeToDeleteCustomFields = !$keepUserData || $this->customEntityLifecycleService->canRemoveAppData($appEntity);
-        if ($appEntity->isActive()) {
-            $this->appStateService->deactivateApp($appEntity->getId(), $context, $isSafeToDeleteCustomFields);
-        }
-
-        $this->removeAppAndRole($appEntity, $context, $keepUserData, true);
-        $this->assetService->removeAssets($appEntity->getName());
-
-        $event = new PostAppDeletedEvent($appEntity->getName(), $appEntity->getSourceType(), $context, $keepUserData);
-        $this->eventDispatcher->dispatch($event);
-    }
-
-    public function ensureIsCompatible(Manifest $manifest): void
-    {
-        $versionParser = new VersionParser();
-        if (!$manifest->getMetadata()->getCompatibility()->matches($versionParser->parseConstraints($this->shopwareVersion))) {
-            throw AppException::notCompatible($manifest->getMetadata()->getName());
-        }
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     */
-    private function updateApp(
-        Manifest $manifest,
-        AppUpdateParameters $parameters,
-        array $metadata,
-        string $id,
-        string $roleId,
-        string $defaultLocale,
-        Context $context,
-        bool $install
-    ): AppEntity {
-        // accessToken is not set on update, but in that case we don't run registration, so we won't need it
-        $secretAccessKey = $metadata['accessToken'] ?? '';
-        unset($metadata['accessToken'], $metadata['icon']);
-        $metadata['path'] = str_replace($this->projectDir . '/', '', $manifest->getPath());
-        $metadata['id'] = $id;
-        $metadata['modules'] = [];
-        $metadata['iconRaw'] = $this->getIcon($manifest);
-        $metadata['cookies'] = $manifest->getCookies() !== null ? $manifest->getCookies()->getCookies() : [];
-        $metadata['baseAppUrl'] = $manifest->getAdmin()?->getBaseAppUrl();
-        $metadata['allowedHosts'] = $manifest->getAllHosts();
-        $metadata['templateLoadPriority'] = $manifest->getStorefront() ? $manifest->getStorefront()->getTemplateLoadPriority() : 0;
-        $metadata['checkoutGatewayUrl'] = $manifest->getGateways()?->getCheckout()?->getUrl();
-        $metadata['contextGatewayUrl'] = $manifest->getGateways()?->getContext()?->getUrl();
-        $metadata['sourceType'] = $manifest->getSourceType() ?? $this->sourceResolver->resolveSourceType($manifest);
-        $metadata['sourceConfig'] = $manifest->getSourceConfig();
-        $metadata['inAppPurchasesGatewayUrl'] = $manifest->getGateways()?->getInAppPurchasesGateway()?->getUrl();
-
-        $this->updateMetadata($metadata, $context);
-
-        $app = $this->loadApp($id, $context);
-
-        $this->updateCustomEntities($app, $manifest);
-
-        $this->permissionLifecycle->updatePrivileges(
-            $manifest->getPermissions(),
-            $id,
-            $manifest->validatesPermissions() === false && $parameters->acceptPermissions,
-            $context
-        );
-
-        // If the app has no secret yet, but now specifies setup data we do a registration to get an app secret
-        // this mostly happens during install, but may happen in the update case if the app previously worked without an external server
-        // additionally during install it might happen that we still have an old secret stored for the app from a previous installation
-        // in that case we still need to run the registration to rotate that secret
-        if ((!$app->getAppSecret() || $install) && $manifest->getSetup()) {
-            try {
-                $this->registrationService->registerApp($manifest, $id, $secretAccessKey, $context);
-            } catch (AppRegistrationException $e) {
-                $this->removeAppAndRole($app, $context);
-
-                throw $e;
-            }
-        }
-
-        // Refetch app to get secret after registration
-        $app = $this->loadApp($id, $context);
-
-        try {
-            $this->appFeatureValidator->validate($app, $manifest);
-        } catch (AppException $e) {
-            $this->removeAppAndRole($app, $context);
-
-            throw $e;
-        }
-
-        $this->runPersisters(new AppLifecycleContext(
-            manifest: $manifest,
-            app: $app,
-            context: $context,
-            appFilesystem: $this->sourceResolver->filesystemForManifest($manifest),
-            defaultLocale: $defaultLocale,
-            isInstall: $install,
-        ));
-
-        $this->assetService->copyAssetsFromApp($app->getName(), $app->getPath());
-
-        $updatePayload = [
-            'id' => $app->getId(),
-            'configurable' => $this->handleConfigUpdates($app, $manifest, $install),
-            'allowDisable' => $this->customEntityLifecycleService->allowsDisabling($app),
-        ];
-        $this->updateMetadata($updatePayload, $context);
-
-        return $app;
-    }
-
-    /**
-     * @return array<array<string, mixed>>|null
-     */
-    private function getAppConfig(AppEntity $app): ?array
-    {
-        $fs = $this->sourceResolver->filesystemForApp($app);
-
-        if (!$fs->has('Resources/config/config.xml')) {
-            return null;
-        }
-
-        return $this->configReader->read($fs->path('Resources/config/config.xml'));
-    }
-
-    private function removeAppAndRole(AppEntity $app, Context $context, bool $keepUserData = false, bool $softDelete = false): void
-    {
-        // throw event before deleting app from db as it may be delivered via webhook to the deleted app
-        $event = new AppDeletedEvent($app->getId(), $context, $keepUserData);
-        $this->eventDispatcher->dispatch($event);
-        $this->scriptExecutor->execute(new AppDeletedHook($event));
-
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($app, $softDelete, $keepUserData): void {
-            if (!$keepUserData) {
-                $config = $this->getAppConfig($app);
-
-                if ($config) {
-                    $this->systemConfigService->deleteExtensionConfiguration($app->getName(), $config);
-                }
-            }
-
-            $this->customEntityLifecycleService->removeApp($app, $context, $keepUserData);
-
-            $this->appRepository->delete([['id' => $app->getId()]], $context);
-
-            if ($softDelete) {
-                $this->integrationRepository->update([[
-                    'id' => $app->getIntegrationId(),
-                    'deletedAt' => new \DateTimeImmutable(),
-                ]], $context);
-                $this->permissionLifecycle->softDeleteRole($app->getAclRoleId());
-            } else {
-                $this->integrationRepository->delete([['id' => $app->getIntegrationId()]], $context);
-                $this->permissionLifecycle->removeRole($app->getAclRoleId());
-            }
-
-            $this->deleteAclRole($app->getName(), $context);
-        });
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     */
-    private function updateMetadata(array $metadata, Context $context): void
-    {
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($metadata): void {
-            $this->appRepository->upsert([$metadata], $context);
-        });
-    }
-
-    /**
-     * @param array<string, mixed> $metadata
-     *
-     * @return array<string, mixed>
-     */
-    private function enrichInstallMetadata(Manifest $manifest, array $metadata, string $roleId): array
-    {
-        $secret = AccessKeyHelper::generateSecretAccessKey();
-        $appName = $manifest->getMetadata()->getName();
-
-        $metadata['integration'] = [
-            'label' => $appName,
-            'accessKey' => AccessKeyHelper::generateAccessKey('integration'),
-            'secretAccessKey' => $secret,
-            'admin' => false,
-        ];
-
-        $metadata['aclRole'] = [
-            'id' => $roleId,
-            'name' => $appName,
-        ];
-        $metadata['accessToken'] = $secret;
-        // Always install as inactive, activation will be handled by `AppStateService` in `install()` method.
-        $metadata['active'] = false;
-        // when the app was installed before and we have the old secret stored, we set it here
-        // so the registration is signed correctly with the old secret
-        $oldSecret = $this->deletedAppsGateway->getDeletedAppSecret($appName);
-        if ($oldSecret !== null) {
-            $metadata['appSecret'] = $oldSecret;
-        }
-
-        return $metadata;
+        $this->appManager->delete($this->loadApp($app['id'], $context), $context, $keepUserData);
     }
 
     private function loadApp(string $id, Context $context): AppEntity
     {
         $app = $this->appRepository->search(new Criteria([$id]), $context)->getEntities()->first();
-        \assert($app !== null);
+        if ($app === null) {
+            throw AppException::notFound($id);
+        }
 
         return $app;
-    }
-
-    private function loadAppByName(string $name, Context $context): ?AppEntity
-    {
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('name', $name));
-
-        return $this->appRepository->search($criteria, $context)->getEntities()->first();
-    }
-
-    private function getDefaultLocale(Context $context): string
-    {
-        $criteria = new Criteria([Defaults::LANGUAGE_SYSTEM]);
-        $criteria->addAssociation('translationCode');
-
-        $language = $this->languageRepository->search($criteria, $context)->getEntities()->first();
-        $locale = $language?->getTranslationCode();
-        \assert($locale !== null);
-
-        return $locale->getCode();
-    }
-
-    private function updateAclRole(string $appName, Context $context): void
-    {
-        $criteria = new Criteria();
-        $criteria->addFilter(new NotEqualsFilter('users.id', null));
-        $roles = $this->aclRoleRepository->search($criteria, $context)->getEntities();
-
-        $newPrivileges = [
-            'app.' . $appName,
-        ];
-        $dataUpdate = [];
-
-        foreach ($roles as $role) {
-            $currentPrivileges = $role->getPrivileges();
-
-            if (\in_array('app.all', $currentPrivileges, true)) {
-                $currentPrivileges = array_merge($currentPrivileges, $newPrivileges);
-                $currentPrivileges = array_unique($currentPrivileges);
-
-                $dataUpdate[] = [
-                    'id' => $role->getId(),
-                    'privileges' => $currentPrivileges,
-                ];
-            }
-        }
-
-        if ($dataUpdate !== []) {
-            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($dataUpdate): void {
-                $this->aclRoleRepository->update($dataUpdate, $context);
-            });
-        }
-    }
-
-    private function deleteAclRole(string $appName, Context $context): void
-    {
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('app.id', null));
-        $roles = $this->aclRoleRepository->search($criteria, $context)->getEntities();
-
-        $appPrivileges = 'app.' . $appName;
-        $dataUpdate = [];
-
-        foreach ($roles as $role) {
-            $currentPrivileges = $role->getPrivileges();
-
-            if (($key = array_search($appPrivileges, $currentPrivileges, true)) !== false) {
-                unset($currentPrivileges[$key]);
-
-                $dataUpdate[] = [
-                    'id' => $role->getId(),
-                    'privileges' => $currentPrivileges,
-                ];
-            }
-        }
-
-        if ($dataUpdate !== []) {
-            $this->aclRoleRepository->update($dataUpdate, $context);
-        }
-    }
-
-    private function updateCustomEntities(AppEntity $app, Manifest $manifest): void
-    {
-        $entities = $this->customEntityLifecycleService->updateApp($app)?->getEntities()?->getEntities();
-
-        foreach ($entities ?? [] as $entity) {
-            $manifest->addPermissions([
-                $entity->getName() => [
-                    AclRoleDefinition::PRIVILEGE_READ,
-                    AclRoleDefinition::PRIVILEGE_CREATE,
-                    AclRoleDefinition::PRIVILEGE_UPDATE,
-                    AclRoleDefinition::PRIVILEGE_DELETE,
-                ],
-            ]);
-        }
-    }
-
-    private function handleConfigUpdates(AppEntity $app, Manifest $manifest, bool $install): bool
-    {
-        $config = $this->getAppConfig($app);
-        if ($config === null) {
-            return false;
-        }
-
-        $configError = $this->configValidator->validate($manifest, null)->first();
-        if ($configError) {
-            // only one error can be in the returned collection
-            throw AppException::invalidConfiguration($manifest->getMetadata()->getName(), $configError);
-        }
-
-        $this->systemConfigService->saveConfig($config, $app->getName() . '.config.', $install);
-
-        return true;
-    }
-
-    private function getIcon(Manifest $manifest): ?string
-    {
-        if (!$iconPath = $manifest->getMetadata()->getIcon()) {
-            return null;
-        }
-
-        $fs = $this->sourceResolver->filesystemForManifest($manifest);
-
-        return $fs->has($iconPath) ? $fs->read($iconPath) : null;
-    }
-
-    private function runPersisters(AppLifecycleContext $context): void
-    {
-        foreach ($this->persisters as $persister) {
-            $persister->persist($context);
-        }
-    }
-
-    private function ensureMeetsRequirements(Manifest $manifest): void
-    {
-        $violations = $this->requirementsValidator->validate($manifest);
-        if (\count($violations) > 0) {
-            throw AppException::requirementsNotMet(...$violations);
-        }
     }
 }

--- a/src/Core/Framework/App/Lifecycle/AppManager.php
+++ b/src/Core/Framework/App/Lifecycle/AppManager.php
@@ -1,0 +1,542 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Lifecycle;
+
+use Composer\Semver\VersionParser;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
+use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
+use Shopware\Core\Framework\App\Event\AppActivatedEvent;
+use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
+use Shopware\Core\Framework\App\Event\AppDeletedEvent;
+use Shopware\Core\Framework\App\Event\AppInstalledEvent;
+use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
+use Shopware\Core\Framework\App\Event\Hooks\AppActivatedHook;
+use Shopware\Core\Framework\App\Event\Hooks\AppDeactivatedHook;
+use Shopware\Core\Framework\App\Event\Hooks\AppDeletedHook;
+use Shopware\Core\Framework\App\Event\Hooks\AppInstalledHook;
+use Shopware\Core\Framework\App\Event\Hooks\AppUpdatedHook;
+use Shopware\Core\Framework\App\Event\PostAppDeletedEvent;
+use Shopware\Core\Framework\App\Exception\AppRegistrationException;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
+use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
+use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
+use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Source\SourceResolver;
+use Shopware\Core\Framework\App\Validation\AppRequirementsValidator;
+use Shopware\Core\Framework\App\Validation\ConfigValidator;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\CustomEntity\CustomEntityLifecycleService;
+use Shopware\Core\System\Integration\IntegrationCollection;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\SystemConfig\Util\ConfigReader;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class AppManager
+{
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     * @param EntityRepository<LanguageCollection> $languageRepository
+     * @param EntityRepository<IntegrationCollection> $integrationRepository
+     * @param EntityRepository<AclRoleCollection> $aclRoleRepository
+     * @param iterable<PersisterInterface> $persisters
+     */
+    public function __construct(
+        private readonly iterable $persisters,
+        private readonly EntityRepository $appRepository,
+        private readonly PermissionLifecycleService $permissionLifecycle,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly AppRegistrationService $registrationService,
+        private readonly ActiveAppsLoader $activeAppsLoader,
+        private readonly EntityRepository $languageRepository,
+        private readonly SystemConfigService $systemConfigService,
+        private readonly ConfigValidator $configValidator,
+        private readonly EntityRepository $integrationRepository,
+        private readonly EntityRepository $aclRoleRepository,
+        private readonly AssetService $assetService,
+        private readonly ScriptExecutor $scriptExecutor,
+        private readonly string $projectDir,
+        private readonly CustomEntityLifecycleService $customEntityLifecycleService,
+        private readonly string $shopwareVersion,
+        private readonly AppFeatureValidator $appFeatureValidator,
+        private readonly SourceResolver $sourceResolver,
+        private readonly ConfigReader $configReader,
+        private readonly DeletedAppsGateway $deletedAppsGateway,
+        private readonly AppRequirementsValidator $requirementsValidator,
+    ) {
+    }
+
+    public function install(Manifest $manifest, AppInstallParameters $parameters, Context $context): void
+    {
+        $this->ensureIsCompatible($manifest);
+        $this->ensureMeetsRequirements($manifest);
+
+        $app = $this->loadAppByName($manifest->getMetadata()->getName(), $context);
+        if ($app) {
+            throw AppException::alreadyInstalled($manifest->getMetadata()->getName());
+        }
+
+        $defaultLocale = $this->getDefaultLocale($context);
+        $metadata = $manifest->getMetadata()->toArray($defaultLocale);
+        $appId = Uuid::randomHex();
+        $roleId = Uuid::randomHex();
+        $metadata = $this->enrichInstallMetadata($manifest, $metadata, $roleId);
+
+        $app = $this->persistApp(
+            $manifest,
+            new AppUpdateParameters(acceptPermissions: $parameters->acceptPermissions),
+            $metadata,
+            $appId,
+            $defaultLocale,
+            $context,
+            true
+        );
+
+        $event = new AppInstalledEvent($app, $manifest, $context);
+        $this->eventDispatcher->dispatch($event);
+        $this->scriptExecutor->execute(new AppInstalledHook($event));
+
+        if ($parameters->activate) {
+            $this->activate($app, $context);
+        }
+
+        $this->updateAclRole($app->getName(), $context);
+    }
+
+    public function update(Manifest $manifest, AppUpdateParameters $parameters, AppEntity $app, Context $context): void
+    {
+        $this->ensureIsCompatible($manifest);
+        $this->ensureMeetsRequirements($manifest);
+
+        $defaultLocale = $this->getDefaultLocale($context);
+        $metadata = $manifest->getMetadata()->toArray($defaultLocale);
+        $appEntity = $this->persistApp(
+            $manifest,
+            $parameters,
+            $metadata,
+            $app->getId(),
+            $defaultLocale,
+            $context,
+            false
+        );
+
+        $event = new AppUpdatedEvent($appEntity, $manifest, $context);
+        $this->eventDispatcher->dispatch($event);
+        $this->scriptExecutor->execute(new AppUpdatedHook($event));
+    }
+
+    public function delete(AppEntity $app, Context $context, bool $keepUserData = false): void
+    {
+        $canRemoveAppData = !$keepUserData || $this->customEntityLifecycleService->canRemoveAppData($app);
+        if ($app->isActive()) {
+            $this->deactivate($app, $context, $canRemoveAppData);
+        }
+
+        $this->removeAppData($app, $context, $keepUserData, true);
+        $this->assetService->removeAssets($app->getName());
+
+        $event = new PostAppDeletedEvent($app->getName(), $app->getSourceType(), $context, $keepUserData);
+        $this->eventDispatcher->dispatch($event);
+    }
+
+    public function activate(AppEntity $app, Context $context): void
+    {
+        if ($app->isActive()) {
+            return;
+        }
+
+        $this->appRepository->update([['id' => $app->getId(), 'active' => true]], $context);
+        // manually set active flag to true, so we don't need to re-fetch the app from DB
+        $app->setActive(true);
+        $this->runPersisters(static fn (PersisterInterface $persister) => $persister->activate($app, $context));
+
+        $this->activeAppsLoader->reset();
+
+        $event = new AppActivatedEvent($app, $context);
+        $this->eventDispatcher->dispatch($event);
+        $this->scriptExecutor->execute(new AppActivatedHook($event));
+    }
+
+    public function deactivate(AppEntity $app, Context $context, bool $deactivateForDeletion = false): void
+    {
+        if (!$app->isActive()) {
+            return;
+        }
+        if (!$deactivateForDeletion && !$app->getAllowDisable()) {
+            throw AppException::restrictDeletePreventsDeactivation($app->getName());
+        }
+
+        // throw event before deactivating app in db as theme configs from the app need to be removed beforehand
+        $event = new AppDeactivatedEvent($app, $context);
+        $this->eventDispatcher->dispatch($event);
+        $this->scriptExecutor->execute(new AppDeactivatedHook($event));
+
+        $this->appRepository->update([['id' => $app->getId(), 'active' => false]], $context);
+        $app->setActive(false);
+        $this->runPersisters(static fn (PersisterInterface $persister) => $persister->deactivate($app, $context));
+
+        // reset only after new state is in the DB
+        $this->activeAppsLoader->reset();
+    }
+
+    private function ensureIsCompatible(Manifest $manifest): void
+    {
+        $versionParser = new VersionParser();
+        if (!$manifest->getMetadata()->getCompatibility()->matches($versionParser->parseConstraints($this->shopwareVersion))) {
+            throw AppException::notCompatible($manifest->getMetadata()->getName());
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function persistApp(
+        Manifest $manifest,
+        AppUpdateParameters $parameters,
+        array $metadata,
+        string $id,
+        string $defaultLocale,
+        Context $context,
+        bool $install
+    ): AppEntity {
+        // accessToken is not set on update, but in that case we don't run registration, so we won't need it
+        $secretAccessKey = $metadata['accessToken'] ?? '';
+        unset($metadata['accessToken'], $metadata['icon']);
+        $metadata['path'] = str_replace($this->projectDir . '/', '', $manifest->getPath());
+        $metadata['id'] = $id;
+        $metadata['modules'] = [];
+        $metadata['iconRaw'] = $this->getIcon($manifest);
+        $metadata['cookies'] = $manifest->getCookies() !== null ? $manifest->getCookies()->getCookies() : [];
+        $metadata['baseAppUrl'] = $manifest->getAdmin()?->getBaseAppUrl();
+        $metadata['allowedHosts'] = $manifest->getAllHosts();
+        $metadata['templateLoadPriority'] = $manifest->getStorefront() ? $manifest->getStorefront()->getTemplateLoadPriority() : 0;
+        $metadata['checkoutGatewayUrl'] = $manifest->getGateways()?->getCheckout()?->getUrl();
+        $metadata['contextGatewayUrl'] = $manifest->getGateways()?->getContext()?->getUrl();
+        $metadata['sourceType'] = $manifest->getSourceType() ?? $this->sourceResolver->resolveSourceType($manifest);
+        $metadata['sourceConfig'] = $manifest->getSourceConfig();
+        $metadata['inAppPurchasesGatewayUrl'] = $manifest->getGateways()?->getInAppPurchasesGateway()?->getUrl();
+
+        $this->updateMetadata($metadata, $context);
+
+        $app = $this->loadApp($id, $context);
+
+        $this->updateCustomEntities($app, $manifest);
+
+        $this->permissionLifecycle->updatePrivileges(
+            $manifest->getPermissions(),
+            $id,
+            $manifest->validatesPermissions() === false && $parameters->acceptPermissions,
+            $context
+        );
+
+        // If the app has no secret yet, but now specifies setup data we do a registration to get an app secret
+        // this mostly happens during install, but may happen in the update case if the app previously worked without an external server
+        // additionally during install it might happen that we still have an old secret stored for the app from a previous installation
+        // in that case we still need to run the registration to rotate that secret
+        if ((!$app->getAppSecret() || $install) && $manifest->getSetup()) {
+            try {
+                $this->registrationService->registerApp($manifest, $id, $secretAccessKey, $context);
+            } catch (AppRegistrationException $e) {
+                $this->removeAppData($app, $context);
+
+                throw $e;
+            }
+        }
+
+        // Refetch app to get secret after registration
+        $app = $this->loadApp($id, $context);
+
+        try {
+            $this->appFeatureValidator->validate($app, $manifest);
+        } catch (AppException $e) {
+            $this->removeAppData($app, $context);
+
+            throw $e;
+        }
+
+        $appLifecycleContext = new AppLifecycleContext(
+            manifest: $manifest,
+            app: $app,
+            context: $context,
+            appFilesystem: $this->sourceResolver->filesystemForManifest($manifest),
+            defaultLocale: $defaultLocale,
+            isInstall: $install,
+        );
+
+        $this->runPersisters(static fn (PersisterInterface $persister) => $persister->persist($appLifecycleContext));
+
+        $this->assetService->copyAssetsFromApp($app->getName(), $app->getPath());
+
+        $updatePayload = [
+            'id' => $app->getId(),
+            'configurable' => $this->handleConfigUpdates($app, $manifest, $install),
+            'allowDisable' => $this->customEntityLifecycleService->allowsDisabling($app),
+        ];
+        $this->updateMetadata($updatePayload, $context);
+
+        return $app;
+    }
+
+    /**
+     * @return array<array<string, mixed>>|null
+     */
+    private function getAppConfig(AppEntity $app): ?array
+    {
+        $fs = $this->sourceResolver->filesystemForApp($app);
+
+        if (!$fs->has('Resources/config/config.xml')) {
+            return null;
+        }
+
+        return $this->configReader->read($fs->path('Resources/config/config.xml'));
+    }
+
+    private function removeAppData(AppEntity $app, Context $context, bool $keepUserData = false, bool $softDelete = false): void
+    {
+        // throw event before deleting app from db as it may be delivered via webhook to the deleted app
+        $event = new AppDeletedEvent($app->getId(), $context, $keepUserData);
+        $this->eventDispatcher->dispatch($event);
+        $this->scriptExecutor->execute(new AppDeletedHook($event));
+
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($app, $softDelete, $keepUserData): void {
+            if (!$keepUserData) {
+                $config = $this->getAppConfig($app);
+
+                if ($config) {
+                    $this->systemConfigService->deleteExtensionConfiguration($app->getName(), $config);
+                }
+            }
+
+            $this->customEntityLifecycleService->removeApp($app, $context, $keepUserData);
+
+            $this->appRepository->delete([['id' => $app->getId()]], $context);
+
+            if ($softDelete) {
+                $this->integrationRepository->update([[
+                    'id' => $app->getIntegrationId(),
+                    'deletedAt' => new \DateTimeImmutable(),
+                ]], $context);
+                $this->permissionLifecycle->softDeleteRole($app->getAclRoleId());
+            } else {
+                $this->integrationRepository->delete([['id' => $app->getIntegrationId()]], $context);
+                $this->permissionLifecycle->removeRole($app->getAclRoleId());
+            }
+
+            $this->deleteAclRole($app->getName(), $context);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function updateMetadata(array $metadata, Context $context): void
+    {
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($metadata): void {
+            $this->appRepository->upsert([$metadata], $context);
+        });
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return array<string, mixed>
+     */
+    private function enrichInstallMetadata(Manifest $manifest, array $metadata, string $roleId): array
+    {
+        $secret = AccessKeyHelper::generateSecretAccessKey();
+        $appName = $manifest->getMetadata()->getName();
+
+        $metadata['integration'] = [
+            'label' => $appName,
+            'accessKey' => AccessKeyHelper::generateAccessKey('integration'),
+            'secretAccessKey' => $secret,
+            'admin' => false,
+        ];
+
+        $metadata['aclRole'] = [
+            'id' => $roleId,
+            'name' => $appName,
+        ];
+        $metadata['accessToken'] = $secret;
+        // Always install as inactive, activation will be handled by `AppManager` in `install()` method.
+        $metadata['active'] = false;
+        // when the app was installed before and we have the old secret stored, we set it here
+        // so the registration is signed correctly with the old secret
+        $oldSecret = $this->deletedAppsGateway->getDeletedAppSecret($appName);
+        if ($oldSecret !== null) {
+            $metadata['appSecret'] = $oldSecret;
+        }
+
+        return $metadata;
+    }
+
+    private function loadApp(string $id, Context $context): AppEntity
+    {
+        $app = $this->appRepository->search(new Criteria([$id]), $context)->getEntities()->first();
+        \assert($app !== null);
+
+        return $app;
+    }
+
+    private function loadAppByName(string $name, Context $context): ?AppEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+
+        return $this->appRepository->search($criteria, $context)->getEntities()->first();
+    }
+
+    private function getDefaultLocale(Context $context): string
+    {
+        $criteria = new Criteria([Defaults::LANGUAGE_SYSTEM]);
+        $criteria->addAssociation('translationCode');
+
+        $language = $this->languageRepository->search($criteria, $context)->getEntities()->first();
+        $locale = $language?->getTranslationCode();
+        \assert($locale !== null);
+
+        return $locale->getCode();
+    }
+
+    private function updateAclRole(string $appName, Context $context): void
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new NotEqualsFilter('users.id', null));
+        $roles = $this->aclRoleRepository->search($criteria, $context)->getEntities();
+
+        $newPrivileges = [
+            'app.' . $appName,
+        ];
+        $dataUpdate = [];
+
+        foreach ($roles as $role) {
+            $currentPrivileges = $role->getPrivileges();
+
+            if (\in_array('app.all', $currentPrivileges, true)) {
+                $currentPrivileges = array_merge($currentPrivileges, $newPrivileges);
+                $currentPrivileges = array_unique($currentPrivileges);
+
+                $dataUpdate[] = [
+                    'id' => $role->getId(),
+                    'privileges' => $currentPrivileges,
+                ];
+            }
+        }
+
+        if ($dataUpdate !== []) {
+            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($dataUpdate): void {
+                $this->aclRoleRepository->update($dataUpdate, $context);
+            });
+        }
+    }
+
+    private function deleteAclRole(string $appName, Context $context): void
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('app.id', null));
+        $roles = $this->aclRoleRepository->search($criteria, $context)->getEntities();
+
+        $appPrivileges = 'app.' . $appName;
+        $dataUpdate = [];
+
+        foreach ($roles as $role) {
+            $currentPrivileges = $role->getPrivileges();
+
+            if (($key = array_search($appPrivileges, $currentPrivileges, true)) !== false) {
+                unset($currentPrivileges[$key]);
+
+                $dataUpdate[] = [
+                    'id' => $role->getId(),
+                    'privileges' => $currentPrivileges,
+                ];
+            }
+        }
+
+        if ($dataUpdate !== []) {
+            $this->aclRoleRepository->update($dataUpdate, $context);
+        }
+    }
+
+    private function updateCustomEntities(AppEntity $app, Manifest $manifest): void
+    {
+        $entities = $this->customEntityLifecycleService->updateApp($app)?->getEntities()?->getEntities();
+
+        foreach ($entities ?? [] as $entity) {
+            $manifest->addPermissions([
+                $entity->getName() => [
+                    AclRoleDefinition::PRIVILEGE_READ,
+                    AclRoleDefinition::PRIVILEGE_CREATE,
+                    AclRoleDefinition::PRIVILEGE_UPDATE,
+                    AclRoleDefinition::PRIVILEGE_DELETE,
+                ],
+            ]);
+        }
+    }
+
+    private function handleConfigUpdates(AppEntity $app, Manifest $manifest, bool $install): bool
+    {
+        $config = $this->getAppConfig($app);
+        if ($config === null) {
+            return false;
+        }
+
+        $configError = $this->configValidator->validate($manifest, null)->first();
+        if ($configError) {
+            // only one error can be in the returned collection
+            throw AppException::invalidConfiguration($manifest->getMetadata()->getName(), $configError);
+        }
+
+        $this->systemConfigService->saveConfig($config, $app->getName() . '.config.', $install);
+
+        return true;
+    }
+
+    private function getIcon(Manifest $manifest): ?string
+    {
+        if (!$iconPath = $manifest->getMetadata()->getIcon()) {
+            return null;
+        }
+
+        $fs = $this->sourceResolver->filesystemForManifest($manifest);
+
+        return $fs->has($iconPath) ? $fs->read($iconPath) : null;
+    }
+
+    /**
+     * @param callable(PersisterInterface): void $callback
+     */
+    private function runPersisters(callable $callback): void
+    {
+        foreach ($this->persisters as $persister) {
+            $callback($persister);
+        }
+    }
+
+    private function ensureMeetsRequirements(Manifest $manifest): void
+    {
+        $violations = $this->requirementsValidator->validate($manifest);
+        if (\count($violations) > 0) {
+            throw AppException::requirementsNotMet(...$violations);
+        }
+    }
+}

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -184,11 +184,8 @@
         </service>
 
         <service id="Shopware\Core\Framework\App\AppStateService">
+            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppManager"/>
             <argument type="service" id="app.repository"/>
-            <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Shopware\Core\Framework\App\ActiveAppsLoader"/>
-            <argument type="service" id="Shopware\Core\Framework\Script\Execution\ScriptExecutor"/>
-            <argument type="tagged_iterator" tag="shopware.app_lifecycle.persister"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper" public="true">
@@ -284,6 +281,10 @@
             <argument type="service" id="Shopware\Core\Framework\App\Manifest\ManifestFactory"/>
         </service>
 
+        <service id="Shopware\Core\Framework\App\Lifecycle\AppFeatureValidator">
+            <argument>%kernel.environment%</argument>
+        </service>
+
         <service id="Shopware\Core\Framework\App\Lifecycle\Registration\HandshakeFactory">
             <argument type="string">%env(APP_URL)%</argument>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
@@ -291,17 +292,13 @@
             <argument>%kernel.shopware_version%</argument>
         </service>
 
-        <service id="Shopware\Core\Framework\App\Lifecycle\AppFeatureValidator">
-            <argument>%kernel.environment%</argument>
-        </service>
-
-        <service id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle">
+        <service id="Shopware\Core\Framework\App\Lifecycle\AppManager">
             <argument type="tagged_iterator" tag="shopware.app_lifecycle.persister"/>
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService"/>
-            <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
+            <argument type="service" id="Shopware\Core\Framework\App\ActiveAppsLoader"/>
             <argument type="service" id="language.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Framework\App\Validation\ConfigValidator"/>
@@ -317,6 +314,11 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\Util\ConfigReader"/>
             <argument type="service" id="Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway"/>
             <argument type="service" id="Shopware\Core\Framework\App\Validation\AppRequirementsValidator"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle">
+            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppManager"/>
+            <argument type="service" id="app.repository"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Lifecycle\AppLifecycleIterator">

--- a/src/Core/Framework/DependencyInjection/app_test.xml
+++ b/src/Core/Framework/DependencyInjection/app_test.xml
@@ -5,34 +5,6 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd http://symfony.com/schema/dic/monolog http://symfony.com/schema/dic/monolog/monolog-1.0.xsd">
 
     <services>
-        <service id="app-feature-validator-dev" class="Shopware\Core\Framework\App\Lifecycle\AppFeatureValidator">
-            <argument>dev</argument>
-        </service>
-
-        <service id="app-life-cycle-dev" public="true" class="Shopware\Core\Framework\App\Lifecycle\AppLifecycle">
-            <argument type="tagged_iterator" tag="shopware.app_lifecycle.persister"/>
-            <argument type="service" id="app.repository"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService"/>
-            <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService"/>
-            <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
-            <argument type="service" id="language.repository"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Validation\ConfigValidator"/>
-            <argument type="service" id="integration.repository"/>
-            <argument type="service" id="acl_role.repository"/>
-            <argument type="service" id="Shopware\Core\Framework\Plugin\Util\AssetService"/>
-            <argument type="service" id="Shopware\Core\Framework\Script\Execution\ScriptExecutor"/>
-            <argument type="string">%kernel.project_dir%</argument>
-            <argument type="service" id="Shopware\Core\System\CustomEntity\CustomEntityLifecycleService"/>
-            <argument>%kernel.shopware_version%</argument>
-            <argument type="service" id="app-feature-validator-dev"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Source\SourceResolver"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\Util\ConfigReader"/>
-            <argument type="service" id="Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Validation\AppRequirementsValidator"/>
-        </service>
-
         <service id="Shopware\Core\Framework\App\Source\SourceResolver">
             <argument type="tagged_iterator" tag="app.source_resolver" />
             <argument type="service" id="app.repository"/>

--- a/src/Core/Test/Stub/EventDispatcher/CollectingEventDispatcher.php
+++ b/src/Core/Test/Stub/EventDispatcher/CollectingEventDispatcher.php
@@ -39,6 +39,18 @@ class CollectingEventDispatcher implements EventDispatcherInterface
         return $this->events;
     }
 
+    /**
+     * @template TEvent of object
+     *
+     * @param class-string<TEvent> $eventClass
+     *
+     * @return list<TEvent>
+     */
+    public function getEventsOfClass(string $eventClass): array
+    {
+        return array_values(array_filter($this->events, static fn (object $event): bool => $event instanceof $eventClass));
+    }
+
     public function addListener(string $eventName, callable $listener, int $priority = 0): void
     {
         if (!isset($this->listeners[$eventName])) {

--- a/tests/integration/Core/Framework/App/Command/DeactivateAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/DeactivateAppCommandTest.php
@@ -31,7 +31,7 @@ class DeactivateAppCommandTest extends TestCase
         $this->appRepository = static::getContainer()->get('app.repository');
     }
 
-    public function testDeactivateApp(): void
+    public function testDeactivate(): void
     {
         $this->loadAppsFromDir(__DIR__ . '/_fixtures/withoutPermissions');
         $appName = 'withoutPermissions';

--- a/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
@@ -26,8 +26,7 @@ use Shopware\Core\Framework\App\Event\Hooks\AppDeletedHook;
 use Shopware\Core\Framework\App\Event\Hooks\AppInstalledHook;
 use Shopware\Core\Framework\App\Event\Hooks\AppUpdatedHook;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
-use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
-use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
 use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
@@ -54,11 +53,11 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
-class AppLifecycleTest extends TestCase
+class AppManagerTest extends TestCase
 {
     use GuzzleTestClientBehaviour;
 
-    private AbstractAppLifecycle $appLifecycle;
+    private AppManager $appManager;
 
     /**
      * @var EntityRepository<AppCollection>
@@ -81,7 +80,7 @@ class AppLifecycleTest extends TestCase
         $this->appRepository = static::getContainer()->get('app.repository');
         $this->actionButtonRepository = static::getContainer()->get('app_action_button.repository');
 
-        $this->appLifecycle = static::getContainer()->get(AppLifecycle::class);
+        $this->appManager = static::getContainer()->get(AppManager::class);
 
         $userId = static::getContainer()->get('user.repository')->searchIds(new Criteria(), Context::createDefaultContext())->firstId();
         $source = new AdminApiSource($userId);
@@ -109,7 +108,7 @@ class AppLifecycleTest extends TestCase
         };
         $this->eventDispatcher->addListener(AppInstalledEvent::class, $onAppInstalled);
 
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppInstalledHook::HOOK_NAME, $traces);
@@ -171,7 +170,7 @@ class AppLifecycleTest extends TestCase
         $wasThrown = false;
 
         try {
-            $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+            $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
         } catch (AppRegistrationException) {
             $wasThrown = true;
         }
@@ -185,7 +184,7 @@ class AppLifecycleTest extends TestCase
     public function testInstallMinimalManifest(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/minimal/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -198,7 +197,7 @@ class AppLifecycleTest extends TestCase
     public function testInstallOnlyCallsAppLifecycleScriptsForAffectedApps(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppInstalledHook::HOOK_NAME, $traces);
@@ -206,7 +205,7 @@ class AppLifecycleTest extends TestCase
         static::assertSame('installed', $traces[AppInstalledHook::HOOK_NAME][0]['output'][0]);
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/minimal/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppInstalledHook::HOOK_NAME, $traces);
@@ -216,7 +215,7 @@ class AppLifecycleTest extends TestCase
     public function testInstallWithoutDescription(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/withoutDescription/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -233,7 +232,7 @@ class AppLifecycleTest extends TestCase
         $this->setNewSystemLanguage('en-GB');
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
 
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -247,7 +246,7 @@ class AppLifecycleTest extends TestCase
     public function testInstallSavesConfig(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/withConfig/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -268,16 +267,16 @@ class AppLifecycleTest extends TestCase
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/withInvalidConfig/manifest.xml');
 
         $this->expectExceptionObject(AppException::invalidConfiguration('withInvalidConfig', new ConfigurationError(['test'])));
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
     }
 
     public function testInstallThrowsIfAppIsAlreadyInstalled(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/withoutDescription/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $this->expectExceptionObject(AppException::alreadyInstalled($manifest->getMetadata()->getName()));
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
     }
 
     public function testUpdateInactiveApp(): void
@@ -402,7 +401,7 @@ class AppLifecycleTest extends TestCase
         };
         $this->eventDispatcher->addListener(AppUpdatedEvent::class, $onAppUpdated);
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppUpdatedHook::HOOK_NAME, $traces);
@@ -561,7 +560,7 @@ class AppLifecycleTest extends TestCase
         };
         $this->eventDispatcher->addListener(AppUpdatedEvent::class, $onAppUpdated);
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppUpdatedHook::HOOK_NAME, $traces);
@@ -650,7 +649,7 @@ class AppLifecycleTest extends TestCase
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         static::assertTrue($this->didRegisterApp());
 
@@ -708,7 +707,7 @@ class AppLifecycleTest extends TestCase
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/withConfig/manifest.xml');
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
         static::assertSame([
@@ -757,7 +756,7 @@ class AppLifecycleTest extends TestCase
         $systemConfigService = static::getContainer()->get(SystemConfigService::class);
         $systemConfigService->set('withConfig.config.email', 'my-shop@test.com');
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         static::assertSame([
             'withConfig.config.email' => 'my-shop@test.com',
@@ -796,7 +795,7 @@ class AppLifecycleTest extends TestCase
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -841,7 +840,7 @@ class AppLifecycleTest extends TestCase
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/minimal/manifest.xml');
 
-        $this->appLifecycle->update($manifest, new AppUpdateParameters(), $app, $this->context);
+        $this->appManager->update($manifest, new AppUpdateParameters(), $this->loadApp($app['id']), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -906,7 +905,7 @@ class AppLifecycleTest extends TestCase
         };
         $this->eventDispatcher->addListener(AppDeletedEvent::class, $onAppDeleted);
 
-        $this->appLifecycle->delete('Test', $app, $this->context);
+        $this->appManager->delete($this->loadApp($app['id']), $this->context);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
         static::assertArrayHasKey(AppDeletedHook::HOOK_NAME, $traces);
@@ -933,7 +932,7 @@ class AppLifecycleTest extends TestCase
     public function testDeleteRemovesInstalledAppAssets(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
         static::assertCount(1, $apps);
@@ -943,9 +942,7 @@ class AppLifecycleTest extends TestCase
         $app = $apps->first();
         static::assertNotNull($app);
 
-        $this->appLifecycle->delete('test', [
-            'id' => $app->getId(),
-        ], $this->context);
+        $this->appManager->delete($app, $this->context);
 
         $apps = $this->appRepository->searchIds(new Criteria(), $this->context)->getIds();
         static::assertCount(0, $apps);
@@ -956,7 +953,7 @@ class AppLifecycleTest extends TestCase
     public function testDeleteAppDeletesConfigWhenUserDataShouldNotBeKept(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/withConfig/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -970,7 +967,7 @@ class AppLifecycleTest extends TestCase
             'withConfig.config.email' => 'no-reply@shopware.de',
         ], $systemConfigService->getDomain('withConfig.config'));
 
-        $this->appLifecycle->delete('withConfig', ['id' => $appEntity->getId()], $this->context);
+        $this->appManager->delete($appEntity, $this->context);
 
         static::assertSame([], $systemConfigService->getDomain('withConfig.config'));
     }
@@ -978,7 +975,7 @@ class AppLifecycleTest extends TestCase
     public function testDeleteAppDoesNotDeleteConfigWhenUserDataShouldBeKept(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/withConfig/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -992,7 +989,7 @@ class AppLifecycleTest extends TestCase
             'withConfig.config.email' => 'no-reply@shopware.de',
         ], $systemConfigService->getDomain('withConfig.config'));
 
-        $this->appLifecycle->delete('withConfig', ['id' => $appEntity->getId()], $this->context, true);
+        $this->appManager->delete($appEntity, $this->context, true);
 
         static::assertSame([
             'withConfig.config.email' => 'no-reply@shopware.de',
@@ -1012,7 +1009,7 @@ class AppLifecycleTest extends TestCase
 
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
 
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $criteria = new Criteria();
         $criteria->addAssociation('integration');
@@ -1038,7 +1035,7 @@ class AppLifecycleTest extends TestCase
     public function testDeleteWithDeleteAclRole(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
         static::assertCount(1, $apps);
@@ -1049,9 +1046,7 @@ class AppLifecycleTest extends TestCase
         $appPrivilege = 'app.' . $app->getName();
         $this->createAclRole($aclRoleId, [$appPrivilege]);
 
-        $this->appLifecycle->delete('test', [
-            'id' => $app->getId(),
-        ], $this->context);
+        $this->appManager->delete($app, $this->context);
 
         $apps = $this->appRepository->searchIds(new Criteria(), $this->context)->getIds();
         static::assertCount(0, $apps);
@@ -1067,7 +1062,7 @@ class AppLifecycleTest extends TestCase
     public function testInstallWithAllowedHosts(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/_fixtures/withAllowedHosts/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -1086,7 +1081,7 @@ class AppLifecycleTest extends TestCase
     public function testUninstallFlowEventUsedInFlowBuilder(): void
     {
         $manifest = Manifest::createFromXmlFile(__DIR__ . '/../Manifest/_fixtures/test/manifest.xml');
-        $this->appLifecycle->install($manifest, new AppInstallParameters(), $this->context);
+        $this->appManager->install($manifest, new AppInstallParameters(), $this->context);
 
         $appId = $this->getAppId();
         static::assertIsString($appId);
@@ -1110,7 +1105,7 @@ class AppLifecycleTest extends TestCase
             'id' => $appId,
         ];
 
-        $this->appLifecycle->delete('test', $app, $this->context);
+        $this->appManager->delete($this->loadApp($app['id']), $this->context);
 
         $flow = $this->getAppFlowEventFromFlow($flowEvents[0]['id']);
         static::assertNull($flow);
@@ -1330,6 +1325,7 @@ class AppLifecycleTest extends TestCase
         static::assertCount(1, $cachedScripts['product-page-loaded']);
         static::assertInstanceOf(Script::class, $cachedScripts['product-page-loaded'][0]);
         static::assertSame($script->getName(), $cachedScripts['product-page-loaded'][0]->getName());
+        static::assertSame($active, $cachedScripts['product-page-loaded'][0]->isActive());
     }
 
     private function assertDefaultPaymentMethods(string $appId): void
@@ -1589,6 +1585,14 @@ class AppLifecycleTest extends TestCase
             'tax-provider.app',
             'tax-provider-2.app',
         ], $app->getAllowedHosts());
+    }
+
+    private function loadApp(string $id): AppEntity
+    {
+        $app = $this->appRepository->search(new Criteria([$id]), $this->context)->getEntities()->first();
+        \assert($app instanceof AppEntity);
+
+        return $app;
     }
 
     /**

--- a/tests/unit/Core/Framework/App/AppFixture.php
+++ b/tests/unit/Core/Framework/App/AppFixture.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\Locale\LocaleEntity;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\Framework\Util\StaticFilesystem;
 
@@ -23,13 +26,18 @@ final class AppFixture
     {
     }
 
-    public static function createAppEntity(string $name = 'testApp', ?string $id = null): AppEntity
+    public static function createAppEntity(string $name = 'testApp', ?string $id = null, bool $active = true, bool $allowDisable = true): AppEntity
     {
         $app = new AppEntity();
         $app->setId($id ?? Uuid::randomHex());
         $app->setName($name);
         $app->setPath($name);
-        $app->setActive(true);
+        $app->setActive($active);
+        $app->setAllowDisable($allowDisable);
+        $app->setVersion('1.0.0');
+        $app->setIntegrationId('integration-id');
+        $app->setAclRoleId('acl-role-id');
+        $app->setSourceType('static');
 
         return $app;
     }
@@ -41,6 +49,26 @@ final class AppFixture
     {
         /** @var StaticEntityRepository<AppCollection> $repository */
         $repository = new StaticEntityRepository([new AppCollection($apps)]);
+
+        return $repository;
+    }
+
+    /**
+     * @return StaticEntityRepository<LanguageCollection>
+     */
+    public static function createLanguageRepository(string $locale = 'en-GB'): StaticEntityRepository
+    {
+        $localeEntity = new LocaleEntity();
+        $localeEntity->assign(['code' => $locale]);
+
+        $languageEntity = new LanguageEntity();
+        $languageEntity->assign([
+            'id' => 'language-id',
+            'translationCode' => $localeEntity,
+        ]);
+
+        /** @var StaticEntityRepository<LanguageCollection> $repository */
+        $repository = new StaticEntityRepository([new LanguageCollection([$languageEntity])]);
 
         return $repository;
     }

--- a/tests/unit/Core/Framework/App/AppStateServiceTest.php
+++ b/tests/unit/Core/Framework/App/AppStateServiceTest.php
@@ -4,17 +4,12 @@ namespace Shopware\Tests\Unit\Core\Framework\App;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\Exception\AppNotFoundException;
-use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -22,142 +17,40 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(AppStateService::class)]
 class AppStateServiceTest extends TestCase
 {
-    public function testActivateThrowsIfAppDoesNotExist(): void
-    {
-        $this->expectException(AppNotFoundException::class);
-
-        $this->buildService($this->buildAppRepository(), [])
-            ->activateApp('missing-app', Context::createDefaultContext());
-    }
-
-    public function testDeactivateThrowsIfAppDoesNotExist(): void
-    {
-        $this->expectException(AppNotFoundException::class);
-
-        $this->buildService($this->buildAppRepository(), [])
-            ->deactivateApp('missing-app', Context::createDefaultContext());
-    }
-
-    public function testActivateUpdatesAppAndPersisters(): void
+    public function testDelegatesToAppManager(): void
     {
         $context = Context::createDefaultContext();
-        $app = $this->buildApp(active: false);
-        $appRepository = $this->buildAppRepository($app);
+        $activateApp = AppFixture::createAppEntity(id: 'activate-app-id');
+        $deactivateApp = AppFixture::createAppEntity(id: 'deactivate-app-id');
+        /** @var StaticEntityRepository<AppCollection> $appRepository */
+        $appRepository = new StaticEntityRepository([
+            new AppCollection([$activateApp]),
+            new AppCollection([$deactivateApp]),
+        ]);
 
-        $persister = $this->createMock(PersisterInterface::class);
-        $persister->expects($this->once())
+        $appManager = $this->createMock(AppManager::class);
+        $appManager->expects($this->once())
             ->method('activate')
-            ->with($app, $context);
+            ->with($activateApp, $context);
 
-        $activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
-        $activeAppsLoader->expects($this->once())->method('reset');
-
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher->expects($this->once())
-            ->method('dispatch')
-            ->willReturnArgument(0);
-
-        $scriptExecutor = $this->createMock(ScriptExecutor::class);
-        $scriptExecutor->expects($this->once())->method('execute');
-
-        $appStateService = new AppStateService(
-            $appRepository,
-            $eventDispatcher,
-            $activeAppsLoader,
-            $scriptExecutor,
-            [$persister],
-        );
-
-        $appStateService->activateApp($app->getId(), $context);
-
-        static::assertTrue($app->isActive());
-        static::assertSame([
-            ['id' => $app->getId(), 'active' => true],
-        ], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
-    }
-
-    public function testDeactivateUpdatesAppAndPersisters(): void
-    {
-        $context = Context::createDefaultContext();
-        $app = $this->buildApp(active: true);
-        $appRepository = $this->buildAppRepository($app);
-
-        $persister = $this->createMock(PersisterInterface::class);
-        $persister->expects($this->once())
+        $appManager->expects($this->once())
             ->method('deactivate')
-            ->with($app, $context);
+            ->with($deactivateApp, $context, true);
 
-        $activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
-        $activeAppsLoader->expects($this->once())->method('reset');
+        $appStateService = new AppStateService($appManager, $appRepository);
+        $appStateService->activateApp('activate-app-id', $context);
+        $appStateService->deactivateApp('deactivate-app-id', $context, true);
+    }
 
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher->expects($this->once())
-            ->method('dispatch')
-            ->willReturnArgument(0);
-
-        $scriptExecutor = $this->createMock(ScriptExecutor::class);
-        $scriptExecutor->expects($this->once())->method('execute');
-
+    public function testThrowsIfAppDoesNotExist(): void
+    {
         $appStateService = new AppStateService(
-            $appRepository,
-            $eventDispatcher,
-            $activeAppsLoader,
-            $scriptExecutor,
-            [$persister],
+            $this->createMock(AppManager::class),
+            AppFixture::createAppRepository(),
         );
 
-        $appStateService->deactivateApp($app->getId(), $context);
+        $this->expectExceptionObject(AppException::notFound('missing-app-id'));
 
-        static::assertFalse($app->isActive());
-        static::assertSame([
-            ['id' => $app->getId(), 'active' => false],
-        ], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
-    }
-
-    public function testDeactivateThrowsIfDisableIsNotAllowed(): void
-    {
-        $app = $this->buildApp(active: true, allowDisable: false);
-
-        $this->expectException(AppException::class);
-
-        $this->buildService($this->buildAppRepository($app), [])
-            ->deactivateApp($app->getId(), Context::createDefaultContext());
-    }
-
-    /**
-     * @param StaticEntityRepository<AppCollection> $appRepository
-     * @param list<PersisterInterface> $persisters
-     */
-    private function buildService(StaticEntityRepository $appRepository, array $persisters): AppStateService
-    {
-        return new AppStateService(
-            $appRepository,
-            $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(ActiveAppsLoader::class),
-            $this->createMock(ScriptExecutor::class),
-            $persisters,
-        );
-    }
-
-    private function buildApp(bool $active, bool $allowDisable = true): AppEntity
-    {
-        $app = new AppEntity();
-        $app->setId('test-app');
-        $app->setName('Test app');
-        $app->setActive($active);
-        $app->setAllowDisable($allowDisable);
-
-        return $app;
-    }
-
-    /**
-     * @return StaticEntityRepository<AppCollection>
-     */
-    private function buildAppRepository(AppEntity ...$apps): StaticEntityRepository
-    {
-        /** @var StaticEntityRepository<AppCollection> $repository */
-        $repository = new StaticEntityRepository([new AppCollection($apps)]);
-
-        return $repository;
+        $appStateService->activateApp('missing-app-id', Context::createDefaultContext());
     }
 }

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -4,517 +4,85 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Administration\Snippet\AppAdministrationSnippetPersister;
-use Shopware\Administration\Snippet\AppLifecycleSubscriber;
-use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
-use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
-use Shopware\Core\Framework\App\Event\AppInstalledEvent;
-use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
-use Shopware\Core\Framework\App\Lifecycle\AppFeatureValidator;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
-use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
-use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
-use Shopware\Core\Framework\App\Manifest\Manifest;
-use Shopware\Core\Framework\App\Validation\AppRequirementsValidator;
-use Shopware\Core\Framework\App\Validation\ConfigValidator;
-use Shopware\Core\Framework\App\Validation\Requirements\UnmetRequirement;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\Plugin\Util\AssetService;
-use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
-use Shopware\Core\Framework\Test\TestCaseBase\EventDispatcherBehaviour;
-use Shopware\Core\Framework\Util\Filesystem;
-use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\CustomEntity\CustomEntityLifecycleService;
-use Shopware\Core\System\Language\LanguageCollection;
-use Shopware\Core\System\Language\LanguageEntity;
-use Shopware\Core\System\Locale\LocaleEntity;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Core\System\SystemConfig\Util\ConfigReader;
-use Shopware\Core\Test\Stub\App\StaticSourceResolver;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
+use Shopware\Tests\Unit\Core\Framework\App\Manifest\ManifestFixture;
 
 /**
  * @internal
- *
- * @phpstan-type AppEntities list<array{id: string, path: string, name?: string, configurable?: bool, allowDisable?: bool}>
  */
 #[CoversClass(AppLifecycle::class)]
 class AppLifecycleTest extends TestCase
 {
-    use EventDispatcherBehaviour;
-
-    private EventDispatcher $eventDispatcher;
-
-    protected function setUp(): void
+    public function testInstallDelegatesToAppManager(): void
     {
-        $this->eventDispatcher = new EventDispatcher();
+        $manifest = ManifestFixture::empty();
+        $parameters = new AppInstallParameters();
+        $context = Context::createDefaultContext();
+
+        $appManager = $this->createMock(AppManager::class);
+        $appManager->expects($this->once())
+            ->method('install')
+            ->with($manifest, $parameters, $context);
+
+        $appLifecycle = new AppLifecycle($appManager, AppFixture::createAppRepository());
+
+        $appLifecycle->install($manifest, $parameters, $context);
     }
 
-    public function testInstallNotCompatibleApp(): void
+    public function testUpdateLoadsAppAndDelegatesToAppManager(): void
     {
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-        $manifest->getMetadata()->assign(['compatibility' => '~7.0.0']);
+        $app = AppFixture::createAppEntity(id: 'app-id');
+        $manifest = ManifestFixture::empty();
+        $parameters = new AppUpdateParameters();
+        $context = Context::createDefaultContext();
 
-        $appRepository = $this->createMock(EntityRepository::class);
-        $appRepository->expects($this->never())->method('upsert');
+        $appManager = $this->createMock(AppManager::class);
+        $appManager->expects($this->once())
+            ->method('update')
+            ->with($manifest, $parameters, $app, $context);
 
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([]);
+        $appLifecycle = new AppLifecycle($appManager, AppFixture::createAppRepository($app));
 
-        $appLifecycle = $this->getAppLifecycle($appRepository, $languageRepository, new StaticSourceResolver());
-
-        $this->expectExceptionObject(AppException::notCompatible('test'));
-        $appLifecycle->install($manifest, new AppInstallParameters(), Context::createDefaultContext());
+        $appLifecycle->update($manifest, $parameters, ['id' => 'app-id', 'roleId' => 'role-id'], $context);
     }
 
-    public function testUpdateNotCompatibleApp(): void
+    public function testDeleteLoadsAppAndDelegatesToAppManager(): void
     {
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-        $manifest->getMetadata()->assign(['compatibility' => '~7.0.0']);
+        $app = AppFixture::createAppEntity(id: 'app-id');
+        $context = Context::createDefaultContext();
 
-        $appRepository = $this->createMock(EntityRepository::class);
-        $appRepository->expects($this->never())->method('upsert');
+        $appManager = $this->createMock(AppManager::class);
+        $appManager->expects($this->once())
+            ->method('delete')
+            ->with($app, $context, true);
 
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([]);
+        $appLifecycle = new AppLifecycle($appManager, AppFixture::createAppRepository($app));
 
-        $appLifecycle = $this->getAppLifecycle($appRepository, $languageRepository, new StaticSourceResolver());
-
-        $this->expectExceptionObject(AppException::notCompatible('test'));
-        $appLifecycle->update($manifest, new AppUpdateParameters(), ['id' => 'test', 'roleId' => 'test'], Context::createDefaultContext());
+        $appLifecycle->delete('test', ['id' => 'app-id'], $context, true);
     }
 
-    public function testInstallSavesSnippetsGiven(): void
+    public function testUpdateThrowsWhenAppDoesNotExist(): void
     {
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
+        $appLifecycle = new AppLifecycle($this->createMock(AppManager::class), AppFixture::createAppRepository());
 
-        $appEntities = [
-            [],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'name' => 'test',
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-        ];
+        static::expectException(AppException::class);
 
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $sourceResolver = $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml', __DIR__ . '/../_fixtures/app-with-snippets');
-        $appRepository = $this->getAppRepositoryMock($appEntities);
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $sourceResolver,
-        );
-
-        $this->registerSubscriber(
-            $sourceResolver,
-            $appEntities[2],
-            expectedSnippets: ['en-GB' => '{"snippetKey":"snippetTranslation"}' . \PHP_EOL],
-        );
-
-        $appLifecycle->install($manifest, new AppInstallParameters(activate: false), Context::createDefaultContext());
-
-        static::assertCount(1, $appRepository->upserts[0]);
-        static::assertSame('test', $appRepository->upserts[0][0]['name']);
+        $appLifecycle->update(ManifestFixture::empty(), new AppUpdateParameters(), ['id' => 'missing', 'roleId' => 'role-id'], Context::createDefaultContext());
     }
 
-    public function testInstallSavesOldSecretIfItExists(): void
+    public function testGetDecoratedThrows(): void
     {
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
+        $appLifecycle = new AppLifecycle($this->createMock(AppManager::class), AppFixture::createAppRepository());
 
-        $appEntities = [
-            [],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'name' => 'test',
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-        ];
+        static::expectException(DecorationPatternException::class);
 
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $sourceResolver = $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml');
-        $appRepository = $this->getAppRepositoryMock($appEntities);
-        $appDeletedGateway = $this->createMock(DeletedAppsGateway::class);
-        $appDeletedGateway->expects($this->once())
-            ->method('getDeletedAppSecret')
-            ->with($manifest->getMetadata()->getName())
-            ->willReturn('oldSecretValue');
-
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $sourceResolver,
-            $appDeletedGateway,
-        );
-
-        $this->registerSubscriber($sourceResolver, $appEntities[2]);
-
-        $appLifecycle->install($manifest, new AppInstallParameters(false), Context::createDefaultContext());
-
-        static::assertCount(1, $appRepository->upserts[0]);
-        static::assertSame('test', $appRepository->upserts[0][0]['name']);
-        static::assertSame('oldSecretValue', $appRepository->upserts[0][0]['appSecret']);
-    }
-
-    public function testUpdateSavesNoSnippetsGiven(): void
-    {
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
-
-        $appEntities = [
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'name' => 'test',
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-        ];
-
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-        $appRepository = $this->getAppRepositoryMock($appEntities);
-        $sourceResolver = $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml');
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $sourceResolver
-        );
-
-        $this->registerSubscriber($sourceResolver, $appEntities[1], AppUpdatedEvent::class);
-
-        $appLifecycle->update($manifest, new AppUpdateParameters(), ['id' => 'appId', 'roleId' => 'roleId'], Context::createDefaultContext());
-
-        static::assertCount(1, $appRepository->upserts[0]);
-        static::assertSame('test', $appRepository->upserts[0][0]['name']);
-    }
-
-    public function testUpdateSavesSnippets(): void
-    {
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
-
-        $appEntities = [
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'name' => 'test',
-                    'path' => '',
-                    'configurable' => false,
-                    'allowDisable' => true,
-                ],
-            ],
-        ];
-
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $appRepository = $this->getAppRepositoryMock($appEntities);
-        $sourceResolver = $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml', __DIR__ . '/../_fixtures/app-with-snippets');
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $sourceResolver,
-        );
-
-        $this->registerSubscriber(
-            $sourceResolver,
-            $appEntities[1],
-            AppUpdatedEvent::class,
-            ['en-GB' => '{"snippetKey":"snippetTranslation"}' . \PHP_EOL]
-        );
-
-        $appLifecycle->update($manifest, new AppUpdateParameters(), ['id' => 'appId', 'roleId' => 'roleId'], Context::createDefaultContext());
-
-        static::assertCount(1, $appRepository->upserts[0]);
-        static::assertSame('test', $appRepository->upserts[0][0]['name']);
-    }
-
-    public function testInstallThrowsWhenRequirementsNotMet(): void
-    {
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $validator = $this->createMock(AppRequirementsValidator::class);
-        $validator->expects($this->once())
-            ->method('validate')
-            ->with($manifest)
-            ->willReturn([
-                new UnmetRequirement('test', 'public-access', 'APP_URL must be publicly reachable'),
-            ]);
-
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
-
-        $appRepository = $this->getAppRepositoryMock([[]]);
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml'),
-            static::createStub(DeletedAppsGateway::class),
-            $validator
-        );
-
-        $expected = AppException::requirementsNotMet(
-            new UnmetRequirement('test', 'public-access', 'APP_URL must be publicly reachable'),
-        );
-        $this->expectExceptionObject($expected);
-        $appLifecycle->install($manifest, new AppInstallParameters(), Context::createDefaultContext());
-    }
-
-    public function testUpdateThrowsWhenRequirementsNotMet(): void
-    {
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $validator = $this->createMock(AppRequirementsValidator::class);
-        $validator->expects($this->once())
-            ->method('validate')
-            ->with($manifest)
-            ->willReturn([
-                new UnmetRequirement('test', 'public-access', 'APP_URL must be publicly reachable'),
-            ]);
-
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
-
-        $appRepository = $this->getAppRepositoryMock([[['id' => Uuid::randomHex(), 'path' => '', 'configurable' => false, 'allowDisable' => true]]]);
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml'),
-            static::createStub(DeletedAppsGateway::class),
-            $validator
-        );
-
-        $expected = AppException::requirementsNotMet(
-            new UnmetRequirement('test', 'public-access', 'APP_URL must be publicly reachable'),
-        );
-        $this->expectExceptionObject($expected);
-        $appLifecycle->update($manifest, new AppUpdateParameters(), ['id' => 'appId', 'roleId' => 'roleId'], Context::createDefaultContext());
-    }
-
-    public function testUpdateResetsConfigurableFlagToFalseWhenConfigXMLWasRemoved(): void
-    {
-        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
-        $languageRepository = new StaticEntityRepository([$this->getLanguageCollection()]);
-
-        $appId = Uuid::randomHex();
-
-        $appEntities = [
-            [
-                [
-                    'id' => Uuid::randomHex(),
-                    'path' => '',
-                ],
-            ],
-            [
-                [
-                    'id' => $appId,
-                    'name' => 'test',
-                    'path' => '',
-                ],
-            ],
-        ];
-
-        $manifest = Manifest::createFromXmlFile(__DIR__ . '/../_fixtures/manifest.xml');
-
-        $appRepository = $this->getAppRepositoryMock($appEntities);
-        $appLifecycle = $this->getAppLifecycle(
-            $appRepository,
-            $languageRepository,
-            $this->getSourceResolver(__DIR__ . '/../_fixtures/manifest.xml', __DIR__ . '/../_fixtures/app-without-config')
-        );
-
-        $appLifecycle->update($manifest, new AppUpdateParameters(), ['id' => $appId, 'roleId' => 'roleId'], Context::createDefaultContext());
-
-        static::assertCount(1, $appRepository->upserts[0]);
-
-        static::assertSame([['id' => $appId, 'configurable' => false, 'allowDisable' => true]], $appRepository->upserts[1]);
-    }
-
-    /**
-     * @param EntityRepository<AppCollection> $appRepository
-     * @param EntityRepository<LanguageCollection> $languageRepository
-     */
-    private function getAppLifecycle(
-        EntityRepository $appRepository,
-        EntityRepository $languageRepository,
-        StaticSourceResolver $appSourceResolver,
-        ?DeletedAppsGateway $deletedAppsGateway = null,
-        ?AppRequirementsValidator $requirementsValidator = null,
-    ): AppLifecycle {
-        /** @var StaticEntityRepository<AclRoleCollection> $aclRoleRepo */
-        $aclRoleRepo = new StaticEntityRepository([new AclRoleCollection()]);
-
-        if (!$deletedAppsGateway) {
-            $deletedAppsGateway = $this->createMock(DeletedAppsGateway::class);
-        }
-
-        $customEntityLifecycleService = $this->createMock(CustomEntityLifecycleService::class);
-        $customEntityLifecycleService->method('allowsDisabling')->willReturn(true);
-        $customEntityLifecycleService->method('canRemoveAppData')->willReturn(true);
-
-        return new AppLifecycle(
-            [],
-            $appRepository,
-            $this->createMock(PermissionLifecycleService::class),
-            $this->eventDispatcher,
-            $this->createMock(AppRegistrationService::class),
-            $this->createMock(AppStateService::class),
-            $languageRepository,
-            $this->createMock(SystemConfigService::class),
-            $this->createMock(ConfigValidator::class),
-            $this->createMock(EntityRepository::class),
-            $aclRoleRepo,
-            $this->createMock(AssetService::class),
-            $this->createMock(ScriptExecutor::class),
-            __DIR__,
-            $customEntityLifecycleService,
-            '6.5.0.0',
-            $this->createMock(AppFeatureValidator::class),
-            $appSourceResolver,
-            $this->createMock(ConfigReader::class),
-            $deletedAppsGateway,
-            $requirementsValidator ?? static::createStub(AppRequirementsValidator::class)
-        );
-    }
-
-    private function getLanguageCollection(): LanguageCollection
-    {
-        $languageEntity = new LanguageEntity();
-        $languageEntity->assign([
-            'id' => Uuid::randomHex(),
-            'translationCode' => $this->getLocaleEntity(),
-        ]);
-
-        return new LanguageCollection([$languageEntity]);
-    }
-
-    private function getLocaleEntity(): LocaleEntity
-    {
-        $localeEntity = new LocaleEntity();
-        $localeEntity->assign(['code' => 'en-GB']);
-
-        return $localeEntity;
-    }
-
-    /**
-     * @param list<AppEntities> $appEntities
-     *
-     * @return StaticEntityRepository<AppCollection>
-     */
-    private function getAppRepositoryMock(array $appEntities): StaticEntityRepository
-    {
-        $searchResults = [];
-        foreach ($appEntities as $entities) {
-            $searchResults[] = $this->getAppCollection($entities);
-        }
-
-        /** @var StaticEntityRepository<AppCollection> $repo */
-        $repo = new StaticEntityRepository($searchResults);
-
-        return $repo;
-    }
-
-    /**
-     * @param AppEntities $appEntities
-     */
-    private function getAppCollection(array $appEntities): AppCollection
-    {
-        $entities = [];
-
-        foreach ($appEntities as $entity) {
-            $appEntity = new AppEntity();
-            $appEntity->assign($entity);
-            $appEntity->setUniqueIdentifier($entity['id']);
-
-            $entities[] = $appEntity;
-        }
-
-        return new AppCollection($entities);
-    }
-
-    /**
-     * @param AppEntities $appEntities
-     * @param class-string<AppInstalledEvent|AppUpdatedEvent> $event
-     * @param array<string, string> $expectedSnippets
-     */
-    private function registerSubscriber(
-        StaticSourceResolver $sourceResolver,
-        array $appEntities,
-        string $event = AppInstalledEvent::class,
-        array $expectedSnippets = []
-    ): void {
-        $appEntityCollection = $this->getAppCollection($appEntities)->first();
-
-        $persister = $this->createMock(AppAdministrationSnippetPersister::class);
-        $persister
-            ->expects($this->once())
-            ->method('updateSnippets')
-            ->with($appEntityCollection, $expectedSnippets, Context::createDefaultContext());
-
-        $this->addEventListener(
-            $this->eventDispatcher,
-            $event,
-            (new AppLifecycleSubscriber($sourceResolver, $persister))->onAppUpdate(...),
-        );
-    }
-
-    private function getSourceResolver(string $manifestPath, ?string $appPath = null): StaticSourceResolver
-    {
-        return new StaticSourceResolver([
-            'test' => new Filesystem($appPath ?? \dirname($manifestPath)),
-        ]);
+        $appLifecycle->getDecorated();
     }
 }

--- a/tests/unit/Core/Framework/App/Lifecycle/AppManagerTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppManagerTest.php
@@ -1,0 +1,418 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Lifecycle;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleCollection;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
+use Shopware\Core\Framework\App\Event\AppActivatedEvent;
+use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
+use Shopware\Core\Framework\App\Event\AppDeletedEvent;
+use Shopware\Core\Framework\App\Event\PostAppDeletedEvent;
+use Shopware\Core\Framework\App\Exception\AppRegistrationException;
+use Shopware\Core\Framework\App\Lifecycle\AppFeatureValidator;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
+use Shopware\Core\Framework\App\Lifecycle\PermissionLifecycleService;
+use Shopware\Core\Framework\App\Lifecycle\Persister\PersisterInterface;
+use Shopware\Core\Framework\App\Lifecycle\Registration\AppRegistrationService;
+use Shopware\Core\Framework\App\Source\SourceResolver;
+use Shopware\Core\Framework\App\Validation\AppRequirementsValidator;
+use Shopware\Core\Framework\App\Validation\ConfigValidator;
+use Shopware\Core\Framework\App\Validation\Requirements\UnmetRequirement;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
+use Shopware\Core\System\CustomEntity\CustomEntityLifecycleService;
+use Shopware\Core\System\Integration\IntegrationCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\SystemConfig\Util\ConfigReader;
+use Shopware\Core\Test\Stub\App\StaticSourceResolver;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
+use Shopware\Core\Test\Stub\Framework\Util\StaticFilesystem;
+use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
+use Shopware\Tests\Unit\Core\Framework\App\Manifest\ManifestFixture;
+
+/**
+ * @internal
+ */
+#[CoversClass(AppManager::class)]
+class AppManagerTest extends TestCase
+{
+    private CollectingEventDispatcher $eventDispatcher;
+
+    private PermissionLifecycleService $permissionLifecycle;
+
+    private AppRegistrationService $registrationService;
+
+    private ActiveAppsLoader $activeAppsLoader;
+
+    private SystemConfigService $systemConfigService;
+
+    /**
+     * @var StaticEntityRepository<IntegrationCollection>
+     */
+    private StaticEntityRepository $integrationRepository;
+
+    private AssetService $assetService;
+
+    private ScriptExecutor $scriptExecutor;
+
+    private CustomEntityLifecycleService $customEntityLifecycleService;
+
+    private SourceResolver $sourceResolver;
+
+    private ConfigReader $configReader;
+
+    private AppRequirementsValidator $requirementsValidator;
+
+    protected function setUp(): void
+    {
+        $this->eventDispatcher = new CollectingEventDispatcher();
+        $this->permissionLifecycle = $this->createMock(PermissionLifecycleService::class);
+        $this->registrationService = $this->createMock(AppRegistrationService::class);
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->integrationRepository = new StaticEntityRepository([]);
+        $this->assetService = $this->createMock(AssetService::class);
+        $this->scriptExecutor = $this->createMock(ScriptExecutor::class);
+        $this->customEntityLifecycleService = $this->createDefaultCustomEntityLifecycleService();
+        $this->sourceResolver = new StaticSourceResolver();
+        $this->configReader = $this->createMock(ConfigReader::class);
+        $this->requirementsValidator = static::createStub(AppRequirementsValidator::class);
+    }
+
+    public function testInstallThrowsIfAppIsNotCompatible(): void
+    {
+        $manifest = ManifestFixture::empty();
+        $manifest->getMetadata()->assign(['compatibility' => '~7.0.0']);
+
+        $this->expectExceptionObject(AppException::notCompatible('test'));
+
+        $this->createAppManager(AppFixture::createAppRepository())
+            ->install($manifest, new AppInstallParameters(), Context::createDefaultContext());
+    }
+
+    public function testUpdateThrowsIfAppIsNotCompatible(): void
+    {
+        $manifest = ManifestFixture::empty();
+        $manifest->getMetadata()->assign(['compatibility' => '~7.0.0']);
+
+        $this->expectExceptionObject(AppException::notCompatible('test'));
+
+        $this->createAppManager(AppFixture::createAppRepository())
+            ->update($manifest, new AppUpdateParameters(), AppFixture::createAppEntity(active: false), Context::createDefaultContext());
+    }
+
+    public function testInstallThrowsWhenRequirementsAreNotMet(): void
+    {
+        $manifest = ManifestFixture::empty();
+        $violation = new UnmetRequirement('test', 'https', 'Use HTTPS');
+
+        $requirementsValidator = $this->createMock(AppRequirementsValidator::class);
+        $requirementsValidator->expects($this->once())
+            ->method('validate')
+            ->with($manifest)
+            ->willReturn([$violation]);
+
+        $this->expectExceptionObject(AppException::requirementsNotMet($violation));
+
+        $this->requirementsValidator = $requirementsValidator;
+
+        $this->createAppManager(AppFixture::createAppRepository())
+            ->install($manifest, new AppInstallParameters(), Context::createDefaultContext());
+    }
+
+    public function testUpdateThrowsWhenRequirementsAreNotMet(): void
+    {
+        $manifest = ManifestFixture::empty();
+        $violation = new UnmetRequirement('test', 'https', 'Use HTTPS');
+
+        $requirementsValidator = $this->createMock(AppRequirementsValidator::class);
+        $requirementsValidator->expects($this->once())
+            ->method('validate')
+            ->with($manifest)
+            ->willReturn([$violation]);
+
+        $this->expectExceptionObject(AppException::requirementsNotMet($violation));
+
+        $this->requirementsValidator = $requirementsValidator;
+
+        $this->createAppManager(AppFixture::createAppRepository())
+            ->update($manifest, new AppUpdateParameters(), AppFixture::createAppEntity(active: false), Context::createDefaultContext());
+    }
+
+    public function testInstallThrowsIfAppAlreadyExists(): void
+    {
+        $existingApp = AppFixture::createAppEntity(name: 'test', id: 'test-app', active: false);
+        $appRepository = AppFixture::createAppRepository($existingApp);
+
+        $this->expectExceptionObject(AppException::alreadyInstalled('test'));
+
+        $this->createAppManager($appRepository)
+            ->install(ManifestFixture::empty(), new AppInstallParameters(), Context::createDefaultContext());
+    }
+
+    public function testInstallRollsBackAppDataWhenRegistrationFails(): void
+    {
+        $context = Context::createDefaultContext();
+        $manifest = ManifestFixture::empty()->withSetup();
+        $appRepository = AppFixture::createAppRepository();
+        $installedApp = AppFixture::createAppEntity(name: 'test', id: 'test-app', active: false);
+        $appRepository->addSearch(new AppCollection([$installedApp]));
+
+        $this->registrationService = $this->createMock(AppRegistrationService::class);
+        $this->registrationService->expects($this->once())
+            ->method('registerApp')
+            ->willThrowException(AppException::registrationFailed('test', 'registration failed'));
+
+        $this->integrationRepository = new StaticEntityRepository([]);
+        $this->permissionLifecycle = $this->createMock(PermissionLifecycleService::class);
+        $this->permissionLifecycle->expects($this->once())->method('removeRole');
+
+        try {
+            $this->createAppManager($appRepository)
+                ->install($manifest, new AppInstallParameters(), $context);
+            static::fail('Expected app registration to fail');
+        } catch (AppRegistrationException) {
+            static::assertCount(1, $appRepository->getPayloads(StaticEntityRepository::UPSERT));
+            static::assertSame([['id' => $installedApp->getId()]], $appRepository->getPayloads(StaticEntityRepository::DELETE));
+            static::assertSame([['id' => 'integration-id']], $this->integrationRepository->getPayloads(StaticEntityRepository::DELETE));
+        }
+    }
+
+    public function testActivateDoesNothingIfAppIsAlreadyActive(): void
+    {
+        $app = AppFixture::createAppEntity(id: 'test-app', active: true);
+        $appRepository = AppFixture::createAppRepository($app);
+        $persister = $this->createMock(PersisterInterface::class);
+        $persister->expects($this->never())->method('activate');
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->activeAppsLoader->expects($this->never())->method('reset');
+
+        $this->createAppManager(
+            $appRepository,
+            persisters: [$persister],
+        )->activate($app, Context::createDefaultContext());
+
+        static::assertSame([], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
+    }
+
+    public function testActivateUpdatesAppAndPersisters(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(id: 'test-app', active: false);
+        $appRepository = AppFixture::createAppRepository($app);
+
+        $persister = $this->createMock(PersisterInterface::class);
+        $persister->expects($this->once())
+            ->method('activate')
+            ->with($app, $context);
+
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->activeAppsLoader->expects($this->once())->method('reset');
+
+        $this->scriptExecutor = $this->createMock(ScriptExecutor::class);
+        $this->scriptExecutor->expects($this->once())->method('execute');
+
+        $this->createAppManager(
+            $appRepository,
+            persisters: [$persister],
+        )->activate($app, $context);
+
+        static::assertTrue($app->isActive());
+        static::assertCount(1, $this->eventDispatcher->getEventsOfClass(AppActivatedEvent::class));
+        static::assertSame([
+            ['id' => $app->getId(), 'active' => true],
+        ], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
+    }
+
+    public function testDeactivateDoesNothingIfAppIsAlreadyInactive(): void
+    {
+        $app = AppFixture::createAppEntity(id: 'test-app', active: false);
+        $appRepository = AppFixture::createAppRepository($app);
+        $persister = $this->createMock(PersisterInterface::class);
+        $persister->expects($this->never())->method('deactivate');
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->activeAppsLoader->expects($this->never())->method('reset');
+
+        $this->createAppManager(
+            $appRepository,
+            persisters: [$persister],
+        )->deactivate($app, Context::createDefaultContext());
+
+        static::assertSame([], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
+    }
+
+    public function testDeactivateUpdatesAppAndPersisters(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(id: 'test-app', active: true);
+        $appRepository = AppFixture::createAppRepository($app);
+
+        $persister = $this->createMock(PersisterInterface::class);
+        $persister->expects($this->once())
+            ->method('deactivate')
+            ->with($app, $context);
+
+        $this->activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $this->activeAppsLoader->expects($this->once())->method('reset');
+
+        $this->scriptExecutor = $this->createMock(ScriptExecutor::class);
+        $this->scriptExecutor->expects($this->once())->method('execute');
+
+        $this->createAppManager(
+            $appRepository,
+            persisters: [$persister],
+        )->deactivate($app, $context);
+
+        static::assertFalse($app->isActive());
+        static::assertCount(1, $this->eventDispatcher->getEventsOfClass(AppDeactivatedEvent::class));
+        static::assertSame([
+            ['id' => $app->getId(), 'active' => false],
+        ], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
+    }
+
+    public function testDeactivateThrowsIfDisableIsNotAllowed(): void
+    {
+        $app = AppFixture::createAppEntity(id: 'test-app', active: true, allowDisable: false);
+
+        $this->expectException(AppException::class);
+
+        $this->createAppManager(AppFixture::createAppRepository($app))
+            ->deactivate($app, Context::createDefaultContext());
+    }
+
+    public function testDeleteDeactivatesActiveAppBeforeRemovingData(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(id: 'test-app', active: true, allowDisable: false);
+        $appRepository = AppFixture::createAppRepository($app);
+
+        $persister = $this->createMock(PersisterInterface::class);
+        $persister->expects($this->once())
+            ->method('deactivate')
+            ->with($app, $context);
+
+        $this->customEntityLifecycleService = $this->createMock(CustomEntityLifecycleService::class);
+        $this->customEntityLifecycleService->expects($this->once())
+            ->method('canRemoveAppData')
+            ->with($app)
+            ->willReturn(true);
+        $this->customEntityLifecycleService->expects($this->once())
+            ->method('removeApp')
+            ->with($app, $context, true);
+
+        $this->integrationRepository = new StaticEntityRepository([]);
+        $this->permissionLifecycle = $this->createMock(PermissionLifecycleService::class);
+        $this->permissionLifecycle->expects($this->once())->method('softDeleteRole')->with($app->getAclRoleId());
+
+        $this->assetService = $this->createMock(AssetService::class);
+        $this->assetService->expects($this->once())->method('removeAssets')->with($app->getName());
+
+        $this->createAppManager(
+            $appRepository,
+            persisters: [$persister],
+        )->delete($app, $context, true);
+
+        static::assertSame([
+            ['id' => $app->getId(), 'active' => false],
+        ], $appRepository->getPayloads(StaticEntityRepository::UPDATE));
+        static::assertSame([['id' => $app->getId()]], $appRepository->getPayloads(StaticEntityRepository::DELETE));
+        static::assertCount(1, $this->eventDispatcher->getEventsOfClass(AppDeletedEvent::class));
+        static::assertCount(1, $this->eventDispatcher->getEventsOfClass(PostAppDeletedEvent::class));
+
+        $integrationUpdates = $this->integrationRepository->getPayloads(StaticEntityRepository::UPDATE);
+        static::assertCount(1, $integrationUpdates);
+        static::assertSame($app->getIntegrationId(), $integrationUpdates[0]['id']);
+        static::assertInstanceOf(\DateTimeImmutable::class, $integrationUpdates[0]['deletedAt']);
+    }
+
+    public function testDeleteRemovesConfigOnlyWhenUserDataIsNotKept(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(name: 'test', id: 'test-app', active: false);
+        $app->setPath('');
+        $appRepository = AppFixture::createAppRepository();
+        $this->sourceResolver = new StaticSourceResolver([
+            'test' => new StaticFilesystem([
+                'Resources/config/config.xml' => <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <card>
+        <input-field type="text">
+            <name>email</name>
+            <label>Email</label>
+        </input-field>
+    </card>
+</config>
+XML,
+            ]),
+        ]);
+        $config = [['name' => 'email']];
+        $this->configReader = $this->createMock(ConfigReader::class);
+        $this->configReader->expects($this->once())->method('read')->willReturn($config);
+
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->systemConfigService->expects($this->once())
+            ->method('deleteExtensionConfiguration')
+            ->with('test', $config);
+
+        $this->createAppManager($appRepository)->delete($app, $context);
+
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->systemConfigService->expects($this->never())->method('deleteExtensionConfiguration');
+
+        $this->createAppManager(AppFixture::createAppRepository())->delete($app, $context, true);
+    }
+
+    /**
+     * @param StaticEntityRepository<AppCollection> $appRepository
+     * @param list<PersisterInterface> $persisters
+     */
+    private function createAppManager(
+        StaticEntityRepository $appRepository,
+        array $persisters = [],
+    ): AppManager {
+        /** @var StaticEntityRepository<AclRoleCollection> $aclRoleRepository */
+        $aclRoleRepository = new StaticEntityRepository([new AclRoleCollection()]);
+
+        return new AppManager(
+            $persisters,
+            $appRepository,
+            $this->permissionLifecycle,
+            $this->eventDispatcher,
+            $this->registrationService,
+            $this->activeAppsLoader,
+            AppFixture::createLanguageRepository(),
+            $this->systemConfigService,
+            $this->createMock(ConfigValidator::class),
+            $this->integrationRepository,
+            $aclRoleRepository,
+            $this->assetService,
+            $this->scriptExecutor,
+            __DIR__,
+            $this->customEntityLifecycleService,
+            '6.5.0.0',
+            $this->createMock(AppFeatureValidator::class),
+            $this->sourceResolver,
+            $this->configReader,
+            $this->createMock(DeletedAppsGateway::class),
+            $this->requirementsValidator,
+        );
+    }
+
+    private function createDefaultCustomEntityLifecycleService(): CustomEntityLifecycleService
+    {
+        $customEntityLifecycleService = $this->createMock(CustomEntityLifecycleService::class);
+        $customEntityLifecycleService->method('allowsDisabling')->willReturn(true);
+
+        return $customEntityLifecycleService;
+    }
+}

--- a/tests/unit/Core/Framework/App/Manifest/ManifestFixture.php
+++ b/tests/unit/Core/Framework/App/Manifest/ManifestFixture.php
@@ -5,12 +5,17 @@ namespace Shopware\Tests\Unit\Core\Framework\App\Manifest;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\Xml\Administration\Admin;
 use Shopware\Core\Framework\App\Manifest\Xml\Administration\Module;
+use Shopware\Core\Framework\App\Manifest\Xml\Cookie\Cookies;
 use Shopware\Core\Framework\App\Manifest\Xml\CustomField\CustomFieldTypes\CustomFieldType;
+use Shopware\Core\Framework\App\Manifest\Xml\Gateway\Gateways;
 use Shopware\Core\Framework\App\Manifest\Xml\Meta\Metadata;
 use Shopware\Core\Framework\App\Manifest\Xml\PaymentMethod\PaymentMethod;
 use Shopware\Core\Framework\App\Manifest\Xml\PaymentMethod\Payments;
+use Shopware\Core\Framework\App\Manifest\Xml\Permission\Permissions;
 use Shopware\Core\Framework\App\Manifest\Xml\RuleCondition\RuleCondition;
 use Shopware\Core\Framework\App\Manifest\Xml\RuleCondition\RuleConditions;
+use Shopware\Core\Framework\App\Manifest\Xml\Setup\Setup;
+use Shopware\Core\Framework\App\Manifest\Xml\Storefront\Storefront;
 use Shopware\Core\Framework\App\Manifest\Xml\Tax\Tax;
 use Shopware\Core\Framework\App\Manifest\Xml\Tax\TaxProvider;
 use Shopware\Core\Framework\App\Manifest\Xml\Webhook\Webhook;
@@ -28,6 +33,8 @@ class ManifestFixture extends Manifest
     private ?Payments $payments = null;
 
     private ?RuleConditions $ruleConditions = null;
+
+    private ?Setup $setup = null;
 
     private ?Tax $tax = null;
 
@@ -99,6 +106,15 @@ class ManifestFixture extends Manifest
         return $this;
     }
 
+    public function withSetup(?Setup $setup = null): self
+    {
+        $this->setup = $setup ?? Setup::fromArray([
+            'registrationUrl' => 'https://example.com/register',
+        ]);
+
+        return $this;
+    }
+
     public function withTaxProvider(?TaxProvider $taxProvider = null): self
     {
         $taxProviders = $this->tax?->getTaxProviders() ?? [];
@@ -145,14 +161,34 @@ class ManifestFixture extends Manifest
         return $this->metadata;
     }
 
+    public function validatesPermissions(): bool
+    {
+        return false;
+    }
+
+    public function getSetup(): ?Setup
+    {
+        return $this->setup;
+    }
+
     public function getAdmin(): ?Admin
     {
         return $this->admin;
     }
 
+    public function getPermissions(): ?Permissions
+    {
+        return null;
+    }
+
     public function getWebhooks(): ?Webhooks
     {
         return $this->webhooks;
+    }
+
+    public function getCookies(): ?Cookies
+    {
+        return null;
     }
 
     public function getPayments(): ?Payments
@@ -165,9 +201,27 @@ class ManifestFixture extends Manifest
         return $this->ruleConditions;
     }
 
+    public function getStorefront(): ?Storefront
+    {
+        return null;
+    }
+
     public function getTax(): ?Tax
     {
         return $this->tax;
+    }
+
+    public function getGateways(): ?Gateways
+    {
+        return null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getAllHosts(): array
+    {
+        return [];
     }
 
     private static function createMetadata(string $name): Metadata

--- a/tests/unit/Core/Test/Stub/EventDispatcher/CollectingEventDispatcherTest.php
+++ b/tests/unit/Core/Test/Stub/EventDispatcher/CollectingEventDispatcherTest.php
@@ -42,4 +42,17 @@ class CollectingEventDispatcherTest extends TestCase
         static::assertSame($event1, $events['event.one']);
         static::assertSame($event2, $events[0]);
     }
+
+    public function testFiltersEventsByClass(): void
+    {
+        $dispatcher = new CollectingEventDispatcher();
+
+        $event = new class {};
+        $eventClass = $event::class;
+
+        $dispatcher->dispatch(new \stdClass());
+        $dispatcher->dispatch($event);
+
+        static::assertSame([$event], $dispatcher->getEventsOfClass($eventClass));
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

This PR introduces `AppManager` as the shared internal implementation for app lifecycle operations:

- install
- update
- uninstall
- activate
- deactivate

Until now lifecycle behavior was split between `AppLifecycle` and `AppStateService`. This PR moves that behavior behind `AppManager`, so the existing entry points can stay small and continue to support the current id-based app APIs.

That gives us one place for the actual lifecycle implementation, while follow-up PRs can focus on changing how apps and services are resolved before calling it.

This PR is intended as a non-breaking refactoring step. `AppLifecycle` and `AppStateService` remain the existing entry points for app operations and keep their id-based APIs. They now delegate to `AppManager` internally.

The goal is to create a foundation for follow-up changes where app/service resolution can move into dedicated repositories and where services can use the lower-level lifecycle implementation without changing public app-facing behavior in this PR.

### 2. What does this change do, exactly?

- Adds `AppManager` as the internal lifecycle implementation.
- Moves lifecycle orchestration from `AppLifecycle` and `AppStateService` into `AppManager`.
- Keeps `AppLifecycle` and `AppStateService` as compatibility entry points that delegate to `AppManager`.
- Moves the AppLifecycle integration coverage to AppManager where the behavior now lives.
- Keeps AppStateService covered by a small delegation test.