### PR TITLE
fix: make svg violation exceptions more verbose

### DIFF
--- a/src/Core/Content/Media/File/SvgContentValidator.php
+++ b/src/Core/Content/Media/File/SvgContentValidator.php
@@ -6,7 +6,6 @@ use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 #[Package('discovery')]

--- a/src/Core/Content/Media/File/SvgContentValidator.php
+++ b/src/Core/Content/Media/File/SvgContentValidator.php
@@ -7,9 +7,10 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('discovery')]
-class SvgContentValidator extends AbstractFileContentValidator
+class SvgContentValidator extends AbstractFileContentValidator implements ResetInterface
 {
     private const SVG = 'svg';
     private const STYLE = 'style';
@@ -42,7 +43,7 @@ class SvgContentValidator extends AbstractFileContentValidator
      */
     private readonly array $allowedReferenceAttributes;
 
-    private readonly ConstraintViolationList $violations;
+    private ConstraintViolationList $violations;
 
     /**
      * @internal
@@ -74,12 +75,10 @@ class SvgContentValidator extends AbstractFileContentValidator
 
     public function validate(MediaFile $mediaFile): void
     {
+        $this->reset();
+
         if ($this->supports($mediaFile) === false) {
             return;
-        }
-
-        while ($this->violations->count() > 0) {
-            $this->violations->offsetUnset(0);
         }
 
         $previousErrorHandling = $this->captureLibxmlErrors();
@@ -103,6 +102,11 @@ class SvgContentValidator extends AbstractFileContentValidator
         } finally {
             $this->restoreLibxmlErrorHandling($previousErrorHandling);
         }
+    }
+
+    public function reset(): void
+    {
+        $this->violations = new ConstraintViolationList();
     }
 
     private function validateDocument(\XMLReader $reader): void

--- a/src/Core/Content/Media/File/SvgContentValidator.php
+++ b/src/Core/Content/Media/File/SvgContentValidator.php
@@ -227,38 +227,17 @@ class SvgContentValidator extends AbstractFileContentValidator
 
     private function getViolationsMessage(): string
     {
-        $groupedInvalidValues = array_reduce(
-            iterator_to_array($this->violations->getIterator()),
-            static function (array $acc, ConstraintViolationInterface $violation): array {
-                $acc[(string) $violation->getMessage()] = array_unique(
-                    array_merge(
-                        $acc[(string) $violation->getMessage()] ?? [],
-                        [$violation->getInvalidValue()]
-                    )
-                );
+        $valuesByMessage = [];
+        foreach ($this->violations as $violation) {
+            $valuesByMessage[(string) $violation->getMessage()][] = $violation->getInvalidValue();
+        }
 
-                return $acc;
-            },
-            []
-        );
+        $lines = [self::ACTIVE_CONTENT_MESSAGE];
+        foreach ($valuesByMessage as $message => $values) {
+            $lines[] = \sprintf('%s: %s', $message, implode(', ', array_unique($values)));
+        }
 
-        return \sprintf(
-            '%s%s%s',
-            self::ACTIVE_CONTENT_MESSAGE,
-            \PHP_EOL,
-            implode(
-                \PHP_EOL,
-                array_map(
-                    static fn (string $message, array $values): string => \sprintf(
-                        '%s: %s',
-                        $message,
-                        implode(', ', $values)
-                    ),
-                    array_keys($groupedInvalidValues),
-                    $groupedInvalidValues,
-                )
-            )
-        );
+        return implode(\PHP_EOL, $lines);
     }
 
     /**

--- a/src/Core/Content/Media/File/SvgContentValidator.php
+++ b/src/Core/Content/Media/File/SvgContentValidator.php
@@ -5,6 +5,9 @@ namespace Shopware\Core\Content\Media\File;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 #[Package('discovery')]
 class SvgContentValidator extends AbstractFileContentValidator
@@ -18,6 +21,12 @@ class SvgContentValidator extends AbstractFileContentValidator
     private const XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
     private const XMLNS_NAMESPACE = 'http://www.w3.org/2000/xmlns/';
     private const XML_NAMESPACE = 'http://www.w3.org/XML/1998/namespace';
+    private const DISALLOWED_NODE_TYPE = 'Node types not allowed';
+    private const DISALLOWED_ELEMENT = 'Elements not allowed';
+    private const DISALLOWED_EVENT_HANDLER_ATTRIBUTE = 'Event handler attributes not allowed';
+    private const DISALLOWED_ATTRIBUTE = 'Attributes not allowed';
+    private const DISALLOWED_EXTERNAL_REFERENCE = 'External references not allowed';
+    private const DISALLOWED_EXTERNAL_STYLE_REFERENCE = 'External style references not allowed';
 
     /**
      * @var list<string>
@@ -34,6 +43,8 @@ class SvgContentValidator extends AbstractFileContentValidator
      */
     private readonly array $allowedReferenceAttributes;
 
+    private readonly ConstraintViolationList $violations;
+
     /**
      * @internal
      *
@@ -49,6 +60,7 @@ class SvgContentValidator extends AbstractFileContentValidator
         $this->allowedElements = $this->normalizeAllowlist($allowedElements);
         $this->allowedAttributes = $this->normalizeAllowlist($allowedAttributes);
         $this->allowedReferenceAttributes = $this->normalizeAllowlist($allowedReferenceAttributes);
+        $this->violations = new ConstraintViolationList();
     }
 
     public function getDecorated(): AbstractFileContentValidator
@@ -67,6 +79,10 @@ class SvgContentValidator extends AbstractFileContentValidator
             return;
         }
 
+        while ($this->violations->count() > 0) {
+            $this->violations->offsetUnset(0);
+        }
+
         $previousErrorHandling = $this->captureLibxmlErrors();
 
         try {
@@ -81,6 +97,10 @@ class SvgContentValidator extends AbstractFileContentValidator
             if ($this->hasCollectedLibxmlErrors()) {
                 throw MediaException::invalidFile(self::PARSE_ERROR_MESSAGE);
             }
+
+            if ($this->violations->count() > 0) {
+                throw MediaException::invalidFile($this->getViolationsMessage());
+            }
         } finally {
             $this->restoreLibxmlErrorHandling($previousErrorHandling);
         }
@@ -92,7 +112,7 @@ class SvgContentValidator extends AbstractFileContentValidator
 
         while ($reader->read()) {
             if ($this->isDisallowedNodeType($reader->nodeType)) {
-                $this->rejectActiveContent();
+                $this->buildViolation(self::DISALLOWED_NODE_TYPE, $reader->name);
             }
 
             if ($reader->nodeType !== \XMLReader::ELEMENT) {
@@ -136,7 +156,7 @@ class SvgContentValidator extends AbstractFileContentValidator
     private function assertElementAllowed(string $elementName): void
     {
         if (!\in_array($elementName, $this->allowedElements, true)) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_ELEMENT, $elementName);
         }
     }
 
@@ -160,20 +180,20 @@ class SvgContentValidator extends AbstractFileContentValidator
         $attributeName = mb_strtolower($reader->name);
 
         if ($this->isEventHandlerAttribute($attributeName)) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_EVENT_HANDLER_ATTRIBUTE, $attributeName);
         }
 
         if (!$this->isAllowedAttribute($reader, $attributeName)) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_ATTRIBUTE, $attributeName);
         }
 
         $isReferenceAttribute = \in_array($attributeName, $this->allowedReferenceAttributes, true);
         if ($isReferenceAttribute && $this->isExternalReference($reader->value)) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_EXTERNAL_REFERENCE, $attributeName);
         }
 
         if ($this->containsExternalStyleReference($reader->value)) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_EXTERNAL_STYLE_REFERENCE, $attributeName);
         }
     }
 
@@ -189,13 +209,56 @@ class SvgContentValidator extends AbstractFileContentValidator
         }
 
         if ($this->containsExternalStyleReference($reader->readInnerXml())) {
-            $this->rejectActiveContent();
+            $this->buildViolation(self::DISALLOWED_EXTERNAL_STYLE_REFERENCE, $elementName);
         }
     }
 
-    private function rejectActiveContent(): never
+    private function buildViolation(string $violation, string $invalidValue): void
     {
-        throw MediaException::invalidFile(self::ACTIVE_CONTENT_MESSAGE);
+        $this->violations->add(new ConstraintViolation(
+            $violation,
+            '',
+            [],
+            null,
+            '',
+            $invalidValue
+        ));
+    }
+
+    private function getViolationsMessage(): string
+    {
+        $groupedInvalidValues = array_reduce(
+            iterator_to_array($this->violations->getIterator()),
+            static function (array $acc, ConstraintViolationInterface $violation): array {
+                $acc[(string) $violation->getMessage()] = array_unique(
+                    array_merge(
+                        $acc[(string) $violation->getMessage()] ?? [],
+                        [$violation->getInvalidValue()]
+                    )
+                );
+
+                return $acc;
+            },
+            []
+        );
+
+        return \sprintf(
+            '%s%s%s',
+            self::ACTIVE_CONTENT_MESSAGE,
+            \PHP_EOL,
+            implode(
+                \PHP_EOL,
+                array_map(
+                    static fn (string $message, array $values): string => \sprintf(
+                        '%s: %s',
+                        $message,
+                        implode(', ', $values)
+                    ),
+                    array_keys($groupedInvalidValues),
+                    $groupedInvalidValues,
+                )
+            )
+        );
     }
 
     /**

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -192,7 +192,11 @@ class MediaUploadControllerTest extends TestCase
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         static::assertSame('CONTENT__MEDIA_INVALID_FILE', $responseData['errors'][0]['code']);
-        static::assertSame('Provided file is invalid: SVG files with active content are not allowed..', $responseData['errors'][0]['detail']);
+        static::assertSame(
+            'Provided file is invalid: SVG files with active content are not allowed.'
+            . \PHP_EOL . 'Event handler attributes not allowed: onload'
+            . \PHP_EOL . 'Attributes not allowed: onload.',
+            $responseData['errors'][0]['detail']);
         static::assertEmpty($media->getPath());
         static::assertNull($this->thrownMediaEvent);
     }

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -196,7 +196,8 @@ class MediaUploadControllerTest extends TestCase
             'Provided file is invalid: SVG files with active content are not allowed.'
             . \PHP_EOL . 'Event handler attributes not allowed: onload'
             . \PHP_EOL . 'Attributes not allowed: onload.',
-            $responseData['errors'][0]['detail']);
+            $responseData['errors'][0]['detail']
+        );
         static::assertEmpty($media->getPath());
         static::assertNull($this->thrownMediaEvent);
     }

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -153,7 +153,11 @@ SVG;
         $this->mediaRepository->create([['id' => $mediaId]], $context);
 
         try {
-            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.'));
+            $this->expectExceptionObject(MediaException::invalidFile(
+                'SVG files with active content are not allowed.'
+                . \PHP_EOL . 'Event handler attributes not allowed: onload'
+                . \PHP_EOL . 'Attributes not allowed: onload'
+            ));
 
             $this->fileSaver->persistFileToMedia($mediaFile, 'unsafe-svg', $mediaId, $context);
         } finally {

--- a/tests/unit/Core/Content/Media/File/SvgContentValidatorTest.php
+++ b/tests/unit/Core/Content/Media/File/SvgContentValidatorTest.php
@@ -102,12 +102,12 @@ SVG);
     }
 
     #[DataProvider('unsafeSvgProvider')]
-    public function testUnsafeSvgIsRejected(string $svgContent): void
+    public function testUnsafeSvgIsRejected(string $svgContent, string $messageAppendix): void
     {
         $file = $this->createSvgFile($svgContent);
 
         try {
-            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.'));
+            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.' . \PHP_EOL . $messageAppendix));
 
             $this->validator->validate($file);
         } finally {
@@ -161,6 +161,7 @@ SVG);
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>
 SVG,
+            'Event handler attributes not allowed: onload' . \PHP_EOL . 'Attributes not allowed: onload',
         ];
 
         yield 'script element' => [
@@ -168,6 +169,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>
 SVG,
+            'Elements not allowed: script',
         ];
 
         yield 'style element with url reference' => [
@@ -175,6 +177,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><style>.a{fill:url(https://attacker.invalid/fill);}</style></svg>
 SVG,
+            'External style references not allowed: style',
         ];
 
         yield 'foreign object element' => [
@@ -182,6 +185,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><foreignObject><body/></foreignObject></svg>
 SVG,
+            'Elements not allowed: foreignobject, body',
         ];
 
         yield 'external href' => [
@@ -189,6 +193,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><image href="https://attacker.invalid/x.png"/></svg>
 SVG,
+            'External references not allowed: href',
         ];
 
         yield 'xlink href with data uri' => [
@@ -196,6 +201,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4="/></svg>
 SVG,
+            'External references not allowed: xlink:href',
         ];
 
         yield 'fill with external url' => [
@@ -203,6 +209,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect fill="url(https://attacker.invalid/pattern)"/></svg>
 SVG,
+            'External style references not allowed: fill',
         ];
 
         yield 'stroke with data url' => [
@@ -210,6 +217,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0h10" stroke="url(data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=)"/></svg>
 SVG,
+            'External style references not allowed: stroke',
         ];
 
         yield 'mask with external url' => [
@@ -217,6 +225,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect mask="url(https://attacker.invalid/mask)"/></svg>
 SVG,
+            'External style references not allowed: mask',
         ];
 
         yield 'clip-path with external url' => [
@@ -224,6 +233,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect clip-path="url(https://attacker.invalid/clip)"/></svg>
 SVG,
+            'External style references not allowed: clip-path',
         ];
 
         yield 'style element with @import rule' => [
@@ -231,6 +241,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><style>@import "https://attacker.invalid/evil.css";</style></svg>
 SVG,
+            'External style references not allowed: style',
         ];
 
         yield 'style attribute with @import rule' => [
@@ -238,6 +249,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect style="@import 'https://attacker.invalid/evil.css'"/></svg>
 SVG,
+            'External style references not allowed: style',
         ];
 
         yield 'animation element' => [
@@ -245,6 +257,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><animate attributeName="x" from="0" to="10" dur="1s"/></svg>
 SVG,
+            'Elements not allowed: animate' . \PHP_EOL . 'Attributes not allowed: attributename, from, to, dur',
         ];
 
         yield 'processing instruction' => [
@@ -253,6 +266,7 @@ SVG,
 <?xml-stylesheet href="https://attacker.invalid/x.css" type="text/css"?>
 <svg xmlns="http://www.w3.org/2000/svg"></svg>
 SVG,
+            'Node types not allowed: xml-stylesheet',
         ];
 
         yield 'doctype' => [
@@ -261,6 +275,7 @@ SVG,
 <!DOCTYPE svg>
 <svg xmlns="http://www.w3.org/2000/svg"></svg>
 SVG,
+            'Node types not allowed: svg',
         ];
     }
 
@@ -461,12 +476,12 @@ SVG);
     }
 
     #[DataProvider('anchorElementBypassAttemptsProvider')]
-    public function testAnchorElementDoesNotBypassReferenceChecks(string $svgContent): void
+    public function testAnchorElementDoesNotBypassReferenceChecks(string $svgContent, string $messageAppendix): void
     {
         $file = $this->createSvgFile($svgContent);
 
         try {
-            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.'));
+            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.' . \PHP_EOL . $messageAppendix));
 
             $this->validator->validate($file);
         } finally {
@@ -481,6 +496,7 @@ SVG);
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><a href="https://attacker.invalid"><rect width="10" height="10"/></a></svg>
 SVG,
+            'External references not allowed: href',
         ];
 
         yield 'anchor with javascript pseudo scheme' => [
@@ -488,6 +504,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><rect width="10" height="10"/></a></svg>
 SVG,
+            'External references not allowed: href',
         ];
 
         yield 'anchor with data uri' => [
@@ -495,6 +512,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="data:image/svg+xml;base64,PHN2Zy8+"><rect width="10" height="10"/></a></svg>
 SVG,
+            'External references not allowed: xlink:href',
         ];
     }
 
@@ -555,12 +573,12 @@ SVG);
      * must still be rejected.
      */
     #[DataProvider('newlyAllowedAttributesDoNotBypassValueChecksProvider')]
-    public function testNewlyAllowedAttributesDoNotBypassValueChecks(string $svgContent): void
+    public function testNewlyAllowedAttributesDoNotBypassValueChecks(string $svgContent, string $messageAppendix): void
     {
         $file = $this->createSvgFile($svgContent);
 
         try {
-            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.'));
+            $this->expectExceptionObject(MediaException::invalidFile('SVG files with active content are not allowed.' . \PHP_EOL . $messageAppendix));
 
             $this->validator->validate($file);
         } finally {
@@ -575,6 +593,7 @@ SVG);
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect cursor="url(https://attacker.invalid/cursor.png), auto"/></svg>
 SVG,
+            'External style references not allowed: cursor',
         ];
 
         yield 'filter with external url' => [
@@ -582,6 +601,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><rect filter="url(https://attacker.invalid/filter)"/></svg>
 SVG,
+            'External style references not allowed: filter',
         ];
 
         yield 'marker-end with external url' => [
@@ -589,6 +609,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><line x1="0" y1="0" x2="10" y2="0" stroke="black" marker-end="url(https://attacker.invalid/arrow)"/></svg>
 SVG,
+            'External style references not allowed: marker-end',
         ];
 
         yield 'event handler on newly allowlisted-capable element (image)' => [
@@ -596,6 +617,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><image href="#x" onload="alert(1)"/></svg>
 SVG,
+            'Event handler attributes not allowed: onload' . \PHP_EOL . 'Attributes not allowed: onload',
         ];
 
         yield 'image element with external href' => [
@@ -603,6 +625,7 @@ SVG,
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"><image href="https://attacker.invalid/leak.png"/></svg>
 SVG,
+            'External references not allowed: href',
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
SVGs containing disallowed elements, attributes etc are validated and an exception is thrown. The exception does not point out which elements/attributes are violating the rules.

### 2. What does this change do, exactly?
Make the exception message more verbose so it exposes the violating elements/attributes.

### 3. Describe each step to reproduce the issue or behaviour.
Upload an SVG containing disallowed elements/attributes e.g. `<filter>`

### 4. Please link to the relevant issues (if any).
- closes #17154 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
