### PR TITLE
fix: unskip and update GoogleReCaptchaV3 acceptance tests

### DIFF
--- a/src/Storefront/Framework/Captcha/GoogleReCaptchaV3.php
+++ b/src/Storefront/Framework/Captcha/GoogleReCaptchaV3.php
@@ -51,7 +51,9 @@ class GoogleReCaptchaV3 extends AbstractCaptcha
             $responseRaw = $response->getBody()->getContents();
             $response = json_decode($responseRaw, true);
 
-            $thresholdScore = !empty($captchaConfig['config']['thresholdScore']) ? (float) $captchaConfig['config']['thresholdScore'] : self::DEFAULT_THRESHOLD_SCORE;
+            $thresholdScore = isset($captchaConfig['config']['thresholdScore']) && $captchaConfig['config']['thresholdScore'] !== ''
+                ? (float) $captchaConfig['config']['thresholdScore']
+                : self::DEFAULT_THRESHOLD_SCORE;
 
             return $response && (bool) $response['success'] && (float) $response['score'] >= $thresholdScore;
         } catch (ClientExceptionInterface) {

--- a/tests/acceptance/tests/Forms/GoogleReCaptchaV2.spec.ts
+++ b/tests/acceptance/tests/Forms/GoogleReCaptchaV2.spec.ts
@@ -207,6 +207,7 @@ test('As a customer, I want to fill out and submit the contact form that is vali
         DefaultSalesChannel,
         TestDataService,
         InstanceMeta,
+        StorefrontFooter,
     }) => {
 
         test.skip(InstanceMeta.isSaaS, 'SaaS just support FriendlyCaptcha');
@@ -228,7 +229,7 @@ test('As a customer, I want to fill out and submit the contact form that is vali
 
         await test.step('Open the contact form modal on home page.', async () => {
             await ShopCustomer.goesTo(StorefrontHome.url());
-            await ShopCustomer.presses(StorefrontHome.contactFormLink);
+            await ShopCustomer.presses(StorefrontFooter.footerContactFormLink);
             await ShopCustomer.expects(StorefrontContactForm.cardTitle).toContainText('Contact');
 
             const reCaptchaNotice = StorefrontContactForm.page.getByText('This site is protected by reCAPTCHA');
@@ -253,13 +254,7 @@ test('As a customer, I want to fill out and submit the contact form that is vali
                     `${process.env['APP_URL'] + 'test-' + DefaultSalesChannel.salesChannel.id}/form/contact`
                 );
 
-                // eslint-disable-next-line playwright/no-conditional-in-test
-                if (InstanceMeta.features['ACCESSIBILITY_TWEAKS']) {
-                    await ShopCustomer.presses(StorefrontContactForm.submitButton);
-                } else {
-                    await StorefrontContactForm.submitButton.click();
-                }
-
+                await ShopCustomer.presses(StorefrontContactForm.submitButton);
                 const contactFormResponse = await contactFormPromise;
 
                 expect(contactFormResponse.ok()).toBeTruthy();

--- a/tests/acceptance/tests/Forms/GoogleReCaptchaV3.spec.ts
+++ b/tests/acceptance/tests/Forms/GoogleReCaptchaV3.spec.ts
@@ -4,7 +4,7 @@ import { satisfies } from 'compare-versions';
 const reCaptcha_V3_site_key = '6LeNJ-UqAAAAAPmLzX0ekQuuv7f4HR8FVyaF4FrR';
 const reCaptcha_V3_secret_key = '6LeNJ-UqAAAAAGIxrxNBjVvQwPUZ6_DJxWlqXC9u';
 
-test.skip('As a customer, I can perform a registration by validating to be not a robot via the Google reCaptcha V3.',
+test('As a customer, I can perform a registration by validating to be not a robot via the Google reCaptcha V3.',
     { tag: ['@Form', '@Registration', '@Captcha', '@Storefront'] },
     async ({
         ShopCustomer,
@@ -26,7 +26,7 @@ test.skip('As a customer, I can perform a registration by validating to be not a
                     config: {
                         siteKey: reCaptcha_V3_site_key,
                         secretKey: reCaptcha_V3_secret_key,
-                        thresholdScore: 0.5,
+                        thresholdScore: 0.0,
                     },
                 },
             },
@@ -47,7 +47,7 @@ test.skip('As a customer, I can perform a registration by validating to be not a
     }
 );
 
-test.skip('As a customer, I can perform a registration that is validated by the invisible Google reCaptcha V3 even after a false input.',
+test('As a customer, I can perform a registration that is validated by the invisible Google reCaptcha V3 even after a false input.',
     { tag: ['@Form', '@Registration', '@Captcha', '@Storefront'] },
     async ({
         ShopCustomer,
@@ -68,7 +68,7 @@ test.skip('As a customer, I can perform a registration that is validated by the 
                     config: {
                         siteKey: reCaptcha_V3_site_key,
                         secretKey: reCaptcha_V3_secret_key,
-                        thresholdScore: 0.5,
+                        thresholdScore: 0.0,
                     },
                 },
             },
@@ -82,7 +82,7 @@ test.skip('As a customer, I can perform a registration that is validated by the 
             password: 'shopware',
             street: 'Ebbinghof 10',
             city: 'Schöppingen',
-            country: 'Germany',
+            country: 'United Kingdom',
             postalCode: '48624',
         };
 
@@ -95,17 +95,19 @@ test.skip('As a customer, I can perform a registration that is validated by the 
 
         await test.step('Customer attempts to register but forgets to fill out a required field', async () => {
 
+            await ShopCustomer.presses(StorefrontAccountLogin.salutationSelect);
             await StorefrontAccountLogin.salutationSelect.selectOption(customer.salutation);
-            await StorefrontAccountLogin.firstNameInput.fill(customer.firstName);
-            await StorefrontAccountLogin.registerEmailInput.fill(customer.email);
-            await StorefrontAccountLogin.registerPasswordInput.fill(customer.password);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.firstNameInput, customer.firstName);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.registerEmailInput, customer.email);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.registerPasswordInput, customer.password);
 
-            await StorefrontAccountLogin.streetAddressInput.fill(customer.street);
-            await StorefrontAccountLogin.postalCodeInput.fill(customer.postalCode);
-            await StorefrontAccountLogin.cityInput.fill(customer.city);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.streetAddressInput, customer.street);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.postalCodeInput, customer.postalCode);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.cityInput, customer.city);
+            await ShopCustomer.presses(StorefrontAccountLogin.countryInput);
             await StorefrontAccountLogin.countryInput.selectOption({ label: customer.country });
 
-            await StorefrontAccountLogin.registerButton.click();
+            await ShopCustomer.presses(StorefrontAccountLogin.registerButton);
 
             /**
              * Submitting the form triggers a request to google to validate the captcha.
@@ -124,17 +126,18 @@ test.skip('As a customer, I can perform a registration that is validated by the 
         });
 
         await test.step('Customer fills out the missing field and re-attempts the registration', async () => {
-            await StorefrontAccountLogin.lastNameInput.fill(customer.lastName);
+            await ShopCustomer.fillsIn(StorefrontAccountLogin.lastNameInput, customer.lastName);
 
-            await StorefrontAccountLogin.registerButton.click();
+            await ShopCustomer.presses(StorefrontAccountLogin.registerButton);
+            // await StorefrontAccount.page.waitForURL('**/account', { waitUntil: 'commit' });
 
             await ShopCustomer.expects(StorefrontAccount.page.getByText(customer.email, { exact: true })).toBeVisible();
         });
     }
 );
 
-test.skip('As a customer, I want to fill out and submit the contact form that is validated by the invisible Google reCaptcha V3.',
-    { tag: ['@Form', '@Registration', '@Captcha', '@Storefront'] },
+test('As a customer, I want to fill out and submit the contact form that is validated by the invisible Google reCaptcha V3.',
+    { tag: ['@Form', '@Contact', '@Captcha', '@Storefront'] },
     async ({
         ShopCustomer,
         StorefrontHome,
@@ -142,9 +145,11 @@ test.skip('As a customer, I want to fill out and submit the contact form that is
         DefaultSalesChannel,
         TestDataService,
         InstanceMeta,
+        StorefrontFooter,
     }) => {
 
         test.skip(InstanceMeta.isSaaS, 'SaaS just support FriendlyCaptcha');
+        test.slow(); // Necessary for multiple retries due to rate limiting
 
         await TestDataService.setSystemConfig({
             'core.basicInformation.activeCaptchasV2': {
@@ -154,7 +159,7 @@ test.skip('As a customer, I want to fill out and submit the contact form that is
                     config: {
                         siteKey: reCaptcha_V3_site_key,
                         secretKey: reCaptcha_V3_secret_key,
-                        thresholdScore: 0.5,
+                        thresholdScore: 0.0,
                     },
                 },
             },
@@ -162,7 +167,7 @@ test.skip('As a customer, I want to fill out and submit the contact form that is
 
         await test.step('Open the contact form modal on home page.', async () => {
             await ShopCustomer.goesTo(StorefrontHome.url());
-            await StorefrontHome.contactFormLink.click();
+            await ShopCustomer.presses(StorefrontFooter.footerContactFormLink);
             await ShopCustomer.expects(StorefrontContactForm.cardTitle).toContainText('Contact');
 
             const reCaptchaNotice = StorefrontContactForm.page.getByText('This site is protected by reCAPTCHA');
@@ -170,29 +175,34 @@ test.skip('As a customer, I want to fill out and submit the contact form that is
         });
 
         await test.step('Fill out all necessary contact information.', async () => {
+            await ShopCustomer.presses(StorefrontContactForm.salutationSelect);
             await StorefrontContactForm.salutationSelect.selectOption('Mr.');
-            await StorefrontContactForm.firstNameInput.fill('John');
-            await StorefrontContactForm.lastNameInput.fill('Doe');
-            await StorefrontContactForm.emailInput.fill('mail@test.com');
-            await StorefrontContactForm.phoneInput.fill('0123456789');
-            await StorefrontContactForm.subjectInput.fill('Test: Product question');
-            await StorefrontContactForm.commentInput.fill('Test: Hello, I have a question about your products.');
-            await StorefrontContactForm.privacyPolicyCheckbox.click();
+            await ShopCustomer.fillsIn(StorefrontContactForm.firstNameInput, 'John');
+            await ShopCustomer.fillsIn(StorefrontContactForm.lastNameInput, 'Doe');
+            await ShopCustomer.fillsIn(StorefrontContactForm.emailInput, 'mail@test.com');
+            await ShopCustomer.fillsIn(StorefrontContactForm.phoneInput, '0123456789');
+            await ShopCustomer.fillsIn(StorefrontContactForm.subjectInput, 'Test: Product question');
+            await ShopCustomer.fillsIn(StorefrontContactForm.commentInput, 'Test: Hello, I have a question about your products.');
+            await ShopCustomer.presses(StorefrontContactForm.privacyPolicyCheckbox);
         });
 
-        await test.step('Send and validate the contact form.', async () => {
-            const contactFormPromise = StorefrontContactForm.page.waitForResponse(
-                `${process.env['APP_URL'] + 'test-' + DefaultSalesChannel.salesChannel.id}/form/contact`
-            );
+        await ShopCustomer.expects(async () => {
+            await test.step('Send and validate the contact form.', async () => {
+                const contactFormPromise = StorefrontContactForm.page.waitForResponse(
+                    `${process.env['APP_URL'] + 'test-' + DefaultSalesChannel.salesChannel.id}/form/contact`
+                );
 
-            await StorefrontContactForm.submitButton.click();
-            const contactFormResponse = await contactFormPromise;
+                await ShopCustomer.presses(StorefrontContactForm.submitButton);
+                const contactFormResponse = await contactFormPromise;
 
-            expect(contactFormResponse.ok()).toBeTruthy();
+                expect(contactFormResponse.ok()).toBeTruthy();
 
-            await ShopCustomer.expects(StorefrontContactForm.contactSuccessMessage).toHaveText(
-                'We have received your contact request and will process it as soon as possible.'
-            );
+                await ShopCustomer.expects(StorefrontContactForm.contactSuccessMessage).toHaveText(
+                    'We have received your contact request and will process it as soon as possible.'
+                );
+            });
+        }).toPass({
+            intervals: [30_000], // retry after 30 seconds
         });
     }
 );


### PR DESCRIPTION
Fixes: #14100

## 1. Why is this change necessary?

The Google reCAPTCHA V3 acceptance tests were skipped and had become unreliable due to outdated storefront selectors, non-a11y interactions, rate-limit sensitivity, and a threshold handling bug in the PHP validator. This PR restores those tests and updates the implementation so the scenarios run reliably again.

## 2. What does this change do, exactly?

This PR:

- unskips all Google reCAPTCHA V3 acceptance tests
- updates acceptance tests to use a11y-friendly interactions (`presses()` / `fillsIn()`) instead of raw `click()` / `fill()`
- replaces the deprecated `StorefrontHome.contactFormLink` selector with `StorefrontFooter.footerContactFormLink`
- removes the conditional `ACCESSIBILITY_TWEAKS` submit handling in the V2 contact-form test and uses `presses()` consistently
- improves the V3 contact-form test to better tolerate reCAPTCHA rate limiting by wrapping submission assertions in `toPass({ intervals: [30_000] })`
- restores the success-message assertion for the V3 contact-form flow
- fixes threshold handling in `GoogleReCaptchaV3::isValid()` so an explicitly configured value of `0.0` is respected
- sets `thresholdScore: 0.0` in the affected V3 test configurations so valid tokens from headless browsers are accepted during test execution

## 3. Describe each step to reproduce the issue or behaviour.

1. Enable Google reCAPTCHA V3 for the affected storefront forms.
2. Run the acceptance tests covering:
   - storefront registration
   - registration retry after validation errors
   - storefront contact form submission
3. Observe that:
   - the V3 tests are skipped, or
   - interactions rely on outdated/deprecated selectors and non-a11y helpers, or
   - submissions can become flaky due to low reCAPTCHA scores / rate limiting in headless environments.
4. In addition, configure `thresholdScore` to `0.0` and observe that the PHP validator still falls back to the default threshold because `!empty(0.0)` evaluates unexpectedly for this use case.

## 4. Please link to the relevant issues (if any).

- Fixes #14100

## 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them