### PR TITLE
docs: update release notes to show correct versions

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -22,6 +22,12 @@ Implement `previewPatternByNumberRangeId()` for persisted number-range previews 
 The type-based `previewPattern()` method remains available for backwards compatibility in 6.7, but is deprecated and will be removed in 6.8.
 Use `previewPatternByNumberRangeId()` when previewing or editing an existing number range.
 
+### Elasticsearch: Dedicated `completion` field for admin-search autocomplete
+
+Admin-search autocomplete now flows through a new `completion` field (ngram-indexed, populated with name-shaped values per entity). The ngram subfield has been dropped from `text`/`textBoosted` so identifiers (EAN, productNumber, orderNumber, etc.) no longer feed ngram scoring — fixing a regression where a full GTIN search could be outranked by unrelated products with overlapping digit substrings.
+
+Run `bin/console es:admin:index` after deploying. Identifier search works immediately on the old index; substring autocomplete is degraded to prefix-only until the reindex completes.
+
 ## App System
 
 ### [Opt-in] Webhook delivery rework
@@ -421,12 +427,6 @@ Stored values are 64 hexadecimal characters instead of 32. The database column w
 A migration registers the product indexer so that only the variant listing updater (`product.variant-listing`, the step that maintains `display_group`) is queued.
 That pass runs with the usual deferred indexing after an update or installation finishes, not inside the migration.
 If your integration or plugin assumes a 32-character `display_group`, compares against previously stored MD5 values, or relies on custom SQL with the old column width, update it to accept 64-character hashes and the new column definition.
-
-### Elasticsearch: Dedicated `completion` field for admin-search autocomplete
-
-Admin-search autocomplete now flows through a new `completion` field (ngram-indexed, populated with name-shaped values per entity). The ngram subfield has been dropped from `text`/`textBoosted` so identifiers (EAN, productNumber, orderNumber, etc.) no longer feed ngram scoring — fixing a regression where a full GTIN search could be outranked by unrelated products with overlapping digit substrings.
-
-Run `bin/console es:admin:index` after deploying. Identifier search works immediately on the old index; substring autocomplete is degraded to prefix-only until the reindex completes.
 
 ### "Find best variant setting" is now applied for storefront filtering
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,4 +1,47 @@
-# 6.7.11.0 (upcoming)
+# 6.7.12.0 (upcoming)
+
+## API
+
+### Number range previews can target a concrete number range
+
+The Admin API now supports previewing a persisted number range by id via `/api/_action/number-range/{numberRangeId}/preview-pattern`.
+Use this route when editing an existing number range, because it reads the state for the concrete `number_range.id`.
+
+The previous type-based preview route `/api/_action/number-range/preview-pattern/{type}` remains available in 6.7 for backwards compatibility, but is deprecated and will be removed in 6.8.
+It can only resolve global number ranges and therefore does not support non-global number range state.
+The allocation route `/api/_action/number-range/reserve/{type}` is unchanged.
+
+## Core
+
+### Number range value generator interface deprecated
+
+`NumberRangeValueGeneratorInterface` is deprecated in favor of `AbstractNumberRangeValueGenerator`.
+Custom number range value generator implementations and decorators should extend the abstract class instead.
+Implement `previewPatternByNumberRangeId()` for persisted number-range previews and continue using `getValue()` for actual number allocation.
+
+The type-based `previewPattern()` method remains available for backwards compatibility in 6.7, but is deprecated and will be removed in 6.8.
+Use `previewPatternByNumberRangeId()` when previewing or editing an existing number range.
+
+## App System
+
+### [Opt-in] Webhook delivery rework
+
+Webhook delivery moves to a new dedicated `webhook` Messenger transport, rolled out behind the `WEBHOOKS_REWORK` feature flag.
+When the flag is disabled (which is the default), the `webhook` transport forwards to `async` and Messenger owns retries.
+When the flag is enabled, every webhook is persisted to a database-backed outbox before the first HTTP attempt, and Shopware controls when and how often each delivery is retried.
+
+With the flag enabled:
+
+- **Failed deliveries are retried for up to four hours.** Failures back off on a fixed `5s → 30s → 5min → 30min → 4h` schedule, so a brief DNS outage or upstream restart does not exhaust retries before the endpoint recovers.
+- **Synchronous deliveries are audited.** Deliveries that bypass the queue — those triggered by the admin worker or by forced-sync app lifecycle calls — produce the same audit row as async deliveries, so failures on those paths are inspectable in the database and via the Admin API.
+- **In-flight deliveries survive worker crashes.** If a worker dies while sending a webhook, the next worker picks up the in-flight delivery and retries it.
+- **Identity headers on every HTTP POST.** Every request carries `X-Shopware-Event-Id`, `X-Shopware-Sequence`, and `X-Shopware-Attempt` headers plus a `source.sequence` field in the body. Consumers can use them to deduplicate retries and reorder events independent of HTTP arrival order. The same headers ship for every webhook, regardless of how it is delivered.
+
+Enabling the flag requires configuration changes — the worker consume command must list the new `webhook` transport, and `shopware.admin_worker.transports` may need updating if it was overridden. Rolling the flag back off also has its own steps. See `UPGRADE-6.7.md` for the full procedure.
+
+Tracked in [shopware/shopware#16560](https://github.com/shopware/shopware/issues/16560).
+
+# 6.7.11.0
 
 ## Features
 
@@ -18,15 +61,6 @@ To enable this feature, set the `MCP_SERVER` feature flag to `true`. The MCP end
 A `debug:mcp` CLI command is available to list all registered MCP tools, prompts, and resources.
 
 ## API
-
-### Number range previews can target a concrete number range
-
-The Admin API now supports previewing a persisted number range by id via `/api/_action/number-range/{numberRangeId}/preview-pattern`.
-Use this route when editing an existing number range, because it reads the state for the concrete `number_range.id`.
-
-The previous type-based preview route `/api/_action/number-range/preview-pattern/{type}` remains available in 6.7 for backwards compatibility, but is deprecated and will be removed in 6.8.
-It can only resolve global number ranges and therefore does not support non-global number range state.
-The allocation route `/api/_action/number-range/reserve/{type}` is unchanged.
 
 ### New foreign key resolvers for the Sync API
 
@@ -62,15 +96,6 @@ The `/api/_action/mail-template/send` payload now also has a first-class `extens
 Arbitrary unknown top-level keys are still forwarded for backwards compatibility in 6.7, but they are deprecated and will stop being forwarded in Shopware 6.8.
 
 ## Core
-
-### Number range value generator interface deprecated
-
-`NumberRangeValueGeneratorInterface` is deprecated in favor of `AbstractNumberRangeValueGenerator`.
-Custom number range value generator implementations and decorators should extend the abstract class instead.
-Implement `previewPatternByNumberRangeId()` for persisted number-range previews and continue using `getValue()` for actual number allocation.
-
-The type-based `previewPattern()` method remains available for backwards compatibility in 6.7, but is deprecated and will be removed in 6.8.
-Use `previewPatternByNumberRangeId()` when previewing or editing an existing number range.
 
 ### Backward compatible invalid locales
 
@@ -309,25 +334,6 @@ Set the parameter to a narrower list (for example `['productNumber']`) to restor
 ### Thumbnail `sizes` attribute now emits a value for the XXL breakpoint
 
 The auto-generated `sizes` attribute produced by `thumbnail.html.twig` now includes a value for the XXL breakpoint. The `xxl` key is the open-ended top (`container / columns`), and `xl` is a closed range bounded by `breakpoint.xxl - 1`, matching the pattern used by smaller breakpoints. Templates that pass a manual `sizes` map to `sw_thumbnails` should add an `xxl` entry to keep parity.
-
-## App System
-
-### [Opt-in] Webhook delivery rework
-
-Webhook delivery moves to a new dedicated `webhook` Messenger transport, rolled out behind the `WEBHOOKS_REWORK` feature flag.
-When the flag is disabled (which is the default), the `webhook` transport forwards to `async` and Messenger owns retries.
-When the flag is enabled, every webhook is persisted to a database-backed outbox before the first HTTP attempt, and Shopware controls when and how often each delivery is retried.
-
-With the flag enabled:
-
-- **Failed deliveries are retried for up to four hours.** Failures back off on a fixed `5s → 30s → 5min → 30min → 4h` schedule, so a brief DNS outage or upstream restart does not exhaust retries before the endpoint recovers.
-- **Synchronous deliveries are audited.** Deliveries that bypass the queue — those triggered by the admin worker or by forced-sync app lifecycle calls — produce the same audit row as async deliveries, so failures on those paths are inspectable in the database and via the Admin API.
-- **In-flight deliveries survive worker crashes.** If a worker dies while sending a webhook, the next worker picks up the in-flight delivery and retries it.
-- **Identity headers on every HTTP POST.** Every request carries `X-Shopware-Event-Id`, `X-Shopware-Sequence`, and `X-Shopware-Attempt` headers plus a `source.sequence` field in the body. Consumers can use them to deduplicate retries and reorder events independent of HTTP arrival order. The same headers ship for every webhook, regardless of how it is delivered.
-
-Enabling the flag requires configuration changes — the worker consume command must list the new `webhook` transport, and `shopware.admin_worker.transports` may need updating if it was overridden. Rolling the flag back off also has its own steps. See `UPGRADE-6.7.md` for the full procedure.
-
-Tracked in [shopware/shopware#16560](https://github.com/shopware/shopware/issues/16560).
 
 ## Hosting & Configuration
 

--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,4 +1,4 @@
-# 6.7.11.0
+# 6.7.12.0
 
 ## (Opt-in) Dedicated `webhook` Messenger transport for webhook delivery
 


### PR DESCRIPTION
This pull request updates release documentation for version 6.7.12.0, introducing new features and deprecations in the Admin API, Core, and App System. The most important changes include support for previewing number ranges by ID, deprecation of the number range value generator interface, and a new opt-in webhook delivery system. The release notes and upgrade guide are updated to reflect these changes.

**API Changes:**
* Added support to preview a persisted number range by ID via `/api/_action/number-range/{numberRangeId}/preview-pattern`, with the old type-based route deprecated for removal in 6.8.
  
**Core Changes:**
* Deprecated `NumberRangeValueGeneratorInterface` in favor of `AbstractNumberRangeValueGenerator`, recommending implementers extend the abstract class and use the new `previewPatternByNumberRangeId()` method.

**App System Changes:**
* Introduced an opt-in webhook delivery rework behind the `WEBHOOKS_REWORK` feature flag, including a dedicated `webhook` Messenger transport, improved retry/audit mechanisms, and new identity headers for every delivery. Configuration and rollback steps are detailed in the upgrade guide. [[1]](diffhunk://#diff-819080d3452b5ad5bc86679c15267c543f1920c1f4dae27011f14ccd463ffcdcL313-L331) [[2]](diffhunk://#diff-a1e93f1340af0c133ed30642f3886db4c5d1b05920920ac420cab52d7bd8b2d2L1-R1)

**Documentation Updates:**
* Bumped the release version in `RELEASE_INFO-6.7.md` and `UPGRADE-6.7.md` from 6.7.11.0 to 6.7.12.0. [[1]](diffhunk://#diff-819080d3452b5ad5bc86679c15267c543f1920c1f4dae27011f14ccd463ffcdcL1-R44) [[2]](diffhunk://#diff-a1e93f1340af0c133ed30642f3886db4c5d1b05920920ac420cab52d7bd8b2d2L1-R1)