### PR TITLE
fix: Only use MySQL constant if supported

### DIFF
--- a/src/Core/Framework/Adapter/Database/MySQLFactory.php
+++ b/src/Core/Framework/Adapter/Database/MySQLFactory.php
@@ -78,7 +78,7 @@ class MySQLFactory
             $parameters['driverOptions'][Mysql::ATTR_SSL_KEY] = $sslCertKey;
         }
 
-        if (EnvironmentHelper::getVariable('DATABASE_SSL_DONT_VERIFY_SERVER_CERT')) {
+        if (EnvironmentHelper::getVariable('DATABASE_SSL_DONT_VERIFY_SERVER_CERT') && \defined('\Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')) {
             $parameters['driverOptions'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] = false;
         }
 

--- a/src/Core/Maintenance/System/Command/SystemSetupCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemSetupCommand.php
@@ -226,7 +226,7 @@ class SystemSetupCommand extends Command
             $env['DATABASE_SSL_KEY'] = $dbSslKey;
         }
 
-        if ($dbSslDontVerify) {
+        if ($dbSslDontVerify && \defined('\Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')) {
             $params['driverOptions'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] = false;
             $env['DATABASE_SSL_DONT_VERIFY_SERVER_CERT'] = '1';
         }

--- a/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
+++ b/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
@@ -126,7 +126,7 @@ class DatabaseConnectionInformation extends Struct
             $parameters['driverOptions'][Mysql::ATTR_SSL_KEY] = $this->sslCertKeyPath;
         }
 
-        if ($this->sslDontVerifyServerCert) {
+        if ($this->sslDontVerifyServerCert && \defined('\Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT')) {
             $parameters['driverOptions'][Mysql::ATTR_SSL_VERIFY_SERVER_CERT] = false;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It is possible that the `PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT` is not available, which causes the PHP polyfill to also not provide the used constant `\Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT`. See https://www.php.net/manual/en/class.pdo-mysql.php#pdo-mysql.constants.attr-ssl-verify-server-cert

By coincidence PHPStan is also failing, but only as it takes the first class definition into account, which is provided by the polyfill. (see https://github.com/symfony/polyfill/blob/v1.38.1/src/Php84/Resources/stubs/Pdo/Mysql.php#L58) And that class does not define the needed constant.  

### 2. What does this change do, exactly?

Add an extra check, if the constant is available, which fixes both issues. 

### 3. Describe each step to reproduce the issue or behaviour.

Update to current polyfill (1.38.1 at creation of this PR)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
