### PR TITLE
feat(mcp): return McpAllowlist value object from the allowlist provider

### DIFF
--- a/src/Core/Framework/Mcp/AllowList/McpAllowlist.php
+++ b/src/Core/Framework/Mcp/AllowList/McpAllowlist.php
@@ -16,6 +16,10 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 final class McpAllowlist
 {
+    public const TOOLS = 'tools';
+    public const RESOURCES = 'resources';
+    public const PROMPTS = 'prompts';
+
     /**
      * @param list<string>|null $tools null = all tools allowed
      * @param list<string>|null $resources null = all resources allowed
@@ -50,9 +54,9 @@ final class McpAllowlist
         }
 
         return new self(
-            tools: self::extractList($data, McpAllowlistProvider::TOOLS),
-            resources: self::extractList($data, McpAllowlistProvider::RESOURCES),
-            prompts: self::extractList($data, McpAllowlistProvider::PROMPTS),
+            tools: self::extractList($data, self::TOOLS),
+            resources: self::extractList($data, self::RESOURCES),
+            prompts: self::extractList($data, self::PROMPTS),
         );
     }
 

--- a/src/Core/Framework/Mcp/AllowList/McpAllowlistProvider.php
+++ b/src/Core/Framework/Mcp/AllowList/McpAllowlistProvider.php
@@ -26,10 +26,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[Package('framework')]
 class McpAllowlistProvider
 {
-    public const TOOLS = 'tools';
-    public const RESOURCES = 'resources';
-    public const PROMPTS = 'prompts';
-
     /**
      * @param array<string, list<string>> $toolDependencies tool-name => [dep-name, ...]
      *
@@ -47,7 +43,7 @@ class McpAllowlistProvider
      */
     public function toolsForCurrentRequest(): ?array
     {
-        return $this->forCurrentRequest()[self::TOOLS];
+        return $this->forCurrentRequest()->tools;
     }
 
     /**
@@ -55,7 +51,7 @@ class McpAllowlistProvider
      */
     public function resourcesForCurrentRequest(): ?array
     {
-        return $this->forCurrentRequest()[self::RESOURCES];
+        return $this->forCurrentRequest()->resources;
     }
 
     /**
@@ -63,18 +59,15 @@ class McpAllowlistProvider
      */
     public function promptsForCurrentRequest(): ?array
     {
-        return $this->forCurrentRequest()[self::PROMPTS];
+        return $this->forCurrentRequest()->prompts;
     }
 
-    /**
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    public function forCurrentRequest(): array
+    public function forCurrentRequest(): McpAllowlist
     {
         $request = $this->requestStack->getMainRequest();
 
         if ($request === null) {
-            return $this->unrestricted();
+            return McpAllowlist::unrestricted();
         }
 
         $clientId = $request->attributes->getString(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID);
@@ -110,13 +103,10 @@ class McpAllowlistProvider
             return $this->forUserId($userId);
         }
 
-        return $this->unrestricted();
+        return McpAllowlist::unrestricted();
     }
 
-    /**
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    public function forAccessKey(string $accessKey): array
+    public function forAccessKey(string $accessKey): McpAllowlist
     {
         $json = $this->connection->fetchOne(
             'SELECT `mcp_allowlist` FROM `integration` WHERE `access_key` = :key AND `deleted_at` IS NULL',
@@ -126,10 +116,7 @@ class McpAllowlistProvider
         return $this->fromAllowlist(McpAllowlist::fromJson(\is_string($json) ? $json : null));
     }
 
-    /**
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    public function forUserId(string $userId): array
+    public function forUserId(string $userId): McpAllowlist
     {
         $row = $this->connection->fetchAssociative(
             'SELECT `mcp_allowlist`, `admin` FROM `user` WHERE `id` = :id AND `active` = 1',
@@ -138,16 +125,13 @@ class McpAllowlistProvider
 
         // Admin users bypass ACL checks — mirror that for MCP allowlist.
         if ($row === false || (bool) $row['admin']) {
-            return $this->unrestricted();
+            return McpAllowlist::unrestricted();
         }
 
         return $this->fromAllowlist(McpAllowlist::fromJson(\is_string($row['mcp_allowlist']) ? $row['mcp_allowlist'] : null));
     }
 
-    /**
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    private function forUserAccessKey(string $accessKey): array
+    private function forUserAccessKey(string $accessKey): McpAllowlist
     {
         $userId = $this->connection->fetchOne(
             'SELECT `user_id` FROM `user_access_key` WHERE `access_key` = :key',
@@ -155,30 +139,19 @@ class McpAllowlistProvider
         );
 
         if (!\is_string($userId) || $userId === '') {
-            return $this->unrestricted();
+            return McpAllowlist::unrestricted();
         }
 
         return $this->forUserId(Uuid::fromBytesToHex($userId));
     }
 
-    /**
-     * @return array{tools: null, resources: null, prompts: null}
-     */
-    private function unrestricted(): array
+    private function fromAllowlist(McpAllowlist $allowlist): McpAllowlist
     {
-        return [self::TOOLS => null, self::RESOURCES => null, self::PROMPTS => null];
-    }
-
-    /**
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    private function fromAllowlist(McpAllowlist $allowlist): array
-    {
-        return [
-            self::TOOLS => $allowlist->tools !== null ? $this->expandWithDependencies($allowlist->tools) : null,
-            self::RESOURCES => $allowlist->resources,
-            self::PROMPTS => $allowlist->prompts,
-        ];
+        return new McpAllowlist(
+            tools: $allowlist->tools !== null ? $this->expandWithDependencies($allowlist->tools) : null,
+            resources: $allowlist->resources,
+            prompts: $allowlist->prompts,
+        );
     }
 
     /**
@@ -208,19 +181,13 @@ class McpAllowlistProvider
         return array_keys($expanded);
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $a
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $b
-     *
-     * @return array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}
-     */
-    private function intersect(array $a, array $b): array
+    private function intersect(McpAllowlist $a, McpAllowlist $b): McpAllowlist
     {
-        return [
-            self::TOOLS => $this->intersectList($a[self::TOOLS], $b[self::TOOLS]),
-            self::RESOURCES => $this->intersectList($a[self::RESOURCES], $b[self::RESOURCES]),
-            self::PROMPTS => $this->intersectList($a[self::PROMPTS], $b[self::PROMPTS]),
-        ];
+        return new McpAllowlist(
+            tools: $this->intersectList($a->tools, $b->tools),
+            resources: $this->intersectList($a->resources, $b->resources),
+            prompts: $this->intersectList($a->prompts, $b->prompts),
+        );
     }
 
     /**

--- a/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
+++ b/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
@@ -74,7 +74,7 @@ class DebugMcpCommand extends Command
         $toolsAllowlist = null;
         if ($integration !== null && $integration !== '') {
             $allowlist = $this->allowlistProvider->forAccessKey($integration);
-            $toolsAllowlist = $allowlist['tools'];
+            $toolsAllowlist = $allowlist->tools;
             if ($toolsAllowlist === null) {
                 $io->note(\sprintf('Integration "%s": no tool restriction (all tools allowed).', $integration));
             } else {

--- a/src/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistController.php
+++ b/src/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistController.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\Integration\IntegrationCollection;
@@ -87,7 +87,7 @@ class IntegrationMcpAllowlistController
      */
     private function isValidAllowlist(array $allowlist): bool
     {
-        $knownKeys = [McpAllowlistProvider::TOOLS, McpAllowlistProvider::RESOURCES, McpAllowlistProvider::PROMPTS];
+        $knownKeys = [McpAllowlist::TOOLS, McpAllowlist::RESOURCES, McpAllowlist::PROMPTS];
 
         if (array_diff(array_keys($allowlist), $knownKeys) !== []) {
             return false;

--- a/src/Core/Framework/Mcp/Controller/McpServerController.php
+++ b/src/Core/Framework/Mcp/Controller/McpServerController.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistFilter;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
 use Shopware\Core\Framework\Mcp\McpException;
@@ -130,10 +131,7 @@ class McpServerController
         return $this->httpFoundationFactory->createResponse($psrResponse, $streamed);
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
-     */
-    private function checkAllowlistEarlyReject(Request $request, array $allowlist): ?Response
+    private function checkAllowlistEarlyReject(Request $request, McpAllowlist $allowlist): ?Response
     {
         $body = $this->decodeJson($request->getContent());
 
@@ -143,9 +141,9 @@ class McpServerController
 
         $method = $body['method'] ?? null;
 
-        if ($method === CallToolRequest::getMethod() && $allowlist[McpAllowlistProvider::TOOLS] !== null) {
+        if ($method === CallToolRequest::getMethod() && $allowlist->tools !== null) {
             $toolName = $body['params']['name'] ?? '';
-            if ($this->allowlistFilter->isToolCallDenied($toolName, $allowlist[McpAllowlistProvider::TOOLS])) {
+            if ($this->allowlistFilter->isToolCallDenied($toolName, $allowlist->tools)) {
                 return $this->jsonRpcError(
                     $body['id'] ?? null,
                     $toolName !== ''
@@ -155,9 +153,9 @@ class McpServerController
             }
         }
 
-        if ($method === ReadResourceRequest::getMethod() && $allowlist[McpAllowlistProvider::RESOURCES] !== null) {
+        if ($method === ReadResourceRequest::getMethod() && $allowlist->resources !== null) {
             $resourceUri = $body['params']['uri'] ?? '';
-            if ($this->allowlistFilter->isResourceReadDenied($resourceUri, $allowlist[McpAllowlistProvider::RESOURCES])) {
+            if ($this->allowlistFilter->isResourceReadDenied($resourceUri, $allowlist->resources)) {
                 return $this->jsonRpcError(
                     $body['id'] ?? null,
                     $resourceUri !== ''
@@ -167,9 +165,9 @@ class McpServerController
             }
         }
 
-        if ($method === GetPromptRequest::getMethod() && $allowlist[McpAllowlistProvider::PROMPTS] !== null) {
+        if ($method === GetPromptRequest::getMethod() && $allowlist->prompts !== null) {
             $promptName = $body['params']['name'] ?? '';
-            if ($this->allowlistFilter->isPromptGetDenied($promptName, $allowlist[McpAllowlistProvider::PROMPTS])) {
+            if ($this->allowlistFilter->isPromptGetDenied($promptName, $allowlist->prompts)) {
                 return $this->jsonRpcError(
                     $body['id'] ?? null,
                     $promptName !== ''
@@ -182,10 +180,7 @@ class McpServerController
         return null;
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
-     */
-    private function filterListResponse(Request $request, PsrResponseInterface $psrResponse, array $allowlist): PsrResponseInterface
+    private function filterListResponse(Request $request, PsrResponseInterface $psrResponse, McpAllowlist $allowlist): PsrResponseInterface
     {
         \assert($this->streamFactory !== null);
 
@@ -217,27 +212,21 @@ class McpServerController
             ->withHeader('Content-Length', (string) \strlen($newBody));
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
-     */
-    private function hasListFilter(?string $method, array $allowlist): bool
+    private function hasListFilter(?string $method, McpAllowlist $allowlist): bool
     {
-        return ($method === ListToolsRequest::getMethod() && $allowlist[McpAllowlistProvider::TOOLS] !== null)
-            || ($method === ListResourcesRequest::getMethod() && $allowlist[McpAllowlistProvider::RESOURCES] !== null)
-            || ($method === ListPromptsRequest::getMethod() && $allowlist[McpAllowlistProvider::PROMPTS] !== null);
+        return ($method === ListToolsRequest::getMethod() && $allowlist->tools !== null)
+            || ($method === ListResourcesRequest::getMethod() && $allowlist->resources !== null)
+            || ($method === ListPromptsRequest::getMethod() && $allowlist->prompts !== null);
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
-     */
-    private function applyAllowlistFilter(McpJsonRpcResponse $response, ?string $method, array $allowlist): void
+    private function applyAllowlistFilter(McpJsonRpcResponse $response, ?string $method, McpAllowlist $allowlist): void
     {
-        if ($method === ListToolsRequest::getMethod() && $allowlist[McpAllowlistProvider::TOOLS] !== null) {
-            $response->filterTools($allowlist[McpAllowlistProvider::TOOLS]);
-        } elseif ($method === ListResourcesRequest::getMethod() && $allowlist[McpAllowlistProvider::RESOURCES] !== null) {
-            $response->filterResources($allowlist[McpAllowlistProvider::RESOURCES]);
-        } elseif ($method === ListPromptsRequest::getMethod() && $allowlist[McpAllowlistProvider::PROMPTS] !== null) {
-            $response->filterPrompts($allowlist[McpAllowlistProvider::PROMPTS]);
+        if ($method === ListToolsRequest::getMethod() && $allowlist->tools !== null) {
+            $response->filterTools($allowlist->tools);
+        } elseif ($method === ListResourcesRequest::getMethod() && $allowlist->resources !== null) {
+            $response->filterResources($allowlist->resources);
+        } elseif ($method === ListPromptsRequest::getMethod() && $allowlist->prompts !== null) {
+            $response->filterPrompts($allowlist->prompts);
         }
     }
 

--- a/src/Core/Framework/Mcp/Controller/McpToolListController.php
+++ b/src/Core/Framework/Mcp/Controller/McpToolListController.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Mcp\Controller;
 use Mcp\Server\Builder;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\McpCapabilityCatalog;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
@@ -70,9 +70,9 @@ class McpToolListController
         $this->builder->build();
 
         return new JsonResponse([
-            McpAllowlistProvider::TOOLS => $this->catalog->enrichedTools(),
-            McpAllowlistProvider::RESOURCES => $this->catalog->enrichedResources(),
-            McpAllowlistProvider::PROMPTS => $this->catalog->enrichedPrompts(),
+            McpAllowlist::TOOLS => $this->catalog->enrichedTools(),
+            McpAllowlist::RESOURCES => $this->catalog->enrichedResources(),
+            McpAllowlist::PROMPTS => $this->catalog->enrichedPrompts(),
         ]);
     }
 }

--- a/src/Core/Framework/Mcp/Controller/UserMcpAllowlistController.php
+++ b/src/Core/Framework/Mcp/Controller/UserMcpAllowlistController.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\User\UserCollection;
@@ -89,7 +89,7 @@ class UserMcpAllowlistController
      */
     private function isValidAllowlist(array $allowlist): bool
     {
-        $knownKeys = [McpAllowlistProvider::TOOLS, McpAllowlistProvider::RESOURCES, McpAllowlistProvider::PROMPTS];
+        $knownKeys = [McpAllowlist::TOOLS, McpAllowlist::RESOURCES, McpAllowlist::PROMPTS];
 
         if (array_diff(array_keys($allowlist), $knownKeys) !== []) {
             return false;

--- a/tests/unit/Core/Framework/Mcp/AllowList/McpAllowlistProviderTest.php
+++ b/tests/unit/Core/Framework/Mcp/AllowList/McpAllowlistProviderTest.php
@@ -26,9 +26,9 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, $this->requestStackWithKey());
 
         $result = $provider->forCurrentRequest();
-        static::assertSame(['shopware-entity-search', 'shopware-entity-schema'], $result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertSame(['shopware-entity-search', 'shopware-entity-schema'], $result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testToolsForCurrentRequestDelegatesToForCurrentRequest(): void
@@ -57,9 +57,9 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, $this->requestStackWithKey());
 
         $result = $provider->forCurrentRequest();
-        static::assertNull($result['tools']);
-        static::assertSame(['shopware://entities'], $result['resources']);
-        static::assertSame(['shopware-context'], $result['prompts']);
+        static::assertNull($result->tools);
+        static::assertSame(['shopware://entities'], $result->resources);
+        static::assertSame(['shopware-context'], $result->prompts);
     }
 
     public function testExpandsDirectDependenciesIntoToolAllowlist(): void
@@ -72,9 +72,9 @@ class McpAllowlistProviderTest extends TestCase
         ]);
 
         $result = $provider->forCurrentRequest();
-        static::assertNotNull($result['tools']);
-        static::assertContains('shopware-entity-search', $result['tools']);
-        static::assertContains('shopware-entity-schema', $result['tools']);
+        static::assertNotNull($result->tools);
+        static::assertContains('shopware-entity-search', $result->tools);
+        static::assertContains('shopware-entity-schema', $result->tools);
     }
 
     public function testExpandsTransitiveDependencies(): void
@@ -88,10 +88,10 @@ class McpAllowlistProviderTest extends TestCase
         ]);
 
         $result = $provider->forCurrentRequest();
-        static::assertNotNull($result['tools']);
-        static::assertContains('shopware-entity-delete', $result['tools']);
-        static::assertContains('shopware-entity-search', $result['tools']);
-        static::assertContains('shopware-entity-schema', $result['tools']);
+        static::assertNotNull($result->tools);
+        static::assertContains('shopware-entity-delete', $result->tools);
+        static::assertContains('shopware-entity-search', $result->tools);
+        static::assertContains('shopware-entity-schema', $result->tools);
     }
 
     public function testDoesNotDuplicateToolsAlreadyInAllowlist(): void
@@ -104,9 +104,9 @@ class McpAllowlistProviderTest extends TestCase
         ]);
 
         $result = $provider->forCurrentRequest();
-        static::assertNotNull($result['tools']);
-        static::assertSame(array_unique($result['tools']), $result['tools']);
-        static::assertCount(2, $result['tools']);
+        static::assertNotNull($result->tools);
+        static::assertSame(array_unique($result->tools), $result->tools);
+        static::assertCount(2, $result->tools);
     }
 
     public function testReturnsEmptyToolsArrayWhenToolsAllowlistIsEmptyJsonArray(): void
@@ -117,7 +117,7 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, $this->requestStackWithKey());
 
         $result = $provider->forCurrentRequest();
-        static::assertSame([], $result['tools']);
+        static::assertSame([], $result->tools);
     }
 
     public function testReturnsUnrestrictedWhenNoRequest(): void
@@ -128,9 +128,9 @@ class McpAllowlistProviderTest extends TestCase
         );
 
         $result = $provider->forCurrentRequest();
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testReturnsUnrestrictedWhenNoAccessKey(): void
@@ -144,9 +144,9 @@ class McpAllowlistProviderTest extends TestCase
         );
 
         $result = $provider->forCurrentRequest();
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     /**
@@ -169,9 +169,9 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, $this->requestStackWithKey());
 
         $result = $provider->forCurrentRequest();
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testForAccessKeyReturnsAllowlistForValidKey(): void
@@ -182,7 +182,7 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, new RequestStack());
 
         $result = $provider->forAccessKey('SWIA-test');
-        static::assertSame(['shopware-entity-search', 'shopware-entity-schema'], $result['tools']);
+        static::assertSame(['shopware-entity-search', 'shopware-entity-schema'], $result->tools);
     }
 
     public function testForAccessKeyExpandsDependencies(): void
@@ -195,9 +195,9 @@ class McpAllowlistProviderTest extends TestCase
         ]);
 
         $result = $provider->forAccessKey('SWIA-test');
-        static::assertNotNull($result['tools']);
-        static::assertContains('shopware-entity-delete', $result['tools']);
-        static::assertContains('shopware-entity-search', $result['tools']);
+        static::assertNotNull($result->tools);
+        static::assertContains('shopware-entity-delete', $result->tools);
+        static::assertContains('shopware-entity-search', $result->tools);
     }
 
     public function testForAccessKeyReturnsUnrestrictedWhenKeyNotFound(): void
@@ -208,9 +208,9 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, new RequestStack());
 
         $result = $provider->forAccessKey('SWIA-unknown');
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testReturnsNullForKeyWhenValueIsNonArrayNonNull(): void
@@ -221,9 +221,9 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, $this->requestStackWithKey());
 
         $result = $provider->forCurrentRequest();
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testForAccessKeyReturnsUnrestrictedForInvalidJson(): void
@@ -234,7 +234,7 @@ class McpAllowlistProviderTest extends TestCase
         $provider = new McpAllowlistProvider($connection, new RequestStack());
 
         $result = $provider->forAccessKey('SWIA-test');
-        static::assertNull($result['tools']);
+        static::assertNull($result->tools);
     }
 
     // --- Bearer JWT, client_credentials ---
@@ -258,9 +258,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
-        static::assertSame(['cc-tool'], $result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertSame(['cc-tool'], $result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     // --- forUserId / bearer JWT ---
@@ -285,9 +285,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
-        static::assertSame(['bearer-tool'], $result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertSame(['bearer-tool'], $result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testBearerJwtWithoutUserIdIsUnrestricted(): void
@@ -304,9 +304,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testAdminUserAlwaysUnrestrictedRegardlessOfAllowlist(): void
@@ -321,9 +321,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, new RequestStack()))->forUserId($userId);
 
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testForUserIdReturnsUnrestrictedWhenUserNotFound(): void
@@ -333,9 +333,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, new RequestStack()))->forUserId(Uuid::randomHex());
 
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testForUserIdReturnsUnrestrictedWhenAllowlistIsNull(): void
@@ -348,7 +348,7 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, new RequestStack()))->forUserId(Uuid::randomHex());
 
-        static::assertNull($result['tools']);
+        static::assertNull($result->tools);
     }
 
     public function testForUserIdReturnsUnrestrictedForInvalidJson(): void
@@ -361,9 +361,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, new RequestStack()))->forUserId(Uuid::randomHex());
 
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testForUserIdReturnsUnrestrictedWhenJsonIsNotArray(): void
@@ -376,9 +376,9 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, new RequestStack()))->forUserId(Uuid::randomHex());
 
-        static::assertNull($result['tools']);
-        static::assertNull($result['resources']);
-        static::assertNull($result['prompts']);
+        static::assertNull($result->tools);
+        static::assertNull($result->resources);
+        static::assertNull($result->prompts);
     }
 
     public function testUserAccessKeyPathLooksUpUserAndAppliesAllowlist(): void
@@ -395,7 +395,7 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $this->requestStackWithKey('SWUAtestuseraccesskey00')))->forCurrentRequest();
 
-        static::assertSame(['user-key-tool'], $result['tools']);
+        static::assertSame(['user-key-tool'], $result->tools);
     }
 
     public function testUserAccessKeyReturnsUnrestrictedWhenKeyNotFound(): void
@@ -406,7 +406,7 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $this->requestStackWithKey('SWUAtestuseraccesskey00')))->forCurrentRequest();
 
-        static::assertNull($result['tools']);
+        static::assertNull($result->tools);
     }
 
     // --- Copilot intersection ---
@@ -437,7 +437,7 @@ class McpAllowlistProviderTest extends TestCase
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
         // Intersection: only tool-b is in both allowlists.
-        static::assertSame(['tool-b'], $result['tools']);
+        static::assertSame(['tool-b'], $result->tools);
     }
 
     public function testCopilotIntersectionWithNullIntegrationAllowlistUsesUserAllowlist(): void
@@ -463,7 +463,7 @@ class McpAllowlistProviderTest extends TestCase
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
         // null ∩ [tool-a] = [tool-a]
-        static::assertSame(['tool-a'], $result['tools']);
+        static::assertSame(['tool-a'], $result->tools);
     }
 
     public function testCopilotIntersectionWithNullUserAllowlistUsesIntegrationAllowlist(): void
@@ -490,7 +490,7 @@ class McpAllowlistProviderTest extends TestCase
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
         // [tool-b] ∩ null = [tool-b]
-        static::assertSame(['tool-b'], $result['tools']);
+        static::assertSame(['tool-b'], $result->tools);
     }
 
     public function testCopilotIntersectionWithBothNullIsUnrestricted(): void
@@ -514,7 +514,7 @@ class McpAllowlistProviderTest extends TestCase
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
         // null ∩ null = null (unrestricted)
-        static::assertNull($result['tools']);
+        static::assertNull($result->tools);
     }
 
     public function testAppUserIdHeaderUuidIsPassedToUserLookup(): void
@@ -565,7 +565,7 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
-        static::assertSame(['integration-tool'], $result['tools']);
+        static::assertSame(['integration-tool'], $result->tools);
     }
 
     public function testCopilotIntersectionWithBothEmptyArrayIsEmpty(): void
@@ -589,7 +589,7 @@ class McpAllowlistProviderTest extends TestCase
 
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
-        static::assertSame([], $result['tools']);
+        static::assertSame([], $result->tools);
     }
 
     public function testCopilotAdminUserBypassesIntersection(): void
@@ -616,7 +616,7 @@ class McpAllowlistProviderTest extends TestCase
         $result = (new McpAllowlistProvider($connection, $stack))->forCurrentRequest();
 
         // [tool-b] ∩ null (admin bypass) = [tool-b]
-        static::assertSame(['tool-b'], $result['tools']);
+        static::assertSame(['tool-b'], $result->tools);
     }
 
     private function requestStackWithKey(string $accessKey = 'SWIAtestintegrationkey00'): RequestStack

--- a/tests/unit/Core/Framework/Mcp/Command/DebugMcpCommandTest.php
+++ b/tests/unit/Core/Framework/Mcp/Command/DebugMcpCommandTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
 use Shopware\Core\Framework\Mcp\Command\DebugMcpCommand;
 use Shopware\Core\Framework\Mcp\Loader\AppMcpPrivilegeProvider;
@@ -347,7 +348,7 @@ class DebugMcpCommandTest extends TestCase
         $registry->registerTool(new Tool('tool-b', null, self::inputSchema(), null, null), 'Acme\\ToolB', true);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forAccessKey')->willReturn(['tools' => null, 'resources' => null, 'prompts' => null]);
+        $allowlistProvider->method('forAccessKey')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: null));
 
         $tester = new CommandTester($this->makeCommand($registry, allowlistProvider: $allowlistProvider));
         $tester->execute(['--integration' => 'SWIA-test-key']);
@@ -366,7 +367,7 @@ class DebugMcpCommandTest extends TestCase
         $registry->registerTool(new Tool('tool-b', null, self::inputSchema(), null, null), 'Acme\\ToolB', true);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forAccessKey')->willReturn(['tools' => ['tool-a'], 'resources' => null, 'prompts' => null]);
+        $allowlistProvider->method('forAccessKey')->willReturn(new McpAllowlist(tools: ['tool-a'], resources: null, prompts: null));
 
         $tester = new CommandTester($this->makeCommand($registry, allowlistProvider: $allowlistProvider));
         $tester->execute(['--integration' => 'SWIA-restricted']);
@@ -384,7 +385,7 @@ class DebugMcpCommandTest extends TestCase
         $registry->registerTool(new Tool('tool-a', null, self::inputSchema(), null, null), 'Acme\\ToolA', true);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forAccessKey')->willReturn(['tools' => [], 'resources' => null, 'prompts' => null]);
+        $allowlistProvider->method('forAccessKey')->willReturn(new McpAllowlist(tools: [], resources: null, prompts: null));
 
         $tester = new CommandTester($this->makeCommand($registry, allowlistProvider: $allowlistProvider));
         $tester->execute(['--integration' => 'SWIA-empty']);
@@ -585,7 +586,7 @@ class DebugMcpCommandTest extends TestCase
 
         if ($allowlistProvider === null) {
             $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-            $allowlistProvider->method('forAccessKey')->willReturn(['tools' => null, 'resources' => null, 'prompts' => null]);
+            $allowlistProvider->method('forAccessKey')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: null));
         }
 
         $catalog ??= new McpCapabilityCatalog($registry, $this->stubPrivilegeProvider());

--- a/tests/unit/Core/Framework/Mcp/Controller/McpServerControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/McpServerControllerTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistFilter;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
 use Shopware\Core\Framework\Mcp\Controller\McpServerController;
@@ -151,11 +152,7 @@ class McpServerControllerTest extends TestCase
         $httpFoundationFactory->method('createResponse')->willReturn(new Response('', 400));
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => ['shopware-entity-search'],
-            'resources' => null,
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: ['shopware-entity-search'], resources: null, prompts: null));
 
         $controller = $this->buildController($psrRequest, $httpFoundationFactory, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: 'not-json');
@@ -166,25 +163,22 @@ class McpServerControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{string, array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}}>
+     * @return iterable<string, array{string, McpAllowlist}>
      */
     public static function allowedToolCallProvider(): iterable
     {
         yield 'tool explicitly in allowlist' => [
             'shopware-entity-search',
-            ['tools' => ['shopware-entity-search'], 'resources' => null, 'prompts' => null],
+            new McpAllowlist(tools: ['shopware-entity-search'], resources: null, prompts: null),
         ];
         yield 'null tools allows all tools' => [
             'any-tool',
-            ['tools' => null, 'resources' => null, 'prompts' => null],
+            new McpAllowlist(tools: null, resources: null, prompts: null),
         ];
     }
 
-    /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
-     */
     #[DataProvider('allowedToolCallProvider')]
-    public function testToolCallNotBlockedWhenAllowed(string $toolName, array $allowlist): void
+    public function testToolCallNotBlockedWhenAllowed(string $toolName, McpAllowlist $allowlist): void
     {
         $body = json_encode([
             'jsonrpc' => '2.0',
@@ -208,30 +202,29 @@ class McpServerControllerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null}, list<string>}>
+     * @return iterable<string, array{McpAllowlist, list<string>}>
      */
     public static function toolsListFilterProvider(): iterable
     {
         yield 'restricted allowlist shows only allowed tool' => [
-            ['tools' => ['tool-a'], 'resources' => null, 'prompts' => null],
+            new McpAllowlist(tools: ['tool-a'], resources: null, prompts: null),
             ['tool-a'],
         ];
         yield 'null tools allowlist shows all tools' => [
-            ['tools' => null, 'resources' => null, 'prompts' => null],
+            new McpAllowlist(tools: null, resources: null, prompts: null),
             ['tool-a', 'tool-b'],
         ];
         yield 'empty tools allowlist hides all tools' => [
-            ['tools' => [], 'resources' => null, 'prompts' => null],
+            new McpAllowlist(tools: [], resources: null, prompts: null),
             [],
         ];
     }
 
     /**
-     * @param array{tools: list<string>|null, resources: list<string>|null, prompts: list<string>|null} $allowlist
      * @param list<string> $expectedToolNames
      */
     #[DataProvider('toolsListFilterProvider')]
-    public function testToolsListIsFilteredByAllowlist(array $allowlist, array $expectedToolNames): void
+    public function testToolsListIsFilteredByAllowlist(McpAllowlist $allowlist, array $expectedToolNames): void
     {
         $server = Server::builder()
             ->addTool(static fn (): string => '[]', name: 'tool-a', description: 'Tool A')
@@ -313,11 +306,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => ['shopware-entity-search'],
-            'resources' => null,
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: ['shopware-entity-search'], resources: null, prompts: null));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -341,11 +330,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => [],
-            'resources' => null,
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: [], resources: null, prompts: null));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -367,11 +352,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => ['shopware://entities'],
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: ['shopware://entities'], prompts: null));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -397,11 +378,7 @@ class McpServerControllerTest extends TestCase
         $httpFoundationFactory->method('createResponse')->willReturn(new Response('{}', 200));
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => ['shopware://entities'],
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: ['shopware://entities'], prompts: null));
 
         $controller = $this->buildController($psrRequest, $httpFoundationFactory, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -421,11 +398,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => null,
-            'prompts' => ['shopware-context'],
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: ['shopware-context']));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -451,11 +424,7 @@ class McpServerControllerTest extends TestCase
         $httpFoundationFactory->method('createResponse')->willReturn(new Response('{}', 200));
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => null,
-            'prompts' => ['shopware-context'],
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: ['shopware-context']));
 
         $controller = $this->buildController($psrRequest, $httpFoundationFactory, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -475,11 +444,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => ['shopware-entity-search'],
-            'resources' => null,
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: ['shopware-entity-search'], resources: null, prompts: null));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -501,11 +466,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => ['shopware://entities'],
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: ['shopware://entities'], prompts: null));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -527,11 +488,7 @@ class McpServerControllerTest extends TestCase
 
         $psrRequest = new ServerRequest('POST', '/api/_mcp', ['Content-Type' => 'application/json'], $body);
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => null,
-            'prompts' => ['shopware-context'],
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: ['shopware-context']));
 
         $controller = $this->buildController($psrRequest, null, $allowlistProvider);
         $sfRequest = Request::create('/api/_mcp', 'POST', content: $body);
@@ -559,11 +516,7 @@ class McpServerControllerTest extends TestCase
         ], \JSON_THROW_ON_ERROR);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => ['shopware://resource-a'],
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: ['shopware://resource-a'], prompts: null));
 
         $psrRequest = new ServerRequest(
             'POST',
@@ -598,11 +551,7 @@ class McpServerControllerTest extends TestCase
         ], \JSON_THROW_ON_ERROR);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => null,
-            'resources' => null,
-            'prompts' => ['prompt-a'],
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: null, resources: null, prompts: ['prompt-a']));
 
         $psrRequest = new ServerRequest(
             'POST',
@@ -637,11 +586,7 @@ class McpServerControllerTest extends TestCase
         ], \JSON_THROW_ON_ERROR);
 
         $allowlistProvider = static::createStub(McpAllowlistProvider::class);
-        $allowlistProvider->method('forCurrentRequest')->willReturn([
-            'tools' => ['tool-a'],
-            'resources' => null,
-            'prompts' => null,
-        ]);
+        $allowlistProvider->method('forCurrentRequest')->willReturn(new McpAllowlist(tools: ['tool-a'], resources: null, prompts: null));
 
         $psrRequest = new ServerRequest(
             'POST',


### PR DESCRIPTION
### 1. Why is this change necessary?
During review of https://github.com/shopware/shopware/pull/17228/ from a question about using static form, it looks like McpAllowlist & McpAllowlistProvider were tightly coupled and string keys used a bit everywhere

### 2. What does this change do, exactly?
Make McpAllowlist a value object responsible of the constants and break free from McpAllowlistProvider

### 3. Describe each step to reproduce the issue or behaviour.
Run the tests

(this is based upon feat/mcp-server-storefront not trunk)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
