### PR TITLE
fix: media item name overflow

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -190,6 +190,11 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-media-base-item__name-container {
+            // Allow the grid item to shrink below the intrinsic width of long
+            // file names, so the name truncates instead of overflowing the
+            // item and triggering horizontal scrolling.
+            min-width: 0;
+            overflow: hidden;
             margin: 0;
             text-align: left;
             font-size: $font-size-xs;

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -190,9 +190,6 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-media-base-item__name-container {
-            // Allow the grid item to shrink below the intrinsic width of long
-            // file names, so the name truncates instead of overflowing the
-            // item and triggering horizontal scrolling.
             min-width: 0;
             overflow: hidden;
             margin: 0;


### PR DESCRIPTION

  ### 1. Why is this change necessary?

  In the Administration media library, media items with long file names did not
  truncate. The name container is a flex child, and because it had no `min-width`
  constraint it refused to shrink below its content width. As a result the
  existing text-overflow/ellipsis on the name never took effect — long names
  overflowed their grid item and broke the layout of the media list.

  ### 2. What does this change do, exactly?

  It adds two properties to `.sw-media-base-item__name-container` in
  `sw-media-base-item.scss`:

  - `min-width: 0;` — allows the flex item to shrink below its intrinsic content
    width, which is the prerequisite for any child truncation to work.
  - `overflow: hidden;` — clips the overflowing text so the ellipsis applies and
    the name stays within the item bounds.

  No markup or component logic is changed; this is a CSS-only fix.

  ### 3. Describe each step to reproduce the issue or behaviour.

  1. Open the Administration and go to **Content → Media**.
  2. Upload (or rename) a file so it has a very long file name, e.g.
     `this-is-a-really-long-media-file-name-that-should-be-truncated.jpg`.
  3. View the media item in the grid/list.
  4. **Before:** the name overflows the item and disrupts the layout.
  
<img width="1278" height="789" alt="image" src="https://github.com/user-attachments/assets/bea6203e-0d76-4a87-971f-002010369f28" />

5. **After:** the name is truncated with an ellipsis and the item keeps its
     intended width.
     
     
<img width="885" height="584" alt="image" src="https://github.com/user-attachments/assets/d22751a5-638c-433d-af72-0ee785f41b1c" />


  ### 4. Please link to the relevant issues (if any).

  <!-- No related issue. -->

  ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [x] I have written or adjusted the documentation according to my changes
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them