### PR TITLE
fix: load admin search length from info config

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-context.ts
@@ -36,6 +36,7 @@ export interface ContextState {
                 appsRequireAppUrl: boolean;
                 disableExtensionManagement: boolean;
                 firstMigrationDate?: string | null;
+                minSearchTermLength: number;
             };
             version: null | string;
             versionRevision: null | string;

--- a/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.js
@@ -27,6 +27,8 @@ const searchTypeConstants = Object.freeze({
     MODULE: 'module',
 });
 
+const DEFAULT_MIN_SEARCH_TERM_LENGTH = 2;
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export const KEY_USER_SEARCH_PREFERENCE = 'search.preferences';
 /**
@@ -43,11 +45,9 @@ export default function createSearchRankingService() {
     const cacheModules = {};
     let cacheUserSearchConfiguration;
     let cacheDefaultUserSearchPreference;
-    let minSearchTermLength = 2;
+    let minSearchTermLength = getConfiguredMinSearchTermLength();
 
     loginService.addOnLoginListener(clearCacheUserSearchConfiguration);
-
-    getMinSearchTermLength();
 
     return {
         getSearchFieldsByEntity,
@@ -183,14 +183,7 @@ export default function createSearchRankingService() {
     }
 
     async function getMinSearchTermLength() {
-        try {
-            const response = await _getMinSearchTermLength();
-            minSearchTermLength = response;
-            return response;
-        } catch (error) {
-            minSearchTermLength = 2;
-            return error;
-        }
+        return minSearchTermLength;
     }
 
     async function saveMinSearchTermLength(newMinSearchTermLength) {
@@ -199,6 +192,10 @@ export default function createSearchRankingService() {
         try {
             await systemConfigApiService.saveValues({ 'core.search.minSearchTermLength': newMinSearchTermLength });
             minSearchTermLength = newMinSearchTermLength;
+            Shopware.Context.app.config.settings = {
+                ...(Shopware.Context.app.config.settings ?? {}),
+                minSearchTermLength: newMinSearchTermLength,
+            };
             return newMinSearchTermLength;
         } catch (error) {
             return error;
@@ -478,18 +475,13 @@ export default function createSearchRankingService() {
         return cacheModules[entityName];
     }
 
-    /**
-     * @private
-     * @returns {Promise<number>}
-     */
-    async function _getMinSearchTermLength() {
-        const systemConfigApiService = Service('systemConfigApiService');
+    function getConfiguredMinSearchTermLength() {
+        const configuredMinSearchTermLength = Shopware.Context.app.config?.settings?.minSearchTermLength;
 
-        try {
-            const response = await systemConfigApiService.getValues('core.search');
-            return response['core.search.minSearchTermLength'] ?? 2;
-        } catch (error) {
-            return error;
+        if (typeof configuredMinSearchTermLength !== 'number') {
+            return DEFAULT_MIN_SEARCH_TERM_LENGTH;
         }
+
+        return configuredMinSearchTermLength;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.spec.js
@@ -191,6 +191,8 @@ describe('app/service/search-ranking.service.js', () => {
             ...(Shopware.Context.app.config.settings ?? {}),
             minSearchTermLength: 2,
         };
+
+        clearModules();
     });
 
     const userConfigSearchPreferenceCase = [
@@ -276,10 +278,6 @@ describe('app/service/search-ranking.service.js', () => {
 
         Shopware.Service('userConfigService').search = () => Promise.resolve({ data });
     }
-
-    beforeEach(async () => {
-        clearModules();
-    });
 
     it('Should get default user search preferences', async () => {
         createModules(searchRankingModules);

--- a/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-ranking.service.spec.js
@@ -22,7 +22,8 @@ Shopware.Service().register('loginService', () => {
 
 Shopware.Service().register('systemConfigApiService', () => {
     return {
-        getValues: () => Promise.resolve({ 'core.search.minSearchTermLength': 2 }),
+        getValues: jest.fn(),
+        saveValues: jest.fn(),
     };
 });
 
@@ -184,6 +185,13 @@ describe('app/service/search-ranking.service.js', () => {
             new Criteria(1, 25).setTerm('       '),
         ],
     ];
+
+    beforeEach(() => {
+        Shopware.Context.app.config.settings = {
+            ...(Shopware.Context.app.config.settings ?? {}),
+            minSearchTermLength: 2,
+        };
+    });
 
     const userConfigSearchPreferenceCase = [
         [
@@ -899,14 +907,22 @@ describe('app/service/search-ranking.service.js', () => {
         expect(service.isValidTerm('')).toBe(false);
     });
 
-    it('should get minSearchTermLength from config', async () => {
-        const originalService = Shopware.Service('systemConfigApiService');
-        originalService.getValues = jest.fn().mockResolvedValue({ 'core.search.minSearchTermLength': 1 });
+    it('should get minSearchTermLength from app config', async () => {
+        Shopware.Context.app.config.settings.minSearchTermLength = 1;
 
         const service = new SearchRankingService();
         await service.getMinSearchTermLength();
 
         expect(service.isValidTerm('a')).toBe(true);
+    });
+
+    it('should not fetch minSearchTermLength from system config when service is created', () => {
+        const originalService = Shopware.Service('systemConfigApiService');
+        originalService.getValues = jest.fn();
+
+        new SearchRankingService();
+
+        expect(originalService.getValues).not.toHaveBeenCalled();
     });
 
     it('should save minSearchTermLength to config', async () => {

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -221,6 +221,7 @@ class InfoController extends AbstractController
                 'enableHtmlSanitizer' => $this->params->get('shopware.html_sanitizer.enabled'),
                 'enableStagingMode' => $this->params->get('shopware.staging.administration.show_banner') && $this->systemConfigService->getBool(SetupStagingEvent::CONFIG_FLAG),
                 'disableExtensionManagement' => !$this->params->get('shopware.deployment.runtime_extension_management'),
+                'minSearchTermLength' => $this->systemConfigService->getInt('core.search.minSearchTermLength') ?: 2,
             ],
             'inAppPurchases' => $this->inAppPurchase->all(),
         ];

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -148,6 +148,7 @@ class InfoControllerTest extends TestCase
                 'enableHtmlSanitizer' => true,
                 'enableStagingMode' => false,
                 'disableExtensionManagement' => false,
+                'minSearchTermLength' => 2,
             ],
             'inAppPurchases' => [],
         ];

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -139,6 +139,8 @@ class InfoControllerTest extends TestCase
         static::assertFalse($settings['private_allowed_extensions']);
         static::assertArrayHasKey('enableHtmlSanitizer', $settings);
         static::assertTrue($settings['enableHtmlSanitizer']);
+        static::assertArrayHasKey('minSearchTermLength', $settings);
+        static::assertSame(2, $settings['minSearchTermLength']);
 
         static::assertArrayHasKey('inAppPurchases', $data);
         $inAppPurchases = $data['inAppPurchases'];


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration global search currently needs to fetch `core.search.minSearchTermLength` through a standalone system config request. That makes every page load depend on system config access even though the search minimum is global Admin bootstrap data.

### 2. What does this change do, exactly?

- Adds `minSearchTermLength` to the Admin API info config response.
- Stores the value in `Shopware.Context.app.config.settings` during Admin bootstrap.
- Reads the search minimum from the bootstrapped app config in the search ranking service.
- Keeps saving the value through system config where the setting is edited.
- Updates PHP and Administration unit coverage for the new source.

#### Global system_config ACL needed
<img width="1397" height="595" alt="Screenshot 2026-05-26 at 11 59 23" src="https://github.com/user-attachments/assets/ca9f355c-cbe4-4963-9c05-176f5676fe37" />

Search component did a plain request to system_config to fetch min search lenght, so everyone needed system_config permissions

Fix: add min search lenght to general config call and remove separate system_config call

### 3. Describe each step to reproduce the issue or behaviour.

1. Log into the Administration with a role that can use global search but should not need broad system config access.
2. Open any Administration page.
3. Before this change, the search ranking service performs a standalone system config lookup for `core.search.minSearchTermLength` during page load.
4. After this change, the value is already available from the global info config response.

### 4. Please link to the relevant issues (if any).

- relates #8053
- follow-up to #16981

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
