### PR TITLE
fix: allow extending EntitySearchResult

### DIFF
--- a/changelog/_unreleased/2026-05-26-allow-extending-entity-search-result.md
+++ b/changelog/_unreleased/2026-05-26-allow-extending-entity-search-result.md
@@ -1,8 +1,0 @@
----
-title: Allow extending EntitySearchResult
-author: Umut Dogan
-author_email: u.dogan@shopware.com
-author_github: @umutdogan
----
-# Core
-* Removed the `@final` annotation from `Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult` and updated `createNew()` to preserve the concrete entity collection type for extending classes.

--- a/changelog/_unreleased/2026-05-26-allow-extending-entity-search-result.md
+++ b/changelog/_unreleased/2026-05-26-allow-extending-entity-search-result.md
@@ -1,0 +1,8 @@
+---
+title: Allow extending EntitySearchResult
+author: Umut Dogan
+author_email: u.dogan@shopware.com
+author_github: @umutdogan
+---
+# Core
+* Removed the `@final` annotation from `Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult` and updated `createNew()` to preserve the concrete entity collection type for extending classes.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -76,11 +76,6 @@ parameters:
 
         # allowed extension of internal classes with @final annotation only for specific classes
         -
-            message: '#.*extends @final class Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\EntitySearchResult\.#'
-            paths:
-                - src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
-                - src/Core/Content/Product/SalesChannel/Review/ProductReviewResult.php
-        -
             message: '#.*extends @final class Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityRepository.#'
             paths:
                 - src/Core/Content/Test/ImportExport/MockRepository.php

--- a/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
 
 /**
- * @final
- *
  * @template TEntityCollection of EntityCollection
  *
  * @phpstan-type TElement template-type<TEntityCollection, EntityCollection, 'TElement'>
@@ -167,8 +165,10 @@ class EntitySearchResult extends EntityCollection
      */
     protected function createNew(iterable $elements = []): static
     {
-        if (!$elements instanceof EntityCollection) {
-            $elements = new EntityCollection($elements);
+        $collectionClass = $this->entities::class;
+
+        if (!$elements instanceof $collectionClass) {
+            $elements = new $collectionClass($elements);
         }
 
         return new static(

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/EntitySearchResultTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/EntitySearchResultTest.php
@@ -71,6 +71,20 @@ class EntitySearchResultTest extends TestCase
         static::assertSame($entitySearchResult->getContext(), $newInstance->getContext());
     }
 
+    public function testCreateNewPreservesConcreteEntityCollectionType(): void
+    {
+        $entitySearchResult = $this->createTypedEntitySearchResult();
+
+        $newInstance = $entitySearchResult->createFromElements([
+            new ArrayEntity(['id' => Uuid::randomHex()]),
+            new ArrayEntity(['id' => Uuid::randomHex()]),
+        ]);
+
+        static::assertSame(TestEntitySearchResult::class, $newInstance::class);
+        static::assertSame(TestEntityCollection::class, $newInstance->getEntities()::class);
+        static::assertSame(2, $newInstance->getTotal());
+    }
+
     public static function resultPageCriteriaDataProvider(): \Generator
     {
         // Criteria, Page
@@ -101,5 +115,46 @@ class EntitySearchResultTest extends TestCase
             new Criteria(),
             Context::createDefaultContext()
         );
+    }
+
+    private function createTypedEntitySearchResult(): TestEntitySearchResult
+    {
+        $entityCollection = new TestEntityCollection([
+            new ArrayEntity(['id' => Uuid::randomHex()]),
+        ]);
+
+        return new TestEntitySearchResult(
+            ArrayEntity::class,
+            $entityCollection->count(),
+            $entityCollection,
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+    }
+}
+
+/**
+ * @internal
+ *
+ * @extends EntityCollection<ArrayEntity>
+ */
+class TestEntityCollection extends EntityCollection
+{
+}
+
+/**
+ * @internal
+ *
+ * @extends EntitySearchResult<TestEntityCollection>
+ */
+class TestEntitySearchResult extends EntitySearchResult
+{
+    /**
+     * @param iterable<ArrayEntity> $elements
+     */
+    public function createFromElements(iterable $elements): static
+    {
+        return $this->createNew($elements);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php` carries the `@final` docblock, but core itself extends it in `src/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php:14`. Symfony's `DebugClassLoader` reports the violation on every kernel boot.

### 2. What does this change do, exactly?
- Removes the `@final` docblock annotation from `EntitySearchResult`. The native `final` constructor stays, so the constructor signature is still protected from changes.
- Updates `EntitySearchResult::createNew()` to construct the wrap using the concrete class of `$this->entities` instead of the base `EntityCollection`, so typed subclasses keep their
  entity collection type.

### 3. Describe each step to reproduce the issue or behaviour.
- Empty Shopware project on trunk
- Boot kernel (any request / cache warmup)
- Observe the deprecation in var/log/dev.log

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/16739

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
