### PR TITLE
feat: add DeploymentReadinessCheck and deprecate system:is-installed

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -21,6 +21,13 @@ For cache efficiency, clients should consistently either omit `sw-language-id` a
 
 ## Core
 
+### `system:is-installed` command deprecated
+
+The `system:is-installed` command is deprecated and will be removed in v6.8.0.
+Use `system:check --context=cli` instead, which runs a set of deployment readiness checks directly against the database.
+
+The new `DeploymentReadinessCheck` verifies: pending migrations, admin user existence, a sales channel domain matching `APP_URL`, and registered scheduled tasks.
+
 ### Number range value generator interface deprecated
 
 `NumberRangeValueGeneratorInterface` is deprecated in favor of `AbstractNumberRangeValueGenerator`.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -145,6 +145,14 @@ Previously, these routes could return all customer addresses because the underly
 
 <details>
 
+## `system:is-installed` command removed
+
+The `system:is-installed` command has been removed. Use `system:check --context=cli` instead.
+
+**Why:** The old command only checked for the existence of the `migration` table, which was insufficient to verify a complete Shopware installation. The new command runs deployment readiness checks: pending migrations, admin user existence, a sales channel domain matching `APP_URL`, and registered scheduled tasks.
+
+**How to adapt:** Replace any call to `bin/console system:is-installed` with `bin/console system:check --context=cli`. The new command returns exit code `0` on success and `1` on failure, preserving the same scripting behaviour.
+
 ## Number range value generator interface removed
 
 `Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface` was removed.

--- a/src/Core/Maintenance/DependencyInjection/services.xml
+++ b/src/Core/Maintenance/DependencyInjection/services.xml
@@ -23,6 +23,12 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\Maintenance\System\SystemCheck\DeploymentReadinessCheck">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="string">%env(APP_URL)%</argument>
+            <tag name="shopware.system_check"/>
+        </service>
+
         <service id="Shopware\Core\Maintenance\System\Command\SystemGenerateAppSecretCommand">
             <tag name="console.command"/>
         </service>

--- a/src/Core/Maintenance/System/Command/SystemIsInstalledCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemIsInstalledCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Maintenance\System\Command;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -13,6 +14,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * This command can be used to detect if the system is installed to script a Shopware installation or update.
+ *
+ * @deprecated tag:v6.8.0 - Use the "system:check" command instead, which provides comprehensive deployment readiness checks.
  *
  * @internal
  */
@@ -34,6 +37,13 @@ class SystemIsInstalledCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        $io->warning('system:is-installed is deprecated and will be removed in v6.8.0. Use "system:check --context=cli" instead, which provides comprehensive deployment readiness checks.');
+
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            'The "system:is-installed" command is deprecated and will be removed in v6.8.0. Use "system:check --context=cli" instead.'
+        );
 
         try {
             if (TableHelper::tableExists($this->connection, 'migration')) {

--- a/src/Core/Maintenance/System/SystemCheck/DeploymentReadinessCheck.php
+++ b/src/Core/Maintenance/System/SystemCheck/DeploymentReadinessCheck.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Maintenance\System\SystemCheck;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\SystemCheck\BaseCheck;
+use Shopware\Core\Framework\SystemCheck\Check\Category;
+use Shopware\Core\Framework\SystemCheck\Check\Result;
+use Shopware\Core\Framework\SystemCheck\Check\Status;
+use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class DeploymentReadinessCheck extends BaseCheck
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly string $appUrl,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'DeploymentReadiness';
+    }
+
+    public function category(): Category
+    {
+        return Category::SYSTEM;
+    }
+
+    public function run(): Result
+    {
+        $failures = [];
+
+        // Check 1: No pending migrations
+        $pendingMigrations = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM `migration` WHERE `update` IS NULL'
+        );
+        if ($pendingMigrations > 0) {
+            $failures[] = \sprintf('%d pending migration(s) not yet executed', $pendingMigrations);
+        }
+
+        // Check 2: At least one admin user exists
+        $adminUsers = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM `user` WHERE `admin` = 1'
+        );
+        if ($adminUsers === 0) {
+            $failures[] = 'No admin user found';
+        }
+
+        // Check 3: Sales channel domain matching APP_URL exists
+        $salesChannelExists = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM `sales_channel_domain` WHERE `url` = :url',
+            ['url' => rtrim($this->appUrl, '/')]
+        );
+        if ($salesChannelExists === 0) {
+            $failures[] = \sprintf('No sales channel domain found matching APP_URL "%s"', $this->appUrl);
+        }
+
+        // Check 4: Scheduled tasks are registered
+        $scheduledTasks = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM `scheduled_task`'
+        );
+        if ($scheduledTasks === 0) {
+            $failures[] = 'No scheduled tasks registered';
+        }
+
+        $healthy = $failures === [];
+        $status = $healthy ? Status::OK : Status::FAILURE;
+
+        return new Result(
+            $this->name(),
+            $status,
+            $healthy ? 'System is ready for deployment' : 'System is not ready for deployment',
+            $healthy,
+            $failures,
+        );
+    }
+
+    protected function allowedSystemCheckExecutionContexts(): array
+    {
+        return [SystemCheckExecutionContext::CLI, SystemCheckExecutionContext::PRE_ROLLOUT];
+    }
+}

--- a/tests/unit/Core/Maintenance/System/Command/SystemIsInstalledCommandTest.php
+++ b/tests/unit/Core/Maintenance/System/Command/SystemIsInstalledCommandTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Maintenance\System\Command\SystemIsInstalledCommand;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -16,6 +17,10 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(SystemIsInstalledCommand::class)]
 class SystemIsInstalledCommandTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testInstalled(): void
     {
         $schemaManager = $this->createMock(AbstractSchemaManager::class);
@@ -30,6 +35,10 @@ class SystemIsInstalledCommandTest extends TestCase
         static::assertSame(Command::SUCCESS, $tester->execute([]));
     }
 
+    /**
+     * @deprecated tag:v6.8.0
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testNotInstalled(): void
     {
         $schemaManager = $this->createMock(AbstractSchemaManager::class);

--- a/tests/unit/Core/Maintenance/System/SystemCheck/DeploymentReadinessCheckTest.php
+++ b/tests/unit/Core/Maintenance/System/SystemCheck/DeploymentReadinessCheckTest.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Maintenance\System\SystemCheck;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\SystemCheck\Check\Category;
+use Shopware\Core\Framework\SystemCheck\Check\Status;
+use Shopware\Core\Framework\SystemCheck\Check\SystemCheckExecutionContext;
+use Shopware\Core\Maintenance\System\SystemCheck\DeploymentReadinessCheck;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DeploymentReadinessCheck::class)]
+class DeploymentReadinessCheckTest extends TestCase
+{
+    private const APP_URL = 'https://example.com';
+
+    public function testName(): void
+    {
+        $check = new DeploymentReadinessCheck($this->createMock(Connection::class), self::APP_URL);
+
+        static::assertSame('DeploymentReadiness', $check->name());
+    }
+
+    public function testCategory(): void
+    {
+        $check = new DeploymentReadinessCheck($this->createMock(Connection::class), self::APP_URL);
+
+        static::assertSame(Category::SYSTEM, $check->category());
+    }
+
+    public function testAllowedExecutionContexts(): void
+    {
+        $check = new DeploymentReadinessCheck($this->createMock(Connection::class), self::APP_URL);
+
+        static::assertTrue($check->allowedToRunIn(SystemCheckExecutionContext::CLI));
+        static::assertTrue($check->allowedToRunIn(SystemCheckExecutionContext::PRE_ROLLOUT));
+        static::assertFalse($check->allowedToRunIn(SystemCheckExecutionContext::RECURRENT));
+        static::assertFalse($check->allowedToRunIn(SystemCheckExecutionContext::WEB));
+    }
+
+    public function testRunReturnsOkWhenAllCheckPass(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback($this->allHealthyCallback());
+
+        $check = new DeploymentReadinessCheck($connection, self::APP_URL);
+        $result = $check->run();
+
+        static::assertSame(Status::OK, $result->status);
+        static::assertSame('System is ready for deployment', $result->message);
+        static::assertTrue($result->healthy);
+        static::assertSame([], $result->extra);
+    }
+
+    public function testRunReturnsFailureWhenMigrationsArePending(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            $this->allHealthyCallback(pendingMigrations: 3)
+        );
+
+        $result = (new DeploymentReadinessCheck($connection, self::APP_URL))->run();
+
+        static::assertSame(Status::FAILURE, $result->status);
+        static::assertFalse($result->healthy);
+        static::assertContains('3 pending migration(s) not yet executed', $result->extra);
+    }
+
+    public function testRunReturnsFailureWhenNoAdminUserExists(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            $this->allHealthyCallback(adminUsers: 0)
+        );
+
+        $result = (new DeploymentReadinessCheck($connection, self::APP_URL))->run();
+
+        static::assertSame(Status::FAILURE, $result->status);
+        static::assertFalse($result->healthy);
+        static::assertContains('No admin user found', $result->extra);
+    }
+
+    public function testRunReturnsFailureWhenNoSalesChannelMatchesAppUrl(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            $this->allHealthyCallback(salesChannelExists: 0)
+        );
+
+        $result = (new DeploymentReadinessCheck($connection, self::APP_URL))->run();
+
+        static::assertSame(Status::FAILURE, $result->status);
+        static::assertFalse($result->healthy);
+        static::assertContains(
+            \sprintf('No sales channel domain found matching APP_URL "%s"', self::APP_URL),
+            $result->extra
+        );
+    }
+
+    public function testRunReturnsFailureWhenNoScheduledTasksRegistered(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            $this->allHealthyCallback(scheduledTasks: 0)
+        );
+
+        $result = (new DeploymentReadinessCheck($connection, self::APP_URL))->run();
+
+        static::assertSame(Status::FAILURE, $result->status);
+        static::assertFalse($result->healthy);
+        static::assertContains('No scheduled tasks registered', $result->extra);
+    }
+
+    public function testRunReturnsAllFailuresAtOnce(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            $this->allHealthyCallback(
+                pendingMigrations: 2,
+                adminUsers: 0,
+                salesChannelExists: 0,
+                scheduledTasks: 0
+            )
+        );
+
+        $result = (new DeploymentReadinessCheck($connection, self::APP_URL))->run();
+
+        static::assertSame(Status::FAILURE, $result->status);
+        static::assertFalse($result->healthy);
+        static::assertCount(4, $result->extra);
+    }
+
+    public function testAppUrlTrailingSlashIsStripped(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            function (string $sql, array $params = []) {
+                if (str_contains($sql, 'sales_channel_domain')) {
+                    static::assertSame('https://example.com', $params['url']);
+
+                    return '1';
+                }
+
+                return '1';
+            }
+        );
+
+        (new DeploymentReadinessCheck($connection, 'https://example.com/'))->run();
+    }
+
+    /**
+     * Returns a fetchOne callback where every check is healthy by default.
+     * Individual counts can be overridden to simulate failures.
+     */
+    private function allHealthyCallback(
+        int $pendingMigrations = 0,
+        int $adminUsers = 1,
+        int $salesChannelExists = 1,
+        int $scheduledTasks = 5,
+    ): \Closure {
+        return function (string $sql) use ($pendingMigrations, $adminUsers, $salesChannelExists, $scheduledTasks): string {
+            return match (true) {
+                str_contains($sql, 'migration') => (string) $pendingMigrations,
+                str_contains($sql, 'user') => (string) $adminUsers,
+                str_contains($sql, 'sales_channel_domain') => (string) $salesChannelExists,
+                str_contains($sql, 'scheduled_task') => (string) $scheduledTasks,
+                default => '0',
+            };
+        };
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
`system:is-installed` only checks if the `migration` table exists - too shallow to confirm a working Shopware instance. Deployment pipelines need a reliable way to verify the system is fully operational before proceeding.

### 2. What does this change do, exactly?
Adds `DeploymentReadinessCheck` - a new CLI-context check plugged into the existing `system:check` - that verifies pending migrations, admin user existence, a sales channel domain matching `APP_URL`, and registered scheduled tasks. Deprecates `system:is-installed` in favour of `system:check --context=cli`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install Shopware without completing all setup steps (e.g. skip sales channel setup)
2. Run `bin/console system:is-installed` → exits `0` (falsely reports installed)                                                                              
3. Run `bin/console system:check --context=cli` → exits `1` with a clear failure message indicating what is missing

### 4. Please link to the relevant issues (if any).
- closes #17130
- relates shopware/deployment-helper#5

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
