### PR TITLE
fix: make media delete restricted exception more verbose

### DIFF
--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BlobField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
@@ -86,6 +87,13 @@ class MediaDefinition extends EntityDefinition
     public function getHydratorClass(): string
     {
         return MediaHydrator::class;
+    }
+
+    public function getRestrictDeleteMetaFields(): FieldCollection
+    {
+        return $this->getFields()->filter(
+            static fn (Field $field) => \in_array($field->getPropertyName(), ['id', 'fileName', 'fileExtension'], true)
+        );
     }
 
     protected function defineFields(): FieldCollection

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -1170,7 +1170,7 @@ class DataAbstractionLayerException extends HttpException
     }
 
     /**
-     * @param array<string, list<string>> $restrictions
+     * @param array<string, list<array<string, mixed>>> $restrictions
      */
     public static function restrictDeleteViolations(EntityDefinition $definition, array $restrictions): RestrictDeleteViolationException
     {

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -21,9 +21,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageDefinition;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Determines all associated data for a definition.
@@ -32,8 +34,10 @@ use Shopware\Core\System\Language\LanguageDefinition;
  * @internal
  */
 #[Package('framework')]
-class EntityForeignKeyResolver
+class EntityForeignKeyResolver implements ResetInterface
 {
+    private ArrayStruct $restrictDeleteMetaFields;
+
     /**
      * @internal
      */
@@ -41,6 +45,7 @@ class EntityForeignKeyResolver
         private readonly Connection $connection,
         private readonly EntityDefinitionQueryHelper $queryHelper
     ) {
+        $this->restrictDeleteMetaFields = new ArrayStruct();
     }
 
     /**
@@ -48,14 +53,14 @@ class EntityForeignKeyResolver
      * Example:
      *  [
      *      "order_customer" => [
-     *          "cace68bdbca140b6ac43a083fb19f82b",
-     *          "50330f5531ed485fbd72ba016b20ea2a",
+     *          ["id => "cace68bdbca140b6ac43a083fb19f82b"],
+     *          ["id => "50330f5531ed485fbd72ba016b20ea2a"],
      *      ],
      *      "order_address" => [
-     *          "29d6334b01e64be28c89a5f1757fd661",
-     *          "484ef1124595434fa9b14d6d2cc1e9f8",
-     *          "601133b1173f4ca3aeda5ef64ad38355",
-     *          "9fd6c61cf9844a8984a45f4e5b55a59c",
+     *          ["id => "29d6334b01e64be28c89a5f1757fd661"],
+     *          ["id => "484ef1124595434fa9b14d6d2cc1e9f8"],
+     *          ["id => "601133b1173f4ca3aeda5ef64ad38355"],
+     *          ["id => "9fd6c61cf9844a8984a45f4e5b55a59c"],
      *      ]
      *  ]
      *
@@ -63,7 +68,7 @@ class EntityForeignKeyResolver
      *
      * @throws \RuntimeException
      *
-     * @return array<string, list<string>>
+     * @return array<string, list<array<string, mixed>>>
      */
     public function getAffectedDeleteRestrictions(
         EntityDefinition $definition,
@@ -71,7 +76,11 @@ class EntityForeignKeyResolver
         Context $context,
         bool $restrictDeleteOnlyFirstLevel = false
     ): array {
-        return $this->fetch($definition, $ids, RestrictDelete::class, $context, $restrictDeleteOnlyFirstLevel);
+        $this->reset();
+
+        $this->fetch($definition, $ids, RestrictDelete::class, $context, $restrictDeleteOnlyFirstLevel);
+
+        return $this->restrictDeleteMetaFields->getVars();
     }
 
     /**
@@ -147,6 +156,11 @@ class EntityForeignKeyResolver
     public function getAllReverseInherited(EntityDefinition $definition, array $ids, Context $context): array
     {
         return $this->fetch($definition, $ids, ReverseInherited::class, $context);
+    }
+
+    public function reset(): void
+    {
+        $this->restrictDeleteMetaFields = new ArrayStruct();
     }
 
     /**
@@ -226,6 +240,21 @@ class EntityForeignKeyResolver
             $alias .= '.mapping';
         }
 
+        if ($class === RestrictDelete::class) {
+            foreach ($root->getRestrictDeleteMetaFields() as $field) {
+                if (!$field instanceof StorageAware) {
+                    continue;
+                }
+
+                $query->addSelect(\sprintf(
+                    '%s.%s as _%s',
+                    EntityDefinitionQueryHelper::escape($root->getEntityName()),
+                    EntityDefinitionQueryHelper::escape($field->getStorageName()),
+                    $field->getPropertyName()
+                ));
+            }
+        }
+
         $primaryKeys = $association->getReferenceDefinition()->getPrimaryKeys()->filter(static function (Field $field) {
             if ($field instanceof ReferenceVersionField || $field instanceof VersionField) {
                 return false;
@@ -275,14 +304,27 @@ class EntityForeignKeyResolver
         if ($primaryKeys->count() === 1) {
             $property = $primaryKeys->first()?->getPropertyName();
             \assert(\is_string($property));
-            $affected = array_column($affected, $property);
 
             // prevent infinite loop when entity points to itself
             if ($root === $association->getReferenceDefinition()) {
                 $flatIds = array_column($ids, $property);
 
-                $affected = array_values(array_diff($affected, $flatIds));
+                $affected = array_values(array_filter(
+                    $affected,
+                    static fn (array $row) => !\in_array($row[$property], $flatIds, true)
+                ));
             }
+
+            if ($class === RestrictDelete::class) {
+                $this->buildRestrictDeleteMetaData(
+                    $association->getReferenceDefinition()->getEntityName(),
+                    $root,
+                    $affected,
+                    $property
+                );
+            }
+
+            $affected = array_column($affected, $property);
         }
 
         // prevent circular reference for many to many
@@ -307,5 +349,34 @@ class EntityForeignKeyResolver
         $nested = $this->fetch($association->getReferenceDefinition(), $affected, $class, $context, $restrictDeleteOnlyFirstLevel);
 
         return array_merge($formatted, $nested);
+    }
+
+    /**
+     * @param list<array<string, string>> $affected
+     */
+    private function buildRestrictDeleteMetaData(
+        string $entityName,
+        EntityDefinition $root,
+        array $affected,
+        string $property,
+    ): void {
+        foreach ($affected as $row) {
+            $params = [$property => $row[$property]];
+
+            $rootParams = $root->getRestrictDeleteMetaFields()->map(
+                static fn (Field $field) => $field instanceof IdField
+                    ? Uuid::fromBytesToHex($row['_' . $field->getPropertyName()])
+                    : $row['_' . $field->getPropertyName()]
+            );
+
+            if ($rootParams !== []) {
+                $params[$root->getEntityName()] = $rootParams;
+            }
+
+            $merged = $this->restrictDeleteMetaFields->get($entityName) ?? [];
+            $merged[] = $params;
+
+            $this->restrictDeleteMetaFields->set($entityName, $merged);
+        }
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
@@ -434,6 +434,11 @@ abstract class EntityDefinition
         return $this->getFields()->getExtensionFields();
     }
 
+    public function getRestrictDeleteMetaFields(): FieldCollection
+    {
+        return new FieldCollection([]);
+    }
+
     protected function getParentDefinitionClass(): ?string
     {
         return null;

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolation.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolation.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 class RestrictDeleteViolation
 {
     /**
-     * @param array<string, list<string>> $restrictions
+     * @param array<string, list<array<string, mixed>>> $restrictions
      */
     public function __construct(
         /**
@@ -17,16 +17,16 @@ class RestrictDeleteViolation
          *
          * Example:
          * [
-         *     "order_customer" => [
-         *         "cace68bdbca140b6ac43a083fb19f82b",
-         *         "50330f5531ed485fbd72ba016b20ea2a",
-         *     ],
-         *     "order_address" => [
-         *         "29d6334b01e64be28c89a5f1757fd661",
-         *         "484ef1124595434fa9b14d6d2cc1e9f8",
-         *         "601133b1173f4ca3aeda5ef64ad38355",
-         *         "9fd6c61cf9844a8984a45f4e5b55a59c",
-         *     ]
+         *      "order_customer" => [
+         *          ["id => "cace68bdbca140b6ac43a083fb19f82b"],
+         *          ["id => "50330f5531ed485fbd72ba016b20ea2a"],
+         *      ],
+         *      "order_address" => [
+         *          ["id => "29d6334b01e64be28c89a5f1757fd661"],
+         *          ["id => "484ef1124595434fa9b14d6d2cc1e9f8"],
+         *          ["id => "601133b1173f4ca3aeda5ef64ad38355"],
+         *          ["id => "9fd6c61cf9844a8984a45f4e5b55a59c"],
+         *      ]
          * ]
          */
         private readonly array $restrictions
@@ -34,7 +34,7 @@ class RestrictDeleteViolation
     }
 
     /**
-     * @return array<string, list<string>>
+     * @return array<string, list<array<string, mixed>>>
      */
     public function getRestrictions(): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolationException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolationException.php
@@ -26,20 +26,24 @@ class RestrictDeleteViolationException extends ShopwareHttpException
         $usages = [];
         $usagesStrings = [];
 
-        foreach ($restriction->getRestrictions() as $entityName => $ids) {
+        foreach ($restriction->getRestrictions() as $entityName => $rows) {
             $name = $entityName;
             $usages[] = [
                 'entityName' => $name,
-                'count' => \count($ids),
+                'count' => \count($rows),
             ];
-            $usagesStrings[] = \sprintf('%s (%d)', $name, \count($ids));
+            $usagesStrings[] = \sprintf('%s (%d)', $name, \count($rows));
         }
 
         $this->restrictions = $restrictions;
 
+        $metaData = array_merge(
+            ...array_map(static fn (RestrictDeleteViolation $violation) => $violation->getRestrictions(), $restrictions)
+        );
+
         parent::__construct(
             'The delete request for {{ entity }} was denied due to a conflict. The entity is currently in use by: {{ usagesString }}',
-            ['entity' => $definition->getEntityName(), 'usagesString' => implode(', ', $usagesStrings), 'usages' => $usages]
+            ['entity' => $definition->getEntityName(), 'usagesString' => implode(', ', $usagesStrings), 'usages' => $usages, 'metaData' => $metaData]
         );
     }
 

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -511,11 +511,14 @@ class MediaRepositoryTest extends TestCase
 
     public function testItDoesNotDeleteFilesIfMediaHasDeleteRestrictions(): void
     {
+        $cmsPageId = Uuid::randomHex();
         $mediaId = Uuid::randomHex();
+        $fileName = $mediaId . '-' . (new \DateTime())->getTimestamp();
 
         $cmsPageRepository = static::getContainer()->get('cms_page.repository');
 
         $cmsPageRepository->create([[
+            'id' => $cmsPageId,
             'name' => 'cms-page',
             'type' => 'page',
             'previewMedia' => [
@@ -523,7 +526,7 @@ class MediaRepositoryTest extends TestCase
                 'name' => 'test media',
                 'mimeType' => 'image/png',
                 'fileExtension' => 'png',
-                'fileName' => $mediaId . '-' . (new \DateTime())->getTimestamp(),
+                'fileName' => $fileName,
             ],
         ]], $this->context);
 
@@ -540,8 +543,32 @@ class MediaRepositoryTest extends TestCase
         try {
             $this->mediaRepository->delete([['id' => $mediaId]], $this->context);
             static::fail('asserted DeleteRestrictViolationException');
-        } catch (RestrictDeleteViolationException) {
-            // ignore asserted exception
+        } catch (RestrictDeleteViolationException $exception) {
+            static::assertSame(
+                [
+                    'entity' => 'media',
+                    'usagesString' => 'cms_page (1)',
+                    'usages' => [
+                        [
+                            'entityName' => 'cms_page',
+                            'count' => 1,
+                        ],
+                    ],
+                    'metaData' => [
+                        'cms_page' => [
+                            [
+                                'id' => $cmsPageId,
+                                'media' => [
+                                    'id' => $mediaId,
+                                    'fileExtension' => 'png',
+                                    'fileName' => $fileName,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                $exception->getParameters()
+            );
         }
 
         static::assertTrue($this->getPublicFilesystem()->has($mediaUrl));

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -179,7 +179,7 @@ class EntityForeignKeyResolverTest extends TestCase
 
         static::assertCount(1, $affected);
         static::assertArrayHasKey('shipping_method', $affected);
-        static::assertContains($ids->get('shipping-method'), $affected['shipping_method']);
+        static::assertSame($ids->get('shipping-method'), $affected['shipping_method'][0]['id']);
         static::assertArrayNotHasKey('sales_channel', $affected);
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentDefinition;
+use Shopware\Core\Checkout\DocumentV2\Aggregate\DocumentFile\DocumentFileDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderLineItemDownload\OrderLineItemDownloadDefinition;
+use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockDefinition;
+use Shopware\Core\Content\Cms\Aggregate\CmsSection\CmsSectionDefinition;
+use Shopware\Core\Content\Cms\CmsPageDefinition;
+use Shopware\Core\Content\Media\MediaDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductDownload\ProductDownloadDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(EntityForeignKeyResolver::class)]
+class EntityForeignKeyResolverTest extends TestCase
+{
+    private Connection&MockObject $connection;
+
+    private EntityForeignKeyResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->resolver = new EntityForeignKeyResolver(
+            $this->connection,
+            $this->createMock(EntityDefinitionQueryHelper::class)
+        );
+    }
+
+    public function testMetaFieldsEnrichedInRestrictions(): void
+    {
+        $mediaId = Uuid::randomHex();
+        $cmsPageId = Uuid::randomHex();
+        $downloadId = Uuid::randomHex();
+
+        $emptyResult = $this->createMock(Result::class);
+
+        $downloadResult = $this->createMock(Result::class);
+        $downloadResult->method('fetchAllAssociative')->willReturn([
+            [
+                'id' => $downloadId,
+                '_id' => Uuid::fromHexToBytes($mediaId),
+                '_fileName' => 'shopware-logo',
+                '_fileExtension' => 'png',
+            ],
+        ]);
+
+        $cmsPageResult = $this->createMock(Result::class);
+        $cmsPageResult->method('fetchAllAssociative')->willReturn([
+            [
+                'id' => $cmsPageId,
+                '_id' => Uuid::fromHexToBytes($mediaId),
+                '_fileName' => 'shopware-logo',
+                '_fileExtension' => 'png',
+            ],
+        ]);
+
+        $this->connection->method('executeQuery')->willReturnOnConsecutiveCalls(
+            $downloadResult,
+            $emptyResult,
+            $emptyResult,
+            $emptyResult,
+            $cmsPageResult,
+            $emptyResult,
+            $emptyResult,
+            $emptyResult,
+        );
+
+        $rootDef = $this->buildRegistry();
+
+        $result = $this->resolver->getAffectedDeleteRestrictions(
+            $rootDef,
+            [['id' => $mediaId]],
+            Context::createDefaultContext(),
+            true
+        );
+
+        static::assertSame([
+            'product_download' => [
+                [
+                    'id' => $downloadId,
+                    'media' => [
+                        'id' => $mediaId,
+                        'fileExtension' => 'png',
+                        'fileName' => 'shopware-logo',
+                    ],
+                ],
+            ],
+            'cms_page' => [
+                [
+                    'id' => $cmsPageId,
+                    'media' => [
+                        'id' => $mediaId,
+                        'fileExtension' => 'png',
+                        'fileName' => 'shopware-logo',
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+
+    private function buildRegistry(): MediaDefinition
+    {
+        $rootDef = new MediaDefinition();
+
+        new StaticDefinitionInstanceRegistry(
+            [
+                $rootDef,
+                new CmsPageDefinition(),
+                new CmsBlockDefinition(),
+                new CmsSectionDefinition(),
+                new ProductDownloadDefinition(),
+                new OrderLineItemDownloadDefinition(),
+                new DocumentDefinition(),
+                new DocumentFileDefinition(),
+            ],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+
+        return $rootDef;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

  When the `media.cleanup_corrupted_media` scheduled task attempts to delete corrupted media files that still have active associations (e.g. to documents or CMS pages), it throws a
  `FRAMEWORK__DELETE_RESTRICTED` exception. The error currently only surfaces the entity type and count of blocking associations — there is no way to identify *which* specific media files are
  blocked or *where* they are referenced, making manual remediation extremely difficult.

 ### 2. What does this change do, exactly?

  A new `metaData` key is added to the `FRAMEWORK__DELETE_RESTRICTED` exception parameters, alongside the existing `usages` key (which is unchanged for backwards compatibility). `metaData` maps
  each blocking entity name to an array of its blocking rows, each enriched with identifying data about the entity being deleted.

  The enrichment is opt-in per definition via a new `EntityDefinition::getRestrictDeleteMetaFields()` hook. Definitions override this method to declare which of their own fields should be
  included alongside each blocking row. `MediaDefinition` overrides it to expose `id`, `fileName`, and `fileExtension`, so the error response now contains enough information to identify the
  exact file and look it up by path.

  Concretely, the `meta.parameters` of the exception now include:

  ```json
  {
    "entity": "media",
    "usagesString": "cms_page (1)",
    "usages": [{ "entityName": "cms_page", "count": 1 }],
    "metaData": {
      "cms_page": [
        {
          "id": "<cms-page-id>",
          "media": {
            "id": "<media-id>",
            "fileName": "invoice-2024",
            "fileExtension": "pdf"
          }
        }
      ]
    }
  }
```

  EntityForeignKeyResolver now implements ResetInterface to support safe usage in long-running workers.

 ### 3. Describe each step to reproduce the issue or behaviour.

  1. Create a media file with file_size = NULL (simulating a corrupted upload) and assign it to a CMS page or document.
  2. Trigger media.cleanup_corrupted_media (or attempt to delete the media via API).
  3. Before: The 409 response only states "document (500)" — no file identity, no path.
  4. After: The 409 response includes metaData with the blocking entity IDs and the affected media's fileName + fileExtension, which can be combined to reconstruct the storage path
  (fileName.fileExtension).

 ### 4. Please link to the relevant issues (if any).

  - closes #17265

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
