### PR TITLE
chore: bump scssphp version to 2.x

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -49,6 +49,14 @@ This prevents leading or trailing whitespace from being stored in standard addre
 
 Existing customer address records are not changed.
 
+### scssphp 2.x replaces scssphp 1.x
+
+`scssphp/scssphp` was bumped from `v1.12.0` to `v2.1.0`, a full dart-sass port. Changes relevant for themes:
+* SCSS color arithmetic (e.g. `#fff + #000`) is rejected (use Sass color functions).
+* `rgb()`/`hsl()` channels must be numeric and `/` is only the alpha separator, so values like `rgb(#fff / 0.5)` or `rgb($color / 0.5)` are no longer accepted (`rgb(255 0 0 / 0.5)` still works).
+* `@import` of a plain CSS file with an explicit `.css` extension is no longer inlined and stays a literal `@import`. Drop the extension to keep inlining the file contents.
+* The library's integrated cache and CLI were removed.
+
 ### Optional SCSS compile cache
 
 SCSS compilation can now reuse previously compiled output through the new `CachedScssCompiler` decorator, backed by `cache.app.taggable` (tag `scss_compiler`, 1h lifetime).

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "psr/log": "^3.0.0",
         "psr/simple-cache": "^3.0.0",
         "ramsey/uuid": "^4.7",
-        "scssphp/scssphp": "v1.12.0",
+        "scssphp/scssphp": "v2.1.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
         "shopware/conflicts": "0.6.1",

--- a/src/Storefront/Theme/Validator/SCSSValidator.php
+++ b/src/Storefront/Theme/Validator/SCSSValidator.php
@@ -175,7 +175,7 @@ class SCSSValidator
         return (str_starts_with($value, '#') && self::isHex(substr($value, 1)))
             || (str_starts_with($value, 'hsl') && self::isHSL($value))
             || (str_starts_with($value, 'rgb') && self::isRGB($value))
-            || (!str_starts_with($value, '#') && Colors::colorNameToRGBa($value) !== null);
+            || (!str_starts_with($value, '#') && Colors::colorNameToColor($value) !== null);
     }
 
     private static function initVariables(string $value, string $varVal): string

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -35,7 +35,7 @@
         "league/flysystem-local": "^3.29.0",
         "league/flysystem-memory": "^3.10.3",
         "meyfa/php-svg": "^0.16.1",
-        "scssphp/scssphp": "v1.12.0",
+        "scssphp/scssphp": "v2.1.0",
         "shopware/core": "*",
         "symfony/asset": "~7.4.0",
         "symfony/cache": "~7.4.12",

--- a/tests/integration/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerTest.php
@@ -507,6 +507,7 @@ PHP_EOL;
   background: #fff;
   color: #eee;
 }
+
 .test-selector-app {
   background: #aaa;
   color: #eee;
@@ -630,15 +631,15 @@ PHP_EOL;
 PHP_EOL;
 
         $expectedCssOutput = <<<PHP_EOL
+@import '~vendor/library.min.css';
 .plain-css-from-library {
   color: red;
 }
-.plain-css-from-library {
-  color: red;
-}
+
 .another-lib {
   color: #0d9c0d;
 }
+
 .another-lib {
   color: #0d9c0d;
 }

--- a/tests/integration/Storefront/Theme/ThemeTest.php
+++ b/tests/integration/Storefront/Theme/ThemeTest.php
@@ -516,8 +516,11 @@ class ThemeTest extends TestCase
             $themeCompiled = $this->themeService->assignTheme($childTheme->getId(), TestDefaults::SALES_CHANNEL, $this->context);
             static::assertTrue($themeCompiled);
         } catch (ThemeCompileException $e) {
-            // ignore files not found exception
-            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". `~vendor/bootstrap/scss/functions` file not found for @import: src/Storefront/Resources/app/storefront/src/scss/variables.scss')) {
+            // The storefront vendor assets (bootstrap) are not built in the PHP integration test
+            // environment, so scssphp 2.x cannot resolve the bootstrap import. Ignore only that
+            // failure; any other compile error must still surface.
+            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". Can\'t find stylesheet to import.')
+                || !str_contains($e->getMessage(), 'bootstrap/scss/functions')) {
                 throw $e;
             }
         }
@@ -783,8 +786,11 @@ class ThemeTest extends TestCase
                 Context::createDefaultContext()
             );
         } catch (ThemeCompileException $e) {
-            // ignore files not found exception
-            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". `~vendor/bootstrap/scss/functions` file not found for @import: src/Storefront/Resources/app/storefront/src/scss/variables.scss')) {
+            // The storefront vendor assets (bootstrap) are not built in the PHP integration test
+            // environment, so scssphp 2.x cannot resolve the bootstrap import. Ignore only that
+            // failure; any other compile error must still surface.
+            if (!str_starts_with($e->getMessage(), 'Unable to compile the theme "Storefront - Theme-ID: ' . $childTheme->getId() . '". Can\'t find stylesheet to import.')
+                || !str_contains($e->getMessage(), 'bootstrap/scss/functions')) {
                 throw $e;
             }
         }

--- a/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
+++ b/tests/unit/Storefront/Theme/Validator/SCSSValidatorTest.php
@@ -519,19 +519,24 @@ class SCSSValidatorTest extends TestCase
             ],
             'rgb(255 0 0 / 0.5)',
         ];
-        yield 'color correct rgb modern with variable' => [
+        // scssphp 2.x (dart-sass) requires numeric rgb() channels and treats `/` purely as the
+        // alpha separator; a variable or hex color in that position is invalid and now rejected.
+        // scssphp 1.x wrongly accepted these by interpreting `/` as division.
+        yield 'color rgb modern with variable is rejected' => [
             [
                 'type' => 'color',
                 'value' => 'rgb($myColor / 0.5)',
             ],
-            'rgb($myColor / 0.5)',
+            '',
+            true,
         ];
-        yield 'color correct rgb modern with hex color' => [
+        yield 'color rgb modern with hex color is rejected' => [
             [
                 'type' => 'color',
                 'value' => 'rgb(#fff / 0.5)',
             ],
-            'rgb(#fff / 0.5)',
+            '',
+            true,
         ];
         yield 'color correct rgba' => [
             [


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow up of https://github.com/shopware/shopware/pull/17391
⚠️ Not to be merged directly in the parent branch, this has been derived to show how little changes are nessary

### 2. What does this change do, exactly?

Focus solely on bump of the lib in 2.x
This cannot fly without major upgrade, as breaking changes involved by the lib cannot be gated (unless we use shopware conflicts mechanism and feature disable for the tests)

=> Caching is now a separable, individually testable concern.

### 3. Describe each step to reproduce the issue or behaviour.

Run the tests (some have been adapted)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
