### PR TITLE
chore: move fix data grid release note to next minor

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -119,6 +119,10 @@ Rule Builder cart total condition labels now describe more clearly which cart va
 | `cartLineItemGoodsTotal` | Total quantity of all products -> Total product quantity (units) | Gesamtanzahl aller Produkte -> Gesamtmenge der Produkte (Stück) | Total unit count of goods in the cart |
 | `cartGoodsCount` | Total quantity of distinct products -> Number of distinct products | Gesamtanzahl unterschiedlicher Produkte -> Anzahl unterschiedlicher Produkte | Number of distinct products in the cart |
 
+### `sw-data-grid` column labels fall back to the default locale
+
+Column headers and the column visibility settings in `sw-data-grid` now resolve their labels against the configured i18n fallback locale when the snippet is missing in the current locale, instead of rendering the raw snippet key. This matches the behavior users expect when a translation is only available in English.
+
 ## App System
 
 ### [Opt-in] Webhook delivery rework
@@ -388,9 +392,6 @@ ESLint now warns for Administration test files with 500 lines or more and errors
 ### Resolving download errors by renaming media
 When merchants rename a media file, its URL automatically updates so they can download it without issues.
 
-### `sw-data-grid` column labels fall back to the default locale
-
-Column headers and the column visibility settings in `sw-data-grid` now resolve their labels against the configured i18n fallback locale when the snippet is missing in the current locale, instead of rendering the raw snippet key. This matches the behavior users expect when a translation is only available in English.
 ### App action button icons are aligned in Administration context menus
 
 App action buttons that use an app manifest icon now render the icon at the normal context-menu size and align it on the same row as the action label.


### PR DESCRIPTION
### 1. Why is this change necessary?

See required version https://github.com/shopware/shopware/pull/16824

The `sw-data-grid` column-label fallback release note is not part of the current `6.7.11.x` release scope and should be listed in the next minor section instead.

### 2. What does this change do, exactly?

Moves only the ``sw-data-grid` column labels fall back to the default locale` entry from `6.7.11.0` to `6.7.12.0 (upcoming)` in `RELEASE_INFO-6.7.md`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open `RELEASE_INFO-6.7.md`.
2. Check the `6.7.11.0` Administration section.
3. Observe that the ``sw-data-grid` column labels fall back to the default locale` entry is listed there instead of under the next minor release.

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Verification:

- Verified the entry exists once in `6.7.12.0`.
- Verified the entry no longer exists in `6.7.11.0`.
- Ran `git diff --check`.
