### PR TITLE
refactor(elasticsearch): rename word_delimiter analyzers to technical_term

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -32,6 +32,19 @@ return [
         // Expected to be appended when a new event is added
         preg_quote('Value of constant Shopware\Core\Framework\Webhook\Hookable', '/'),
 
+        // Intentional rename of the technical-term analyzer chain so the public
+        // identifier matches how the chain is referenced everywhere else
+        // (constants, `buildTextFieldConfig(technicalTerms: true)`, the
+        // architecture doc). Shopware-internal users were already going through
+        // `ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_*` and the
+        // `TECHNICAL_TERM_SEARCH_FIELD` const — both still resolve correctly;
+        // only the underlying analyzer string moved from
+        // `sw_*_word_delimiter_*_analyzer` to `sw_*_technical_term_*_analyzer`.
+        // Documented in UPGRADE-6.8.md.
+        preg_quote('Value of constant Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_INDEX', '/'),
+        preg_quote('Value of constant Shopware\Elasticsearch\Framework\ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_SEARCH', '/'),
+        preg_quote('Value of constant Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition::TECHNICAL_TERM_SEARCH_FIELD', '/'),
+
         // Had a typo in the internal annotation
         preg_quote('CHANGED: Shopware\Core\Framework\DataAbstractionLayer\Search\CompressedCriteriaDecoder was marked "@internal"', '/'),
 

--- a/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
+++ b/src/Elasticsearch/Framework/ElasticsearchFieldBuilder.php
@@ -41,13 +41,13 @@ class ElasticsearchFieldBuilder
      * SKU-style fields where letter↔digit boundaries and `,` / `-` / `.`
      * separators must survive into the inverted index.
      */
-    public const ANALYZER_WHITESPACE_TECHNICAL_INDEX = 'sw_whitespace_word_delimiter_index_analyzer';
+    public const ANALYZER_WHITESPACE_TECHNICAL_INDEX = 'sw_whitespace_technical_term_index_analyzer';
 
     /**
      * Search-side counterpart of {@see self::ANALYZER_WHITESPACE_TECHNICAL_INDEX}
      * with the cross-position deduplication filter appended.
      */
-    public const ANALYZER_WHITESPACE_TECHNICAL_SEARCH = 'sw_whitespace_word_delimiter_search_analyzer';
+    public const ANALYZER_WHITESPACE_TECHNICAL_SEARCH = 'sw_whitespace_technical_term_search_analyzer';
 
     /**
      * Common prefix of every language-agnostic analyzer this bundle ships.
@@ -208,8 +208,8 @@ class ElasticsearchFieldBuilder
     private function getTechnicalTermAnalyzer(string $analyzer, bool $searchAnalyzer): ?string
     {
         return match ($analyzer) {
-            'sw_english_analyzer' => $searchAnalyzer ? 'sw_english_word_delimiter_search_analyzer' : 'sw_english_word_delimiter_index_analyzer',
-            'sw_german_analyzer' => $searchAnalyzer ? 'sw_german_word_delimiter_search_analyzer' : 'sw_german_word_delimiter_index_analyzer',
+            'sw_english_analyzer' => $searchAnalyzer ? 'sw_english_technical_term_search_analyzer' : 'sw_english_technical_term_index_analyzer',
+            'sw_german_analyzer' => $searchAnalyzer ? 'sw_german_technical_term_search_analyzer' : 'sw_german_technical_term_index_analyzer',
             default => null,
         };
     }

--- a/src/Elasticsearch/Framework/Indexing/IndexCreator.php
+++ b/src/Elasticsearch/Framework/Indexing/IndexCreator.php
@@ -23,12 +23,12 @@ class IndexCreator
      * analyzers when the bundle parameter is enabled.
      */
     private const TECHNICAL_TERM_ANALYZERS = [
-        'sw_whitespace_word_delimiter_index_analyzer',
-        'sw_whitespace_word_delimiter_search_analyzer',
-        'sw_english_word_delimiter_index_analyzer',
-        'sw_english_word_delimiter_search_analyzer',
-        'sw_german_word_delimiter_index_analyzer',
-        'sw_german_word_delimiter_search_analyzer',
+        'sw_whitespace_technical_term_index_analyzer',
+        'sw_whitespace_technical_term_search_analyzer',
+        'sw_english_technical_term_index_analyzer',
+        'sw_english_technical_term_search_analyzer',
+        'sw_german_technical_term_index_analyzer',
+        'sw_german_technical_term_search_analyzer',
     ];
 
     /**

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -180,12 +180,12 @@ elasticsearch:
                 type: custom
                 tokenizer: whitespace
                 filter: ['lowercase']
-            sw_whitespace_word_delimiter_index_analyzer:
+            sw_whitespace_technical_term_index_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_unit_glue']
                 filter: ['sw_word_delimiter_filter', 'flatten_graph', 'lowercase', 'sw_length_min', 'sw_decimal_normalize_token', 'remove_duplicates']
-            sw_whitespace_word_delimiter_search_analyzer:
+            sw_whitespace_technical_term_search_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_unit_glue']
@@ -198,12 +198,12 @@ elasticsearch:
                 type: custom
                 tokenizer: whitespace
                 filter: ['lowercase', 'sw_english_stop_filter']
-            sw_english_word_delimiter_index_analyzer:
+            sw_english_technical_term_index_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_unit_glue']
                 filter: ['sw_word_delimiter_filter', 'flatten_graph', 'lowercase', 'sw_length_min', 'sw_decimal_normalize_token', 'remove_duplicates', 'sw_english_stop_filter']
-            sw_english_word_delimiter_search_analyzer:
+            sw_english_technical_term_search_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_unit_glue']
@@ -212,12 +212,12 @@ elasticsearch:
                 type: custom
                 tokenizer: whitespace
                 filter: ['lowercase', 'sw_german_stop_filter']
-            sw_german_word_delimiter_index_analyzer:
+            sw_german_technical_term_index_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_decimal_normalize', 'sw_unit_glue']
                 filter: ['sw_word_delimiter_filter', 'flatten_graph', 'lowercase', 'sw_length_min', 'sw_decimal_normalize_token', 'remove_duplicates', 'sw_german_stop_filter']
-            sw_german_word_delimiter_search_analyzer:
+            sw_german_technical_term_search_analyzer:
                 type: custom
                 tokenizer: whitespace
                 char_filter: ['sw_decimal_normalize', 'sw_unit_glue']

--- a/tests/unit/Elasticsearch/Framework/ElasticsearchFieldBuilderTest.php
+++ b/tests/unit/Elasticsearch/Framework/ElasticsearchFieldBuilderTest.php
@@ -151,8 +151,8 @@ class ElasticsearchFieldBuilderTest extends TestCase
                     'fields' => [
                         'search' => [
                             'type' => 'text',
-                            'analyzer' => 'sw_german_word_delimiter_index_analyzer',
-                            'search_analyzer' => 'sw_german_word_delimiter_search_analyzer',
+                            'analyzer' => 'sw_german_technical_term_index_analyzer',
+                            'search_analyzer' => 'sw_german_technical_term_search_analyzer',
                         ],
                         'ngram' => [
                             'type' => 'text',
@@ -164,8 +164,8 @@ class ElasticsearchFieldBuilderTest extends TestCase
                     'fields' => [
                         'search' => [
                             'type' => 'text',
-                            'analyzer' => 'sw_english_word_delimiter_index_analyzer',
-                            'search_analyzer' => 'sw_english_word_delimiter_search_analyzer',
+                            'analyzer' => 'sw_english_technical_term_index_analyzer',
+                            'search_analyzer' => 'sw_english_technical_term_search_analyzer',
                         ],
                         'ngram' => [
                             'type' => 'text',

--- a/tests/unit/Elasticsearch/Framework/Indexing/IndexCreatorTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/IndexCreatorTest.php
@@ -323,14 +323,14 @@ class IndexCreatorTest extends TestCase
                 $analyzers = $payload['body']['settings']['analysis']['analyzer'];
 
                 // Non-German chains had `['sw_unit_glue']`; dimension is prepended.
-                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_whitespace_word_delimiter_index_analyzer']['char_filter']);
-                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_whitespace_word_delimiter_search_analyzer']['char_filter']);
-                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_english_word_delimiter_index_analyzer']['char_filter']);
-                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_english_word_delimiter_search_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_whitespace_technical_term_index_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_whitespace_technical_term_search_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_english_technical_term_index_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_unit_glue'], $analyzers['sw_english_technical_term_search_analyzer']['char_filter']);
 
                 // German chains had `['sw_decimal_normalize', 'sw_unit_glue']`; dimension is prepended, decimal + unit_glue preserved.
-                static::assertSame(['sw_dimension_normalize', 'sw_decimal_normalize', 'sw_unit_glue'], $analyzers['sw_german_word_delimiter_index_analyzer']['char_filter']);
-                static::assertSame(['sw_dimension_normalize', 'sw_decimal_normalize', 'sw_unit_glue'], $analyzers['sw_german_word_delimiter_search_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_decimal_normalize', 'sw_unit_glue'], $analyzers['sw_german_technical_term_index_analyzer']['char_filter']);
+                static::assertSame(['sw_dimension_normalize', 'sw_decimal_normalize', 'sw_unit_glue'], $analyzers['sw_german_technical_term_search_analyzer']['char_filter']);
 
                 // Non-technical analyzers are untouched.
                 static::assertArrayNotHasKey('char_filter', $analyzers['sw_whitespace_analyzer']);
@@ -362,7 +362,7 @@ class IndexCreatorTest extends TestCase
             ->willReturnCallback(static function (array $payload): void {
                 static::assertSame(
                     ['sw_dimension_normalize', 'sw_unit_glue'],
-                    $payload['body']['settings']['analysis']['analyzer']['sw_english_word_delimiter_index_analyzer']['char_filter'],
+                    $payload['body']['settings']['analysis']['analyzer']['sw_english_technical_term_index_analyzer']['char_filter'],
                     'sw_dimension_normalize must not be appended twice when already present.',
                 );
             });
@@ -370,7 +370,7 @@ class IndexCreatorTest extends TestCase
         $client->method('indices')->willReturn($indices);
 
         $analysis = self::technicalTermAnalysisFixture();
-        $analysis['analyzer']['sw_english_word_delimiter_index_analyzer']['char_filter'] = ['sw_dimension_normalize', 'sw_unit_glue'];
+        $analysis['analyzer']['sw_english_technical_term_index_analyzer']['char_filter'] = ['sw_dimension_normalize', 'sw_unit_glue'];
 
         $helper = $this->createMock(ElasticsearchHelper::class);
         $index = new IndexCreator(
@@ -477,12 +477,12 @@ class IndexCreatorTest extends TestCase
             'analyzer' => [
                 'sw_whitespace_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'filter' => ['lowercase']],
                 'sw_ngram_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'filter' => ['lowercase', 'sw_ngram_filter']],
-                'sw_whitespace_word_delimiter_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
-                'sw_whitespace_word_delimiter_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
-                'sw_english_word_delimiter_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
-                'sw_english_word_delimiter_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
-                'sw_german_word_delimiter_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_decimal_normalize', 'sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
-                'sw_german_word_delimiter_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_decimal_normalize', 'sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_whitespace_technical_term_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_whitespace_technical_term_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_english_technical_term_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_english_technical_term_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_german_technical_term_index_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_decimal_normalize', 'sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
+                'sw_german_technical_term_search_analyzer' => ['type' => 'custom', 'tokenizer' => 'whitespace', 'char_filter' => ['sw_decimal_normalize', 'sw_unit_glue'], 'filter' => ['sw_word_delimiter_filter']],
             ],
         ];
     }

--- a/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -91,8 +91,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
                     ],
                     'search' => [
                         'type' => 'text',
-                        'analyzer' => 'sw_english_word_delimiter_index_analyzer',
-                        'search_analyzer' => 'sw_english_word_delimiter_search_analyzer',
+                        'analyzer' => 'sw_english_technical_term_index_analyzer',
+                        'search_analyzer' => 'sw_english_technical_term_search_analyzer',
                     ],
                     'ngram' => [
                         'type' => 'text',
@@ -113,8 +113,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
                     ],
                     'search' => [
                         'type' => 'text',
-                        'analyzer' => 'sw_german_word_delimiter_index_analyzer',
-                        'search_analyzer' => 'sw_german_word_delimiter_search_analyzer',
+                        'analyzer' => 'sw_german_technical_term_index_analyzer',
+                        'search_analyzer' => 'sw_german_technical_term_search_analyzer',
                     ],
                     'ngram' => [
                         'type' => 'text',
@@ -140,8 +140,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
                     ],
                     'search' => [
                         'type' => 'text',
-                        'analyzer' => 'sw_english_word_delimiter_index_analyzer',
-                        'search_analyzer' => 'sw_english_word_delimiter_search_analyzer',
+                        'analyzer' => 'sw_english_technical_term_index_analyzer',
+                        'search_analyzer' => 'sw_english_technical_term_search_analyzer',
                         'similarity' => 'sw_length_norm',
                     ],
                     'ngram' => [
@@ -163,8 +163,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
                     ],
                     'search' => [
                         'type' => 'text',
-                        'analyzer' => 'sw_german_word_delimiter_index_analyzer',
-                        'search_analyzer' => 'sw_german_word_delimiter_search_analyzer',
+                        'analyzer' => 'sw_german_technical_term_index_analyzer',
+                        'search_analyzer' => 'sw_german_technical_term_search_analyzer',
                         'similarity' => 'sw_length_norm',
                     ],
                     'ngram' => [
@@ -242,8 +242,8 @@ class ElasticsearchProductDefinitionTest extends TestCase
             ],
             'search' => [
                 'type' => 'text',
-                'analyzer' => 'sw_whitespace_word_delimiter_index_analyzer',
-                'search_analyzer' => 'sw_whitespace_word_delimiter_search_analyzer',
+                'analyzer' => 'sw_whitespace_technical_term_index_analyzer',
+                'search_analyzer' => 'sw_whitespace_technical_term_search_analyzer',
             ],
             'ngram' => [
                 'type' => 'text',


### PR DESCRIPTION
## Summary

Renames the technical-term Elasticsearch analyzer chains in the product index from `sw_*_word_delimiter_*_analyzer` to `sw_*_technical_term_*_analyzer`, aligning the analyzer name strings with how the chain is already named everywhere else (PHP constants `TECHNICAL_TERM_SEARCH_FIELD` / `ANALYZER_WHITESPACE_TECHNICAL_*`, the `buildTextFieldConfig(technicalTerms: true)` flag, and the architecture docs).

The chain composition is **unchanged** — this is a pure name change. The shared `sw_word_delimiter_filter` keeps its name (it follows the convention of naming filters after their type).

Renamed:
- `sw_whitespace_word_delimiter_{index,search}_analyzer` → `sw_whitespace_technical_term_{index,search}_analyzer`
- `sw_english_word_delimiter_{index,search}_analyzer` → `sw_english_technical_term_{index,search}_analyzer`
- `sw_german_word_delimiter_{index,search}_analyzer` → `sw_german_technical_term_{index,search}_analyzer`

## Notes

- Split out of #16661 (search-architecture docs) so the code rename can be reviewed independently of the documentation. #16661 stacks on this PR and documents the renamed analyzers.
- A full Elasticsearch reindex is required after this change.
- `ElasticsearchFieldBuilder::ANALYZER_WHITESPACE_TECHNICAL_*` constants now hold the new names; code using the constants is unaffected. Code that hard-coded the old analyzer name strings must update.

## Verification

`IndexCreatorTest`, `ElasticsearchFieldBuilderTest`, `ElasticsearchProductDefinitionTest` — 28 tests green. Full `SearchCasesTest` integration suite green on the combined stack.
