### PR TITLE
fix: PHPBench execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -197,7 +197,7 @@
         "nikic/php-parser": "^5.4.0",
         "opis/json-schema": "^2.3.0",
         "phpat/phpat": "0.12.4",
-        "phpbench/phpbench": "^1.2.15",
+        "phpbench/phpbench": "^1.6.1",
         "phpdocumentor/reflection-docblock": "^5.6.4",
         "phpdocumentor/type-resolver": "^1.7.1",
         "phpstan/extension-installer": "^1.4.3",

--- a/tests/performance/bench/BenchExtension.php
+++ b/tests/performance/bench/BenchExtension.php
@@ -40,7 +40,10 @@ class BenchExtension implements ExtensionInterface
             ->setProjectDir($_ENV['PROJECT_DIR'] ?? null)
             ->bootstrap();
 
-        (new Fixtures())->load(__DIR__ . '/data.json');
+        $fixtures = new Fixtures();
+        $fixtures->load(__DIR__ . '/data-initial.json');
+        Fixtures::getIds(); // Load the saved IDs to use them for the customer
+        $fixtures->load(__DIR__ . '/data-customer.json'); // Customer needs some data to be present in the DB, so it could not be created in the same sync operation as the other data
 
         // TODO: Resolve autoloading to [Commercial]/tests/performance/bench so native phpbench `core.extensions` can be used
         $fixturePath = $bootstrapper->getPluginPath('SwagCommercial') . '/tests/performance/bench/Common';

--- a/tests/performance/bench/data-customer.json
+++ b/tests/performance/bench/data-customer.json
@@ -1,0 +1,38 @@
+{
+  "customer": [
+    {
+      "id": "{customer-0}",
+      "customerNumber": "customer-0",
+      "firstName": "Max",
+      "lastName": "Mustermann",
+      "email": "max@mustermann.com",
+      "groupId": "{customer-group}",
+      "defaultBillingAddressId": "{default-billing-address}",
+      "defaultBillingAddress": {
+        "firstName": "Max",
+        "lastName": "Mustermann",
+        "city": "Bielefeld",
+        "salutationId": "{salutation}",
+        "street": "Buchenweg 5",
+        "zipcode": "33062",
+        "countryId": "{country}",
+        "id": "{default-billing-address}"
+      },
+      "defaultShippingAddressId": "{default-billing-address}",
+      "defaultPaymentMethodId": "{default-payment-method}",
+      "salesChannelId": "{sales-channel}",
+      "addresses": {
+        "default-address": {
+          "firstName": "Max",
+          "lastName": "Mustermann",
+          "city": "Bielefeld",
+          "salutationId": "{salutation}",
+          "street": "Buchenweg 5",
+          "zipcode": "33062",
+          "countryId": "{country}"
+        }
+      },
+      "salutationId": "{salutation}"
+    }
+  ]
+}

--- a/tests/performance/bench/data-initial.json
+++ b/tests/performance/bench/data-initial.json
@@ -1228,42 +1228,6 @@
       "letterName": "test"
     }
   ],
-  "customer": [
-    {
-      "id": "{customer-0}",
-      "customerNumber": "customer-0",
-      "firstName": "Max",
-      "lastName": "Mustermann",
-      "email": "max@mustermann.com",
-      "groupId": "{customer-group}",
-      "defaultBillingAddressId": "{default-billing-address}",
-      "defaultBillingAddress": {
-        "firstName": "Max",
-        "lastName": "Mustermann",
-        "city": "Bielefeld",
-        "salutationId": "{salutation}",
-        "street": "Buchenweg 5",
-        "zipcode": "33062",
-        "countryId": "{country}",
-        "id": "{default-billing-address}"
-      },
-      "defaultShippingAddressId": "{default-billing-address}",
-      "defaultPaymentMethodId": "{default-payment-method}",
-      "salesChannelId": "{sales-channel}",
-      "addresses": {
-        "default-address": {
-          "firstName": "Max",
-          "lastName": "Mustermann",
-          "city": "Bielefeld",
-          "salutationId": "{salutation}",
-          "street": "Buchenweg 5",
-          "zipcode": "33062",
-          "countryId": "{country}"
-        }
-      },
-      "salutationId": "{salutation}"
-    }
-  ],
   "sales_channel": [
     {
       "id": "{sales-channel}",


### PR DESCRIPTION
### 1. Why is this change necessary?

PHPBench cannot be executed

### 2. What does this change do, exactly?

Extract customer creation from other test data

### 3. Describe each step to reproduce the issue or behaviour.

Try to execute PHPBench

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
