### PR TITLE
fix: prevent 0 byte media uploads

### DIFF
--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -41,6 +41,10 @@ class FileFetcher
             throw MediaException::invalidContentLength();
         }
 
+        if ($bytesWritten === 0) {
+            throw MediaException::emptyFile();
+        }
+
         return new MediaFile(
             $fileName,
             FileInfoHelper::getMimeType($fileName, $extension),
@@ -73,6 +77,10 @@ class FileFetcher
         } finally {
             fclose($inputStream);
             fclose($destStream);
+        }
+
+        if ($writtenBytes === 0) {
+            throw MediaException::emptyFile();
         }
 
         $mimeType = FileInfoHelper::getMimeType($fileName, $fileExtension);

--- a/src/Core/Content/Media/MediaException.php
+++ b/src/Core/Content/Media/MediaException.php
@@ -195,6 +195,15 @@ class MediaException extends HttpException
         );
     }
 
+    public static function emptyFile(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::MEDIA_EMPTY_FILE,
+            'Provided file is empty.'
+        );
+    }
+
     public static function invalidFile(string $cause): self
     {
         return new self(

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -304,7 +304,9 @@ class DocumentGeneratorTest extends TestCase
             false,
             new Request([
                 'extension' => PdfRenderer::FILE_EXTENSION,
-            ]),
+            ], [], [], [], [], [
+                'HTTP_CONTENT_LENGTH' => \strlen('this is some content'),
+            ], 'this is some content'),
             true,
             DocumentException::generationError('Parameter "fileName" is missing'),
         ];

--- a/tests/unit/Core/Content/Media/File/FileFetcherTest.php
+++ b/tests/unit/Core/Content/Media/File/FileFetcherTest.php
@@ -23,6 +23,7 @@ class FileFetcherTest extends TestCase
     private const IMAGE_URL_WITHOUT_EXTENSION = __DIR__ . '/_fixtures/image1x1';
     private const IMAGE_URL_WITH_EXTENSION = __DIR__ . '/_fixtures/image1x1.png';
     private const BINARY_FILE_URL_WITHOUT_EXTENSION = __DIR__ . '/_fixtures/binary';
+    private const EMPTY_FILE_URL = __DIR__ . '/_fixtures/empty';
     private const IMAGE_FILE_SIZE = 95;
     private const IMAGE_EXTENSION = 'png';
     private const IMAGE_MIME_TYPE = 'image/png';
@@ -95,6 +96,43 @@ class FileFetcherTest extends TestCase
             'extension' => '',
             'expectedException' => MediaException::missingFileExtension(),
         ];
+    }
+
+    public function testFetchRequestDataThrowsOnEmptyFile(): void
+    {
+        $fileFetcher = new FileFetcher($this->createMock(FileUrlValidatorInterface::class), new FileService());
+
+        $content = fopen(self::EMPTY_FILE_URL, 'r');
+        static::assertIsResource($content);
+
+        $request = new Request([], [], [], [], [], [], $content);
+        $request->query->set('extension', self::IMAGE_EXTENSION);
+        $request->headers = new HeaderBag();
+        $request->headers->set('content-length', '0');
+
+        $this->expectExceptionObject(MediaException::emptyFile());
+        $fileFetcher->fetchRequestData($request, self::TEMP_FILE);
+    }
+
+    public function testFetchFromURLThrowsOnEmptyFile(): void
+    {
+        $fileValidatorMock = $this->createMock(FileUrlValidatorInterface::class);
+        $fileValidatorMock->method('isValid')->willReturn(true);
+
+        $fileServiceMock = $this->createMock(FileService::class);
+        $fileServiceMock->method('isUrl')->willReturn(true);
+
+        $fileFetcher = new FileFetcher($fileValidatorMock, $fileServiceMock);
+
+        $this->expectExceptionObject(MediaException::emptyFile());
+
+        try {
+            $fileFetcher->fetchFromURL(self::EMPTY_FILE_URL, self::TEMP_FILE, self::IMAGE_EXTENSION);
+        } finally {
+            if (\is_file(self::TEMP_FILE)) {
+                unlink(self::TEMP_FILE);
+            }
+        }
     }
 
     #[DataProvider('fetchFileFromUrlDataProvider')]


### PR DESCRIPTION
### 1. Why is this change necessary?
Uploading a 0-byte file via the media upload endpoint is silently accepted. The content-length check in FileFetcher only validates that the declared length matches the actual bytes written — when both are 0 they match, so no exception is raised. Empty files have no valid use case in the media system and should be rejected explicitly.

### 2. What does this change do, exactly?
After writing the uploaded bytes to the destination stream, FileFetcher::fetchRequestData() and FileFetcher::fetchFromURL() now check whether zero bytes were written and throw MediaException::emptyFile() (HTTP 400) if so. The emptyFile() factory method was added to MediaException for the already-existing MEDIA_EMPTY_FILE error code constant.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a 0-byte file: touch empty.png
* Upload it to the media endpoint
* Observe that the API returns a 2xx response and the media entity is updated with a 0-byte file

### 4. Please link to the relevant issues (if any).
closes: #6296

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
