### PR TITLE
fix(admin): prevent media replace failure when used in product slot config

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
@@ -205,11 +205,14 @@ export default {
         },
 
         loadProductAssociations() {
-            this.products = this.item.productMedia;
+            // Clone to avoid mutating the media entity's productMedia collection when
+            // slot-config products are appended below — a plain `{ product }` wrapper in
+            // an entity collection breaks ChangesetGenerator on the next save.
+            this.products = [...this.item.productMedia];
         },
 
         loadCategoryAssociations() {
-            this.categories = this.item.categories;
+            this.categories = [...this.item.categories];
         },
 
         loadManufacturerAssociations() {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
@@ -205,9 +205,6 @@ export default {
         },
 
         loadProductAssociations() {
-            // Clone to avoid mutating the media entity's productMedia collection when
-            // slot-config products are appended below — a plain `{ product }` wrapper in
-            // an entity collection breaks ChangesetGenerator on the next save.
             this.products = [...this.item.productMedia];
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
@@ -216,4 +216,52 @@ describe('module/sw-media/components/sw-media-quickinfo-usage', () => {
         expect(usages.some((usage) => usage.name === 'Landing Page Media Test')).toBeTruthy();
         expect(usages.some((usage) => usage.name === 'CMS Page Media Test')).toBeTruthy();
     });
+
+    it('must not mutate the media entity productMedia / categories collections when loading slot-config usages', async () => {
+        await wrapper.unmount();
+
+        wrapper = await createWrapper({
+            create: (entityName) => {
+                return {
+                    search: () => {
+                        if (entityName === 'product') {
+                            return Promise.resolve([
+                                { id: 'slot-product-id', translated: { name: 'Slot Product' } },
+                            ]);
+                        }
+
+                        if (entityName === 'category') {
+                            return Promise.resolve([
+                                { id: 'slot-category-id', translated: { name: 'Slot Category' } },
+                            ]);
+                        }
+
+                        return Promise.resolve([]);
+                    },
+                };
+            },
+        });
+
+        register('sw-product', moduleMock);
+        register('sw-category', moduleMock);
+
+        const item = itemDeleteMock();
+        const originalProductMedia = item.productMedia;
+        const originalCategories = item.categories;
+
+        await wrapper.setProps({ item });
+        await wrapper.vm.loadSlotConfigAssociations();
+
+        // The media entity's own collections must not be polluted with non-entity
+        // (or unrelated) items, otherwise ChangesetGenerator crashes on the next save.
+        expect(item.productMedia).toBe(originalProductMedia);
+        expect(item.productMedia).toHaveLength(0);
+        expect(item.categories).toBe(originalCategories);
+        expect(item.categories).toHaveLength(0);
+
+        // The display layer should still surface the slot-config usages.
+        const usages = wrapper.vm.getUsages;
+        expect(usages.some((usage) => usage.name === 'Slot Product')).toBeTruthy();
+        expect(usages.some((usage) => usage.name === 'Slot Category')).toBeTruthy();
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
@@ -252,14 +252,11 @@ describe('module/sw-media/components/sw-media-quickinfo-usage', () => {
         await wrapper.setProps({ item });
         await wrapper.vm.loadSlotConfigAssociations();
 
-        // The media entity's own collections must not be polluted with non-entity
-        // (or unrelated) items, otherwise ChangesetGenerator crashes on the next save.
         expect(item.productMedia).toBe(originalProductMedia);
         expect(item.productMedia).toHaveLength(0);
         expect(item.categories).toBe(originalCategories);
         expect(item.categories).toHaveLength(0);
 
-        // The display layer should still surface the slot-config usages.
         const usages = wrapper.vm.getUsages;
         expect(usages.some((usage) => usage.name === 'Slot Product')).toBeTruthy();
         expect(usages.some((usage) => usage.name === 'Slot Category')).toBeTruthy();


### PR DESCRIPTION
### 1. Why is this change necessary?

When a media file is used as a per-product CMS slot override (`product.slotConfig.<slotId>.media.value`), replacing that file via **Content → Media → Replace** fails: after uploading the new file the "Replace" button stays disabled and the browser console logs

```
Uncaught (in promise) TypeError: e.getEntityName is not a function
    at ChangesetGenerator.recursion
    at ChangesetGenerator.handleOneToMany
```

### 2. What does this change do, exactly?

`sw-media-quickinfo-usage` was assigning the media entity's OneToMany collections **by reference** and then pushing display wrappers into them:

```js
loadProductAssociations() { this.products = this.item.productMedia; }
...
this.products.push({ product: foundInProduct }); // ← mutates media.productMedia
```

The pushed plain object (no `getEntityName` / `getOrigin` / `getDraft`) ends up inside the media entity's `productMedia` collection. The next save of the media — triggered internally by `sw-media-upload-v2` during replace — runs `ChangesetGenerator.handleOneToMany` over the polluted collection and crashes, leaving the upload promise rejected and the button disabled. The same shape applies to `categories`, though the pushed items there are real entities so it didn't crash on save but still mutated loaded entity state.

The fix clones the entity collections in the loaders (`[...this.item.productMedia]` / `[...this.item.categories]`), so the slot-config augmentation goes onto a display-only array and the media entity stays clean. No public API, twig, schema or store changed — additive and non-breaking.

A regression test in `sw-media-quickinfo-usage.spec.js` pins the new behavior: it fails on `trunk` (`Received length: 1, Received array: [{ product: ... }]`) and passes with the fix.

### 3. Describe each step to reproduce the issue or behaviour.

1. Admin → Catalogues → Products → open any product.
2. On the product's **Layout** tab, assign a CMS layout that contains an image-bearing element (image, image-slider, text-teaser, …).
3. In the Layout view, open an image slot and assign a specific media file as a per-product override.
4. Save the product.
5. Admin → Content → Media → click the media file you assigned.
6. In the sidebar's "Used in" section the product now appears.
7. Click the **Replace** icon, drop or pick a new image file.
8. **Before the fix:** the "Replace" button stays grayed out; devtools console shows `e.getEntityName is not a function`.
9. **After the fix:** the "Replace" button activates and replacement completes; no console error.

### 4. Please link to the relevant issues (if any).

- closes #16895

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers (not relevant: bugfix with no developer-facing API change)
- [x] I have written or adjusted the documentation according to my changes (not applicable: bugfix only)
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them