### PR TITLE
test: use expectExceptionObject in core system tests

### DIFF
--- a/tests/unit/Core/Installer/Requirements/Struct/RequirementsCheckCollectionTest.php
+++ b/tests/unit/Core/Installer/Requirements/Struct/RequirementsCheckCollectionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Installer\Requirements\Struct\PathCheck;
 use Shopware\Core\Installer\Requirements\Struct\RequirementCheck;
 use Shopware\Core\Installer\Requirements\Struct\RequirementsCheckCollection;
@@ -23,7 +24,7 @@ class RequirementsCheckCollectionTest extends TestCase
 
         $collection->add(new PathCheck('name', RequirementCheck::STATUS_SUCCESS));
 
-        static::expectExceptionMessage('Expected collection element of type Shopware\Core\Installer\Requirements\Struct\RequirementCheck got Shopware\Core\Content\Product\ProductEntity');
+        $this->expectExceptionObject(FrameworkException::collectionElementInvalidType(RequirementCheck::class, ProductEntity::class));
         $collection->add(new ProductEntity()); /** @phpstan-ignore argument.type (for test purpose) */
     }
 

--- a/tests/unit/Core/Service/ServiceClientTest.php
+++ b/tests/unit/Core/Service/ServiceClientTest.php
@@ -101,8 +101,7 @@ class ServiceClientTest extends TestCase
 
     public function testLatestInfoThrowsExceptionWhenTransportErrorOccurs(): void
     {
-        static::expectException(ServiceException::class);
-        static::expectExceptionMessage('Error performing request. Error: host unreachable');
+        $this->expectExceptionObject(ServiceException::requestTransportError(new \Exception('host unreachable')));
 
         $httpClient = new MockHttpClient([
             new MockResponse('', ['error' => 'host unreachable']),

--- a/tests/unit/Core/System/Locale/Util/BackwardCompatibleNumberFormatterTest.php
+++ b/tests/unit/Core/System/Locale/Util/BackwardCompatibleNumberFormatterTest.php
@@ -31,8 +31,7 @@ class BackwardCompatibleNumberFormatterTest extends TestCase
 
     public function testItThrowsExceptionIfGivenLocaleIsInvalid(): void
     {
-        static::expectException(FeatureException::class);
-        static::expectExceptionMessage('Tried to access deprecated functionality: The locale "us" is no valid PHP locale. Please use a valid locale.');
+        $this->expectExceptionObject(FeatureException::error('Tried to access deprecated functionality: The locale "us" is no valid PHP locale. Please use a valid locale.'));
 
         new BackwardCompatibleNumberFormatter('us', \NumberFormatter::DECIMAL);
     }

--- a/tests/unit/Core/System/Snippet/Api/SnippetControllerTest.php
+++ b/tests/unit/Core/System/Snippet/Api/SnippetControllerTest.php
@@ -30,7 +30,6 @@ class SnippetControllerTest extends TestCase
         if ($exception !== null) {
             $snippetService->expects($this->never())->method('getList');
             static::expectExceptionObject($exception);
-            static::expectExceptionMessage($exception->getMessage());
 
             $controller = new SnippetController($snippetService, new SnippetFileCollection());
 

--- a/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
+++ b/tests/unit/Core/System/Snippet/Command/InstallTranslationCommandTest.php
@@ -53,8 +53,7 @@ class InstallTranslationCommandTest extends TestCase
         $command = $this->getCommand();
         $tester = new CommandTester($command);
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('You must specify either --all or --locales to run the InstallTranslationCommand.');
+        $this->expectExceptionObject(SnippetException::noArgumentsProvided());
         $tester->execute([], ['interactive' => false]);
     }
 

--- a/tests/unit/Core/System/Snippet/Service/TranslationConfigLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationConfigLoaderTest.php
@@ -68,8 +68,7 @@ class TranslationConfigLoaderTest extends TestCase
     {
         $this->translationConfigLoader->setConfigFileName('translation_invalid_url.yaml');
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The repository URL "invalid_url" is invalid: "repository-url" must contain a schema and a host.');
+        $this->expectExceptionObject(SnippetException::invalidRepositoryUrl('invalid_url', new \Exception('"repository-url" must contain a schema and a host.')));
         $this->translationConfigLoader->load();
     }
 
@@ -77,8 +76,7 @@ class TranslationConfigLoaderTest extends TestCase
     {
         $this->translationConfigLoader->setConfigFileName('translation_broken_url.yaml');
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The repository URL "http://" is invalid: Unable to parse URI: http://');
+        $this->expectExceptionObject(SnippetException::invalidRepositoryUrl('http://', new \Exception('Unable to parse URI: http://')));
         $this->translationConfigLoader->load();
     }
 
@@ -86,8 +84,7 @@ class TranslationConfigLoaderTest extends TestCase
     {
         $this->translationConfigLoader->setConfigFileName('translation_non_string_url.yaml');
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The repository URL "4" is invalid: "repository-url" in the translation config must be a string.');
+        $this->expectExceptionObject(SnippetException::invalidRepositoryUrl('4', new \Exception('"repository-url" in the translation config must be a string.')));
         $this->translationConfigLoader->load();
     }
 
@@ -95,8 +92,7 @@ class TranslationConfigLoaderTest extends TestCase
     {
         $this->translationConfigLoader->setConfigFileName('translation_empty_string_url.yaml');
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The repository URL "" is invalid: "repository-url" in the translation config must not be empty.');
+        $this->expectExceptionObject(SnippetException::invalidRepositoryUrl('', new \Exception('"repository-url" in the translation config must not be empty.')));
         $this->translationConfigLoader->load();
     }
 
@@ -111,16 +107,14 @@ class TranslationConfigLoaderTest extends TestCase
     public function testThrowsOnNonExistingConfigurationFile(): void
     {
         $this->translationConfigLoader->setConfigFileName('non-existing-file');
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('Translation configuration file does not exist: "non-existing-file".');
+        $this->expectExceptionObject(SnippetException::translationConfigurationFileDoesNotExist('non-existing-file'));
         $this->translationConfigLoader->load();
     }
 
     public function testThrowsOnEmptyConfigurationFile(): void
     {
         $this->translationConfigLoader->setConfigFileName('translation_empty.yaml');
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('Translation configuration file exists, but is empty: "translation_empty.yaml".');
+        $this->expectExceptionObject(SnippetException::translationConfigurationFileIsEmpty('translation_empty.yaml'));
         $this->translationConfigLoader->load();
     }
 

--- a/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationLoaderTest.php
@@ -103,8 +103,7 @@ class TranslationLoaderTest extends TestCase
 
         $loader = $this->getTranslationLoader();
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The configured locale "es-ES" does not exist.');
+        $this->expectExceptionObject(SnippetException::localeDoesNotExist('es-ES'));
         $loader->load('es-ES', $this->context);
     }
 
@@ -317,8 +316,7 @@ class TranslationLoaderTest extends TestCase
 
         $loader = $this->getTranslationLoader();
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('The configured locale "es-ES" does not exist.');
+        $this->expectExceptionObject(SnippetException::localeDoesNotExist('es-ES'));
         $loader->load('es-ES', $this->context);
     }
 

--- a/tests/unit/Core/System/Snippet/Service/TranslationMetadataLoaderTest.php
+++ b/tests/unit/Core/System/Snippet/Service/TranslationMetadataLoaderTest.php
@@ -105,8 +105,7 @@ class TranslationMetadataLoaderTest extends TestCase
         $this->client = $client;
         $loader = $this->getTranslationMetadataLoader();
 
-        static::expectException(SnippetException::class);
-        static::expectExceptionMessage('Failed to download translation metadata from "http://localhost:8000/metadata.json": Error');
+        $this->expectExceptionObject(SnippetException::translationMetadataDownloadFailed(new Uri('http://localhost:8000/metadata.json'), new \Exception('Error')));
         $loader->getUpdatedLocalMetadata(['es-ES', 'it-IT']);
     }
 

--- a/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
@@ -65,8 +65,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
         $entityDispatcher->expects($this->never())
             ->method('dispatch');
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage('No allowed entity definition found. Skipping dispatching of entity sync message. Entity: non_existing_entity, Operation: create');
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException('No allowed entity definition found. Skipping dispatching of entity sync message. Entity: non_existing_entity, Operation: create'));
 
         $consentService = $this->createMock(ConsentService::class);
 
@@ -137,8 +136,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
             $shopIdProvider
         );
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage(\sprintf('The consent was never accepted. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName()));
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException(\sprintf('The consent was never accepted. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName())));
         $handler(new DispatchEntityMessage(
             SyncEntityDefinition::ENTITY_NAME,
             Operation::CREATE,
@@ -192,8 +190,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
             $shopIdProvider
         );
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage(\sprintf('Message dispatched for old shopId. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName()));
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException(\sprintf('Message dispatched for old shopId. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName())));
         $handler(new DispatchEntityMessage(
             SyncEntityDefinition::ENTITY_NAME,
             Operation::CREATE,
@@ -505,8 +502,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
             $shopIdProvider,
         );
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage(\sprintf('Entity sync does not support composite primary keys. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName()));
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException(\sprintf('Entity sync does not support composite primary keys. Skipping dispatching of entity sync message. Entity: %s, Operation: create', $definition->getEntityName())));
         $handler(new DispatchEntityMessage(
             $definition->getEntityName(),
             Operation::CREATE,

--- a/tests/unit/Core/System/UsageData/EntitySync/IterateEntitiesQueryBuilderTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/IterateEntitiesQueryBuilderTest.php
@@ -76,15 +76,13 @@ class IterateEntitiesQueryBuilderTest extends TestCase
 
     public function testThrowsEntityDoesNotHaveCreatedAndUpdatedAtFields(): void
     {
-        static::expectException(UsageDataException::class);
-        static::expectExceptionMessage('Entity "test_mapping_entity" is not allowed to be used for usage data');
+        $this->expectExceptionObject(UsageDataException::entityNotAllowed('test_mapping_entity'));
         $this->iteratorFactory->create(TestMappingEntityDefinition::ENTITY_NAME, Operation::CREATE, new \DateTimeImmutable(), null);
     }
 
     public function testCreateThrowsExceptionIfEntityDoesNotExist(): void
     {
-        static::expectException(UsageDataException::class);
-        static::expectExceptionMessage('Entity "no_entity" is not allowed to be used for usage data');
+        $this->expectExceptionObject(UsageDataException::entityNotAllowed('no_entity'));
         $this->iteratorFactory->create('no_entity', Operation::CREATE, new \DateTimeImmutable(), null);
     }
 

--- a/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
+++ b/tests/unit/Core/System/UsageData/EntitySync/IterateEntityMessageHandlerTest.php
@@ -82,8 +82,7 @@ class IterateEntityMessageHandlerTest extends TestCase
             $this->createMock(LoggerInterface::class),
         );
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage('The consent was never accepted. Skipping dispatching of entity sync message. Entity: test-entity, Operation: delete');
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException('The consent was never accepted. Skipping dispatching of entity sync message. Entity: test-entity, Operation: delete'));
         $handler(new IterateEntityMessage('test-entity', Operation::DELETE, new \DateTimeImmutable('2023-08-16'), new \DateTimeImmutable()));
 
         $dispatchedMessages = $messageBus->getMessages();
@@ -181,8 +180,7 @@ class IterateEntityMessageHandlerTest extends TestCase
             $this->createMock(LoggerInterface::class),
         );
 
-        static::expectException(UnrecoverableMessageHandlingException::class);
-        static::expectExceptionMessage('Entity definition for entity test-entity not found.');
+        $this->expectExceptionObject(new UnrecoverableMessageHandlingException('Entity definition for entity test-entity not found.'));
         $handler(new IterateEntityMessage('test-entity', Operation::CREATE, new \DateTimeImmutable('2023-08-16'), new \DateTimeImmutable()));
 
         $dispatchedMessages = $messageBus->getMessages();

--- a/tests/unit/Core/System/User/Recovery/UserRecoveryServiceTest.php
+++ b/tests/unit/Core/System/User/Recovery/UserRecoveryServiceTest.php
@@ -93,8 +93,7 @@ class UserRecoveryServiceTest extends TestCase
 
     public function testGenerateUserRecoveryWithNoSalesChannel(): void
     {
-        static::expectException(UserException::class);
-        static::expectExceptionMessage('No sales channel found.');
+        $this->expectExceptionObject(UserException::salesChannelNotFound());
 
         $userEmail = 'existing@example.com';
         $context = new Context(new SystemSource(), [], Defaults::CURRENCY, [Defaults::LANGUAGE_SYSTEM]);


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/17163

We forgot the static form

### 2. What does this change do, exactly?

Fix all the tests

### 3. Describe each step to reproduce the issue or behaviour.

Run the modified tests, same output

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/issues/16792

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
