### PR TITLE
fix: set cms_page_version_id when backfilling default category cms page

### DIFF
--- a/src/Core/Migration/V6_7/Migration1776691515SetDefaultCmsPageIdForCategories.php
+++ b/src/Core/Migration/V6_7/Migration1776691515SetDefaultCmsPageIdForCategories.php
@@ -29,17 +29,25 @@ class Migration1776691515SetDefaultCmsPageIdForCategories extends MigrationStep
         }
 
         $batchSize = 1000;
+        $liveVersionId = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
 
+        // `cms_page_version_id` must be written together with `cms_page_id`.
+        // The composite foreign key (cms_page_id, cms_page_version_id) is not
+        // enforced while `cms_page_id` IS NULL, so affected rows may carry a
+        // stale, non-live version id. Setting only `cms_page_id` would then
+        // activate the FK against a non-existent (page, version) pair and fail.
         do {
             $affectedRows = $connection->executeStatement(
-                'UPDATE `category` SET `cms_page_id` = :cmsPageId WHERE `cms_page_id` IS NULL AND `type` = :type LIMIT :batchSize',
+                'UPDATE `category` SET `cms_page_id` = :cmsPageId, `cms_page_version_id` = :cmsPageVersionId WHERE `cms_page_id` IS NULL AND `type` = :type LIMIT :batchSize',
                 [
                     'cmsPageId' => Uuid::fromHexToBytes($cmsPageId),
+                    'cmsPageVersionId' => $liveVersionId,
                     'type' => CategoryDefinition::TYPE_PAGE,
                     'batchSize' => $batchSize,
                 ],
                 [
                     'cmsPageId' => ParameterType::BINARY,
+                    'cmsPageVersionId' => ParameterType::BINARY,
                     'type' => ParameterType::STRING,
                     'batchSize' => ParameterType::INTEGER,
                 ]

--- a/tests/migration/Core/V6_7/Migration1776691515SetDefaultCmsPageIdForCategoriesTest.php
+++ b/tests/migration/Core/V6_7/Migration1776691515SetDefaultCmsPageIdForCategoriesTest.php
@@ -106,6 +106,26 @@ class Migration1776691515SetDefaultCmsPageIdForCategoriesTest extends TestCase
         static::assertNull($this->getCategoryCmsPageId($categoryId));
     }
 
+    public function testMigrationResetsStaleNonLiveCmsPageVersionId(): void
+    {
+        $configuredCmsPageId = $this->getAnyCmsPageId();
+        $this->setConfiguredDefaultCmsPageConfigurationValue(
+            json_encode(['_value' => $configuredCmsPageId], \JSON_THROW_ON_ERROR)
+        );
+
+        // Category with no cms_page_id but a stale, non-live cms_page_version_id.
+        // The composite FK (cms_page_id, cms_page_version_id) is not enforced
+        // while cms_page_id IS NULL, so such rows can exist in real databases.
+        // Backfilling only cms_page_id would activate the FK against a
+        // non-existent (page, version) pair and throw an integrity violation.
+        $categoryId = $this->insertCategoryWithoutCmsPageId(Uuid::randomHex());
+
+        $this->migrate();
+
+        static::assertSame($configuredCmsPageId, $this->getCategoryCmsPageId($categoryId));
+        static::assertSame(Defaults::LIVE_VERSION, $this->getCategoryCmsPageVersionId($categoryId));
+    }
+
     public function testMigrationDoesNotOverwriteExistingCmsPageId(): void
     {
         $existingCmsPageId = $this->getAnyCmsPageId();
@@ -149,7 +169,7 @@ class Migration1776691515SetDefaultCmsPageIdForCategoriesTest extends TestCase
         (new Migration1776691515SetDefaultCmsPageIdForCategories())->update($this->connection);
     }
 
-    private function insertCategoryWithoutCmsPageId(): string
+    private function insertCategoryWithoutCmsPageId(?string $cmsPageVersionId = null): string
     {
         $categoryId = Uuid::randomHex();
 
@@ -158,6 +178,7 @@ class Migration1776691515SetDefaultCmsPageIdForCategoriesTest extends TestCase
             'version_id' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
             'type' => CategoryDefinition::TYPE_PAGE,
             'cms_page_id' => null,
+            'cms_page_version_id' => Uuid::fromHexToBytes($cmsPageVersionId ?? Defaults::LIVE_VERSION),
             'product_assignment_type' => CategoryDefinition::PRODUCT_ASSIGNMENT_TYPE_PRODUCT,
             'active' => 1,
             'visible' => 1,
@@ -172,6 +193,17 @@ class Migration1776691515SetDefaultCmsPageIdForCategoriesTest extends TestCase
     {
         $result = $this->connection->fetchOne(
             'SELECT LOWER(HEX(`cms_page_id`)) FROM `category` WHERE `id` = :id',
+            ['id' => Uuid::fromHexToBytes($categoryId)],
+            ['id' => ParameterType::BINARY]
+        );
+
+        return \is_string($result) ? $result : null;
+    }
+
+    private function getCategoryCmsPageVersionId(string $categoryId): ?string
+    {
+        $result = $this->connection->fetchOne(
+            'SELECT LOWER(HEX(`cms_page_version_id`)) FROM `category` WHERE `id` = :id',
             ['id' => Uuid::fromHexToBytes($categoryId)],
             ['id' => ParameterType::BINARY]
         );


### PR DESCRIPTION
## Summary

`Migration1776691515SetDefaultCmsPageIdForCategories` backfills `category.cms_page_id` but never writes `category.cms_page_version_id`. The foreign key is composite over both columns and is not enforced while `cms_page_id` IS NULL, so affected rows can hold a stale, non-live `cms_page_version_id`. Once the migration sets `cms_page_id`, the FK activates against a `(page, version)` pair that does not exist and fails with a 1452 integrity violation on upgrade.

Reported in #16378.

## What Changed

- write `cms_page_version_id` (live version) together with `cms_page_id` in the backfill UPDATE
- add a regression test for a category with NULL `cms_page_id` and a stale non-live `cms_page_version_id`

## Notes

- fixed in place (same class/timestamp): the migration crashes, so it stays pending (`update IS NULL`) and re-runs on the next `database:migrate`. No separate repair migration is needed and already-migrated shops are untouched (the `WHERE cms_page_id IS NULL` guard skips them).