### PR TITLE
refactor: decouple storefront uninstall resolver decorator

### DIFF
--- a/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
@@ -3,14 +3,12 @@
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
 use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -30,10 +28,6 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
     public function __construct(
         private readonly EntityRepository $appRepository,
         private readonly ShopIdProvider $shopIdProvider,
-        /**
-         * @phpstan-ignore phpat.restrictNamespacesInCore (Storefront dependency is nullable. Don't do that! Will be fixed with https://github.com/shopware/shopware/issues/12966)
-         */
-        private readonly ?ThemeAppLifecycleHandler $themeLifecycleHandler
     ) {
     }
 
@@ -58,10 +52,7 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
 
         foreach ($this->appRepository->search(new Criteria(), $context)->getEntities() as $app) {
             // Delete app manually, to not inform the app backend about the deactivation
-            // as the app is still running in the old shop with the same shopId
-            if ($this->themeLifecycleHandler) {
-                $this->themeLifecycleHandler->handleUninstall(new AppDeactivatedEvent($app, $context));
-            }
+            // as the app is still running in the old shop with the same shopId.
             $this->appRepository->delete([['id' => $app->getId()]], $context);
         }
     }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -586,7 +586,6 @@
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy">
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
-            <argument type="service" id="Shopware\Storefront\Theme\ThemeAppLifecycleHandler" on-invalid="null"/>
 
             <tag name="shopware.app_url_changed_resolver" priority="0"/>
         </service>

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -120,6 +120,14 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Storefront\Theme\ThemeCleanupResolverDecorator"
+                 decorates="Shopware\Core\Framework\App\ShopIdChangeResolver\Resolver" public="true">
+            <argument type="service" id="Shopware\Storefront\Theme\ThemeCleanupResolverDecorator.inner"/>
+            <argument type="service" id="app.repository"/>
+            <argument type="service" id="Shopware\Storefront\Theme\StorefrontPluginRegistry"/>
+            <argument type="service" id="Shopware\Storefront\Theme\ThemeLifecycleHandler"/>
+        </service>
+
         <service id="Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>

--- a/src/Storefront/Theme/ThemeCleanupResolverDecorator.php
+++ b/src/Storefront/Theme/ThemeCleanupResolverDecorator.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\Resolver;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+
+/**
+ * Decorates the Core shop-id-change Resolver to run Storefront theme cleanup after the silent uninstall
+ * strategy completed, without Core having to know about themes. The app names are captured before the
+ * strategy runs because the uninstall path deletes the app rows.
+ *
+ * @internal
+ */
+#[Package('framework')]
+readonly class ThemeCleanupResolverDecorator extends Resolver
+{
+    /**
+     * @param EntityRepository<AppCollection> $appRepository
+     */
+    public function __construct(
+        private Resolver $inner,
+        private EntityRepository $appRepository,
+        private StorefrontPluginRegistry $themeRegistry,
+        private ThemeLifecycleHandler $themeLifecycleHandler,
+    ) {
+        parent::__construct([]);
+    }
+
+    public function resolve(string $strategyName, Context $context): void
+    {
+        if ($strategyName !== UninstallAppsStrategy::STRATEGY_NAME) {
+            $this->inner->resolve($strategyName, $context);
+
+            return;
+        }
+
+        // Capture the technical names before the strategy deletes the app rows.
+        $uninstalledNames = [];
+        foreach ($this->appRepository->search(new Criteria(), $context)->getEntities() as $app) {
+            $uninstalledNames[] = $app->getName();
+        }
+
+        $this->inner->resolve($strategyName, $context);
+
+        $this->cleanupThemes($uninstalledNames, $context);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getAvailableStrategies(): array
+    {
+        return $this->inner->getAvailableStrategies();
+    }
+
+    /**
+     * @param array<string> $uninstalledNames
+     */
+    private function cleanupThemes(array $uninstalledNames, Context $context): void
+    {
+        foreach ($uninstalledNames as $name) {
+            $config = $this->themeRegistry->getConfigurations()->getByTechnicalName($name);
+            if ($config !== null) {
+                $this->themeLifecycleHandler->handleThemeUninstall($config, $context);
+            }
+        }
+
+        $remaining = $this->themeRegistry
+            ->getConfigurations()
+            ->filter(static fn (StorefrontPluginConfiguration $config): bool => !\in_array($config->getTechnicalName(), $uninstalledNames, true));
+
+        $this->themeLifecycleHandler->refreshAllActiveThemeImportMaps($context, $remaining);
+    }
+}

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\App\AppUrlChangeResolver;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
@@ -15,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -57,20 +55,12 @@ class UninstallAppsStrategyTest extends TestCase
 
         $shopId = $this->changeAppUrl();
 
-        $themeLifecycleHandler = null;
-        if (class_exists(ThemeAppLifecycleHandler::class)) {
-            $themeLifecycleHandler = $this->createMock(ThemeAppLifecycleHandler::class);
-            $themeLifecycleHandler->expects($this->once())
-                ->method('handleUninstall')
-                ->with(
-                    static::callback(static fn (AppDeactivatedEvent $event) => $event->getApp()->getName() === $app->getName())
-                );
-        }
-
+        // Theme cleanup is no longer the strategy's concern: it is handled by the Storefront-side
+        // ThemeCleanupResolverDecorator around the Core Resolver. The strategy only deletes the apps
+        // and regenerates the shop id.
         $uninstallAppsResolver = new UninstallAppsStrategy(
             static::getContainer()->get('app.repository'),
             $this->shopIdProvider,
-            $themeLifecycleHandler
         );
 
         $uninstallAppsResolver->resolve($this->context);

--- a/tests/unit/Storefront/Theme/ThemeCleanupResolverDecoratorTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCleanupResolverDecoratorTest.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\AbstractShopIdChangeStrategy;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\Resolver;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+use Shopware\Storefront\Theme\StorefrontPluginRegistry;
+use Shopware\Storefront\Theme\ThemeCleanupResolverDecorator;
+use Shopware\Storefront\Theme\ThemeLifecycleHandler;
+
+/**
+ * @internal
+ */
+#[CoversClass(ThemeCleanupResolverDecorator::class)]
+class ThemeCleanupResolverDecoratorTest extends TestCase
+{
+    #[TestDox('Uninstall strategy: cleans up themes for the apps that were installed, then refreshes import maps')]
+    public function testUninstallStrategyCleansThemesForUninstalledApps(): void
+    {
+        $config = new StorefrontPluginConfiguration('SwagTheme');
+
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn(new StorefrontPluginConfigurationCollection([$config]));
+
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->once())->method('handleThemeUninstall')->with($config, static::isInstanceOf(Context::class));
+        $lifecycle->expects($this->once())->method('refreshAllActiveThemeImportMaps');
+
+        $strategy = $this->uninstallStrategy();
+        $strategy->expects($this->once())->method('resolve');
+
+        $decorator = new ThemeCleanupResolverDecorator(
+            new Resolver([$strategy]),
+            $this->appRepository('SwagTheme', 'PlainApp'),
+            $registry,
+            $lifecycle,
+        );
+
+        $decorator->resolve(UninstallAppsStrategy::STRATEGY_NAME, Context::createDefaultContext());
+    }
+
+    #[TestDox('Theme cleanup runs after the inner strategy (which deletes the apps), using the pre-captured names')]
+    public function testThemeCleanupRunsAfterInnerResolve(): void
+    {
+        $order = [];
+
+        $strategy = $this->uninstallStrategy();
+        $strategy->method('resolve')->willReturnCallback(static function () use (&$order): void {
+            $order[] = 'resolve';
+        });
+
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->method('refreshAllActiveThemeImportMaps')->willReturnCallback(static function () use (&$order): void {
+            $order[] = 'cleanup';
+        });
+
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn(new StorefrontPluginConfigurationCollection());
+
+        $decorator = new ThemeCleanupResolverDecorator(
+            new Resolver([$strategy]),
+            $this->appRepository('SwagTheme'),
+            $registry,
+            $lifecycle,
+        );
+
+        $decorator->resolve(UninstallAppsStrategy::STRATEGY_NAME, Context::createDefaultContext());
+
+        static::assertSame(['resolve', 'cleanup'], $order);
+    }
+
+    #[TestDox('Other strategies are delegated untouched: no app lookup and no theme cleanup')]
+    public function testOtherStrategiesAreDelegatedWithoutThemeCleanup(): void
+    {
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->expects($this->never())->method('getConfigurations');
+
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->never())->method('handleThemeUninstall');
+        $lifecycle->expects($this->never())->method('refreshAllActiveThemeImportMaps');
+
+        $strategy = $this->createMock(AbstractShopIdChangeStrategy::class);
+        $strategy->method('getName')->willReturn('reinstall-apps');
+        $strategy->expects($this->once())->method('resolve');
+
+        $decorator = new ThemeCleanupResolverDecorator(
+            new Resolver([$strategy]),
+            $this->appRepository(),
+            $registry,
+            $lifecycle,
+        );
+
+        $decorator->resolve('reinstall-apps', Context::createDefaultContext());
+    }
+
+    public function testGetAvailableStrategiesIsDelegatedToInner(): void
+    {
+        $strategy = $this->uninstallStrategy();
+        $strategy->method('getDescription')->willReturn('uninstall description');
+
+        $decorator = new ThemeCleanupResolverDecorator(
+            new Resolver([$strategy]),
+            $this->appRepository(),
+            $this->createMock(StorefrontPluginRegistry::class),
+            $this->createMock(ThemeLifecycleHandler::class),
+        );
+
+        static::assertSame(
+            [UninstallAppsStrategy::STRATEGY_NAME => 'uninstall description'],
+            $decorator->getAvailableStrategies(),
+        );
+    }
+
+    private function uninstallStrategy(): AbstractShopIdChangeStrategy&MockObject
+    {
+        $strategy = $this->createMock(AbstractShopIdChangeStrategy::class);
+        $strategy->method('getName')->willReturn(UninstallAppsStrategy::STRATEGY_NAME);
+
+        return $strategy;
+    }
+
+    /**
+     * @return StaticEntityRepository<AppCollection>
+     */
+    private function appRepository(string ...$names): StaticEntityRepository
+    {
+        $apps = [];
+        foreach ($names as $i => $name) {
+            $app = new AppEntity();
+            $app->setUniqueIdentifier('app-' . $i);
+            $app->assign(['id' => 'app-' . $i, 'name' => $name]);
+            $apps[] = $app;
+        }
+
+        /** @var StaticEntityRepository<AppCollection> $repository */
+        $repository = new StaticEntityRepository([new AppCollection($apps)]);
+
+        return $repository;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
\Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy carries an implicit dependency on Storefront through a nullable ?ThemeAppLifecycleHandler $themeLifecycleHandler constructor parameter.

Core should not need to be aware of it.

Initially discarded, but after exploring https://github.com/shopware/shopware/pull/17181 it could be an option

### 2. What does this change do, exactly?
Decorating UninstallAppsStrategy from Storefront via the existing AbstractShopIdChangeStrategy::getDecorated() pattern

### 3. Describe each step to reproduce the issue or behaviour.
Run the tests

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/17119
- relates https://github.com/shopware/shopware/issues/12966

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
