### PR TITLE
test:  flaky order-dependent TypeNotRegistered flaky from BackupStaticProperties

### DIFF
--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
@@ -132,133 +132,133 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('id', $table->getPrimaryKeyConstraint()?->getColumnNames()[0]->toString());
 
         static::assertTrue($table->hasColumn('id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('id')->getType());
 
         static::assertTrue($table->hasColumn('version_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('version_id')->getType());
 
         static::assertTrue($table->hasColumn('created_by_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('created_by_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('created_by_id')->getType());
 
         static::assertTrue($table->hasColumn('updated_by_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('updated_by_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('updated_by_id')->getType());
 
         static::assertTrue($table->hasColumn('state_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('state_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('state_id')->getType());
 
         static::assertTrue($table->hasColumn('created_at'));
-        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
+        static::assertSame(Type::getType(Types::DATETIME_MUTABLE), $table->getColumn('created_at')->getType());
 
         static::assertTrue($table->hasColumn('updated_at'));
-        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
+        static::assertSame(Type::getType(Types::DATETIME_MUTABLE), $table->getColumn('updated_at')->getType());
 
         static::assertTrue($table->hasColumn('datetime'));
-        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('datetime')->getType()));
+        static::assertSame(Type::getType(Types::DATETIME_MUTABLE), $table->getColumn('datetime')->getType());
 
         static::assertTrue($table->hasColumn('date'));
-        static::assertSame(Types::DATE_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('date')->getType()));
+        static::assertSame(Type::getType(Types::DATE_MUTABLE), $table->getColumn('date')->getType());
 
         static::assertTrue($table->hasColumn('cart_price'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cart_price')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('cart_price')->getType());
 
         static::assertTrue($table->hasColumn('calculated_price'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('calculated_price')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('calculated_price')->getType());
 
         static::assertTrue($table->hasColumn('price'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('price')->getType());
 
         static::assertTrue($table->hasColumn('price_definition'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('price_definition')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('price_definition')->getType());
 
         static::assertTrue($table->hasColumn('json'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('json')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('json')->getType());
 
         static::assertTrue($table->hasColumn('list'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('list')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('list')->getType());
 
         static::assertTrue($table->hasColumn('config_json'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('config_json')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('config_json')->getType());
 
         static::assertTrue($table->hasColumn('custom_fields'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('custom_fields')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('custom_fields')->getType());
 
         static::assertTrue($table->hasColumn('breadcrumb'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('breadcrumb')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('breadcrumb')->getType());
 
         static::assertTrue($table->hasColumn('cash_rounding_config'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('cash_rounding_config')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('cash_rounding_config')->getType());
 
         static::assertTrue($table->hasColumn('object'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('object')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('object')->getType());
 
         static::assertTrue($table->hasColumn('tax_free_config'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tax_free_config')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('tax_free_config')->getType());
 
         static::assertTrue($table->hasColumn('tree_breadcrumb'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('tree_breadcrumb')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('tree_breadcrumb')->getType());
 
         static::assertTrue($table->hasColumn('variant_listing_config'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('variant_listing_config')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('variant_listing_config')->getType());
 
         static::assertTrue($table->hasColumn('version_data_payload'));
-        static::assertSame(Types::JSON, Type::getTypeRegistry()->lookupName($table->getColumn('version_data_payload')->getType()));
+        static::assertSame(Type::getType(Types::JSON), $table->getColumn('version_data_payload')->getType());
 
         static::assertTrue($table->hasColumn('child_count'));
-        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('child_count')->getType()));
+        static::assertSame(Type::getType(Types::INTEGER), $table->getColumn('child_count')->getType());
 
         static::assertTrue($table->hasColumn('auto_increment'));
-        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
+        static::assertSame(Type::getType(Types::INTEGER), $table->getColumn('auto_increment')->getType());
 
         static::assertTrue($table->hasColumn('int'));
-        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('int')->getType()));
+        static::assertSame(Type::getType(Types::INTEGER), $table->getColumn('int')->getType());
 
         static::assertTrue($table->hasColumn('auto_increment'));
-        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('auto_increment')->getType()));
+        static::assertSame(Type::getType(Types::INTEGER), $table->getColumn('auto_increment')->getType());
 
         static::assertTrue($table->hasColumn('tree_level'));
-        static::assertSame(Types::INTEGER, Type::getTypeRegistry()->lookupName($table->getColumn('tree_level')->getType()));
+        static::assertSame(Type::getType(Types::INTEGER), $table->getColumn('tree_level')->getType());
 
         static::assertTrue($table->hasColumn('bool'));
-        static::assertSame(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('bool')->getType()));
+        static::assertSame(Type::getType(Types::BOOLEAN), $table->getColumn('bool')->getType());
 
         static::assertTrue($table->hasColumn('locked'));
-        static::assertSame(Types::BOOLEAN, Type::getTypeRegistry()->lookupName($table->getColumn('locked')->getType()));
+        static::assertSame(Type::getType(Types::BOOLEAN), $table->getColumn('locked')->getType());
 
         static::assertTrue($table->hasColumn('password'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('password')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('password')->getType());
 
         static::assertTrue($table->hasColumn('string'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('string')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('string')->getType());
 
         static::assertTrue($table->hasColumn('timezone'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('timezone')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('timezone')->getType());
 
         static::assertTrue($table->hasColumn('cron_interval'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('cron_interval')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('cron_interval')->getType());
 
         static::assertTrue($table->hasColumn('date_interval'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('date_interval')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('date_interval')->getType());
 
         static::assertTrue($table->hasColumn('email'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('email')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('email')->getType());
 
         static::assertTrue($table->hasColumn('remote_address'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('remote_address')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('remote_address')->getType());
 
         static::assertTrue($table->hasColumn('number_range'));
-        static::assertSame(Types::STRING, Type::getTypeRegistry()->lookupName($table->getColumn('number_range')->getType()));
+        static::assertSame(Type::getType(Types::STRING), $table->getColumn('number_range')->getType());
 
         static::assertTrue($table->hasColumn('blob'));
-        static::assertSame(Types::BLOB, Type::getTypeRegistry()->lookupName($table->getColumn('blob')->getType()));
+        static::assertSame(Type::getType(Types::BLOB), $table->getColumn('blob')->getType());
 
         static::assertTrue($table->hasColumn('float'));
-        static::assertSame(Types::DECIMAL, Type::getTypeRegistry()->lookupName($table->getColumn('float')->getType()));
+        static::assertSame(Type::getType(Types::DECIMAL), $table->getColumn('float')->getType());
 
         static::assertTrue($table->hasColumn('tree_path'));
-        static::assertSame(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('tree_path')->getType()));
+        static::assertSame(Type::getType(Types::TEXT), $table->getColumn('tree_path')->getType());
 
         static::assertTrue($table->hasColumn('long_text'));
-        static::assertSame(Types::TEXT, Type::getTypeRegistry()->lookupName($table->getColumn('long_text')->getType()));
+        static::assertSame(Type::getType(Types::TEXT), $table->getColumn('long_text')->getType());
     }
 
     public function testForeignKeys(): void
@@ -270,31 +270,31 @@ class SchemaBuilderTest extends TestCase
         static::assertSame('id', $table->getPrimaryKeyConstraint()?->getColumnNames()[0]->toString());
 
         static::assertTrue($table->hasColumn('id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('id')->getType());
 
         static::assertTrue($table->hasColumn('version_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('version_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('version_id')->getType());
 
         static::assertTrue($table->hasColumn('parent_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('parent_id')->getType());
 
         static::assertTrue($table->hasColumn('parent_version_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('parent_version_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('parent_version_id')->getType());
 
         static::assertTrue($table->hasColumn('created_at'));
-        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('created_at')->getType()));
+        static::assertSame(Type::getType(Types::DATETIME_MUTABLE), $table->getColumn('created_at')->getType());
 
         static::assertTrue($table->hasColumn('updated_at'));
-        static::assertSame(Types::DATETIME_MUTABLE, Type::getTypeRegistry()->lookupName($table->getColumn('updated_at')->getType()));
+        static::assertSame(Type::getType(Types::DATETIME_MUTABLE), $table->getColumn('updated_at')->getType());
 
         static::assertTrue($table->hasColumn('association_id'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('association_id')->getType());
 
         static::assertTrue($table->hasColumn('association_id2'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id2')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('association_id2')->getType());
 
         static::assertTrue($table->hasColumn('association_id3'));
-        static::assertSame(Types::BINARY, Type::getTypeRegistry()->lookupName($table->getColumn('association_id3')->getType()));
+        static::assertSame(Type::getType(Types::BINARY), $table->getColumn('association_id3')->getType());
 
         static::assertTrue($table->hasForeignKey('fk__test_entity_with_foreign_keys__association_id'));
         static::assertTrue($table->hasForeignKey('fk__test_entity_with_foreign_keys__association_id2'));

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Framework\Plugin;
 
 use Composer\Autoload\ClassLoader;
-use PHPUnit\Framework\Attributes\BackupStaticProperties;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -131,6 +130,15 @@ class PluginLifecycleServiceTest extends TestCase
             $this->requestStackMock,
             new NativeClock()
         );
+    }
+
+    protected function tearDown(): void
+    {
+        // uninstallPlugin() populates PluginLifecycleService::$pluginToBeDeleted; reset just that
+        // one static so it doesn't leak into other tests. Do NOT use #[BackupStaticProperties(true)]:
+        // it serialize-restores every loaded class's statics, which desyncs Doctrine's global
+        // Type registry (spl_object_id-keyed reverse index) and breaks Type::lookupName() worker-wide.
+        (new \ReflectionClass(PluginLifecycleService::class))->setStaticPropertyValue('pluginToBeDeleted', null);
     }
 
     public function testInstallPlugin(): void
@@ -405,7 +413,6 @@ class PluginLifecycleServiceTest extends TestCase
         $this->pluginLifecycleService->updatePlugin($plugin, Context::createDefaultContext());
     }
 
-    #[BackupStaticProperties(true)]
     public function testUninstallPluginWithComposerCommandExecutionDisabledAfterUpdateWithoutCli(): void
     {
         $pluginLifecycleService = $this->getMockBuilder(PluginLifecycleService::class)


### PR DESCRIPTION
### 1. Why is this change necessary?
Follow up of https://github.com/shopware/shopware/pull/17248

The attribute  `#[BackupStaticProperties(true)]`desynced Doctrine's Type registry worker-wide.

So it sounded a nice idea at first to cleanup a reflection usage, turns out it disrupts beyond the scope other static: 
it  hits Doctrine\DBAL\Types\Type::$typeRegistry.

And in the test SchemaBuilder it fails with a desynced on its spl_object_id, reversed index and breaking lookupName()

### 2. What does this change do, exactly?
- Reset only PluginLifecycleService::$pluginToBeDeleted in tearDow
- Secure SchemaBuilder (replace lookupName usage)

### 3. Describe each step to reproduce the issue or behaviour.

Run the unit test with seed 1780910578

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
