### PR TITLE
fix: Use correct shopware/conflicts version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
         "scssphp/scssphp": "^v1.11.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "dev-feat/allow-twig as 0.1.30",
+        "shopware/conflicts": ">=0.1.30",
         "shyim/opensearch-php-dsl": "^1.0.1",
         "squirrelphp/twig-php-syntax": "^1.13.0",
         "symfony/asset": "~6.4.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -81,7 +81,7 @@
         "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "^3.0.0",
         "ramsey/uuid": "^4.7",
-        "shopware/conflicts": ">= 0.1.23",
+        "shopware/conflicts": ">= 0.1.30",
         "symfony/asset": "~6.4.0",
         "symfony/cache": "~6.4.4",
         "symfony/cache-contracts": "~3.1.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

Previous PR was merged with dev version. After the release of the new version of the conflicts package, we can use it directly

### 2. What does this change do, exactly?

Adjust composer dependencies 

### 3. Describe each step to reproduce the issue or behaviour.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
