### PR TITLE
fix: keep product stream value layout in sync

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
@@ -54,7 +54,12 @@ export default {
     data() {
         return {
             value: null,
+            // Actual rendered child count used by CSS.
             childComponentsCount: null,
+            // Pending timer id for the delayed recount.
+            childComponentsCountUpdateTimeout: null,
+            // Observer object watching DOM child changes.
+            childComponentsCountObserver: null,
             searchTerm: '',
         };
     },
@@ -440,13 +445,46 @@ export default {
     },
 
     mounted() {
-        // Wait for all child components to be mounted. $nextTick is not enough here.
-        setTimeout(() => {
-            this.childComponentsCount = Object.keys(this.$refs ?? {}).length;
-        });
+        if (typeof MutationObserver !== 'undefined') {
+            this.childComponentsCountObserver = new MutationObserver(() => {
+                this.updateChildComponentsCount();
+            });
+            this.childComponentsCountObserver.observe(this.$el, {
+                childList: true,
+                subtree: true,
+            });
+        }
+
+        this.updateChildComponentsCount();
+    },
+
+    updated() {
+        this.updateChildComponentsCount();
+    },
+
+    beforeUnmount() {
+        clearTimeout(this.childComponentsCountUpdateTimeout);
+        this.childComponentsCountObserver?.disconnect();
     },
 
     methods: {
+        /**
+         * Recount child controls after async DOM updates so the growth class stays in sync.
+         */
+        updateChildComponentsCount() {
+            // Wait for all child components to be mounted. $nextTick is not enough here.
+            clearTimeout(this.childComponentsCountUpdateTimeout);
+            this.childComponentsCountUpdateTimeout = setTimeout(() => {
+                const childComponentsCount = this.$el?.children.length ?? 0;
+
+                if (this.childComponentsCount === childComponentsCount) {
+                    return;
+                }
+
+                this.childComponentsCount = childComponentsCount;
+            });
+        },
+
         onChangeType(type, parameters) {
             this.$emit('type-change', { type, parameters });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.spec.js
@@ -68,6 +68,7 @@ async function createWrapper(privileges = [], fieldType = null, conditionType = 
                 },
                 conditionDataProviderService: {
                     getOperatorSet: () => [],
+                    isRelativeTimeType: () => false,
                     allowedJsonAccessors: {
                         'json.test': {
                             value: 'json.test',
@@ -187,6 +188,63 @@ describe('src/module/sw-product-stream/component/sw-product-stream-value', () =>
         });
 
         expect(wrapper.get('.sw-product-stream-value__placeholder').exists()).toBe(true);
+    });
+
+    it('should update the growth class when value controls are rendered asynchronously', async () => {
+        const wrapper = await createWrapper(['product_stream.viewer'], '', 'contains', '');
+
+        await new Promise((resolve) => {
+            setTimeout(resolve);
+        });
+
+        expect(wrapper.vm.childComponentsCount).toBe(1);
+        expect(wrapper.classes()).toContain('sw-product-stream-value--grow-1');
+
+        await wrapper.setProps({
+            fieldName: 'name',
+            definition: {
+                entity: 'product',
+                getField: () => ({ type: 'string' }),
+                isJsonField: () => false,
+            },
+            condition: {
+                type: 'contains',
+                value: 'OSS',
+            },
+        });
+
+        await flushPromises();
+        await new Promise((resolve) => {
+            setTimeout(resolve);
+        });
+
+        expect(wrapper.vm.childComponentsCount).toBeGreaterThan(1);
+        expect(wrapper.classes()).not.toContain('sw-product-stream-value--grow-1');
+        expect(wrapper.classes()).toContain(`sw-product-stream-value--grow-${wrapper.vm.childComponentsCount}`);
+    });
+
+    it('should update the growth class when child controls render without a parent update', async () => {
+        const wrapper = await createWrapper(['product_stream.viewer'], '', 'contains', '');
+
+        await new Promise((resolve) => {
+            setTimeout(resolve);
+        });
+
+        expect(wrapper.vm.childComponentsCount).toBe(1);
+
+        const asyncControl = document.createElement('div');
+        wrapper.element.appendChild(asyncControl);
+
+        await Promise.resolve();
+        await new Promise((resolve) => {
+            setTimeout(resolve);
+        });
+        await new Promise((resolve) => {
+            setTimeout(resolve);
+        });
+
+        expect(wrapper.vm.childComponentsCount).toBe(wrapper.element.children.length);
+        expect(wrapper.classes()).toContain(`sw-product-stream-value--grow-${wrapper.element.children.length}`);
     });
 
     it('should return correct fieldDefinition', async () => {


### PR DESCRIPTION
## Issue

Fixes #16785.

Reloading a Dynamic Product Group detail page can leave the product stream value area with an outdated growth class. The saved condition value is still present, but the value control is squeezed visually and the filter row looks unusable until the user clicks Save.

## Solution

Update `sw-product-stream-value` so the rendered child controls are recounted whenever async value controls are inserted into the DOM. The component now:

- observes nested child changes with a `MutationObserver`
- schedules a delayed recount so async controls can settle
- updates the growth class only when the rendered child count changes
- cleans up the observer and pending timer on unmount

This keeps `sw-product-stream-value--grow-*` in sync after reload, instead of relying on a later Save action to trigger another render.

## Acceptance Criteria

- Reloading a Dynamic Product Group detail page keeps existing filter values visible.
- The value input is usable immediately after reload without clicking Save.
- The product stream value growth class updates when async child controls render.
- Observer and timer cleanup happens when the component unmounts.
- Unit tests cover async value control rendering and DOM child changes without a parent update.

## Reproduce Step

1. Open Administration > Catalogues > Dynamic Product Groups.
2. Create or open a Dynamic Product Group with a condition such as `Name` / `Contains` / `OSS`.
3. Save the Dynamic Product Group.
4. Reload the detail page.
5. Before this fix, the `OSS` value input is visually missing or squeezed until Save is clicked.
6. After this fix, the value input remains visible and usable immediately after reload.
