### PR TITLE
fix: Write state machine history and state atomically

### DIFF
--- a/src/Core/System/DependencyInjection/state_machine.xml
+++ b/src/Core/System/DependencyInjection/state_machine.xml
@@ -20,6 +20,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Shopware\Core\System\StateMachine\StateMachineLocker"/>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="kernel.reset" method="reset"/>
         </service>

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -200,7 +201,7 @@ class StateMachineRegistry implements ResetInterface
         // first on purpose: if it fails, the state update (and its entity-written events for indexers,
         // cache invalidation and webhooks) is never performed. Nested DAL transactions are handled via
         // DBAL savepoints.
-        $this->connection->transactional(function () use ($repository, $data, $stateMachineHistoryEntity, $context): void {
+        RetryableTransaction::transactional($this->connection, function () use ($repository, $data, $stateMachineHistoryEntity, $context): void {
             $this->stateMachineHistoryRepository->create([$stateMachineHistoryEntity], $context);
             $repository->upsert($data, $context);
         });

--- a/src/Core/System/StateMachine/StateMachineRegistry.php
+++ b/src/Core/System/StateMachine/StateMachineRegistry.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\StateMachine;
 
+use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
@@ -49,7 +50,8 @@ class StateMachineRegistry implements ResetInterface
         private readonly EntityRepository $stateMachineHistoryRepository,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly DefinitionInstanceRegistry $definitionRegistry,
-        private readonly StateMachineLocker $stateMachineLocker
+        private readonly StateMachineLocker $stateMachineLocker,
+        private readonly Connection $connection
     ) {
     }
 
@@ -191,11 +193,17 @@ class StateMachineRegistry implements ResetInterface
             'internalComment' => $transition->getInternalComment(),
         ];
 
-        $this->stateMachineHistoryRepository->create([$stateMachineHistoryEntity], $context);
-
         $data = [['id' => $transition->getEntityId(), $transition->getStateFieldName() => $toPlace->getId()]];
 
-        $repository->upsert($data, $context);
+        // Record the history entry and apply the new state atomically, so a failure of either write
+        // cannot leave the entity state and the state_machine_history out of sync. The history is written
+        // first on purpose: if it fails, the state update (and its entity-written events for indexers,
+        // cache invalidation and webhooks) is never performed. Nested DAL transactions are handled via
+        // DBAL savepoints.
+        $this->connection->transactional(function () use ($repository, $data, $stateMachineHistoryEntity, $context): void {
+            $this->stateMachineHistoryRepository->create([$stateMachineHistoryEntity], $context);
+            $repository->upsert($data, $context);
+        });
 
         $stateMachineStateCollection = new StateMachineStateCollection();
 

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\System\StateMachine;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -42,6 +43,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(StateMachineTransitionResult::class)]
 class StateMachineRegistryTest extends TestCase
 {
+    private int $transactionalCalls = 0;
+
     public function testTransitionWritesHistoryAndUpdatesEntityInsideLock(): void
     {
         $transition = new Transition('order_transaction', Uuid::randomHex(), 'paid', 'stateId', 'internal comment');
@@ -81,6 +84,53 @@ class StateMachineRegistryTest extends TestCase
         static::assertSame($fromPlace, $stateMachineStates->get('fromPlace'));
         static::assertSame($toPlace, $stateMachineStates->get('toPlace'));
         static::assertCount(3, $dispatcher->events);
+    }
+
+    public function testTransitionDoesNotUpdateStateWhenHistoryWriteFails(): void
+    {
+        $transition = new Transition('order_transaction', Uuid::randomHex(), 'paid', 'stateId');
+        $context = Context::createDefaultContext();
+        $fromPlace = $this->createState('open');
+        $toPlace = $this->createState('paid');
+        $stateMachine = $this->createStateMachine([
+            $this->createStateTransition('paid', $fromPlace, $toPlace),
+        ]);
+        $dispatcher = new CollectingEventDispatcher();
+        $fixture = $this->createRegistryFixture($stateMachine, $fromPlace, $dispatcher);
+
+        // The history entry is written first inside the transaction; if it fails, the state must not be
+        // updated, so no entity-written events are dispatched for a state change that never commits.
+        $fixture->historyRepository->method('create')
+            ->willThrowException(new \RuntimeException('history write failed'));
+
+        $fixture->entityRepository->expects($this->never())
+            ->method('upsert');
+
+        $this->expectExceptionObject(new \RuntimeException('history write failed'));
+
+        $fixture->registry->transition($transition, $context);
+    }
+
+    public function testTransitionWritesHistoryAndStateInsideTransaction(): void
+    {
+        $transition = new Transition('order_transaction', Uuid::randomHex(), 'paid', 'stateId');
+        $context = Context::createDefaultContext();
+        $fromPlace = $this->createState('open');
+        $toPlace = $this->createState('paid');
+        $stateMachine = $this->createStateMachine([
+            $this->createStateTransition('paid', $fromPlace, $toPlace),
+        ]);
+        $fixture = $this->createRegistryFixture($stateMachine, $fromPlace, new CollectingEventDispatcher());
+
+        $fixture->historyRepository->expects($this->once())
+            ->method('create');
+        $fixture->entityRepository->expects($this->once())
+            ->method('upsert');
+
+        $fixture->registry->transition($transition, $context);
+
+        // The history and state writes must be performed inside a single transaction.
+        static::assertSame(1, $this->transactionalCalls);
     }
 
     public function testTransitionSkipsWritesAndEventsForUnnecessaryTransition(): void
@@ -231,8 +281,22 @@ class StateMachineRegistryTest extends TestCase
             $this->createMock(EntityRepository::class),
             $dispatcher,
             $this->createMock(DefinitionInstanceRegistry::class),
-            $locker
+            $locker,
+            $this->createConnection()
         );
+    }
+
+    private function createConnection(): Connection&MockObject
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('transactional')
+            ->willReturnCallback(function (\Closure $func): mixed {
+                ++$this->transactionalCalls;
+
+                return $func();
+            });
+
+        return $connection;
     }
 
     private function createRegistryFixture(
@@ -290,7 +354,8 @@ class StateMachineRegistryTest extends TestCase
                 $historyRepository,
                 $dispatcher,
                 $definitionRegistry,
-                $locker
+                $locker,
+                $this->createConnection()
             ),
             $entityRepository,
             $historyRepository


### PR DESCRIPTION
### 1. Why is this change necessary?

`StateMachineRegistry::transitionState()` writes the state machine history entry and the new entity
state as two separate, ungrouped DAL writes:

```php
$this->stateMachineHistoryRepository->create([$stateMachineHistoryEntity], $context);
// ...
$repository->upsert($data, $context);
```

If the second write fails (DB error, constraint violation, lock timeout), the first one is already
committed. That leaves a `state_machine_history` row describing a transition that was never applied
to the entity, so the audit trail and the actual entity state can drift apart.

### 2. What does this change do, exactly?

Wraps both writes in a single transaction so they commit or roll back together:

```php
$this->connection->transactional(function () use ($repository, $data, $stateMachineHistoryEntity, $context): void {
    $this->stateMachineHistoryRepository->create([$stateMachineHistoryEntity], $context);
    $repository->upsert($data, $context);
});
```

Details:

- The history entry is written **first** on purpose. If it fails, the state `upsert()` (and the
  entity-written events that drive indexers, cache invalidation and webhooks) is never performed, so
  no side effects are emitted for a state change that does not commit.
- `RetryableTransaction::transactional()` is used. It keeps the same no-retry semantics as a plain
  `Connection::transactional()` (a failed write is not retried here), but additionally repairs the
  DBAL transaction nesting level after a rollback (doctrine/dbal issue 6651), so a failed transition cannot
  leave the connection in a bad state for a later operation. Nested DAL writes are handled via DBAL
  savepoints. `OrderStateTool` currently uses the plain wrapper for the same kind of grouped writes.
- `Connection` is injected into `StateMachineRegistry`. Its constructor is marked internal (an internal-only DocBlock tag, meaning it is
  meant to be resolved through the DI container), so adding a constructor argument is not a public BC
  concern. The service definition is updated accordingly.

The same history entry and state update are written, in the same order as before. The only difference
is that both now happen inside one explicit transaction; see the note below on event timing.

#### Note on transaction and event semantics

The DAL `EntityWrittenEvent`s are dispatched synchronously inside the transaction, before it commits.
If the transaction rolls back (because either write fails), those events have already been emitted for
that attempt - this applies both to `state_machine_history.written` (no core subscribers, though
custom subscribers could observe it) and to entity events such as `order.written` /
`order_transaction.written`. This is the same behavior as any DAL write wrapped in a transaction (see
`OrderStateTool`), and it only occurs on the rare failure path. The trade-off is accepted in exchange
for keeping the entity state and its history entry consistent. A transient deadlock now fails the
transition instead of being retried per write; the caller (or the message that triggered it) can
re-drive the transition.

The orphan-history case only applies when `transition()` is not already wrapped in an outer
transaction by the caller. A caller that already runs the transition inside its own transaction would
roll both writes back together; this change makes the guarantee hold on its own, regardless of the
caller.

### 3. Describe each step to reproduce the issue or behaviour.

1. Trigger a state transition where the entity state `upsert` fails after the history entry was
   created (for example, simulate a DB error on the entity write).
2. Before this change: a `state_machine_history` row exists for a transition that was not applied.
3. After this change: both writes roll back together, so no orphaned history row remains.

### 4. Please link to the relevant issues (if any).

None.

I recently wrote my own [state machine plugin](https://github.com/dereuromark/cakephp-workflow) and had to deal
with similar issues to solve.
So I know that under high traffic those things eventually can become relevant, even if they are usually not.

### 5. Checklist

- [x] I have rebased my changes onto the current trunk.
- [x] I have written tests and verified that they fail without my change.
- [x] I have checked all added or updated code for BC breaks.

