### PR TITLE
fix: prevent stale cart quantity on browser back

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -50,6 +50,7 @@
                                   class="line-item-quantity-container {% if isDigital %}disabled{% endif %}"
                                   method="post"
                                   {% if displayMode == 'default' %}
+                                  autocomplete="off"
                                   data-form-auto-submit="true"
                                   data-form-auto-submit-options="{{ autoSubmitOptions|json_encode }}"
                                   {% endif %}


### PR DESCRIPTION
resolves #9094

> Setting `autocomplete="off"` [...] stops the browser from caching form data in the session history. When form data is cached in session history, the information filled in by the user is shown in the case where the user has submitted the form and clicked the Back button to go back to the original form page.

– https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/Turning_off_form_autocompletion