### PR TITLE
fix: administration smart bar actions on small viewports

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -102,6 +102,10 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
         }
     }
 
+    .smart-bar__content > .sw-app-actions__empty {
+        display: none;
+    }
+
     .smart-bar__header {
         flex: 1;
         min-width: 0;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -94,11 +94,21 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
         @media screen and (max-width: 1360px) {
             padding: 15px;
         }
+
+        @media screen and (max-width: 768px) {
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            gap: var(--scale-size-8);
+        }
     }
 
     .smart-bar__header {
         flex: 1;
         min-width: 0;
+
+        @media screen and (max-width: 768px) {
+            flex: 1 1 100%;
+        }
     }
 
     .smart-bar__header h2 {
@@ -128,10 +138,19 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
         white-space: nowrap;
         align-items: center;
 
+        @media screen and (max-width: 768px) {
+            flex: 1 1 100%;
+            gap: var(--scale-size-8);
+        }
+
         .mt-button,
         .sw-button-group,
         .sw-tooltip--wrapper {
             margin-left: var(--scale-size-8);
+
+            @media screen and (max-width: 768px) {
+                margin-left: 0;
+            }
 
             &:first-child {
                 margin-left: 0;

--- a/tests/acceptance/tests/Administration/SmartBar.spec.ts
+++ b/tests/acceptance/tests/Administration/SmartBar.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from '@playwright/test';
+import { test } from '@fixtures/AcceptanceTest';
+
+const viewports = [
+    { name: 'mobile S', width: 375, height: 667 },
+    { name: 'mobile M', width: 390, height: 844 },
+    { name: 'mobile X', width: 414, height: 896 },
+    { name: 'mobile XL', width: 430, height: 932 },
+    { name: 'mobile breakpoint', width: 500, height: 844 },
+    { name: 'above mobile breakpoint', width: 501, height: 844 },
+    { name: 'tablet', width: 768, height: 1024 },
+    { name: 'desktop', width: 1280, height: 720 },
+] as const;
+
+test.describe('Administration: smart bar actions', () => {
+    viewports.forEach((viewport) => {
+        test(`are reachable on ${viewport.name} viewport`, async ({
+            ShopAdmin,
+            TestDataService,
+            AdminManufacturerDetail,
+        }) => {
+            const manufacturer = await TestDataService.createBasicManufacturer();
+
+            await AdminManufacturerDetail.page.setViewportSize({
+                width: viewport.width,
+                height: viewport.height,
+            });
+            await ShopAdmin.goesTo(AdminManufacturerDetail.url(manufacturer.id));
+
+            await expect(AdminManufacturerDetail.cancelButton).toBeVisible();
+            await expect(AdminManufacturerDetail.saveButton).toBeVisible();
+
+            await expect(AdminManufacturerDetail.cancelButton).toBeInViewport({ ratio: 1 });
+            await expect(AdminManufacturerDetail.saveButton).toBeInViewport({ ratio: 1 });
+        });
+    });
+});


### PR DESCRIPTION
Closes #17041

Fixes the administration smart bar layout on small viewports so action buttons remain reachable and consistently aligned when the smart bar content wraps.

 ## Why?

On small screens, smart bar actions like `Cancel` and `Save` could be pushed partially out of the viewport or appear inconsistently aligned depending on the available width.

## How?

  - Allows `sw-page` smart bar content to wrap up to `768px`
  - Keeps wrapped smart bar content left-aligned
  - Moves the smart bar header and actions onto stable rows on smaller viewports
  - Uses existing Shopware spacing variables
  - Adds acceptance coverage for several mobile, breakpoint, tablet, and desktop viewports



https://github.com/user-attachments/assets/f06ff15a-3e9c-4540-9875-bb91d377fbf9

