### PR TITLE
test: isolate search-config mutations in elasticsearch ranking tests

### DIFF
--- a/tests/integration/Elasticsearch/Product/BM25SimilarityRankingTest.php
+++ b/tests/integration/Elasticsearch/Product/BM25SimilarityRankingTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\FilesystemBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -33,6 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class BM25SimilarityRankingTest extends TestCase
 {
     use CacheTestBehaviour;
+    use DatabaseTransactionBehaviour;
     use ElasticsearchTestTestBehaviour;
     use FilesystemBehaviour;
     use KernelTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\FilesystemBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -25,6 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class SearchCasesTest extends TestCase
 {
     use CacheTestBehaviour;
+    use DatabaseTransactionBehaviour;
     use ElasticsearchTestTestBehaviour;
     use FilesystemBehaviour;
     use KernelTestBehaviour;


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/17220 reproducer

These flaky tests are also happening in the normal pipeline
```
1) Shopware\Tests\Integration\Elasticsearch\Product\ElasticsearchProductTest::testEntityAggregationWithTermQuery                                                                                         
  Failed asserting that actual size 0 matches expected size 2.                                                                                                                                             
                                                                                                                                                                                                           
  /home/runner/work/shopware/shopware/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php:1344                                                                                            
                                                                                                                                                                                                           
  2) Shopware\Tests\Integration\Elasticsearch\Product\ElasticsearchProductTest::testTermAlgorithm                                                                                                          
  Term "spachtelmasse" do not match                                                                                                                                                                        
  Failed asserting that 0 is identical to 1.                                                                                                                                                               
                                                                                                                                                                                                           
  /home/runner/work/shopware/shopware/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php:1371                                                                                            
                                                                                                                                                                                                           
  FAILURES!                                                                                                                                                                                                
  Tests: 245, Assertions: 1677, Failures: 2, Skipped: 17.   

```

Follow up of 
https://github.com/shopware/shopware/pull/16188

### 2. What does this change do, exactly?

search-config mutations needed to be isolated, using the trait of DatabaseTransactionBehaviour

⚠️ This PR was first based upon https://github.com/shopware/shopware/pull/17220 to force the reproduction and verify the fix was effective (confirmed with https://github.com/shopware/shopware/actions/runs/26875203952/job/79260547851 )
It has since been move back against trunk

### 3. Describe each step to reproduce the issue or behaviour.

- This PR passes the pipeline
- Run the tests locally with the seed 1780463427

```
  php -d memory_limit=-1 vendor/bin/phpunit  --order-by random --random-order-seed 1780463427 -- tests/integration/{Administration,Elasticsearch}
```

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
