### PR TITLE
fix: incomplete product export with variants excluded

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -24,6 +24,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\SalesChannelReposit
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
@@ -115,6 +117,17 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             ->setOffset($exportBehavior->offset())
             ->setLimit($this->readBufferSize);
 
+        if ($productExport->isIncludeVariants()) {
+            // Only fetch variants and standalone products; parent products that have variants are skipped
+            $criteria->addFilter(new OrFilter([
+                new NotFilter(NotFilter::CONNECTION_AND, [new EqualsFilter('parentId', null)]),
+                new EqualsFilter('childCount', 0),
+            ]));
+        } else {
+            // Only fetch main and standalone products so getTotal() and pagination reflect the renderable count
+            $criteria->addFilter(new EqualsFilter('parentId', null));
+        }
+
         foreach ($associations as $association) {
             $criteria->addAssociation($association);
         }
@@ -170,13 +183,6 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
                 foreach ($productResult->getEntities() as $product) {
                     $data = $productContext->getContext();
                     $data['product'] = $product;
-
-                    if ($productExport->isIncludeVariants() && !$product->getParentId() && $product->getChildCount() > 0) {
-                        continue; // Skip main product if variants are included
-                    }
-                    if (!$productExport->isIncludeVariants() && $product->getParentId()) {
-                        continue; // Skip variants unless they are included
-                    }
 
                     $renderedBody = $this->renderProductBody($productExport, $context, $data);
 

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Content\ProductExport\Struct\ExportBehavior;
 use Shopware\Core\Content\ProductExport\Struct\ProductExportResult;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
@@ -38,6 +39,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
@@ -282,6 +284,54 @@ class ProductExportGeneratorTest extends TestCase
         yield 'British pound iso code' => ['GBP'];
     }
 
+    /**
+     * @param list<string> $expectedIds
+     */
+    #[DataProvider('exportResultProductIdDataProvider')]
+    public function testExportWithIncludedAndExcludedVariants(bool $includeVariants, array $expectedIds): void
+    {
+        $ids = $this->createMixedVariantAndStandAloneProducts();
+        $productStreamId = $this->getProductStreamId(array_values($ids->all()));
+
+        $productExportId = Uuid::randomHex();
+        $this->repository->upsert([
+            [
+                'id' => $productExportId,
+                'fileName' => 'Testexport.csv',
+                'accessKey' => Uuid::randomHex(),
+                'encoding' => ProductExportEntity::ENCODING_UTF8,
+                'fileFormat' => ProductExportEntity::FILE_FORMAT_CSV,
+                'interval' => 0,
+                'headerTemplate' => 'id',
+                'bodyTemplate' => '{{ product.id }}',
+                'productStreamId' => $productStreamId,
+                'storefrontSalesChannelId' => $this->getSalesChannelDomain()->getSalesChannelId(),
+                'salesChannelId' => $this->getSalesChannelId(),
+                'salesChannelDomainId' => $this->getSalesChannelDomainId(),
+                'generateByCronjob' => false,
+                'currencyId' => Defaults::CURRENCY,
+                'includeVariants' => $includeVariants,
+            ],
+        ], $this->context);
+
+        $criteria = $this->createProductExportCriteria($productExportId);
+
+        $productExport = $this->repository->search($criteria, $this->context)->first();
+        static::assertInstanceOf(ProductExportEntity::class, $productExport);
+
+        $exportResult = $this->service->generate($productExport, new ExportBehavior());
+
+        static::assertInstanceOf(ProductExportResult::class, $exportResult);
+        $expectedContent = 'id' . \PHP_EOL . implode(\PHP_EOL, $ids->getList($expectedIds)) . \PHP_EOL;
+        static::assertSame($expectedContent, $exportResult->getContent());
+    }
+
+    public static function exportResultProductIdDataProvider(): \Generator
+    {
+        yield 'included variants' => [true, ['variant-1', 'variant-2', 'stand-alone-1']];
+        yield 'excluded variants' => [false, ['parent-1', 'stand-alone-1']];
+    }
+
     private function createProductExportCriteria(string $id): Criteria
     {
         $criteria = new Criteria([$id]);
@@ -440,5 +490,56 @@ class ProductExportGeneratorTest extends TestCase
         $productRepository->create($products, $this->context);
 
         return $products;
+    }
+
+    /**
+     * @param list<string> $productIds
+     */
+    private function getProductStreamId(array $productIds): string
+    {
+        $id = Uuid::randomHex();
+
+        static::getContainer()->get('product_stream.repository')->create([
+            [
+                'id' => $id,
+                'filters' => [
+                    [
+                        'type' => 'equalsAny',
+                        'field' => 'id',
+                        'value' => implode('|', $productIds),
+                    ],
+                ],
+                'name' => 'testStream',
+            ],
+        ], $this->context);
+
+        return $id;
+    }
+
+    private function createMixedVariantAndStandAloneProducts(): IdsCollection
+    {
+        $ids = new IdsCollection();
+        $productRepository = static::getContainer()->get('product.repository');
+
+        $products = [
+            (new ProductBuilder($ids, 'parent-1'))
+                ->price(100)
+                ->visibility($this->getSalesChannelDomain()->getSalesChannelId())
+                ->variant(
+                    (new ProductBuilder($ids, 'variant-1'))->build()
+                )
+                ->variant(
+                    (new ProductBuilder($ids, 'variant-2'))->build()
+                )
+                ->build(),
+            (new ProductBuilder($ids, 'stand-alone-1'))
+                ->price(100)
+                ->visibility($this->getSalesChannelDomain()->getSalesChannelId())
+                ->build(),
+        ];
+
+        $productRepository->create($products, Context::createDefaultContext());
+
+        return $ids;
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
@@ -434,34 +435,35 @@ class ProductExportGeneratorTest extends TestCase
         $productExport->setIncludeVariants(false);
 
         $context = $this->createSalesChannelContext();
-        $variant = $this->createProduct('variant-id', 'parent-id');
-        $simple = $this->createProduct('simple-id');
+        $product = $this->createProduct('product-id');
 
         $this->prepareGeneratorDependencies($context, '{{ product.id }}');
+
         $this->productRepository->expects($this->exactly(2))
             ->method('searchIds')
-            ->willReturnOnConsecutiveCalls(
-                IdSearchResult::fromIds(['variant-id', 'simple-id'], new Criteria(), $context->getContext()),
-                IdSearchResult::fromIds([], new Criteria(), $context->getContext())
-            );
+            ->willReturnCallback(static function (Criteria $criteria, SalesChannelContext $salesChannelContext) use ($context): IdSearchResult {
+                $filters = $criteria->getFilters();
+                $parentIdFilters = array_filter($filters, static fn ($f) => $f instanceof EqualsFilter && $f->getField() === 'parentId' && $f->getValue() === null);
+                static::assertNotEmpty($parentIdFilters, 'Criteria must contain a parentId = null filter when variants are excluded');
+
+                return IdSearchResult::fromIds(['product-id'], $criteria, $context->getContext());
+            });
+
         $this->productRepository->expects($this->exactly(2))
             ->method('search')
             ->willReturnOnConsecutiveCalls(
-                $this->createProductSearchResultCollection([$variant, $simple], $context),
+                $this->createProductSearchResult($product, $context),
                 $this->createEmptyProductSearchResult($context)
             );
-        $this->productExportRender->expects($this->once())
-            ->method('renderBody')
-            ->with($productExport, $context, static::callback(static fn (array $data): bool => $data['product'] === $simple))
-            ->willReturn('simple');
-        $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->with('simple', '', $context)->willReturnArgument(0);
-        $this->productExportValidator->expects($this->once())->method('validate')->with($productExport, 'simple')->willReturn([]);
+
+        $this->productExportRender->method('renderBody')->willReturn('product');
+        $this->seoUrlPlaceholderHandler->method('replace')->willReturnArgument(0);
+        $this->productExportValidator->method('validate')->willReturn([]);
         $this->connection->expects($this->once())->method('delete');
 
         $result = $this->createGenerator()->generate($productExport, new ExportBehavior(false, false, false, false, false));
 
         static::assertNotNull($result);
-        static::assertSame('simple', $result->getContent());
     }
 
     public function testGenerateSkipsParentProductsWhenVariantsAreIncluded(): void
@@ -473,34 +475,35 @@ class ProductExportGeneratorTest extends TestCase
         $productExport->setIncludeVariants(true);
 
         $context = $this->createSalesChannelContext();
-        $parent = $this->createProduct('parent-id', null, 1);
         $variant = $this->createProduct('variant-id', 'parent-id');
 
         $this->prepareGeneratorDependencies($context, '{{ product.id }}');
+
         $this->productRepository->expects($this->exactly(2))
             ->method('searchIds')
-            ->willReturnOnConsecutiveCalls(
-                IdSearchResult::fromIds(['parent-id', 'variant-id'], new Criteria(), $context->getContext()),
-                IdSearchResult::fromIds([], new Criteria(), $context->getContext())
-            );
+            ->willReturnCallback(static function (Criteria $criteria, SalesChannelContext $salesChannelContext) use ($context): IdSearchResult {
+                $filters = $criteria->getFilters();
+                $orFilters = array_filter($filters, static fn ($f) => $f instanceof OrFilter);
+                static::assertNotEmpty($orFilters, 'Criteria must contain an OrFilter to exclude parent products when variants are included');
+
+                return IdSearchResult::fromIds(['variant-id'], $criteria, $context->getContext());
+            });
+
         $this->productRepository->expects($this->exactly(2))
             ->method('search')
             ->willReturnOnConsecutiveCalls(
-                $this->createProductSearchResultCollection([$parent, $variant], $context),
+                $this->createProductSearchResult($variant, $context),
                 $this->createEmptyProductSearchResult($context)
             );
-        $this->productExportRender->expects($this->once())
-            ->method('renderBody')
-            ->with($productExport, $context, static::callback(static fn (array $data): bool => $data['product'] === $variant))
-            ->willReturn('variant');
-        $this->seoUrlPlaceholderHandler->expects($this->once())->method('replace')->with('variant', '', $context)->willReturnArgument(0);
-        $this->productExportValidator->expects($this->once())->method('validate')->with($productExport, 'variant')->willReturn([]);
+
+        $this->productExportRender->method('renderBody')->willReturn('variant');
+        $this->seoUrlPlaceholderHandler->method('replace')->willReturnArgument(0);
+        $this->productExportValidator->method('validate')->willReturn([]);
         $this->connection->expects($this->once())->method('delete');
 
         $result = $this->createGenerator()->generate($productExport, new ExportBehavior(false, false, false, false, false));
 
         static::assertNotNull($result);
-        static::assertSame('variant', $result->getContent());
     }
 
     public function testGenerateJsonlSkipsParentProductsAndAddsLineSeparators(): void
@@ -630,6 +633,7 @@ class ProductExportGeneratorTest extends TestCase
         $productExport->setSalesChannelId('salesChannelId');
         $productExport->setStorefrontSalesChannelId('storefrontSalesChannelId');
         $productExport->setProductStreamId('productStreamId');
+        $productExport->setIncludeVariants(false);
 
         $salesChannelDomain = new SalesChannelDomainEntity();
         $salesChannelDomain->setLanguageId('languageId');


### PR DESCRIPTION
### 1. Why is this change necessary?
  When "Export variants as discrete products" is disabled, the product feed generator fetches all products — including variants — from the database in pages of readBufferSize (default 100).
  Variant filtering happens in PHP afterwards. This means a page can consist entirely of variants, producing empty content for that batch. Because getTotal() counts all products (including
  variants), the partial generation handler correctly dispatches subsequent batches in most cases, but the underlying mismatch between the paginated total and the actually renderable product
  count makes the feed fragile and inefficient: every batch containing only variants is a wasted message-queue round-trip that produces nothing. In edge cases (e.g. a stream where all products
   returned in a single batch are variants), this has caused feed generation to stall.

### 2. What does this change do, exactly?

  The variant/parent filter is pushed down into the database Criteria before the iterator is constructed, instead of being applied in PHP after fetching:

  - When includeVariants = false: adds EqualsFilter('parentId', null) so only main and standalone products are fetched.
  - When includeVariants = true: adds an OrFilter (parentId IS NOT NULL OR childCount = 0) so only variants and standalone products are fetched, excluding parent products that have variants.

  This ensures getTotal() and pagination always reflect the count of products that will actually be rendered. Empty-batch pages become impossible, and the handler's offset + bufferSize < total
   continuation check is accurate.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a product with a large number of variants (e.g. 200+ variants, 1 main product).
* In the sales channel, create a product export and disable "Export variants as discrete products".
* Trigger feed generation via the scheduler (ProductExportGenerateTask).
* Observe that the generated feed is empty or incomplete — the main product is missing because its batch position happened to fall outside the first page of results, and all 100 products in
   the first page were variants that were silently skipped, causing the batch handler to either stall or produce a feed with incorrect pagination.

### 4. Please link to the relevant issues (if any).
- closes #7292

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
