### PR TITLE
fix(product-listing): Mark images as decorative (6.6.x)

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -53,10 +53,17 @@
                                                     } %}
                                                 {% endblock %}
                                             {% else %}
-                                                {% set attributes = attributes|merge({
-                                                    alt: (cover.translated.alt ?: name),
-                                                    loading: 'lazy'
-                                                }) %}
+                                                {% if feature('ACCESSIBILITY_TWEAKS') %}
+                                                    {% if cover.translated.alt %}
+                                                        {% set attributes = attributes|merge({ alt: cover.translated.alt }) %}
+                                                    {% else %}
+                                                        {% set attributes = attributes|merge({ alt: '', 'aria-hidden': 'true' }) %}
+                                                    {% endif %}
+                                                {% else %}
+                                                    {% set attributes = attributes|merge({ alt: (cover.translated.alt ?: name) }) %}
+                                                {% endif %}
+
+                                                {% set attributes = attributes|merge({ loading: 'lazy' }) %}
 
                                                 {% if displayMode == 'cover' or displayMode == 'contain' %}
                                                     {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}


### PR DESCRIPTION
fixes #7086
backports https://github.com/shopware/shopware/pull/17026

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Images in listing are decorative, so a11y should reflect that

### 2. What does this change do, exactly?
aria-hidden on product image cards

### 3. Describe each step to reproduce the issue or behaviour.
Use product listing and try a screenreader. Images should not be catched

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
