### PR TITLE
fix: avoid busy polling admin worker queue

### DIFF
--- a/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
+++ b/src/Core/Framework/MessageQueue/Api/ConsumeMessagesController.php
@@ -80,7 +80,7 @@ class ConsumeMessagesController extends AbstractController
 
         $worker = new Worker([$this->defaultTransportName => $receiver], $this->bus, $workerDispatcher);
 
-        $worker->run(['sleep' => 50]);
+        $worker->run();
 
         $consumerLock->release();
 

--- a/tests/unit/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/Api/ConsumeMessagesControllerTest.php
@@ -4,16 +4,23 @@ namespace Shopware\Tests\Unit\Core\Framework\MessageQueue\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Increment\AbstractIncrementer;
+use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
 use Shopware\Core\Framework\MessageQueue\Api\ConsumeMessagesController;
 use Shopware\Core\Framework\MessageQueue\MessageQueueException;
+use Shopware\Core\Framework\MessageQueue\Stats\AbstractStatsRepository;
+use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\MessageQueue\Subscriber\EarlyReturnMessagesListener;
 use Shopware\Core\Framework\MessageQueue\Subscriber\MessageQueueStatsSubscriber;
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\SharedLockInterface;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 /**
  * @internal
@@ -71,5 +78,103 @@ class ConsumeMessagesControllerTest extends TestCase
         $request = new Request();
         $request->request->set('receiver', 'async');
         $controller->consumeMessages($request);
+    }
+
+    public function testWorkerDoesNotBusyPollReceiverDuringLongPollAfterHandlingMessage(): void
+    {
+        $receiver = new class implements ReceiverInterface {
+            public int $getCalls = 0;
+
+            private bool $messageSent = false;
+
+            public function get(): iterable
+            {
+                ++$this->getCalls;
+
+                if ($this->messageSent) {
+                    return [];
+                }
+
+                $this->messageSent = true;
+
+                return [new Envelope(new \stdClass())];
+            }
+
+            public function ack(Envelope $envelope): void
+            {
+            }
+
+            public function reject(Envelope $envelope): void
+            {
+            }
+        };
+
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(true);
+        $lock
+            ->expects($this->once())
+            ->method('release');
+
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lockFactory
+            ->method('createLock')
+            ->willReturn($lock);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus
+            ->method('dispatch')
+            ->willReturnCallback(static fn (Envelope $envelope): Envelope => $envelope);
+
+        $controller = new ConsumeMessagesController(
+            new ServiceLocator(['async' => static fn (): ReceiverInterface => $receiver]),
+            $bus,
+            new StopWorkerOnRestartSignalListener(new NullAdapter()),
+            new EarlyReturnMessagesListener(),
+            $this->createMessageQueueStatsSubscriber(),
+            'async',
+            '-1',
+            1,
+            $lockFactory
+        );
+
+        $request = new Request();
+        $request->request->set('receiver', 'async');
+
+        $response = $controller->consumeMessages($request);
+
+        static::assertSame('{"handledMessages":1}', $response->getContent());
+        static::assertLessThan(100, $receiver->getCalls);
+    }
+
+    private function createMessageQueueStatsSubscriber(): MessageQueueStatsSubscriber
+    {
+        $incrementer = new class extends AbstractIncrementer {
+            public function __construct()
+            {
+                $this->setPool(IncrementGatewayRegistry::MESSAGE_QUEUE_POOL);
+            }
+
+            public function decrement(string $cluster, string $key): void
+            {
+            }
+
+            public function increment(string $cluster, string $key): void
+            {
+            }
+
+            public function list(string $cluster, int $limit = 5, int $offset = 0): array
+            {
+                return [];
+            }
+
+            public function reset(string $cluster, ?string $key = null): void
+            {
+            }
+        };
+
+        return new MessageQueueStatsSubscriber(
+            new IncrementGatewayRegistry([$incrementer]),
+            new StatsService($this->createMock(AbstractStatsRepository::class), false)
+        );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

I noticed regular temporary slowdowns in my local env seems the root cause was:
The Admin worker consume endpoint deliberately long-polls for up to the configured poll interval. However, the controller passed `['sleep' => 50]` to Symfony Messenger's worker, and that value is interpreted as microseconds. After handling a message, the long-poll worker could repeatedly poll the receiver in a tight loop until the poll interval elapsed, creating unnecessary database load and slowing unrelated local requests.

Git history does not show a current reason to override Symfony's default worker sleep: the manual value was introduced with `NEXT-8112`, removed by the Rector cleanup in `NEXT-25051`, and reintroduced with `NEXT-28470` while adding receiver locking.

### 2. What does this change do, exactly?

- Removes the manual `sleep => 50` override and lets Symfony use its default worker sleep.
- Keeps the existing long-poll duration controlled by `StopWorkerOnTimeLimitListener` and the Shopware admin worker poll interval.
- Adds a unit regression test that handles one message and asserts the worker does not busy-poll the receiver during the remaining long-poll window.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration so the Admin worker is running.
2. Let the worker handle an async message, for example one queued by scheduled task execution.
3. Observe the consume request staying open for the poll interval while repeatedly polling the receiver with an extremely small sleep interval.
4. With this change, the request still long-polls, but idle receiver polling uses Symfony's default sleep (1s) instead of a 50 microsecond loop.