### PR TITLE
feat: display database name in system:setup:staging command confirmation

### DIFF
--- a/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
+++ b/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
+use Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -50,8 +51,9 @@ class SystemSetupStagingCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new ShopwareStyle($input, $output);
+        $databaseConnectionInformation = DatabaseConnectionInformation::fromEnv();
 
-        if (!$input->getOption('force') && !$io->confirm('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in this database, make sure you use a staging database and have a backup', false)) {
+        if (!$input->getOption('force') && !$io->confirm(\sprintf('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in the "%s" database, make sure you use a staging database and have a backup', $databaseConnectionInformation->getDatabaseName()), false)) {
             return self::FAILURE;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It would be helpful to identify that I am inside the correct environment when using the `system:setup:staging` command if the database name is displayed in the confirmation message.

### 2. What does this change do, exactly?
Add the database name to the confirmation message.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
