### PR TITLE
refactor: decouple storefront uninstall tagged subscriber

### DIFF
--- a/src/Core/Framework/App/ShopIdChangeResolver/AppsUninstalledHandler.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/AppsUninstalledHandler.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
+
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Port implemented outside Core (e.g. Storefront) to react to apps being silently uninstalled by the
+ * uninstall-apps shop-id-change strategy. Called with the live app entities BEFORE they are deleted, so
+ * implementations still have everything they need (e.g. technical names for theme cleanup). Core only
+ * knows this contract; it does not know who implements it.
+ *
+ * @internal only for use by the app-system
+ */
+#[Package('framework')]
+interface AppsUninstalledHandler
+{
+    public function uninstalled(AppCollection $apps, Context $context): void;
+}

--- a/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
+++ b/src/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategy.php
@@ -3,14 +3,12 @@
 namespace Shopware\Core\Framework\App\ShopIdChangeResolver;
 
 use Shopware\Core\Framework\App\AppCollection;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -26,14 +24,12 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
 
     /**
      * @param EntityRepository<AppCollection> $appRepository
+     * @param iterable<AppsUninstalledHandler> $subscribers
      */
     public function __construct(
         private readonly EntityRepository $appRepository,
         private readonly ShopIdProvider $shopIdProvider,
-        /**
-         * @phpstan-ignore phpat.restrictNamespacesInCore (Storefront dependency is nullable. Don't do that! Will be fixed with https://github.com/shopware/shopware/issues/12966)
-         */
-        private readonly ?ThemeAppLifecycleHandler $themeLifecycleHandler
+        private readonly iterable $subscribers,
     ) {
     }
 
@@ -56,12 +52,21 @@ class UninstallAppsStrategy extends AbstractShopIdChangeStrategy
     {
         $this->shopIdProvider->deleteShopId();
 
-        foreach ($this->appRepository->search(new Criteria(), $context)->getEntities() as $app) {
+        $apps = $this->appRepository->search(new Criteria(), $context)->getEntities();
+
+        if ($apps->count() === 0) {
+            return;
+        }
+
+        // Notify subscribers before the deletes, so they can act on the live app entities
+        // (e.g. Storefront theme cleanup) without Core knowing who reacts.
+        foreach ($this->subscribers as $subscriber) {
+            $subscriber->uninstalled($apps, $context);
+        }
+
+        foreach ($apps as $app) {
             // Delete app manually, to not inform the app backend about the deactivation
-            // as the app is still running in the old shop with the same shopId
-            if ($this->themeLifecycleHandler) {
-                $this->themeLifecycleHandler->handleUninstall(new AppDeactivatedEvent($app, $context));
-            }
+            // as the app is still running in the old shop with the same shopId.
             $this->appRepository->delete([['id' => $app->getId()]], $context);
         }
     }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -586,7 +586,7 @@
         <service id="Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy">
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
-            <argument type="service" id="Shopware\Storefront\Theme\ThemeAppLifecycleHandler" on-invalid="null"/>
+            <argument type="tagged_iterator" tag="shopware.apps_uninstalled_handler"/>
 
             <tag name="shopware.app_url_changed_resolver" priority="0"/>
         </service>

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -120,6 +120,13 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Storefront\Theme\ThemeAppsUninstalledHandler">
+            <argument type="service" id="Shopware\Storefront\Theme\StorefrontPluginRegistry"/>
+            <argument type="service" id="Shopware\Storefront\Theme\ThemeLifecycleHandler"/>
+
+            <tag name="shopware.apps_uninstalled_handler"/>
+        </service>
+
         <service id="Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>

--- a/src/Storefront/Theme/ThemeAppsUninstalledHandler.php
+++ b/src/Storefront/Theme/ThemeAppsUninstalledHandler.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Theme;
+
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\AppsUninstalledHandler;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+
+/**
+ * Storefront adapter for the Core {@see AppsUninstalledHandler} port: cleans up themes for apps
+ * removed by the silent uninstall strategy. Core only depends on the interface; this implementation is wired
+ * in via the `shopware.apps_uninstalled_handler` tag.
+ *
+ * @internal
+ */
+#[Package('framework')]
+readonly class ThemeAppsUninstalledHandler implements AppsUninstalledHandler
+{
+    public function __construct(
+        private StorefrontPluginRegistry $themeRegistry,
+        private ThemeLifecycleHandler $themeLifecycleHandler,
+    ) {
+    }
+
+    public function uninstalled(AppCollection $apps, Context $context): void
+    {
+        $uninstalledNames = array_values($apps->map(static fn ($app): string => $app->getName()));
+
+        foreach ($uninstalledNames as $name) {
+            $config = $this->themeRegistry->getConfigurations()->getByTechnicalName($name);
+            if ($config !== null) {
+                $this->themeLifecycleHandler->handleThemeUninstall($config, $context);
+            }
+        }
+
+        $remaining = $this->themeRegistry
+            ->getConfigurations()
+            ->filter(static fn (StorefrontPluginConfiguration $config): bool => !\in_array($config->getTechnicalName(), $uninstalledNames, true));
+
+        $this->themeLifecycleHandler->refreshAllActiveThemeImportMaps($context, $remaining);
+    }
+}

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Core\Framework\App\AppUrlChangeResolver;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
-use Shopware\Core\Framework\App\Event\AppDeactivatedEvent;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
@@ -15,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
-use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
 
 /**
  * @internal
@@ -57,20 +55,13 @@ class UninstallAppsStrategyTest extends TestCase
 
         $shopId = $this->changeAppUrl();
 
-        $themeLifecycleHandler = null;
-        if (class_exists(ThemeAppLifecycleHandler::class)) {
-            $themeLifecycleHandler = $this->createMock(ThemeAppLifecycleHandler::class);
-            $themeLifecycleHandler->expects($this->once())
-                ->method('handleUninstall')
-                ->with(
-                    static::callback(static fn (AppDeactivatedEvent $event) => $event->getApp()->getName() === $app->getName())
-                );
-        }
-
+        // Theme cleanup is no longer the strategy's concern: Storefront registers a SilentlyUninstalledAppsSubscriber
+        // (ThemeSilentUninstallSubscriber) via tag. The strategy only notifies subscribers, deletes the apps and
+        // regenerates the shop id; here we pass no subscribers.
         $uninstallAppsResolver = new UninstallAppsStrategy(
             static::getContainer()->get('app.repository'),
             $this->shopIdProvider,
-            $themeLifecycleHandler
+            [],
         );
 
         $uninstallAppsResolver->resolve($this->context);

--- a/tests/unit/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/unit/Core/Framework/App/ShopIdChangeResolver/UninstallAppsStrategyTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\ShopIdChangeResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\AppsUninstalledHandler;
+use Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[CoversClass(UninstallAppsStrategy::class)]
+class UninstallAppsStrategyTest extends TestCase
+{
+    #[TestDox('Notifies subscribers with the live apps before deleting them, and regenerates the shop id')]
+    public function testNotifiesSubscribersBeforeDeletingApps(): void
+    {
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('deleteShopId');
+
+        $subscriber = $this->createMock(AppsUninstalledHandler::class);
+        $subscriber->expects($this->once())
+            ->method('uninstalled')
+            ->with(
+                static::callback(static fn (AppCollection $apps): bool => $apps->count() === 2),
+                static::isInstanceOf(Context::class),
+            );
+
+        $strategy = new UninstallAppsStrategy(
+            $this->appRepository('SwagTheme', 'PlainApp'),
+            $shopIdProvider,
+            [$subscriber],
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+    }
+
+    #[TestDox('Skips subscriber notification when no apps are installed')]
+    public function testSkipsNotificationWhenNoAppsInstalled(): void
+    {
+        $shopIdProvider = $this->createMock(ShopIdProvider::class);
+        $shopIdProvider->expects($this->once())->method('deleteShopId');
+
+        $subscriber = $this->createMock(AppsUninstalledHandler::class);
+        $subscriber->expects($this->never())->method('uninstalled');
+
+        $strategy = new UninstallAppsStrategy(
+            $this->appRepository(),
+            $shopIdProvider,
+            [$subscriber],
+        );
+
+        $strategy->resolve(Context::createDefaultContext());
+    }
+
+    /**
+     * @return StaticEntityRepository<AppCollection>
+     */
+    private function appRepository(string ...$names): StaticEntityRepository
+    {
+        $apps = [];
+        foreach ($names as $i => $name) {
+            $app = new AppEntity();
+            $app->setUniqueIdentifier('app-' . $i);
+            $app->assign(['id' => 'app-' . $i, 'name' => $name]);
+            $apps[] = $app;
+        }
+
+        /** @var StaticEntityRepository<AppCollection> $repository */
+        $repository = new StaticEntityRepository([new AppCollection($apps)]);
+
+        return $repository;
+    }
+}

--- a/tests/unit/Storefront/Theme/ThemeAppsUninstalledHandlerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeAppsUninstalledHandlerTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Theme;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+use Shopware\Storefront\Theme\StorefrontPluginRegistry;
+use Shopware\Storefront\Theme\ThemeAppsUninstalledHandler;
+use Shopware\Storefront\Theme\ThemeLifecycleHandler;
+
+/**
+ * @internal
+ */
+#[CoversClass(ThemeAppsUninstalledHandler::class)]
+class ThemeAppsUninstalledHandlerTest extends TestCase
+{
+    #[TestDox('Cleans up themes for the uninstalled apps and refreshes the remaining import maps')]
+    public function testCleansUpThemesForUninstalledApps(): void
+    {
+        $config = new StorefrontPluginConfiguration('SwagTheme');
+
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn(new StorefrontPluginConfigurationCollection([$config]));
+
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->once())->method('handleThemeUninstall')->with($config, static::isInstanceOf(Context::class));
+        $lifecycle->expects($this->once())->method('refreshAllActiveThemeImportMaps');
+
+        $subscriber = new ThemeAppsUninstalledHandler($registry, $lifecycle);
+        $subscriber->uninstalled($this->apps('SwagTheme', 'PlainApp'), Context::createDefaultContext());
+    }
+
+    #[TestDox('Skips apps without a theme configuration but still refreshes import maps')]
+    public function testSkipsAppsWithoutThemeConfig(): void
+    {
+        $registry = $this->createMock(StorefrontPluginRegistry::class);
+        $registry->method('getConfigurations')->willReturn(new StorefrontPluginConfigurationCollection());
+
+        $lifecycle = $this->createMock(ThemeLifecycleHandler::class);
+        $lifecycle->expects($this->never())->method('handleThemeUninstall');
+        $lifecycle->expects($this->once())->method('refreshAllActiveThemeImportMaps');
+
+        $subscriber = new ThemeAppsUninstalledHandler($registry, $lifecycle);
+        $subscriber->uninstalled($this->apps('PlainApp'), Context::createDefaultContext());
+    }
+
+    private function apps(string ...$names): AppCollection
+    {
+        $apps = [];
+        foreach ($names as $i => $name) {
+            $app = new AppEntity();
+            $app->setUniqueIdentifier('app-' . $i);
+            $app->assign(['id' => 'app-' . $i, 'name' => $name]);
+            $apps[] = $app;
+        }
+
+        return new AppCollection($apps);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
\Shopware\Core\Framework\App\ShopIdChangeResolver\UninstallAppsStrategy carries an implicit dependency on Storefront through a nullable ?ThemeAppLifecycleHandler $themeLifecycleHandler constructor parameter.

Core should not need to be aware of it.

Last alternative using tagging

### 2. What does this change do, exactly?

Port + adapter via tagged collection where Core defines a contract and Storefront implements it. 
This means no explicit event, and Resolver is untouched

### 3. Describe each step to reproduce the issue or behaviour.

Run the tests

### 4. Please link to the relevant issues (if any).

- closes https://github.com/shopware/shopware/issues/17119
- relates https://github.com/shopware/shopware/issues/12966

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
