### PR TITLE
fix: include product export sales channel id for rule evaluation

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -27,6 +27,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\SalesChannelRule;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
@@ -93,7 +95,10 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             $languageId,
             $productExport->getCurrencyId()
         );
-        $contextServiceParameters->addExtension(ProductExportEntity::class, $productExport);
+        $contextServiceParameters->addExtension(
+            SalesChannelRule::PRODUCT_EXPORT_SALES_CHANNEL,
+            new ArrayStruct(['id' => $productExport->getSalesChannelId()])
+        );
         $context = $this->salesChannelContextService->get($contextServiceParameters);
 
         $this->translator->injectSettings(

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -87,14 +87,14 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
 
         $languageId = $domain->getLanguageId();
 
-        $context = $this->salesChannelContextService->get(
-            new SalesChannelContextServiceParameters(
-                $productExport->getStorefrontSalesChannelId(),
-                $contextToken,
-                $languageId,
-                $productExport->getCurrencyId()
-            )
+        $contextServiceParameters = new SalesChannelContextServiceParameters(
+            $productExport->getStorefrontSalesChannelId(),
+            $contextToken,
+            $languageId,
+            $productExport->getCurrencyId()
         );
+        $contextServiceParameters->addExtension(ProductExportEntity::class, $productExport);
+        $context = $this->salesChannelContextService->get($contextServiceParameters);
 
         $this->translator->injectSettings(
             $productExport->getStorefrontSalesChannelId(),

--- a/src/Core/Framework/Rule/SalesChannelRule.php
+++ b/src/Core/Framework/Rule/SalesChannelRule.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Rule;
 
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
@@ -27,7 +28,14 @@ class SalesChannelRule extends Rule
 
     public function match(RuleScope $scope): bool
     {
-        return RuleComparison::uuids([$scope->getSalesChannelContext()->getSalesChannelId()], $this->salesChannelIds, $this->operator);
+        $currentSalesChannelIds = [$scope->getSalesChannelContext()->getSalesChannelId()];
+
+        $productExport = $scope->getSalesChannelContext()->getExtension(ProductExportEntity::class);
+        if ($productExport instanceof ProductExportEntity) {
+            $currentSalesChannelIds[] = $productExport->getSalesChannelId();
+        }
+
+        return RuleComparison::uuids($currentSalesChannelIds, $this->salesChannelIds, $this->operator);
     }
 
     public function getConstraints(): array

--- a/src/Core/Framework/Rule/SalesChannelRule.php
+++ b/src/Core/Framework/Rule/SalesChannelRule.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Core\Framework\Rule;
 
-use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
 /**
@@ -13,6 +13,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 class SalesChannelRule extends Rule
 {
     final public const RULE_NAME = 'salesChannel';
+
+    final public const PRODUCT_EXPORT_SALES_CHANNEL = 'product-export-sales-channel';
 
     /**
      * @param list<string>|null $salesChannelIds
@@ -30,9 +32,9 @@ class SalesChannelRule extends Rule
     {
         $currentSalesChannelIds = [$scope->getSalesChannelContext()->getSalesChannelId()];
 
-        $productExport = $scope->getSalesChannelContext()->getExtension(ProductExportEntity::class);
-        if ($productExport instanceof ProductExportEntity) {
-            $currentSalesChannelIds[] = $productExport->getSalesChannelId();
+        $extension = $scope->getSalesChannelContext()->getExtension(self::PRODUCT_EXPORT_SALES_CHANNEL);
+        if ($extension instanceof ArrayStruct && $extension->has('id')) {
+            $currentSalesChannelIds[] = $extension->get('id');
         }
 
         return RuleComparison::uuids($currentSalesChannelIds, $this->salesChannelIds, $this->operator);

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -115,6 +115,8 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
                 $context->addState(Context::ELASTICSEARCH_EXPLAIN_MODE);
             }
 
+            $context->addExtensions($parameters->getExtensions());
+
             $this->eventDispatcher->dispatch(new SalesChannelContextCreatedEvent($context, $token, $session));
 
             $currentRequest = $this->requestStack->getCurrentRequest();

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Rule\SalesChannelRule;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
@@ -386,8 +387,10 @@ class ProductExportGeneratorTest extends TestCase
                 'encoding' => ProductExportEntity::ENCODING_UTF8,
                 'fileFormat' => ProductExportEntity::FILE_FORMAT_CSV,
                 'interval' => 0,
-                'headerTemplate' => 'name,stock,category',
-                'bodyTemplate' => '{{ product.name }},{{ product.stock }},{%- if product.categories.count > 0 -%}{{ product.categories.first.name }}{%- endif -%}',
+                'headerTemplate' => 'name,stock,category,price',
+                'bodyTemplate' => '{{ product.name }},{{ product.stock }},{%- if product.categories.count > 0 -%}{{ product.categories.first.name }}{%- endif -%},'
+                    . '{% set price = product.calculatedPrice %}{%- if product.calculatedPrices.count > 0 -%}{% set price = product.calculatedPrices.last %}{%- endif -%}'
+                    . '{{ price.unitPrice|number_format(context.currency.itemRounding.decimals, \'.\', \'\') }} {{ context.currency.isoCode }}',
                 'productStreamId' => '137b079935714281ba80b40f83f8d7eb',
                 'storefrontSalesChannelId' => $this->getSalesChannelDomain()->getSalesChannelId(),
                 'salesChannelId' => $this->getSalesChannelId(),
@@ -440,7 +443,28 @@ class ProductExportGeneratorTest extends TestCase
                 'productNumber' => Uuid::randomHex(),
                 'stock' => 1,
                 'name' => 'Test',
-                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'price' => [
+                    ['currencyId' => Defaults::CURRENCY, 'gross' => 100, 'net' => 90, 'linked' => false],
+                ],
+                'prices' => [
+                    [
+                        'quantityStart' => 1,
+                        'rule' => [
+                            'name' => 'Test rule',
+                            'priority' => 1,
+                            'conditions' => [
+                                [
+                                    'type' => (new SalesChannelRule())->getName(),
+                                    'value' => [
+                                        'salesChannelIds' => [$this->getSalesChannelId()],
+                                        'operator' => SalesChannelRule::OPERATOR_EQ,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                    ],
+                ],
                 'manufacturer' => ['id' => $manufacturerId, 'name' => 'test'],
                 'tax' => ['id' => $taxId, 'taxRate' => 17, 'name' => 'with id'],
                 'visibilities' => [

--- a/tests/integration/Core/Content/ProductExport/Service/fixtures/test-export.csv
+++ b/tests/integration/Core/Content/ProductExport/Service/fixtures/test-export.csv
@@ -1,3 +1,3 @@
-name,stock,category
-Test,1,Foobar
-Test,1,
+name,stock,category,price
+Test,1,Foobar,10.00 EUR
+Test,1,,10.00 EUR

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleConstraints;
@@ -85,6 +86,13 @@ class SalesChannelRuleTest extends TestCase
             null,
             false,
         ];
+
+        yield 'matches with product export sales channel' => [
+            Rule::OPERATOR_EQ,
+            Uuid::fromStringToHex('test'),
+            [Uuid::fromStringToHex('test1'), Uuid::fromStringToHex('product-export-sales-channel-id')],
+            true,
+        ];
     }
 
     public function testProvidesConstraints(): void
@@ -101,12 +109,16 @@ class SalesChannelRuleTest extends TestCase
 
     private function createRuleScope(string $salesChannelId): RuleScope
     {
+        $productExport = new ProductExportEntity();
+        $productExport->setSalesChannelId(Uuid::fromStringToHex('product-export-sales-channel-id'));
+
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
 
         $salesChannelContext = Generator::generateSalesChannelContext(
             salesChannel: $salesChannel
         );
+        $salesChannelContext->addExtension(ProductExportEntity::class, $productExport);
 
         return new CheckoutRuleScope(
             $salesChannelContext

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -6,12 +6,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\CheckoutRuleScope;
-use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
 use Shopware\Core\Framework\Rule\SalesChannelRule;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
@@ -109,16 +109,16 @@ class SalesChannelRuleTest extends TestCase
 
     private function createRuleScope(string $salesChannelId): RuleScope
     {
-        $productExport = new ProductExportEntity();
-        $productExport->setSalesChannelId(Uuid::fromStringToHex('product-export-sales-channel-id'));
-
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setId($salesChannelId);
 
         $salesChannelContext = Generator::generateSalesChannelContext(
             salesChannel: $salesChannel
         );
-        $salesChannelContext->addExtension(ProductExportEntity::class, $productExport);
+        $salesChannelContext->addExtension(
+            SalesChannelRule::PRODUCT_EXPORT_SALES_CHANNEL,
+            new ArrayStruct(['id' => Uuid::fromStringToHex('product-export-sales-channel-id')])
+        );
 
         return new CheckoutRuleScope(
             $salesChannelContext


### PR DESCRIPTION
### 1. Why is this change necessary?
When a rule targeting a specific Export Sales Channel is used for advanced/extended product prices, those prices are not applied during export. This is because the `SalesChannelRule` only evaluates against the Storefront Sales Channel ID used to build the context — not the Export Sales Channel ID the export actually belongs to.

### 2. What does this change do, exactly?
- `ProductExportGenerator` attaches the export sales channel ID to the `SalesChannelContextServiceParameters` as an `ArrayStruct` extension before the context is created, using the key `SalesChannelRule::PRODUCT_EXPORT_SALES_CHANNEL`
- `SalesChannelContextService` propagates all extensions from the parameters onto the created `SalesChannelContext`
- `SalesChannelRule::match()` now reads the export sales channel extension from the context and includes its ID alongside the storefront sales channel ID when evaluating the rule — so a rule targeting either the storefront channel or the export channel will match correctly

### 3. Describe each step to reproduce the issue or behaviour.
  1. Create an Export Sales Channel
  2. Create a rule with condition Sales Channel = [the export sales channel from step 1]
  3. Add an advanced/extended price to a product using that rule (lower than the base price)
  4. Generate the export — the advanced price is not applied; the base price is used instead
  5. After this fix, the advanced price is correctly applied in the export

### 4. Please link to the relevant issues (if any).
- closes #6180

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
