### PR TITLE
fix(price-display): Implement snippet addition solution for list prices

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,15 @@
 
 ## Storefront
 
+### Central extension point for content before/after list prices
+
+A new template `@Storefront/storefront/component/product/list-price-affix.html.twig` is rendered inside every list price display (product box, product detail buy widget, advanced pricing table). It replaces the deprecated `listing.beforeListPrice` / `listing.afterListPrice` snippets as the single place to inject content around list prices.
+
+Content can be provided in two ways:
+
+- Without code: create a translation snippet with a custom key and enter that key in the new sales-channel-aware system config settings `core.listing.beforeListPriceSnippetKey` / `core.listing.afterListPriceSnippetKey`. The snippet content is rendered sanitized, wrapped in a `list-price-affix list-price-affix-{before|after}` span.
+- In a theme or plugin: override the block `component_list_price_affix_content` once; the `position` variable (`before` / `after`) allows position-specific output.
+
 ### Thumbnail `sizes` attribute now emits a value for the XXL breakpoint
 
 The auto-generated `sizes` attribute produced by `thumbnail.html.twig` now includes a value for the XXL breakpoint. The `xxl` key is the open-ended top (`container / columns`), and `xl` is a closed range bounded by `breakpoint.xxl - 1`, matching the pattern used by smaller breakpoints. Templates that pass a manual `sizes` map to `sw_thumbnails` should add an `xxl` entry to keep parity.

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -1308,7 +1308,12 @@ The block `page_product_detail_product_buy_button_label` has been removed. Use `
 
 ## Deprecated `listing.beforeListPrice` / `listing.afterListPrice` snippets
 
-The snippets `listing.beforeListPrice` and `listing.afterListPrice` for injecting markup around the list price are deprecated; their output is removed in 6.8.0. Override the new Twig blocks instead:
+The snippets `listing.beforeListPrice` and `listing.afterListPrice` for injecting markup around the list price are deprecated; their output is removed in 6.8.0. Use one of the following replacements instead:
+
+- Without code, via system config: create a regular translation snippet with a custom key and enter that key in the new system config settings `core.listing.beforeListPriceSnippetKey` / `core.listing.afterListPriceSnippetKey` (Settings > Shop > Listing). The snippet content is rendered sanitized around every list price, per sales channel and language.
+- In a theme or plugin: override the central template `@Storefront/storefront/component/product/list-price-affix.html.twig` (block `component_list_price_affix_content`, with `position` set to `before` or `after`) to inject markup into all list price displays at once.
+
+To target a single display only, override the local Twig blocks instead:
 
 - `buy-widget-price.html.twig`: `buy_widget_was_price_before` / `buy_widget_was_price_after`
 - `block-price.html.twig`: `component_product_detail_block_list_price_before` / `component_product_detail_block_list_price_after`

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -106,5 +106,21 @@
             <helpText lang="de-DE">Die Anzahl der Produkte die auf einer Suchseite oder in einer Produktliste je Seite in der Storefront angezeigt werden.</helpText>
             <min>1</min>
         </input-field>
+
+        <input-field type="text">
+            <name>beforeListPriceSnippetKey</name>
+            <label>Snippet key for content before list prices</label>
+            <label lang="de-DE">Snippet-Key für Inhalt vor Streichpreisen</label>
+            <helpText>The content of this translation snippet is displayed before every list price in the Storefront. Leave empty to display nothing.</helpText>
+            <helpText lang="de-DE">Der Inhalt dieses Übersetzungs-Snippets wird in der Storefront vor jedem Streichpreis angezeigt. Leer lassen, um nichts anzuzeigen.</helpText>
+        </input-field>
+
+        <input-field type="text">
+            <name>afterListPriceSnippetKey</name>
+            <label>Snippet key for content after list prices</label>
+            <label lang="de-DE">Snippet-Key für Inhalt nach Streichpreisen</label>
+            <helpText>The content of this translation snippet is displayed after every list price in the Storefront. Leave empty to display nothing.</helpText>
+            <helpText lang="de-DE">Der Inhalt dieses Übersetzungs-Snippets wird in der Storefront nach jedem Streichpreis angezeigt. Leer lassen, um nichts anzuzeigen.</helpText>
+        </input-field>
     </card>
 </config>

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -121,7 +121,11 @@
 
                     {% block buy_widget_was_price_wrapper %}
                         <span class="product-detail-list-price-wrapper">
-                            {% block buy_widget_was_price_before %}{% endblock %}
+                            {% block buy_widget_was_price_before %}
+                                {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                    position: 'before'
+                                } %}
+                            {% endblock %}
 
                             {# @deprecated tag:v6.8.0 - Snippet listing.beforeListPrice output will be removed. Use twig blocks instead. #}
                             {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans|trim }}{% endif %}
@@ -131,7 +135,11 @@
                             {# @deprecated tag:v6.8.0 - The conditional "list-price-price" class will be set unconditionally. #}
                             <span{% if not (afterListPriceSnippetExists or beforeListPriceSnippetExists) %} class="list-price-price"{% endif %}>{{ listPrice.price|currency }}</span>
 
-                            {% block buy_widget_was_price_after %}{% endblock %}
+                            {% block buy_widget_was_price_after %}
+                                {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                    position: 'after'
+                                } %}
+                            {% endblock %}
 
                             {# @deprecated tag:v6.8.0 - Snippet listing.afterListPrice output will be removed. Use twig blocks instead. #}
                             {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim }}{% endif %}

--- a/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
@@ -14,14 +14,22 @@
                 {% block component_product_detail_block_list_price_wrapper %}
                     {# @deprecated tag:v6.8.0 - The conditional "product-detail-advanced-list-price-wrapper-no-line-through" class will be removed. #}
                     <span class="product-detail-advanced-list-price-wrapper{% if beforeListPriceSnippetExists or afterListPriceSnippetExists %} product-detail-advanced-list-price-wrapper-no-line-through{% endif %}">
-                        {% block component_product_detail_block_list_price_before %}{% endblock %}
+                        {% block component_product_detail_block_list_price_before %}
+                            {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                position: 'before'
+                            } %}
+                        {% endblock %}
 
                         {# @deprecated tag:v6.8.0 - Snippet listing.beforeListPrice output will be removed. Use twig blocks instead. #}
                         {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans }}{% endif %}
 
                         <span class="list-price-price">{{ price.listprice.price|currency }}</span>
 
-                        {% block component_product_detail_block_list_price_after %}{% endblock %}
+                        {% block component_product_detail_block_list_price_after %}
+                            {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                position: 'after'
+                            } %}
+                        {% endblock %}
 
                         {# @deprecated tag:v6.8.0 - Snippet listing.afterListPrice output will be removed. Use twig blocks instead. #}
                         {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans }}{% endif %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -104,7 +104,11 @@
                             {% set beforeListPriceSnippetExists = 'listing.beforeListPrice'|trans|length > 0 %}
 
                             <span class="list-price list-price-no-line-through">
-                                {% block component_product_box_main_price_before %}{% endblock %}
+                                {% block component_product_box_main_price_before %}
+                                    {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                        position: 'before'
+                                    } %}
+                                {% endblock %}
 
                                 {# @deprecated tag:v6.8.0 - Snippet listing.beforeListPrice output will be removed. Use twig blocks instead. #}
                                 {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans|trim|sw_sanitize }}{% endif %}
@@ -113,7 +117,11 @@
 
                                 <span class="list-price-price">{{ price.listPrice.price|currency }}</span>
 
-                                {% block component_product_box_main_price_after %}{% endblock %}
+                                {% block component_product_box_main_price_after %}
+                                    {% sw_include '@Storefront/storefront/component/product/list-price-affix.html.twig' with {
+                                        position: 'after'
+                                    } %}
+                                {% endblock %}
 
                                 {# @deprecated tag:v6.8.0 - Snippet listing.afterListPrice output will be removed. Use twig blocks instead. #}
                                 {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim|sw_sanitize }}{% endif %}

--- a/src/Storefront/Resources/views/storefront/component/product/list-price-affix.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/list-price-affix.html.twig
@@ -1,0 +1,14 @@
+{% block component_list_price_affix %}
+    {% set position = position ?? 'before' %}
+    {% set listPriceAffixSnippetKey = (config('core.listing.' ~ position ~ 'ListPriceSnippetKey') ?? '')|trim %}
+    {% set listPriceAffixContent = listPriceAffixSnippetKey ? listPriceAffixSnippetKey|trans|trim : '' %}
+
+    {% block component_list_price_affix_config %}
+        {# Missing snippets translate to their own key, which must not be rendered. #}
+        {% if listPriceAffixContent and (listPriceAffixContent != listPriceAffixSnippetKey) %}
+            <span class="list-price-affix list-price-affix-{{ position }}">{{ listPriceAffixContent|sw_sanitize }}</span>
+        {% endif %}
+    {% endblock %}
+
+    {% block component_list_price_affix_content %}{% endblock %}
+{% endblock %}


### PR DESCRIPTION
fixes #17335
related: https://github.com/shopware/SwagCommercial/pull/2890

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->
### Demo
<img width="980" height="697" alt="image" src="https://github.com/user-attachments/assets/24896124-03ca-4737-b6c6-56344edb7d1a" />
<img width="337" height="818" alt="image" src="https://github.com/user-attachments/assets/11846680-6ce1-4e55-b266-e671e3d3b380" />

### 1. Why is this change necessary?
We had empty snippets before/after price positions, which is not the best practise of shopware, so we removed them, but we needed a proper solution for easy extensibility

### 2. What does this change do, exactly?
Implement a central template to be included everywhere where's needed + a system config setting to set a snippetkey to be inserted

### 3. Describe each step to reproduce the issue or behaviour.
- E.g. Configure a product with a valid list price
- Create a snippet or re-use an old one in the snippets module
- Enter the snippet key in `Settings > Products`
- E.g. See the product box in the product listing the created snippets

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
