### PR TITLE
fix(storefront): offcanvas back-link returns to main entry from footer subtree

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
@@ -1,5 +1,3 @@
-{# At the top of the footer or service subtree, climbing parents leaves every
-   sales-channel navigation root and would 404 — short-circuit to the main entry. #}
 {% set isAlternateRoot = item.id == context.salesChannel.footerCategoryId
     or item.id == context.salesChannel.serviceCategoryId %}
 

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig
@@ -1,4 +1,9 @@
-{% if item.parentId == context.salesChannel.navigationCategoryId %}
+{# At the top of the footer or service subtree, climbing parents leaves every
+   sales-channel navigation root and would 404 — short-circuit to the main entry. #}
+{% set isAlternateRoot = item.id == context.salesChannel.footerCategoryId
+    or item.id == context.salesChannel.serviceCategoryId %}
+
+{% if isAlternateRoot or item.parentId == context.salesChannel.navigationCategoryId %}
     {% set url = path('frontend.menu.offcanvas') %}
 {% else %}
     {% set url = path('frontend.menu.offcanvas', { navigationId: item.parentId }) %}

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -105,6 +105,52 @@ class NavigationControllerTest extends TestCase
         static::assertSame(200, $response->getStatusCode());
     }
 
+    public function testOffcanvasBackLinkAtFooterRootReturnsToMainEntry(): void
+    {
+        $this->createFooterTree();
+
+        $response = $this->request(
+            'GET',
+            'widgets/menu/offcanvas?navigationId=' . $this->ids->get('issue-13510-footer'),
+            []
+        );
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $backLinkHref = $this->extractBackLinkHref((string) $response->getContent());
+
+        // The back-link must not point at the intermediate parent (which lives
+        // outside every sales-channel navigation root and would 404). It must
+        // route back to the main entry (no navigationId query param).
+        static::assertStringNotContainsString(
+            'navigationId=' . $this->ids->get('issue-13510-intermediate'),
+            $backLinkHref
+        );
+        static::assertStringNotContainsString('navigationId=', $backLinkHref);
+    }
+
+    public function testOffcanvasBackLinkAtFooterSubcategoryClimbsToParent(): void
+    {
+        $this->createFooterTree();
+
+        $response = $this->request(
+            'GET',
+            'widgets/menu/offcanvas?navigationId=' . $this->ids->get('issue-13510-footer-about'),
+            []
+        );
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $backLinkHref = $this->extractBackLinkHref((string) $response->getContent());
+
+        // Mid-tree the climb must still happen normally: back from "About us"
+        // goes up to the footer root.
+        static::assertStringContainsString(
+            'navigationId=' . $this->ids->get('issue-13510-footer'),
+            $backLinkHref
+        );
+    }
+
     private function createData(): void
     {
         /** @var SalesChannelEntity $salesChannel */
@@ -204,5 +250,79 @@ class NavigationControllerTest extends TestCase
         );
 
         return ltrim($seoUrl->getSeoPathInfo(), '/');
+    }
+
+    /**
+     * Builds a sales-channel layout that triggers the issue-13510 back-link bug:
+     *
+     *   sales-channel nav root
+     *     └── intermediate           ← NOT assigned to any nav root
+     *           ├── main entry       ← becomes navigationCategoryId
+     *           └── footer entry     ← becomes footerCategoryId
+     *                 └── about us
+     *
+     * Climbing parents from "footer entry" leaves the intermediate exposed,
+     * which is what the buggy back-link tries to load.
+     */
+    private function createFooterTree(): void
+    {
+        $salesChannelId = $this->getSalesChannelId();
+
+        /** @var SalesChannelEntity $salesChannel */
+        $salesChannel = static::getContainer()->get('sales_channel.repository')->search(
+            new Criteria([$salesChannelId]),
+            Context::createDefaultContext()
+        )->first();
+
+        static::getContainer()->get('category.repository')->create([[
+            'id' => $this->ids->create('issue-13510-intermediate'),
+            'parentId' => $salesChannel->getNavigationCategoryId(),
+            'name' => 'Issue 13510 Intermediate',
+            'type' => 'page',
+            'active' => true,
+            'visible' => true,
+            'children' => [
+                [
+                    'id' => $this->ids->create('issue-13510-main'),
+                    'name' => 'Issue 13510 Main',
+                    'type' => 'page',
+                    'active' => true,
+                    'visible' => true,
+                ],
+                [
+                    'id' => $this->ids->create('issue-13510-footer'),
+                    'name' => 'Issue 13510 Footer',
+                    'type' => 'page',
+                    'active' => true,
+                    'visible' => true,
+                    'children' => [[
+                        'id' => $this->ids->create('issue-13510-footer-about'),
+                        'name' => 'Issue 13510 About',
+                        'type' => 'page',
+                        'active' => true,
+                        'visible' => true,
+                    ]],
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        static::getContainer()->get('sales_channel.repository')->update([[
+            'id' => $salesChannelId,
+            'navigationCategoryId' => $this->ids->get('issue-13510-main'),
+            'footerCategoryId' => $this->ids->get('issue-13510-footer'),
+        ]], Context::createDefaultContext());
+    }
+
+    private function extractBackLinkHref(string $html): string
+    {
+        $matched = preg_match(
+            '#<a[^>]*class="[^"]*\bis-back-link\b[^"]*"[^>]*href="([^"]+)"#',
+            $html,
+            $matches
+        );
+
+        static::assertSame(1, $matched, 'No back-link rendered in offcanvas response.');
+
+        return html_entity_decode($matches[1]);
     }
 }

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -153,7 +153,6 @@ class NavigationControllerTest extends TestCase
 
     private function createData(): void
     {
-        /** @var SalesChannelEntity $salesChannel */
         $salesChannel = static::getContainer()->get('sales_channel.repository')->search(
             (new Criteria())->addFilter(
                 new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT),
@@ -161,6 +160,8 @@ class NavigationControllerTest extends TestCase
             ),
             Context::createDefaultContext()
         )->first();
+
+        static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
 
         $category = [
             'id' => $this->ids->create('category'),

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -119,13 +119,6 @@ class NavigationControllerTest extends TestCase
 
         $backLinkHref = $this->extractBackLinkHref((string) $response->getContent());
 
-        // The back-link must not point at the intermediate parent (which lives
-        // outside every sales-channel navigation root and would 404). It must
-        // route back to the main entry (no navigationId query param).
-        static::assertStringNotContainsString(
-            'navigationId=' . $this->ids->get('issue-13510-intermediate'),
-            $backLinkHref
-        );
         static::assertStringNotContainsString('navigationId=', $backLinkHref);
     }
 
@@ -143,8 +136,6 @@ class NavigationControllerTest extends TestCase
 
         $backLinkHref = $this->extractBackLinkHref((string) $response->getContent());
 
-        // Mid-tree the climb must still happen normally: back from "About us"
-        // goes up to the footer root.
         static::assertStringContainsString(
             'navigationId=' . $this->ids->get('issue-13510-footer'),
             $backLinkHref
@@ -253,18 +244,6 @@ class NavigationControllerTest extends TestCase
         return ltrim($seoUrl->getSeoPathInfo(), '/');
     }
 
-    /**
-     * Builds a sales-channel layout that triggers the issue-13510 back-link bug:
-     *
-     *   sales-channel nav root
-     *     └── intermediate           ← NOT assigned to any nav root
-     *           ├── main entry       ← becomes navigationCategoryId
-     *           └── footer entry     ← becomes footerCategoryId
-     *                 └── about us
-     *
-     * Climbing parents from "footer entry" leaves the intermediate exposed,
-     * which is what the buggy back-link tries to load.
-     */
     private function createFooterTree(): void
     {
         $salesChannelId = $this->getSalesChannelId();


### PR DESCRIPTION
### 1. Why is this change necessary?

On mobile, when a customer lands on a category inside the footer (or service) navigation subtree and opens the hamburger menu, tapping `← back` repeatedly eventually crashes the offcanvas with `Category "<id>" not found`. The customer is left on a non-navigable error state.

The mobile offcanvas back-link blindly climbs `item.parentId`. Once the climb passes the footer entry root, the next request points at a category sitting outside every sales-channel navigation root (`navigationCategoryId`, `footerCategoryId`, `serviceCategoryId`). `NavigationRoute::validate()` rejects that id with `CategoryException::categoryNotFound()`.

### 2. What does this change do, exactly?

`src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/back-link.html.twig` now also recognises the footer and service entry roots as terminal back-stops. When the currently displayed `item` is the footer or service entry root, the back-link routes to the main entry (the existing parameterless `frontend.menu.offcanvas` route) instead of climbing into the intermediate parent. The mid-tree climb is unchanged, so deep categories still walk back one level at a time.

Two integration tests are added to `tests/integration/Storefront/Controller/NavigationControllerTest.php`:

- `testOffcanvasBackLinkAtFooterRootReturnsToMainEntry` — captures the bug: rendered back-link href must not carry a `navigationId` query param when the active category is the footer entry root.
- `testOffcanvasBackLinkAtFooterSubcategoryClimbsToParent` — regression guard for mid-tree climb (back from a footer subcategory must still point at the footer parent).

The first test failed against trunk for the right reason (`navigationId=<intermediate>` in the rendered href); both pass with the template change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a category tree where the main entry and the footer entry are **not** direct children of the sales-channel root, e.g.:

   ```
   Root
   └── My Shop                ← intermediate, NOT assigned to any nav root
       ├── Menu               ← Main entry (navigationCategoryId)
       └── Footer             ← Footer entry (footerCategoryId)
           └── About us
               └── Imprint
   ```

2. Save the sales-channel main entry and footer entry, clear the cache.
3. In a Chromium browser, toggle the device toolbar to a mobile preset and reload.
4. Click the footer link to `Imprint`. You land on `/About-us/Imprint/`.
5. Tap the hamburger icon. The offcanvas opens on **Imprint**.
6. Tap `← back` — shows **About us**.
7. Tap `← back` — shows **Footer**.
8. Tap `← back` once more. Before the fix: the offcanvas issues `GET /widgets/menu/offcanvas?navigationId=<My Shop id>` and the response is `Category "<id>" not found`. After the fix: the request is `GET /widgets/menu/offcanvas` and the main entry (Menu) renders.

### 4. Please link to the relevant issues (if any).

- closes #13510

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details. _(not applicable — internal storefront template fix, no developer-facing API or behaviour change beyond the bug being repaired)_
- [ ] I have written or adjusted the documentation according to my changes _(not applicable)_
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them