### PR TITLE
fix: allow clearing inherited config fields

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/index.js
@@ -136,6 +136,9 @@ export default {
                 }
 
                 if (!this.isInherited && newValue !== this.inheritedValue) {
+                    if (newValue === null || newValue === undefined || (Array.isArray(newValue) && newValue.length <= 0)) {
+                        this.forceInheritanceRemove = true;
+                    }
                     this.updateValue(newValue, 'restore');
                     return;
                 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.spec.js
@@ -77,4 +77,62 @@ describe('src/app/component/utils/sw-inherit-wrapper', () => {
         expect(wrapper.vm).toBeTruthy();
         expect(wrapper.vm.isInherited).toBe(true);
     });
+
+    it('should not re-inherit after the user clears a previously detached field with a truthy parent value', async () => {
+        const wrapper = await createWrapper({
+            propsData: {
+                value: null,
+                inheritedValue: 'parent-id',
+                hasParent: true,
+            },
+            global: createWrapperGlobalValue,
+        });
+
+        expect(wrapper.vm.isInherited).toBe(true);
+
+        wrapper.vm.removeInheritance();
+        await wrapper.setProps({ value: 'parent-id' });
+        expect(wrapper.vm.isInherited).toBe(false);
+
+        wrapper.vm.updateCurrentValue(null);
+        await wrapper.setProps({ value: null });
+        expect(wrapper.vm.isInherited).toBe(false);
+    });
+
+    it('should not re-inherit after the user clears a field that already held its own value', async () => {
+        const wrapper = await createWrapper({
+            propsData: {
+                value: 'own-id',
+                inheritedValue: 'parent-id',
+                hasParent: true,
+            },
+            global: createWrapperGlobalValue,
+        });
+
+        expect(wrapper.vm.isInherited).toBe(false);
+
+        wrapper.vm.updateCurrentValue(null);
+        await wrapper.setProps({ value: null });
+        expect(wrapper.vm.isInherited).toBe(false);
+    });
+
+    it('should re-inherit again after restoreInheritance is called', async () => {
+        const wrapper = await createWrapper({
+            propsData: {
+                value: null,
+                inheritedValue: 'parent-id',
+                hasParent: true,
+            },
+            global: createWrapperGlobalValue,
+        });
+
+        wrapper.vm.removeInheritance();
+        await wrapper.setProps({ value: 'parent-id' });
+        wrapper.vm.updateCurrentValue(null);
+        await wrapper.setProps({ value: null });
+        expect(wrapper.vm.isInherited).toBe(false);
+
+        wrapper.vm.restoreInheritance();
+        expect(wrapper.vm.isInherited).toBe(true);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
@@ -1115,6 +1115,102 @@ describe('src/module/sw-settings/component/sw-system-config/sw-system-config', (
         });
     });
 
+    async function switchToHeadless() {
+        const salesChannelSwitch = wrapper.find('.sw-field[label="sw-settings.system-config.labelSalesChannelSelect"]');
+        await salesChannelSwitch.find('.sw-select__selection').trigger('click');
+        await flushPromises();
+        await salesChannelSwitch.find('.sw-select-option--2').trigger('click');
+        await flushPromises();
+    }
+
+    it('should keep an sw-entity-single-select empty after clearing a field whose inheritance was removed', async () => {
+        const name = 'ConfigRenderer.config.entitySelectField';
+        const fieldSelector = `.sw-system-config--field-${kebabCase(name)}`;
+
+        wrapper = await createWrapper({
+            'ConfigRenderer.config': {
+                null: {
+                    [name]: uuid.get('pullover'),
+                },
+            },
+        });
+        await flushPromises();
+
+        await switchToHeadless();
+
+        // Inherited: child shows the parent value and can unlink
+        let field = wrapper.find(fieldSelector);
+        expect(field.find('.sw-entity-single-select__selection-text').text()).toBe('Pullover');
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Unlink inheritance');
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBeUndefined();
+
+        // Remove inheritance -> child takes over the parent value, becomes editable
+        await field.find('.sw-inheritance-switch .mt-icon').trigger('click');
+        await flushPromises();
+
+        field = wrapper.find(fieldSelector);
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Link inheritance');
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBe(uuid.get('pullover'));
+
+        // Clear the selection -> emits null
+        await field.find('.sw-select__select-indicator-clear').trigger('click');
+        await flushPromises();
+
+        // The cleared value must stick: still null, inheritance NOT restored,
+        // and the inherited value is no longer displayed.
+        field = wrapper.find(fieldSelector);
+        await wrapper.vm.$forceUpdate();
+        await flushPromises();
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBeNull();
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Link inheritance');
+        expect(field.find('.sw-entity-single-select__selection-text').text()).not.toBe('Pullover');
+    });
+
+    it('should keep an sw-media-field empty after clearing a field whose inheritance was removed', async () => {
+        const name = 'ConfigRenderer.config.mediaField';
+        const fieldSelector = `.sw-system-config--field-${kebabCase(name)}`;
+
+        wrapper = await createWrapper({
+            'ConfigRenderer.config': {
+                null: {
+                    [name]: uuid.get('funny-image'),
+                },
+            },
+        });
+        await flushPromises();
+
+        await switchToHeadless();
+
+        // Inherited: child shows the parent media and can unlink
+        let field = wrapper.find(fieldSelector);
+        await wrapper.vm.$forceUpdate();
+        await flushPromises();
+        expect(field.find('.sw-media-base-item__name').text()).toBe('funny-image.jpg');
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Unlink inheritance');
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBeUndefined();
+
+        // Remove inheritance -> child takes over the parent value
+        await field.find('.sw-inheritance-switch .mt-icon').trigger('click');
+        await flushPromises();
+
+        field = wrapper.find(fieldSelector);
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Link inheritance');
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBe(uuid.get('funny-image'));
+
+        // Unlink the media -> emits null
+        await field.find('.sw-media-field__toggle-button').trigger('click');
+        await flushPromises();
+        await field.find('.sw-media-field__action-button.is--remove').trigger('click');
+        await flushPromises();
+
+        // The cleared value must stick: still null and inheritance NOT restored.
+        field = wrapper.find(fieldSelector);
+        await wrapper.vm.$forceUpdate();
+        await flushPromises();
+        expect(wrapper.vm.actualConfigData[uuid.get('headless')][name]).toBeNull();
+        expect(field.find('.sw-inheritance-switch').attributes('aria-label')).toBe('Link inheritance');
+    });
+
     it('should contain ai badge in second card', async () => {
         wrapper = await createWrapper();
         await flushPromises();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It was impossible to empty an inherited config field at the sales-channel level. After detaching a field and clearing it, sw-inherit-wrapper treated the empty value as "not set yet" and silently re-inherited the parent value.

### 2. What does this change do, exactly?
In sw-inherit-wrapper, the currentValue setter now sets forceInheritanceRemove = true when the user clears (null/undefined/empty array) a field that is already detached. This keeps the field detached instead of re-inheriting. Restoring inheritance via the link icon still works, and external nullification (e.g. a deleted referenced entity) still falls back to the parent.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install/activate a plugin with a config containing an sw-entity-single-select (or sw-single-select, sw-media-field, sw-text-editor).
2. On the plugin config for All Sales Channels, set a value and save.
3. Switch the top sales-channel selector to a specific sales channel. The field shows the inherited value.
4. Click the inheritance (unlink) icon next to the field.
5. Clear the field (✕ on the select / unlink on media).
6. Before fix: inheritance is restored and the parent value reappears. After fix: the field stays empty.

### 4. Please link to the relevant issues (if any).
closes https://github.com/shopware/shopware/issues/4535

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
