### PR TITLE
fix: prevent negative checkedElementsCount in category tree

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
@@ -375,7 +375,8 @@ export default {
                 }
 
                 if (checked === true) {
-                    this.$refs.categoryTree.checkedElementsCount -= 1;
+                    this.$refs.categoryTree.checkedElementsCount =
+                        Math.max(0, this.$refs.categoryTree.checkedElementsCount - 1);
                     this.$emit('category-checked-elements-count', this.$refs.categoryTree.checkedElementsCount);
                 }
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
@@ -375,8 +375,10 @@ export default {
                 }
 
                 if (checked === true) {
-                    this.$refs.categoryTree.checkedElementsCount =
-                        Math.max(0, this.$refs.categoryTree.checkedElementsCount - 1);
+                    this.$refs.categoryTree.checkedElementsCount = Math.max(
+                        0,
+                        this.$refs.categoryTree.checkedElementsCount - 1,
+                    );
                     this.$emit('category-checked-elements-count', this.$refs.categoryTree.checkedElementsCount);
                 }
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/sw-category-tree.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/sw-category-tree.spec.js
@@ -366,6 +366,33 @@ describe('src/module/sw-category/component/sw-category-tree', () => {
         expect(wrapper.vm.$refs.categoryTree.checkedElementsCount).toBe(1);
     });
 
+    it('should not allow checked elements count to become negative when deleting the last checked category', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setData({
+            isLoadingInitialData: false,
+        });
+
+        wrapper.vm.$refs.categoryTree.checkedElementsCount = 0;
+
+        const category = {
+            id: '1a',
+            isNew: () => false,
+        };
+
+        await wrapper.vm.onDeleteCategory({
+            data: category,
+            children: [],
+            checked: true,
+        });
+
+        const emitted = wrapper.emitted()['category-checked-elements-count'];
+
+        expect(emitted).toBeTruthy();
+        expect(emitted).toEqual([[0]]);
+        expect(wrapper.vm.$refs.categoryTree.checkedElementsCount).toBe(0);
+    });
+
     it('should fix the sorting right after deleting a single category', async () => {
         const wrapper = await createWrapper();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When deleting a selected category, the category tree decreases
`checkedElementsCount` manually.

In some cases the counter is already `0` when the deletion callback
is executed, causing the value to become `-1`.

This negative value is propagated through the
`category-checked-elements-count` event and can lead to incorrect UI
states in consumers of the event.

### 2. What does this change do, exactly?
Clamp `checkedElementsCount` to `0` when decrementing it after a
category deletion.

### 3. Describe each step to reproduce the issue or behaviour.
Select a category
Click the Delete button
Select a category
Like in #15837 

### 4. Please link to the relevant issues (if any).
- closes #15837 


### 5. Checklist

- [x ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfilled them
