### PR TITLE
fix: hide inactive webhook admin worker transport

### DIFF
--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -272,7 +272,7 @@ class InfoController extends AbstractController
         }
 
         /** @var list<string> $transports */
-        $transports = array_values(array_filter($transports, static fn (mixed $transport): bool => \is_string($transport)));
+        $transports = array_values($transports);
 
         if (Feature::isActive('WEBHOOKS_REWORK')) {
             return $transports;

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -196,7 +196,7 @@ class InfoController extends AbstractController
         $adminWorker = [
             'enableAdminWorker' => $this->params->get('shopware.admin_worker.enable_admin_worker'),
             'enableNotificationWorker' => $this->params->get('shopware.admin_worker.enable_notification_worker'),
-            'transports' => $this->params->get('shopware.admin_worker.transports'),
+            'transports' => $this->getAdminWorkerTransports(),
         ];
 
         if (!Feature::isActive('v6.8.0.0')) {
@@ -259,6 +259,26 @@ class InfoController extends AbstractController
         );
 
         return new JsonResponse(['endpoints' => $endpoints]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getAdminWorkerTransports(): array
+    {
+        $transports = $this->params->get('shopware.admin_worker.transports');
+        if (!\is_array($transports)) {
+            return [];
+        }
+
+        /** @var list<string> $transports */
+        $transports = array_values(array_filter($transports, static fn (mixed $transport): bool => \is_string($transport)));
+
+        if (Feature::isActive('WEBHOOKS_REWORK')) {
+            return $transports;
+        }
+
+        return array_values(array_filter($transports, static fn (string $transport): bool => $transport !== 'webhook'));
     }
 
     /**

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Event\CustomerGroupAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\LogAware;
 use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\Migration\MigrationInfo;
@@ -87,7 +88,9 @@ class InfoControllerTest extends TestCase
             'adminWorker' => [
                 'enableAdminWorker' => true,
                 'enableNotificationWorker' => true,
-                'transports' => ['webhook', 'async', 'low_priority'],
+                'transports' => Feature::isActive('WEBHOOKS_REWORK')
+                    ? ['webhook', 'async', 'low_priority']
+                    : ['async', 'low_priority'],
                 'enableQueueStatsWorker' => true,
             ],
             'bundles' => [],

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Asset\UrlPackage;
@@ -163,32 +164,29 @@ class InfoControllerTest extends TestCase
         static::assertSame('current-shop-id', $data['shopId']);
     }
 
+    #[DisabledFeatures(['WEBHOOKS_REWORK'])]
     public function testConfigHidesWebhookTransportWhenWebhookReworkIsInactive(): void
     {
-        Feature::withFeatureDisabled('WEBHOOKS_REWORK', function (): void {
-            $content = $this->createController(['webhook', 'async', 'low_priority'])
-                ->config(Context::createDefaultContext(), Request::create('http://localhost'))
-                ->getContent();
-            static::assertIsString($content);
+        $content = $this->createController(['webhook', 'async', 'low_priority'])
+            ->config(Context::createDefaultContext(), Request::create('http://localhost'))
+            ->getContent();
+        static::assertIsString($content);
 
-            $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
 
-            static::assertSame(['async', 'low_priority'], $data['adminWorker']['transports']);
-        });
+        static::assertSame(['async', 'low_priority'], $data['adminWorker']['transports']);
     }
 
     public function testConfigKeepsWebhookTransportWhenWebhookReworkIsActive(): void
     {
-        Feature::withFeatureEnabled('WEBHOOKS_REWORK', function (): void {
-            $content = $this->createController(['webhook', 'async', 'low_priority'])
-                ->config(Context::createDefaultContext(), Request::create('http://localhost'))
-                ->getContent();
-            static::assertIsString($content);
+        $content = $this->createController(['webhook', 'async', 'low_priority'])
+            ->config(Context::createDefaultContext(), Request::create('http://localhost'))
+            ->getContent();
+        static::assertIsString($content);
 
-            $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
 
-            static::assertSame(['webhook', 'async', 'low_priority'], $data['adminWorker']['transports']);
-        });
+        static::assertSame(['webhook', 'async', 'low_priority'], $data['adminWorker']['transports']);
     }
 
     public function testConfigExtension(): void

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -163,6 +163,34 @@ class InfoControllerTest extends TestCase
         static::assertSame('current-shop-id', $data['shopId']);
     }
 
+    public function testConfigHidesWebhookTransportWhenWebhookReworkIsInactive(): void
+    {
+        Feature::withFeatureDisabled('WEBHOOKS_REWORK', function (): void {
+            $content = $this->createController(['webhook', 'async', 'low_priority'])
+                ->config(Context::createDefaultContext(), Request::create('http://localhost'))
+                ->getContent();
+            static::assertIsString($content);
+
+            $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+
+            static::assertSame(['async', 'low_priority'], $data['adminWorker']['transports']);
+        });
+    }
+
+    public function testConfigKeepsWebhookTransportWhenWebhookReworkIsActive(): void
+    {
+        Feature::withFeatureEnabled('WEBHOOKS_REWORK', function (): void {
+            $content = $this->createController(['webhook', 'async', 'low_priority'])
+                ->config(Context::createDefaultContext(), Request::create('http://localhost'))
+                ->getContent();
+            static::assertIsString($content);
+
+            $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+
+            static::assertSame(['webhook', 'async', 'low_priority'], $data['adminWorker']['transports']);
+        });
+    }
+
     public function testConfigExtension(): void
     {
         $this->eventDispatcher->addListener(AdminInfoConfigEvent::class, static function (AdminInfoConfigEvent $event): void {
@@ -243,12 +271,15 @@ class InfoControllerTest extends TestCase
         static::assertSame('2020-01-01T00:00:00.123+00:00', $data['settings']['firstMigrationDate']);
     }
 
-    private function createController(): InfoController
+    /**
+     * @param list<string> $adminWorkerTransports
+     */
+    private function createController(array $adminWorkerTransports = ['slow']): InfoController
     {
         $parameterBag = new ParameterBag([
             'shopware.html_sanitizer.enabled' => true,
             'shopware.filesystem.private_allowed_extensions' => false,
-            'shopware.admin_worker.transports' => ['slow'],
+            'shopware.admin_worker.transports' => $adminWorkerTransports,
             'shopware.admin_worker.enable_notification_worker' => true,
             'shopware.admin_worker.enable_queue_stats_worker' => true,
             'shopware.admin_worker.enable_admin_worker' => true,


### PR DESCRIPTION
### 1. Why is this change necessary?

PR #16692 added the `webhook` transport to the default Admin worker transport list. When `WEBHOOKS_REWORK` is disabled, `WebhookTransport::get()` returns no messages, but `/api/_info/config` still advertises the transport to the browser Admin worker. That makes the Admin start an additional no-op consume request for an inactive feature, occupying an Admin worker/FPM request slot during the long-poll window.

The consumer busy-poll fix from #17046 is already present on current `trunk`; this PR addresses the remaining issue that the inactive feature transport is still exposed to the browser worker.

### 2. What does this change do, exactly?

`InfoController` now filters the Admin worker transport list returned by `/api/_info/config`: `webhook` is only included while `WEBHOOKS_REWORK` is active. The configured transport remains registered server-side, so the active feature path and non-browser consumers are unaffected.

Unit coverage now asserts both states: the `webhook` transport is hidden while the feature is inactive and kept while it is active.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the Admin with `WEBHOOKS_REWORK` disabled.
2. Request `/api/_info/config` or open the Administration.
3. Observe that `adminWorker.transports` includes `webhook` even though the feature is inactive.
4. The browser Admin worker starts an additional `/api/_action/message-queue/consume` loop for `webhook`, which cannot consume messages while the feature is inactive.

### 4. Please link to the relevant issues (if any).

- relates #16692
- relates #17046

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not relevant; this is an internal Admin worker transport exposure fix.
- [x] I have written or adjusted the documentation according to my changes
  - Not relevant; no public documentation changes needed.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - Not relevant; no new public package/type/value/function comments are needed.
- [x] I have read the contribution requirements and fulfilled them
