### PR TITLE
fix: Silence breadcrumb deprecation message

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
@@ -54,7 +54,11 @@ class BuildBreadcrumbExtension extends AbstractExtension
      */
     public function getFullBreadcrumb(array $twigContext, CategoryEntity $category, Context|SalesChannelContext $context): array
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+        // Methods still called in Twig behind feature flag. Deprecation is silenced to avoid polluting logs.
+        $method = __METHOD__;
+        Feature::silent('v6.8.0.0', static function () use ($method): void {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, $method, 'v6.8.0.0'));
+        });
 
         if ($context instanceof Context) {
             $context = $this->getSalesChannelContext($twigContext) ?? $context;
@@ -102,7 +106,11 @@ class BuildBreadcrumbExtension extends AbstractExtension
      */
     public function getFullBreadcrumbById(array $twigContext, string $categoryId, Context|SalesChannelContext $context): array
     {
-        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0'));
+        // Methods still called in Twig behind feature flag. Deprecation is silenced to avoid polluting logs.
+        $method = __METHOD__;
+        Feature::silent('v6.8.0.0', static function () use ($method): void {
+            Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedMethodMessage(self::class, $method, 'v6.8.0.0'));
+        });
 
         if ($context instanceof Context) {
             $context = $this->getSalesChannelContext($twigContext) ?? $context;


### PR DESCRIPTION
Fixes: #16734 

### 1. Why is this change necessary?

The implementation of #14158 did not fully switch to the new breadcrumb solution, but still calls the deprecated methods in Twig using the major feature flag. This pollutes logs with a lot of deprecation warnings, because the Twig functions are still used.

### 2. What does this change do, exactly?

The deprecation warnings of the Twig functions are silenced. The initial solution was an external contribution. Changing the actual behavior would need a larger refactoring to implement the feature in a better forward-compatible way without using the deprecated methods in the template. In the future, we need to take a closer look at those changes to ensure they are properly forward-compatible.


