### PR TITLE
fix(administration): rename UI text behind buttons in sw-confirm-field

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-confirm-field/sw-confirm-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-confirm-field/sw-confirm-field.scss
@@ -7,7 +7,7 @@
         }
     }
 
-    .sw-field input {
+    .mt-field input {
         padding: 8px 16px;
     }
 
@@ -19,11 +19,11 @@
     }
 
     &.sw-confirm-field--compact {
-        .sw-field {
+        .mt-field {
             margin-bottom: 0;
         }
 
-        .sw-field input {
+        .mt-field input {
             padding: 2px 16px;
         }
 
@@ -33,7 +33,7 @@
     }
 
     &.sw-confirm-field--editing {
-        .sw-field input {
+        .mt-field input {
             padding-right: 64px;
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

When renaming media (or any other item that uses the inline `sw-confirm-field`), the input value renders behind the cancel/submit icon buttons that float over the right edge of the input, making it impossible to see what you are typing. Reported in #16968.

### 2. What does this change do, exactly?

`sw-confirm-field.scss` still targeted the legacy `.sw-field` class, but the component was migrated to `mt-text-field` in #6822, which renders as `.mt-field`. Every `.sw-field …` selector in that file became dead — most importantly the `&.sw-confirm-field--editing { .sw-field input { padding-right: 64px; } }` rule that was supposed to clear room for the absolutely-positioned cancel/submit buttons during editing.

This PR swaps the four `.sw-field` selectors for `.mt-field`, restoring the editing padding plus the base and compact-mode input padding/margin rules that were also dead. No JS, twig, or markup change is needed since the editing-state class wiring (`sw-confirm-field--editing`, `sw-confirm-field--compact`) is still correct.

Affects every consumer of `sw-confirm-field`: media quickinfo sidebar (the reported case), media folder info, category tree item rename, tree input field, order inline field.

<img width="420" height="228" alt="Bildschirmfoto 2026-05-26 um 16 06 41" src="https://github.com/user-attachments/assets/bd35c517-af2b-4d4d-be5f-807e9ba8301c" />

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the admin and navigate to the **Media** module.
2. Upload an image with a moderately long file name.
3. Click the uploaded image once — the quickinfo sidebar opens on the right.
4. Click into the **Name** field and start typing.
5. Before the fix: the typed text disappears behind the X and ✓ buttons. After the fix: the input gets a 64 px right padding while editing, so the text ends cleanly before the buttons.

Same behaviour is reachable via category tree rename, media folder rename, and the order inline field.

### 4. Please link to the relevant issues (if any).

- closes #16968

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them