### PR TITLE
fix: file name conflicts on replacing media

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/index.js
@@ -1,5 +1,6 @@
 import template from './sw-media-modal-replace.html.twig';
 import './sw-media-modal-replace.scss';
+import { UploadEvents } from '../../../../core/service/api/media.api.service';
 
 const { Mixin } = Shopware;
 
@@ -57,6 +58,10 @@ export default {
     methods: {
         onNewUpload({ data }) {
             this.isUploadDataSet = true;
+
+            // overwrite file name randomly to avoid conflicts on upload before renaming
+            // e.g. you want to replace image.png with shopware.png but shopware.png already exists
+            data[0].fileName = Shopware.Utils.createId();
 
             const newFileExtension = data[0].extension;
             const oldFileExtension = this.itemToReplace.fileExtension;

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/index.js
@@ -1,6 +1,5 @@
 import template from './sw-media-modal-replace.html.twig';
 import './sw-media-modal-replace.scss';
-import { UploadEvents } from '../../../../core/service/api/media.api.service';
 
 const { Mixin } = Shopware;
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/sw-media-modal-replace.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/sw-media-modal-replace.spec.js
@@ -42,7 +42,7 @@ describe('components/media/sw-media-modal-replace', () => {
         };
     });
 
-    it('overwrites the filename with a random id to avoid conflicts with existing files', async () => {
+    it('uploads via mediaService and renames back to the original filename', async () => {
         jest.spyOn(Shopware.Utils, 'createId').mockReturnValue('random-conflict-free-id');
         const wrapper = await createWrapper();
 
@@ -50,12 +50,7 @@ describe('components/media/sw-media-modal-replace', () => {
         wrapper.vm.onNewUpload({ data: uploadData });
 
         expect(uploadData[0].fileName).toBe('random-conflict-free-id');
-    });
 
-    it('uploads via mediaService and renames back to the original filename', async () => {
-        const wrapper = await createWrapper();
-
-        wrapper.vm.onNewUpload({ data: [{ fileName: 'shopware', extension: 'png', src: 'blob:...' }] });
         await wrapper.vm.replaceMediaItem();
 
         expect(mediaService.runUploads).toHaveBeenCalledWith('media-id-123');

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/sw-media-modal-replace.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-replace/sw-media-modal-replace.spec.js
@@ -1,0 +1,64 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+
+const mediaService = {
+    runUploads: jest.fn().mockResolvedValue(),
+    renameMedia: jest.fn().mockResolvedValue(),
+};
+
+const createWrapper = async () => {
+    return mount(await wrapTestComponent('sw-media-modal-replace', { sync: true }), {
+        props: {
+            itemToReplace: {
+                id: 'media-id-123',
+                fileName: 'image',
+                fileExtension: 'png',
+                isLoading: false,
+            },
+        },
+        global: {
+            stubs: {
+                'sw-modal': true,
+                'sw-media-upload-v2': true,
+                'mt-button': true,
+            },
+            provide: {
+                mediaService,
+                mediaPresignedUploadService: {},
+                repositoryFactory: {
+                    create: jest.fn(),
+                },
+            },
+        },
+    });
+};
+
+describe('components/media/sw-media-modal-replace', () => {
+    beforeEach(() => {
+        Shopware.Store.get('context').app.config = {
+            settings: { presignedUploadSupported: false },
+        };
+    });
+
+    it('overwrites the filename with a random id to avoid conflicts with existing files', async () => {
+        jest.spyOn(Shopware.Utils, 'createId').mockReturnValue('random-conflict-free-id');
+        const wrapper = await createWrapper();
+
+        const uploadData = [{ fileName: 'shopware', extension: 'png', src: 'blob:...' }];
+        wrapper.vm.onNewUpload({ data: uploadData });
+
+        expect(uploadData[0].fileName).toBe('random-conflict-free-id');
+    });
+
+    it('uploads via mediaService and renames back to the original filename', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onNewUpload({ data: [{ fileName: 'shopware', extension: 'png', src: 'blob:...' }] });
+        await wrapper.vm.replaceMediaItem();
+
+        expect(mediaService.runUploads).toHaveBeenCalledWith('media-id-123');
+        expect(mediaService.renameMedia).toHaveBeenCalledWith('media-id-123', 'image');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -12,7 +12,6 @@ const missingTests = [
     'src/app/component/media/sw-media-folder-content/index.js',
     'src/app/component/media/sw-media-list-selection-item-v2/index.js',
     'src/app/component/media/sw-media-modal-folder-dissolve/index.js',
-    'src/app/component/media/sw-media-modal-replace/index.js',
     'src/app/component/media/sw-media-replace/index.js',
     'src/app/component/media/sw-sidebar-media-item/index.js',
     'src/app/component/app/sw-app-actions/_fixtures/app-action.fixtures.js',


### PR DESCRIPTION
### 1. Why is this change necessary?
When replacing media in the admin there can be conflicts due to the file name that is supposed to replace a file already existing on its own.

### 2. What does this change do, exactly?
Assign a random file name for temporary use for the file to be upload before ultimately renaming it to the file it's supposed to replace.

### 3. Describe each step to reproduce the issue or behaviour.
* Upload two files to the same folder, e.g. image.png and shopware.png
* Try to replace image.png with shopware.png
* Before the change it failed because shopware.png already existed, despite it being only uploaded to replace image.png  not the existing shopware.png

### 4. Please link to the relevant issues (if any).
- closes #17227

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them