### PR TITLE
fix: empty since version in Feature deprecation notices

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -80,5 +80,8 @@ return [
         preg_quote('CHANGED: Shopware\Core\Framework\Adapter\Twig\SwTwigFunction was marked "@internal"', '/'),
         preg_quote('REMOVED: Method Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::escapeFilter() was removed', '/'),
         preg_quote('REMOVED: Method Shopware\Core\Framework\Adapter\Twig\SwTwigFunction::resetEscapeCache() was removed', '/'),
+
+        // Optional parameter added with default null; existing callers are unaffected
+        preg_quote('ADDED: Parameter introducedIn was added to Method triggerDeprecationOrThrow() of class Shopware\Core\Framework\Feature', '/'),
     ],
 ];

--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,5 +1,11 @@
 # 6.7.11.0
 
+## `Feature::triggerDeprecationOrThrow` accepts an optional `introducedIn` parameter
+
+`Shopware\Core\Framework\Feature::triggerDeprecationOrThrow()` now accepts a third optional `?string $introducedIn = null` argument.
+When provided, the emitted deprecation message is prefixed with `Since shopware/core <introducedIn>:` per Symfony convention, enabling log aggregation by introduction version.
+When omitted, the deprecation is emitted without a `Since` prefix (previously the prefix was rendered with an empty version, producing the malformed `Since shopware/core : ...`).
+
 ## (Opt-in) Dedicated `webhook` Messenger transport for webhook delivery
 
 **Opt-in via the `WEBHOOKS_REWORK` feature flag. Becomes the default in 6.8.** Background and behavioural impact are in `RELEASE_INFO-6.7.md`.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -145,12 +145,6 @@ Previously, these routes could return all customer addresses because the underly
 
 <details>
 
-## `Feature::triggerDeprecationOrThrow` accepts an optional `introducedIn` parameter
-
-`Shopware\Core\Framework\Feature::triggerDeprecationOrThrow()` now accepts a third optional `?string $introducedIn = null` argument.
-When provided, the emitted deprecation message is prefixed with `Since shopware/core <introducedIn>:` per Symfony convention, enabling log aggregation by introduction version.
-When omitted, the deprecation is emitted without a `Since` prefix (previously the prefix was rendered with an empty version, producing the malformed `Since shopware/core : ...`).
-
 ## Number range value generator interface removed
 
 `Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface` was removed.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -145,6 +145,12 @@ Previously, these routes could return all customer addresses because the underly
 
 <details>
 
+## `Feature::triggerDeprecationOrThrow` accepts an optional `introducedIn` parameter
+
+`Shopware\Core\Framework\Feature::triggerDeprecationOrThrow()` now accepts a third optional `?string $introducedIn = null` argument.
+When provided, the emitted deprecation message is prefixed with `Since shopware/core <introducedIn>:` per Symfony convention, enabling log aggregation by introduction version.
+When omitted, the deprecation is emitted without a `Since` prefix (previously the prefix was rendered with an empty version, producing the malformed `Since shopware/core : ...`).
+
 ## Number range value generator interface removed
 
 `Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface` was removed.

--- a/src/Core/Framework/Feature.php
+++ b/src/Core/Framework/Feature.php
@@ -283,7 +283,7 @@ class Feature
             return;
         }
 
-        trigger_deprecation('shopware/core', '', $message);
+        trigger_deprecation('shopware/core', $majorFlag, $message);
     }
 
     public static function deprecatedMethodMessage(string $class, string $method, string $majorVersion, ?string $replacement = null): string

--- a/src/Core/Framework/Feature.php
+++ b/src/Core/Framework/Feature.php
@@ -264,7 +264,7 @@ class Feature
         }
     }
 
-    public static function triggerDeprecationOrThrow(string $majorFlag, string $message): void
+    public static function triggerDeprecationOrThrow(string $majorFlag, string $message, ?string $introducedIn = null): void
     {
         if (!self::$emitDeprecations || !empty(self::$silent[$majorFlag])) {
             return;
@@ -283,7 +283,13 @@ class Feature
             return;
         }
 
-        trigger_deprecation('shopware/core', $majorFlag, $message);
+        if ($introducedIn === null) {
+            trigger_deprecation('', '', $message);
+
+            return;
+        }
+
+        trigger_deprecation('shopware/core', $introducedIn, $message);
     }
 
     public static function deprecatedMethodMessage(string $class, string $method, string $majorVersion, ?string $replacement = null): string

--- a/tests/unit/Core/Framework/Adapter/Twig/TokenParser/FeatureFlagCallTokenParserTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TokenParser/FeatureFlagCallTokenParserTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\TokenParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\TokenParser\FeatureFlagCallTokenParser;
 use Shopware\Core\Framework\Feature;
@@ -20,20 +21,31 @@ class FeatureFlagCallTokenParserTest extends TestCase
 {
     use EnvTestBehaviour;
 
-    #[IgnoreDeprecations]
-    #[DataProvider('providerCode')]
-    public function testCodeRun(string $twigCode, bool $shouldThrow): void
+    #[TestDox('sw_silent_feature_call wrapping an inactive flag suppresses Feature::triggerDeprecationOrThrow inside the rendered closure')]
+    public function testSilentFeatureCallSuppressesDeprecation(): void
     {
         // Deprecation warnings are suppressed in test mode by default
         $this->setEnvVars(['TESTS_RUNNING' => false, 'TEST_TWIG' => false]);
 
-        if ($shouldThrow) {
-            $this->expectUserDeprecationMessageMatches('/Since shopware\/core.*Foooo/');
-        }
+        $this->expectNotToPerformAssertions();
 
-        if (!$shouldThrow) {
-            $this->expectNotToPerformAssertions();
-        }
+        $twig = new Environment(new ArrayLoader([
+            'test.twig' => '{% sw_silent_feature_call "TEST_TWIG" %}{% do foo.call %}{% endsw_silent_feature_call %}',
+        ]));
+        $twig->addTokenParser(new FeatureFlagCallTokenParser());
+        $twig->render('test.twig', [
+            'foo' => new TestService(),
+        ]);
+    }
+
+    #[IgnoreDeprecations]
+    #[DataProvider('providerCode')]
+    public function testCodeRun(string $twigCode): void
+    {
+        // Deprecation warnings are suppressed in test mode by default
+        $this->setEnvVars(['TESTS_RUNNING' => false, 'TEST_TWIG' => false]);
+
+        $this->expectUserDeprecationMessage('Foooo');
 
         $twig = new Environment(new ArrayLoader(['test.twig' => $twigCode]));
         $twig->addTokenParser(new FeatureFlagCallTokenParser());
@@ -43,23 +55,16 @@ class FeatureFlagCallTokenParserTest extends TestCase
     }
 
     /**
-     * @return iterable<array{0: string, 1: bool}>
+     * @return iterable<array{0: string}>
      */
     public static function providerCode(): iterable
     {
-        yield 'silenced' => [
-            '{% sw_silent_feature_call "TEST_TWIG" %}{% do foo.call %}{% endsw_silent_feature_call %}',
-            false,
-        ];
-
         yield 'triggers deprecation' => [
             '{% do foo.call %}',
-            true,
         ];
 
         yield 'test injection' => [
             '{% sw_silent_feature_call "aaa\' . system(\'id\') . \'bbb" %}{% do foo.call %}{% endsw_silent_feature_call %}',
-            true,
         ];
     }
 }

--- a/tests/unit/Core/Framework/FeatureTest.php
+++ b/tests/unit/Core/Framework/FeatureTest.php
@@ -254,21 +254,21 @@ class FeatureTest extends TestCase
     #[IgnoreDeprecations]
     #[DisabledFeatures(['v6.5.0.0'])]
     #[DataProvider('callSilentIfInactiveProvider')]
-    public function testCallSilentIfInactiveProvider(string $majorVersion, string $deprecatedMessage, bool $shouldTriggerDeprecation): void
+    public function testCallSilentIfInactiveProvider(string $majorVersion, string $deprecatedMessage, bool $shouldTriggerDeprecation, ?string $introducedIn = null): void
     {
         // Deprecation warnings are suppressed in test mode by default
         $this->setEnvVars(['TESTS_RUNNING' => false]);
 
-        if ($shouldTriggerDeprecation) {
-            $this->expectUserDeprecationMessageMatches('/Since shopware\/core ' . preg_quote($majorVersion, '/') . ': deprecated message/');
-        }
-
-        if (!$shouldTriggerDeprecation) {
+        if ($shouldTriggerDeprecation && $introducedIn !== null) {
+            $this->expectUserDeprecationMessageMatches('/^Since shopware\/core ' . preg_quote($introducedIn, '/') . ': ' . preg_quote($deprecatedMessage, '/') . '$/');
+        } elseif ($shouldTriggerDeprecation) {
+            $this->expectUserDeprecationMessageMatches('/^' . preg_quote($deprecatedMessage, '/') . '$/');
+        } else {
             $this->expectNotToPerformAssertions();
         }
 
-        Feature::callSilentIfInactive('v6.5.0.0', static function () use ($deprecatedMessage, $majorVersion): void {
-            Feature::triggerDeprecationOrThrow($majorVersion, $deprecatedMessage);
+        Feature::callSilentIfInactive('v6.5.0.0', static function () use ($deprecatedMessage, $majorVersion, $introducedIn): void {
+            Feature::triggerDeprecationOrThrow($majorVersion, $deprecatedMessage, $introducedIn);
         });
     }
 
@@ -334,9 +334,13 @@ class FeatureTest extends TestCase
             'v6.5.0.0', 'deprecated message', false,
         ];
 
-        yield 'Execute a callable with inactivated feature flag and throw a deprecated message' => [
+        yield 'Execute a callable with inactivated feature flag and throw a bare deprecation when introducedIn is omitted' => [
             // `v6.4.0.0` is not registered as feature flag, therefore it will always throw the deprecation
             'v6.4.0.0', 'deprecated message', true,
+        ];
+
+        yield 'Execute a callable with inactivated feature flag and throw a deprecation prefixed with the introduction version' => [
+            'v6.4.0.0', 'deprecated message', true, 'v6.3.0.0',
         ];
     }
 }

--- a/tests/unit/Core/Framework/FeatureTest.php
+++ b/tests/unit/Core/Framework/FeatureTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Framework;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Feature;
@@ -251,21 +252,32 @@ class FeatureTest extends TestCase
         Feature::triggerDeprecationOrThrow('v6.5.0.0', 'test');
     }
 
-    #[IgnoreDeprecations]
+    #[TestDox('Feature::callSilentIfInactive suppresses Feature::triggerDeprecationOrThrow for the same inactive flag, so no E_USER_DEPRECATED is emitted')]
     #[DisabledFeatures(['v6.5.0.0'])]
-    #[DataProvider('callSilentIfInactiveProvider')]
-    public function testCallSilentIfInactiveProvider(string $majorVersion, string $deprecatedMessage, bool $shouldTriggerDeprecation, ?string $introducedIn = null): void
+    public function testCallSilentIfInactiveSuppressesDeprecationForInactiveFeature(): void
     {
         // Deprecation warnings are suppressed in test mode by default
         $this->setEnvVars(['TESTS_RUNNING' => false]);
 
-        if ($shouldTriggerDeprecation && $introducedIn !== null) {
-            $this->expectUserDeprecationMessageMatches('/^Since shopware\/core ' . preg_quote($introducedIn, '/') . ': ' . preg_quote($deprecatedMessage, '/') . '$/');
-        } elseif ($shouldTriggerDeprecation) {
-            $this->expectUserDeprecationMessageMatches('/^' . preg_quote($deprecatedMessage, '/') . '$/');
-        } else {
-            $this->expectNotToPerformAssertions();
-        }
+        $this->expectNotToPerformAssertions();
+
+        Feature::callSilentIfInactive('v6.5.0.0', static function (): void {
+            Feature::triggerDeprecationOrThrow('v6.5.0.0', 'deprecated message');
+        });
+    }
+
+    /**
+     * @param non-empty-string $expectedDeprecation
+     */
+    #[IgnoreDeprecations]
+    #[DisabledFeatures(['v6.5.0.0'])]
+    #[DataProvider('callSilentIfInactiveProvider')]
+    public function testCallSilentIfInactive(string $majorVersion, string $deprecatedMessage, ?string $introducedIn, string $expectedDeprecation): void
+    {
+        // Deprecation warnings are suppressed in test mode by default
+        $this->setEnvVars(['TESTS_RUNNING' => false]);
+
+        $this->expectUserDeprecationMessage($expectedDeprecation);
 
         Feature::callSilentIfInactive('v6.5.0.0', static function () use ($deprecatedMessage, $majorVersion, $introducedIn): void {
             Feature::triggerDeprecationOrThrow($majorVersion, $deprecatedMessage, $introducedIn);
@@ -330,17 +342,13 @@ class FeatureTest extends TestCase
 
     public static function callSilentIfInactiveProvider(): \Generator
     {
-        yield 'Execute a callable with inactivated feature flag in silent' => [
-            'v6.5.0.0', 'deprecated message', false,
-        ];
-
         yield 'Execute a callable with inactivated feature flag and throw a bare deprecation when introducedIn is omitted' => [
             // `v6.4.0.0` is not registered as feature flag, therefore it will always throw the deprecation
-            'v6.4.0.0', 'deprecated message', true,
+            'v6.4.0.0', 'deprecated message', null, 'deprecated message',
         ];
 
         yield 'Execute a callable with inactivated feature flag and throw a deprecation prefixed with the introduction version' => [
-            'v6.4.0.0', 'deprecated message', true, 'v6.3.0.0',
+            'v6.4.0.0', 'deprecated message', 'v6.3.0.0', 'Since shopware/core v6.3.0.0: deprecated message',
         ];
     }
 }

--- a/tests/unit/Core/Framework/FeatureTest.php
+++ b/tests/unit/Core/Framework/FeatureTest.php
@@ -260,7 +260,7 @@ class FeatureTest extends TestCase
         $this->setEnvVars(['TESTS_RUNNING' => false]);
 
         if ($shouldTriggerDeprecation) {
-            $this->expectUserDeprecationMessageMatches('/deprecated message/');
+            $this->expectUserDeprecationMessageMatches('/Since shopware\/core ' . preg_quote($majorVersion, '/') . ': deprecated message/');
         }
 
         if (!$shouldTriggerDeprecation) {


### PR DESCRIPTION
### 1. Why is this change necessary?
All deprecations emitted via Feature::triggerDeprecationOrThrow end up in the log with no version after shopware/core
see https://github.com/shopware/shopware/issues/16736

### 2. What does this change do, exactly?
~~Pass  at least the major flag to trigger_deprecation~~

Suppress the package notion when no version is given through an optional parameter `introducedIn`

### 3. Describe each step to reproduce the issue or behaviour.

- Run the tests
- On local check  var/log/dev.log

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/16736

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
