### PR TITLE
fix: move the revocation button out of the collapsible section

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -8,7 +8,7 @@
                 role="list"
             >
                 {% block layout_footer_navigation_hotline %}
-                    <div class="col-md-4 footer-column js-footer-column">
+                    <div class="col-md-4 footer-column js-footer-column pb-4 pb-md-0">
                         {% block layout_footer_navigation_hotline_headline %}
                             <div class="footer-column-headline footer-headline js-footer-column-headline"
                                  id="collapseFooterHotlineTitle"
@@ -74,39 +74,39 @@
                                         '%url%': contactUrl
                                     })|raw }}
                                 </div>
+                            </div>
 
-                                {% block layout_footer_navigation_revocation_button %}
-                                    {% set revocationRequestSnippetKey = 'footer.serviceRevocationRequestTextPage' %}
-                                    {% set revocationRequestCmsPageId = config('core.basicInformation.revocationRequestPage') %}
-                                    {% set showRevocationButton = config('core.basicInformation.showRevocationButton') %}
+                            {% block layout_footer_navigation_revocation_button %}
+                                {% set revocationRequestSnippetKey = 'footer.serviceRevocationRequestTextPage' %}
+                                {% set revocationRequestCmsPageId = config('core.basicInformation.revocationRequestPage') %}
+                                {% set showRevocationButton = config('core.basicInformation.showRevocationButton') %}
 
-                                    {% if revocationRequestCmsPageId and showRevocationButton %}
-                                        {% set revocationRequestUrl = revocationRequestCmsPageId ? path(cmsPath, { id: revocationRequestCmsPageId }) : '#' %}
+                                {% if revocationRequestCmsPageId and showRevocationButton %}
+                                    {% set revocationRequestUrl = revocationRequestCmsPageId ? path(cmsPath, { id: revocationRequestCmsPageId }) : '#' %}
 
-                                        {# Check for seoUrl and use it if present #}
-                                        {% for serviceMenuItem in footer.serviceMenu %}
-                                            {% if serviceMenuItem.cmsPageId == revocationRequestCmsPageId and serviceMenuItem.seoUrl %}
-                                                {% set revocationRequestUrl = serviceMenuItem.seoUrl %}
+                                    {# Check for seoUrl and use it if present #}
+                                    {% for serviceMenuItem in footer.serviceMenu %}
+                                        {% if serviceMenuItem.cmsPageId == revocationRequestCmsPageId and serviceMenuItem.seoUrl %}
+                                            {% set revocationRequestUrl = serviceMenuItem.seoUrl %}
+                                        {% endif %}
+                                    {% endfor %}
+
+                                    {# Check footer navigation #}
+                                    {% if footer.navigation and footer.navigation.tree %}
+                                        {% for footerItem in footer.navigation.tree %}
+                                            {% if footerItem.category.cmsPageId == revocationRequestCmsPageId and footerItem.category.seoUrl %}
+                                                {% set revocationRequestUrl = footerItem.category.seoUrl %}
                                             {% endif %}
                                         {% endfor %}
-
-                                        {# Check footer navigation #}
-                                        {% if footer.navigation and footer.navigation.tree %}
-                                            {% for footerItem in footer.navigation.tree %}
-                                                {% if footerItem.category.cmsPageId == revocationRequestCmsPageId and footerItem.category.seoUrl %}
-                                                    {% set revocationRequestUrl = footerItem.category.seoUrl %}
-                                                {% endif %}
-                                            {% endfor %}
-                                        {% endif %}
-
-                                        <div class="footer-revocation-button mt-4">
-                                            {{ revocationRequestSnippetKey|trans({
-                                                '%url%': revocationRequestUrl
-                                            })|raw }}
-                                        </div>
                                     {% endif %}
-                                {% endblock %}
-                            </div>
+
+                                    <div class="footer-revocation-button mt-4">
+                                        {{ revocationRequestSnippetKey|trans({
+                                            '%url%': revocationRequestUrl
+                                        })|raw }}
+                                    </div>
+                                {% endif %}
+                            {% endblock %}
                         {% endblock %}
                     </div>
                 {% endblock %}

--- a/tests/acceptance/tests/Forms/RevocationRequestForm.spec.ts
+++ b/tests/acceptance/tests/Forms/RevocationRequestForm.spec.ts
@@ -4,8 +4,9 @@ test(
     'As a merchant, I want to switch on and off the revocation request form',
     { tag: ['@Form', '@Revocation', '@Storefront'] },
     async ({ ShopCustomer, StorefrontHome, TestDataService }) => {
+        const revocationButtonName = /Revoke a contract|Vertrag widerrufen/i;
         const revocationFormButton = () => {
-            return StorefrontHome.page.getByRole('link', { name: /Revoke a contract|Vertrag widerrufen/i });
+            return StorefrontHome.page.getByRole('link', { name: revocationButtonName });
         };
 
         const openStorefrontHome = async () => {
@@ -28,6 +29,28 @@ test(
 
             await ShopCustomer.expects(async () => {
                 await openStorefrontHome();
+                await expect(revocationFormButton()).toBeVisible();
+            }).toPass({
+                intervals: [1_000, 2_500],
+            });
+        });
+
+        await test.step('Check if the revocation button is visible without opening the footer column on mobile', async () => {
+            await TestDataService.setSystemConfig({
+                'core.basicInformation.showRevocationButton': true,
+                'core.basicInformation.useDefaultCookieConsent': false,
+            });
+
+            await StorefrontHome.page.setViewportSize({ width: 390, height: 844 });
+
+            await ShopCustomer.expects(async () => {
+                await openStorefrontHome();
+                await StorefrontHome.page.locator('.footer-main').scrollIntoViewIfNeeded();
+
+                const collapsedHotlineContent = StorefrontHome.page.locator('#collapseFooterHotline');
+
+                await expect(collapsedHotlineContent).toBeHidden();
+                await expect(collapsedHotlineContent.getByRole('link', { name: revocationButtonName })).toHaveCount(0);
                 await expect(revocationFormButton()).toBeVisible();
             }).toPass({
                 intervals: [1_000, 2_500],

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -12,10 +12,12 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedHook;
 use Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoadedHook;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
+use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * @internal
@@ -63,6 +65,23 @@ class NavigationControllerTest extends TestCase
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MenuOffcanvasPageletLoadedHook::HOOK_NAME, $traces);
+    }
+
+    public function testRevocationButtonIsRenderedOutsideCollapsedHotlineContent(): void
+    {
+        $salesChannelId = $this->getSalesChannelId();
+        $systemConfigService = static::getContainer()->get(SystemConfigService::class);
+        $systemConfigService->set('core.basicInformation.revocationRequestPage', $this->ids->create('revocation-request-page'), $salesChannelId);
+        $systemConfigService->set('core.basicInformation.showRevocationButton', true, $salesChannelId);
+
+        $response = $this->request('GET', '_esi/global/footer', [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+
+        $crawler = new Crawler((string) $response->getContent());
+
+        static::assertCount(1, $crawler->filter('.footer-revocation-button'), 'The revocation button should be rendered exactly once.');
+        static::assertCount(0, $crawler->filter('#collapseFooterHotline .footer-revocation-button'), 'The revocation button must not be rendered inside the collapsed hotline content.');
+        static::assertCount(1, $crawler->filter('.footer-column.pb-4.pb-md-0 .footer-revocation-button'), 'The revocation button should remain inside the padded footer column.');
     }
 
     public function testStorefrontRedirectsOutOfRangePaginationTo301(): void

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -12,12 +12,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedHook;
 use Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoadedHook;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
-use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * @internal
@@ -65,23 +63,6 @@ class NavigationControllerTest extends TestCase
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
         static::assertArrayHasKey(MenuOffcanvasPageletLoadedHook::HOOK_NAME, $traces);
-    }
-
-    public function testRevocationButtonIsRenderedOutsideCollapsedHotlineContent(): void
-    {
-        $salesChannelId = $this->getSalesChannelId();
-        $systemConfigService = static::getContainer()->get(SystemConfigService::class);
-        $systemConfigService->set('core.basicInformation.revocationRequestPage', $this->ids->create('revocation-request-page'), $salesChannelId);
-        $systemConfigService->set('core.basicInformation.showRevocationButton', true, $salesChannelId);
-
-        $response = $this->request('GET', '_esi/global/footer', [], [], ['HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
-        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
-
-        $crawler = new Crawler((string) $response->getContent());
-
-        static::assertCount(1, $crawler->filter('.footer-revocation-button'), 'The revocation button should be rendered exactly once.');
-        static::assertCount(0, $crawler->filter('#collapseFooterHotline .footer-revocation-button'), 'The revocation button must not be rendered inside the collapsed hotline content.');
-        static::assertCount(1, $crawler->filter('.footer-column.pb-4.pb-md-0 .footer-revocation-button'), 'The revocation button should remain inside the padded footer column.');
     }
 
     public function testStorefrontRedirectsOutOfRangePaginationTo301(): void


### PR DESCRIPTION
closes #16803

## Summary

  - Move the revocation button out of the collapsible footer hotline content
  - Keep the button visually in the hotline footer column
  - Add mobile bottom spacing so the button does not touch the column border
  - Add an integration test to ensure the button is no longer rendered inside the collapsed footer content
  
  
  
<img width="821" height="1209" alt="image" src="https://github.com/user-attachments/assets/ad40b03e-4dfd-4d8f-9a75-dfb6ec519514" />


<img width="744" height="1209" alt="image" src="https://github.com/user-attachments/assets/fceca6c6-d5a4-48a1-a23f-84da20bbaba8" />
