### PR TITLE
fix(checkout): convert shipping price matrix ranges by currency factor

### DIFF
--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -23,6 +23,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -156,8 +157,14 @@ class DeliveryCalculator
 
         $start = $shippingMethodPrice->getQuantityStart();
         $end = $shippingMethodPrice->getQuantityEnd();
+        $calculation = $shippingMethodPrice->getCalculation();
 
-        $value = match ($shippingMethodPrice->getCalculation()) {
+        if ($calculation === self::CALCULATION_BY_PRICE && Feature::isActive('v6.8.0.0')) {
+            $start = $this->convertPriceMatrixRange($start, $context);
+            $end = $this->convertPriceMatrixRange($end, $context);
+        }
+
+        $value = match ($calculation) {
             self::CALCULATION_BY_PRICE => $delivery->getPositions()->getWithoutDeliveryFree()->getPrices()->getTotalPriceAmount(),
             self::CALCULATION_BY_LINE_ITEM_COUNT => $delivery->getPositions()->getWithoutDeliveryFree()->getQuantity(),
             self::CALCULATION_BY_WEIGHT => $delivery->getPositions()->getWithoutDeliveryFree()->getWeight(),
@@ -167,6 +174,15 @@ class DeliveryCalculator
 
         // $end (optional) exclusive
         return (!$start || FloatComparator::greaterThanOrEquals($value, $start)) && (!$end || FloatComparator::lessThanOrEquals($value, $end));
+    }
+
+    private function convertPriceMatrixRange(?float $value, SalesChannelContext $context): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value * $context->getContext()->getCurrencyFactor();
     }
 
     private function calculateShippingCosts(ShippingMethodEntity $shippingMethod, PriceCollection $priceCollection, LineItemCollection $calculatedLineItems, SalesChannelContext $context, ?CalculatedPrice $manualShippingCost = null): CalculatedPrice

--- a/tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php
@@ -41,6 +41,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -846,6 +847,71 @@ class DeliveryCalculatorTest extends TestCase
         $delivery = $deliveries->first();
         static::assertNotNull($delivery);
         static::assertSame(8.0, $delivery->getShippingCosts()->getTotalPrice());
+    }
+
+    public function testCalculatePriceMatrixCartPriceRangeWithCurrencyFactor(): void
+    {
+        Feature::withFeatureEnabled('v6.8.0.0', function (): void {
+            $shippingMethod = new ShippingMethodEntity();
+            $shippingMethod->setId(Uuid::randomHex());
+            $shippingMethod->setTaxType(ShippingMethodEntity::TAX_TYPE_AUTO);
+            $shippingMethod->setDeliveryTime($this->deliveryTimeEntity);
+
+            $paidShippingPrice = new ShippingMethodPriceEntity();
+            $paidShippingPrice->setUniqueIdentifier(Uuid::randomHex());
+            $paidShippingPrice->setCurrencyPrice(new PriceCollection([
+                new Price(Defaults::CURRENCY, 20, 20, false),
+            ]));
+            $paidShippingPrice->setCalculation(DeliveryCalculator::CALCULATION_BY_PRICE);
+            $paidShippingPrice->setQuantityStart(0);
+            $paidShippingPrice->setQuantityEnd(50);
+
+            $freeShippingPrice = new ShippingMethodPriceEntity();
+            $freeShippingPrice->setUniqueIdentifier(Uuid::randomHex());
+            $freeShippingPrice->setCurrencyPrice(new PriceCollection([
+                new Price(Defaults::CURRENCY, 0, 0, false),
+            ]));
+            $freeShippingPrice->setCalculation(DeliveryCalculator::CALCULATION_BY_PRICE);
+            $freeShippingPrice->setQuantityStart(50);
+
+            $shippingMethod->setPrices(new ShippingMethodPriceCollection([
+                $paidShippingPrice,
+                $freeShippingPrice,
+            ]));
+
+            $context = $this->createMock(SalesChannelContext::class);
+            $baseContext = Context::createDefaultContext();
+            $baseContext->assign(['currencyFactor' => 1.1]);
+            $currencyId = Uuid::randomHex();
+
+            $context->expects($this->atLeastOnce())->method('getContext')->willReturn($baseContext);
+            $context->expects($this->atLeastOnce())->method('getShippingMethod')->willReturn($shippingMethod);
+            $context->method('getCurrencyId')->willReturn($currencyId);
+            $context->method('getItemRounding')->willReturn(new CashRoundingConfig(2, 0.01, true));
+
+            $lineItem = new LineItem(Uuid::randomHex(), 'product', null, 1);
+            $lineItem->setDeliveryInformation(
+                new DeliveryInformation(
+                    50,
+                    22.0,
+                    false,
+                    null,
+                    $this->deliveryTime
+                )
+            );
+            $lineItem->setShippingCostAware(true);
+            $lineItem->setPrice(new CalculatedPrice(52, 52, new CalculatedTaxCollection(), new TaxRuleCollection(), 1));
+
+            $deliveries = $this->buildDeliveries(new LineItemCollection([$lineItem]), $context);
+
+            $data = new CartDataCollection();
+            $data->set(DeliveryProcessor::buildKey($shippingMethod->getId()), $shippingMethod);
+            $this->deliveryCalculator->calculate($data, new Cart('test'), $deliveries, $context);
+
+            $delivery = $deliveries->first();
+            static::assertNotNull($delivery);
+            static::assertSame(22.0, $delivery->getShippingCosts()->getTotalPrice());
+        });
     }
 
     public function testCalculateWithMultiplePricesMissingCalculationPrice(): void


### PR DESCRIPTION
## Summary
- Convert shipping price matrix cart-price ranges by the active currency factor when the v6.8.0.0 major feature flag is active
- Leave existing behavior unchanged while the v6.8.0.0 feature flag is inactive
- Add a regression test for a cart total that should remain below the converted free-shipping threshold

## Why
Shipping costs already fall back from the default-currency price and are converted by the active currency factor. The cart-price matrix ranges were still compared as absolute active-currency values, so a 50 EUR threshold was treated as 50 USD instead of approximately 55 USD when the currency factor was 1.1.

Fixes #14286

## Test plan
- [ ] `php vendor/bin/phpunit tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php --filter testCalculatePriceMatrixCartPriceRangeWithCurrencyFactor`
- [ ] `php vendor/bin/phpunit tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php`
- [ ] `composer ecs -- src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php`

## Local validation
- [x] `git diff --check HEAD~1..HEAD`
- [x] `docker run --rm -v "$PWD":/app -w /app php:8.3-cli php -l src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php`
- [x] `docker run --rm -v "$PWD":/app -w /app php:8.3-cli php -l tests/integration/Core/Checkout/Cart/Delivery/DeliveryCalculatorTest.php`

Full PHPUnit/ECS validation was not run locally because this checkout has no Composer vendor directory installed.
