### PR TITLE
feat: remove redundant back-folder tile from media library grid in administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/index.js
@@ -27,14 +27,6 @@ export default {
         Mixin.getByName('notification'),
     ],
 
-    props: {
-        isParent: {
-            type: Boolean,
-            required: false,
-            default: false,
-        },
-    },
-
     data() {
         return {
             showSettings: false,

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.html.twig
@@ -3,23 +3,13 @@
     class="sw-media-folder-item"
     v-bind="$attrs"
     :truncate-right="true"
-    :allow-multi-select="!isParent"
 >
 
     {% block sw_media_folder_item_preview %}
     <template #preview="{ item }">
-        {% block sw_media_folder_parent_icon%}
-        <img
-            v-if="isParent"
-            :src="assetFilter('/administration/administration/static/img/media/folder--back.svg')"
-            class="sw-media-folder-item__folder-thumbnails"
-            alt="Folder back"
-        >
-        {% endblock %}
-
         {% block sw_media_folder_default_icon%}
         <span
-            v-else-if="!!item.defaultFolderId"
+            v-if="!!item.defaultFolderId"
         >
             <img
                 :src="assetFilter('/administration/administration/static/img/media/' + iconName + '.svg')"
@@ -50,7 +40,7 @@
         {% block sw_media_base_item_name %}
 
         <mt-text-field
-            v-if="!isParent && (isInlineEdit || item.isNew())"
+            v-if="isInlineEdit || item.isNew()"
             v-autofocus
             class="sw-media-base-item__name-field"
             :model-value="item.name"

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -221,26 +221,6 @@ describe('components/media/sw-media-folder-item', () => {
         expect(editMenuItem.attributes().disabled).toBeDefined();
     });
 
-    it('should show the icon when it is not parent', async () => {
-        const wrapper = await createWrapper();
-        await wrapper.setProps({
-            isParent: false,
-        });
-        await wrapper.vm.$nextTick();
-
-        expect(wrapper.text()).toContain('AllowMultiSelect: "true"');
-    });
-
-    it('should not show the icon on back folder', async () => {
-        const wrapper = await createWrapper();
-        await wrapper.setProps({
-            isParent: true,
-        });
-        await wrapper.vm.$nextTick();
-
-        expect(wrapper.text()).toContain('AllowMultiSelect: "false"');
-    });
-
     it('should return filters from filter registry', async () => {
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/index.js
@@ -121,7 +121,6 @@ export default {
             itemTotal: 0,
             folderTotal: 0,
             currentFolder: null,
-            parentFolder: null,
             presentation: 'medium-preview',
             sorting: { sortBy: 'fileName', sortDirection: 'asc' },
             folderSorting: { sortBy: 'name', sortDirection: 'asc' },
@@ -154,14 +153,6 @@ export default {
                 ...this.pendingUploads,
                 ...this.items,
             ];
-        },
-
-        rootFolder() {
-            const root = this.mediaFolderRepository.create(Context.api);
-            root.id = '';
-            root.name = this.$t('sw-media.index.rootFolderName');
-
-            return root;
         },
 
         gridPresentation() {
@@ -483,21 +474,10 @@ export default {
         async fetchAssociatedFolders() {
             if (this.folderId === null) {
                 this.currentFolder = null;
-                this.parentFolder = null;
                 return;
             }
 
             this.currentFolder = await this.mediaFolderRepository.get(this.folderId, Context.api);
-
-            if (this.currentFolder && this.currentFolder.parentId) {
-                this.parentFolder = await this.mediaFolderRepository.get(this.currentFolder.parentId, Context.api);
-            } else {
-                this.parentFolder = this.rootFolder;
-            }
-        },
-
-        goToParentFolder() {
-            this.$emit('media-folder-change', this.parentFolder.id || null);
         },
 
         clearSelection() {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.html.twig
@@ -52,23 +52,6 @@
                 @media-grid-selection-clear="clearSelection"
             >
 
-                {% block sw_media_library_back_to_parent_item %}
-                <sw-media-folder-item
-                    v-if="parentFolder && (!isLoading || selectableItems.length > 0)"
-                    :allow-edit="acl.can('media.editor')"
-                    :allow-delete="acl.can('media.deleter')"
-                    :disabled="disabled"
-                    class="sw-media-library__parent-folder"
-                    :item="parentFolder"
-                    :show-selection-indicator="false"
-                    :show-context-menu-button="false"
-                    :allow-multi-select="allowMultiSelect"
-                    :is-list="showItemsAsList"
-                    is-parent
-                    @media-item-click="goToParentFolder"
-                />
-                {% endblock %}
-
                 {% block sw_media_library_media_item_list %}
                 <sw-media-entity-mapper
                     v-for="(gridItem, index) in selectableItems"

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.scss
@@ -33,18 +33,6 @@ $sw-media-library-color-background: var(--color-elevation-surface-default);
         }
     }
 
-    .sw-media-library__parent-folder {
-        .sw-media-base-item__name-container {
-            font-weight: $font-weight-semi-bold;
-        }
-
-        &:hover .sw-media-base-item__selected-indicator {
-            visibility: hidden;
-        }
-
-        z-index: $z-index-overlay;
-    }
-
     .sw-media-library__scroll-container {
         position: relative;
         width: 100%;


### PR DESCRIPTION
### 1. Why is this change necessary?

In the Administration media library, the media grid rendered a "back to parent
folder" tile as its first item whenever you were inside a subfolder. This
duplicated the back navigation already shown in the page header, so the same
action existed twice on screen. It also consumed a grid slot and is inconsistent
with common OS file-manager conventions, where navigating up is done from the
header/breadcrumb rather than from a tile inside the file grid.

### 2. What does this change do, exactly?

It removes the back-folder tile from the media library grid and the code that
supported only that tile:

- `sw-media-folder-item`: removes the `isParent` prop and the parent-icon /
  multi-select branches that only existed to render the back tile.
- `sw-media-library`: removes the `parentFolder` state, the `rootFolder`
  computed, the `goToParentFolder` handler, the parent-folder lookup in
  `fetchAssociatedFolders`, the `sw_media_library_back_to_parent_item` template
  block, and the `.sw-media-library__parent-folder` styles.
- Removes the now-obsolete `isParent` unit tests.

The existing back navigation in the page header / breadcrumbs is unaffected.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration and go to **Content → Media**.
2. Open any folder that has a parent (navigate at least one level deep).
3. Observe the media grid.
   - **Before:** the first tile is a "back to parent folder" tile, duplicating
     the back action already available in the header.
   - **After:** the grid shows only actual folders and media; navigating up is
     done from the header/breadcrumb.

### 4. Please link to the relevant issues (if any).

closes #17289

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
