### PR TITLE
fix: prevent shortcut tooltip from overlapping save button

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
@@ -54,6 +54,7 @@ $sw-tooltip-border-color-light: $color-gray-300;
     }
 
     &.sw-tooltip--light {
+        pointer-events: none;
         color: var(--color-text-inverse-default);
         font-size: var(--font-size-2xs);
         font-weight: var(--font-weight-regular);

--- a/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.spec.js
@@ -114,4 +114,90 @@ describe('directives/tooltip', () => {
 
         expect(document.body.getElementsByClassName('sw-tooltip').item(0)).not.toBeNull();
     });
+
+    it('should clamp bottom tooltip horizontally when it would overflow the viewport', async () => {
+        const originalInnerWidth = window.innerWidth;
+        const originalInnerHeight = window.innerHeight;
+
+        Object.defineProperty(window, 'innerWidth', {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, 'innerHeight', {
+            configurable: true,
+            value: 500,
+        });
+
+        const offsetWidthSpy = jest.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function () {
+            return this.classList.contains('sw-tooltip') ? 100 : 0;
+        });
+        const offsetHeightSpy = jest.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function () {
+            return this.classList.contains('sw-tooltip') ? 30 : 0;
+        });
+        const getBoundingClientRectSpy = jest
+            .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+            .mockImplementation(function () {
+                if (this.classList.contains('sw-tooltip')) {
+                    const top = parseFloat(this.style.top);
+                    const left = parseFloat(this.style.left);
+
+                    return {
+                        x: left,
+                        y: top,
+                        top,
+                        right: left + this.offsetWidth,
+                        bottom: top + this.offsetHeight,
+                        left,
+                        width: this.offsetWidth,
+                        height: this.offsetHeight,
+                        toJSON: () => {},
+                    };
+                }
+
+                return {
+                    x: 460,
+                    y: 40,
+                    top: 40,
+                    right: 520,
+                    bottom: 80,
+                    left: 460,
+                    width: 60,
+                    height: 40,
+                    toJSON: () => {},
+                };
+            });
+
+        let wrapper;
+
+        try {
+            wrapper = await createWrapper({
+                message: 'a tooltip',
+                position: 'bottom',
+                appearance: 'light',
+            });
+
+            await wrapper.trigger('mouseenter');
+            jest.runAllTimers();
+
+            const tooltip = document.body.getElementsByClassName('sw-tooltip').item(0);
+
+            expect(tooltip).not.toBeNull();
+            expect(tooltip.classList.contains('sw-tooltip--bottom')).toBe(true);
+            expect(tooltip.style.top).toBe('90px');
+            expect(tooltip.style.left).toBe('390px');
+        } finally {
+            wrapper?.unmount();
+            offsetWidthSpy.mockRestore();
+            offsetHeightSpy.mockRestore();
+            getBoundingClientRectSpy.mockRestore();
+            Object.defineProperty(window, 'innerWidth', {
+                configurable: true,
+                value: originalInnerWidth,
+            });
+            Object.defineProperty(window, 'innerHeight', {
+                configurable: true,
+                value: originalInnerHeight,
+            });
+        }
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.ts
+++ b/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.ts
@@ -5,6 +5,11 @@ const utils = Shopware.Utils;
 
 type Placements = 'top' | 'right' | 'bottom' | 'left';
 
+type TooltipPosition = {
+    top: number;
+    left: number;
+};
+
 const availableTooltipPlacements: Placements[] = [
     'top',
     'right',
@@ -364,28 +369,59 @@ class Tooltip {
         const boundingBox = this._parentDOMElement.getBoundingClientRect();
         const secureOffset = 10;
 
-        let top;
-        let left;
+        let top = 0;
+        let left = 0;
 
         switch (placement) {
             case 'bottom':
-                top = `${boundingBox.top + boundingBox.height + secureOffset}px`;
-                left = `${boundingBox.left + boundingBox.width / 2 - this._DOMElement!.offsetWidth / 2}px`;
+                top = boundingBox.top + boundingBox.height + secureOffset;
+                left = boundingBox.left + boundingBox.width / 2 - this._DOMElement!.offsetWidth / 2;
                 break;
             case 'left':
-                top = `${boundingBox.top + boundingBox.height / 2 - this._DOMElement!.offsetHeight / 2}px`;
-                left = `${boundingBox.left - secureOffset - this._DOMElement!.offsetWidth}px`;
+                top = boundingBox.top + boundingBox.height / 2 - this._DOMElement!.offsetHeight / 2;
+                left = boundingBox.left - secureOffset - this._DOMElement!.offsetWidth;
                 break;
             case 'right':
-                top = `${boundingBox.top + boundingBox.height / 2 - this._DOMElement!.offsetHeight / 2}px`;
-                left = `${boundingBox.right + secureOffset}px`;
+                top = boundingBox.top + boundingBox.height / 2 - this._DOMElement!.offsetHeight / 2;
+                left = boundingBox.right + secureOffset;
                 break;
             case 'top':
             default:
-                top = `${boundingBox.top - this._DOMElement!.offsetHeight - secureOffset}px`;
-                left = `${boundingBox.left + boundingBox.width / 2 - this._DOMElement!.offsetWidth / 2}px`;
+                top = boundingBox.top - this._DOMElement!.offsetHeight - secureOffset;
+                left = boundingBox.left + boundingBox.width / 2 - this._DOMElement!.offsetWidth / 2;
         }
-        return { top: top, left: left };
+
+        const position = this._clampTooltipPosition({ top, left }, placement, secureOffset);
+
+        return {
+            top: `${position.top}px`,
+            left: `${position.left}px`,
+        };
+    }
+
+    _clampTooltipPosition(position: TooltipPosition, placement: Placements, secureOffset: number): TooltipPosition {
+        const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+        const windowWidth = window.innerWidth || document.documentElement.clientWidth;
+
+        if (placement === 'top' || placement === 'bottom') {
+            return {
+                ...position,
+                left: this._clamp(position.left, secureOffset, windowWidth - this._DOMElement!.offsetWidth - secureOffset),
+            };
+        }
+
+        return {
+            ...position,
+            top: this._clamp(position.top, secureOffset, windowHeight - this._DOMElement!.offsetHeight - secureOffset),
+        };
+    }
+
+    _clamp(value: number, min: number, max: number): number {
+        if (max < min) {
+            return min;
+        }
+
+        return Math.min(Math.max(value, min), max);
     }
 
     _isElementInViewport(element: HTMLElement) {


### PR DESCRIPTION
Closes: #16539 

### Description

Fixes an administration tooltip issue where shortcut tooltips like CTRL + S could overlap and block the save button on arrow viewports.

The tooltip positioning now keeps top/bottom placements and clamps them horizontally into the viewport instead of flipping to another placement only because of horizontal overflow. Light tooltips also ignore pointer events so they cannot intercept clicks.