### PR TITLE
test: skip first run wizard on PaaS

### DIFF
--- a/tests/acceptance/tests/Settings/RunFirstRunWizard.spec.ts
+++ b/tests/acceptance/tests/Settings/RunFirstRunWizard.spec.ts
@@ -1,5 +1,4 @@
 import { test } from '@fixtures/AcceptanceTest';
-import { isSaaSInstance } from '@fixtures/AcceptanceTest';
 
 /**
  * @sw-package fundamentals@after-sales
@@ -9,9 +8,12 @@ test('Merchant is able to be guided through the First Run Wizard.', { tag: '@Fir
     ShopAdmin,
     DefaultSalesChannel,
     AdminFirstRunWizard,
-    AdminApiContext,
+    InstanceMeta,
 }) => {
-    test.skip(await isSaaSInstance(AdminApiContext),'Skipping test for the first run wizard, because it is disabled on SaaS instances.');
+    test.skip(
+        InstanceMeta.isSaaS || InstanceMeta.isPaaS,
+        'Skipping test for the first run wizard, because it is disabled on SaaS and PaaS instances.',
+    );
 
     await ShopAdmin.goesTo(AdminFirstRunWizard.url());
 


### PR DESCRIPTION
## Summary

- Skip the First Run Wizard acceptance test on PaaS instances.
- Reuse `InstanceMeta.isPaaS` from the updated acceptance test suite instead of adding another environment probe.
- Keep the existing SaaS skip behavior intact.

## Why

The First Run Wizard flow is not compatible with PaaS instances, so the full Platform ATS run should treat it like the existing unsupported SaaS case.

## Validation

- `git diff --check -- tests/acceptance/tests/Settings/RunFirstRunWizard.spec.ts`