### PR TITLE
fix: language switch in cms detail

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -476,11 +476,12 @@ export default {
             this.cmsPageState.setBlock(block);
         },
 
-        onChangeLanguage() {
+        onChangeLanguage(languageId) {
             this.isLoading = true;
 
             const isSystemDefaultLanguage = Shopware.Store.get('context').isSystemDefaultLanguage;
             this.cmsPageState.setIsSystemDefaultLanguage(isSystemDefaultLanguage);
+            Shopware.Store.get('context').setApiLanguageId(languageId);
             return this.loadPage(this.pageId);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -841,4 +841,17 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
 
         expect(resetSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should set api language id on language change', async () => {
+        const wrapper = await createWrapper();
+        const defaultLanguageSpy = jest.spyOn(wrapper.vm.cmsPageState, 'setIsSystemDefaultLanguage');
+        const setApiLanguageSpy = jest.spyOn(Shopware.Store.get('context'), 'setApiLanguageId');
+        const loadPageSpy = jest.spyOn(wrapper.vm, 'loadPage');
+
+        wrapper.vm.onChangeLanguage('new-language');
+
+        expect(defaultLanguageSpy).toHaveBeenCalledWith(true);
+        expect(setApiLanguageSpy).toHaveBeenCalledWith('new-language');
+        expect(loadPageSpy).toHaveBeenCalledWith('1a');
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
API language is not set on language change in CMS detail

### 2. What does this change do, exactly?
Set api language on language switch in CMS detail

### 3. Describe each step to reproduce the issue or behaviour.
* Change language in CMS detail
* Reload the page

### 4. Please link to the relevant issues (if any).
- closes #16701 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
