### PR TITLE
fix: webhook transport DI resolution endless loop

### DIFF
--- a/src/Core/Framework/DependencyInjection/webhook.xml
+++ b/src/Core/Framework/DependencyInjection/webhook.xml
@@ -63,8 +63,8 @@
 
         <service id="Shopware\Core\Framework\Webhook\Transport\WebhookTransportFactory">
             <argument type="service" id="Shopware\Core\Framework\Webhook\Outbox\WebhookOutboxStore"/>
-            <argument type="service" id="messenger.transport.async"/>
-            <argument type="service" id="Shopware\Core\Framework\Webhook\Transport\MySQLWebhookReceiver"/>
+            <argument type="service_closure" id="messenger.transport.async"/>
+            <argument type="service_closure" id="Shopware\Core\Framework\Webhook\Transport\MySQLWebhookReceiver"/>
             <tag name="messenger.transport_factory"/>
         </service>
 

--- a/src/Core/Framework/Webhook/Transport/WebhookTransportFactory.php
+++ b/src/Core/Framework/Webhook/Transport/WebhookTransportFactory.php
@@ -11,15 +11,23 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @internal
  *
+ * Constructor must not eagerly resolve `messenger.transport.*` services — Symfony's
+ * `messenger.transport_factory` iteration would re-enter itself. Defer with
+ * `service_closure` and resolve in `createTransport()`.
+ *
  * @implements TransportFactoryInterface<WebhookTransport>
  */
 #[Package('framework')]
 class WebhookTransportFactory implements TransportFactoryInterface
 {
+    /**
+     * @param \Closure(): TransportInterface $asyncTransportLocator
+     * @param \Closure(): MySQLWebhookReceiver $receiverLocator
+     */
     public function __construct(
         private readonly WebhookOutboxStore $webhookOutboxStore,
-        private readonly TransportInterface $asyncTransport,
-        private readonly MySQLWebhookReceiver $receiver,
+        private readonly \Closure $asyncTransportLocator,
+        private readonly \Closure $receiverLocator,
     ) {
     }
 
@@ -28,7 +36,11 @@ class WebhookTransportFactory implements TransportFactoryInterface
      */
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
-        return new WebhookTransport($this->webhookOutboxStore, $this->asyncTransport, $this->receiver);
+        return new WebhookTransport(
+            $this->webhookOutboxStore,
+            ($this->asyncTransportLocator)(),
+            ($this->receiverLocator)(),
+        );
     }
 
     /**

--- a/tests/integration/Core/Framework/Webhook/Transport/WebhookTransportTest.php
+++ b/tests/integration/Core/Framework/Webhook/Transport/WebhookTransportTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Transport\WebhookTransport;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 
 /**
  * @internal
@@ -33,6 +34,13 @@ class WebhookTransportTest extends TestCase
         $transport = static::getContainer()->get('messenger.transport.webhook');
 
         static::assertInstanceOf(WebhookTransport::class, $transport);
+    }
+
+    public function testAsyncTransportIsResolvableWithoutCycling(): void
+    {
+        $transport = static::getContainer()->get('messenger.transport.async');
+
+        static::assertInstanceOf(TransportInterface::class, $transport);
     }
 
     public function testSendPersistsOutboxEntry(): void

--- a/tests/unit/Core/Framework/Webhook/Transport/WebhookTransportFactoryTest.php
+++ b/tests/unit/Core/Framework/Webhook/Transport/WebhookTransportFactoryTest.php
@@ -49,12 +49,49 @@ class WebhookTransportFactoryTest extends TestCase
         static::assertInstanceOf(WebhookTransport::class, $transport);
     }
 
+    /**
+     * Regression: deferred deps must not be resolved during construction.
+     */
+    public function testConstructorDoesNotResolveDeferredDependencies(): void
+    {
+        $calls = new class {
+            public int $async = 0;
+
+            public int $receiver = 0;
+        };
+
+        $factory = new WebhookTransportFactory(
+            $this->createMock(WebhookOutboxStore::class),
+            function () use ($calls): TransportInterface {
+                ++$calls->async;
+
+                return $this->createMock(TransportInterface::class);
+            },
+            function () use ($calls): MySQLWebhookReceiver {
+                ++$calls->receiver;
+
+                return $this->createMock(MySQLWebhookReceiver::class);
+            },
+        );
+
+        static::assertSame(0, $calls->async, 'Async transport must not be resolved at construction time.');
+        static::assertSame(0, $calls->receiver, 'Receiver must not be resolved at construction time.');
+
+        $factory->createTransport('shopware-webhook://default', [], $this->createMock(SerializerInterface::class));
+
+        static::assertSame(1, $calls->async, 'Async transport should be resolved exactly once when createTransport() is called.');
+        static::assertSame(1, $calls->receiver, 'Receiver should be resolved exactly once when createTransport() is called.');
+    }
+
     private function createFactory(): WebhookTransportFactory
     {
+        $asyncTransport = $this->createMock(TransportInterface::class);
+        $receiver = $this->createMock(MySQLWebhookReceiver::class);
+
         return new WebhookTransportFactory(
             $this->createMock(WebhookOutboxStore::class),
-            $this->createMock(TransportInterface::class),
-            $this->createMock(MySQLWebhookReceiver::class),
+            fn (): TransportInterface => $asyncTransport,
+            fn (): MySQLWebhookReceiver => $receiver,
         );
     }
 }


### PR DESCRIPTION
Closes https://github.com/shopware/shopware/issues/17005

This pull request addresses a Symfony dependency injection issue by deferring the resolution of certain services in the `WebhookTransportFactory`. This avoids premature instantiation and potential cyclic dependencies, particularly when Symfony iterates over `messenger.transport_factory` services. The changes include updates to the service definition, the factory's constructor and usage, and new tests to ensure correct behavior.

Testing and regression coverage:

* Added a regression unit test to ensure deferred dependencies are not resolved during construction, but only when `createTransport()` is called.
* Added an integration test to verify that the `messenger.transport.async` service can be resolved without causing cyclic dependencies.

Test maintenance:

* Added necessary import for `TransportInterface` in the integration test file.