### PR TITLE
fix: add array return type to getSubscribedEvents in three subscribers

### DIFF
--- a/src/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriber.php
+++ b/src/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriber.php
@@ -27,7 +27,7 @@ readonly class RememberDeletedAppsSecretSubscriber implements EventSubscriberInt
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             AppDeletedEvent::class => 'saveSecretFromDeletedApp',

--- a/src/Core/System/Consent/Log/ConsentChangedSubscriber.php
+++ b/src/Core/System/Consent/Log/ConsentChangedSubscriber.php
@@ -19,7 +19,7 @@ class ConsentChangedSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConsentAcceptedEvent::class => 'onConsentAccepted',

--- a/src/Core/System/Consent/Subscriber/SetupStagingEventSubscriber.php
+++ b/src/Core/System/Consent/Subscriber/SetupStagingEventSubscriber.php
@@ -18,7 +18,7 @@ class SetupStagingEventSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             SetupStagingEvent::class => 'removeAllConsents',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Three subscribers have no return type. Without the :array return type, symfony 7.3+ emits this error 
`User Deprecated: Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "..." now to avoid errors or add an explicit @return annotation to suppress this message.
`

### 2. What does this change do, exactly?
Adds array return type to those subscribers

### 3. Describe each step to reproduce the issue or behaviour.

1. Empty Shopware project on trunk
2. Boot kernel (any request / cache warmup)
3. Observe the three deprecation entries in var/log/dev.log

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/16738

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
