### PR TITLE
fix: date range rule json serialization format

### DIFF
--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -102,4 +102,32 @@ class DateRangeRule extends Rule
             'useTime' => [new NotNull(), new Type('bool')],
         ];
     }
+
+    public function assign(array $options)
+    {
+        parent::assign($options);
+
+        try {
+            // convert string dates to DateTime objects
+            $this->__wakeup();
+        } catch (\Exception) {
+            // let validators handle invalid formats
+        }
+
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = parent::jsonSerialize();
+
+        if ($this->fromDate instanceof \DateTimeInterface) {
+            $data['fromDate'] = $this->fromDate->format(self::DATETIME_FORMAT);
+        }
+        if ($this->toDate instanceof \DateTimeInterface) {
+            $data['toDate'] = $this->toDate->format(self::DATETIME_FORMAT);
+        }
+
+        return $data;
+    }
 }

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -122,10 +122,10 @@ class DateRangeRule extends Rule
         $data = parent::jsonSerialize();
 
         if ($this->fromDate instanceof \DateTimeInterface) {
-            $data['fromDate'] = $this->fromDate->format(self::DATETIME_FORMAT);
+            $data['fromDate'] = $this->fromDate->format(\DateTime::ATOM);
         }
         if ($this->toDate instanceof \DateTimeInterface) {
-            $data['toDate'] = $this->toDate->format(self::DATETIME_FORMAT);
+            $data['toDate'] = $this->toDate->format(\DateTime::ATOM);
         }
 
         return $data;

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\DateRangeRule;
 use Shopware\Core\Framework\Rule\RuleScope;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @internal
@@ -235,5 +236,49 @@ class DateRangeRuleTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    public function testSerializationAndValidation(): void
+    {
+        $rule = new DateRangeRule(
+            new \DateTime('2024-01-15 10:30:45'),
+            new \DateTime('2024-01-31 23:59:59'),
+            true,
+            new \DateTimeZone('UTC')
+        );
+
+        $serialized = json_encode($rule);
+
+        static::assertIsString($serialized);
+
+        $data = json_decode($serialized, true);
+
+        static::assertSame('2024-01-15T10:30:45', $data['fromDate']);
+        static::assertSame('2024-01-31T23:59:59', $data['toDate']);
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $constraints = $rule->getConstraints();
+
+        static::assertCount(0, $validator->validate($data['fromDate'], $constraints['fromDate']));
+        static::assertCount(0, $validator->validate($data['toDate'], $constraints['toDate']));
+    }
+
+    public function testAssignWithStringDatesConvertsToDateTime(): void
+    {
+        $rule = new DateRangeRule();
+
+        $rule->assign([
+            'fromDate' => '2024-01-15T10:30:45',
+            'toDate' => '2024-01-31T23:59:59',
+            'useTime' => true,
+            'timezone' => 'UTC',
+        ]);
+
+        $scopeMock = $this->createMock(RuleScope::class);
+        $scopeMock->method('getCurrentTime')->willReturn(new \DateTimeImmutable('2024-01-20 12:00:00'));
+
+        $result = $rule->match($scopeMock);
+
+        static::assertTrue($result);
     }
 }

--- a/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/DateRangeRuleTest.php
@@ -244,7 +244,6 @@ class DateRangeRuleTest extends TestCase
             new \DateTime('2024-01-15 10:30:45'),
             new \DateTime('2024-01-31 23:59:59'),
             true,
-            new \DateTimeZone('UTC')
         );
 
         $serialized = json_encode($rule);
@@ -253,8 +252,8 @@ class DateRangeRuleTest extends TestCase
 
         $data = json_decode($serialized, true);
 
-        static::assertSame('2024-01-15T10:30:45', $data['fromDate']);
-        static::assertSame('2024-01-31T23:59:59', $data['toDate']);
+        static::assertSame('2024-01-15T10:30:45+00:00', $data['fromDate']);
+        static::assertSame('2024-01-31T23:59:59+00:00', $data['toDate']);
 
         $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
         $constraints = $rule->getConstraints();
@@ -271,7 +270,6 @@ class DateRangeRuleTest extends TestCase
             'fromDate' => '2024-01-15T10:30:45',
             'toDate' => '2024-01-31T23:59:59',
             'useTime' => true,
-            'timezone' => 'UTC',
         ]);
 
         $scopeMock = $this->createMock(RuleScope::class);


### PR DESCRIPTION
### 1. Why is this change necessary?
The error https://github.com/shopware/shopware/issues/13642 also occurs in Shopware 6.6

### 2. What does this change do, exactly?
Backport the 6.7 fix. 

### 3. Describe each step to reproduce the issue or behaviour.
Create a promotion which uses the date range rule and use it in a promotion which is present in an order which is serialized and deserialized.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
