### PR TITLE
test: skip mailpit password reset flow on PaaS

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "2.1.2",
-        "@shopware-ag/acceptance-test-suite": "12.12.1",
+        "@shopware-ag/acceptance-test-suite": "12.13.0",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -1204,9 +1204,9 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.12.1.tgz",
-      "integrity": "sha512-ysWINlFjAny7kgqPYXwQ6h9VORSDBCMrdH95oeAN3y6o3Twhw7RqjWKd1hFDcA9xsQ9s3lrsexVKCKbvZ07rhQ==",
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.13.0.tgz",
+      "integrity": "sha512-HbrF/TfQv4ygGtZqtwvUsWJuruKYfXcfLL3MWxoD0iJoqbdlPAag67M0+vU3YXk+fDrB1ZZL3COif/+6ezk4ew==",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "2.1.2",
-    "@shopware-ag/acceptance-test-suite": "12.12.1",
+    "@shopware-ag/acceptance-test-suite": "12.13.0",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/tests/Account/ForgotPassword.spec.ts
+++ b/tests/acceptance/tests/Account/ForgotPassword.spec.ts
@@ -29,6 +29,8 @@ test ('As a customer, I can request a new password without existing customer ema
    StorefrontAccountLogin,
    StorefrontAccountRecover,
 }) => {
+    const uniqueEmail = `forgot-password-${test.info().repeatEachIndex}-${test.info().retry}-${Date.now()}@email.net`;
+    
     await test.step('Navigate to login page and initiate password recovery', async () => {
         await ShopCustomer.goesTo(StorefrontAccountLogin.url());
         await ShopCustomer.presses(StorefrontAccountLogin.forgotPasswordLink);
@@ -40,7 +42,7 @@ test ('As a customer, I can request a new password without existing customer ema
     });
 
     await test.step('Request password reset with a non-existing email', async () => {
-        await ShopCustomer.fillsIn(StorefrontAccountRecover.emailInput, 'test-forgot-password-non-existing@email.net');
+        await ShopCustomer.fillsIn(StorefrontAccountRecover.emailInput, uniqueEmail);
         await ShopCustomer.presses(StorefrontAccountRecover.requestEmailButton);
         // Verify that the success message is shown for security reasons
         await ShopCustomer.expects(StorefrontAccountRecover.passwordResetEmailSentMessage).toBeVisible();

--- a/tests/acceptance/tests/Account/ForgotPassword.spec.ts
+++ b/tests/acceptance/tests/Account/ForgotPassword.spec.ts
@@ -57,7 +57,7 @@ test ('As a customer, I can reset my password using the password recovery proces
     Login,
     DefaultSalesChannel,
 }) => {
-    test.skip(InstanceMeta.isSaaS, 'Skipping test because it requires a local mailpit instance.');
+    test.skip(InstanceMeta.isSaaS || InstanceMeta.isPaaS, 'Skipping test because it requires a local mailpit instance.');
 
     let passwordResetLink = '';
     const newPassword = 'new-password';


### PR DESCRIPTION
## Summary

- Update `@shopware-ag/acceptance-test-suite` to `12.13.0` so acceptance tests can use `InstanceMeta.isPaaS`.
- Skip the password-reset flow that reads Mailpit when running against PaaS.
- Keep the existing SaaS skip behavior unchanged.

## Context

The nightly PaaS ATS workflow sets `SHOPWARE_ACCEPTANCE_INSTANCE_TYPE=paas`. With acceptance-test-suite `12.13.0`, that exposes `InstanceMeta.isPaaS`, allowing tests to opt out of local-infrastructure-only flows without treating PaaS as SaaS.

This first skip is limited to the existing Mailpit-dependent password reset test.

## Testing

- Parsed `tests/acceptance/package.json` and `tests/acceptance/package-lock.json` as JSON.
- `git diff --check` passed.
- Did not run ATS locally; the PaaS workflow provides the deployed app URL and ATS credentials.