### PR TITLE
fix: apply new variant exclusions during regeneration

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js
@@ -337,6 +337,9 @@ export default {
             this.variantsGenerator
                 .saveVariants(this.variantGenerationQueue)
                 .then(() => {
+                    return this.variantsGenerator.saveVariantRestrictions();
+                })
+                .then(() => {
                     this.addOriginalConfiguratorSettings();
                     return this.variantsGenerator.saveConfiguratorSettings(
                         this.product.configuratorSettings,

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js
@@ -675,6 +675,7 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
             variantsGenerator: {
                 ...wrapper.vm.variantsGenerator,
                 saveVariants: () => Promise.resolve(),
+                saveVariantRestrictions: () => Promise.resolve(),
                 saveConfiguratorSettings: () => Promise.resolve(),
             },
         });
@@ -716,6 +717,7 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
             variantsGenerator: {
                 generateVariants: () => Promise.resolve(),
                 saveVariants: () => Promise.resolve(),
+                saveVariantRestrictions: () => Promise.resolve(),
                 saveConfiguratorSettings: () => Promise.resolve(),
             },
         });
@@ -1065,6 +1067,7 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
         const wrapper = await createWrapper();
 
         const saveMock = jest.fn().mockReturnValueOnce(Promise.resolve({}));
+        const saveVariantRestrictionsMock = jest.fn(() => Promise.resolve());
 
         await wrapper.setData({
             productRepository: {
@@ -1084,6 +1087,7 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
             },
             variantsGenerator: {
                 saveVariants: () => Promise.resolve(),
+                saveVariantRestrictions: saveVariantRestrictionsMock,
                 saveConfiguratorSettings: () => Promise.resolve(),
             },
         });
@@ -1094,6 +1098,7 @@ describe('src/module/sw-product/component/sw-product-variants/sw-product-modal-v
         // productRepository.save should NOT be called - variants are saved via sync API
         // and swProductDetailLoadAll() reloads fresh data from server
         expect(saveMock).not.toHaveBeenCalled();
+        expect(saveVariantRestrictionsMock).toHaveBeenCalledTimes(1);
         // The event should still be emitted
         expect(wrapper.emitted('variations-finish-generate')).toHaveLength(1);
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.js
@@ -80,6 +80,31 @@ export default class VariantsGenerator extends EventEmitter {
         );
     }
 
+    saveVariantRestrictions(variantRestrictions = this.product?.variantRestrictions) {
+        if (!this.product?.id || variantRestrictions === undefined) {
+            return Promise.resolve();
+        }
+
+        const payload = [
+            {
+                id: this.product.id,
+                variantRestrictions: variantRestrictions === null ? null : deepCopyObject(variantRestrictions),
+            },
+        ];
+
+        return this.syncService.sync(
+            [
+                {
+                    entity: 'product',
+                    action: 'upsert',
+                    payload,
+                },
+            ],
+            {},
+            { 'single-operation': 1 },
+        );
+    }
+
     /**
      * Saves the variants to the database via sync api.
      */
@@ -219,6 +244,10 @@ export default class VariantsGenerator extends EventEmitter {
 
             // Check if the new variation exists on the server.
             newVariationsSorted.forEach((variation) => {
+                if (this.isVariationRestricted(variation)) {
+                    return;
+                }
+
                 const hash = md5(JSON.stringify(variation));
                 const exist = hashed[hash];
 
@@ -237,6 +266,10 @@ export default class VariantsGenerator extends EventEmitter {
 
             // Check if the new variation exists on the server.
             newVariationsSorted.forEach((variation) => {
+                if (this.isVariationRestricted(variation)) {
+                    return;
+                }
+
                 const hash = md5(JSON.stringify(variation));
                 const exist = hashed[hash];
 
@@ -366,12 +399,12 @@ export default class VariantsGenerator extends EventEmitter {
         return { number, increment };
     }
 
-    filterRestrictions(createQueue) {
+    getValidRestrictions() {
         if (!Array.isArray(this.product.variantRestrictions)) {
-            return createQueue;
+            return [];
         }
 
-        const validRestrictions = this.product.variantRestrictions.filter((restriction) => {
+        return this.product.variantRestrictions.filter((restriction) => {
             return (
                 restriction &&
                 Array.isArray(restriction.values) &&
@@ -379,17 +412,32 @@ export default class VariantsGenerator extends EventEmitter {
                 restriction.values.every((value) => Array.isArray(value.options) && value.options.length > 0)
             );
         });
+    }
+
+    isVariationRestricted(variations, validRestrictions = this.getValidRestrictions()) {
+        if (validRestrictions.length === 0) {
+            return false;
+        }
+
+        return validRestrictions.some((restriction) => {
+            return restriction.values.reduce((exists, restrictionValue) => {
+                const restrictionExist = restrictionValue.options.find((optionId) => {
+                    const idOfOption = optionId.optionId ? optionId.optionId : optionId;
+
+                    return variations.indexOf(idOfOption) >= 0;
+                });
+
+                return restrictionExist ? exists : false;
+            }, true);
+        });
+    }
+
+    filterRestrictions(createQueue) {
+        const validRestrictions = this.getValidRestrictions();
 
         if (validRestrictions.length === 0) {
             return createQueue;
         }
-
-        // Filter to get an array with only the restrictions ids with the single option ids
-        const restrictionsOnly = validRestrictions.map((restriction) => {
-            return restriction.values.map((value) => {
-                return value.options;
-            });
-        });
 
         /**
          * Go through the whole createQueue and check for each variation,
@@ -398,17 +446,7 @@ export default class VariantsGenerator extends EventEmitter {
         return createQueue.filter((newVariation) => {
             const variations = newVariation.options.map((variation) => variation.id);
 
-            return restrictionsOnly.reduce((result, restriction) => {
-                const hasRestriction = restriction.reduce((exists, restrictionArray) => {
-                    const restrictionExist = restrictionArray.find((optionId) => {
-                        return variations.indexOf(optionId) >= 0;
-                    });
-
-                    return restrictionExist ? exists : false;
-                }, true);
-
-                return hasRestriction ? false : result;
-            }, true);
+            return !this.isVariationRestricted(variations, validRestrictions);
         });
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/helper/sw-products-variants-generator.spec.js
@@ -240,6 +240,57 @@ describe('/src/module/sw-product/helper/sw-products-variants-generator.spec.js',
         });
     });
 
+    it('should delete existing variants matching newly added restrictions', async () => {
+        const newVariations = [
+            [
+                'd6e90b99fe4842d487b53b59e50491a4',
+            ],
+            [
+                'e10fed21a07149958427cb5339ee4c31',
+            ],
+        ];
+
+        const variationOnServer = {
+            '455ff20cec764a2aab42d2282d08456c': {
+                options: ['d6e90b99fe4842d487b53b59e50491a4'],
+                productNumber: 'SW10000.1',
+                productStates: '["is-physical"]',
+                productType: '["physical"]',
+            },
+            a6ebe32c706b4a16a69041b31df5d7fb: {
+                options: ['e10fed21a07149958427cb5339ee4c31'],
+                productNumber: 'SW10000.2',
+                productStates: '["is-download"]',
+                productType: '["digital"]',
+            },
+        };
+
+        variantsGenerator.product = {
+            ...product,
+            variantRestrictions: [
+                {
+                    id: 'restriction1',
+                    values: [
+                        {
+                            id: 'value1',
+                            group: 'group1',
+                            options: ['e10fed21a07149958427cb5339ee4c31'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const variants = await variantsGenerator.filterVariations(newVariations, variationOnServer, currencies);
+
+        expect(variants).toEqual({
+            createQueue: [],
+            deleteQueue: [
+                'a6ebe32c706b4a16a69041b31df5d7fb',
+            ],
+        });
+    });
+
     describe('filterRestrictions', () => {
         const mockCreateQueue = [
             {
@@ -377,6 +428,99 @@ describe('/src/module/sw-product/helper/sw-products-variants-generator.spec.js',
                     ],
                 },
             ]);
+        });
+    });
+
+    describe('saveVariantRestrictions', () => {
+        it('should resolve immediately when product is missing', async () => {
+            variantsGenerator.product = null;
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync');
+
+            const result = await variantsGenerator.saveVariantRestrictions([]);
+
+            expect(result).toBeUndefined();
+            expect(syncSpy).not.toHaveBeenCalled();
+
+            syncSpy.mockRestore();
+        });
+
+        it('should resolve immediately when variant restrictions are undefined', async () => {
+            variantsGenerator.product = {
+                id: 'product-123',
+            };
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync');
+
+            const result = await variantsGenerator.saveVariantRestrictions();
+
+            expect(result).toBeUndefined();
+            expect(syncSpy).not.toHaveBeenCalled();
+
+            syncSpy.mockRestore();
+        });
+
+        it('should upsert product variant restrictions', async () => {
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync').mockResolvedValue({});
+            const variantRestrictions = [
+                {
+                    id: 'restriction-1',
+                    values: [
+                        {
+                            id: 'value-1',
+                            group: 'group-1',
+                            options: ['option-1'],
+                        },
+                    ],
+                },
+            ];
+
+            variantsGenerator.product = {
+                id: 'product-123',
+                variantRestrictions,
+            };
+
+            await variantsGenerator.saveVariantRestrictions();
+
+            expect(syncSpy).toHaveBeenCalledWith(
+                [
+                    {
+                        entity: 'product',
+                        action: 'upsert',
+                        payload: [
+                            {
+                                id: 'product-123',
+                                variantRestrictions,
+                            },
+                        ],
+                    },
+                ],
+                {},
+                { 'single-operation': 1 },
+            );
+
+            const calledRestrictions = syncSpy.mock.calls[0][0][0].payload[0].variantRestrictions;
+            expect(calledRestrictions).not.toBe(variantRestrictions);
+
+            syncSpy.mockRestore();
+        });
+
+        it('should persist empty variant restrictions to clear previous exclusions', async () => {
+            const syncSpy = jest.spyOn(variantsGenerator.syncService, 'sync').mockResolvedValue({});
+
+            variantsGenerator.product = {
+                id: 'product-123',
+                variantRestrictions: [],
+            };
+
+            await variantsGenerator.saveVariantRestrictions();
+
+            expect(syncSpy.mock.calls[0][0][0].payload).toEqual([
+                {
+                    id: 'product-123',
+                    variantRestrictions: [],
+                },
+            ]);
+
+            syncSpy.mockRestore();
         });
     });
 


### PR DESCRIPTION
## What changed

- Persist `product.variantRestrictions` through a narrow sync API product upsert during variant generation.
- Treat variant exclusions as part of the desired variant set before finalizing the delete queue, so newly excluded existing combinations are deleted even when the value selection tab is unchanged.
- Added regression coverage for the second-run exclusion case and the narrow restriction persistence path.

## Why

Fixes #16589. After #14660 replaced the full product save with narrower configurator setting sync, exclusions could fall back to previously persisted state. Additionally, newly added exclusions only filtered variants to create, so existing combinations stayed untouched when the selected values did not change.

## Validation

- `./node_modules/.bin/jest --config jest.config.js --ci src/module/sw-product/helper/sw-products-variants-generator.spec.js src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js --runInBand`
- `./node_modules/.bin/eslint src/module/sw-product/helper/sw-products-variants-generator.js src/module/sw-product/helper/sw-products-variants-generator.spec.js src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/index.js src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.spec.js`
- `composer eslint:admin`
- `git diff --check`