### PR TITLE
fix: Checking for unregistered feature flag in Twig

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Extension/FeatureFlagExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/FeatureFlagExtension.php
@@ -37,6 +37,10 @@ class FeatureFlagExtension extends AbstractExtension
 
     public function feature(string $flag): bool
     {
+        if (!Feature::has($flag)) {
+            return false;
+        }
+
         return Feature::isActive($flag);
     }
 

--- a/tests/unit/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/unit/Core/Framework/FeatureFlag/FeatureTest.php
@@ -154,10 +154,6 @@ class FeatureTest extends TestCase
 
     public function testTwigFeatureFlagNotRegistered(): void
     {
-        set_error_handler(static function (int $errno, string $errstr): never {
-            throw new \Exception($errstr, $errno);
-        }, \E_USER_WARNING);
-
         $_SERVER['APP_ENV'] = 'test';
         $_ENV['APP_ENV'] = 'test';
 
@@ -168,14 +164,7 @@ class FeatureTest extends TestCase
         $twig->addExtension(new FeatureFlagExtension());
         $template = $twig->loadTemplate($twig->getTemplateClass('featuretest_unregistered.html.twig'), 'featuretest_unregistered.html.twig');
 
-        $this->expectExceptionMessageMatches('/.*RANDOMFLAGTHATISNOTREGISTERDE471112.*/');
-
-        try {
-            $template->render([]);
-        } catch (\Exception $e) {
-            restore_error_handler();
-            throw $e;
-        }
+        static::assertSame('FeatureIsInactive', $template->render([]));
     }
 
     public function testTwigFeatureFlagNotRegisteredInProd(): void
@@ -190,9 +179,7 @@ class FeatureTest extends TestCase
         $twig->addExtension(new FeatureFlagExtension());
         $template = $twig->loadTemplate($twig->getTemplateClass('featuretest_unregistered.html.twig'), 'featuretest_unregistered.html.twig');
 
-        $this->expectNotToPerformAssertions();
-
-        $template->render([]);
+        static::assertSame('FeatureIsInactive', $template->render([]));
     }
 
     public function testRegisterFeaturesDoesNotOverrideMetaData(): void


### PR DESCRIPTION
Fixes: #16275 

### 1. Why is this change necessary?

Checking for non-existent feature flags in Twig throws an error.

### 2. What does this change do, exactly?

Checking for not existing feature flags will return false.