### PR TITLE
chore: use app repository in app commands

### DIFF
--- a/src/Core/Framework/App/AppStorage.php
+++ b/src/Core/Framework/App/AppStorage.php
@@ -5,7 +5,9 @@ namespace Shopware\Core\Framework\App;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -42,5 +44,28 @@ class AppStorage
         $criteria->addFilter(new EqualsFilter('name', $name));
 
         return $this->repository->search($criteria, $context)->getEntities()->first();
+    }
+
+    public function findAll(Context $context): AppCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('selfManaged', false));
+
+        return $this->repository->search($criteria, $context)->getEntities();
+    }
+
+    public function findAllWithNameOrLabel(string $filter, Context $context): AppCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('selfManaged', false));
+        $criteria->addFilter(new MultiFilter(
+            MultiFilter::CONNECTION_OR,
+            [
+                new ContainsFilter('name', $filter),
+                new ContainsFilter('label', $filter),
+            ]
+        ));
+
+        return $this->repository->search($criteria, $context)->getEntities();
     }
 }

--- a/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
+++ b/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
@@ -3,11 +3,8 @@
 namespace Shopware\Core\Framework\App\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
-use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -20,11 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Package('framework')]
 abstract class AbstractAppActivationCommand extends Command
 {
-    /**
-     * @param EntityRepository<AppCollection> $appRepo
-     */
     public function __construct(
-        protected EntityRepository $appRepo,
+        private readonly AppStorage $appStorage,
         private readonly string $action,
     ) {
         parent::__construct();
@@ -39,18 +33,15 @@ abstract class AbstractAppActivationCommand extends Command
 
         $appName = $input->getArgument('name');
 
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('name', $appName));
+        $app = $this->appStorage->findByName($appName, $context);
 
-        $id = $this->appRepo->searchIds($criteria, $context)->firstId();
-
-        if (!$id) {
+        if (!$app) {
             $io->error("No app found for \"{$appName}\".");
 
             return self::FAILURE;
         }
 
-        $this->runAction($id, $context);
+        $this->runAction($app->getId(), $context);
 
         $io->success(\sprintf('App %sd successfully.', $this->action));
 

--- a/src/Core/Framework/App/Command/ActivateAppCommand.php
+++ b/src/Core/Framework/App/Command/ActivateAppCommand.php
@@ -2,10 +2,9 @@
 
 namespace Shopware\Core\Framework\App\Command;
 
-use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppStateService;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -21,14 +20,11 @@ class ActivateAppCommand extends AbstractAppActivationCommand
 {
     private const ACTION = 'activate';
 
-    /**
-     * @param EntityRepository<AppCollection> $appRepo
-     */
     public function __construct(
-        EntityRepository $appRepo,
+        AppStorage $appStorage,
         private readonly AppStateService $appStateService
     ) {
-        parent::__construct($appRepo, self::ACTION);
+        parent::__construct($appStorage, self::ACTION);
     }
 
     public function runAction(string $appId, Context $context): void

--- a/src/Core/Framework/App/Command/AppListCommand.php
+++ b/src/Core/Framework/App/Command/AppListCommand.php
@@ -3,13 +3,9 @@
 namespace Shopware\Core\Framework\App\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
-use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -26,10 +22,8 @@ class AppListCommand extends Command
 {
     /**
      * @internal
-     *
-     * @param EntityRepository<AppCollection> $appRepository
      */
-    public function __construct(private readonly EntityRepository $appRepository)
+    public function __construct(private readonly AppStorage $appStorage)
     {
         parent::__construct();
     }
@@ -51,20 +45,11 @@ class AppListCommand extends Command
         $io = new ShopwareStyle($input, $output);
         $context = Context::createCLIContext();
 
-        $criteria = new Criteria();
-        $criteria->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
         $filter = $input->getOption('filter');
-        if ($filter) {
-            $criteria->addFilter(new MultiFilter(
-                MultiFilter::CONNECTION_OR,
-                [
-                    new ContainsFilter('name', $filter),
-                    new ContainsFilter('label', $filter),
-                ]
-            ));
-        }
-
-        $apps = $this->appRepository->search($criteria, $context)->getEntities();
+        $apps = \is_string($filter) && $filter !== ''
+            ? $this->appStorage->findAllWithNameOrLabel($filter, $context)
+            : $this->appStorage->findAll($context);
+        $apps->sort(static fn (AppEntity $a, AppEntity $b): int => $a->getName() <=> $b->getName());
 
         if ($input->getOption('json')) {
             $output->write(json_encode($apps, \JSON_THROW_ON_ERROR));

--- a/src/Core/Framework/App/Command/DeactivateAppCommand.php
+++ b/src/Core/Framework/App/Command/DeactivateAppCommand.php
@@ -2,10 +2,9 @@
 
 namespace Shopware\Core\Framework\App\Command;
 
-use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppStateService;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 
@@ -21,14 +20,11 @@ class DeactivateAppCommand extends AbstractAppActivationCommand
 {
     private const ACTION = 'deactivate';
 
-    /**
-     * @param EntityRepository<AppCollection> $appRepo
-     */
     public function __construct(
-        EntityRepository $appRepo,
+        AppStorage $appStorage,
         private readonly AppStateService $appStateService
     ) {
-        parent::__construct($appRepo, self::ACTION);
+        parent::__construct($appStorage, self::ACTION);
     }
 
     public function runAction(string $appId, Context $context): void

--- a/src/Core/Framework/App/Command/UninstallAppCommand.php
+++ b/src/Core/Framework/App/Command/UninstallAppCommand.php
@@ -3,13 +3,9 @@
 namespace Shopware\Core\Framework\App\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
-use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\ThemeLifecycleHandler;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -29,12 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[Package('framework')]
 class UninstallAppCommand extends Command
 {
-    /**
-     * @param EntityRepository<AppCollection> $appRepository
-     */
     public function __construct(
         private readonly AbstractAppLifecycle $appLifecycle,
-        private readonly EntityRepository $appRepository
+        private readonly AppStorage $appStorage
     ) {
         parent::__construct();
     }
@@ -56,7 +49,7 @@ class UninstallAppCommand extends Command
             $context->addState(ThemeLifecycleHandler::STATE_SKIP_THEME_COMPILATION);
         }
 
-        $app = $this->getAppByName($name, $context);
+        $app = $this->appStorage->findByName($name, $context);
 
         if (!$app) {
             $io->error(\sprintf('No app with name "%s" installed.', $name));
@@ -96,13 +89,5 @@ class UninstallAppCommand extends Command
             InputOption::VALUE_NONE,
             'Use this option to skip recompiling of all themes'
         );
-    }
-
-    private function getAppByName(string $name, Context $context): ?AppEntity
-    {
-        $criteria = new Criteria();
-        $criteria->addFilter(new EqualsFilter('name', $name));
-
-        return $this->appRepository->search($criteria, $context)->getEntities()->first();
     }
 }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -502,20 +502,20 @@
 
         <service id="Shopware\Core\Framework\App\Command\UninstallAppCommand">
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
-            <argument type="service" id="app.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\App\AppStorage"/>
 
             <tag name="console.command"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Command\ActivateAppCommand">
-            <argument type="service" id="app.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\App\AppStorage"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
 
             <tag name="console.command"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Command\DeactivateAppCommand">
-            <argument type="service" id="app.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\App\AppStorage"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
 
             <tag name="console.command"/>
@@ -541,7 +541,7 @@
         </service>
 
         <service id="Shopware\Core\Framework\App\Command\AppListCommand">
-            <argument type="service" id="app.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\App\AppStorage"/>
 
             <tag name="console.command"/>
         </service>

--- a/tests/unit/Core/Framework/App/AppStorageTest.php
+++ b/tests/unit/Core/Framework/App/AppStorageTest.php
@@ -45,4 +45,22 @@ class AppStorageTest extends TestCase
         static::assertNull($appStorage->findById('missing-id', Context::createDefaultContext()));
         static::assertNull($appStorage->findByName('missing-name', Context::createDefaultContext()));
     }
+
+    public function testFindAll(): void
+    {
+        $apps = new AppCollection([AppFixture::createAppEntity()]);
+        /** @var StaticEntityRepository<AppCollection> $repository */
+        $repository = new StaticEntityRepository([$apps]);
+
+        static::assertSame($apps, (new AppStorage($repository))->findAll(Context::createDefaultContext()));
+    }
+
+    public function testFindAllByNameOrLabel(): void
+    {
+        $apps = new AppCollection([AppFixture::createAppEntity()]);
+        /** @var StaticEntityRepository<AppCollection> $repository */
+        $repository = new StaticEntityRepository([$apps]);
+
+        static::assertSame($apps, (new AppStorage($repository))->findAllWithNameOrLabel('test-app', Context::createDefaultContext()));
+    }
 }

--- a/tests/unit/Core/Framework/App/Command/ActivateAppCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/ActivateAppCommandTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppStateService;
+use Shopware\Core\Framework\App\AppStorage;
+use Shopware\Core\Framework\App\Command\AbstractAppActivationCommand;
+use Shopware\Core\Framework\App\Command\ActivateAppCommand;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[CoversClass(AbstractAppActivationCommand::class)]
+#[CoversClass(ActivateAppCommand::class)]
+class ActivateAppCommandTest extends TestCase
+{
+    public function testActivateFailsWhenAppCannotBeFound(): void
+    {
+        $appStorage = $this->createMock(AppStorage::class);
+        $appStorage
+            ->expects($this->once())
+            ->method('findByName')
+            ->with('UnknownApp', static::isInstanceOf(Context::class))
+            ->willReturn(null);
+
+        $stateService = $this->createMock(AppStateService::class);
+        $stateService->expects($this->never())->method('activateApp');
+
+        $command = new ActivateAppCommand(
+            $appStorage,
+            $stateService,
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['name' => 'UnknownApp']);
+
+        static::assertSame(1, $commandTester->getStatusCode());
+        static::assertStringContainsString('[ERROR] No app found for "UnknownApp".', $commandTester->getDisplay());
+    }
+}

--- a/tests/unit/Core/Framework/App/Command/AppListCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/AppListCommandTest.php
@@ -7,12 +7,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\AppStorage;
 use Shopware\Core\Framework\App\Command\AppListCommand;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\Context;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -21,30 +18,22 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(AppListCommand::class)]
 class AppListCommandTest extends TestCase
 {
-    /**
-     * @var MockObject&EntityRepository<AppCollection>
-     */
-    private MockObject&EntityRepository $appRepoMock;
+    private MockObject&AppStorage $appStorage;
 
     private AppListCommand $command;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->appRepoMock = $this->createMock(EntityRepository::class);
+        $this->appStorage = $this->createMock(AppStorage::class);
 
-        $this->command = new AppListCommand($this->appRepoMock);
+        $this->command = new AppListCommand($this->appStorage);
     }
 
     public function testCommand(): void
     {
         $app1 = new AppEntity();
         $app2 = new AppEntity();
-
-        $entities = [
-            $app1,
-            $app2,
-        ];
 
         $app1->setUniqueIdentifier('1');
         $app1->assign([
@@ -64,7 +53,11 @@ class AppListCommandTest extends TestCase
             'author' => 'Test Developer',
         ]);
 
-        $this->setupEntityCollection($entities);
+        $this->appStorage
+            ->expects($this->once())
+            ->method('findAll')
+            ->with(static::isInstanceOf(Context::class))
+            ->willReturn(new AppCollection([$app2, $app1]));
 
         $commandTester = $this->executeCommand([]);
         static::assertSame(0, $commandTester->getStatusCode());
@@ -73,6 +66,11 @@ class AppListCommandTest extends TestCase
         static::assertStringContainsString('Shopware App Service', $display);
         static::assertStringContainsString('App List Test', $display);
         static::assertStringContainsString('Inactive App', $display);
+        $appListTestPosition = mb_strpos($display, 'App List Test');
+        $inactiveAppPosition = mb_strpos($display, 'Inactive App');
+        static::assertIsInt($appListTestPosition);
+        static::assertIsInt($inactiveAppPosition);
+        static::assertLessThan($inactiveAppPosition, $appListTestPosition);
         static::assertStringContainsString('2 apps, 1 active', $display);
     }
 
@@ -80,31 +78,11 @@ class AppListCommandTest extends TestCase
     {
         $filterValue = 'test-app';
 
-        $criteria = static::callback(static function (Criteria $criteria) use ($filterValue): bool {
-            $filters = $criteria->getFilters();
-            if (!(\count($filters) === 1 && $filters[0] instanceof MultiFilter)) {
-                return false;
-            }
-            $filter = $filters[0];
-            if ($filter->getOperator() !== MultiFilter::CONNECTION_OR) {
-                return false;
-            }
-            $fields = ['name', 'label'];
-            foreach ($filter->getQueries() as $query) {
-                if (!(
-                    $query instanceof ContainsFilter
-                    && $query->getValue() === $filterValue
-                    && $query->getField() === array_shift($fields)
-                )
-                ) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
-
-        $this->appRepoMock->method('search')->with($criteria, static::anything());
+        $this->appStorage
+            ->expects($this->once())
+            ->method('findAllWithNameOrLabel')
+            ->with($filterValue, static::isInstanceOf(Context::class))
+            ->willReturn(new AppCollection());
 
         $commandTester = $this->executeCommand(['--filter' => $filterValue]);
 
@@ -120,12 +98,18 @@ class AppListCommandTest extends TestCase
         ];
 
         $app1->setUniqueIdentifier('1');
+        $app1->setName('Beta App');
         $app2->setUniqueIdentifier('2');
+        $app2->setName('Alpha App');
 
-        $this->setupEntityCollection($entities);
+        $this->appStorage
+            ->expects($this->once())
+            ->method('findAll')
+            ->with(static::isInstanceOf(Context::class))
+            ->willReturn(new AppCollection($entities));
 
         $options = ['--json' => true];
-        $json = json_encode([$app1->jsonSerialize(), $app2->jsonSerialize()], \JSON_THROW_ON_ERROR);
+        $json = json_encode([$app2->jsonSerialize(), $app1->jsonSerialize()], \JSON_THROW_ON_ERROR);
 
         $commandTester = $this->executeCommand($options);
         static::assertSame(0, $commandTester->getStatusCode());
@@ -141,15 +125,5 @@ class AppListCommandTest extends TestCase
         $commandTester->execute($options);
 
         return $commandTester;
-    }
-
-    /**
-     * @param array<int, AppEntity> $entities
-     */
-    private function setupEntityCollection(array $entities): void
-    {
-        $result = $this->createMock(EntitySearchResult::class);
-        $result->method('getEntities')->willReturn(new AppCollection($entities));
-        $this->appRepoMock->method('search')->willReturn($result);
     }
 }

--- a/tests/unit/Core/Framework/App/Command/DeactivateAppCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/DeactivateAppCommandTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppStateService;
+use Shopware\Core\Framework\App\AppStorage;
+use Shopware\Core\Framework\App\Command\AbstractAppActivationCommand;
+use Shopware\Core\Framework\App\Command\DeactivateAppCommand;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[CoversClass(AbstractAppActivationCommand::class)]
+#[CoversClass(DeactivateAppCommand::class)]
+class DeactivateAppCommandTest extends TestCase
+{
+    public function testDeactivateFailsWhenAppCannotBeFound(): void
+    {
+        $appStorage = $this->createMock(AppStorage::class);
+        $appStorage
+            ->expects($this->once())
+            ->method('findByName')
+            ->with('UnknownApp', static::isInstanceOf(Context::class))
+            ->willReturn(null);
+
+        $stateService = $this->createMock(AppStateService::class);
+        $stateService->expects($this->never())->method('deactivateApp');
+
+        $command = new DeactivateAppCommand(
+            $appStorage,
+            $stateService,
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['name' => 'UnknownApp']);
+
+        static::assertSame(1, $commandTester->getStatusCode());
+        static::assertStringContainsString('[ERROR] No app found for "UnknownApp".', $commandTester->getDisplay());
+    }
+}

--- a/tests/unit/Core/Framework/App/Command/UninstallAppCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/UninstallAppCommandTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppStorage;
+use Shopware\Core\Framework\App\Command\UninstallAppCommand;
+use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+#[CoversClass(UninstallAppCommand::class)]
+class UninstallAppCommandTest extends TestCase
+{
+    public function testUninstallFailsWhenAppCannotBeFound(): void
+    {
+        $appStorage = $this->createMock(AppStorage::class);
+        $appStorage
+            ->expects($this->once())
+            ->method('findByName')
+            ->with('UnknownApp', static::isInstanceOf(Context::class))
+            ->willReturn(null);
+
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('delete');
+
+        $command = new UninstallAppCommand($appLifecycle, $appStorage);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['name' => 'UnknownApp']);
+
+        static::assertSame(1, $commandTester->getStatusCode());
+        static::assertStringContainsString('[ERROR] No app with name "UnknownApp" installed.', $commandTester->getDisplay());
+    }
+}


### PR DESCRIPTION
## What?

- Routes `app:activate`, `app:deactivate`, `app:uninstall`, and `app:list` through `AppStorage` instead of wiring the app DAL repository into the commands.
- Adds explicit `AppStorage` read methods for command usage: `findAll()` and `findAllWithNameOrLabel()`.
- Keeps `app:list` sorting in the command while `AppStorage` keeps the regular-app boundary.

## Why?

The app commands should only operate on regular apps. Routing them through `AppStorage` keeps `selfManaged` services out of these command paths and moves another set of consumers away from direct `app.repository` usage.