### PR TITLE
chore: Use AppManager for services lifecycle

### DIFF
--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -4,8 +4,6 @@ namespace Shopware\Core\Service\Api;
 
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Privileges\Utils;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -15,6 +13,7 @@ use Shopware\Core\Service\DTO\Service;
 use Shopware\Core\Service\LifecycleManager;
 use Shopware\Core\Service\Message\UpdateServiceMessage;
 use Shopware\Core\Service\ServiceException;
+use Shopware\Core\Service\ServiceLifecycle;
 use Shopware\Core\Service\ServiceStorage;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,8 +31,7 @@ class ServiceController
     public function __construct(
         private readonly ServiceStorage $serviceStorage,
         private readonly MessageBusInterface $messageBus,
-        private readonly AppStateService $appStateService,
-        private readonly AbstractAppLifecycle $appLifecycle,
+        private readonly ServiceLifecycle $serviceLifecycle,
         private readonly LifecycleManager $manager,
     ) {
     }
@@ -71,17 +69,9 @@ class ServiceController
     {
         $this->extractIntegrationIdOrFail($context);
 
-        $service = $this->serviceStorage->findByName($serviceName, $context);
-
-        if (!$service) {
-            throw ServiceException::notFound('name', $serviceName);
-        }
-
-        if (!$service->active) {
-            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
-                $this->appStateService->activateApp($service->id, $context);
-            });
-        }
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
+            $this->serviceLifecycle->activate($serviceName, $context);
+        });
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
@@ -99,17 +89,9 @@ class ServiceController
     {
         $this->extractIntegrationIdOrFail($context);
 
-        $service = $this->serviceStorage->findByName($serviceName, $context);
-
-        if (!$service) {
-            throw ServiceException::notFound('name', $serviceName);
-        }
-
-        if ($service->active) {
-            $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
-                $this->appStateService->deactivateApp($service->id, $context);
-            });
-        }
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
+            $this->serviceLifecycle->deactivate($serviceName, $context);
+        });
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
@@ -126,14 +108,9 @@ class ServiceController
     public function uninstall(string $serviceName, Context $context): JsonResponse
     {
         $this->extractIntegrationIdOrFail($context);
-        $service = $this->serviceStorage->findByName($serviceName, $context);
 
-        if (!$service) {
-            throw ServiceException::notFound('name', $serviceName);
-        }
-
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
-            $this->appLifecycle->delete($service->id, ['id' => $service->id], $context);
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
+            $this->serviceLifecycle->uninstall($serviceName, $context);
         });
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/src/Core/Service/DTO/Service.php
+++ b/src/Core/Service/DTO/Service.php
@@ -33,6 +33,7 @@ readonly class Service
         public State $state,
         public array $domains,
         public array $requirements,
+        public AppEntity $app,
     ) {
     }
 
@@ -56,6 +57,7 @@ readonly class Service
             State::state($app),
             array_values($app->getAllowedHosts() ?? []),
             self::requirements($app),
+            $app,
         );
     }
 

--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -12,8 +12,7 @@
         <service id="Shopware\Core\Service\Api\ServiceController" public="true">
             <argument type="service" id="Shopware\Core\Service\ServiceStorage"/>
             <argument type="service" id="messenger.default_bus"/>
-            <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
+            <argument type="service" id="Shopware\Core\Service\ServiceLifecycle"/>
             <argument type="service" id="Shopware\Core\Service\LifecycleManager"/>
         </service>
 
@@ -38,13 +37,12 @@
         <service id="Shopware\Core\Service\ServiceLifecycle">
             <argument type="service" id="Shopware\Core\Service\ServiceRegistry\Client"/>
             <argument type="service" id="Shopware\Core\Service\ServiceClientFactory"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
+            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppManager"/>
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Service\ServiceStorage"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="Shopware\Core\Framework\App\Manifest\ManifestFactory"/>
             <argument type="service" id="Shopware\Core\Service\ServiceSourceResolver"/>
-            <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Service\Requirement\RequirementsValidator"/>
         </service>
@@ -167,7 +165,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\Privileges\Privileges"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="Shopware\Core\Service\ServiceStorage"/>
-            <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
+            <argument type="service" id="Shopware\Core\Service\ServiceLifecycle"/>
             <argument type="service" id="Shopware\Core\Service\AllServiceInstaller"/>
             <argument type="service" id="Shopware\Core\Service\Permission\PermissionsService"/>
             <argument type="service" id="Shopware\Core\Service\ServiceRegistry\Client"/>

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Service;
 
-use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -38,7 +37,7 @@ class LifecycleManager
         private readonly Privileges $privileges,
         private readonly SystemConfigService $systemConfigService,
         private readonly ServiceStorage $serviceStorage,
-        private readonly AbstractAppLifecycle $appLifecycle,
+        private readonly ServiceLifecycle $serviceLifecycle,
         private readonly AllServiceInstaller $serviceInstaller,
         private readonly PermissionsService $permissionsService,
         private readonly Client $client,
@@ -114,7 +113,7 @@ class LifecycleManager
     public function disable(Context $context): void
     {
         foreach ($this->serviceStorage->findAll($context) as $service) {
-            $this->appLifecycle->delete($service->name, ['id' => $service->id], $context);
+            $this->serviceLifecycle->uninstall($service->name, $context);
         }
 
         $this->permissionsService->revoke($context);
@@ -146,7 +145,7 @@ class LifecycleManager
 
         foreach ($services as $service) {
             if (!isset($registryServiceNames[$service->name])) {
-                $this->appLifecycle->delete($service->name, ['id' => $service->id], $context);
+                $this->serviceLifecycle->uninstall($service->name, $context);
             }
         }
     }

--- a/src/Core/Service/ServiceLifecycle.php
+++ b/src/Core/Service/ServiceLifecycle.php
@@ -5,8 +5,7 @@ namespace Shopware\Core\Service;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppException;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
 use Shopware\Core\Framework\App\Manifest\Manifest;
@@ -37,13 +36,12 @@ class ServiceLifecycle
     public function __construct(
         private readonly Client $serviceRegistryClient,
         private readonly ServiceClientFactory $serviceClientFactory,
-        private readonly AbstractAppLifecycle $appLifecycle,
+        private readonly AppManager $appManager,
         private readonly EntityRepository $appRepository,
         private readonly ServiceStorage $serviceStorage,
         private readonly LoggerInterface $logger,
         private readonly ManifestFactory $manifestFactory,
         private readonly ServiceSourceResolver $sourceResolver,
-        private readonly AppStateService $appStateService,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly RequirementsValidator $requirementsValidator,
     ) {
@@ -83,7 +81,7 @@ class ServiceLifecycle
         $manifest = $this->createManifest($fs->path('manifest.xml'), $serviceEntry->host, $appInfo);
 
         try {
-            $this->appLifecycle->install(
+            $this->appManager->install(
                 $manifest,
                 new AppInstallParameters(activate: $serviceEntry->activateOnInstall),
                 Context::createDefaultContext()
@@ -142,13 +140,10 @@ class ServiceLifecycle
         $manifest = $this->createManifest($fs->path('manifest.xml'), $serviceEntry->host, $latestAppInfo);
 
         try {
-            $this->appLifecycle->update(
+            $this->appManager->update(
                 $manifest,
                 new AppUpdateParameters(),
-                [
-                    'id' => $service->id,
-                    'roleId' => $service->aclRoleId,
-                ],
+                $service->app,
                 $context
             );
             $this->logger->debug(\sprintf('Installed service "%s"', $serviceEntry->name));
@@ -161,6 +156,39 @@ class ServiceLifecycle
 
             return false;
         }
+    }
+
+    public function activate(string $serviceName, Context $context): void
+    {
+        $service = $this->serviceStorage->findByName($serviceName, $context);
+
+        if (!$service) {
+            throw ServiceException::notFound('name', $serviceName);
+        }
+
+        $this->appManager->activate($service->app, $context);
+    }
+
+    public function deactivate(string $serviceName, Context $context): void
+    {
+        $service = $this->serviceStorage->findByName($serviceName, $context);
+
+        if (!$service) {
+            throw ServiceException::notFound('name', $serviceName);
+        }
+
+        $this->appManager->deactivate($service->app, $context);
+    }
+
+    public function uninstall(string $serviceName, Context $context): void
+    {
+        $service = $this->serviceStorage->findByName($serviceName, $context);
+
+        if (!$service) {
+            throw ServiceException::notFound('name', $serviceName);
+        }
+
+        $this->appManager->delete($service->app, $context);
     }
 
     /**
@@ -200,7 +228,7 @@ class ServiceLifecycle
         );
 
         // it was possibly disabled during the update process
-        $this->appStateService->activateApp($appId, $context);
+        $this->activate($entry->name, $context);
 
         $result = $this->update($entry->name, $context);
 

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -10,14 +10,13 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\ShopApiSource;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Service\Api\ServiceController;
 use Shopware\Core\Service\LifecycleManager;
 use Shopware\Core\Service\Message\UpdateServiceMessage;
 use Shopware\Core\Service\ServiceException;
+use Shopware\Core\Service\ServiceLifecycle;
 use Shopware\Core\Service\ServiceStorage;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
@@ -42,9 +41,7 @@ class ServiceControllerTest extends TestCase
 
     private MessageBusInterface&MockObject $bus;
 
-    private AppStateService&MockObject $appStateService;
-
-    private AppLifecycle&MockObject $appLifecycle;
+    private ServiceLifecycle&MockObject $serviceLifecycle;
 
     private LifecycleManager&MockObject $manager;
 
@@ -60,9 +57,7 @@ class ServiceControllerTest extends TestCase
         $this->appRepo = new StaticEntityRepository([new AppCollection([$this->app])]);
 
         $this->bus = $this->createMock(MessageBusInterface::class);
-
-        $this->appStateService = $this->createMock(AppStateService::class);
-        $this->appLifecycle = $this->createMock(AppLifecycle::class);
+        $this->serviceLifecycle = $this->createMock(ServiceLifecycle::class);
         $this->manager = $this->createMock(LifecycleManager::class);
     }
 
@@ -75,7 +70,7 @@ class ServiceControllerTest extends TestCase
 
         $this->bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
@@ -90,7 +85,7 @@ class ServiceControllerTest extends TestCase
 
         $this->bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $context = Context::createDefaultContext($source);
 
@@ -103,7 +98,7 @@ class ServiceControllerTest extends TestCase
 
         $this->bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB');
         $context = Context::createDefaultContext($source);
@@ -119,7 +114,7 @@ class ServiceControllerTest extends TestCase
             return new Envelope($msg, []);
         });
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
@@ -132,7 +127,7 @@ class ServiceControllerTest extends TestCase
         $source = new ShopApiSource('AABB');
         static::expectExceptionObject(ServiceException::updateRequiresAdminApiSource($source));
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $context = Context::createDefaultContext($source);
 
@@ -143,7 +138,7 @@ class ServiceControllerTest extends TestCase
     {
         static::expectExceptionObject(ServiceException::updateRequiresIntegration());
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB');
         $context = Context::createDefaultContext($source);
@@ -155,12 +150,15 @@ class ServiceControllerTest extends TestCase
     {
         static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
 
-        /** @var StaticEntityRepository<AppCollection> $appRepo */
-        $appRepo = new StaticEntityRepository([new AppCollection()]);
-        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())
+            ->method('activate')
+            ->with('invalidService', $context)
+            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
 
         $controller->activate('invalidService', $context);
     }
@@ -168,12 +166,12 @@ class ServiceControllerTest extends TestCase
     public function testActivate(): void
     {
         $this->app->setActive(false);
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->appStateService->expects($this->once())->method('activateApp')->with($this->appId, $context);
+        $this->serviceLifecycle->expects($this->once())->method('activate')->with('MyCoolService', $context);
         $controller->activate('MyCoolService', $context);
     }
 
@@ -182,7 +180,7 @@ class ServiceControllerTest extends TestCase
         $source = new ShopApiSource('AABB');
         static::expectExceptionObject(ServiceException::updateRequiresAdminApiSource($source));
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $context = Context::createDefaultContext($source);
 
@@ -193,7 +191,7 @@ class ServiceControllerTest extends TestCase
     {
         static::expectExceptionObject(ServiceException::updateRequiresIntegration());
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB');
         $context = Context::createDefaultContext($source);
@@ -205,12 +203,15 @@ class ServiceControllerTest extends TestCase
     {
         static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
 
-        /** @var StaticEntityRepository<AppCollection> $appRepo */
-        $appRepo = new StaticEntityRepository([new AppCollection()]);
-        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())
+            ->method('deactivate')
+            ->with('invalidService', $context)
+            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
 
         $controller->deactivate('invalidService', $context);
     }
@@ -218,30 +219,30 @@ class ServiceControllerTest extends TestCase
     public function testDeactivate(): void
     {
         $this->app->setActive(true);
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->appStateService->expects($this->once())->method('deactivateApp')->with($this->appId, $context);
+        $this->serviceLifecycle->expects($this->once())->method('deactivate')->with('MyCoolService', $context);
         $controller->deactivate('MyCoolService', $context);
     }
 
     public function testUninstall(): void
     {
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->appLifecycle->expects($this->once())->method('delete')->with($this->appId, ['id' => $this->appId], $context);
+        $this->serviceLifecycle->expects($this->once())->method('uninstall')->with('MyCoolService', $context);
         $controller->uninstall('MyCoolService', $context);
     }
 
     public function testList(): void
     {
         $this->app->setActive(true);
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
@@ -265,7 +266,7 @@ class ServiceControllerTest extends TestCase
 
     public function testDisableServices(): void
     {
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
@@ -276,7 +277,7 @@ class ServiceControllerTest extends TestCase
 
     public function testEnableServices(): void
     {
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $this->manager->expects($this->once())->method('enable');
         $controller->enableServices();
@@ -296,7 +297,7 @@ class ServiceControllerTest extends TestCase
             'product:read',
         ]);
 
-        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $response = $controller->categorizedPermissions('MyCoolService', Context::createDefaultContext());
         $content = $response->getContent();
@@ -343,7 +344,7 @@ class ServiceControllerTest extends TestCase
         /** @var StaticEntityRepository<AppCollection> $appRepo */
         $appRepo = new StaticEntityRepository([new AppCollection()]);
 
-        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController(new ServiceStorage($appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
         $controller->categorizedPermissions('MyCoolService', Context::createDefaultContext());

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
-use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Service\AllServiceInstaller;
@@ -16,6 +15,7 @@ use Shopware\Core\Service\LifecycleManager;
 use Shopware\Core\Service\Permission\PermissionsService;
 use Shopware\Core\Service\Requirement\RequirementsValidator;
 use Shopware\Core\Service\ServiceException;
+use Shopware\Core\Service\ServiceLifecycle;
 use Shopware\Core\Service\ServiceRegistry\Client;
 use Shopware\Core\Service\ServiceRegistry\ServiceEntry;
 use Shopware\Core\Service\ServiceStorage;
@@ -34,7 +34,7 @@ class LifecycleManagerTest extends TestCase
 
     private SystemConfigService&MockObject $systemConfigService;
 
-    private readonly AppLifecycle&MockObject $appLifecycle;
+    private readonly ServiceLifecycle&MockObject $serviceLifecycle;
 
     private AllServiceInstaller&MockObject $serviceInstaller;
 
@@ -50,7 +50,7 @@ class LifecycleManagerTest extends TestCase
     {
         $this->privileges = $this->createMock(Privileges::class);
         $this->systemConfigService = $this->createMock(SystemConfigService::class);
-        $this->appLifecycle = $this->createMock(AppLifecycle::class);
+        $this->serviceLifecycle = $this->createMock(ServiceLifecycle::class);
         $this->serviceInstaller = $this->createMock(AllServiceInstaller::class);
         $this->permissionsService = $this->createMock(PermissionsService::class);
         $this->client = $this->createMock(Client::class);
@@ -108,11 +108,10 @@ class LifecycleManagerTest extends TestCase
             $this->createServiceEntity('service3', 'SwagService3'),
         ]);
 
-        $this->appLifecycle->expects($this->exactly($services->count()))
-            ->method('delete')
-            ->willReturnCallback(function ($name, $options, $context) use ($services): void {
-                static::assertContains($name, $services->map(static fn (AppEntity $service) => $service->getName()));
-                static::assertArrayHasKey('id', $options);
+        $this->serviceLifecycle->expects($this->exactly($services->count()))
+            ->method('uninstall')
+            ->willReturnCallback(function (string $serviceName, Context $context) use ($services): void {
+                static::assertContains($serviceName, $services->map(static fn (AppEntity $service) => $service->getName()));
                 static::assertSame($this->context, $context);
             });
 
@@ -133,8 +132,8 @@ class LifecycleManagerTest extends TestCase
     {
         $services = new AppCollection([]);
 
-        $this->appLifecycle->expects($this->never())
-            ->method('delete');
+        $this->serviceLifecycle->expects($this->never())
+            ->method('uninstall');
 
         $this->permissionsService->expects($this->once())
             ->method('revoke')
@@ -270,9 +269,9 @@ class LifecycleManagerTest extends TestCase
                 new ServiceEntry('SwagService2', 'Swag Service 2', 'https://swag-service2.example.com', '/app-endpoint'),
             ]);
 
-        $this->appLifecycle->expects($this->once())
-            ->method('delete')
-            ->with('OrphanedService', ['id' => 'service3'], $this->context);
+        $this->serviceLifecycle->expects($this->once())
+            ->method('uninstall')
+            ->with('OrphanedService', $this->context);
 
         $manager = $this->createManager($this->createAppRepository($services));
 
@@ -291,7 +290,7 @@ class LifecycleManagerTest extends TestCase
             $this->createMock(Privileges::class),
             new StaticSystemConfigService($systemConfig),
             new ServiceStorage($this->createAppRepository()),
-            $this->createMock(AppLifecycle::class),
+            $this->createMock(ServiceLifecycle::class),
             $this->createMock(AllServiceInstaller::class),
             $this->createMock(PermissionsService::class),
             $this->createMock(Client::class),
@@ -366,7 +365,7 @@ class LifecycleManagerTest extends TestCase
             $this->privileges,
             $this->systemConfigService,
             new ServiceStorage($repository),
-            $this->appLifecycle,
+            $this->serviceLifecycle,
             $this->serviceInstaller,
             $this->permissionsService,
             $this->client,

--- a/tests/unit/Core/Service/ServiceLifecycleTest.php
+++ b/tests/unit/Core/Service/ServiceLifecycleTest.php
@@ -9,9 +9,9 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
-use Shopware\Core\Framework\App\AppStateService;
-use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
+use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
+use Shopware\Core\Framework\App\Lifecycle\Parameters\AppUpdateParameters;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\ManifestFactory;
 use Shopware\Core\Framework\App\Source\TemporaryDirectoryFactory;
@@ -42,7 +42,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(ServiceLifecycle::class)]
 class ServiceLifecycleTest extends TestCase
 {
-    private AbstractAppLifecycle&MockObject $appLifecycle;
+    private AppManager&MockObject $appManager;
 
     private ServiceEntry $entry;
 
@@ -58,8 +58,6 @@ class ServiceLifecycleTest extends TestCase
 
     private ServiceSourceResolver&MockObject $sourceResolver;
 
-    private AppStateService&MockObject $appState;
-
     private AppInfo $appInfo;
 
     /**
@@ -73,7 +71,7 @@ class ServiceLifecycleTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $this->appManager = $this->createMock(AppManager::class);
         $this->entry = new ServiceEntry('MyCoolService', 'MyCoolService', 'https://example.com', '/service/lifecycle/choose-app');
         $this->appInfo = new AppInfo('MyCoolService', '6.6.0.0', 'a1bcd', '6.6.0.0-a1bcd', 'https://example.com/service/lifecycle/app-zip/6.6.0.0', ['service_consent'], 'sha256', '6.6.0.0');
         $this->logger = $this->createMock(LoggerInterface::class);
@@ -82,7 +80,6 @@ class ServiceLifecycleTest extends TestCase
         $this->serviceClientFactory = $this->createMock(ServiceClientFactory::class);
         $this->serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $this->sourceResolver = $this->createMock(ServiceSourceResolver::class);
-        $this->appState = $this->createMock(AppStateService::class);
         $this->appRepo = new StaticEntityRepository([
             [], // empty search for app -> service migration
         ]);
@@ -98,7 +95,7 @@ class ServiceLifecycleTest extends TestCase
 
         $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
 
-        $this->appLifecycle->expects($this->never())->method('install');
+        $this->appManager->expects($this->never())->method('install');
 
         $this->eventDispatcher->expects($this->never())->method('dispatch');
 
@@ -110,13 +107,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository(),
             new ServiceStorage($this->buildAppRepository()),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -145,7 +141,7 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('install')
             ->willThrowException(AppException::notCompatible('MyCoolService'));
 
@@ -159,13 +155,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository(),
             new ServiceStorage($this->buildAppRepository()),
             $this->logger,
             $manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -194,7 +189,7 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('install')
             ->willReturnCallback(static function (Manifest $manifest): void {
                 static::assertSame('https://example.com', $manifest->getPath());
@@ -223,13 +218,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->appRepo,
             new ServiceStorage($this->appRepo),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -259,7 +253,12 @@ class ServiceLifecycleTest extends TestCase
 
                 return [$app];
             },
-            static function (Criteria $criteria) use ($app) { // second load during update
+            static function (Criteria $criteria) use ($app) { // load service for activation
+                $app->setSelfManaged(true);
+
+                return [$app];
+            },
+            static function (Criteria $criteria) use ($app) { // load service during update
                 $app->setSelfManaged(true);
 
                 return [$app];
@@ -285,13 +284,14 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appState->expects($this->once())
-            ->method('activateApp')
-            ->with($app->getId(), $context);
+        $this->appManager->expects($this->once())
+            ->method('activate')
+            ->with($app, $context);
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('update')
-            ->willReturnCallback(static function (Manifest $manifest): void {
+            ->willReturnCallback(static function (Manifest $manifest, AppUpdateParameters $parameters, AppEntity $service) use ($app): void {
+                static::assertSame($app, $service);
                 static::assertSame('https://example.com', $manifest->getPath());
                 static::assertSame([
                     'version' => '6.6.0.0',
@@ -318,13 +318,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $appRepo,
             new ServiceStorage($appRepo),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -365,7 +364,7 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('install')
             ->willReturnCallback(static function (Manifest $manifest, AppInstallParameters $options): void {
                 static::assertFalse($options->activate);
@@ -395,13 +394,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository(),
             new ServiceStorage($this->buildAppRepository()),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -415,7 +413,7 @@ class ServiceLifecycleTest extends TestCase
 
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
-        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appManager = $this->createMock(AppManager::class);
         $logger = $this->createMock(LoggerInterface::class);
         $manifestFactory = $this->createMock(ManifestFactory::class);
 
@@ -425,13 +423,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $serviceRegistryClient,
             $serviceClientFactory,
-            $appLifecycle,
+            $appManager,
             $this->buildAppRepository(),
             new ServiceStorage($this->buildAppRepository()),
             $logger,
             $manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -448,7 +445,7 @@ class ServiceLifecycleTest extends TestCase
 
         $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
 
-        $this->appLifecycle->expects($this->never())->method('update');
+        $this->appManager->expects($this->never())->method('update');
 
         $this->logger
             ->expects($this->once())
@@ -461,13 +458,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository([$app]),
             new ServiceStorage($this->buildAppRepository([$app])),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -482,20 +478,19 @@ class ServiceLifecycleTest extends TestCase
         $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
         $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
         $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('update');
+        $this->appManager->expects($this->never())->method('update');
         $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
         $this->eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository([$app]),
             new ServiceStorage($this->buildAppRepository([$app])),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -522,7 +517,7 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('update')
             ->willThrowException(AppException::notCompatible('MyCoolService'));
 
@@ -537,13 +532,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository([$app]),
             new ServiceStorage($this->buildAppRepository([$app])),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
@@ -570,9 +564,10 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($this->createManifest());
 
-        $this->appLifecycle->expects($this->once())
+        $this->appManager->expects($this->once())
             ->method('update')
-            ->willReturnCallback(static function (Manifest $manifest): void {
+            ->willReturnCallback(static function (Manifest $manifest, AppUpdateParameters $parameters, AppEntity $service) use ($app): void {
+                static::assertSame($app, $service);
                 static::assertSame('https://example.com', $manifest->getPath());
                 static::assertSame([
                     'version' => '6.6.0.0',
@@ -601,18 +596,80 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository([$app]),
             new ServiceStorage($this->buildAppRepository([$app])),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $this->requirementsValidator
         );
 
         static::assertTrue($lifecycle->update('MyCoolService', Context::createDefaultContext()));
+    }
+
+    public function testActivate(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+
+        $this->appManager->expects($this->once())
+            ->method('activate')
+            ->with($app, $context);
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->activate('MyCoolService', $context);
+    }
+
+    public function testActivateThrowsExceptionWhenServiceDoesNotExist(): void
+    {
+        static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
+
+        $this->appManager->expects($this->never())->method('activate');
+
+        $this->createLifecycle($this->buildAppRepository())->activate('MyCoolService', Context::createDefaultContext());
+    }
+
+    public function testDeactivate(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+
+        $this->appManager->expects($this->once())
+            ->method('deactivate')
+            ->with($app, $context);
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->deactivate('MyCoolService', $context);
+    }
+
+    public function testDeactivateThrowsExceptionWhenServiceDoesNotExist(): void
+    {
+        static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
+
+        $this->appManager->expects($this->never())->method('deactivate');
+
+        $this->createLifecycle($this->buildAppRepository())->deactivate('MyCoolService', Context::createDefaultContext());
+    }
+
+    public function testUninstall(): void
+    {
+        $context = Context::createDefaultContext();
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+
+        $this->appManager->expects($this->once())
+            ->method('delete')
+            ->with($app, $context);
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->uninstall('MyCoolService', $context);
+    }
+
+    public function testUninstallThrowsExceptionWhenServiceDoesNotExist(): void
+    {
+        static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
+
+        $this->appManager->expects($this->never())->method('delete');
+
+        $this->createLifecycle($this->buildAppRepository())->uninstall('MyCoolService', Context::createDefaultContext());
     }
 
     public function testInstallReturnsFalseWhenRequirementsAreInvalid(): void
@@ -631,7 +688,7 @@ class ServiceLifecycleTest extends TestCase
 
         $this->sourceResolver->expects($this->never())->method('filesystemForVersion');
         $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('install');
+        $this->appManager->expects($this->never())->method('install');
         $this->eventDispatcher->expects($this->never())->method('dispatch');
 
         $this->logger
@@ -642,13 +699,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository(),
             new ServiceStorage($this->buildAppRepository()),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $requirementsValidator
         );
@@ -675,7 +731,7 @@ class ServiceLifecycleTest extends TestCase
 
         $this->sourceResolver->expects($this->never())->method('filesystemForVersion');
         $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('update');
+        $this->appManager->expects($this->never())->method('update');
         $this->eventDispatcher->expects($this->never())->method('dispatch');
 
         $this->logger
@@ -686,13 +742,12 @@ class ServiceLifecycleTest extends TestCase
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
             $this->serviceClientFactory,
-            $this->appLifecycle,
+            $this->appManager,
             $this->buildAppRepository([$app]),
             new ServiceStorage($this->buildAppRepository([$app])),
             $this->logger,
             $this->manifestFactory,
             $this->sourceResolver,
-            $this->appState,
             $this->eventDispatcher,
             $requirementsValidator
         );
@@ -713,6 +768,25 @@ class ServiceLifecycleTest extends TestCase
         ]);
 
         return $appRepository;
+    }
+
+    /**
+     * @param StaticEntityRepository<AppCollection> $appRepository
+     */
+    private function createLifecycle(StaticEntityRepository $appRepository): ServiceLifecycle
+    {
+        return new ServiceLifecycle(
+            $this->serviceRegistryClient,
+            $this->serviceClientFactory,
+            $this->appManager,
+            $appRepository,
+            new ServiceStorage($appRepository),
+            $this->logger,
+            $this->manifestFactory,
+            $this->sourceResolver,
+            $this->eventDispatcher,
+            $this->requirementsValidator
+        );
     }
 
     private function createManifest(): Manifest


### PR DESCRIPTION
## What changed
- Replaced service-layer `AppLifecycle` usage with `ServiceLifecycle` methods backed by `AppManager`.
- Added service activate, deactivate, and uninstall operations to `ServiceLifecycle` so controllers and lifecycle coordination do not depend on app lifecycle internals.
- Exposed the backing `AppEntity` on the service DTO so `ServiceLifecycle` can pass it directly to `AppManager` without adding new `ServiceStorage` methods.
- Updated service lifecycle, lifecycle manager, and API controller unit tests around the new facade calls.

## Why
`AppLifecycle` reloads apps through app storage that is scoped to non-self-managed apps. Services are self-managed apps, so the service layer should pass the service app entity directly to `AppManager`.