### PR TITLE
fix: avoid redundant order create context updates

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
@@ -47,7 +47,7 @@ export default Component.wrapComponentConfig({
 
     computed: {
         salesChannelId(): string {
-            return Store.get('swOrder').context?.salesChannel?.id ?? '';
+            return this.customer?.salesChannelId ?? Store.get('swOrder').context?.salesChannel?.id ?? '';
         },
 
         salesChannelCriteria(): CriteriaType {
@@ -109,8 +109,11 @@ export default Component.wrapComponentConfig({
         },
 
         'context.currencyId': {
-            async handler(): Promise<void> {
-                // await this.getCurrency();
+            async handler(currencyId: string): Promise<void> {
+                if (!currencyId || currencyId === Store.get('swOrder').context?.context?.currencyId) {
+                    return;
+                }
+
                 await this.updateCartContext();
             },
         },
@@ -128,7 +131,11 @@ export default Component.wrapComponentConfig({
         },
 
         'context.shippingMethodId': {
-            async handler(): Promise<void> {
+            async handler(shippingMethodId: string): Promise<void> {
+                if (!shippingMethodId || shippingMethodId === Store.get('swOrder').context?.shippingMethod?.id) {
+                    return;
+                }
+
                 await this.updateCartContext();
             },
         },
@@ -184,7 +191,7 @@ export default Component.wrapComponentConfig({
         },
 
         async updateCartContext(): Promise<void> {
-            if (!this.salesChannelId) {
+            if (!this.salesChannelId || !this.customer || !this.cart.token) {
                 return;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.spec.js
@@ -55,8 +55,14 @@ const context = {
     salesChannel: {
         id: '1',
     },
+    shippingMethod: {
+        id: 'shipping-method-1',
+    },
     customer: {
         ...customerData,
+    },
+    context: {
+        currencyId: '1',
     },
     currency: {
         isoCode: 'EUR',
@@ -334,6 +340,22 @@ describe('src/module/sw-order/view/sw-order-create-options', () => {
 
         shippingCostField = wrapper.find('.sw-order-create-options__shipping-cost .mt-field__addition:not(.is--prefix)');
         expect(shippingCostField.text()).toBe('$');
+    });
+
+    it('should not update cart context while hydrating existing sales channel values', async () => {
+        const wrapper = await createWrapper();
+        const updateCartContextSpy = jest.spyOn(wrapper.vm, 'updateCartContext');
+
+        await wrapper.setProps({
+            context: {
+                ...wrapper.vm.context,
+                currencyId: '1',
+                shippingMethodId: 'shipping-method-1',
+            },
+        });
+        await flushPromises();
+
+        expect(updateCartContextSpy).not.toHaveBeenCalled();
     });
 
     it('should emit shipping-cost-change event when edit shipping cost field', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/sw-order-create-options.spec.js
@@ -344,7 +344,7 @@ describe('src/module/sw-order/view/sw-order-create-options', () => {
 
     it('should not update cart context while hydrating existing sales channel values', async () => {
         const wrapper = await createWrapper();
-        const updateCartContextSpy = jest.spyOn(wrapper.vm, 'updateCartContext');
+        const updateOrderContextSpy = jest.spyOn(Shopware.Store.get('swOrder'), 'updateOrderContext');
 
         await wrapper.setProps({
             context: {
@@ -355,7 +355,7 @@ describe('src/module/sw-order/view/sw-order-create-options', () => {
         });
         await flushPromises();
 
-        expect(updateCartContextSpy).not.toHaveBeenCalled();
+        expect(updateOrderContextSpy).not.toHaveBeenCalled();
     });
 
     it('should emit shipping-cost-change event when edit shipping cost field', async () => {


### PR DESCRIPTION
Prevent the order create options step from sending no-op Store API context PATCH requests during initial hydration, which removes the harmless `CHECKOUT__CUSTOMER_NOT_LOGGED_IN` console errors when selecting a customer and sales channel.

fixes: https://github.com/shopware/shopware/issues/13945