### PR TITLE
refactor: improve speed of remote thumbnail generation

### DIFF
--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -148,32 +148,43 @@ class RemoteThumbnailLoader implements ResetInterface
             return $this->mediaFolderThumbnailSizes;
         }
 
-        $entities = $this->connection->fetchAllAssociative(
+        /** @var list<array{configuration_id: string, media_thumbnail_size_id: string, width: string, height: string}> $sizes */
+        $sizes = $this->connection->fetchAllAssociative(
             '
             SELECT
-                LOWER(HEX(mf.id)) as media_folder_id,
-                LOWER(HEX(mts.id)) as media_thumbnail_size_id,
+                LOWER(HEX(mfcmts.media_folder_configuration_id)) AS configuration_id,
+                LOWER(HEX(mts.id)) AS media_thumbnail_size_id,
                 mts.width,
                 mts.height
-            FROM media_folder mf
-            INNER JOIN media_folder_configuration mfc ON mf.media_folder_configuration_id = mfc.id
-            INNER JOIN media_folder_configuration_media_thumbnail_size mfcmts ON mfcmts.media_folder_configuration_id = mfc.id
+            FROM media_folder_configuration_media_thumbnail_size mfcmts
             INNER JOIN media_thumbnail_size mts ON mfcmts.media_thumbnail_size_id = mts.id'
         );
 
-        if ($entities === []) {
-            return [];
+        if ($sizes === []) {
+            return $this->mediaFolderThumbnailSizes = [];
         }
 
-        $grouped = [];
-
-        /** @var array{media_folder_id: string, media_thumbnail_size_id: string, width: string, height: string} $entity */
-        foreach ($entities as $entity) {
-            $grouped[$entity['media_folder_id']][] = [
-                'media_thumbnail_size_id' => $entity['media_thumbnail_size_id'],
-                'width' => $entity['width'],
-                'height' => $entity['height'],
+        $configurationSizes = [];
+        foreach ($sizes as $size) {
+            $configurationSizes[$size['configuration_id']][] = [
+                'media_thumbnail_size_id' => $size['media_thumbnail_size_id'],
+                'width' => $size['width'],
+                'height' => $size['height'],
             ];
+        }
+
+        /** @var array<string, string> $folderToConfiguration */
+        $folderToConfiguration = $this->connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(id)), LOWER(HEX(media_folder_configuration_id))
+             FROM media_folder
+             WHERE media_folder_configuration_id IS NOT NULL'
+        );
+
+        $grouped = [];
+        foreach ($folderToConfiguration as $folderId => $configurationId) {
+            if (isset($configurationSizes[$configurationId])) {
+                $grouped[$folderId] = $configurationSizes[$configurationId];
+            }
         }
 
         return $this->mediaFolderThumbnailSizes = $grouped;

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -38,6 +38,9 @@ class RemoteThumbnailLoaderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->method('fetchAllAssociative')->willReturn($thumbnailSizes);
+        $connection->method('fetchAllKeyValue')->willReturn([
+            $ids->get('mediaFolderId') => $ids->get('mediaFolderConfigurationId'),
+        ]);
 
         $dispatcher = new EventDispatcher();
         $extensionDispatcher = new ExtensionDispatcher($dispatcher);
@@ -80,9 +83,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'http://localhost:8000/foo/bar.png',
@@ -104,9 +107,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'http://localhost:8000/foo/bar.png?ts=946684800',
@@ -143,9 +146,9 @@ class RemoteThumbnailLoaderTest extends TestCase
                 'private' => false,
             ]),
             [
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
-                ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+                ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '600', 'height' => '600'],
             ],
             [
                 'media' => 'https://test.com/photo/flower.jpg?ts=946684800',
@@ -164,12 +167,15 @@ class RemoteThumbnailLoaderTest extends TestCase
         $filesystem = new Filesystem(new InMemoryFilesystemAdapter(), ['public_url' => 'http://localhost:8000']);
 
         $thumbnailSizes = [
-            ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
-            ['media_folder_id' => $ids->get('mediaFolderId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
+            ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '200', 'height' => '200'],
+            ['configuration_id' => $ids->get('mediaFolderConfigurationId'), 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'), 'width' => '400', 'height' => '400'],
         ];
 
         $connection = $this->createMock(Connection::class);
         $connection->method('fetchAllAssociative')->willReturn($thumbnailSizes);
+        $connection->method('fetchAllKeyValue')->willReturn([
+            $ids->get('mediaFolderId') => $ids->get('mediaFolderConfigurationId'),
+        ]);
 
         $entity = (new PartialEntity())->assign([
             'id' => $ids->get('media'),
@@ -203,13 +209,13 @@ class RemoteThumbnailLoaderTest extends TestCase
 
         $thumbnailSizes = [
             [
-                'media_folder_id' => $ids->get('mediaFolderId'),
+                'configuration_id' => $ids->get('mediaFolderConfigurationId'),
                 'width' => '200',
                 'height' => '200',
                 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'),
             ],
             [
-                'media_folder_id' => $ids->get('mediaFolderId'),
+                'configuration_id' => $ids->get('mediaFolderConfigurationId'),
                 'width' => '400',
                 'height' => '400',
                 'media_thumbnail_size_id' => $ids->get('mediaThumbnailSizeId'),
@@ -218,6 +224,9 @@ class RemoteThumbnailLoaderTest extends TestCase
 
         $connection = $this->createMock(Connection::class);
         $connection->method('fetchAllAssociative')->willReturn($thumbnailSizes);
+        $connection->method('fetchAllKeyValue')->willReturn([
+            $ids->get('mediaFolderId') => $ids->get('mediaFolderConfigurationId'),
+        ]);
 
         $entity = (new PartialEntity())->assign([
             'id' => $ids->get('media'),


### PR DESCRIPTION
### 1. Why is this change necessary?

The query in RemoteThumbnailLoader::getMediaThumbnailSizes retrieves the thumbnail sizes for each media folder with a Cartesian join on the media_folder_configuration_id. The result is not cached outside of MySQL and called each time RemoteThumbnailLoader is called with media entities.

With a lot of media folders the returned array grows in size, and with each new folder (like products or new articles), the pages with thumbnails become slower and slower, because each folder adds more data to be fetched from the database.

### 2. What does this change do, exactly?

It pulls the configured sizes and maps them onto each folder, keeping the data structure intact but speeding up the process.

### 3. Describe each step to reproduce the issue or behaviour.

I created a benchmark file here: https://gist.github.com/M-arcus/358ffc08840c6d72431cc182cb8402dc

Needs to be put in  `tests/performance/bench/Core/Content/Media/RemoteThumbnailLoaderBench.php` and execute it via `vendor/bin/phpbench run tests/performance/bench/Core/Content/Media --report=compressed`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
