### PR TITLE
test: use expectExceptionObject in core checkout tests

### DIFF
--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -385,8 +385,7 @@ class RecalculationServiceTest extends TestCase
         $cart = $this->generateDemoCart();
         $orderId = $this->persistCart($cart)['orderId'];
 
-        static::expectException(OrderException::class);
-        static::expectExceptionMessage("Order with id $orderId can not be recalculated because it is in the live version. Please create a new version");
+        $this->expectExceptionObject(OrderException::canNotRecalculateLiveVersion($orderId));
 
         $service = static::getContainer()->get(RecalculationService::class);
 

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -230,8 +230,7 @@ class AccountServiceTest extends TestCase
         ]);
         $this->createCustomerOfSalesChannel($context->getSalesChannelId(), $email, true, true, $idCustomer, '2022-10-21 10:00:00', Hasher::hash('test', 'md5'), 'Md5');
 
-        static::expectException(PasswordPoliciesUpdatedException::class);
-        static::expectExceptionMessage('Password policies updated.');
+        $this->expectExceptionObject(new PasswordPoliciesUpdatedException());
         $this->accountService->getCustomerByLogin($email, 'test', $context);
     }
 

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -406,8 +406,7 @@ class DocumentGeneratorTest extends TestCase
     {
         $documentId = Uuid::randomHex();
 
-        static::expectException(DocumentException::class);
-        static::expectExceptionMessage(\sprintf('The document with id "%s" is invalid or could not be found.', $documentId));
+        $this->expectExceptionObject(DocumentException::documentNotFound($documentId));
 
         $this->documentGenerator->readDocument($documentId, $this->context);
     }
@@ -416,8 +415,7 @@ class DocumentGeneratorTest extends TestCase
     {
         $documentId = Uuid::randomHex();
 
-        static::expectException(DocumentException::class);
-        static::expectExceptionMessage(\sprintf('The document with id "%s" is invalid or could not be found.', $documentId));
+        $this->expectExceptionObject(DocumentException::documentNotFound($documentId));
 
         /** @var FilesystemOperator $fileSystem */
         $fileSystem = static::getContainer()->get('shopware.filesystem.private');
@@ -580,8 +578,7 @@ class DocumentGeneratorTest extends TestCase
 
     public function testGenerateWithInvalidType(): void
     {
-        static::expectException(DocumentException::class);
-        static::expectExceptionMessage('Unable to find a document renderer with type "invalid_type"');
+        $this->expectExceptionObject(DocumentException::invalidDocumentRenderer('invalid_type'));
         $this->documentGenerator->generate('invalid_type', [], $this->context);
     }
 

--- a/tests/integration/Core/Checkout/Payment/Cart/PaymentRefundProcessorTest.php
+++ b/tests/integration/Core/Checkout/Payment/Cart/PaymentRefundProcessorTest.php
@@ -66,8 +66,7 @@ class PaymentRefundProcessorTest extends TestCase
 
         $this->orderRepository->upsert([$order], Context::createDefaultContext());
 
-        static::expectException(PaymentException::class);
-        static::expectExceptionMessage('The Refund process failed with following exception: Unknown refund with id ' . $this->ids->get('refund') . '.');
+        $this->expectExceptionObject(PaymentException::unknownRefund($this->ids->get('refund')));
 
         $this->paymentRefundProcessor->processRefund($this->ids->get('refund'), Context::createDefaultContext());
     }
@@ -110,8 +109,7 @@ class PaymentRefundProcessorTest extends TestCase
 
         $this->orderRepository->upsert([$order], Context::createDefaultContext());
 
-        static::expectException(PaymentException::class);
-        static::expectExceptionMessage('The Refund process failed with following exception: Unknown refund handler for refund id ' . $this->ids->get('refund') . '.');
+        $this->expectExceptionObject(PaymentException::unknownRefundHandler($this->ids->get('refund')));
 
         $this->paymentRefundProcessor->processRefund($this->ids->get('refund'), Context::createDefaultContext());
     }
@@ -144,8 +142,7 @@ class PaymentRefundProcessorTest extends TestCase
 
         $this->orderRepository->upsert([$order], Context::createDefaultContext());
 
-        static::expectException(PaymentException::class);
-        static::expectExceptionMessage('The Refund process failed with following exception: Can not process refund with id ' . $refund['id'] . ' as refund has state ' . $stateMachineState . '.');
+        $this->expectExceptionObject(PaymentException::refundInvalidTransition($refund['id'], $stateMachineState));
 
         $this->paymentRefundProcessor->processRefund($this->ids->get('refund'), Context::createDefaultContext());
     }

--- a/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
@@ -358,8 +358,7 @@ class CartOrderRouteTest extends TestCase
         );
 
         // we don't care about the follow-up order process, the event listener above are already tested
-        static::expectException(CartException::class);
-        static::expectExceptionMessage('Order payment failed. The order was not stored.');
+        $this->expectExceptionObject(CartException::invalidPaymentOrderNotStored(Uuid::randomHex()));
 
         $route->order($cart, $context, new RequestDataBag());
     }

--- a/tests/unit/Core/Checkout/Cart/TaxProvider/TaxAdjustmentTest.php
+++ b/tests/unit/Core/Checkout/Cart/TaxProvider/TaxAdjustmentTest.php
@@ -92,8 +92,7 @@ class TaxAdjustmentTest extends TestCase
             ->method('getTotalRounding')
             ->willReturn(new CashRoundingConfig(2, 0.01, true));
 
-        static::expectException(CartException::class);
-        static::expectExceptionMessage('Line item with identifier ' . $this->ids->get('line-item-1') . ' has no price.');
+        $this->expectExceptionObject(CartException::missingLineItemPrice($this->ids->get('line-item-1')));
 
         $this->adjustment->adjust($cart, $struct, $context);
     }

--- a/tests/unit/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionControllerTest.php
+++ b/tests/unit/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionControllerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Customer\Api\CustomerGroupRegistrationActionControlle
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\Event\CustomerGroupRegistrationDeclined;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -72,7 +73,7 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
      * @param CustomerEntity[] $customers
      */
     #[DataProvider('groupRegistrationActionDataProvider')]
-    public function testGroupRegistrationAcceptMatches(?int $expectedResCode, ?array $customers, Request $request, ?string $errorMessage): void
+    public function testGroupRegistrationAcceptMatches(?int $expectedResCode, ?array $customers, Request $request, ?\Exception $expectedException): void
     {
         $context = Context::createDefaultContext();
 
@@ -82,8 +83,8 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
             $this->setCustomerGroupSearchReturn($context, $customerCollection);
         }
 
-        if ($errorMessage !== null && $expectedResCode === null) {
-            static::expectExceptionMessage($errorMessage);
+        if ($expectedException !== null && $expectedResCode === null) {
+            $this->expectExceptionObject($expectedException);
         }
 
         $res = $this->controllerMock->accept($request, $context);
@@ -94,7 +95,7 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
      * @param CustomerEntity[] $customers
      */
     #[DataProvider('groupRegistrationActionDataProvider')]
-    public function testGroupRegistrationDeclineMatches(?int $expectedResCode, ?array $customers, Request $request, ?string $errorMessage): void
+    public function testGroupRegistrationDeclineMatches(?int $expectedResCode, ?array $customers, Request $request, ?\Exception $expectedException): void
     {
         $context = Context::createDefaultContext();
 
@@ -104,8 +105,8 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
             $this->setCustomerGroupSearchReturn($context, $customerCollection);
         }
 
-        if ($errorMessage !== null && $expectedResCode === null) {
-            static::expectExceptionMessage($errorMessage);
+        if ($expectedException !== null && $expectedResCode === null) {
+            $this->expectExceptionObject($expectedException);
         }
 
         $res = $this->controllerMock->decline($request, $context);
@@ -113,22 +114,22 @@ class CustomerGroupRegistrationActionControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{int|null, array<CustomerEntity>|null, Request, string|null}>
+     * @return iterable<string, array{int|null, array<CustomerEntity>|null, Request, \Exception|null}>
      */
     public static function groupRegistrationActionDataProvider(): iterable
     {
         $invalidCustomer = Uuid::randomHex();
-        yield 'without user' => [null, null, self::createRequest([$invalidCustomer]), \sprintf('These customers "%s" are not found', $invalidCustomer)];
+        yield 'without user' => [null, null, self::createRequest([$invalidCustomer]), CustomerException::customersNotFound([$invalidCustomer])];
 
         $missingCustomer = self::createCustomer();
         $missingCustomerId = $missingCustomer->getId();
-        yield 'without customer' => [null, null, self::createRequest([$missingCustomerId]), \sprintf('These customers "%s" are not found', $missingCustomerId)];
+        yield 'without customer' => [null, null, self::createRequest([$missingCustomerId]), CustomerException::customersNotFound([$missingCustomerId])];
 
-        yield 'without customerId' => [null, null, self::createRequest([]), 'Parameter "customerIds" is missing.'];
+        yield 'without customerId' => [null, null, self::createRequest([]), CustomerException::customerIdsParameterIsMissing()];
 
         $customerWithoutRequest = self::createCustomer(false);
         $customerWithoutRequestId = $customerWithoutRequest->getId();
-        yield 'without request group' => [null, [$customerWithoutRequest], self::createRequest([$customerWithoutRequestId]), \sprintf('Group request for customer "%s" is not found', $customerWithoutRequestId)];
+        yield 'without request group' => [null, [$customerWithoutRequest], self::createRequest([$customerWithoutRequestId]), CustomerException::groupRequestNotFound($customerWithoutRequestId)];
 
         $acceptCustomer = self::createCustomer();
         $acceptCustomerId = $acceptCustomer->getId();

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/DownloadRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/DownloadRouteTest.php
@@ -61,8 +61,7 @@ class DownloadRouteTest extends TestCase
 
     public function testCustomerNotLoggedInException(): void
     {
-        static::expectException(CustomerException::class);
-        static::expectExceptionMessage('Customer is not logged in.');
+        $this->expectExceptionObject(CustomerException::customerNotLoggedIn());
 
         $this->downloadRoute->load(new Request(), $this->salesChannelContext);
     }
@@ -92,8 +91,7 @@ class DownloadRouteTest extends TestCase
         $request->attributes->set('downloadId', 'foo');
         $request->attributes->set('orderId', 'bar');
 
-        static::expectException(CustomerException::class);
-        static::expectExceptionMessage('Line item download file with id "foo" not found.');
+        $this->expectExceptionObject(CustomerException::downloadFileNotFound('foo'));
         $this->downloadRoute->load($request, $this->salesChannelContext);
     }
 

--- a/tests/unit/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
+++ b/tests/unit/Core/Checkout/Document/SalesChannel/DocumentRouteTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Core\Checkout\Document\SalesChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\Service\GuestAuthenticator;
@@ -308,8 +307,7 @@ class DocumentRouteTest extends TestCase
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('getCustomer')->willReturn($customer);
 
-        static::expectException(CustomerNotLoggedInException::class);
-        static::expectExceptionMessage('Customer is not logged in.');
+        $this->expectExceptionObject(DocumentException::customerNotLoggedIn());
 
         $route->download(self::DUMMY_DOCUMENT_ID, $request, $context);
     }
@@ -402,8 +400,7 @@ class DocumentRouteTest extends TestCase
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('getCustomer')->willReturn($customer);
 
-        static::expectException(CustomerException::class);
-        static::expectExceptionMessage('Customer is not logged in.');
+        $this->expectExceptionObject(CustomerException::customerNotLoggedIn());
 
         $route->download(self::DUMMY_DOCUMENT_ID, $request, $context);
     }

--- a/tests/unit/Core/Checkout/Gateway/Command/Executor/CheckoutGatewayCommandExecutorTest.php
+++ b/tests/unit/Core/Checkout/Gateway/Command/Executor/CheckoutGatewayCommandExecutorTest.php
@@ -76,8 +76,7 @@ class CheckoutGatewayCommandExecutorTest extends TestCase
             $throwCommand,
         ]);
 
-        static::expectException(CheckoutGatewayException::class);
-        static::expectExceptionMessage('Handler not found for command "this-one-throws"');
+        $this->expectExceptionObject(CheckoutGatewayException::handlerNotFound('this-one-throws'));
 
         $executor->execute($commands, $response, Generator::generateSalesChannelContext());
     }

--- a/tests/unit/Core/Checkout/Payment/Cart/Token/JWTFactoryV2Test.php
+++ b/tests/unit/Core/Checkout/Payment/Cart/Token/JWTFactoryV2Test.php
@@ -134,8 +134,7 @@ class JWTFactoryV2Test extends TestCase
         $tokenStruct = new TokenStruct(null, null, $transaction->getPaymentMethodId(), $transaction->getId(), null, -50);
         $token = $tokenFactory->generateToken($tokenStruct);
 
-        static::expectException(PaymentException::class);
-        static::expectExceptionMessage('The provided token ' . $token . ' is invalidated and the payment could not be processed.');
+        $this->expectExceptionObject(PaymentException::tokenInvalidated($token));
 
         static::assertNotEmpty($token);
 

--- a/tests/unit/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
@@ -37,8 +37,7 @@ class PromotionCodeServiceTest extends TestCase
             $this->createMock(Connection::class)
         );
 
-        static::expectException(PromotionException::class);
-        static::expectExceptionMessage('These promotions "promotionId" are not found');
+        $this->expectExceptionObject(PromotionException::promotionsNotFound(['promotionId']));
         $codeService->addIndividualCodes('promotionId', 10, $context);
     }
 
@@ -59,8 +58,7 @@ class PromotionCodeServiceTest extends TestCase
             $this->createMock(Connection::class)
         );
 
-        static::expectException(PromotionException::class);
-        static::expectExceptionMessage('The amount of possible codes is too low for the current pattern. Make sure your pattern is sufficiently complex.');
+        $this->expectExceptionObject(PromotionException::patternNotComplexEnough());
         $codeService->addIndividualCodes('promotionId', 10, $context);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/17163

We forgot the static form

### 2. What does this change do, exactly?

Fix all the tests

### 3. Describe each step to reproduce the issue or behaviour.

Run the modified tests, same output

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/issues/16792

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
