### PR TITLE
fix(snippets): Cast non-string snippets to string

### DIFF
--- a/src/Core/System/Snippet/Filter/TermFilter.php
+++ b/src/Core/System/Snippet/Filter/TermFilter.php
@@ -27,8 +27,8 @@ class TermFilter extends AbstractFilter implements SnippetFilterInterface
         $result = [];
         foreach ($snippets as $setId => $set) {
             foreach ($set['snippets'] as $translationKey => $snippet) {
-                $keyMatch = mb_stripos($snippet['translationKey'], $requestFilterValue);
-                $valueMatch = mb_stripos($snippet['value'], $requestFilterValue);
+                $keyMatch = mb_stripos((string) $snippet['translationKey'], $requestFilterValue);
+                $valueMatch = mb_stripos(\is_scalar($snippet['value']) ? (string) $snippet['value'] : '', $requestFilterValue);
 
                 if ($keyMatch === false && $valueMatch === false) {
                     continue;

--- a/tests/unit/Core/System/Snippet/Filter/TermFilterTest.php
+++ b/tests/unit/Core/System/Snippet/Filter/TermFilterTest.php
@@ -129,6 +129,55 @@ class TermFilterTest extends TestCase
         static::assertSame($expected, $result);
     }
 
+    public function testFilterWithNonStringValueDoesNotThrow(): void
+    {
+        $snippets = [
+            'firstSetId' => [
+                'snippets' => [
+                    '1.bar' => [
+                        'value' => 42,
+                        'translationKey' => '1.bar',
+                        'origin' => '',
+                        'resetTo' => '',
+                        'author' => '',
+                        'id' => null,
+                        'setId' => '',
+                    ],
+                    '1.bas' => [
+                        'value' => '1_bas',
+                        'translationKey' => '1.bas',
+                        'origin' => '',
+                        'resetTo' => '',
+                        'author' => '',
+                        'id' => null,
+                        'setId' => '',
+                    ],
+                ],
+            ],
+        ];
+
+        $expected = [
+            'firstSetId' => [
+                'snippets' => [
+                    '1.bar' => [
+                        'value' => 42,
+                        'translationKey' => '1.bar',
+                        'origin' => '',
+                        'resetTo' => '',
+                        'author' => '',
+                        'id' => null,
+                        'setId' => '',
+                    ],
+                ],
+            ],
+        ];
+
+        /** @phpstan-ignore argument.type (snippet value is intentionally a non-string here) */
+        $result = (new TermFilter())->filter($snippets, '42');
+
+        static::assertSame($expected, $result);
+    }
+
     public function testFilterWithKeyMatch(): void
     {
         $snippets = [


### PR DESCRIPTION
fixes #13019

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Non-String snippet values cause the filter to crash


### 2. What does this change do, exactly?
Cast non-strings to string


### 3. Describe each step to reproduce the issue or behaviour.
- Add a non-string snippet, e.g. int
- Try to filter for it in the snippet module
- No crash


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
