### PR TITLE
fix(media): declare ext-xmlreader composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         "ext-simplexml": "*",
         "ext-sodium": "*",
         "ext-xml": "*",
+        "ext-xmlreader": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
         "composer-runtime-api": "^2.1",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -63,6 +63,7 @@
         "ext-simplexml": "*",
         "ext-sodium": "*",
         "ext-xml": "*",
+        "ext-xmlreader": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
         "composer-runtime-api": "^2.1",


### PR DESCRIPTION
### 1. Why is this change necessary?

`SvgContentValidator` (`src/Core/Content/Media/File/SvgContentValidator.php`) instantiates `\XMLReader` at runtime, but `ext-xmlreader` was not declared in either the root `composer.json` or `src/Core/composer.json`. On PHP builds that omit the extension — it has its own `--enable-xmlreader` configure switch, separate from `ext-xml` — every SVG upload crashes with `Attempted to load class "XMLReader" from the global namespace`. The dependency was effectively required by the code but undocumented in the composer manifest, so composer let installs proceed and the failure only surfaced at runtime.

### 2. What does this change do, exactly?

Adds `"ext-xmlreader": "*"` to the `require` block of both manifests, alphabetically next to the other XML extensions:

- `composer.json` (root)
- `src/Core/composer.json`

No runtime code changes. Composer now refuses to install on hosts missing the extension and prints a clear error pointing to the fix, instead of letting the install succeed and the validator fatal later. Matches the pattern previously used for adding `ext-session` (commit `95250d86e9d`).

### 3. Describe each step to reproduce the issue or behaviour.

1. Install Shopware 6.7.10.1 on a host that meets the currently documented PHP requirements but does **not** have `ext-xmlreader` loaded.
2. Upload an SVG file via the Media module (or any code path that runs `SvgContentValidator::validate()`).
3. Observe: `Attempted to load class "XMLReader" from the global namespace. Did you forget a "use" statement?` at `SvgContentValidator.php:227`.

After this PR, `composer install`/`composer update` on the same host fails earlier with `shopware/core requires ext-xmlreader * which does not match your installed version`, naming the missing extension directly.

### 4. Please link to the relevant issues (if any).

- closes #16961

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes <!-- planned as a follow-up PR on shopware/docs to add ext-xmlreader to the hosting requirements page -->
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them