### PR TITLE
fix(cms): Downscale embedded images in rich text editor (6.6.x)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
@@ -2,6 +2,7 @@
 
 .sw-cms-el-text {
     height: 100%;
+    overflow: auto;
     position: relative;
     width: 100%;
     word-break: break-word;
@@ -51,5 +52,10 @@
 
     .sw-text-editor.is--disabled .sw-text-editor__content {
         background-color: $color-white;
+    }
+
+    img {
+        max-width: 100%;
+        height: auto;
     }
 }


### PR DESCRIPTION
fixes #13449
backports https://github.com/shopware/shopware/pull/17023

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Images were rendered outside their boundaries

### 2. What does this change do, exactly?
Keep images inside

### 3. Describe each step to reproduce the issue or behaviour.
- Take a text-element and put it into the cms
- Add a huge image via HTML, for example `<img src="https://picsum.photos/4000/3000">`
- Notice no overflow or design breaks, but a scaled down images in admin preview and storefront


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
