### PR TITLE
fix: storefront method switchers in combination with CheckoutGateway (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-05-29-fix-storefront-method-switchers-checkout-gateway.md
+++ b/changelog/_unreleased/2026-05-29-fix-storefront-method-switchers-checkout-gateway.md
@@ -1,0 +1,10 @@
+---
+title: Fix storefront method switchers with checkout gateway
+issue: #16780
+author: Max Stegmeyer
+author_email: m.stegmeyer@shopware.com
+author_github: @mstegmeyer
+---
+# Storefront
+* Changed checkout cart and confirm page loading to resolve payment and shipping methods blocked by the checkout gateway before rendering the page.
+* Changed fallback selection to use checkout gateway available methods, preferring the sales-channel default method when available.

--- a/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacade.php
+++ b/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacade.php
@@ -7,8 +7,12 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
+use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
+use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
@@ -18,6 +22,7 @@ use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
 use Shopware\Storefront\Checkout\Payment\BlockedPaymentMethodSwitcher;
 use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
+use Symfony\Component\HttpFoundation\Request;
 
 #[Package('checkout')]
 class StorefrontCartFacade
@@ -31,7 +36,8 @@ class StorefrontCartFacade
         private readonly BlockedPaymentMethodSwitcher $blockedPaymentMethodSwitcher,
         private readonly AbstractContextSwitchRoute $contextSwitchRoute,
         private readonly CartCalculator $calculator,
-        private readonly AbstractCartPersister $cartPersister
+        private readonly AbstractCartPersister $cartPersister,
+        private readonly AbstractCheckoutGatewayRoute $checkoutGatewayRoute
     ) {
     }
 
@@ -41,10 +47,43 @@ class StorefrontCartFacade
         bool $caching = true,
         bool $taxed = false
     ): Cart {
+        return $this->getCartResult($token, $originalContext, $caching, $taxed)['cart'];
+    }
+
+    public function getWithCheckoutGateway(
+        Request $request,
+        string $token,
+        SalesChannelContext $context,
+        bool $caching = true,
+        bool $taxed = false
+    ): StorefrontCartGatewayResult {
+        $cartResult = $this->getCartResult($token, $context, $caching, $taxed);
+        $cart = $cartResult['cart'];
+        $context = $cartResult['context'];
+        $gatewayResponse = $this->checkoutGatewayRoute->load($request, $cart, $context);
+
+        if ($this->cartContainsBlockedMethods($gatewayResponse->getErrors())) {
+            $cartResult = $this->resolveBlockedMethodsFromGatewayResponse($cart, $context, $gatewayResponse);
+            $cart = $cartResult['cart'];
+            $gatewayResponse->setErrors($cart->getErrors());
+        }
+
+        return new StorefrontCartGatewayResult($cart, $gatewayResponse);
+    }
+
+    /**
+     * @return array{cart: Cart, context: SalesChannelContext}
+     */
+    private function getCartResult(
+        string $token,
+        SalesChannelContext $originalContext,
+        bool $caching = true,
+        bool $taxed = false
+    ): array {
         $originalCart = $this->cartService->getCart($token, $originalContext, $caching, $taxed);
         $cartErrors = $originalCart->getErrors();
         if (!$this->cartContainsBlockedMethods($cartErrors)) {
-            return $originalCart;
+            return ['cart' => $originalCart, 'context' => $originalContext];
         }
 
         // Switch shipping method if blocked
@@ -53,10 +92,22 @@ class StorefrontCartFacade
         // Switch payment method if blocked
         $contextPaymentMethod = $this->blockedPaymentMethodSwitcher->switch($cartErrors, $originalContext);
 
+        return $this->switchCartMethods($originalCart, $originalContext, $contextShippingMethod, $contextPaymentMethod);
+    }
+
+    /**
+     * @return array{cart: Cart, context: SalesChannelContext}
+     */
+    private function switchCartMethods(
+        Cart $originalCart,
+        SalesChannelContext $originalContext,
+        ShippingMethodEntity $contextShippingMethod,
+        PaymentMethodEntity $contextPaymentMethod
+    ): array {
         if ($contextShippingMethod->getId() === $originalContext->getShippingMethod()->getId()
             && $contextPaymentMethod->getId() === $originalContext->getPaymentMethod()->getId()
         ) {
-            return $originalCart;
+            return ['cart' => $originalCart, 'context' => $originalContext];
         }
 
         $updatedContext = clone $originalContext;
@@ -72,13 +123,34 @@ class StorefrontCartFacade
             $this->cartPersister->save($newCart, $updatedContext);
             $this->updateSalesChannelContext($updatedContext);
 
-            return $newCart;
+            return ['cart' => $newCart, 'context' => $updatedContext];
         }
 
         // Recalculated cart contains one or more blocked shipping/payment method, rollback changes
-        $this->removeSwitchNotices($cartErrors);
+        $this->removeSwitchNotices($originalCart->getErrors());
 
-        return $originalCart;
+        return ['cart' => $originalCart, 'context' => $originalContext];
+    }
+
+    /**
+     * @return array{cart: Cart, context: SalesChannelContext}
+     */
+    private function resolveBlockedMethodsFromGatewayResponse(Cart $cart, SalesChannelContext $context, CheckoutGatewayRouteResponse $gatewayResponse): array
+    {
+        $cartErrors = $gatewayResponse->getErrors();
+
+        $contextShippingMethod = $this->blockedShippingMethodSwitcher->switch(
+            $cartErrors,
+            $context,
+            $gatewayResponse->getShippingMethods()
+        );
+        $contextPaymentMethod = $this->blockedPaymentMethodSwitcher->switch(
+            $cartErrors,
+            $context,
+            $gatewayResponse->getPaymentMethods()
+        );
+
+        return $this->switchCartMethods($cart, $context, $contextShippingMethod, $contextPaymentMethod);
     }
 
     private function cartContainsBlockedMethods(ErrorCollection $errors): bool

--- a/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartGatewayResult.php
+++ b/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartGatewayResult.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Checkout\Cart\SalesChannel;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ *
+ * @internal
+ */
+#[Package('checkout')]
+class StorefrontCartGatewayResult
+{
+    public function __construct(
+        public readonly Cart $cart,
+        public readonly CheckoutGatewayRouteResponse $gatewayResponse,
+    ) {
+    }
+}

--- a/src/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcher.php
+++ b/src/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcher.php
@@ -2,15 +2,13 @@
 
 namespace Shopware\Storefront\Checkout\Payment;
 
-use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\Error;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Payment\SalesChannel\AbstractPaymentMethodRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
@@ -26,14 +24,25 @@ class BlockedPaymentMethodSwitcher
     {
     }
 
-    public function switch(ErrorCollection $errors, SalesChannelContext $salesChannelContext): PaymentMethodEntity
-    {
+    public function switch(
+        ErrorCollection $errors,
+        SalesChannelContext $salesChannelContext,
+        ?PaymentMethodCollection $paymentMethods = null
+    ): PaymentMethodEntity {
         $originalPaymentMethod = $salesChannelContext->getPaymentMethod();
         if (!$this->paymentMethodBlocked($errors)) {
             return $originalPaymentMethod;
         }
 
-        $paymentMethod = $this->getPaymentMethodToChangeTo($errors, $salesChannelContext);
+        $paymentMethod = $this->getPaymentMethodToChangeTo(
+            $errors,
+            $salesChannelContext,
+            $paymentMethods ?? $this->paymentMethodRoute->load(
+                new Request(['onlyAvailable' => true]),
+                $salesChannelContext,
+                new Criteria(),
+            )->getPaymentMethods(),
+        );
         if ($paymentMethod === null) {
             return $originalPaymentMethod;
         }
@@ -54,33 +63,43 @@ class BlockedPaymentMethodSwitcher
         return false;
     }
 
-    private function getPaymentMethodToChangeTo(ErrorCollection $errors, SalesChannelContext $salesChannelContext): ?PaymentMethodEntity
-    {
-        $blockedPaymentMethodNames = $errors->fmap(static fn (Error $error) => $error instanceof PaymentMethodBlockedError ? $error->getName() : null);
+    private function getPaymentMethodToChangeTo(
+        ErrorCollection $errors,
+        SalesChannelContext $salesChannelContext,
+        PaymentMethodCollection $paymentMethods
+    ): ?PaymentMethodEntity {
+        $blocked = $this->getBlockedPaymentMethodLookup($errors);
 
-        $request = new Request(['onlyAvailable' => true]);
-        $defaultPaymentMethod = $this->paymentMethodRoute->load(
-            $request,
-            $salesChannelContext,
-            new Criteria([$salesChannelContext->getSalesChannel()->getPaymentMethodId()])
-        )->getPaymentMethods()->first();
-
-        if ($defaultPaymentMethod !== null && !\in_array($defaultPaymentMethod->getName(), $blockedPaymentMethodNames, true)) {
+        $defaultPaymentMethod = $paymentMethods->get($salesChannelContext->getSalesChannel()->getPaymentMethodId());
+        if ($defaultPaymentMethod !== null && !$this->isBlocked($defaultPaymentMethod, $blocked)) {
             return $defaultPaymentMethod;
         }
 
-        $criteria = new Criteria();
-        $criteria->addFilter(
-            new NandFilter([
-                new EqualsAnyFilter('name', $blockedPaymentMethodNames),
-            ])
-        );
+        foreach ($paymentMethods as $paymentMethod) {
+            if (!$this->isBlocked($paymentMethod, $blocked)) {
+                return $paymentMethod;
+            }
+        }
 
-        return $this->paymentMethodRoute->load(
-            $request,
-            $salesChannelContext,
-            $criteria
-        )->getPaymentMethods()->first();
+        return null;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getBlockedPaymentMethodLookup(ErrorCollection $errors): array
+    {
+        return \array_flip($errors->fmap(static fn (Error $error) => $error instanceof PaymentMethodBlockedError ? $error->getName() : null));
+    }
+
+    /**
+     * @param array<string, int> $blocked
+     */
+    private function isBlocked(PaymentMethodEntity $paymentMethod, array $blocked): bool
+    {
+        $name = $paymentMethod->getName();
+
+        return $name !== null && isset($blocked[$name]);
     }
 
     private function addNoticeToCart(ErrorCollection $cartErrors, PaymentMethodEntity $paymentMethod): void

--- a/src/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcher.php
+++ b/src/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcher.php
@@ -2,15 +2,13 @@
 
 namespace Shopware\Storefront\Checkout\Shipping;
 
-use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\Error;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
 use Shopware\Core\Checkout\Shipping\SalesChannel\AbstractShippingMethodRoute;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
@@ -26,14 +24,25 @@ class BlockedShippingMethodSwitcher
     {
     }
 
-    public function switch(ErrorCollection $errors, SalesChannelContext $salesChannelContext): ShippingMethodEntity
-    {
+    public function switch(
+        ErrorCollection $errors,
+        SalesChannelContext $salesChannelContext,
+        ?ShippingMethodCollection $shippingMethods = null
+    ): ShippingMethodEntity {
         $originalShippingMethod = $salesChannelContext->getShippingMethod();
         if (!$this->shippingMethodBlocked($errors)) {
             return $originalShippingMethod;
         }
 
-        $shippingMethod = $this->getShippingMethodToChangeTo($errors, $salesChannelContext);
+        $shippingMethod = $this->getShippingMethodToChangeTo(
+            $errors,
+            $salesChannelContext,
+            $shippingMethods ?? $this->shippingMethodRoute->load(
+                new Request(['onlyAvailable' => true]),
+                $salesChannelContext,
+                new Criteria(),
+            )->getShippingMethods(),
+        );
         if ($shippingMethod === null) {
             return $originalShippingMethod;
         }
@@ -54,34 +63,43 @@ class BlockedShippingMethodSwitcher
         return false;
     }
 
-    private function getShippingMethodToChangeTo(ErrorCollection $errors, SalesChannelContext $salesChannelContext): ?ShippingMethodEntity
-    {
-        $blockedShippingMethodNames = $errors->fmap(static fn (Error $error) => $error instanceof ShippingMethodBlockedError ? $error->getName() : null);
+    private function getShippingMethodToChangeTo(
+        ErrorCollection $errors,
+        SalesChannelContext $salesChannelContext,
+        ShippingMethodCollection $shippingMethods
+    ): ?ShippingMethodEntity {
+        $blocked = $this->getBlockedShippingMethodLookup($errors);
 
-        $request = new Request(['onlyAvailable' => true]);
-        $defaultShippingMethod = $this->shippingMethodRoute->load(
-            $request,
-            $salesChannelContext,
-            new Criteria([$salesChannelContext->getSalesChannel()->getShippingMethodId()])
-        )->getShippingMethods()->first();
-
-        if ($defaultShippingMethod !== null && !\in_array($defaultShippingMethod->getName(), $blockedShippingMethodNames, true)) {
+        $defaultShippingMethod = $shippingMethods->get($salesChannelContext->getSalesChannel()->getShippingMethodId());
+        if ($defaultShippingMethod !== null && !$this->isBlocked($defaultShippingMethod, $blocked)) {
             return $defaultShippingMethod;
         }
 
-        // Default excluded take next shipping method
-        $criteria = new Criteria();
-        $criteria->addFilter(
-            new NandFilter([
-                new EqualsAnyFilter('name', $blockedShippingMethodNames),
-            ]),
-        );
+        foreach ($shippingMethods as $shippingMethod) {
+            if (!$this->isBlocked($shippingMethod, $blocked)) {
+                return $shippingMethod;
+            }
+        }
 
-        return $this->shippingMethodRoute->load(
-            $request,
-            $salesChannelContext,
-            $criteria
-        )->getShippingMethods()->first();
+        return null;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getBlockedShippingMethodLookup(ErrorCollection $errors): array
+    {
+        return \array_flip($errors->fmap(static fn (Error $error) => $error instanceof ShippingMethodBlockedError ? $error->getName() : null));
+    }
+
+    /**
+     * @param array<string, int> $blocked
+     */
+    private function isBlocked(ShippingMethodEntity $shippingMethod, array $blocked): bool
+    {
+        $name = $shippingMethod->getName();
+
+        return $name !== null && isset($blocked[$name]);
     }
 
     private function addNoticeToCart(ErrorCollection $cartErrors, ShippingMethodEntity $shippingMethod): void

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -37,6 +37,7 @@
             <argument type="service" id="Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\CartPersister"/>
+            <argument type="service" id="Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute"/>
         </service>
 
         <service id="Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher">
@@ -301,7 +302,6 @@
         <service id="Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoader">
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade"/>
-            <argument type="service" id="Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute"/>
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\Validation\AddressValidationFactory"/>
             <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
@@ -312,7 +312,6 @@
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade"/>
-            <argument type="service" id="Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute"/>
             <argument type="service" id="Shopware\Core\System\Country\SalesChannel\CountryRoute"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
         </service>

--- a/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
+++ b/src/Storefront/Page/Checkout/Cart/CheckoutCartPageLoader.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Storefront\Page\Checkout\Cart;
 
-use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
@@ -35,7 +34,6 @@ class CheckoutCartPageLoader
         private readonly GenericPageLoaderInterface $genericLoader,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly StorefrontCartFacade $cartService,
-        private readonly AbstractCheckoutGatewayRoute $checkoutGatewayRoute,
         private readonly AbstractCountryRoute $countryRoute,
         private readonly ?AbstractTranslator $translator = null
     ) {
@@ -55,9 +53,9 @@ class CheckoutCartPageLoader
 
         $page->setCountries($this->getCountries($salesChannelContext));
 
-        $cart = $this->cartService->get($salesChannelContext->getToken(), $salesChannelContext);
-
-        $gatewayResponse = $this->checkoutGatewayRoute->load($request, $cart, $salesChannelContext);
+        $cartGatewayResult = $this->cartService->getWithCheckoutGateway($request, $salesChannelContext->getToken(), $salesChannelContext);
+        $cart = $cartGatewayResult->cart;
+        $gatewayResponse = $cartGatewayResult->gatewayResponse;
 
         $page->setPaymentMethods($gatewayResponse->getPaymentMethods());
         $page->setCart($cart);

--- a/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
+++ b/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
@@ -8,7 +8,6 @@ use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
-use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
@@ -38,7 +37,6 @@ class CheckoutConfirmPageLoader
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly StorefrontCartFacade $cartService,
-        private readonly AbstractCheckoutGatewayRoute $checkoutGatewayRoute,
         private readonly GenericPageLoaderInterface $genericPageLoader,
         private readonly DataValidationFactoryInterface $addressValidationFactory,
         private readonly DataValidator $validator,
@@ -56,9 +54,9 @@ class CheckoutConfirmPageLoader
         $page = CheckoutConfirmPage::createFrom($page);
         $this->setMetaInformation($page);
 
-        $cart = $this->cartService->get($context->getToken(), $context, false, true);
-
-        $response = $this->checkoutGatewayRoute->load($request, $cart, $context);
+        $cartGatewayResult = $this->cartService->getWithCheckoutGateway($request, $context->getToken(), $context, false, true);
+        $cart = $cartGatewayResult->cart;
+        $response = $cartGatewayResult->gatewayResponse;
 
         $page->setPaymentMethods($response->getPaymentMethods());
         $page->setShippingMethods($response->getShippingMethods());

--- a/tests/integration/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/tests/integration/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Checkout\Cart\SalesChannel;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItemFactoryRegistry;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
+use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
+use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
+use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
+use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
+use Shopware\Storefront\Checkout\Payment\BlockedPaymentMethodSwitcher;
+use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class StorefrontCartFacadeTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private IdsCollection $ids;
+
+    private SalesChannelContext $context;
+
+    private CartService $cartService;
+
+    protected function setUp(): void
+    {
+        $this->ids = new IdsCollection();
+        $this->cartService = $this->getContainer()->get(CartService::class);
+    }
+
+    public function testCheckoutGatewayBlockedPaymentMethodSwitchesToDefaultPaymentMethod(): void
+    {
+        $cashOnDeliveryPaymentMethod = $this->getPaymentMethodByTechnicalName('payment_cashpayment');
+        $paidInAdvancePaymentMethod = $this->getPaymentMethodByTechnicalName('payment_prepayment');
+
+        static::getContainer()->get('sales_channel.repository')->update([
+            [
+                'id' => TestDefaults::SALES_CHANNEL,
+                'paymentMethodId' => $paidInAdvancePaymentMethod->getId(),
+            ],
+        ], Context::createDefaultContext());
+
+        static::getContainer()->get(SalesChannelContextPersister::class)
+            ->save($this->ids->get('token'), ['paymentMethodId' => $cashOnDeliveryPaymentMethod->getId()], TestDefaults::SALES_CHANNEL);
+
+        $this->context = self::getContainer()
+            ->get(SalesChannelContextService::class)
+            ->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $this->ids->get('token')));
+
+        static::assertSame($cashOnDeliveryPaymentMethod->getId(), $this->context->getPaymentMethod()->getId());
+
+        $cart = new Cart($this->ids->get('token'));
+        $this->cartService->add($cart, $this->createProduct(), $this->context);
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(static function (Request $request, Cart $cart, SalesChannelContext $context) use ($cashOnDeliveryPaymentMethod, $paidInAdvancePaymentMethod): CheckoutGatewayRouteResponse {
+                $cart->getErrors()->add(new PaymentMethodBlockedError(
+                    (string) $cashOnDeliveryPaymentMethod->getTranslation('name'),
+                    'not allowed'
+                ));
+
+                return new CheckoutGatewayRouteResponse(
+                    new PaymentMethodCollection([$paidInAdvancePaymentMethod]),
+                    new ShippingMethodCollection([$context->getShippingMethod()]),
+                    $cart->getErrors(),
+                );
+            });
+
+        $cartFacade = new StorefrontCartFacade(
+            $this->cartService,
+            static::getContainer()->get(BlockedShippingMethodSwitcher::class),
+            static::getContainer()->get(BlockedPaymentMethodSwitcher::class),
+            static::getContainer()->get(ContextSwitchRoute::class),
+            static::getContainer()->get(CartCalculator::class),
+            static::getContainer()->get(CartPersister::class),
+            $checkoutGatewayRoute,
+        );
+
+        $result = $cartFacade->getWithCheckoutGateway(new Request(), $this->ids->get('token'), $this->context);
+
+        static::assertCount(0, $result->cart->getErrors()->filterInstance(PaymentMethodBlockedError::class));
+        static::assertCount(1, $result->cart->getErrors()->filterInstance(PaymentMethodChangedError::class));
+
+        $persistedContext = self::getContainer()
+            ->get(SalesChannelContextService::class)
+            ->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $this->ids->get('token')));
+
+        static::assertSame($paidInAdvancePaymentMethod->getId(), $persistedContext->getPaymentMethod()->getId());
+    }
+
+    private function getPaymentMethodByTechnicalName(string $technicalName): PaymentMethodEntity
+    {
+        $paymentMethodRepository = $this->getContainer()->get('payment_method.repository');
+
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', $technicalName));
+        $paymentMethod = $paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
+
+        static::assertInstanceOf(PaymentMethodEntity::class, $paymentMethod);
+
+        return $paymentMethod;
+    }
+
+    private function createProduct(): LineItem
+    {
+        $productRepository = $this->getContainer()->get('product.repository');
+
+        $standardTaxId = static::getContainer()->get('tax.repository')
+            ->searchIds((new Criteria())->addFilter(new EqualsFilter('taxRate', 19.0)), Context::createDefaultContext())->firstId();
+
+        static::assertNotNull($standardTaxId);
+
+        $this->ids->set('tax-id', $standardTaxId);
+
+        $product = new ProductBuilder($this->ids, 'product-1');
+        $product->price(10);
+        $product->visibility();
+        $product->tax('tax-id');
+
+        $productRepository->create([$product->build()], Context::createDefaultContext());
+
+        $productFactory = $this->getContainer()->get(LineItemFactoryRegistry::class);
+
+        return $productFactory->create(
+            ['type' => 'product', 'id' => $this->ids->get('product-1'), 'referencedId' => $this->ids->get('product-1')],
+            $this->context
+        );
+    }
+}

--- a/tests/integration/Storefront/Page/Checkout/CartPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/CartPageTest.php
@@ -3,14 +3,15 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Checkout;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
-use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Country\SalesChannel\CountryRoute;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
+use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartGatewayResult;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoadedEvent;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader;
 use Shopware\Storefront\Page\GenericPageLoader;
@@ -48,20 +49,19 @@ class CartPageTest extends TestCase
             new ErrorCollection()
         );
 
-        $route = $this->createMock(AbstractCheckoutGatewayRoute::class);
-        $route
-            ->method('load')
-            ->willReturn($response);
+        $context = $this->createSalesChannelContextWithNavigation();
+
+        $cartService = $this->createMock(StorefrontCartFacade::class);
+        $cartService
+            ->method('getWithCheckoutGateway')
+            ->willReturn(new StorefrontCartGatewayResult(new Cart($context->getToken()), $response));
 
         $loader = new CheckoutCartPageLoader(
             static::getContainer()->get(GenericPageLoader::class),
             static::getContainer()->get('event_dispatcher'),
-            static::getContainer()->get(StorefrontCartFacade::class),
-            $route,
+            $cartService,
             static::getContainer()->get(CountryRoute::class)
         );
-
-        $context = $this->createSalesChannelContextWithNavigation();
 
         $result = $loader->load(new Request(), $context);
 

--- a/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -15,21 +15,29 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
+use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
+use Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
 use Shopware\Storefront\Checkout\Payment\BlockedPaymentMethodSwitcher;
 use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -319,6 +327,7 @@ class StorefrontCartFacadeTest extends TestCase
             static::createMock(ContextSwitchRoute::class),
             static::createMock(CartCalculator::class),
             static::createMock(AbstractCartPersister::class),
+            static::createMock(AbstractCheckoutGatewayRoute::class),
         );
 
         $cartFacade->get(
@@ -327,6 +336,208 @@ class StorefrontCartFacadeTest extends TestCase
             false,
             true
         );
+    }
+
+    public function testGetWithCheckoutGatewaySwitchesBlockedPaymentMethodToGatewayDefault(): void
+    {
+        $cart = $this->getCart();
+        $paymentMethods = new PaymentMethodCollection([
+            $this->createPaymentMethod('gateway-default-payment-method-id', 'Gateway default payment method'),
+            $this->createPaymentMethod('gateway-other-payment-method-id', 'Gateway other payment method'),
+        ]);
+        $shippingMethods = new ShippingMethodCollection([
+            $this->createShippingMethod('original-shipping-method-id', 'Original shipping method'),
+        ]);
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(static function (Request $request, Cart $loadedCart, SalesChannelContext $context) use ($paymentMethods, $shippingMethods): CheckoutGatewayRouteResponse {
+                $loadedCart->getErrors()->add(new PaymentMethodBlockedError('original-payment-method-name', 'not allowed'));
+
+                return new CheckoutGatewayRouteResponse($paymentMethods, $shippingMethods, $loadedCart->getErrors());
+            });
+
+        $salesChannelContext = $this->getSalesChannelContextWithDefaults(
+            defaultPaymentMethodId: 'gateway-default-payment-method-id',
+            defaultShippingMethodId: 'original-shipping-method-id',
+        );
+
+        $cartFacade = $this->getStorefrontCartFacade(
+            cart: $cart,
+            checkoutGatewayRoute: $checkoutGatewayRoute,
+        );
+
+        $result = $cartFacade->getWithCheckoutGateway(new Request(), 'token', $salesChannelContext);
+
+        static::assertSame($cart, $result->cart);
+        static::assertSame($paymentMethods, $result->gatewayResponse->getPaymentMethods());
+
+        $errors = $result->cart->getErrors();
+        static::assertCount(0, $errors->filterInstance(PaymentMethodBlockedError::class));
+        $changedErrors = $errors->filterInstance(PaymentMethodChangedError::class);
+        static::assertCount(1, $changedErrors);
+        $changedError = $changedErrors->first();
+        static::assertInstanceOf(PaymentMethodChangedError::class, $changedError);
+        static::assertSame('original-payment-method-name', $changedError->getOldPaymentMethodName());
+        static::assertSame('Gateway default payment method', $changedError->getNewPaymentMethodName());
+    }
+
+    public function testGetWithCheckoutGatewayUsesSwitchedContextForGatewayLoad(): void
+    {
+        $cart = $this->getCart();
+        $cart->setErrors($this->getCartErrorCollection(blockPaymentMethod: true));
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(static function (Request $request, Cart $loadedCart, SalesChannelContext $context): CheckoutGatewayRouteResponse {
+                static::assertSame('fallback-payment-method-id', $context->getPaymentMethod()->getId());
+
+                return new CheckoutGatewayRouteResponse(
+                    new PaymentMethodCollection([
+                        $context->getPaymentMethod(),
+                    ]),
+                    new ShippingMethodCollection([
+                        $context->getShippingMethod(),
+                    ]),
+                    $loadedCart->getErrors(),
+                );
+            });
+
+        $cartFacade = $this->getStorefrontCartFacade(
+            cart: $cart,
+            paymentSwitcherCallbackMethod: $this->callbackPaymentMethodSwitcherReturnFallbackMethod(...),
+            checkoutGatewayRoute: $checkoutGatewayRoute,
+        );
+
+        $cartFacade->getWithCheckoutGateway(new Request(), 'token', $this->getSalesChannelContextWithDefaults(
+            defaultPaymentMethodId: 'original-payment-method-id',
+            defaultShippingMethodId: 'original-shipping-method-id',
+        ));
+    }
+
+    public function testGetWithCheckoutGatewaySwitchesBlockedPaymentMethodToFirstGatewayMethodWhenDefaultIsUnavailable(): void
+    {
+        $cart = $this->getCart();
+        $firstGatewayMethod = $this->createPaymentMethod('gateway-first-payment-method-id', 'Gateway first payment method');
+        $paymentMethods = new PaymentMethodCollection([
+            $firstGatewayMethod,
+            $this->createPaymentMethod('gateway-second-payment-method-id', 'Gateway second payment method'),
+        ]);
+        $shippingMethods = new ShippingMethodCollection([
+            $this->createShippingMethod('original-shipping-method-id', 'Original shipping method'),
+        ]);
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(static function (Request $request, Cart $loadedCart, SalesChannelContext $context) use ($paymentMethods, $shippingMethods): CheckoutGatewayRouteResponse {
+                $loadedCart->getErrors()->add(new PaymentMethodBlockedError('original-payment-method-name', 'not allowed'));
+
+                return new CheckoutGatewayRouteResponse($paymentMethods, $shippingMethods, $loadedCart->getErrors());
+            });
+
+        $salesChannelContext = $this->getSalesChannelContextWithDefaults(
+            defaultPaymentMethodId: 'unavailable-default-payment-method-id',
+            defaultShippingMethodId: 'original-shipping-method-id',
+        );
+
+        $cartFacade = $this->getStorefrontCartFacade(
+            cart: $cart,
+            checkoutGatewayRoute: $checkoutGatewayRoute,
+        );
+
+        $result = $cartFacade->getWithCheckoutGateway(new Request(), 'token', $salesChannelContext);
+
+        static::assertSame($cart, $result->cart);
+        $changedErrors = $result->cart->getErrors()->filterInstance(PaymentMethodChangedError::class);
+        static::assertCount(1, $changedErrors);
+        $changedError = $changedErrors->first();
+        static::assertInstanceOf(PaymentMethodChangedError::class, $changedError);
+        static::assertSame($firstGatewayMethod->getTranslation('name'), $changedError->getNewPaymentMethodName());
+    }
+
+    public function testGetWithCheckoutGatewayKeepsBlockedPaymentMethodWhenGatewayHasNoFallback(): void
+    {
+        $cart = $this->getCart();
+        $paymentMethods = new PaymentMethodCollection();
+        $shippingMethods = new ShippingMethodCollection([
+            $this->createShippingMethod('original-shipping-method-id', 'Original shipping method'),
+        ]);
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturnCallback(static function (Request $request, Cart $loadedCart, SalesChannelContext $context) use ($paymentMethods, $shippingMethods): CheckoutGatewayRouteResponse {
+                $loadedCart->getErrors()->add(new PaymentMethodBlockedError('original-payment-method-name', 'not allowed'));
+
+                return new CheckoutGatewayRouteResponse($paymentMethods, $shippingMethods, $loadedCart->getErrors());
+            });
+
+        $salesChannelContext = $this->getSalesChannelContextWithDefaults(
+            defaultPaymentMethodId: 'gateway-default-payment-method-id',
+            defaultShippingMethodId: 'original-shipping-method-id',
+        );
+
+        $cartFacade = $this->getStorefrontCartFacade(
+            cart: $cart,
+            checkoutGatewayRoute: $checkoutGatewayRoute,
+        );
+
+        $result = $cartFacade->getWithCheckoutGateway(new Request(), 'token', $salesChannelContext);
+
+        static::assertSame($cart, $result->cart);
+        static::assertSame('original-payment-method-id', $salesChannelContext->getPaymentMethod()->getId());
+        static::assertCount(1, $result->cart->getErrors()->filterInstance(PaymentMethodBlockedError::class));
+        static::assertCount(0, $result->cart->getErrors()->filterInstance(PaymentMethodChangedError::class));
+    }
+
+    public function testGetWithCheckoutGatewayReturnsGatewayResponseWithoutSwitchWhenNoMethodIsBlocked(): void
+    {
+        $cart = $this->getCart();
+        $paymentMethods = new PaymentMethodCollection([
+            $this->createPaymentMethod('original-payment-method-id', 'Original payment method'),
+        ]);
+        $shippingMethods = new ShippingMethodCollection([
+            $this->createShippingMethod('original-shipping-method-id', 'Original shipping method'),
+        ]);
+
+        $response = new CheckoutGatewayRouteResponse($paymentMethods, $shippingMethods, $cart->getErrors());
+
+        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
+        $checkoutGatewayRoute
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($response);
+
+        $cartCalculator = $this->createMock(CartCalculator::class);
+        $cartCalculator
+            ->expects($this->never())
+            ->method('calculate');
+
+        $salesChannelContext = $this->getSalesChannelContextWithDefaults(
+            defaultPaymentMethodId: 'original-payment-method-id',
+            defaultShippingMethodId: 'original-shipping-method-id',
+        );
+
+        $cartFacade = $this->getStorefrontCartFacade(
+            cart: $cart,
+            cartCalculator: $cartCalculator,
+            checkoutGatewayRoute: $checkoutGatewayRoute,
+        );
+
+        $result = $cartFacade->getWithCheckoutGateway(new Request(), 'token', $salesChannelContext);
+
+        static::assertSame($cart, $result->cart);
+        static::assertSame($paymentMethods, $result->gatewayResponse->getPaymentMethods());
+        static::assertSame($shippingMethods, $result->gatewayResponse->getShippingMethods());
+        static::assertSame($cart->getErrors(), $result->gatewayResponse->getErrors());
+        static::assertSame('original-payment-method-id', $salesChannelContext->getPaymentMethod()->getId());
     }
 
     public function callbackShippingMethodSwitcherReturnOriginalMethod(ErrorCollection $errors, SalesChannelContext $salesChannelContext): ShippingMethodEntity
@@ -470,21 +681,36 @@ class StorefrontCartFacadeTest extends TestCase
      * @param callable(ErrorCollection, SalesChannelContext): ShippingMethodEntity|null $shippingSwitcherCallbackMethod
      * @param callable(ErrorCollection, SalesChannelContext): PaymentMethodEntity|null $paymentSwitcherCallbackMethod
      */
-    private function getStorefrontCartFacade(Cart $cart, ?callable $shippingSwitcherCallbackMethod = null, ?callable $paymentSwitcherCallbackMethod = null): StorefrontCartFacade
-    {
+    private function getStorefrontCartFacade(
+        Cart $cart,
+        ?callable $shippingSwitcherCallbackMethod = null,
+        ?callable $paymentSwitcherCallbackMethod = null,
+        ?CartCalculator $cartCalculator = null,
+        ?AbstractCheckoutGatewayRoute $checkoutGatewayRoute = null,
+    ): StorefrontCartFacade {
         $cartService = $this->createMock(CartService::class);
         $cartService->method('getCart')->willReturn($cart);
 
+        $shippingCallback = $shippingSwitcherCallbackMethod ?? $this->callbackShippingMethodSwitcherReturnOriginalMethod(...);
+        $realShippingSwitcher = new BlockedShippingMethodSwitcher($this->createMock(ShippingMethodRoute::class));
         $blockedShippingMethodSwitcher = $this->createMock(BlockedShippingMethodSwitcher::class);
-        $blockedShippingMethodSwitcher->method('switch')->willReturnCallback($shippingSwitcherCallbackMethod ?? $this->callbackShippingMethodSwitcherReturnOriginalMethod(...));
+        $blockedShippingMethodSwitcher->method('switch')->willReturnCallback(
+            static fn (ErrorCollection $errors, SalesChannelContext $context, ?ShippingMethodCollection $methods = null): ShippingMethodEntity => $methods === null ? $shippingCallback($errors, $context) : $realShippingSwitcher->switch($errors, $context, $methods),
+        );
 
+        $paymentCallback = $paymentSwitcherCallbackMethod ?? $this->callbackPaymentMethodSwitcherReturnOriginalMethod(...);
+        $realPaymentSwitcher = new BlockedPaymentMethodSwitcher($this->createMock(PaymentMethodRoute::class));
         $blockedPaymentMethodSwitcher = $this->createMock(BlockedPaymentMethodSwitcher::class);
-        $blockedPaymentMethodSwitcher->method('switch')->willReturnCallback($paymentSwitcherCallbackMethod ?? $this->callbackPaymentMethodSwitcherReturnOriginalMethod(...));
+        $blockedPaymentMethodSwitcher->method('switch')->willReturnCallback(
+            static fn (ErrorCollection $errors, SalesChannelContext $context, ?PaymentMethodCollection $methods = null): PaymentMethodEntity => $methods === null ? $paymentCallback($errors, $context) : $realPaymentSwitcher->switch($errors, $context, $methods),
+        );
 
         $contextSwitchRoute = $this->createMock(ContextSwitchRoute::class);
 
-        $cartCalculator = $this->createMock(CartCalculator::class);
-        $cartCalculator->method('calculate')->willReturnArgument(0);
+        if ($cartCalculator === null) {
+            $cartCalculator = $this->createMock(CartCalculator::class);
+            $cartCalculator->method('calculate')->willReturnArgument(0);
+        }
 
         $cartPersister = $this->createMock(CartPersister::class);
 
@@ -495,7 +721,40 @@ class StorefrontCartFacadeTest extends TestCase
             $contextSwitchRoute,
             $cartCalculator,
             $cartPersister,
+            $checkoutGatewayRoute ?? $this->createMock(AbstractCheckoutGatewayRoute::class),
         );
+    }
+
+    private function getSalesChannelContextWithDefaults(string $defaultPaymentMethodId, string $defaultShippingMethodId): SalesChannelContext
+    {
+        $shippingMethod = $this->createShippingMethod('original-shipping-method-id', 'original-shipping-method-name');
+        $paymentMethod = $this->createPaymentMethod('original-payment-method-id', 'original-payment-method-name');
+
+        $salesChannelContext = Generator::generateSalesChannelContext(paymentMethod: $paymentMethod, shippingMethod: $shippingMethod);
+        $salesChannelContext->getSalesChannel()->setPaymentMethodId($defaultPaymentMethodId);
+        $salesChannelContext->getSalesChannel()->setShippingMethodId($defaultShippingMethodId);
+
+        return $salesChannelContext;
+    }
+
+    private function createPaymentMethod(string $id, string $name): PaymentMethodEntity
+    {
+        $paymentMethod = new PaymentMethodEntity();
+        $paymentMethod->setId($id);
+        $paymentMethod->setName($name);
+        $paymentMethod->setTranslated(['name' => $name]);
+
+        return $paymentMethod;
+    }
+
+    private function createShippingMethod(string $id, string $name): ShippingMethodEntity
+    {
+        $shippingMethod = new ShippingMethodEntity();
+        $shippingMethod->setId($id);
+        $shippingMethod->setName($name);
+        $shippingMethod->setTranslated(['name' => $name]);
+
+        return $shippingMethod;
     }
 
     /**

--- a/tests/unit/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcherTest.php
+++ b/tests/unit/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcherTest.php
@@ -13,10 +13,9 @@ use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
 use Shopware\Storefront\Checkout\Payment\BlockedPaymentMethodSwitcher;
@@ -67,9 +66,8 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
 
         static::assertSame('original-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
 
         static::assertCount(0, $errorCollectionFiltered);
@@ -82,9 +80,8 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
 
         static::assertSame('default-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
         static::assertCount(1, $errorCollectionFiltered);
         $error = $errorCollectionFiltered->first();
@@ -110,9 +107,8 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
         $newPaymentMethod = $this->switcher->switch($errorCollection, $this->salesChannelContext);
         static::assertSame('translated-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
         static::assertCount(1, $errorCollectionFiltered);
         $error = $errorCollectionFiltered->first();
@@ -130,9 +126,8 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
 
         static::assertSame('any-other-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
         static::assertCount(2, $errorCollectionFiltered);
 
@@ -160,9 +155,8 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
 
         static::assertSame('any-other-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
 
         static::assertCount(1, $errorCollectionFiltered);
@@ -170,6 +164,44 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
         static::assertInstanceOf(PaymentMethodChangedError::class, $error);
         static::assertSame([
             'newPaymentMethodName' => 'any-other-payment-method-name',
+            'oldPaymentMethodName' => 'original-payment-method-name',
+        ], $error->getParameters());
+    }
+
+    public function testSwitchWithProvidedPaymentMethodsDoesNotLoadRoute(): void
+    {
+        $errorCollection = $this->getErrorCollection(['original-payment-method-name']);
+
+        $paymentMethodRoute = $this->createMock(PaymentMethodRoute::class);
+        $paymentMethodRoute
+            ->expects($this->never())
+            ->method('load');
+
+        $switcher = new BlockedPaymentMethodSwitcher($paymentMethodRoute);
+        $anyOtherPaymentMethod = $this->paymentMethodCollection->get('any-other-payment-method-id');
+        $defaultPaymentMethod = $this->paymentMethodCollection->get('default-payment-method-id');
+        static::assertInstanceOf(PaymentMethodEntity::class, $anyOtherPaymentMethod);
+        static::assertInstanceOf(PaymentMethodEntity::class, $defaultPaymentMethod);
+
+        $newPaymentMethod = $switcher->switch(
+            $errorCollection,
+            $this->salesChannelContext,
+            new PaymentMethodCollection([
+                $anyOtherPaymentMethod,
+                $defaultPaymentMethod,
+            ])
+        );
+
+        static::assertSame('default-payment-method-id', $newPaymentMethod->getId());
+
+        $errorCollectionFiltered = $errorCollection->filter(
+            static fn ($error) => $error instanceof PaymentMethodChangedError
+        );
+        static::assertCount(1, $errorCollectionFiltered);
+        $error = $errorCollectionFiltered->first();
+        static::assertInstanceOf(PaymentMethodChangedError::class, $error);
+        static::assertSame([
+            'newPaymentMethodName' => 'default-payment-method-name',
             'oldPaymentMethodName' => 'original-payment-method-name',
         ], $error->getParameters());
     }
@@ -184,67 +216,59 @@ class BlockedPaymentMethodSwitcherTest extends TestCase
 
         static::assertSame('original-payment-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof PaymentMethodChangedError
+            static fn ($error) => $error instanceof PaymentMethodChangedError
         );
 
         static::assertCount(0, $errorCollectionFiltered);
     }
 
+    public function testOnlyAvailableFlagIsSet(): void
+    {
+        $paymentMethod = $this->paymentMethodCollection->get('original-payment-method-id');
+        static::assertInstanceOf(PaymentMethodEntity::class, $paymentMethod);
+
+        $errors = $this->getErrorCollection(['original-payment-method-name']);
+        $context = Generator::generateSalesChannelContext(paymentMethod: $paymentMethod);
+
+        $response = $this->createMock(PaymentMethodRouteResponse::class);
+        $response
+            ->method('getPaymentMethods')
+            ->willReturn(new PaymentMethodCollection());
+
+        $paymentMethodRoute = $this->createMock(PaymentMethodRoute::class);
+        $paymentMethodRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::equalTo(new Request(['onlyAvailable' => true])),
+                $context,
+                static::isInstanceOf(Criteria::class)
+            )
+            ->willReturn($response);
+
+        $switcher = new BlockedPaymentMethodSwitcher($paymentMethodRoute);
+        $switcher->switch($errors, $context);
+    }
+
     public function callbackLoadPaymentMethods(Request $request, SalesChannelContext $context, Criteria $criteria): PaymentMethodRouteResponse
     {
-        $searchIds = $criteria->getIds();
-
-        if ($searchIds === []) {
-            static::assertCount(1, $criteria->getFilters());
-
-            $nand = $criteria->getFilters()[0];
-
-            static::assertInstanceOf(NandFilter::class, $nand);
-            static::assertCount(1, $nand->getQueries());
-
-            $nameFilter = $nand->getQueries()[0];
-
-            static::assertInstanceOf(EqualsAnyFilter::class, $nameFilter);
-
-            $names = $nameFilter->getValue();
-
-            $collection = $this->paymentMethodCollection->filter(
-                fn (PaymentMethodEntity $entity) => !\in_array($entity->getName() ?? '', $names, true)
-            );
-        } else {
-            $collection = $this->paymentMethodCollection->filter(
-                fn (PaymentMethodEntity $entity) => \in_array($entity->getId(), $searchIds, true)
-            );
-        }
-
         $paymentMethodResponse = $this->createMock(PaymentMethodRouteResponse::class);
         $paymentMethodResponse
             ->expects($this->once())
             ->method('getPaymentMethods')
-            ->willReturn($collection);
+            ->willReturn($this->paymentMethodCollection);
 
         return $paymentMethodResponse;
     }
 
     public function callbackLoadPaymentMethodsForAllBlocked(Request $request, SalesChannelContext $context, Criteria $criteria): PaymentMethodRouteResponse
     {
-        $searchIds = $criteria->getIds();
-
-        if ($searchIds === []) {
-            $collection = new PaymentMethodCollection();
-        } else {
-            $collection = $this->paymentMethodCollection->filter(
-                fn (PaymentMethodEntity $entity) => \in_array($entity->getId(), $searchIds, true)
-            );
-        }
-
         $paymentMethodResponse = $this->createMock(PaymentMethodRouteResponse::class);
         $paymentMethodResponse
             ->expects($this->once())
             ->method('getPaymentMethods')
-            ->willReturn($collection);
+            ->willReturn(new PaymentMethodCollection());
 
         return $paymentMethodResponse;
     }

--- a/tests/unit/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcherTest.php
+++ b/tests/unit/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcherTest.php
@@ -13,10 +13,9 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
 use Shopware\Storefront\Checkout\Shipping\BlockedShippingMethodSwitcher;
@@ -67,9 +66,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
         static::assertSame('original-shipping-method-id', $newShippingMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
 
         static::assertCount(0, $errorCollectionFiltered);
@@ -82,9 +80,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
         static::assertSame('default-shipping-method-id', $newShippingMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
         static::assertCount(1, $errorCollectionFiltered);
         $error = $errorCollectionFiltered->first();
@@ -110,9 +107,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
         $newPaymentMethod = $this->switcher->switch($errorCollection, $this->salesChannelContext);
         static::assertSame('translated-shipping-method-id', $newPaymentMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
         static::assertCount(1, $errorCollectionFiltered);
         $error = $errorCollectionFiltered->first();
@@ -130,9 +126,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
         static::assertSame('any-other-shipping-method-id', $newShippingMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
         static::assertCount(2, $errorCollectionFiltered);
 
@@ -160,9 +155,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
         static::assertSame('any-other-shipping-method-id', $newShippingMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
 
         static::assertCount(1, $errorCollectionFiltered);
@@ -170,6 +164,44 @@ class BlockedShippingMethodSwitcherTest extends TestCase
         static::assertInstanceOf(ShippingMethodChangedError::class, $error);
         static::assertSame([
             'newShippingMethodName' => 'any-other-shipping-method-name',
+            'oldShippingMethodName' => 'original-shipping-method-name',
+        ], $error->getParameters());
+    }
+
+    public function testSwitchWithProvidedShippingMethodsDoesNotLoadRoute(): void
+    {
+        $errorCollection = $this->getErrorCollection(['original-shipping-method-name']);
+
+        $shippingMethodRoute = $this->createMock(ShippingMethodRoute::class);
+        $shippingMethodRoute
+            ->expects($this->never())
+            ->method('load');
+
+        $switcher = new BlockedShippingMethodSwitcher($shippingMethodRoute);
+        $anyOtherShippingMethod = $this->shippingMethodCollection->get('any-other-shipping-method-id');
+        $defaultShippingMethod = $this->shippingMethodCollection->get('default-shipping-method-id');
+        static::assertInstanceOf(ShippingMethodEntity::class, $anyOtherShippingMethod);
+        static::assertInstanceOf(ShippingMethodEntity::class, $defaultShippingMethod);
+
+        $newShippingMethod = $switcher->switch(
+            $errorCollection,
+            $this->salesChannelContext,
+            new ShippingMethodCollection([
+                $anyOtherShippingMethod,
+                $defaultShippingMethod,
+            ])
+        );
+
+        static::assertSame('default-shipping-method-id', $newShippingMethod->getId());
+
+        $errorCollectionFiltered = $errorCollection->filter(
+            static fn ($error) => $error instanceof ShippingMethodChangedError
+        );
+        static::assertCount(1, $errorCollectionFiltered);
+        $error = $errorCollectionFiltered->first();
+        static::assertInstanceOf(ShippingMethodChangedError::class, $error);
+        static::assertSame([
+            'newShippingMethodName' => 'default-shipping-method-name',
             'oldShippingMethodName' => 'original-shipping-method-name',
         ], $error->getParameters());
     }
@@ -184,9 +216,8 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
         static::assertSame('original-shipping-method-id', $newShippingMethod->getId());
 
-        // Assert notices
         $errorCollectionFiltered = $errorCollection->filter(
-            fn ($error) => $error instanceof ShippingMethodChangedError
+            static fn ($error) => $error instanceof ShippingMethodChangedError
         );
 
         static::assertCount(0, $errorCollectionFiltered);
@@ -194,59 +225,52 @@ class BlockedShippingMethodSwitcherTest extends TestCase
 
     public function callbackLoadShippingMethods(Request $request, SalesChannelContext $context, Criteria $criteria): ShippingMethodRouteResponse
     {
-        $searchIds = $criteria->getIds();
-
-        if ($searchIds === []) {
-            static::assertCount(1, $criteria->getFilters());
-
-            $nand = $criteria->getFilters()[0];
-
-            static::assertInstanceOf(NandFilter::class, $nand);
-            static::assertCount(1, $nand->getQueries());
-
-            $nameFilter = $nand->getQueries()[0];
-
-            static::assertInstanceOf(EqualsAnyFilter::class, $nameFilter);
-
-            $names = $nameFilter->getValue();
-
-            $collection = $this->shippingMethodCollection->filter(
-                fn (ShippingMethodEntity $entity) => !\in_array($entity->getName() ?? '', $names, true)
-            );
-        } else {
-            $collection = $this->shippingMethodCollection->filter(
-                fn (ShippingMethodEntity $entity) => \in_array($entity->getId(), $searchIds, true)
-            );
-        }
-
         $shippingMethodResponse = $this->createMock(ShippingMethodRouteResponse::class);
         $shippingMethodResponse
             ->expects($this->once())
             ->method('getShippingMethods')
-            ->willReturn($collection);
+            ->willReturn($this->shippingMethodCollection);
 
         return $shippingMethodResponse;
     }
 
     public function callbackLoadShippingMethodsForAllBlocked(Request $request, SalesChannelContext $context, Criteria $criteria): ShippingMethodRouteResponse
     {
-        $searchIds = $criteria->getIds();
-
-        if ($searchIds === []) {
-            $collection = new ShippingMethodCollection();
-        } else {
-            $collection = $this->shippingMethodCollection->filter(
-                fn (ShippingMethodEntity $entity) => \in_array($entity->getId(), $searchIds, true)
-            );
-        }
-
         $shippingMethodResponse = $this->createMock(ShippingMethodRouteResponse::class);
         $shippingMethodResponse
             ->expects($this->once())
             ->method('getShippingMethods')
-            ->willReturn($collection);
+            ->willReturn(new ShippingMethodCollection());
 
         return $shippingMethodResponse;
+    }
+
+    public function testOnlyAvailableFlagIsSet(): void
+    {
+        $shippingMethod = $this->shippingMethodCollection->get('original-shipping-method-id');
+        static::assertInstanceOf(ShippingMethodEntity::class, $shippingMethod);
+
+        $errors = $this->getErrorCollection(['original-shipping-method-name']);
+        $context = Generator::generateSalesChannelContext(shippingMethod: $shippingMethod);
+
+        $response = $this->createMock(ShippingMethodRouteResponse::class);
+        $response
+            ->method('getShippingMethods')
+            ->willReturn(new ShippingMethodCollection());
+
+        $shippingMethodRoute = $this->createMock(ShippingMethodRoute::class);
+        $shippingMethodRoute
+            ->expects($this->once())
+            ->method('load')
+            ->with(
+                static::equalTo(new Request(['onlyAvailable' => true])),
+                $context,
+                static::isInstanceOf(Criteria::class)
+            )
+            ->willReturn($response);
+
+        $switcher = new BlockedShippingMethodSwitcher($shippingMethodRoute);
+        $switcher->switch($errors, $context);
     }
 
     /**

--- a/tests/unit/Storefront/Page/Checkout/Cart/CheckoutCartPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Checkout/Cart/CheckoutCartPageLoaderTest.php
@@ -4,10 +4,10 @@ namespace Shopware\Tests\Unit\Storefront\Page\Checkout\Cart;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
-use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
@@ -25,6 +25,7 @@ use Shopware\Core\System\Country\SalesChannel\CountryRoute;
 use Shopware\Core\System\Country\SalesChannel\CountryRouteResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
+use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartGatewayResult;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPage;
 use Shopware\Storefront\Page\Checkout\Cart\CheckoutCartPageLoader;
 use Shopware\Storefront\Page\GenericPageLoader;
@@ -48,15 +49,7 @@ class CheckoutCartPageLoaderTest extends TestCase
             ->method('load')
             ->willReturn($page);
 
-        $checkoutCartPageLoader = new CheckoutCartPageLoader(
-            $pageLoader,
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $this->createMock(CountryRoute::class)
-        );
-
-        $page = $checkoutCartPageLoader->load(
+        $page = $this->createLoader(pageLoader: $pageLoader)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -74,15 +67,7 @@ class CheckoutCartPageLoaderTest extends TestCase
             ->method('load')
             ->willReturn($page);
 
-        $checkoutCartPageLoader = new CheckoutCartPageLoader(
-            $pageLoader,
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $this->createMock(CountryRoute::class)
-        );
-
-        $page = $checkoutCartPageLoader->load(
+        $page = $this->createLoader(pageLoader: $pageLoader)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -124,11 +109,11 @@ class CheckoutCartPageLoaderTest extends TestCase
             )
         );
 
-        $checkoutGatewayRoute = $this->createMock(AbstractCheckoutGatewayRoute::class);
-        $checkoutGatewayRoute
-            ->method('load')
+        $cartService = $this->createMock(StorefrontCartFacade::class);
+        $cartService
+            ->method('getWithCheckoutGateway')
             ->withAnyParameters()
-            ->willReturn($response);
+            ->willReturn(new StorefrontCartGatewayResult(new Cart('test'), $response));
 
         $countryRoute = $this->createMock(CountryRoute::class);
         $countryRoute
@@ -136,17 +121,14 @@ class CheckoutCartPageLoaderTest extends TestCase
             ->withAnyParameters()
             ->willReturn($countryResponse);
 
-        $checkoutCartPageLoader = new CheckoutCartPageLoader(
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $checkoutGatewayRoute,
-            $countryRoute
-        );
+        $context = $this->createMock(SalesChannelContext::class);
+        $context
+            ->method('getToken')
+            ->willReturn('token');
 
-        $page = $checkoutCartPageLoader->load(
+        $page = $this->createLoader(cartService: $cartService, countryRoute: $countryRoute)->load(
             new Request(),
-            $this->createMock(SalesChannelContext::class)
+            $context
         );
 
         static::assertSame($paymentMethods, $page->getPaymentMethods());
@@ -178,15 +160,7 @@ class CheckoutCartPageLoaderTest extends TestCase
             ->withAnyParameters()
             ->willReturn($countryResponse);
 
-        $checkoutCartPageLoader = new CheckoutCartPageLoader(
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $countryRoute
-        );
-
-        $page = $checkoutCartPageLoader->load(
+        $page = $this->createLoader(countryRoute: $countryRoute)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -196,6 +170,65 @@ class CheckoutCartPageLoaderTest extends TestCase
         } else {
             static::assertSame($countries, $page->getCountries());
         }
+    }
+
+    private function createLoader(
+        ?GenericPageLoader $pageLoader = null,
+        ?StorefrontCartFacade $cartService = null,
+        ?CountryRoute $countryRoute = null
+    ): CheckoutCartPageLoader {
+        return new CheckoutCartPageLoader(
+            $pageLoader ?? $this->createPageLoader(),
+            new EventDispatcher(),
+            $cartService ?? $this->createCartService(),
+            $countryRoute ?? $this->createCountryRoute()
+        );
+    }
+
+    private function createPageLoader(): GenericPageLoader
+    {
+        $pageLoader = $this->createMock(GenericPageLoader::class);
+        $pageLoader
+            ->method('load')
+            ->willReturn(new CheckoutCartPage());
+
+        return $pageLoader;
+    }
+
+    private function createCartService(): StorefrontCartFacade
+    {
+        $cartService = $this->createMock(StorefrontCartFacade::class);
+        $cartService
+            ->method('getWithCheckoutGateway')
+            ->willReturn(new StorefrontCartGatewayResult(
+                new Cart('test'),
+                new CheckoutGatewayRouteResponse(
+                    new PaymentMethodCollection(),
+                    new ShippingMethodCollection(),
+                    new ErrorCollection()
+                )
+            ));
+
+        return $cartService;
+    }
+
+    private function createCountryRoute(): CountryRoute
+    {
+        $route = $this->createMock(CountryRoute::class);
+        $route
+            ->method('load')
+            ->willReturn(new CountryRouteResponse(
+                new EntitySearchResult(
+                    CountryDefinition::ENTITY_NAME,
+                    0,
+                    new CountryCollection(),
+                    null,
+                    new Criteria(),
+                    Context::createDefaultContext()
+                )
+            ));
+
+        return $route;
     }
 
     private function getContextWithDummyCustomer(?string $countryId = null): SalesChannelContext
@@ -212,6 +245,9 @@ class CheckoutCartPageLoaderTest extends TestCase
         $context
             ->method('getCustomer')
             ->willReturn($customer);
+        $context
+            ->method('getToken')
+            ->willReturn('token');
 
         return $context;
     }

--- a/tests/unit/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoaderTest.php
@@ -12,13 +12,12 @@ use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEnt
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Validation\AddressValidationFactory;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
-use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
-use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRoute;
 use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
@@ -27,6 +26,7 @@ use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
+use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartGatewayResult;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPage;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoader;
@@ -36,6 +36,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -53,16 +54,7 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             ->method('load')
             ->willReturn($page);
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $pageLoader,
-            $this->createMock(AddressValidationFactory::class),
-            $this->createMock(DataValidator::class)
-        );
-
-        $page = $checkoutConfirmPageLoader->load(
+        $page = $this->createLoader(pageLoader: $pageLoader)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -80,16 +72,7 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             ->method('load')
             ->willReturn($page);
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $pageLoader,
-            $this->createMock(AddressValidationFactory::class),
-            $this->createMock(DataValidator::class)
-        );
-
-        $page = $checkoutConfirmPageLoader->load(
+        $page = $this->createLoader(pageLoader: $pageLoader)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -115,22 +98,13 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             new ErrorCollection()
         );
 
-        $checkoutGatewayRoute = $this->createMock(CheckoutGatewayRoute::class);
-        $checkoutGatewayRoute
-            ->method('load')
+        $cartService = $this->createMock(StorefrontCartFacade::class);
+        $cartService
+            ->method('getWithCheckoutGateway')
             ->withAnyParameters()
-            ->willReturn($response);
+            ->willReturn(new StorefrontCartGatewayResult(new Cart('test'), $response));
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $checkoutGatewayRoute,
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $this->createMock(DataValidator::class)
-        );
-
-        $page = $checkoutConfirmPageLoader->load(
+        $page = $this->createLoader(cartService: $cartService)->load(
             new Request(),
             $this->getContextWithDummyCustomer()
         );
@@ -141,26 +115,20 @@ class CheckoutConfirmPageLoaderTest extends TestCase
 
     public function testCustomerNotLoggedInException(): void
     {
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $this->createMock(DataValidator::class)
-        );
-
         $context = $this->createMock(SalesChannelContext::class);
         $context
             ->method('getCustomer')
             ->willReturn(null);
+        $context
+            ->method('getToken')
+            ->willReturn('token');
 
         $expected = CartException::customerNotLoggedIn()::class;
 
         static::expectException($expected);
         static::expectExceptionMessage('Customer is not logged in');
 
-        $checkoutConfirmPageLoader->load(new Request(), $context);
+        $this->createLoader()->load(new Request(), $context);
     }
 
     public function testViolationsAreAddedAsCartErrorsWithSameAddress(): void
@@ -185,19 +153,10 @@ class CheckoutConfirmPageLoaderTest extends TestCase
 
         $cartService = $this->createMock(StorefrontCartFacade::class);
         $cartService
-            ->method('get')
-            ->willReturn($cart);
+            ->method('getWithCheckoutGateway')
+            ->willReturn($this->createCartGatewayResult($cart));
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $cartService,
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $validator
-        );
-
-        $page = $checkoutConfirmPageLoader->load(new Request(), $this->getContextWithDummyCustomer());
+        $page = $this->createLoader(cartService: $cartService, validator: $validator)->load(new Request(), $this->getContextWithDummyCustomer());
 
         static::assertCount(1, $page->getCart()->getErrors());
         static::assertArrayHasKey('billing-address-invalid', $page->getCart()->getErrors()->getElements());
@@ -240,28 +199,18 @@ class CheckoutConfirmPageLoaderTest extends TestCase
 
         $cartService = $this->createMock(StorefrontCartFacade::class);
         $cartService
-            ->method('get')
-            ->willReturn($cart);
-
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $cartService,
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $validator
-        );
+            ->method('getWithCheckoutGateway')
+            ->willReturn($this->createCartGatewayResult($cart));
 
         $context = $this->getContextWithDummyCustomer();
 
         static::assertNotNull($context->getCustomer());
 
-        // different shipping address
         $context->getCustomer()->assign([
             'activeShippingAddress' => (new CustomerAddressEntity())->assign(['id' => Uuid::randomHex(), 'countryId' => Uuid::randomHex()]),
         ]);
 
-        $page = $checkoutConfirmPageLoader->load(new Request(), $context);
+        $page = $this->createLoader(cartService: $cartService, validator: $validator)->load(new Request(), $context);
 
         static::assertCount(2, $page->getCart()->getErrors());
         static::assertArrayHasKey('billing-address-invalid', $page->getCart()->getErrors()->getElements());
@@ -305,15 +254,6 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             ->expects($this->never())
             ->method('getViolations');
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $validator
-        );
-
         $context = $this->getContextWithDummyCustomer();
 
         static::assertNotNull($context->getCustomer());
@@ -323,7 +263,7 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             'activeShippingAddress' => null,
         ]);
 
-        $checkoutConfirmPageLoader->load(new Request(), $context);
+        $this->createLoader(validator: $validator)->load(new Request(), $context);
     }
 
     public function testValidationEventIsDispatched(): void
@@ -331,22 +271,15 @@ class CheckoutConfirmPageLoaderTest extends TestCase
         $eventDispatcher = new CollectingEventDispatcher();
 
         $addressValidationMock = $this->createMock(AddressValidationFactory::class);
-
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $eventDispatcher,
-            $this->createMock(StorefrontCartFacade::class),
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $addressValidationMock,
-            $this->createMock(DataValidator::class)
-        );
-
         $addressValidationMock->expects($this->exactly(2))->method('create')->willReturnOnConsecutiveCalls(
             new DataValidationDefinition('address.create'),
             new DataValidationDefinition('address.update'),
         );
 
-        $checkoutConfirmPageLoader->load(new Request(), $this->getContextWithDummyCustomer());
+        $this->createLoader(
+            eventDispatcher: $eventDispatcher,
+            addressValidationFactory: $addressValidationMock
+        )->load(new Request(), $this->getContextWithDummyCustomer());
 
         $events = $eventDispatcher->getEvents();
         static::assertCount(3, $events);
@@ -361,19 +294,11 @@ class CheckoutConfirmPageLoaderTest extends TestCase
         $cartService = static::createMock(StorefrontCartFacade::class);
         $cartService
             ->expects($this->once())
-            ->method('get')
-            ->with(null, static::isInstanceOf(SalesChannelContext::class), false, true);
+            ->method('getWithCheckoutGateway')
+            ->with(static::isInstanceOf(Request::class), 'token', static::isInstanceOf(SalesChannelContext::class), false, true)
+            ->willReturn($this->createCartGatewayResult());
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $this->createMock(EventDispatcher::class),
-            $cartService,
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $this->createMock(AddressValidationFactory::class),
-            $this->createMock(DataValidator::class)
-        );
-
-        $checkoutConfirmPageLoader->load(new Request(), $this->getContextWithDummyCustomer());
+        $this->createLoader(cartService: $cartService)->load(new Request(), $this->getContextWithDummyCustomer());
     }
 
     public function testValidationEventIsDispatchedWithZipcodeDefinition(): void
@@ -384,8 +309,8 @@ class CheckoutConfirmPageLoaderTest extends TestCase
 
         $cartService = $this->createMock(StorefrontCartFacade::class);
         $cartService
-            ->method('get')
-            ->willReturn($cart);
+            ->method('getWithCheckoutGateway')
+            ->willReturn($this->createCartGatewayResult($cart));
 
         $addressValidation = $this->createMock(DataValidationFactoryInterface::class);
         $addressValidation->method('create')->willReturn(new DataValidationDefinition('address.create'));
@@ -409,18 +334,81 @@ class CheckoutConfirmPageLoaderTest extends TestCase
             return $validationEvent;
         });
 
-        $checkoutConfirmPageLoader = new CheckoutConfirmPageLoader(
-            $dispatcher,
-            $cartService,
-            $this->createMock(CheckoutGatewayRoute::class),
-            $this->createMock(GenericPageLoader::class),
-            $addressValidation,
-            $this->createMock(DataValidator::class),
+        $context = $this->getContextWithDummyCustomer($countryId);
+
+        $this->createLoader(
+            eventDispatcher: $dispatcher,
+            cartService: $cartService,
+            addressValidationFactory: $addressValidation
+        )->load(new Request(), $context);
+    }
+
+    private function createLoader(
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?StorefrontCartFacade $cartService = null,
+        ?GenericPageLoader $pageLoader = null,
+        ?DataValidationFactoryInterface $addressValidationFactory = null,
+        ?DataValidator $validator = null
+    ): CheckoutConfirmPageLoader {
+        return new CheckoutConfirmPageLoader(
+            $eventDispatcher ?? new EventDispatcher(),
+            $cartService ?? $this->createCartService(),
+            $pageLoader ?? $this->createPageLoader(),
+            $addressValidationFactory ?? $this->createAddressValidationFactory(),
+            $validator ?? $this->createValidator()
         );
+    }
 
-        $context = $this->getContextWithDummyCustomer();
+    private function createCartService(): StorefrontCartFacade
+    {
+        $cartService = $this->createMock(StorefrontCartFacade::class);
+        $cartService
+            ->method('getWithCheckoutGateway')
+            ->willReturn($this->createCartGatewayResult());
 
-        $checkoutConfirmPageLoader->load(new Request(), $context);
+        return $cartService;
+    }
+
+    private function createPageLoader(): GenericPageLoader
+    {
+        $pageLoader = $this->createMock(GenericPageLoader::class);
+        $pageLoader
+            ->method('load')
+            ->willReturn(new CheckoutConfirmPage());
+
+        return $pageLoader;
+    }
+
+    private function createAddressValidationFactory(): DataValidationFactoryInterface
+    {
+        $addressValidationFactory = $this->createMock(DataValidationFactoryInterface::class);
+        $addressValidationFactory
+            ->method('create')
+            ->willReturn(new DataValidationDefinition('address.create'));
+
+        return $addressValidationFactory;
+    }
+
+    private function createValidator(): DataValidator
+    {
+        $validator = $this->createMock(DataValidator::class);
+        $validator
+            ->method('getViolations')
+            ->willReturn(new ConstraintViolationList());
+
+        return $validator;
+    }
+
+    private function createCartGatewayResult(?Cart $cart = null): StorefrontCartGatewayResult
+    {
+        return new StorefrontCartGatewayResult(
+            $cart ?? new Cart('test'),
+            new CheckoutGatewayRouteResponse(
+                new PaymentMethodCollection(),
+                new ShippingMethodCollection(),
+                new ErrorCollection()
+            )
+        );
     }
 
     private function getContextWithDummyCustomer(?string $countryId = null): SalesChannelContext
@@ -437,6 +425,12 @@ class CheckoutConfirmPageLoaderTest extends TestCase
         $context
             ->method('getCustomer')
             ->willReturn($customer);
+        $context
+            ->method('getToken')
+            ->willReturn('token');
+        $context
+            ->method('getContext')
+            ->willReturn(Context::createDefaultContext());
 
         return $context;
     }


### PR DESCRIPTION
Backport of #16780 to 6.6.x.

Adjusted for 6.6.x:
- kept name-based blocked method errors
- moved checkout gateway handling into `StorefrontCartFacade`
- carried the switched sales-channel context into checkout gateway loading
- added a 6.6-style changelog entry in `changelog/_unreleased`
- added focused unit coverage for gateway-provided fallback methods

Validation:
- `git diff --check origin/6.6.x..HEAD`
- `php -l` on changed PHP files
- custom changelog validation for the new unreleased changelog entry
- focused PHPUnit unit tests: 43 tests, 218 assertions
