### PR TITLE
test: cover state transition updated_at

### DIFF
--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -10,6 +10,8 @@ use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
+use Shopware\Core\Checkout\Order\OrderCollection;
+use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -164,6 +166,45 @@ EOF;
         $toPlace = $stateCollection->get('toPlace');
         static::assertSame(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $fromPlace->getTechnicalName());
         static::assertSame(OrderDeliveryStates::STATE_PARTIALLY_RETURNED, $toPlace->getTechnicalName());
+    }
+
+    public function testStateMachineTransitionUpdatesEntityUpdatedAt(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+
+        $orderBuilder = new OrderBuilder($ids, 'o-1');
+
+        /** @var EntityRepository<OrderCollection> $orderRepo */
+        $orderRepo = self::getContainer()->get('order.repository');
+        static::assertInstanceOf(EntityRepository::class, $orderRepo);
+        $orderRepo->create([$orderBuilder->build()], Context::createCLIContext());
+
+        $this->connection->executeStatement(
+            'UPDATE `order` SET `updated_at` = NULL WHERE `id` = :id AND `version_id` = :version',
+            [
+                'id' => Uuid::fromHexToBytes($ids->get('o-1')),
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
+            ]
+        );
+
+        $orderBefore = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->first();
+        static::assertInstanceOf(OrderEntity::class, $orderBefore);
+        static::assertNull($orderBefore->getUpdatedAt());
+
+        $stateCollection = $this->stateMachineRegistry->transition(
+            new Transition('order', $ids->get('o-1'), 'process', 'stateId'),
+            $context
+        );
+
+        $toPlace = $stateCollection->get('toPlace');
+        static::assertNotNull($toPlace);
+
+        $orderAfter = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->first();
+        static::assertInstanceOf(OrderEntity::class, $orderAfter);
+
+        static::assertSame($toPlace->getId(), $orderAfter->getStateId());
+        static::assertNotNull($orderAfter->getUpdatedAt());
     }
 
     public function testStateMachineTransitionStoresUserAndIntegrationIdAndInternalComment(): void


### PR DESCRIPTION
## What

Adds an integration test for `StateMachineRegistry` that verifies a successful state-machine transition updates the transitioned order entity's `updated_at` timestamp.