### PR TITLE
fix: match all line items returns false when no line items are present

### DIFF
--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -40,21 +40,18 @@ class MatchAllLineItemsRule extends Container
         $lineItems = $scope instanceof LineItemScope ? new LineItemCollection([$scope->getLineItem()]) : $scope->getCart()->getLineItems();
         $originalCount = $lineItems->filter(static fn (LineItem $lineItem): bool => $lineItem->getType() !== LineItem::PROMOTION_LINE_ITEM_TYPE)->count();
 
+        if ($originalCount === 0) {
+            return $this->minimumShouldMatch === null;
+        }
+
         if ($this->type !== null) {
             $lineItems = $lineItems->filterFlatByType($this->type);
         }
 
         $filteredCount = \is_array($lineItems) ? \count($lineItems) : $lineItems->count();
+
         if ($filteredCount === 0) {
-            if ($this->type !== null && $originalCount > 0) {
-                return false;
-            }
-
-            return $this->minimumShouldMatch === null;
-        }
-
-        if (!\is_array($lineItems) && $lineItems->count() === 0) {
-            return $this->minimumShouldMatch === null;
+            return false;
         }
 
         $context = $scope->getSalesChannelContext();

--- a/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
+++ b/src/Core/Framework/Rule/Container/MatchAllLineItemsRule.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Rule\Container;
 
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
@@ -37,12 +38,18 @@ class MatchAllLineItemsRule extends Container
         }
 
         $lineItems = $scope instanceof LineItemScope ? new LineItemCollection([$scope->getLineItem()]) : $scope->getCart()->getLineItems();
+        $originalCount = $lineItems->filter(static fn (LineItem $lineItem): bool => $lineItem->getType() !== LineItem::PROMOTION_LINE_ITEM_TYPE)->count();
 
         if ($this->type !== null) {
             $lineItems = $lineItems->filterFlatByType($this->type);
         }
 
-        if (\is_array($lineItems) && \count($lineItems) === 0) {
+        $filteredCount = \is_array($lineItems) ? \count($lineItems) : $lineItems->count();
+        if ($filteredCount === 0) {
+            if ($this->type !== null && $originalCount > 0) {
+                return false;
+            }
+
             return $this->minimumShouldMatch === null;
         }
 

--- a/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -230,6 +230,7 @@ class MatchAllLineItemsRuleTest extends TestCase
 
     #[DataProvider('getEmptyFilteredLineItemsTestData')]
     public function testEmptyFilteredLineItemsWithCartScope(
+        string $lineItemType,
         ?int $minimumShouldMatch,
         bool $expected
     ): void {
@@ -242,8 +243,7 @@ class MatchAllLineItemsRuleTest extends TestCase
         $allLineItemsRule = new MatchAllLineItemsRule([], $minimumShouldMatch, 'product');
         $allLineItemsRule->addRule($lineItemRule);
 
-        $promotionLineItem = $this->createLineItem(LineItem::PROMOTION_LINE_ITEM_TYPE, 1, 'PROMO')
-            ->setPayloadValue('promotionId', 'A');
+        $promotionLineItem = $this->createLineItem($lineItemType, 1, 'PRODUCT');
         $cart = $this->createCart(new LineItemCollection([$promotionLineItem]));
 
         $match = $allLineItemsRule->match(new CartRuleScope(
@@ -260,8 +260,10 @@ class MatchAllLineItemsRuleTest extends TestCase
     public static function getEmptyFilteredLineItemsTestData(): array
     {
         return [
-            'no type match / no minimum / returns true (vacuously true)' => [null, true],
-            'no type match / minimum set / returns false' => [1, false],
+            'no type match / promotion / no minimum / returns true (vacuously true)' => [LineItem::PROMOTION_LINE_ITEM_TYPE, null, true],
+            'no type match / promotion / minimum set / returns false' => [LineItem::PROMOTION_LINE_ITEM_TYPE, 1, false],
+            'no type match / custom / no minimum / returns false' => [LineItem::CUSTOM_LINE_ITEM_TYPE, null, false],
+            'no type match / custom / minimum set / returns false' => [LineItem::CUSTOM_LINE_ITEM_TYPE, 1, false],
         ];
     }
 

--- a/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -255,7 +255,7 @@ class MatchAllLineItemsRuleTest extends TestCase
     }
 
     /**
-     * @return array<string, mixed[]>
+     * @return array<string, array>
      */
     public static function getEmptyFilteredLineItemsTestData(): array
     {

--- a/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/MatchAllLineItemsRuleTest.php
@@ -255,7 +255,7 @@ class MatchAllLineItemsRuleTest extends TestCase
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, mixed[]>
      */
     public static function getEmptyFilteredLineItemsTestData(): array
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Line item rules return true, when no product item is in cart. This behavior was introduced in 6.6 backport PR https://github.com/shopware/shopware/pull/15168. That PR fixes an problem with promotion.

### 2. What does this change do, exactly?

It adjust the fix introduced in https://github.com/shopware/shopware/pull/15168 to correctly respect 'promotion' type line items but changes the behavior for the filtering to change the return to false.

Also some test cases added to dataProvider

### 3. Describe each step to reproduce the issue or behaviour.

When a cart only has line items with type "custom" and a LineItemTagRule Rule has the "All" -> "Are one of" -> "Tag" it will always evaluate to true. This is wrong.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/14555
https://github.com/shopware/shopware/pull/14962
https://github.com/shopware/shopware/pull/15168

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
