### PR TITLE
fix: hide agentic commerce sales channel type conditionally

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -963,8 +963,8 @@ export default {
                  * if the SwagAgenticCommerce plugin is installed.
                  */
                 if (
-                    saleChannelType.id === Defaults.agenticCommerceTypeId
-                    && !Shopware.Context.app.config.bundles?.SwagAgenticCommerce
+                    saleChannelType.id === Defaults.agenticCommerceTypeId &&
+                    !Shopware.Context.app.config.bundles?.SwagAgenticCommerce
                 ) {
                     return salesChannelTypes;
                 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -1,7 +1,7 @@
 import template from './sw-search-bar.html.twig';
 import './sw-search-bar.scss';
 
-const { Application, Context } = Shopware;
+const { Application, Context, Defaults } = Shopware;
 const { Criteria } = Shopware.Data;
 const utils = Shopware.Utils;
 const { cloneDeep } = utils.object;
@@ -953,6 +953,19 @@ export default {
         getSalesChannelTypesBySearchTerm(regex) {
             return this.salesChannelTypes.reduce((salesChannelTypes, saleChannelType) => {
                 if (!saleChannelType?.translated.name.toLowerCase().match(regex)) {
+                    return salesChannelTypes;
+                }
+
+                /**
+                 * @deprecated tag:v6.8.0 - condition can be removed.
+                 *
+                 * Only reveal the agentic commerce sales channel as a search result
+                 * if the SwagAgenticCommerce plugin is installed.
+                 */
+                if (
+                    saleChannelType.id === Defaults.agenticCommerceTypeId
+                    && !Shopware.Context.app.config.bundles?.SwagAgenticCommerce
+                ) {
                     return salesChannelTypes;
                 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-agentic-commerce-tracking-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-agentic-commerce-tracking-config/index.js
@@ -4,6 +4,7 @@
 
 import template from './sw-agentic-commerce-tracking-config.html.twig';
 
+/** @deprecated tag:v6.8.0 - Will be removed */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -79,12 +79,7 @@ export default {
              */
             this.showAgenticCommerceType().then((showAgenticCommerceType) => {
                 if (!showAgenticCommerceType) {
-                    criteria.addFilter(
-                        Criteria.not(
-                            'AND',
-                            [Criteria.equals('id', Defaults.agenticCommerceTypeId)]
-                        )
-                    );
+                    criteria.addFilter(Criteria.not('AND', [Criteria.equals('id', Defaults.agenticCommerceTypeId)]));
                 }
 
                 this.salesChannelTypeRepository.search(criteria, context).then((response) => {
@@ -123,8 +118,7 @@ export default {
             criteria.addAssociation('type');
             criteria.addFilter(Criteria.equals('type.id', Defaults.agenticCommerceTypeId));
 
-            return this.salesChannelRepository.searchIds(criteria)
-                .then((response) => Promise.resolve(response.total > 0));
-        }
+            return this.salesChannelRepository.searchIds(criteria).then((response) => Promise.resolve(response.total > 0));
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -47,6 +47,11 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.8.0 - Will be removed */
+        salesChannelRepository() {
+            return this.repositoryFactory.create('sales_channel');
+        },
+
         salesChannelTypeRepository() {
             return this.repositoryFactory.create('sales_channel_type');
         },
@@ -63,10 +68,30 @@ export default {
                 ...Shopware.Context.api,
                 languageId: Shopware.Store.get('session').languageId,
             };
-            this.salesChannelTypeRepository.search(new Criteria(1, 500), context).then((response) => {
-                this.total = response.total;
-                this.salesChannelTypes = response;
-                this.isLoading = false;
+            const criteria = new Criteria(1, 500);
+
+            /**
+             * @deprecated tag:v6.8.0 - keep only the type search of the promise callback.
+             *
+             * Only show the option to create a new agentic commerce sales channel
+             * if one had been created using a previous release and still exists
+             * OR the SwagAgenticCommerce plugin is installed
+             */
+            this.showAgenticCommerceType().then((showAgenticCommerceType) => {
+                if (!showAgenticCommerceType) {
+                    criteria.addFilter(
+                        Criteria.not(
+                            'AND',
+                            [Criteria.equals('id', Defaults.agenticCommerceTypeId)]
+                        )
+                    );
+                }
+
+                this.salesChannelTypeRepository.search(criteria, context).then((response) => {
+                    this.total = response.total;
+                    this.salesChannelTypes = response;
+                    this.isLoading = false;
+                });
             });
         },
 
@@ -79,6 +104,7 @@ export default {
             this.$emit('grid-detail-open', detailType);
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         isAgenticCommerceSalesChannelType(salesChannelTypeId) {
             return salesChannelTypeId === Defaults.agenticCommerceTypeId;
         },
@@ -86,5 +112,19 @@ export default {
         isProductComparisonSalesChannelType(salesChannelTypeId) {
             return salesChannelTypeId === Defaults.productComparisonTypeId;
         },
+
+        /** @deprecated tag:v6.8.0 - Will be removed */
+        showAgenticCommerceType() {
+            if (Shopware.Context.app.config.bundles?.SwagAgenticCommerce) {
+                return Promise.resolve(true);
+            }
+
+            const criteria = new Criteria(1, 1);
+            criteria.addAssociation('type');
+            criteria.addFilter(Criteria.equals('type.id', Defaults.agenticCommerceTypeId));
+
+            return this.salesChannelRepository.searchIds(criteria)
+                .then((response) => Promise.resolve(response.total > 0));
+        }
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -23,6 +23,7 @@ export default {
 
     provide() {
         return {
+            /** @deprecated tag:v6.8.0 - Will be removed */
             swSalesChannelDetailGetAgenticCommerceExportConfig: () => this.agenticCommerceExportConfig,
         };
     },
@@ -53,6 +54,7 @@ export default {
                 showTemplateModal: false,
                 selectedTemplate: null,
             },
+            /** @deprecated tag:v6.8.0 - Will be removed */
             agenticCommerceExportConfig: [],
         };
     },
@@ -108,6 +110,7 @@ export default {
             return this.salesChannel.typeId === Defaults.apiSalesChannelTypeId;
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         isAgenticCommerce() {
             if (!this.salesChannel) {
                 return this.$route.params.typeId === Defaults.agenticCommerceTypeId;
@@ -163,6 +166,7 @@ export default {
             return this.acl.can('sales_channel.editor');
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         defaultAgenticCommerceExportConfig() {
             return [
                 {
@@ -439,6 +443,7 @@ export default {
             this.loadEntityData();
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         validateAgenticCommerceExportConfig() {
             const requiredError = new ShopwareError({ code: 'c1051bb4-d103-4f74-8988-acbcafc7fdc3' });
             const activeProvider = this.productExport?.provider ?? this.defaultAgenticCommerceExportConfig[0]?.provider;
@@ -458,6 +463,7 @@ export default {
             return isValid;
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         async loadAgenticCommerceExportConfig() {
             this.agenticCommerceExportConfig = this.defaultAgenticCommerceExportConfig.map((configEntry) => {
                 return {
@@ -501,6 +507,7 @@ export default {
             );
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         async saveAgenticCommerceExportConfig() {
             if (!this.isAgenticCommerce || !this.salesChannel?.id) {
                 return true;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-create-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-create-base/index.js
@@ -25,6 +25,7 @@ export default {
             }
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         prefillAgenticCommerceDefaults() {
             this.productExport.fileName = `agentic-commerce-${utils.createId()}.jsonl`;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -26,6 +26,7 @@ export default {
         repositoryFactory: 'repositoryFactory',
         knownIpsService: 'knownIpsService',
         acl: 'acl',
+        /** @deprecated tag:v6.8.0 - Will be removed */
         swSalesChannelDetailGetAgenticCommerceExportConfig: {
             from: 'swSalesChannelDetailGetAgenticCommerceExportConfig',
             default: () => [],
@@ -146,6 +147,7 @@ export default {
             return this.salesChannel && this.salesChannel.typeId === Defaults.productComparisonTypeId;
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         isAgenticCommerce() {
             return this.salesChannel && this.salesChannel.typeId === Defaults.agenticCommerceTypeId;
         },
@@ -158,6 +160,7 @@ export default {
             return this.templateName === 'google-product-search-de';
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         resolvedAgenticCommerceExportConfig() {
             let entries = [];
 
@@ -913,6 +916,7 @@ export default {
             return utils.string.isValidIp(term) || utils.string.isValidCidr(term);
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         getAgenticCommerceExportElementBind(element) {
             const bind = objectHelper.deepCopyObject(element);
 
@@ -933,6 +937,7 @@ export default {
             return bind;
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         getAgenticCommerceExportCardTitle(configEntry) {
             if (configEntry?.titleSnippet) {
                 return this.$t(configEntry.titleSnippet);
@@ -941,6 +946,7 @@ export default {
             return configEntry?.provider ?? '';
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         getAgenticCommerceExportCardPositionIdentifier(configEntry) {
             if (configEntry?.positionIdentifier) {
                 return configEntry.positionIdentifier;
@@ -948,6 +954,7 @@ export default {
             return 'sw-sales-channel-detail-base-agentic-commerce-export-config-provider';
         },
 
+        /** @deprecated tag:v6.8.0 - Will be removed */
         onAgenticCommerceExportFieldUpdate(configEntry, fieldName, value) {
             configEntry.values[fieldName] = value;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-product-comparison/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-product-comparison/index.js
@@ -58,6 +58,7 @@ export default {
     },
 
     computed: {
+        /** @deprecated tag:v6.8.0 - Will be removed */
         isAgenticCommerce() {
             return this.salesChannel?.typeId === Defaults.agenticCommerceTypeId;
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
The option to create an agentic commerce sales channel should only be shown if either
* An agentic commerce sales channel was created on a previous version and still exists
* The plugin `SwagAgenticCommerce` is installed

### 2. What does this change do, exactly?
Filters the sales channel type for agentic commerce depending on the conditions above

### 3. Describe each step to reproduce the issue or behaviour.
* Create a new sales channel
* Option for agentic commerce should only appear on the condition described above

### 4. Please link to the relevant issues (if any).
- closes [#1715](https://github.com/shopware/shopware/issues/17158)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
