### PR TITLE
test: use expectExceptionObject in frontend tests

### DIFF
--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -62,8 +62,7 @@ class CountryStateControllerTest extends TestCase
 
     public function testEmptyCountryId(): void
     {
-        static::expectException(RoutingException::class);
-        static::expectExceptionMessage('Parameter "countryId" is missing.');
+        $this->expectExceptionObject(RoutingException::missingRequestParameter('countryId'));
         $this->countryStateController->getCountryData(new Request([], ['countryId' => null]), $this->salesChannelContext);
     }
 

--- a/tests/unit/Administration/Framework/Search/CriteriaCollectionTest.php
+++ b/tests/unit/Administration/Framework/Search/CriteriaCollectionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Administration\Framework\Search\CriteriaCollection;
 use Shopware\Administration\Notification\NotificationEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\FrameworkException;
 
 /**
  * @internal
@@ -20,7 +21,7 @@ class CriteriaCollectionTest extends TestCase
 
         $collection->add(new Criteria());
 
-        static::expectExceptionMessage(\sprintf('Expected collection element of type %s got %s', Criteria::class, NotificationEntity::class));
+        $this->expectExceptionObject(FrameworkException::collectionElementInvalidType(Criteria::class, NotificationEntity::class));
         /** @phpstan-ignore argument.type (for test purpose) */
         $collection->add(new NotificationEntity());
 

--- a/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
+++ b/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
@@ -118,8 +118,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Could not find indicator manifest or tag in deprecation annotation');
+        $this->expectExceptionObject(new \InvalidArgumentException('Could not find indicator manifest or tag in deprecation annotation.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -135,8 +134,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated will be removed';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Could not find indicator manifest or tag in deprecation');
+        $this->expectExceptionObject(new \InvalidArgumentException('Could not find indicator manifest or tag in deprecation annotation.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -144,8 +142,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated administration:v6.5.0.0';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Could not find indicator manifest or tag in deprecation');
+        $this->expectExceptionObject(new \InvalidArgumentException('Could not find indicator manifest or tag in deprecation annotation.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -153,8 +150,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated tag:v6.5.0.0';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The tag version should start with `v` and comprise 3 digits separated by periods.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -162,8 +158,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated tag:v6.5';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The tag version should start with `v` and comprise 3 digits separated by periods.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -171,8 +166,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated tag:v6.3.0';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -180,8 +174,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated tag:v6.4.0';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -197,8 +190,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated manifest:v1';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Manifest version must have 2 digits.');
+        $this->expectExceptionObject(new \InvalidArgumentException('Manifest version must have 2 digits.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -206,8 +198,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated manifest:v1.0';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -215,8 +206,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@deprecated manifest:v0.1';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateDeprecatedAnnotations($deprecatedContent);
     }
 
@@ -224,23 +214,20 @@ class AnnotationTagTesterTest extends TestCase
     {
         $this->annotationTagTester->validateDeprecationElements('<deprecated>tag:v6.5.0</deprecated>');
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateDeprecationElements('<deprecated>tag:v6.3.0</deprecated>');
     }
 
     public function testIncorrectDeprecationTagFormat(): void
     {
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Deprecation tag is not found in the file.');
+        $this->expectExceptionObject(new \InvalidArgumentException('Deprecation tag is not found in the file.'));
         $this->annotationTagTester->validateDeprecationElements('<deprecatedd>tag:v6.5</deprecatedd>');
     }
 
     #[DataProvider('incorrectExperimentalAnnotationsFormatProvider')]
     public function testExperimentalWithIncorrectPropertiesDeclarationWillThrowException(string $content): void
     {
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared');
+        $this->expectExceptionObject(new \InvalidArgumentException('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared.'));
         $this->annotationTagTester->validateExperimentalAnnotations($content);
     }
 
@@ -256,8 +243,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental tag:v6.5.0 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Could not find property stableVersion in experimental annotation');
+        $this->expectExceptionObject(new \InvalidArgumentException('Could not find property stableVersion in experimental annotation.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -265,8 +251,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:v6.5.0 name:testFeature';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('Could not find property feature in experimental annotation');
+        $this->expectExceptionObject(new \InvalidArgumentException('Could not find property feature in experimental annotation.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -274,8 +259,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:v6.5.0.0 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The tag version should start with `v` and comprise 3 digits separated by periods.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -283,8 +267,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:a6.5.0 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The tag version should start with `v` and comprise 3 digits separated by periods.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -292,8 +275,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:v6.5 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The tag version should start with `v` and comprise 3 digits separated by periods.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -301,8 +283,7 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:v6.3.0 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
@@ -310,16 +291,14 @@ class AnnotationTagTesterTest extends TestCase
     {
         $deprecatedContent = '@experimental stableVersion:v6.4.0 feature:TEST_FEATURE';
 
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The version you used for deprecation or experimental annotation is already live.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
         $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
     }
 
     #[DataProvider('incorrectFeaturePropertyValueProvider')]
     public function testExperimentalWithIncorrectFeatureValueWillThrowException(string $content): void
     {
-        static::expectException(\InvalidArgumentException::class);
-        static::expectExceptionMessage('The value of feature-property can not be empty, contain white spaces and must be in ALL_CAPS format.');
+        $this->expectExceptionObject(new \InvalidArgumentException('The value of feature-property can not be empty, contain white spaces and must be in ALL_CAPS format.'));
         $this->annotationTagTester->validateExperimentalAnnotations($content);
     }
 

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -178,8 +178,7 @@ class CriteriaParserTest extends TestCase
 
         $parser = new CriteriaParser(new EntityDefinitionQueryHelper(), $this->createMock(CustomFieldService::class), new ArrayKeyValueStorage([]));
 
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage(\sprintf('Provided filter of class %s is not supported', CustomFilter::class));
+        $this->expectExceptionObject(ElasticsearchException::unsupportedFilter(CustomFilter::class));
         $parser->parseFilter(new CustomFilter(), $definition, ProductDefinition::ENTITY_NAME, Context::createDefaultContext());
     }
 

--- a/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -154,8 +154,7 @@ class ElasticsearchIndexerTest extends TestCase
 
         $offset = new IndexerOffset(['foo'], null);
 
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage('Definition foo not found');
+        $this->expectExceptionObject(ElasticsearchException::definitionNotFound('foo'));
 
         $indexer->iterate($offset);
     }
@@ -222,8 +221,7 @@ class ElasticsearchIndexerTest extends TestCase
 
         $indexer = $this->getIndexer();
 
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage('Definition not_existing not found');
+        $this->expectExceptionObject(ElasticsearchException::definitionNotFound('not_existing'));
 
         $indexer($message);
     }
@@ -242,8 +240,7 @@ class ElasticsearchIndexerTest extends TestCase
 
         $indexer = $this->getIndexer();
 
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage('Empty indexing request provided');
+        $this->expectExceptionObject(ElasticsearchException::emptyIndexingRequest());
 
         $indexer($message);
     }

--- a/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/unit/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -84,8 +84,7 @@ class ProductSearchQueryBuilderTest extends TestCase
 
     public function testBuildEmptyQuery(): void
     {
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage('Empty query provided');
+        $this->expectExceptionObject(ElasticsearchException::emptyQuery());
 
         $builder = $this->getBuilder([
             self::config(field: 'restockTime', ranking: 500, tokenize: true, and: false),
@@ -100,8 +99,7 @@ class ProductSearchQueryBuilderTest extends TestCase
 
     public function testBuildWithoutFields(): void
     {
-        static::expectException(ElasticsearchException::class);
-        static::expectExceptionMessage('Empty query provided');
+        $this->expectExceptionObject(ElasticsearchException::emptyQuery());
 
         $builder = $this->getBuilder(null);
 

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
@@ -49,8 +49,7 @@ class ProductPageSeoUrlRouteTest extends TestCase
     {
         $route = new ProductPageSeoUrlRoute($this->createMock(ProductDefinition::class));
 
-        static::expectException(StorefrontFrameworkException::class);
-        static::expectExceptionMessage('SEO URL Mapping expects argument to be a ProductEntity');
+        $this->expectExceptionObject(StorefrontFrameworkException::invalidArgument('SEO URL Mapping expects argument to be a ProductEntity'));
         $route->getMapping(new ArrayEntity(), new SalesChannelEntity());
     }
 

--- a/tests/unit/Storefront/Theme/Command/ThemePrepareIconsCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemePrepareIconsCommandTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Storefront\Theme\Command\ThemePrepareIconsCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -36,7 +37,7 @@ class ThemePrepareIconsCommandTest extends TestCase
 
     public function testThemePrepareIconsCommandMissingPackageArg(): void
     {
-        static::expectExceptionMessage('Not enough arguments (missing: "package")');
+        $this->expectExceptionObject(new RuntimeException('Not enough arguments (missing: "package")'));
         $this->commandTester->execute([
             'path' => $this->testDir,
         ]);
@@ -44,7 +45,7 @@ class ThemePrepareIconsCommandTest extends TestCase
 
     public function testThemePrepareIconsCommandMissingPathArg(): void
     {
-        static::expectExceptionMessage('Not enough arguments (missing: "path")');
+        $this->expectExceptionObject(new RuntimeException('Not enough arguments (missing: "path")'));
         $this->commandTester->execute([
             'package' => 'default',
         ]);

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileAvailableThemeProviderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileAvailableThemeProviderTest.php
@@ -19,8 +19,7 @@ class StaticFileAvailableThemeProviderTest extends TestCase
 {
     public function testFileNotExisting(): void
     {
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Cannot find theme configuration. Did you run bin/console theme:dump');
+        $this->expectExceptionObject(new \RuntimeException('Cannot find theme configuration. Did you run bin/console theme:dump'));
 
         $fs = new Filesystem(new InMemoryFilesystemAdapter());
         $s = new StaticFileAvailableThemeProvider($fs);

--- a/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
+++ b/tests/unit/Storefront/Theme/ConfigLoader/StaticFileConfigLoaderTest.php
@@ -22,8 +22,7 @@ class StaticFileConfigLoaderTest extends TestCase
 {
     public function testFileNotExisting(): void
     {
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Cannot find theme configuration. Did you run bin/console theme:dump');
+        $this->expectExceptionObject(new \RuntimeException('Cannot find theme configuration. Did you run bin/console theme:dump'));
 
         $fs = new Filesystem(new InMemoryFilesystemAdapter());
         $s = new StaticFileConfigLoader($fs);


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/17163

We forgot the static form

### 2. What does this change do, exactly?

Fix all the tests

### 3. Describe each step to reproduce the issue or behaviour.

Run the modified tests, same output

### 4. Please link to the relevant issues (if any).
relates https://github.com/shopware/shopware/issues/16792

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
