### PR TITLE
feat(ai): add fix issue local workflow

### DIFF
--- a/.agents-templates/issue-fix.md
+++ b/.agents-templates/issue-fix.md
@@ -94,6 +94,7 @@ The agent must perform these steps in order:
 16. Suggest one very short Conventional Commit message for the staged change.
 17. Suggest a short pull request title and description.
 18. Commit and create the pull request only if the user explicitly signs off on the staged changes.
+19. After creating the pull request, give the user the pull request link.
 
 ## Validation Rules
 
@@ -236,12 +237,11 @@ After explicit user sign-off, the agent should:
 3. use the Conventional Commit message as the PR title unless the user requested a different title
 4. include a short PR description
 5. include a `Fixes: <issue-reference>` line in the PR description
+6. return the created pull request URL to the user
 
 The PR description should stay short and include:
 
 - a concise summary of the fix
-- the root cause in one short paragraph or bullet
-- the checks that were run
 - `Fixes: <issue-reference>`
 
 ## Output Requirements

--- a/.agents-templates/issue-fix.md
+++ b/.agents-templates/issue-fix.md
@@ -1,0 +1,272 @@
+# GUI-First `issue-fix` Workflow
+
+This repository uses a GUI-first GitHub issue fixing workflow for Claude and Codex.
+
+The canonical operation name is `issue-fix`.
+
+Preferred invocations:
+
+- `issue-fix 12345`
+- `/issue-fix 12345`
+- `Run issue-fix for GitHub issue 12345`
+
+This workflow is intentionally agent-side. It must use local `gh`, `git`, and repository inspection from the active Claude or Codex session instead of a Symfony command in Shopware core.
+
+`gh` is a required prerequisite for this workflow.
+
+## Input
+
+- A single GitHub issue reference from the current repository:
+  - an issue number, or
+  - a full GitHub issue URL
+
+If the issue reference is missing, the agent must ask for it before proceeding.
+
+If a full GitHub issue URL is provided, the agent should extract the issue number from it and continue with the same workflow.
+
+If `gh` is missing or not authenticated, the agent must pause and guide the user through installing or authenticating `gh` before continuing. The agent should not silently switch to a different issue-ingestion path in v1.
+
+## Prerequisites
+
+Before reading the issue, the agent must verify:
+
+- `gh` is installed locally
+- `gh` is authenticated for GitHub access
+
+The agent should prefer checking `gh` from the same environment it plans to use for GitHub commands. If a sandboxed check reports an invalid or missing token, but the failure could plausibly come from keychain or credential-store isolation, the agent must retry the `gh` auth check unsandboxed before concluding that authentication is actually broken.
+
+If either check fails:
+
+- stop before branch creation or code changes
+- explain that `issue-fix` requires `gh`
+- guide the user through the missing setup step
+- resume the workflow only after `gh` is ready
+
+## `gh` Authentication Troubleshooting
+
+When `gh` authentication appears broken, the agent must distinguish between a real auth problem and an execution-environment problem.
+
+Treat it as an environment problem first when:
+
+- sandboxed `gh auth status` says the token is invalid
+- sandboxed `gh auth token` reports no token found
+- the user expects keychain-backed or credential-store-backed authentication
+
+In that case, the agent should:
+
+1. retry the `gh` auth check unsandboxed
+2. use the unsandboxed result as the source of truth for GitHub access
+3. continue the workflow with unsandboxed `gh` commands if auth is healthy there
+
+Only tell the user their GitHub authentication is broken when the unsandboxed check also fails.
+
+## Issue Ingestion
+
+When reading the issue, the agent must collect:
+
+- the issue title
+- the issue body
+- labels and status
+- linked metadata visible through GitHub
+- issue comments, if any
+
+Comments are part of the required context. The agent must read them before deciding whether the issue is still actionable.
+
+## Required Workflow
+
+The agent must perform these steps in order:
+
+1. Read the GitHub issue with `gh`.
+2. Validate that the issue is actionable for this repository.
+3. Detect ambiguity or missing context.
+4. Ask the user before proceeding if important ambiguity remains.
+5. Determine the correct git repository for the fix.
+6. Decide whether the work is a `fix/...` or `feat/...` branch.
+7. Create and switch to the branch in the correct repository.
+8. Analyze the root cause in the current codebase.
+9. Explain how and why the issue happens.
+10. Implement the fix using current repository patterns and Shopware 6 best practices.
+11. Run the relevant checks for the touched file types.
+12. Perform a self code review of the produced diff.
+13. Fix the review findings before finishing.
+14. Stage the changes for user review.
+15. Explain the final fix, why it was chosen, and why it resolves the issue.
+16. Suggest one very short Conventional Commit message for the staged change.
+17. Suggest a short pull request title and description.
+18. Commit and create the pull request only if the user explicitly signs off on the staged changes.
+
+## Validation Rules
+
+The issue is actionable only if all of the following are true:
+
+- `gh` is installed and authenticated.
+- The issue can be read successfully from GitHub.
+- The issue belongs to the current repository context.
+- The issue contains enough context to start analysis.
+- The issue is asking for repository work rather than unrelated support or operations work.
+- The issue does not already appear resolved, obsolete, or superseded by newer context.
+- There is no existing in-progress pull request that already covers the same fix direction.
+
+If validation fails, stop and report the blocking reason. Do not create a branch and do not edit files.
+
+## Triage Before Fixing
+
+Before creating a branch, the agent must actively evaluate whether the issue should be fixed at all.
+
+The agent may recommend not proceeding when the issue appears to be:
+
+- already fixed
+- outdated
+- no longer worth fixing
+- superseded by newer decisions or comments
+- already being worked on in an existing pull request
+
+If the agent finds strong evidence for one of those cases, it should:
+
+- explain the evidence clearly
+- link the conclusion back to the issue body, comments, repository state, or existing PR context
+- recommend not proceeding with a fix
+- ask the user whether they still want implementation work
+
+In these cases, the agent must not create a branch or edit files unless the user explicitly wants to continue anyway.
+
+## Ambiguity Rules
+
+The agent must stop and ask the user before proceeding when any of these are true:
+
+- The expected behavior is unclear.
+- The issue could reasonably map to more than one implementation direction.
+- The issue depends on screenshots, linked discussions, or outside context that is not available locally.
+- The issue could be either a bugfix or a feature and the branch type cannot be inferred confidently.
+- The requested scope is broad enough that more than one substantial fix would be reasonable.
+- The issue comments meaningfully change, narrow, or contradict the original issue description.
+- There is evidence that a PR may already be in progress, but the agent cannot confidently determine whether it fully covers the issue.
+
+The clarification request should be concrete and short. Do not continue to implementation until the ambiguity is resolved.
+
+## Existing PR Check
+
+Before implementation, the agent should check whether there is already a pull request in progress for the issue or the same problem area.
+
+If a relevant PR already exists, the agent should prefer recommending that the user review or continue that work instead of starting a parallel fix branch.
+
+## Branch Naming
+
+Branch names must use a short kebab-case summary derived from the issue title.
+
+- Bugfix work: `fix/<short-issue-summary>`
+- Feature work: `feat/<short-issue-summary>`
+
+Guidance:
+
+- Prefer `fix/...` when the issue describes broken, missing, incorrect, or regressed behavior.
+- Prefer `feat/...` when the issue requests new behavior or a product enhancement.
+- If the classification is not clear from the issue, ask the user before creating the branch.
+- Keep the slug short, stable, and implementation-agnostic.
+
+## Repository Targeting
+
+Before creating a branch, the agent must determine which git repository should contain the fix.
+
+Default:
+
+- If the issue affects Shopware core, create the branch in the Shopware root repository.
+
+Plugin rule:
+
+- If the issue clearly affects a plugin located under `custom/` and that plugin has its own git repository, create and switch to the branch inside the plugin repository instead of the Shopware root repository.
+
+The agent must not create the branch in the Shopware root repository when:
+
+- the intended code changes belong only to a plugin repository under `custom/`
+- creating the branch in the root repo would leave the root worktree unchanged
+
+When targeting a plugin repository, the agent should:
+
+- identify the correct plugin directory first
+- confirm that the plugin directory is its own git repository
+- create the `fix/...` or `feat/...` branch inside that plugin repository
+- perform status, diff, staging, and final reporting relative to that plugin repository
+
+If the correct target repository is unclear, the agent must ask before creating any branch.
+
+## Implementation Rules
+
+- Follow the existing patterns in the affected area of the repository.
+- Apply Shopware 6 best practices from `AGENTS.md` and `coding-guidelines/`.
+- Prefer events over decorators when extending behavior unless the timing requires decoration.
+- Use DAL patterns instead of Doctrine ORM assumptions.
+- Do not invent a parallel architecture when a local pattern already exists.
+
+## Checks And Review
+
+Run only the relevant checks for the touched file types, using the lint/test matrix from `AGENTS.md`.
+
+At minimum, the self review must cover:
+
+- behavioral correctness
+- regressions and edge cases
+- missing tests
+- style or pattern mismatches with the surrounding code
+
+If the self review finds issues, fix them before finishing.
+
+## Sign-Off Gate
+
+The default workflow ends with staged changes, a suggested Conventional Commit message, and a suggested pull request description.
+
+The agent must not commit or create a pull request automatically.
+
+It may commit and open the pull request only after the user clearly signs off on the produced changes.
+
+Accepted sign-off examples:
+
+- "looks good, commit it"
+- "go ahead and create the PR"
+- "please commit and open the PR"
+
+Until that sign-off exists, the agent must stop after staging and explanation.
+
+## Commit And PR Rules
+
+After explicit user sign-off, the agent should:
+
+1. commit the staged changes using the suggested Conventional Commit message unless the user requested a different message
+2. create a pull request
+3. use the Conventional Commit message as the PR title unless the user requested a different title
+4. include a short PR description
+5. include a `Fixes: <issue-reference>` line in the PR description
+
+The PR description should stay short and include:
+
+- a concise summary of the fix
+- the root cause in one short paragraph or bullet
+- the checks that were run
+- `Fixes: <issue-reference>`
+
+## Output Requirements
+
+Before implementation, the agent should create a brief using `.agents-templates/issue-fix/templates/brief.md.tpl`.
+
+If clarification is needed, the agent should use `.agents-templates/issue-fix/templates/clarification-questions.md.tpl`.
+
+Before finishing, the agent should produce:
+
+- a self review checklist using `.agents-templates/issue-fix/templates/self-review-checklist.md.tpl`
+- a final explanation using `.agents-templates/issue-fix/templates/final-summary.md.tpl`
+- one very short Conventional Commit message suggestion
+- one short pull request description written inline
+
+The final state must be:
+
+- branch created and checked out
+- changes staged
+- no commit created
+- clear explanation ready for user review
+- one suggested Conventional Commit message ready for copy/paste
+- one suggested pull request description ready for copy/paste
+
+After explicit user sign-off, the workflow may continue to:
+
+- create the commit
+- create the pull request

--- a/.agents-templates/issue-fix/examples/issue-fix-brief.example.md
+++ b/.agents-templates/issue-fix/examples/issue-fix-brief.example.md
@@ -1,0 +1,37 @@
+# Issue Fix Brief
+
+## Issue
+
+- Number: 12345
+- Title: Cart line item label is empty after promotion recalculation
+- URL: https://github.com/shopware/shopware/issues/12345
+
+## Goal
+
+Fix the regression where recalculating promotions can leave a cart line item without a visible label in the storefront and downstream cart handling.
+
+## Current Understanding
+
+- The issue reports that the label disappears after promotion recalculation.
+- The expected behavior is that the label remains stable across recalculation.
+- The affected area is likely in cart processing or line item reconstruction during promotion handling.
+
+## Constraints
+
+- Follow existing repository patterns.
+- Apply Shopware 6 best practices.
+- Run only the relevant checks for touched files.
+- Stage changes only. Do not commit.
+
+## Planned Approach
+
+1. Reproduce the recalculation path in the cart code.
+2. Identify where the line item label is lost or overwritten.
+3. Preserve the label through recalculation with the smallest safe change.
+4. Add or update a test covering the regression.
+5. Run relevant PHP checks and tests.
+6. Perform self review and fix review findings.
+
+## Open Questions
+
+- None at this time.

--- a/.agents-templates/issue-fix/examples/issue-fix-clarification.example.md
+++ b/.agents-templates/issue-fix/examples/issue-fix-clarification.example.md
@@ -1,0 +1,19 @@
+# Clarification Required
+
+The issue cannot be implemented safely yet.
+
+## Why Clarification Is Needed
+
+- The report does not say whether the requested behavior is a bugfix or a new feature.
+- The issue references a screenshot-only admin state that is not available in the repository.
+
+## Questions For The User
+
+1. Should this preserve the current behavior everywhere, or only for the admin case shown in the screenshot?
+2. Should this work be treated as a bugfix on a `fix/...` branch or as a feature on a `feat/...` branch?
+
+## What Is Blocked
+
+- Branch creation: blocked pending branch type
+- Code changes: blocked
+- Final fix proposal: pending clarification

--- a/.agents-templates/issue-fix/examples/issue-fix-final-summary.example.md
+++ b/.agents-templates/issue-fix/examples/issue-fix-final-summary.example.md
@@ -1,0 +1,37 @@
+# Final Fix Summary
+
+## Root Cause
+
+The recalculation path rebuilt the affected line item from promotion data without carrying over the previously resolved label. As a result, the storefront later rendered an empty label for the recalculated item.
+
+## Chosen Fix
+
+The fix preserves the resolved label when rebuilding the recalculated line item and adds a regression test in the same cart area. This was chosen because it keeps the existing cart processing structure intact and changes only the missing state transfer.
+
+## Why This Resolves The Issue
+
+The label is now preserved across recalculation, so the storefront and downstream cart consumers continue to receive the expected line item data after promotions are recomputed.
+
+## Checks
+
+- Checks run: relevant PHPUnit test, `composer ecs`
+- Self review completed: yes
+- Review findings fixed: yes
+
+## Git State
+
+- Branch: fix/preserve-line-item-label-on-recalculation
+- Changes staged: yes
+- Commit created: no
+
+## Suggested Commit Message
+
+`fix: preserve recalculated line item labels`
+
+## Suggested PR Title
+
+`fix: preserve recalculated line item labels`
+
+## Suggested PR Description
+
+Preserve resolved line item labels during promotion recalculation and keep labels stable after promotion recomputation. Fixes: #12345

--- a/.agents-templates/issue-fix/templates/brief.md.tpl
+++ b/.agents-templates/issue-fix/templates/brief.md.tpl
@@ -1,0 +1,37 @@
+# Issue Fix Brief
+
+## Issue
+
+- Number: {{ issue_number }}
+- Title: {{ issue_title }}
+- URL: {{ issue_url }}
+
+## Goal
+
+State the user-visible problem in one short paragraph.
+
+## Current Understanding
+
+- Summarize the reported behavior.
+- Note the expected behavior.
+- Mention any repository area that looks relevant.
+
+## Constraints
+
+- Follow existing repository patterns.
+- Apply Shopware 6 best practices.
+- Run only the relevant checks for touched files.
+- Stage changes only. Do not commit.
+
+## Planned Approach
+
+1. Explain how and why the issue happens.
+2. Identify the affected code path.
+3. Implement the smallest correct fix.
+4. Add or adjust tests when needed.
+5. Run relevant checks.
+6. Perform self review and fix review findings.
+
+## Open Questions
+
+- List only unresolved questions that must be answered before implementation.

--- a/.agents-templates/issue-fix/templates/clarification-questions.md.tpl
+++ b/.agents-templates/issue-fix/templates/clarification-questions.md.tpl
@@ -1,0 +1,19 @@
+# Clarification Required
+
+The issue cannot be implemented safely yet.
+
+## Why Clarification Is Needed
+
+- {{ blocking_reason_1 }}
+- {{ blocking_reason_2 }}
+
+## Questions For The User
+
+1. {{ question_1 }}
+2. {{ question_2 }}
+
+## What Is Blocked
+
+- Branch creation: {{ branch_creation_state }}
+- Code changes: blocked
+- Final fix proposal: pending clarification

--- a/.agents-templates/issue-fix/templates/final-summary.md.tpl
+++ b/.agents-templates/issue-fix/templates/final-summary.md.tpl
@@ -1,0 +1,37 @@
+# Final Fix Summary
+
+## Root Cause
+
+Explain exactly how and why the issue happened.
+
+## Chosen Fix
+
+Explain what was changed and why this approach matches the repository patterns.
+
+## Why This Resolves The Issue
+
+Connect the code changes back to the reported behavior.
+
+## Checks
+
+- Checks run: {{ checks_run }}
+- Self review completed: yes
+- Review findings fixed: yes
+
+## Git State
+
+- Branch: {{ branch_name }}
+- Changes staged: yes
+- Commit created: no
+
+## Suggested Commit Message
+
+`{{ suggested_commit_message }}`
+
+## Suggested PR Title
+
+`{{ suggested_commit_message }}`
+
+## Suggested PR Description
+
+{{ suggested_pr_description }}

--- a/.agents-templates/issue-fix/templates/self-review-checklist.md.tpl
+++ b/.agents-templates/issue-fix/templates/self-review-checklist.md.tpl
@@ -1,0 +1,10 @@
+# Self Review Checklist
+
+- I verified the fix matches the issue scope.
+- I checked the surrounding code for existing local patterns and followed them.
+- I reviewed behavior changes for regressions and edge cases.
+- I added or updated tests where the change required coverage.
+- I ran the relevant checks for the touched file types.
+- I reviewed the diff for unnecessary changes.
+- I fixed the review findings before finishing.
+- I staged the final changes without creating a commit.

--- a/.claude/commands/issue-fix.md
+++ b/.claude/commands/issue-fix.md
@@ -1,0 +1,11 @@
+---
+description: Run the shared Shopware GitHub issue-fix workflow
+argument-hint: <issue-number-or-url>
+---
+
+Run the shared Shopware GitHub `issue-fix` workflow for issue `$ARGUMENTS`.
+
+Follow the shared source of truth:
+- `.agents-templates/issue-fix.md`
+- `.agents-templates/issue-fix/templates/`
+- `.agents-templates/issue-fix/examples/`

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,12 @@ yalc.lock
 .codewhispererignore
 .chunkhound*
 
+!.claude/
+.claude/*
+!.claude/commands/
+.claude/commands/*
+!.claude/commands/issue-fix.md
+
 # GIT worktrees
 .worktrees
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,7 @@ shopware/
 | **Twig** (Storefront)  | `composer ludtwig:storefront` | `composer ludtwig:storefront:fix`            |
 | **Snippets**           | `composer translation:lint`   | Manual fix required                          |
 | **Prettier** (Admin)   | `composer format:admin`       | `composer format:admin:fix`                  |
+
+## AI Issue Fix Workflow
+
+When the user asks to fix a GitHub issue from Claude or Codex, prefer the shared `issue-fix` AI command/tool and follow the canonical workflow in `.agents-templates/issue-fix.md`.


### PR DESCRIPTION
Add a shared `issue-fix` workflow for AI-assisted GitHub issue fixes, including triage, repo-aware branching, staged review handoff, and post-signoff commit/PR guidance. 

Run it in Codex with `Run issue-fix for <issue-number-or-url>` 
Run it Claude with `/issue-fix <issue-number-or-url>` when the command is available, otherwise use the same natural-language prompt.