### PR TITLE
fix(media): apply search term on route query change

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js
@@ -70,8 +70,26 @@ export default {
 
     watch: {
         routeFolderId() {
-            this.term = '';
+            // Adopt the term from the new route query (e.g. when the user clicks a
+            // global search-bar suggestion that points at a different folder) instead
+            // of unconditionally clearing it.
+            this.term = this.$route.query?.term ?? '';
+            this.clearSelection();
             this.updateFolder();
+        },
+
+        '$route.query.term'(value) {
+            // When the route changes only in its `term` query (same folder, e.g. the
+            // user clicks a media search suggestion while already on `sw.media.index`),
+            // the `routeFolderId` watcher does not fire — sync the term explicitly so
+            // the media library reloads with the new search.
+            const next = value ?? '';
+            if (this.term === next) {
+                return;
+            }
+
+            this.term = next;
+            this.clearSelection();
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.spec.js
@@ -2,9 +2,13 @@
  * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
+import { reactive } from 'vue';
 
-async function createWrapper() {
+async function createWrapper({ route, props = {} } = {}) {
+    const $route = reactive(route ?? { query: {} });
+
     return mount(await wrapTestComponent('sw-media-index', { sync: true }), {
+        props,
         global: {
             renderStubDefaultSlot: true,
             stubs: {
@@ -23,9 +27,7 @@ async function createWrapper() {
                 'sw-loader': true,
             },
             mocks: {
-                $route: {
-                    query: '',
-                },
+                $route,
             },
             provide: {
                 repositoryFactory: {
@@ -128,5 +130,43 @@ describe('src/module/sw-media/page/sw-media-index', () => {
         expect(wrapper.vm.reloadList).not.toHaveBeenCalled();
         expect(wrapper.vm.uploads).toHaveLength(0);
         expect(wrapper.vm.pendingUploadsCount).toBe(1);
+    });
+
+    it('seeds the search term from the initial route query', async () => {
+        const wrapper = await createWrapper({ route: { query: { term: 'logo.png' } } });
+
+        expect(wrapper.vm.term).toBe('logo.png');
+    });
+
+    it('syncs the search term when the route query.term changes in the same folder', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.$route.query = { term: 'logo.png' };
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.term).toBe('logo.png');
+        expect(wrapper.vm.selectedItems).toHaveLength(0);
+    });
+
+    it('adopts the route query.term when the folder changes', async () => {
+        const wrapper = await createWrapper({ route: { query: { term: 'first.png' } } });
+        expect(wrapper.vm.term).toBe('first.png');
+
+        // Simulate clicking a search suggestion that targets a different folder
+        // with a different term — both the routeFolderId prop and $route.query.term change.
+        wrapper.vm.$route.query = { term: 'second.png' };
+        await wrapper.setProps({ routeFolderId: 'folder-id' });
+
+        expect(wrapper.vm.term).toBe('second.png');
+    });
+
+    it('clears the search term when the folder changes without a route query.term', async () => {
+        const wrapper = await createWrapper({ route: { query: { term: 'first.png' } } });
+        expect(wrapper.vm.term).toBe('first.png');
+
+        wrapper.vm.$route.query = {};
+        await wrapper.setProps({ routeFolderId: 'folder-id' });
+
+        expect(wrapper.vm.term).toBe('');
     });
 });


### PR DESCRIPTION
## Fix which issue

Closes #14242

## What exactly the issue is

When OpenSearch is enabled for the Administration (`SHOPWARE_ADMIN_ES_ENABLED=1`) and a user searches for media files via the global search bar on the media overview, clicking a result in the suggestion dropdown updates the URL to `…/media/index?term=<filename>` but the media grid does **not** filter to the result. Only a hard reload (F5) renders the filtered list.

The same symptom occurs when pasting a `…/media/index?term=…` URL into the address bar while already on the media overview: the search input shows the term but no search request is dispatched.

## Root causes

`src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js` initializes `term` from `this.$route.query?.term` once in `data()`, then mutates it only via:

- `onSearch(value)` — when the user types into the search input and emits `@search`.
- `routeFolderId()` watcher — when navigating to a different folder.
- `updateRoute(newFolderId)` — when changing folder programmatically.

There is **no watcher on `$route.query.term`**, so when the route changes only in its `term` query (same folder, e.g. a suggestion click while already on `sw.media.index`), the local `term` data stays stale. The media library's `term` prop never updates and its term watcher never fires.

In addition, the `routeFolderId()` watcher unconditionally reset `term = ''`. That swallowed the new query term when a suggestion targeted a different folder than the one currently open — the breadcrumb switched, but the term was wiped.

## Solution

`src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/index.js`:

- Added a `'$route.query.term'(value)` watcher that syncs `this.term` whenever the route's `term` query changes without a folder change. Clears the current selection on change and short-circuits when the value is already in sync.
- Changed the `routeFolderId()` watcher to seed `this.term` from `this.$route.query?.term ?? ''` instead of always clearing it, so a suggestion that lives in another folder still applies its term after the folder swap. Also clears the selection on the folder switch for consistency with the existing search flow.

The media library already watches its `term` prop and reloads — the missing piece was upstream propagation.

`src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.spec.js`:

- Reactive `$route` mock so prop and route mutations actually trigger watchers.
- Four new unit tests covering: initial term from query, same-folder term sync, cross-folder term adoption, and folder change without a term clears the term.

## Acceptance criteria

- Clicking a media search suggestion while on `sw.media.index` updates the URL **and** filters the grid in a single action, regardless of whether the suggestion lives in the current folder or another one.
- Pasting `…/media/index?term=<filename>` into the address bar while already on the media overview triggers the search request and renders the filtered grid.
- Existing flows are unchanged: typing in the search input (`onSearch`), navigating folders without a term, navigating folders with an existing term (the `updateRoute()` fallback from #12017), browser back/forward.
- All unit tests pass — 12/12 in `sw-media-index.spec.js`, including the four new tests.

## Steps to reproduce

Pre-conditions: a Shopware instance with `SHOPWARE_ADMIN_ES_ENABLED=1` and `bin/console es:admin:index` run after enabling.

1. Open Admin → Content → Media.
2. In the header search bar, type a media filename (e.g. `logo`).
3. Wait for the result dropdown.
4. Click one of the results.

**Before this PR:** URL becomes `#/sw/media/index?term=logo.png`, but the grid still shows all media. Only a hard reload renders the filtered result.

**After this PR:** URL updates and the grid filters to the searched term in the same action, no reload needed.

Alternative reproduction: while on `#/sw/media/index`, change the URL to `#/sw/media/index?term=logo.png` directly. Before the PR, the input shows the term but the grid does not filter. After the PR, the search request fires and the grid filters.