### PR TITLE
fix: cleanup mailer settings appearance

### DIFF
--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,5 +1,9 @@
 # 6.7.12.0
 
+## Deprecation of `sw_settings_mailer_headline_agent` twig block
+
+The block `sw_settings_mailer_headline_agent` in `src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig` has been deprecated and will be removed in v6.8.0.
+
 ## `Feature::triggerDeprecationOrThrow` accepts an optional `introducedIn` parameter
 
 `Shopware\Core\Framework\Feature::triggerDeprecationOrThrow()` now accepts a third optional `?string $introducedIn = null` argument.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.html.twig
@@ -1,7 +1,6 @@
 {% block sw_settings_mailer_smtp %}
 <div class="sw-settings-mailer-smtp">
     {% block sw_settings_mailer_smtp_host %}
-
     <mt-text-field
         v-model="mailerSettings['core.mailerSettings.host']"
         :label="$t('sw-settings-mailer.card-smtp.host')"
@@ -27,7 +26,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_username %}
-
     <mt-text-field
         v-if="!isOauth"
         v-model="mailerSettings['core.mailerSettings.username']"
@@ -46,7 +44,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_oauth_url %}
-
     <mt-text-field
         v-if="isOauth"
         v-model="mailerSettings['core.mailerSettings.oauthUrl']"
@@ -57,7 +54,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_oauth_scope %}
-
     <mt-text-field
         v-if="isOauth"
         v-model="mailerSettings['core.mailerSettings.oauthScope']"
@@ -68,7 +64,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_client_id %}
-
     <mt-text-field
         v-if="isOauth"
         v-model="mailerSettings['core.mailerSettings.clientId']"
@@ -99,7 +94,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_sender_address %}
-
     <mt-text-field
         v-model="mailerSettings['core.mailerSettings.senderAddress']"
         :label="$t('sw-settings-mailer.card-smtp.sender-address')"
@@ -109,7 +103,6 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_delivery_address %}
-
     <mt-text-field
         v-model="mailerSettings['core.mailerSettings.deliveryAddress']"
         :label="$t('sw-settings-mailer.card-smtp.delivery-address')"
@@ -120,10 +113,10 @@
     {% endblock %}
 
     {% block sw_settings_mailer_smtp_disable_delivery %}
-
     <mt-switch
         v-model="mailerSettings['core.mailerSettings.disableDelivery']"
         :label="$t('sw-settings-mailer.card-smtp.disable-delivery')"
+        :bordered="true"
     />
     {% endblock %}
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.scss
@@ -1,5 +1,5 @@
 .sw-settings-mailer-smtp {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    grid-column-gap: 30px;
+    grid-column-gap: var(--scale-size-24);
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/component/sw-settings-mailer-smtp/sw-settings-mailer-smtp.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package framework
+ * @sw-package after-sales
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
@@ -100,6 +100,7 @@
                         :to="$t('sw-settings-mailer.general.docsLink')"
                         type="external"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         {{ $t('sw-settings-mailer.general.docsLabel') }}
                     </mt-link>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
@@ -1,6 +1,5 @@
 {% block sw_settings_mailer_index %}
 <sw-page class="sw-settings-mailer">
-
     {% block sw_settings_mailer_smart_bar_header %}
     <template #smart-bar-header>
         {% block sw_settings_mailer_smart_bar_header_title %}
@@ -11,7 +10,8 @@
                 name="regular-chevron-right-xs"
                 size="12px"
             />
-            {{ $t('sw-settings-mailer.general.textHeadline') }}
+
+            <span>{{ $t('sw-settings-mailer.general.textHeadline') }}</span>
             {% endblock %}
         </h2>
         {% endblock %}
@@ -37,14 +37,26 @@
     {% block sw_settings_mailer_content %}
     <template #content>
         <sw-card-view>
-            <sw-skeleton v-if="isLoading" />
-
             <mt-card
-                v-else
                 position-identifier="sw-settings-mailer-configuration"
                 :is-loading="isLoading"
                 :title="$t('sw-settings-mailer.mailer-configuration.card-title')"
             >
+                <mt-banner
+                    class="sw-settings-mailer__help-text"
+                    variant="info"
+                >
+                    <span>{{ $t('sw-settings-mailer.general.helpText') }}</span>
+
+                    <mt-link
+                        as="a"
+                        :to="$t('sw-settings-mailer.general.docsLink')"
+                        type="external"
+                        target="_blank"
+                    >
+                        {{ $t('sw-settings-mailer.general.docsLabel') }}
+                    </mt-link>
+                </mt-banner>
 
                 {% block sw_settings_mailer_first_configuration %}
                 <div
@@ -53,30 +65,28 @@
                 >
                     {% block sw_settings_mailer_first_configuration_headline %}
                     <h4 class="sw-settings-mailer__headline">
-                        <strong>
-                            {{ $t('sw-settings-mailer.first-configuration.headline') }}
-                        </strong>
+                        {{ $t('sw-settings-mailer.first-configuration.headline') }}
                     </h4>
                     {% endblock %}
 
                     {% block sw_settings_mailer_first_configuration_description %}
-                    <p>
+                    <p class="sw-settings-mailer__description">
                         {{ $t('sw-settings-mailer.first-configuration.description') }}
                     </p>
                     {% endblock %}
                 </div>
                 {% endblock %}
 
+                {# @deprecated tag:v6.8.0 - Will be removed. #}
                 {% block sw_settings_mailer_headline_agent %}
-                <p class="sw-settings-mailer__headline">
-                    {{ $t('sw-settings-mailer.mailer-configuration.agent') }}
-                </p>
                 {% endblock %}
 
                 <div class="sw-settings-mailer__radio-selection">
                     {% block sw_settings_mailer_agent_options %}
                     <mt-select
                         v-model="mailerSettings['core.mailerSettings.emailAgent']"
+                        class="sw-settings-mailer__select-agent"
+                        :label="$t('sw-settings-mailer.mailer-configuration.agent')"
                         :options="emailAgentOptions"
                     />
 
@@ -88,11 +98,10 @@
                     {% endblock %}
                 </div>
 
-                <p v-html="$t('sw-settings-mailer.helpText')"></p>
-
                 <mt-switch
                     v-if="!isSmtpMode"
                     v-model="mailerSettings['core.mailerSettings.disableDelivery']"
+                    class="sw-settings-mailer__switch-disable-delivery"
                     :label="$t('sw-settings-mailer.card-smtp.disable-delivery')"
                 />
             </mt-card>
@@ -105,7 +114,6 @@
                 title="SMTP server"
                 class="sw-settings-mailer__input-fields"
             >
-
                 {% block sw_settings_mailer_smtp_settings %}
                 <sw-settings-mailer-smtp
                     :mailer-settings="mailerSettings"
@@ -115,7 +123,6 @@
                     @port-changed="resetSmtpPortError"
                 />
                 {% endblock %}
-
             </mt-card>
             {% endblock %}
         </sw-card-view>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.html.twig
@@ -42,22 +42,6 @@
                 :is-loading="isLoading"
                 :title="$t('sw-settings-mailer.mailer-configuration.card-title')"
             >
-                <mt-banner
-                    class="sw-settings-mailer__help-text"
-                    variant="info"
-                >
-                    <span>{{ $t('sw-settings-mailer.general.helpText') }}</span>
-
-                    <mt-link
-                        as="a"
-                        :to="$t('sw-settings-mailer.general.docsLink')"
-                        type="external"
-                        target="_blank"
-                    >
-                        {{ $t('sw-settings-mailer.general.docsLabel') }}
-                    </mt-link>
-                </mt-banner>
-
                 {% block sw_settings_mailer_first_configuration %}
                 <div
                     v-if="isFirstConfiguration"
@@ -104,6 +88,22 @@
                     class="sw-settings-mailer__switch-disable-delivery"
                     :label="$t('sw-settings-mailer.card-smtp.disable-delivery')"
                 />
+
+                <mt-banner
+                    class="sw-settings-mailer__help-text"
+                    variant="info"
+                >
+                    <span>{{ $t('sw-settings-mailer.general.helpText') }}</span>
+
+                    <mt-link
+                        as="a"
+                        :to="$t('sw-settings-mailer.general.docsLink')"
+                        type="external"
+                        target="_blank"
+                    >
+                        {{ $t('sw-settings-mailer.general.docsLabel') }}
+                    </mt-link>
+                </mt-banner>
             </mt-card>
 
             {% block sw_settings_mailer_smtp %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.scss
@@ -1,23 +1,28 @@
-@import "~scss/variables";
-
 .sw-settings-mailer {
-    .sw-settings-mailer__first-configuration {
-        margin-bottom: 16px;
+    &__first-configuration {
+        margin-bottom: var(--scale-size-18);
     }
 
-    .sw-settings-mailer__headline {
-        font-weight: bold;
-        margin-bottom: 16px;
+    .mt-card__content .sw-settings-mailer__headline {
+        font-weight: var(--font-weight-medium);
+        margin-bottom: var(--scale-size-8);
+        font-size: var(--font-size-s);
+        line-height: var(--font-line-height-s);
     }
 
-    .sw-settings-mailer__additional_settings {
-        margin-left: 10px;
-        margin-bottom: 5px;
+    &__description {
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
     }
 
-    .sw-settings-mailer__radio-selection {
+    &__additional_settings {
+        margin-left: var(--scale-size-10);
+        margin-bottom: var(--scale-size-4);
+    }
+
+    &__radio-selection {
         .sw-field--radio {
-            margin-bottom: 8px;
+            margin-bottom: var(--scale-size-8);
         }
 
         .sw-field__radio-group {
@@ -25,7 +30,7 @@
         }
 
         .sw-field__radio-option {
-            margin-right: 32px;
+            margin-right: var(--scale-size-32);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.scss
@@ -1,6 +1,6 @@
 .sw-settings-mailer {
     &__first-configuration {
-        margin-bottom: var(--scale-size-18);
+        margin-bottom: var(--scale-size-32);
     }
 
     .mt-card__content .sw-settings-mailer__headline {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package framework
+ * @sw-package after-sales
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/de.json
@@ -4,7 +4,9 @@
       "mainMenuItemGeneral": "Mailer",
       "textHeadline": "Mailer",
       "buttonSave": "Speichern",
-      "helpText": "Für weitere Informationen schaue bitte in die <a target=\"_blank\" href=\"https://docs.shopware.com/de/shopware-6-de\">Dokumentation</a>"
+      "helpText": "Für weitere Informationen schaue bitte in die",
+      "docsLabel": "Dokumentation.",
+      "docsLink": "https://docs.shopware.com/de/shopware-6-de/einstellungen/mailer"
     },
     "mailer-configuration": {
       "card-title": "Mailer-Konfiguration",
@@ -56,8 +58,7 @@
       "no-encryption": "Keine Verschlüsselung",
       "ssl": "SSL",
       "tls": "TLS"
-    },
-    "helpText": "Für weitere Informationen schaue bitte in die <a target=\"_blank\" href=\"https://docs.shopware.com/de/shopware-6-de\">Dokumentation</a>"
+    }
   }
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/de.json
@@ -5,7 +5,7 @@
       "textHeadline": "Mailer",
       "buttonSave": "Speichern",
       "helpText": "Für weitere Informationen schaue bitte in die",
-      "docsLabel": "Dokumentation.",
+      "docsLabel": "Dokumentation",
       "docsLink": "https://docs.shopware.com/de/shopware-6-de/einstellungen/mailer"
     },
     "mailer-configuration": {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
@@ -4,7 +4,9 @@
       "mainMenuItemGeneral": "Mailer",
       "textHeadline": "Mailer",
       "buttonSave": "Save",
-      "helpText": "For more information look at <a href='https://docs.shopware.com/en/shopware-6-en'>documentation</a>"
+      "helpText": "For more information please check out the",
+      "docsLabel": "documentation.",
+      "docsLink": "https://docs.shopware.com/en/shopware-6-en/settings/mailer"
     },
     "mailer-configuration": {
       "card-title": "Mailer configuration",
@@ -56,8 +58,7 @@
       "no-encryption": "No encryption",
       "ssl": "SSL",
       "tls": "TLS"
-    },
-    "helpText": "For more information please check out the <a target=\"_blank\", href=\"https://docs.shopware.com/en/shopware-6-en\">documentation.</a>"
+    }
   }
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/snippet/en.json
@@ -5,7 +5,7 @@
       "textHeadline": "Mailer",
       "buttonSave": "Save",
       "helpText": "For more information please check out the",
-      "docsLabel": "documentation.",
+      "docsLabel": "documentation",
       "docsLink": "https://docs.shopware.com/en/shopware-6-en/settings/mailer"
     },
     "mailer-configuration": {


### PR DESCRIPTION
#### before

<img width="1409" height="1033" alt="Screenshot 2026-05-29 at 14 05 20" src="https://github.com/user-attachments/assets/da5b8a3a-1946-4e7a-953d-518f6224d1a4" />

#### after

<img width="1409" height="1033" alt="Screenshot 2026-05-29 at 14 02 08" src="https://github.com/user-attachments/assets/5ef886ba-eafc-4463-bc64-b21aff06862f" />
