### PR TITLE
fix: Use non-deprecated newsletter subscribe/unsubscribe methods

### DIFF
--- a/src/Storefront/Controller/FormController.php
+++ b/src/Storefront/Controller/FormController.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\ContactForm\SalesChannel\AbstractContactFormRoute;
 use Shopware\Core\Content\Newsletter\SalesChannel\AbstractNewsletterSubscribeRoute;
 use Shopware\Core\Content\Newsletter\SalesChannel\AbstractNewsletterUnsubscribeRoute;
 use Shopware\Core\Content\RevocationRequest\SalesChannel\AbstractRevocationRequestRoute;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;

--- a/src/Storefront/Controller/FormController.php
+++ b/src/Storefront/Controller/FormController.php
@@ -176,7 +176,12 @@ class FormController extends StorefrontController
         try {
             $data->set('storefrontUrl', $request->attributes->get(RequestTransformer::STOREFRONT_URL));
 
-            $this->subscribeRoute->subscribe($data, $context, false);
+            if (Feature::isActive('v6.8.0.0')) {
+                $this->subscribeRoute->subscribeWithResponse($data, $context, false);
+            } else {
+                $this->subscribeRoute->subscribe($data, $context, false);
+            }
+
             $response[] = [
                 'type' => 'success',
                 'alert' => $this->trans('newsletter.subscriptionPersistedSuccess'),

--- a/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
+++ b/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Framework\Adapter\Request\RequestParamHelper;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -109,11 +110,19 @@ class NewsletterAccountPageletLoader
     protected function subscribe(RequestDataBag $dataBag, CustomerEntity $customer, SalesChannelContext $context, NewsletterAccountPagelet $newsletterAccountPagelet): NewsletterAccountPagelet
     {
         try {
-            $this->newsletterSubscribeRoute->subscribe(
-                $this->hydrateFromCustomer($dataBag, $customer),
-                $context,
-                false
-            );
+            if (Feature::isActive('v6.8.0.0')) {
+                $this->newsletterSubscribeRoute->subscribeWithResponse(
+                    $this->hydrateFromCustomer($dataBag, $customer),
+                    $context,
+                    false
+                );
+            } else {
+                $this->newsletterSubscribeRoute->subscribe(
+                    $this->hydrateFromCustomer($dataBag, $customer),
+                    $context,
+                    false
+                );
+            }
 
             $newsletterAccountPagelet->setSuccess(true);
             if ($newsletterAccountPagelet->isNewsletterDoi()) {
@@ -147,10 +156,17 @@ class NewsletterAccountPageletLoader
     protected function unsubscribe(RequestDataBag $dataBag, CustomerEntity $customer, SalesChannelContext $context, NewsletterAccountPagelet $newsletterAccountPagelet): NewsletterAccountPagelet
     {
         try {
-            $this->newsletterUnsubscribeRoute->unsubscribe(
-                $this->hydrateFromCustomer($dataBag, $customer),
-                $context
-            );
+            if (Feature::isActive('v6.8.0.0')) {
+                $this->newsletterUnsubscribeRoute->unsubscribe(
+                    $this->hydrateFromCustomer($dataBag, $customer),
+                    $context
+                );
+            } else {
+                $this->newsletterUnsubscribeRoute->unsubscribeWithResponse(
+                    $this->hydrateFromCustomer($dataBag, $customer),
+                    $context
+                );
+            }
 
             $newsletterAccountPagelet->setSuccess(true);
             $newsletterAccountPagelet->setMessages(
@@ -203,7 +219,7 @@ class NewsletterAccountPageletLoader
         $newsletterAccountPagelet = new NewsletterAccountPagelet();
         $newsletterAccountPagelet->setCustomer($customer);
         $newsletterAccountPagelet->setNewsletterDoi(
-            (bool) $this->systemConfigService->get('core.newsletter.doubleOptInRegistered', $salesChannelId)
+            $this->systemConfigService->getBool('core.newsletter.doubleOptInRegistered', $salesChannelId)
         );
 
         return $newsletterAccountPagelet;

--- a/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
+++ b/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
@@ -157,12 +157,12 @@ class NewsletterAccountPageletLoader
     {
         try {
             if (Feature::isActive('v6.8.0.0')) {
-                $this->newsletterUnsubscribeRoute->unsubscribe(
+                $this->newsletterUnsubscribeRoute->unsubscribeWithResponse(
                     $this->hydrateFromCustomer($dataBag, $customer),
                     $context
                 );
             } else {
-                $this->newsletterUnsubscribeRoute->unsubscribeWithResponse(
+                $this->newsletterUnsubscribeRoute->unsubscribe(
                     $this->hydrateFromCustomer($dataBag, $customer),
                     $context
                 );


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the `NewsletterAccountPageletLoader` uses deprecated methods even, when the `v6.8.0.0` feature flag is activated.

### 2. What does this change do, exactly?
When the feature flag 6.8.0.0 is active, the new methods are used. We cannot generally change the method itself, as this would be a breaking change, when the `subscribe` method is decorated.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
