### PR TITLE
ci: reproduce flaky elasticsearch product term tests with pinned seed

### DIFF
--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 $php = ['8.2'];
 $db = ['mysql:8.0'];
@@ -10,36 +10,18 @@ if ($nightly) {
     $db = ['mysql:8.0', 'mariadb:11', 'quay.io/mariadb-foundation/mariadb-devel:verylatest'];
 }
 
+// Reproducer branch: run only the flaky {Administration,Elasticsearch} path with a pinned random seed
+// (see integration.yml) so the ElasticsearchProductTest term-search failures reproduce deterministically.
 $matrix = [
     'fail-fast' => false,
     'matrix' => [
         'test' => [
-            ['path' => 'Core/Checkout'],
-            ['path' => 'Core/Content'],
-            ['testsuite' => 'core-framework-batch1'],
-            ['testsuite' => 'core-framework-batch2'],
-            ['testsuite' => 'core-framework-batch3'],
-            ['path' => 'Storefront'],
             ['path' => '{Administration,Elasticsearch}'],
-            ['path' => '{Core/Installer,Core/Maintenance,Core/Service,Core/System}'],
-            ['testsuite' => 'migration'],
         ],
         'php' => $php,
         'db' => $db,
         'opensearch' => ['opensearchproject/opensearch:3'],
-        'include' => [
-            [
-                'test' => ['testsuite' => 'migration'],
-                'php' => '8.2',
-                'db' => 'mariadb:11'
-            ],
-            [
-                'test' => ['testsuite' => 'devops'],
-                'php' => '8.5',
-                'db' => 'mariadb:11'
-            ]
-        ]
-    ]
+    ],
 ];
 
 if ($nightly) {

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -184,11 +184,11 @@ jobs:
 
       - name: Run PHPUnit testsuite
         if: ${{ matrix.test.testsuite != '' }}
-        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "${{ matrix.test.testsuite }}"
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --order-by random --random-order-seed 1780463427 --testsuite "${{ matrix.test.testsuite }}"
 
       - name: Run PHPUnit path
         if: ${{ matrix.test.path != '' }}
-        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml -- tests/integration/${{ matrix.test.path }}
+        run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --order-by random --random-order-seed 1780463427 -- tests/integration/${{ matrix.test.path }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a flaky test, we need to verify with a reproducer
```
1) Shopware\Tests\Integration\Elasticsearch\Product\ElasticsearchProductTest::testEntityAggregationWithTermQuery                                                                                         
  Failed asserting that actual size 0 matches expected size 2.                                                                                                                                             
                                                                                                                                                                                                           
  /home/runner/work/shopware/shopware/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php:1344                                                                                            
                                                                                                                                                                                                           
  2) Shopware\Tests\Integration\Elasticsearch\Product\ElasticsearchProductTest::testTermAlgorithm                                                                                                          
  Term "spachtelmasse" do not match                                                                                                                                                                        
  Failed asserting that 0 is identical to 1.                                                                                                                                                               
                                                                                                                                                                                                           
  /home/runner/work/shopware/shopware/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php:1371                                                                                            
                                                                                                                                                                                                           
  FAILURES!                                                                                                                                                                                                
  Tests: 245, Assertions: 1677, Failures: 2, Skipped: 17.   

```

### 2. What does this change do, exactly?

Forces the seed as a reproducer in one of the job that was failing

### 3. Describe each step to reproduce the issue or behaviour.

Pipeline is failing

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
