### PR TITLE
test: use expectExceptionObject in core content tests

### DIFF
--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Content\ContactForm\Event\ContactFormEvent;
 use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Events\FlowSendMailActionEvent;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsBuilder;
 use Shopware\Core\Content\Mail\Service\MailFactory;
@@ -587,8 +588,7 @@ class SendMailActionTest extends TestCase
             $mailFilterEvent = $event;
         });
 
-        static::expectException(MailEventConfigurationException::class);
-        static::expectExceptionMessage('The recipient value in the flow action configuration is missing.');
+        $this->expectExceptionObject(new MailEventConfigurationException('The recipient value in the flow action configuration is missing.', StorableFlow::class));
 
         $flowFactory = static::getContainer()->get(FlowFactory::class);
         $flow = $flowFactory->create($event);

--- a/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Exception\ProductLineItemDifferentIdException;
 use Shopware\Core\Content\Product\Exception\ProductLineItemInconsistentException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
@@ -156,7 +157,9 @@ class ProductLineItemCommandValidatorTest extends TestCase
         static::assertArrayHasKey('productNumber', $first->getPayload());
 
         $this->expectExceptionObject(
-            (new WriteException())->add(new ProductLineItemInconsistentException($first->getId()))
+            (new WriteException())
+                ->add(new ProductLineItemDifferentIdException($first->getId()))
+                ->add(new ProductLineItemInconsistentException($first->getId()))
         );
 
         $this->lineItemRepository->update([

--- a/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Exception\ProductLineItemInconsistentException;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -154,8 +155,9 @@ class ProductLineItemCommandValidatorTest extends TestCase
         static::assertIsArray($first->getPayload());
         static::assertArrayHasKey('productNumber', $first->getPayload());
 
-        static::expectException(WriteException::class);
-        static::expectExceptionMessage('To change the product of line item (' . $first->getId() . '), the following properties must also be updated: `productId`, `referencedId`, `payload.productNumber`.');
+        $this->expectExceptionObject(
+            (new WriteException())->add(new ProductLineItemInconsistentException($first->getId()))
+        );
 
         $this->lineItemRepository->update([
             ['id' => $first->getId(), 'productId' => $secondId],

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
@@ -34,8 +34,7 @@ class ProductSearchConfigFieldExceptionHandlerTest extends TestCase
             ],
         ];
 
-        static::expectException(DuplicateProductSearchConfigFieldException::class);
-        static::expectExceptionMessage('Product search config with field test already exists.');
+        $this->expectExceptionObject(new DuplicateProductSearchConfigFieldException('test', new \Exception()));
 
         static::getContainer()->get('product_search_config.repository')
             ->create([$config], Context::createDefaultContext());

--- a/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -3,8 +3,8 @@
 namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\FindVariant;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Product\Exception\VariantNotFoundException;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRoute;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
@@ -151,12 +151,10 @@ class FindProductVariantRouteTest extends TestCase
             $this->ids->get('new') => $this->ids->get('new'),
         ];
 
-        static::expectException(VariantNotFoundException::class);
-        static::expectExceptionMessage(
-            'Variant for productId '
-            . $this->ids->get('base') . ' with options {"' . $this->ids->get('new') . '":"' . $this->ids->get('new')
-            . '"} not found.'
-        );
+        $this->expectExceptionObject(ProductException::variantNotFound(
+            $this->ids->get('base'),
+            [$this->ids->get('new') => $this->ids->get('new')]
+        ));
 
         $this->findProductVariantRoute->load(
             $this->ids->get('base'),

--- a/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
+++ b/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
@@ -79,8 +79,7 @@ class ProductExportGenerateCommandTest extends TestCase
 
         $commandTester = new CommandTester($this->productExportGenerateCommand);
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('Only sales channels from type "Storefront" can be used for exports.');
+        $this->expectExceptionObject(ProductExportException::salesChannelNotAllowed());
 
         $commandTester->execute([
             'sales-channel-id' => $nonStorefrontSalesChannelId,

--- a/tests/integration/Core/Content/ProductExport/ProductExportRepositoryTest.php
+++ b/tests/integration/Core/Content/ProductExport/ProductExportRepositoryTest.php
@@ -208,8 +208,7 @@ class ProductExportRepositoryTest extends TestCase
             ],
         ], $this->context);
 
-        static::expectException(DuplicateFileNameException::class);
-        static::expectExceptionMessage('File name "Testexport" already exists.');
+        $this->expectExceptionObject(new DuplicateFileNameException('Testexport'));
 
         $secondId = Uuid::randomHex();
         $this->productExportRepository->upsert([

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
@@ -73,8 +73,7 @@ class ProductExporterTest extends TestCase
 
     public function testExportNotFound(): void
     {
-        static::expectException(ExportNotFoundException::class);
-        static::expectExceptionMessage('No product exports found');
+        $this->expectExceptionObject(new ExportNotFoundException());
 
         $this->service->export($this->salesChannelContext, new ExportBehavior());
     }
@@ -83,8 +82,7 @@ class ProductExporterTest extends TestCase
     {
         $id = Uuid::randomHex();
 
-        static::expectException(ExportNotFoundException::class);
-        static::expectExceptionMessage(\sprintf('Product export with ID %s not found', $id));
+        $this->expectExceptionObject(new ExportNotFoundException($id));
 
         $this->service->export($this->salesChannelContext, new ExportBehavior(), $id);
     }

--- a/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationSerializerTest.php
+++ b/tests/unit/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/TranslationSerializerTest.php
@@ -58,8 +58,7 @@ class TranslationSerializerTest extends TestCase
 
         $field = new BlobField('foo', 'bar');
 
-        static::expectException(ImportExportException::class);
-        static::expectExceptionMessage('Expected "associationField" to be an instance of "Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField".');
+        $this->expectExceptionObject(ImportExportException::invalidInstanceType('associationField', TranslationsAssociationField::class));
 
         $translations = \iterator_to_array($translationsSerializer->serialize($this->getConfig(), $field, []));
 
@@ -136,8 +135,7 @@ class TranslationSerializerTest extends TestCase
 
         $field = new BlobField('foo', 'bar');
 
-        static::expectException(ImportExportException::class);
-        static::expectExceptionMessage('Expected "associationField" to be an instance of "*ToOneField".');
+        $this->expectExceptionObject(ImportExportException::invalidInstanceType('associationField', '*ToOneField'));
 
         $translations = $translationsSerializer->deserialize($this->getConfig(), $field, []);
 

--- a/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
+++ b/tests/unit/Core/Content/ImportExport/Service/DownloadServiceTest.php
@@ -11,8 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\ImportExport\Aggregate\ImportExportFile\ImportExportFileEntity;
-use Shopware\Core\Content\ImportExport\Exception\FileNotFoundException;
-use Shopware\Core\Content\ImportExport\Exception\InvalidFileAccessTokenException;
+use Shopware\Core\Content\ImportExport\ImportExportException;
 use Shopware\Core\Content\ImportExport\Service\DownloadService;
 use Shopware\Core\Content\Media\File\DownloadResponseGenerator;
 use Shopware\Core\Framework\Context;
@@ -40,8 +39,7 @@ class DownloadServiceTest extends TestCase
     #[DataProvider('dataProviderInvalidAccessToken')]
     public function testInvalidAccessToken(ImportExportFileEntity $fileEntity, string $accessToken): void
     {
-        static::expectException(InvalidFileAccessTokenException::class);
-        static::expectExceptionMessage('Access to file denied due to invalid access token');
+        $this->expectExceptionObject(ImportExportException::invalidFileAccessToken());
         /** @var StaticEntityRepository<EntityCollection<ImportExportFileEntity>> $fileRepository */
         $fileRepository = new StaticEntityRepository([new EntityCollection([$fileEntity])]);
 
@@ -53,8 +51,7 @@ class DownloadServiceTest extends TestCase
     #[DataProvider('dataProviderNotFoundFile')]
     public function testNotFoundFile(ImportExportFileEntity $fileEntity, string $accessToken, string $fileId): void
     {
-        static::expectException(FileNotFoundException::class);
-        static::expectExceptionMessage(\sprintf('Cannot find import/export file with id %s', $fileId));
+        $this->expectExceptionObject(ImportExportException::fileNotFound($fileId));
 
         /** @var StaticEntityRepository<EntityCollection<ImportExportFileEntity>> $fileRepository */
         $fileRepository = new StaticEntityRepository([new EntityCollection([$fileEntity])]);

--- a/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailSenderTest.php
@@ -227,8 +227,7 @@ class MailSenderTest extends TestCase
         $mail = new Email();
         $mail->text('foobar');
 
-        static::expectException(MailException::class);
-        static::expectExceptionMessage('Mail body is too long. Maximum allowed length is 5');
+        $this->expectExceptionObject(MailException::mailBodyTooLong(5));
 
         $mailSender->send($mail);
     }

--- a/tests/unit/Core/Content/Mail/Transport/MailerTransportLoaderTest.php
+++ b/tests/unit/Core/Content/Mail/Transport/MailerTransportLoaderTest.php
@@ -161,8 +161,7 @@ class MailerTransportLoaderTest extends TestCase
             $this->createMock(EntityRepository::class)
         );
 
-        static::expectException(MailException::class);
-        static::expectExceptionMessage('Given sendmail option "bla" is invalid');
+        $this->expectExceptionObject(MailException::givenSendMailOptionIsInvalid('bla', ['-bs', '-i', '-t']));
 
         $loader->fromString('null://null');
     }
@@ -196,8 +195,7 @@ class MailerTransportLoaderTest extends TestCase
             $this->createMock(EntityRepository::class)
         );
 
-        static::expectException(MailException::class);
-        static::expectExceptionMessage('Invalid mail agent given "test"');
+        $this->expectExceptionObject(MailException::givenMailAgentIsInvalid('test'));
 
         $loader->fromString('null://null');
     }

--- a/tests/unit/Core/Content/MailTemplate/Service/MailTemplateServiceTest.php
+++ b/tests/unit/Core/Content/MailTemplate/Service/MailTemplateServiceTest.php
@@ -81,8 +81,7 @@ class MailTemplateServiceTest extends TestCase
             $mailTemplateRepository
         );
 
-        static::expectException(MailTemplateException::class);
-        static::expectExceptionMessage('Mail Template not found.');
+        $this->expectExceptionObject(MailTemplateException::templateNotFound());
 
         $mailTemplateService->loadTemplate(Uuid::randomHex(), Context::createDefaultContext());
     }

--- a/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitConverterTest.php
+++ b/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitConverterTest.php
@@ -152,8 +152,7 @@ class MeasurementUnitConverterTest extends TestCase
                 ['kg', $toUnitInfo],
             ]);
 
-        static::expectException(MeasurementSystemException::class);
-        static::expectExceptionMessage('The measurement units "mm" and "kg" are incompatible.');
+        $this->expectExceptionObject(MeasurementSystemException::incompatibleMeasurementUnits('mm', 'kg'));
 
         $this->converter->convert(10.0, 'mm', 'kg');
     }
@@ -250,8 +249,7 @@ class MeasurementUnitConverterTest extends TestCase
                 ['cm', $toUnitInfo],
             ]);
 
-        static::expectException(MeasurementSystemException::class);
-        static::expectExceptionMessage('The measurement system unit "cm" cannot have a factor of zero.');
+        $this->expectExceptionObject(MeasurementSystemException::measurementUnitCantHaveZeroFactor('cm'));
         $this->converter->convert(1.0, 'mm', 'cm');
     }
 

--- a/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitProviderTest.php
+++ b/tests/unit/Core/Content/MeasurementSystem/Unit/MeasurementUnitProviderTest.php
@@ -95,8 +95,7 @@ class MeasurementUnitProviderTest extends TestCase
             ->with(static::isInstanceOf(Criteria::class), static::isInstanceOf(Context::class))
             ->willReturn($searchResult);
 
-        static::expectException(MeasurementSystemException::class);
-        static::expectExceptionMessage('The measurement system unit "nonexistent" is not supported. Possible units are: mm');
+        $this->expectExceptionObject(MeasurementSystemException::unsupportedMeasurementUnit('nonexistent', ['mm']));
 
         $this->provider->getUnitInfo('nonexistent');
     }

--- a/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/unit/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -140,8 +140,7 @@ class MediaUploadControllerTest extends TestCase
         $context = Context::createDefaultContext();
         $request = new Request([], ['fileName' => '']);
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('A valid filename must be provided.');
+        $this->expectExceptionObject(MediaException::emptyMediaFilename());
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -159,8 +158,7 @@ class MediaUploadControllerTest extends TestCase
         $context = Context::createDefaultContext();
         $request = new Request(['fileName' => '', 'extension' => 'jpg']);
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('A valid filename must be provided.');
+        $this->expectExceptionObject(MediaException::emptyMediaFilename());
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -178,8 +176,7 @@ class MediaUploadControllerTest extends TestCase
         $context = Context::createDefaultContext();
         $request = new Request(['fileName' => 'test', 'extension' => '']);
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('No file extension provided. Please use the "extension" query parameter to specify the extension of the uploaded file.');
+        $this->expectExceptionObject(MediaException::missingFileExtension());
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -196,8 +193,7 @@ class MediaUploadControllerTest extends TestCase
     {
         self::$simulateFailedTempnam = true;
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Cannot create a temp file.');
+        $this->expectExceptionObject(MediaException::cannotCreateTempFile());
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -212,8 +208,7 @@ class MediaUploadControllerTest extends TestCase
 
     public function testUploadThrowsOnIllegalFileName(): void
     {
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('is not permitted');
+        $this->expectExceptionObject(MediaException::illegalFileName("\xFF\xFE", 'Path encoding is invalid'));
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -228,8 +223,7 @@ class MediaUploadControllerTest extends TestCase
 
     public function testRenameThrowsOnIllegalFileName(): void
     {
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('is not permitted');
+        $this->expectExceptionObject(MediaException::illegalFileName("\xFF\xFE", 'Path encoding is invalid'));
 
         $controller = new MediaUploadController(
             $this->mediaService,
@@ -244,8 +238,7 @@ class MediaUploadControllerTest extends TestCase
 
     public function testProvideNameThrowsOnIllegalFileName(): void
     {
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('is not permitted');
+        $this->expectExceptionObject(MediaException::illegalFileName("\xFF\xFE", 'Path encoding is invalid'));
 
         $controller = new MediaUploadController(
             $this->mediaService,

--- a/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -979,8 +979,7 @@ class UnusedMediaPurgerTest extends TestCase
 
     public function testDeleteNotUsedMediaThrowsExceptionWithInvalidFolderRestriction(): void
     {
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Could not find a default folder with entity "product"');
+        $this->expectExceptionObject(MediaException::defaultMediaFolderWithEntityNotFound('product'));
 
         $this->configureRegistry([
             'Media' => $mediaDefinition = $this->getMediaDefinition([]),

--- a/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
+++ b/tests/unit/Core/Content/Media/Upload/MediaUploadServiceTest.php
@@ -551,8 +551,7 @@ class MediaUploadServiceTest extends TestCase
 
     public function testValidateExternalUrlThrowsForInvalidFormat(): void
     {
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Provided URL "not-a-valid-url" is invalid.');
+        $this->expectExceptionObject(MediaException::invalidUrl('not-a-valid-url'));
 
         $this->mediaUploadService->assertValidExternalUrl('not-a-valid-url');
     }
@@ -573,8 +572,7 @@ class MediaUploadServiceTest extends TestCase
             $validator,
         );
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Provided URL "http://10.0.0.1/image.jpg" is not allowed.');
+        $this->expectExceptionObject(MediaException::illegalUrl('http://10.0.0.1/image.jpg'));
 
         $service->assertValidExternalUrl('http://10.0.0.1/image.jpg');
     }
@@ -586,8 +584,7 @@ class MediaUploadServiceTest extends TestCase
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Provided URL "not-a-valid-url" is invalid.');
+        $this->expectExceptionObject(MediaException::invalidUrl('not-a-valid-url'));
 
         MediaUploadService::validateExternalUrl('not-a-valid-url');
     }
@@ -610,8 +607,7 @@ class MediaUploadServiceTest extends TestCase
 
         $this->httpClient->expects($this->never())->method('request');
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Provided URL "http://10.0.0.1/image.jpg" is not allowed.');
+        $this->expectExceptionObject(MediaException::illegalUrl('http://10.0.0.1/image.jpg'));
 
         $params = new MediaUploadParameters();
         $params->mimeType = 'image/jpeg';
@@ -692,8 +688,7 @@ class MediaUploadServiceTest extends TestCase
             new ExternalThumbnailData('http://10.0.0.1/thumb.jpg', 100, 100),
         ]);
 
-        static::expectException(MediaException::class);
-        static::expectExceptionMessage('Provided URL "http://10.0.0.1/thumb.jpg" is not allowed.');
+        $this->expectExceptionObject(MediaException::illegalUrl('http://10.0.0.1/thumb.jpg'));
 
         $service->addExternalThumbnailsToMedia(Uuid::randomHex(), $thumbnails, $this->context);
     }

--- a/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRouteTest.php
+++ b/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterUnsubscribeRouteTest.php
@@ -112,8 +112,7 @@ class NewsletterUnsubscribeRouteTest extends TestCase
             $this->createMock(RequestStack::class),
         );
 
-        static::expectException(NewsletterException::class);
-        static::expectExceptionMessage('The email parameter is missing.');
+        $this->expectExceptionObject(NewsletterException::missingEmailParameter());
         $response = $newsletterSubscribeRoute->unsubscribeWithResponse($requestData, $this->salesChannelContext);
 
         static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
@@ -147,8 +146,7 @@ class NewsletterUnsubscribeRouteTest extends TestCase
             $this->createMock(RequestStack::class),
         );
 
-        static::expectException(NewsletterException::class);
-        static::expectExceptionMessage('The NewsletterRecipient with the identifier "email" - test@example.com was not found.');
+        $this->expectExceptionObject(NewsletterException::recipientNotFound('email', 'test@example.com'));
         $response = $newsletterSubscribeRoute->unsubscribeWithResponse($requestData, $this->salesChannelContext);
         static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
     }

--- a/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -59,11 +59,7 @@ class FindProductVariantRouteTest extends TestCase
 
     public function testNoDecoration(): void
     {
-        static::expectException(DecorationPatternException::class);
-        static::expectExceptionMessage(
-            'The getDecorated() function of core class ' . FindProductVariantRoute::class
-            . ' cannot be used. This class is the base class.'
-        );
+        $this->expectExceptionObject(new DecorationPatternException(FindProductVariantRoute::class));
 
         $this->route->getDecorated();
     }
@@ -231,11 +227,10 @@ class FindProductVariantRouteTest extends TestCase
                 ),
             );
 
-        static::expectException(VariantNotFoundException::class);
-        static::expectExceptionMessage(
-            'Variant for productId ' . $this->ids->get('productId') . ' with options {"' . $this->ids->get('group2')
-            . '":"' . $this->ids->get('option2') . '"} not found.'
-        );
+        $this->expectExceptionObject(ProductException::variantNotFound(
+            $this->ids->get('productId'),
+            [$this->ids->get('group2') => $this->ids->get('option2')]
+        ));
 
         try {
             $this->route->load($this->ids->get('productId'), $request, $this->createMock(SalesChannelContext::class));
@@ -256,8 +251,7 @@ class FindProductVariantRouteTest extends TestCase
                 'options' => $options,
             ]
         );
-        static::expectException(ProductException::class);
-        static::expectExceptionMessage('The parameter options is invalid.');
+        $this->expectExceptionObject(ProductException::invalidOptionsParameter());
 
         $this->route->load($this->ids->get('productId'), $request, $this->createMock(SalesChannelContext::class));
     }

--- a/tests/unit/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
+++ b/tests/unit/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
@@ -50,8 +50,7 @@ class ProductExportGenerateCommandTest extends TestCase
 
         $this->salesChannelContextFactory->method('create')->willReturn($salesChannelContext);
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('Only sales channels from type "Storefront" can be used for exports.');
+        $this->expectExceptionObject(ProductExportException::salesChannelNotAllowed());
 
         $this->commandTester->execute([
             'sales-channel-id' => $salesChannelId,

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -133,8 +133,7 @@ class ProductExportGeneratorTest extends TestCase
             $this->parserFactory
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage(ProductExportException::productExportNotFound($productExport->getId())->getMessage());
+        $this->expectExceptionObject(ProductExportException::productExportNotFound($productExport->getId()));
 
         $generator->generate($productExport, new ExportBehavior());
     }
@@ -172,8 +171,7 @@ class ProductExportGeneratorTest extends TestCase
             $this->parserFactory
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage(ProductExportException::renderProductException($errorMessage)->getMessage());
+        $this->expectExceptionObject(ProductExportException::renderProductException($errorMessage));
 
         $generator->generate($productExport, new ExportBehavior());
     }
@@ -367,8 +365,9 @@ class ProductExportGeneratorTest extends TestCase
 
         $generator = $this->createGenerator();
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('The JSONL row for product export "productExportId" could not be normalized');
+        $this->expectExceptionObject(ProductExportException::renderProductException(
+            'The JSONL row for product export "' . $productExport->getId() . '" could not be normalized: Syntax error'
+        ));
 
         $generator->generate($productExport, new ExportBehavior(false, false, false, false, false));
     }
@@ -384,8 +383,7 @@ class ProductExportGeneratorTest extends TestCase
 
         $generator = $this->createGenerator();
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage(ProductExportException::salesChannelDomainNotFound('productExportId')->getMessage());
+        $this->expectExceptionObject(ProductExportException::salesChannelDomainNotFound('productExportId'));
 
         $generator->generate($productExport, new ExportBehavior());
     }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -104,8 +104,7 @@ class ProductExportRendererTest extends TestCase
             $dispatcher,
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('error');
+        $this->expectExceptionObject(ProductExportException::renderHeaderException(AdapterException::renderingTemplateFailed('error')->getMessage()));
 
         $renderer->renderHeader($productExport, $this->context);
     }
@@ -208,8 +207,7 @@ class ProductExportRendererTest extends TestCase
             $dispatcher,
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('error');
+        $this->expectExceptionObject(ProductExportException::renderFooterException(AdapterException::renderingTemplateFailed('error')->getMessage()));
 
         $renderer->renderFooter($productExport, $this->context);
     }
@@ -228,8 +226,7 @@ class ProductExportRendererTest extends TestCase
             $dispatcher,
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('Template body not set');
+        $this->expectExceptionObject(ProductExportException::templateBodyNotSet());
 
         $renderer->renderBody($productExport, $this->context, []);
     }
@@ -259,8 +256,7 @@ class ProductExportRendererTest extends TestCase
             $dispatcher,
         );
 
-        static::expectException(ProductExportException::class);
-        static::expectExceptionMessage('error');
+        $this->expectExceptionObject(ProductExportException::renderProductException(AdapterException::renderingTemplateFailed('error')->getMessage()));
 
         $renderer->renderBody($productExport, $this->context, []);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/17163

We forgot the static form

### 2. What does this change do, exactly?

Fix all the tests

### 3. Describe each step to reproduce the issue or behaviour.

Run the modified tests, same output

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/issues/16792

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
