### PR TITLE
refactor: decouple storefront from uninstall apps strategy by shop id resolved event

### DIFF
--- a/src/Core/Framework/App/Event/ShopIdResolvedEvent.php
+++ b/src/Core/Framework/App/Event/ShopIdResolvedEvent.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Fired by the shop-id-change Resolver after a strategy has run.
+ * Listeners can gate on $strategyName (e.g. theme cleanup for the uninstall-apps strategy) and read $affectedApps for the
+ * id/name pairs of all apps that were installed when resolution started. The Resolver snapshots them BEFORE running the
+ * strategy because the uninstall path deletes the app rows, yet downstream listeners still need their technical names.
+ *
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+final class ShopIdResolvedEvent extends Event
+{
+    /**
+     * @param list<array{id: string, name: string}> $affectedApps
+     */
+    public function __construct(
+        public readonly string $strategyName,
+        public readonly array $affectedApps,
+        public readonly Context $context,
+    ) {
+    }
+}

--- a/src/Core/Framework/App/ShopIdChangeResolver/Resolver.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/Resolver.php
@@ -2,9 +2,14 @@
 
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
+use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Event\ShopIdResolvedEvent;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
@@ -14,9 +19,12 @@ readonly class Resolver
 {
     /**
      * @param AbstractShopIdChangeStrategy[] $strategies
+     * @param EntityRepository<AppCollection> $appRepository
      */
     public function __construct(
-        private iterable $strategies
+        private iterable $strategies,
+        private EntityRepository $appRepository,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -24,7 +32,15 @@ readonly class Resolver
     {
         foreach ($this->strategies as $strategy) {
             if ($strategy->getName() === $strategyName) {
+                // Snapshot the installed apps BEFORE running the strategy: the uninstall strategy deletes the rows,
+                // so listeners reacting to the resulting event would otherwise lose the technical names they need.
+                $affectedApps = $this->snapshotInstalledApps($context);
+
                 $strategy->resolve($context);
+
+                $this->eventDispatcher->dispatch(
+                    new ShopIdResolvedEvent($strategyName, $affectedApps, $context)
+                );
 
                 return;
             }
@@ -45,5 +61,18 @@ readonly class Resolver
         }
 
         return $strategies;
+    }
+
+    /**
+     * @return list<array{id: string, name: string}>
+     */
+    private function snapshotInstalledApps(Context $context): array
+    {
+        $snapshot = [];
+        foreach ($this->appRepository->search(new Criteria(), $context)->getEntities() as $app) {
+            $snapshot[] = ['id' => $app->getId(), 'name' => $app->getName()];
+        }
+
+        return $snapshot;
     }
 }

--- a/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
@@ -3,14 +3,12 @@
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
 use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -30,10 +28,6 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
     public function __construct(
         private readonly EntityRepository $appRepository,
         private readonly ShopIdProvider $shopIdProvider,
-        /**
-         * @phpstan-ignore phpat.restrictNamespacesInCore (Storefront dependency is nullable. Don't do that! Will be fixed with https://github.com/shopware/shopware/issues/12966)
-         */
-        private readonly ?ThemeAppLifecycleHandler $themeLifecycleHandler
     ) {
     }
 
@@ -58,10 +52,7 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
 
         foreach ($this->appRepository->search(new Criteria(), $context)->getEntities() as $app) {
             // Delete app manually, to not inform the app backend about the deactivation
-            // as the app is still running in the old shop with the same shopId
-            if ($this->themeLifecycleHandler) {
-                $this->themeLifecycleHandler->handleUninstall(new AppDeactivatedEvent($app, $context));
-            }
+            // as the app is still running in the old shop with the same shopId.
             $this->appRepository->delete([['id' => $app->getId()]], $context);
         }
     }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -562,6 +562,8 @@
 
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\Resolver" public="true">
             <argument type="tagged_iterator" tag="shopware.app_url_changed_resolver"/>
+            <argument type="service" id="app.repository"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\MoveShopPermanentlyStrategy">
@@ -586,7 +588,6 @@
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy">
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
-            <argument type="service" id="Shopware\Storefront\Theme\ThemeAppLifecycleHandler" on-invalid="null"/>
 
             <tag name="shopware.app_url_changed_resolver" priority="0"/>
         </service>

--- a/src/Storefront/Theme/ThemeAppLifecycleHandler.php
+++ b/src/Storefront/Theme/ThemeAppLifecycleHandler.php
@@ -6,6 +6,8 @@ use Shopware\Core\Framework\App\Event\AppActivatedEvent;
 use Shopware\Core\Framework\App\Event\AppChangedEvent;
 use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
+use Shopware\Core\Framework\App\Event\ShopIdResolvedEvent;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\AbstractStorefrontPluginConfigurationFactory;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
@@ -33,6 +35,7 @@ class ThemeAppLifecycleHandler implements EventSubscriberInterface
             AppUpdatedEvent::class => 'handleAppActivationOrUpdate',
             AppActivatedEvent::class => 'handleAppActivationOrUpdate',
             AppDeactivatedEvent::class => 'handleUninstall',
+            ShopIdResolvedEvent::class => 'handleShopIdResolved',
         ];
     }
 
@@ -78,5 +81,29 @@ class ThemeAppLifecycleHandler implements EventSubscriberInterface
         $this->themeLifecycleHandler->handleThemeUninstall($config, $event->getContext());
 
         $this->themeLifecycleHandler->refreshAllActiveThemeImportMaps($event->getContext(), $configurationCollection);
+    }
+
+    public function handleShopIdResolved(ShopIdResolvedEvent $event): void
+    {
+        // Theme cleanup only applies to the silent-uninstall strategy. Other strategies (reinstall, move-permanently)
+        // keep their app rows and themes intact, so this handler is a no-op for them.
+        if ($event->strategyName !== UninstallAppsStrategy::STRATEGY_NAME) {
+            return;
+        }
+
+        $uninstalledNames = array_column($event->affectedApps, 'name');
+
+        foreach ($uninstalledNames as $name) {
+            $config = $this->themeRegistry->getConfigurations()->getByTechnicalName($name);
+            if ($config !== null) {
+                $this->themeLifecycleHandler->handleThemeUninstall($config, $event->context);
+            }
+        }
+
+        $remaining = $this->themeRegistry
+            ->getConfigurations()
+            ->filter(static fn (StorefrontPluginConfiguration $registeredConfig): bool => !\in_array($registeredConfig->getTechnicalName(), $uninstalledNames, true));
+
+        $this->themeLifecycleHandler->refreshAllActiveThemeImportMaps($event->context, $remaining);
     }
 }

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\App\AppUrlChangeResolver;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
@@ -15,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -57,20 +55,12 @@ class UninstallAppsStrategyTest extends TestCase
 
         $shopId = $this->changeAppUrl();
 
-        $themeLifecycleHandler = null;
-        if (class_exists(ThemeAppLifecycleHandler::class)) {
-            $themeLifecycleHandler = $this->createMock(ThemeAppLifecycleHandler::class);
-            $themeLifecycleHandler->expects($this->once())
-                ->method('handleUninstall')
-                ->with(
-                    static::callback(static fn (AppDeactivatedEvent $event) => $event->getApp()->getName() === $app->getName())
-                );
-        }
-
+        // Theme cleanup is no longer the strategy's concern: it is driven by the ShopIdResolvedEvent the Resolver
+        // dispatches afterwards (covered in ResolverTest + ThemeAppLifecycleHandlerTest). The strategy only deletes
+        // the apps and regenerates the shop id.
         $uninstallAppsResolver = new UninstallAppsStrategy(
             static::getContainer()->get('app.repository'),
             $this->shopIdProvider,
-            $themeLifecycleHandler
         );
 
         $uninstallAppsResolver->resolve($this->context);

--- a/tests/unit/Core/Framework/App/ShopIdChangeResolver/ResolverTest.php
+++ b/tests/unit/Core/Framework/App/ShopIdChangeResolver/ResolverTest.php
@@ -3,12 +3,18 @@
 namespace Shopware\Tests\Unit\Core\Framework\App\ShopIdChangeResolver;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\App\Event\ShopIdResolvedEvent;
 use Shopware\Core\Framework\App\ShopIdChangeResolver\AbstractShopIdChangeStrategy;
 use Shopware\Core\Framework\App\ShopIdChangeResolver\Resolver;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @internal
@@ -20,45 +26,109 @@ class ResolverTest extends TestCase
 
     private MockObject&AbstractShopIdChangeStrategy $secondStrategy;
 
-    private Resolver $appUrlChangedResolverStrategy;
+    private EventDispatcher $eventDispatcher;
+
+    private Resolver $resolver;
 
     protected function setUp(): void
     {
         $this->firstStrategy = $this->createMock(AbstractShopIdChangeStrategy::class);
-        $this->firstStrategy->method('getName')
-            ->willReturn('FirstStrategy');
+        $this->firstStrategy->method('getName')->willReturn('FirstStrategy');
 
         $this->secondStrategy = $this->createMock(AbstractShopIdChangeStrategy::class);
-        $this->secondStrategy->method('getName')
-            ->willReturn('SecondStrategy');
+        $this->secondStrategy->method('getName')->willReturn('SecondStrategy');
 
-        $this->appUrlChangedResolverStrategy = new Resolver([
-            $this->firstStrategy,
-            $this->secondStrategy,
+        $this->eventDispatcher = new EventDispatcher();
+
+        /** @var StaticEntityRepository<AppCollection> $appRepository */
+        $appRepository = new StaticEntityRepository([
+            new AppCollection([
+                $this->createApp('app-1', 'SwagTheme'),
+                $this->createApp('app-2', 'SwagPlain'),
+            ]),
         ]);
+
+        $this->resolver = new Resolver(
+            [$this->firstStrategy, $this->secondStrategy],
+            $appRepository,
+            $this->eventDispatcher,
+        );
     }
 
     public function testItCallsRightStrategy(): void
     {
-        $this->firstStrategy->expects($this->once())
-            ->method('resolve');
+        $this->firstStrategy->expects($this->once())->method('resolve');
+        $this->secondStrategy->expects($this->never())->method('resolve');
 
-        $this->secondStrategy->expects($this->never())
-            ->method('resolve');
+        $this->resolver->resolve('FirstStrategy', Context::createDefaultContext());
+    }
 
-        $this->appUrlChangedResolverStrategy->resolve('FirstStrategy', Context::createDefaultContext());
+    #[TestDox('Dispatches ShopIdResolvedEvent with the strategy name and a snapshot of all installed apps')]
+    public function testItDispatchesShopIdResolvedEventWithAppSnapshot(): void
+    {
+        $captured = null;
+        $this->eventDispatcher->addListener(
+            ShopIdResolvedEvent::class,
+            static function (ShopIdResolvedEvent $event) use (&$captured): void {
+                $captured = $event;
+            }
+        );
+
+        $context = Context::createDefaultContext();
+        $this->resolver->resolve('FirstStrategy', $context);
+
+        static::assertInstanceOf(ShopIdResolvedEvent::class, $captured);
+        static::assertSame('FirstStrategy', $captured->strategyName);
+        static::assertSame($context, $captured->context);
+        static::assertSame([
+            ['id' => 'app-1', 'name' => 'SwagTheme'],
+            ['id' => 'app-2', 'name' => 'SwagPlain'],
+        ], $captured->affectedApps);
+    }
+
+    #[TestDox('Snapshots the apps before the strategy runs, then dispatches the event afterwards')]
+    public function testItSnapshotsAppsBeforeRunningTheStrategy(): void
+    {
+        $order = [];
+
+        $this->firstStrategy->method('resolve')->willReturnCallback(
+            static function () use (&$order): void {
+                $order[] = 'resolve';
+            }
+        );
+
+        $this->eventDispatcher->addListener(
+            ShopIdResolvedEvent::class,
+            static function () use (&$order): void {
+                $order[] = 'event';
+            }
+        );
+
+        $this->resolver->resolve('FirstStrategy', Context::createDefaultContext());
+
+        static::assertSame(['resolve', 'event'], $order);
     }
 
     public function testItThrowsOnUnknownStrategy(): void
     {
-        $this->firstStrategy->expects($this->never())
-            ->method('resolve');
+        $this->firstStrategy->expects($this->never())->method('resolve');
+        $this->secondStrategy->expects($this->never())->method('resolve');
 
-        $this->secondStrategy->expects($this->never())
-            ->method('resolve');
+        $eventDispatched = false;
+        $this->eventDispatcher->addListener(
+            ShopIdResolvedEvent::class,
+            static function () use (&$eventDispatched): void {
+                $eventDispatched = true;
+            }
+        );
 
         $this->expectExceptionObject(AppException::shopIdChangeResolveStrategyNotFound('ThirdStrategy'));
-        $this->appUrlChangedResolverStrategy->resolve('ThirdStrategy', Context::createDefaultContext());
+
+        try {
+            $this->resolver->resolve('ThirdStrategy', Context::createDefaultContext());
+        } finally {
+            static::assertFalse($eventDispatched);
+        }
     }
 
     public function testGetAvailableStrategies(): void
@@ -74,6 +144,15 @@ class ResolverTest extends TestCase
         static::assertSame([
             'FirstStrategy' => 'first description',
             'SecondStrategy' => 'second description',
-        ], $this->appUrlChangedResolverStrategy->getAvailableStrategies());
+        ], $this->resolver->getAvailableStrategies());
+    }
+
+    private function createApp(string $id, string $name): AppEntity
+    {
+        $app = new AppEntity();
+        $app->setUniqueIdentifier($id);
+        $app->assign(['id' => $id, 'name' => $name]);
+
+        return $app;
     }
 }

--- a/tests/unit/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Event\AppActivatedEvent;
 use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
+use Shopware\Core\Framework\App\Event\ShopIdResolvedEvent;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
 use Shopware\Core\Framework\Context;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\AbstractStorefrontPluginConfigurationFactory;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
@@ -112,5 +114,68 @@ class ThemeAppLifecycleHandlerTest extends TestCase
 
         $app = (new AppEntity())->assign(['name' => 'ComponentTestApp']);
         $handler->handleUninstall(new AppDeactivatedEvent($app, Context::createDefaultContext()));
+    }
+
+    public function testShopIdResolvedUninstallStrategyCleansUpThemesForAffectedApps(): void
+    {
+        $config = new StorefrontPluginConfiguration('ComponentTestApp');
+        $configurations = new StorefrontPluginConfigurationCollection([$config]);
+
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn($configurations);
+
+        $factory = $this->createMock(AbstractStorefrontPluginConfigurationFactory::class);
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->once())->method('handleThemeUninstall')->with($config, static::isInstanceOf(Context::class));
+        $lifecycle->expects($this->once())->method('refreshAllActiveThemeImportMaps');
+
+        $handler = new ThemeAppLifecycleHandler($registry, $factory, $lifecycle);
+
+        $event = new ShopIdResolvedEvent(
+            UninstallAppsStrategy::STRATEGY_NAME,
+            [['id' => 'app-1', 'name' => 'ComponentTestApp']],
+            Context::createDefaultContext(),
+        );
+        $handler->handleShopIdResolved($event);
+    }
+
+    public function testShopIdResolvedUninstallStrategySkipsAppsWithoutThemeConfig(): void
+    {
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn(new StorefrontPluginConfigurationCollection());
+
+        $factory = $this->createMock(AbstractStorefrontPluginConfigurationFactory::class);
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->never())->method('handleThemeUninstall');
+        $lifecycle->expects($this->once())->method('refreshAllActiveThemeImportMaps');
+
+        $handler = new ThemeAppLifecycleHandler($registry, $factory, $lifecycle);
+
+        $event = new ShopIdResolvedEvent(
+            UninstallAppsStrategy::STRATEGY_NAME,
+            [['id' => 'app-1', 'name' => 'PlainApp']],
+            Context::createDefaultContext(),
+        );
+        $handler->handleShopIdResolved($event);
+    }
+
+    public function testShopIdResolvedIgnoresNonUninstallStrategies(): void
+    {
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->expects($this->never())->method('getConfigurations');
+
+        $factory = $this->createMock(AbstractStorefrontPluginConfigurationFactory::class);
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->never())->method('handleThemeUninstall');
+        $lifecycle->expects($this->never())->method('refreshAllActiveThemeImportMaps');
+
+        $handler = new ThemeAppLifecycleHandler($registry, $factory, $lifecycle);
+
+        $event = new ShopIdResolvedEvent(
+            'reinstall-apps',
+            [['id' => 'app-1', 'name' => 'ComponentTestApp']],
+            Context::createDefaultContext(),
+        );
+        $handler->handleShopIdResolved($event);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
 `\Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy` carries an implicit dependency on Storefront through a nullable `?ThemeAppLifecycleHandler $themeLifecycleHandler` constructor parameter. 

Core should not need to be aware of it.

Alternative of https://github.com/shopware/shopware/pull/17150 and  https://github.com/shopware/shopware/pull/17120

### 2. What does this change do, exactly?
 No strategy API change, resolve() stays void. Instead:

  - Resolver gains app.repository + event_dispatcher. It snapshots all installed apps ([{id,name}]) before running the matched strategy, then dispatches ShopIdResolvedEvent($strategyName, $snapshot, $context) after. Snapshot-before is essential because the uninstall strategy deletes the rows.

  - UninstallAppsStrategy drops the ?ThemeAppLifecycleHandler Storefront dependency (and the phpat ignore) entirely: it just deletes apps + regenerates the shop id.

  - ShopIdResolvedEvent (new, Core): the decoupling part.

  - ThemeAppLifecycleHandler (Storefront) subscribes to ShopIdResolvedEvent, gates on strategyName === uninstall-apps, and cleans up themes by the snapshotted names.

### 3. Describe each step to reproduce the issue or behaviour.
Run the tests

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/17119
- relates https://github.com/shopware/shopware/issues/12966

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
