### PR TITLE
feat(ci): fix-verification pipeline (RFC, stacked on #17348)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,30 @@
+# Shopware AI Skills
+
+Portable AI capabilities packaged in the [Anthropic Agent Skills](https://agentskills.io)
+format. Auto-loaded by Claude Code, opencode, Codex CLI, Cursor, Gemini CLI and other
+Agent-Skills-compatible runtimes when their `description` matches the user's message.
+
+## Available skills
+
+| Skill | Trigger phrases (examples) | What it does |
+|---|---|---|
+| [`reproduce`](reproduce/SKILL.md) | "reproduce #16638", "does this bug still happen on trunk?", "is this fixed?" | Turns a Shopware 6 bug issue into a repro plan (cheapest faithful layer, minimal build, exact fixtures + assertion), reproduces it on the reported version and on trunk, and emits evidence (the verbatim script plus HTTP/Playwright/PHPUnit output). |
+
+## How auto-loading works
+
+When you start a session in this repo with Claude Code / opencode / Codex CLI:
+
+1. The runtime scans `.claude/skills/` for `SKILL.md` files.
+2. Each skill's `description` frontmatter is matched against your message.
+3. If a skill matches, its body (plus on-demand `references/`) is injected into the agent's context.
+
+No flags, no plugins — drop into a session and just describe what you want.
+
+## Unattended CI twin
+
+A skill can also run unattended in CI. The `reproduce` skill's CI surface is a
+hand-written multi-job workflow at [`.github/workflows/reproduce.yml`](../../.github/workflows/reproduce.yml)
+(a parallel reported‖trunk matrix), which shares the skill's rubric and
+[`references/SCHEMA.md`](reproduce/references/SCHEMA.md) so the interactive and
+unattended paths cannot drift. See the pipeline overview at
+[`.github/actions/repro/README.md`](../../.github/actions/repro/README.md).

--- a/.claude/skills/reproduce/SKILL.md
+++ b/.claude/skills/reproduce/SKILL.md
@@ -59,7 +59,9 @@ expensive paths.
 
 ## Reference files
 
-- `references/SCHEMA.md` — the three JSON contracts and their rules.
+- `references/SCHEMA.md` — the three JSON contracts and the universal rules.
+- `references/executors/{http,playwright,direct}.md` — the per-executor authoring
+  contract. After choosing the `layer`, read ONLY the file for its executor.
 
 ## Output format
 

--- a/.claude/skills/reproduce/SKILL.md
+++ b/.claude/skills/reproduce/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: reproduce
+description: >
+  Reproduce a Shopware 6 GitHub bug issue in CI. Read the issue, derive a repro
+  plan (cheapest faithful layer, minimal build, exact fixtures and assertion),
+  reproduce on the reported version and on trunk, and emit evidence (the verbatim
+  script plus Playwright/HTTP output). Use when the user asks to reproduce a bug,
+  verify whether an issue still occurs, check if a defect is fixed on trunk, or
+  references an issue by number (e.g. "#16638") in a reproduction context.
+license: MIT
+allowed-tools: Bash(rg:*) Bash(git log:*) Bash(git show:*) Bash(git diff:*) Bash(git blame:*) Bash(gh issue view:*) Bash(gh issue list:*) Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr list:*) Bash(gh api repos/*/issues/*:*) Bash(gh api repos/*/pulls/*:*) Bash(find:*) Bash(ls:*) Read Glob Grep
+---
+
+# Shopware Issue Reproduction
+
+## Context
+
+You operate inside the `shopware/shopware` monorepo with read access to the codebase
+and to GitHub. This skill turns a reported bug into a **repro plan** and, in CI,
+drives the deterministic jobs that execute it. You do **not** label, comment, or push —
+the structured output is the deliverable.
+
+This skill drives the **interactive** path (Claude Code / opencode / Codex CLI in the
+repo). The **unattended CI path** is a hand-written multi-job workflow at
+`.github/workflows/reproduce.yml` — a parallel reported‖trunk matrix that a single-job
+agentic workflow can't express — which runs the Analyze phase via
+`anthropics/claude-code-action` and the deterministic legs as plain jobs. Both surfaces
+share this rubric and `references/SCHEMA.md` so they cannot drift.
+
+## Phases
+
+```
+Analyze  ──▶  Reproduce (matrix: reported ‖ trunk, parallel)  ──▶  Report
+```
+
+The agent owns only the thin slices — **Analyze**, repro-script derivation, and
+**Report**. Provisioning, building, and running (HTTP client or Playwright) are
+deterministic CI jobs, not agent turns. Cost = turns × context: keep the agent off the
+expensive paths.
+
+1. **Analyze** — emit `analysis.json` (see `references/SCHEMA.md`). Pick the cheapest
+   faithful `layer`, the minimal `build_profile`, and derive `fixtures` + `assertion`
+   from the linked fix PR's regression test and the DAL schema. **Derive, don't discover.**
+2. **Reproduce** — one leg per `target`. The leg's `executor` is chosen by `layer`:
+   `direct` (instantiate the service), `http` (input → output, HAR evidence), or
+   `playwright` (UI only; screenshot/video/trace). Build only the surface the bug lives on.
+3. **Report** — merge legs into `repro-output.json`, apply the verdict map, render a
+   self-contained GitHub comment that embeds each leg's **verbatim script** and trimmed
+   reporter output, and links the (ephemeral) artifacts.
+
+## Discipline
+
+- **Match env to surface.** `direct` / `http` legs build neither storefront nor theme.
+- **Reuse over rebuild.** Pin the exact reported version; collapse to one leg when
+  reported == trunk or on manual rerun.
+- **Fail fast.** `not_reproduced` after one bounded re-check; `blocked` when the env is
+  dead after one rebuild. Never grind, never yield mid-build (one-shot provision, poll
+  until READY).
+
+## Reference files
+
+- `references/SCHEMA.md` — the three JSON contracts and their rules.
+
+## Output format
+
+- Wrapper-fed / CI: schema-compatible JSON only (`analysis.json`, `result.json`, or
+  `repro-output.json` depending on phase).
+- Interactive: compact Markdown — verdict, the layer chosen, and the verbatim repro
+  script. No JSON, no telemetry.

--- a/.claude/skills/reproduce/references/SCHEMA.md
+++ b/.claude/skills/reproduce/references/SCHEMA.md
@@ -90,13 +90,22 @@ Rules:
   reused by both legs (it fails on the buggy version → `reproduced`). Because the SAME
   spec runs on both versions, it must use **version-stable, semantic locators**
   (`getByRole`/`getByLabel`/`getByText` with case-insensitive regex; never CSS/data-test
-  ids) and separate **precondition** from **symptom**: navigation/setup verifies each
-  element it depends on exists and `throw`s `PRECONDITION_NOT_FOUND` (or `test.skip`) if
-  not, then makes exactly one `expect()` symptom assertion. `run-playwright.sh` classifies
-  a failure accordingly: a genuine `expect()` assertion → `reproduced`; a
-  `PRECONDITION_NOT_FOUND`/skip, a navigation/connection error, or a non-assertion
-  locator/timeout failure → `inconclusive` (cross-version UI drift, never a bogus
-  `reproduced`).
+  ids) and separate **precondition** from **symptom**:
+  - **Precondition** — `await locator.waitFor({state:'visible',timeout}).catch(() => { throw
+    new Error('PRECONDITION_NOT_FOUND: …') })`. NEVER `isVisible()`/`isHidden()` (they don't
+    wait — they return current state and ignore the timeout) and NEVER `expect()` for a
+    precondition (a timed-out `expect` is misread as the symptom → false `reproduced`). Don't
+    wait via `networkidle` (the admin SPA never settles) or `waitForURL()` on an already-true
+    pattern — wait for a concrete element.
+  - **Symptom** — exactly one `await expect(...)`. For a hidden/closed/off-canvas symptom use
+    `not.toBeInViewport()` or `toHaveAttribute('aria-hidden','true')`, NOT `not.toBeVisible()`
+    (a transform/translate-off-screen element is still "visible" to Playwright, so it fails on
+    BOTH versions and fakes a reproduction).
+
+  `run-playwright.sh` classifies a failure accordingly: a genuine `expect()` assertion →
+  `reproduced`; a `PRECONDITION_NOT_FOUND`/skip, a navigation/connection error, or a
+  non-assertion locator/timeout failure → `inconclusive` (cross-version UI drift, never a
+  bogus `reproduced`).
 - `script_path` is also required for the `direct` executor — a generated PHPUnit
   integration test (`ReproTest.php`, namespace `Shopware\Tests\Integration\Repro`,
   `extends TestCase` with `IntegrationTestBehaviour`). `run-direct.sh` drops it under the

--- a/.claude/skills/reproduce/references/SCHEMA.md
+++ b/.claude/skills/reproduce/references/SCHEMA.md
@@ -75,47 +75,19 @@ Rules:
   (e.g. `0192f3c4a5b67890abcdef0123456789`) — the admin sync API rejects non-UUID
   strings (`FRAMEWORK__WRITE_CONSTRAINT_VIOLATION`). Use `{{SC}}/{{NAV_CAT}}/{{TAX}}/
   {{CURRENCY}}` placeholders for install-specific ids; `seed.sh` resolves them.
-- `request` (single object) OR `requests` (array, for a multi-step flow) is required for
-  the `http` executor; the assertion runs on the FINAL response. The executor injects
-  `sw-access-key` and captures/carries `sw-context-token` across the sequence — do NOT put
-  those in the plan. Reference install-specific ids via placeholders the executor resolves
-  against the shop: `{{SC}} {{NAV_CAT}} {{COUNTRY}} {{SALUTATION}} {{SALUTATION2}} {{TAX}}
-  {{CURRENCY}} {{LANGUAGE}} {{STOREFRONT_URL}}` (also valid in `assertion.expect`). Entities
-  you create yourself go in `fixtures.json` with known hex UUIDs. A non-2xx non-final
-  request → `blocked`; a missing field on a non-2xx final response → `inconclusive` (never
-  a bogus `reproduced`). `assertion.field` is a jq path used only by `response_field`;
+- **Executor authoring contracts live in [`references/executors/`](executors/)** — once you
+  pick the layer, read the ONE file for its executor and follow it:
+  - [`executors/http.md`](executors/http.md) — `request`/`requests` (assertion on the FINAL
+    response), sw-context handling, install-id placeholders, false-positive guard. No
+    separate script file — the executor generates `repro.sh` from the plan.
+  - [`executors/playwright.md`](executors/playwright.md) — `repro.spec.ts`: version-stable
+    semantic locators, precondition-vs-symptom structure, the `waitFor` (not `isVisible`/
+    `expect`) and `toBeInViewport` (not `toBeVisible`) rules.
+  - [`executors/direct.md`](executors/direct.md) — `ReproTest.php`: a PHPUnit integration
+    test reusing the fix PR's setup; PHPUnit summary → status mapping.
+- `script_path` names the generated script (`repro.spec.ts` for playwright, `ReproTest.php`
+  for direct; omit for http). `assertion.field` is a jq path used only by `response_field`;
   `assertion.locator` is a human reference to the endpoint/UI element.
-- `script_path` is required for the `playwright` executor — the generated spec
-  (`repro.spec.ts`) that asserts the HEALTHY behaviour, generated ONCE by Analyze and
-  reused by both legs (it fails on the buggy version → `reproduced`). Because the SAME
-  spec runs on both versions, it must use **version-stable, semantic locators**
-  (`getByRole`/`getByLabel`/`getByText` with case-insensitive regex; never CSS/data-test
-  ids) and separate **precondition** from **symptom**:
-  - **Precondition** — `await locator.waitFor({state:'visible',timeout}).catch(() => { throw
-    new Error('PRECONDITION_NOT_FOUND: …') })`. NEVER `isVisible()`/`isHidden()` (they don't
-    wait — they return current state and ignore the timeout) and NEVER `expect()` for a
-    precondition (a timed-out `expect` is misread as the symptom → false `reproduced`). Don't
-    wait via `networkidle` (the admin SPA never settles) or `waitForURL()` on an already-true
-    pattern — wait for a concrete element.
-  - **Symptom** — exactly one `await expect(...)`. For a hidden/closed/off-canvas symptom use
-    `not.toBeInViewport()` or `toHaveAttribute('aria-hidden','true')`, NOT `not.toBeVisible()`
-    (a transform/translate-off-screen element is still "visible" to Playwright, so it fails on
-    BOTH versions and fakes a reproduction).
-
-  `run-playwright.sh` classifies a failure accordingly: a genuine `expect()` assertion →
-  `reproduced`; a `PRECONDITION_NOT_FOUND`/skip, a navigation/connection error, or a
-  non-assertion locator/timeout failure → `inconclusive` (cross-version UI drift, never a
-  bogus `reproduced`).
-- `script_path` is also required for the `direct` executor — a generated PHPUnit
-  integration test (`ReproTest.php`, namespace `Shopware\Tests\Integration\Repro`,
-  `extends TestCase` with `IntegrationTestBehaviour`). `run-direct.sh` drops it under the
-  shop's `tests/integration/Repro/` (PSR-4 autoload) and runs `vendor/bin/phpunit`. The
-  test asserts the HEALTHY behaviour, so the summary maps: `OK` → `not_reproduced`,
-  `FAILURES!` → `reproduced`, `ERRORS!`/fatal/no-tests → `inconclusive` (the test could not
-  bootstrap — usually a cross-version API mismatch on the reported leg, never a bogus pass),
-  anything else → `blocked`. Use the `direct` layer only when neither `http` nor
-  `playwright` can fire the bug faithfully (license-gated, internal service, heavy domain
-  setup); reuse the fix PR's regression-test setup rather than reinventing it.
 - `scenario` is a plain-English, numbered Given/When/Then list of the repro steps,
   rendered in the comment above the script so a human reads the intent first. The
   generated script (curl or spec) must comment every step (what it does + asserts).

--- a/.claude/skills/reproduce/references/SCHEMA.md
+++ b/.claude/skills/reproduce/references/SCHEMA.md
@@ -87,7 +87,16 @@ Rules:
   `assertion.locator` is a human reference to the endpoint/UI element.
 - `script_path` is required for the `playwright` executor — the generated spec
   (`repro.spec.ts`) that asserts the HEALTHY behaviour, generated ONCE by Analyze and
-  reused by both legs (it fails on the buggy version → `reproduced`).
+  reused by both legs (it fails on the buggy version → `reproduced`). Because the SAME
+  spec runs on both versions, it must use **version-stable, semantic locators**
+  (`getByRole`/`getByLabel`/`getByText` with case-insensitive regex; never CSS/data-test
+  ids) and separate **precondition** from **symptom**: navigation/setup verifies each
+  element it depends on exists and `throw`s `PRECONDITION_NOT_FOUND` (or `test.skip`) if
+  not, then makes exactly one `expect()` symptom assertion. `run-playwright.sh` classifies
+  a failure accordingly: a genuine `expect()` assertion → `reproduced`; a
+  `PRECONDITION_NOT_FOUND`/skip, a navigation/connection error, or a non-assertion
+  locator/timeout failure → `inconclusive` (cross-version UI drift, never a bogus
+  `reproduced`).
 - `script_path` is also required for the `direct` executor — a generated PHPUnit
   integration test (`ReproTest.php`, namespace `Shopware\Tests\Integration\Repro`,
   `extends TestCase` with `IntegrationTestBehaviour`). `run-direct.sh` drops it under the

--- a/.claude/skills/reproduce/references/SCHEMA.md
+++ b/.claude/skills/reproduce/references/SCHEMA.md
@@ -116,11 +116,17 @@ Rules:
   `reproduced` when `actual != expect` (symptom present) and `not_reproduced` when
   `actual == expect` (healthy). This matches running the fix PR's regression test:
   it fails on the buggy version and passes on the fixed one.
-- `confidence` (0..1) is how faithful the plan is believed to be: a plan derived from a
-  linked fix PR's regression test is high (~0.95); one where the repro had to be inferred
-  with no fix PR to anchor on is low. Whenever `confidence < 0.7`, ALSO set
-  `confidence_reason` (one sentence on what makes it uncertain) — it is surfaced to the
-  human instead of a bare number. Two bands gate behaviour:
+- `confidence` (0..1) measures how FAITHFULLY the plan reproduces the reported symptom —
+  **not** whether a fix exists. HIGH when the symptom is deterministically assertable
+  (clear expected-vs-actual, stable endpoint/field/locator) and the environment is
+  reproducible in CI; LOW when it is vague, non-deterministic, environment-dependent
+  (timing/network/hardware/third-party state CI can't reproduce), or the failing layer is
+  unclear. A linked fix PR's regression test is the **preferred source** to derive the
+  assertion from, but its absence is **neutral** — derive from the issue's symptom and stay
+  confident if it is concrete. Never dock confidence merely for "no fix PR": open, unfixed
+  bugs are the pipeline's primary case. Whenever `confidence < 0.7`, ALSO set
+  `confidence_reason` to the faithfulness obstacle (one sentence) — never "no fix PR"; it is
+  surfaced to the human instead of a bare number. Two bands gate behaviour:
   - **`confidence < 0.4`** → the run is **not executed**. The matrix step posts the draft
     scenario + `confidence_reason` and asks a human to confirm before spending provision
     budget (provisioning two installs to test a guess is the wasteful case; below 0.4 there

--- a/.claude/skills/reproduce/references/SCHEMA.md
+++ b/.claude/skills/reproduce/references/SCHEMA.md
@@ -1,0 +1,224 @@
+# Output Shape
+
+Three contracts, one per pipeline seam. Emit JSON only in wrapper-fed / CI mode —
+no markdown fence, no prose.
+
+- `analysis.json` — produced by **Analyze**, consumed by **Reproduce**. The repro plan.
+- `result.json` — produced by each **Reproduce** leg (one per target).
+- `repro-output.json` — produced by **Report**, merges the legs, renders the GitHub comment.
+
+Every phase may be a stub first (emit a hand-written object that satisfies the
+contract) and an agent later. Downstream phases bind to the shape, not the source.
+
+## Analysis (`analysis.json`)
+
+The repro plan. Picks the cheapest faithful surface and the minimal build.
+
+```json
+{
+    "schema_version": "1",
+    "issue": 16638,
+    "layer": "service | store-api | admin-api | storefront-ui | admin-ui",
+    "executor": "direct | http | playwright",
+    "version": "6.6.10.0",
+    "build_profile": {
+        "admin_build": false,
+        "storefront_build": false,
+        "theme_build": false
+    },
+    "fixtures": {
+        "demodata": false,
+        "sync_payload_path": "/tmp/repro/fixtures.json"
+    },
+    "scenario": [
+        "Given a category with at least one product visible in the Storefront sales channel",
+        "When POST /store-api/product-listing/{categoryId}?p=99 (a page past the last)",
+        "Then a healthy shop returns HTTP 404 with PRODUCT__LISTING_PAGE_OUT_OF_RANGE"
+    ],
+    "request": {
+        "method": "POST",
+        "path": "/store-api/checkout/cart",
+        "headers": { "Content-Type": "application/json" },
+        "body": "{}"
+    },
+    "script_path": "repro.spec.ts",
+    "assertion": {
+        "kind": "http_status | response_field | exception | ui_state",
+        "expect": "400",
+        "field": ".errors[0].code",
+        "locator": "/store-api/checkout/cart"
+    },
+    "plugins": [{ "name": "SwagFoo", "activate": true }],
+    "derived_from": "PR#16640 tests/.../MultiWarehouseTest.php",
+    "confidence": 0.82,
+    "blocked_reason": null,
+    "needs_info": null
+}
+```
+
+Rules:
+
+- `layer` is the cheapest surface that genuinely exercises the symptom. Order:
+  `service` < `store-api` / `admin-api` < `storefront-ui` / `admin-ui`. Escalate
+  only when a cheaper layer cannot fire the symptom; record why in the agent's reasoning.
+- `executor` follows `layer`: `service` → `direct`, `*-api` → `http`, `*-ui` → `playwright`.
+- `build_profile` enables only the surface `layer` needs. `storefront_build` /
+  `theme_build` are `true` only for `storefront-ui`. A `direct` or `http` plan builds neither.
+- The agent does NOT choose which versions to run — the **workflow** computes that from
+  `version`: two legs (reported = `version`, trunk) normally; **one leg (trunk only) when
+  `version == trunk` or on a manual `workflow_dispatch` rerun** ("not on manual rerun").
+  So a dispatch always runs trunk alone; use the **label/comment** trigger for both legs.
+- `fixtures.sync_payload_path` seeds exactly the entities the bug needs via the admin
+  sync API with `demodata: false`. Entity and field names come from the DAL schema,
+  never from probing the API.
+- `fixtures.sync_payload` entity ids MUST be 32-char lowercase-hex Shopware UUIDs
+  (e.g. `0192f3c4a5b67890abcdef0123456789`) — the admin sync API rejects non-UUID
+  strings (`FRAMEWORK__WRITE_CONSTRAINT_VIOLATION`). Use `{{SC}}/{{NAV_CAT}}/{{TAX}}/
+  {{CURRENCY}}` placeholders for install-specific ids; `seed.sh` resolves them.
+- `request` (single object) OR `requests` (array, for a multi-step flow) is required for
+  the `http` executor; the assertion runs on the FINAL response. The executor injects
+  `sw-access-key` and captures/carries `sw-context-token` across the sequence — do NOT put
+  those in the plan. Reference install-specific ids via placeholders the executor resolves
+  against the shop: `{{SC}} {{NAV_CAT}} {{COUNTRY}} {{SALUTATION}} {{SALUTATION2}} {{TAX}}
+  {{CURRENCY}} {{LANGUAGE}} {{STOREFRONT_URL}}` (also valid in `assertion.expect`). Entities
+  you create yourself go in `fixtures.json` with known hex UUIDs. A non-2xx non-final
+  request → `blocked`; a missing field on a non-2xx final response → `inconclusive` (never
+  a bogus `reproduced`). `assertion.field` is a jq path used only by `response_field`;
+  `assertion.locator` is a human reference to the endpoint/UI element.
+- `script_path` is required for the `playwright` executor — the generated spec
+  (`repro.spec.ts`) that asserts the HEALTHY behaviour, generated ONCE by Analyze and
+  reused by both legs (it fails on the buggy version → `reproduced`).
+- `script_path` is also required for the `direct` executor — a generated PHPUnit
+  integration test (`ReproTest.php`, namespace `Shopware\Tests\Integration\Repro`,
+  `extends TestCase` with `IntegrationTestBehaviour`). `run-direct.sh` drops it under the
+  shop's `tests/integration/Repro/` (PSR-4 autoload) and runs `vendor/bin/phpunit`. The
+  test asserts the HEALTHY behaviour, so the summary maps: `OK` → `not_reproduced`,
+  `FAILURES!` → `reproduced`, `ERRORS!`/fatal/no-tests → `inconclusive` (the test could not
+  bootstrap — usually a cross-version API mismatch on the reported leg, never a bogus pass),
+  anything else → `blocked`. Use the `direct` layer only when neither `http` nor
+  `playwright` can fire the bug faithfully (license-gated, internal service, heavy domain
+  setup); reuse the fix PR's regression-test setup rather than reinventing it.
+- `scenario` is a plain-English, numbered Given/When/Then list of the repro steps,
+  rendered in the comment above the script so a human reads the intent first. The
+  generated script (curl or spec) must comment every step (what it does + asserts).
+- `assertion` is derived from the linked fix PR's regression test or an existing test
+  when one exists (`derived_from`), not discovered by trial-and-error.
+- `assertion.expect` is the **healthy** value (what a fixed shop returns). A leg is
+  `reproduced` when `actual != expect` (symptom present) and `not_reproduced` when
+  `actual == expect` (healthy). This matches running the fix PR's regression test:
+  it fails on the buggy version and passes on the fixed one.
+- `confidence` (0..1) is how faithful the plan is believed to be: a plan derived from a
+  linked fix PR's regression test is high (~0.95); one where the repro had to be inferred
+  with no fix PR to anchor on is low. Whenever `confidence < 0.7`, ALSO set
+  `confidence_reason` (one sentence on what makes it uncertain) — it is surfaced to the
+  human instead of a bare number. Two bands gate behaviour:
+  - **`confidence < 0.4`** → the run is **not executed**. The matrix step posts the draft
+    scenario + `confidence_reason` and asks a human to confirm before spending provision
+    budget (provisioning two installs to test a guess is the wasteful case; below 0.4 there
+    is usually no regression test to validate the legs against anyway). Terminal, like
+    `needs_info`.
+  - **`0.4 ≤ confidence < 0.7`** (or no faithful layer → `blocked_reason`) → the legs DO
+    run, but the verdict is forced to `needs_human_review`: the evidence is shown, the
+    definitive action (labels/attribution) is withheld, and `confidence_reason` is rendered
+    so the human adjudicates from real leg output.
+- **`needs_info`**: when the issue is too vague/contradictory/incomplete to derive a
+  FAITHFUL plan, emit ONLY `{schema_version, issue, needs_info: "<one specific question>"}`
+  and omit the plan. The workflow posts the question and aborts — no provisioning. (A
+  cheaper deterministic version runs first in `gate`: a missing "Steps to reproduce"
+  section is rejected before any agent runs.) `needs_info` is a terminal state, like
+  `blocked`/`needs_human_review`.
+
+## Repro Result (`result.json`)
+
+One object per Reproduce leg.
+
+```json
+{
+    "schema_version": "1",
+    "issue": 16638,
+    "target": "reported | trunk",
+    "version": "6.6.10.0",
+    "executor": "playwright",
+    "status": "reproduced | not_reproduced | blocked | inconclusive",
+    "assertion": { "expect": "400", "actual": "200", "matched": false },
+    "duration_s": 47,
+    "evidence": {
+        "script": "import { test, expect } from '@playwright/test';\n…",
+        "script_lang": "ts | php | sh",
+        "reporter_output": "✘ checkout › cart returns 400\n  Expected 400, received 200",
+        "http": [{ "method": "POST", "path": "/store-api/checkout/cart", "status": 200 }],
+        "artifacts": [
+            { "kind": "trace | video | screenshot | html_report | har", "name": "trace.zip", "run_artifact": "repro-reported" }
+        ],
+        "truncated": false
+    },
+    "blocked_reason": null
+}
+```
+
+Rules:
+
+- `status` is one-shot and bounded. `not_reproduced` only after a single re-check.
+  `blocked` when the env is dead — plugin install or theme build failed after one
+  rebuild; never grind. `inconclusive` = env READY but the fixture could not be triggered.
+- `evidence.script` is the full generated repro source, verbatim, always inline — the
+  report stays self-contained after artifacts expire.
+- `evidence.reporter_output` is the trimmed console reporter (Playwright `list`, PHPUnit,
+  or the curl exchange). `evidence.http` carries the request/response (HAR) for
+  `http` and `playwright` legs.
+- `evidence.artifacts` are run-artifact references only and may expire. `screenshot`,
+  `video`, and `trace` are emitted only by the `playwright` executor — never force a
+  browser screenshot on a `direct` or `http` leg.
+- The verdict in `status` / `assertion` never depends on fetching an artifact.
+- Set `truncated: true` and trim `reporter_output` first when the rendered comment would
+  exceed GitHub's 65 535-character limit; trim `script` last.
+- Redact secrets, tokens, and instance hostnames to `[REDACTED_KEY]`, `[REDACTED_ID]`,
+  `[REDACTED_URL]` before emit.
+
+## Merged Report (`repro-output.json`)
+
+```json
+{
+    "schema_version": "1",
+    "issue": 16638,
+    "verdict": "live_bug | fixed_on_trunk | regression | not_reproducible | blocked | needs_human_review",
+    "fix_candidate": "PR#16575 (backport candidate; from analyze derived_from when fixed_on_trunk)",
+    "layer": "store-api",
+    "results": { "reported": { "...": "result.json" }, "trunk": { "...": "result.json" } },
+    "summary": "1-3 sentences naming the symptom and the surface it fired on.",
+    "label": "ci:reproduced | ci:not-reproduced | ci:fixed-on-trunk | ci:repro-blocked",
+    "requires_human": false
+}
+```
+
+Verdict map (first match wins, top to bottom):
+
+| reported         | trunk            | verdict              |
+| ---------------- | ---------------- | -------------------- |
+| any `blocked`    | —                | `blocked`            |
+| analyze `blocked_reason` set or `0.4 ≤ confidence < 0.7` | — | `needs_human_review` |
+| any `inconclusive` | —              | `needs_human_review` |
+| `reproduced`     | `reproduced`     | `live_bug`           |
+| `reproduced`     | `not_reproduced` | `fixed_on_trunk`     |
+| `not_reproduced` | `reproduced`     | `regression`         |
+| `not_reproduced` | `not_reproduced` | `not_reproducible`   |
+| anything else    | —                | `needs_human_review` |
+
+Notes:
+
+- `needs_human_review` is **deliberate**, not a catch-all: it fires when the plan is
+  untrustworthy (`blocked_reason`/low confidence) or a leg is `inconclusive`. The
+  trailing row is a logged safety net.
+- `regression` carries a false-negative caveat: a `not_reproduced` reported leg may
+  have under-exercised the symptom (e.g. missing fixture). Surface the caveat.
+- `fix_candidate` is set for `fixed_on_trunk` from analyze's `derived_from` (the fix
+  PR). When absent, the `attribute` phase finds the fixing/introducing commit.
+
+Rules:
+
+- When `targets` collapsed to one leg, the missing leg is `null`. A single-leg run can
+  only yield `live_bug` (trunk reproduced), `not_reproducible`, or `needs_human_review`.
+- `label` and `summary` are the only fields Report turns into write-actions. The comment
+  body embeds each leg's `evidence.script` and trimmed `reporter_output`, and links
+  `evidence.artifacts`.
+- `requires_human` is `true` for `blocked` and `needs_human_review`.

--- a/.claude/skills/reproduce/references/executors/direct.md
+++ b/.claude/skills/reproduce/references/executors/direct.md
@@ -1,0 +1,33 @@
+# Executor: `direct` (service / DAL — PHPUnit integration test)
+
+Use when the bug can't fire faithfully through store-api (`http`) or the UI (`playwright`)
+— license-gated paths, an internal service/indexer/calculation, or heavy domain setup. The
+symptom is typically a computed value or a service behaviour, not an HTTP/DOM surface.
+
+## What you author
+Generate `ReproTest.php` (set `script_path: "ReproTest.php"`):
+- namespace `Shopware\Tests\Integration\Repro`
+- `class ReproTest extends TestCase` using `IntegrationTestBehaviour` (which pulls in
+  `KernelTestBehaviour`); resolve services via `$this->getContainer()`.
+- **REUSE the fix PR's regression-test setup** where it exists (`./fixpr.diff`) — do NOT
+  reinvent the bootstrap.
+- A single test method that ASSERTS THE HEALTHY (fixed) behaviour, so it FAILS on the buggy
+  version and PASSES when healthy.
+
+`run-direct.sh` drops the file under the shop's `tests/integration/Repro/` (PSR-4
+autoload) and runs `vendor/bin/phpunit`.
+
+## Cross-version faithfulness
+Prefer STABLE service/DAL APIs so the SAME test also compiles + runs on the reported
+version. If it can only compile on trunk, that is fine — the reported leg reports
+`inconclusive` (not a bogus pass).
+
+## How `run-direct.sh` classifies the PHPUnit summary
+- `OK` → `not_reproduced` (healthy)
+- `FAILURES!` → `reproduced` (the symptom assertion failed)
+- `ERRORS!` / fatal / no-tests → `inconclusive` (couldn't bootstrap/compile — usually a
+  cross-version API mismatch on the reported leg, never a bogus pass)
+- anything else → `blocked`
+
+## Comment every step
+Comment the setup and the single healthy assertion (what it does + what it proves).

--- a/.claude/skills/reproduce/references/executors/http.md
+++ b/.claude/skills/reproduce/references/executors/http.md
@@ -1,0 +1,38 @@
+# Executor: `http` (store-/admin-API)
+
+Use when the symptom surfaces on a store-api or admin-api **response**. Cheapest faithful
+layer for most API bugs. Builds neither storefront nor theme.
+
+## What you author
+Put the request(s) in `analysis.json` — there is **no** separate script file (the executor
+generates `repro.sh` from the plan and runs it). Use:
+
+- `request` — a single object: `{ method, path, headers, body }`, OR
+- `requests` — an array for a multi-step flow (e.g. create context → add to cart → read).
+  The assertion runs on the **FINAL** response.
+
+The executor injects `sw-access-key` and captures/carries `sw-context-token` across the
+sequence — **do NOT** put those in the plan.
+
+## Install-specific ids → placeholders
+Reference pre-existing install ids via the placeholders the executor resolves against the
+running shop (see SCHEMA "fixtures" for the full catalog):
+`{{SC}} {{NAV_CAT}} {{COUNTRY}} {{SALUTATION}} {{SALUTATION2}} {{TAX}} {{CURRENCY}}
+{{LANGUAGE}} {{STOREFRONT_URL}}` — also valid inside `assertion.expect`.
+Entities you create yourself go in `fixtures.json` with known 32-char hex UUIDs.
+
+## Assertion
+- `assertion.kind`: `http_status` | `response_field` | `exception`.
+- `assertion.expect` is the **healthy** value (what a FIXED shop returns). Leg is
+  `reproduced` when `actual != expect`, `not_reproduced` when `actual == expect`.
+- `assertion.field` is a jq path, used only by `response_field`.
+- `assertion.locator` is a human reference to the endpoint.
+- Send `Accept: application/json` when you need the flat (non-JSON:API) response shape.
+
+## Failure semantics (no false positives)
+- A non-2xx on a **non-final** request → `blocked` (setup broke; body shown).
+- A **missing field** on a non-2xx **final** response → `inconclusive`, never a bogus
+  `reproduced` (the symptom couldn't be evaluated).
+
+## Comment every step
+Comment each request explaining what it does and what the final assertion checks.

--- a/.claude/skills/reproduce/references/executors/playwright.md
+++ b/.claude/skills/reproduce/references/executors/playwright.md
@@ -17,6 +17,15 @@ injected). Comment every step.
 - **Scope inside the relevant landmark + use SPECIFIC names** to avoid strict-mode
   ambiguity: `getByRole('navigation').getByRole('link', {name:/^Products$/i})`, NOT a broad
   regex with `.first()`.
+- **Anchor names and pin the role** — a broad regex matches sibling controls and throws a
+  strict-mode violation. Real example: `getByLabel(/password/i)` matched the field, the
+  "Show password" toggle, AND the "Forgot your password?" link. Use `/^password$/i` and pin
+  the role: `getByRole('textbox', {name:/^password$/i})` (a password input is a `textbox`;
+  the toggle is a `button`), so only the field matches.
+- **Beware untranslated snippet keys.** If the target admin renders raw keys (e.g.
+  `global.sw-admin-menu.navigation.label` instead of "Navigation"), accessible-name / text
+  locators can't match. Prefer the issue's own visible strings + structural roles; a
+  name-not-found is a `PRECONDITION_NOT_FOUND` (→ inconclusive), never the symptom.
 - **NEVER** use CSS classes, data-test ids, or attribute selectors — not even as a
   fallback. An element no semantic locator can reach IS a `PRECONDITION_NOT_FOUND` (and may
   mean the bug isn't faithfully automatable — set low confidence).

--- a/.claude/skills/reproduce/references/executors/playwright.md
+++ b/.claude/skills/reproduce/references/executors/playwright.md
@@ -1,0 +1,54 @@
+# Executor: `playwright` (UI — storefront / admin)
+
+Use ONLY for a genuine UI bug (rendered state, interaction). The most expensive layer —
+escalate here only when neither `http` nor `direct` can fire the symptom.
+
+## What you author
+Generate `repro.spec.ts` (set `script_path: "repro.spec.ts"`). It asserts the HEALTHY
+behaviour, is generated ONCE, and the SAME spec runs on BOTH the reported and trunk
+versions — so it must tolerate cross-version UI drift. Use relative paths (`baseURL` is
+injected). Comment every step.
+
+## Locators — version-stable, semantic ONLY
+- Use `getByRole(role, {name})` / `getByLabel` / `getByText` / `getByPlaceholder` with
+  case-insensitive regex and accessible/visible names. `getByRole` and `getByLabel` both
+  resolve `aria-label` / `aria-labelledby` / associated `<label>` — Shopware's `mt-*`
+  fields expose their label as the accessible name, so both work for inputs.
+- **Scope inside the relevant landmark + use SPECIFIC names** to avoid strict-mode
+  ambiguity: `getByRole('navigation').getByRole('link', {name:/^Products$/i})`, NOT a broad
+  regex with `.first()`.
+- **NEVER** use CSS classes, data-test ids, or attribute selectors — not even as a
+  fallback. An element no semantic locator can reach IS a `PRECONDITION_NOT_FOUND` (and may
+  mean the bug isn't faithfully automatable — set low confidence).
+
+## Structure: precondition vs symptom (this drives the verdict)
+**(1) Navigation / precondition** — reach the state and WAIT for each element it depends on:
+```ts
+await locator.waitFor({ state: 'visible', timeout })
+  .catch(() => { throw new Error('PRECONDITION_NOT_FOUND: <what>') });
+```
+- NEVER gate a precondition on `isVisible()`/`isHidden()` — they return the CURRENT state
+  immediately and IGNORE the timeout, so right after `page.goto()` they false-negative
+  while the SPA is still bootstrapping.
+- NEVER gate a precondition on `expect()`/`toBeVisible()` — a timed-out `expect` is
+  classified as the SYMPTOM → false `reproduced`.
+- Do NOT wait via `waitForLoadState('networkidle')` (the admin SPA long-polls and never
+  settles) or `waitForURL()` on a pattern already true before the action — wait for a
+  concrete post-action element.
+
+**(2) Symptom** — exactly ONE `await expect(...)` of the HEALTHY behaviour, with a generous
+timeout. This is the ONLY failure that may mean `reproduced`.
+- For a hidden / closed / collapsed / off-canvas symptom use
+  `await expect(locator).not.toBeInViewport()` or assert explicit state
+  (`toHaveAttribute('aria-hidden','true')`) — **NOT** `not.toBeVisible()`: an element moved
+  off-screen via transform/translate is still "visible" to Playwright, so `toBeVisible`
+  fails on BOTH versions and FAKES a reproduction.
+
+## How `run-playwright.sh` classifies the result
+- genuine `expect()` assertion failure → `reproduced`
+- `PRECONDITION_NOT_FOUND` / `test.skip`, navigation/connection error, or a non-assertion
+  locator/timeout failure → `inconclusive` (cross-version UI drift, never a bogus
+  `reproduced`)
+- all pass → `not_reproduced`; no tests collected / unparseable → `inconclusive` / `blocked`
+
+Evidence (screenshot, video, trace) is captured automatically under `test-results/`.

--- a/.claude/skills/reproduce/tests/README.md
+++ b/.claude/skills/reproduce/tests/README.md
@@ -1,0 +1,52 @@
+# Reproduce skill tests
+
+> [!WARNING]
+> Running the evals is cost-intensive (each task spawns a real agent run).
+
+End-to-end evals for the `.claude/skills/reproduce` skill's **Analyze** phase,
+built on [skillgrade](https://github.com/mgechev/skillgrade). They check that
+Analyze **derives** a correct, schema-valid repro plan from a bug report + the
+fix PR's regression test — the "derive, don't discover" contract.
+
+## Layout
+
+```
+tests/
+├── eval.yaml            # task definitions
+├── _lib.sh              # shared check/emit helpers (mounted into every workspace)
+└── analyze/<issue>/     # input.json, issue.md, regression-test.php, grader.sh
+```
+
+Fixtures are **self-contained** (the issue body and the fix PR's test are checked
+in as files), so the eval is deterministic — no live `gh` fetch, no issue drift.
+
+## Prerequisites
+
+- Node 20+ (`npm i -g skillgrade zod`)
+- `jq`
+- `claude` CLI on `$PATH` with an authenticated session (or `CLAUDE_CODE_OAUTH_TOKEN`)
+
+## Running
+
+From this directory:
+
+```bash
+# One task (cheapest sanity check).
+skillgrade --provider=local --agent=claude --eval=analyze-16511-listing-pagination --trials=1
+
+# All tasks.
+skillgrade --provider=local --agent=claude --trials=1
+
+# Tighter pass-rate estimate for CI.
+skillgrade --provider=local --agent=claude --reliable --ci --threshold=0.8
+```
+
+Or trigger the **`Reproduce Skill Eval`** workflow (`workflow_dispatch`) and pick a
+branch — runs the same thing in CI (needs `CLAUDE_CODE_OAUTH_TOKEN`).
+
+## Grading
+
+Each `grader.sh` sources `_lib.sh`, asserts the produced `output.json` against the
+plan's `SCHEMA.md` shape (`check_schema_analysis`) plus task-specific predicates
+(right layer/executor, verbatim request, **healthy** assertion value, minimal
+fixtures, `derived_from` the test). Score is `passed/total`; threshold `0.8`.

--- a/.claude/skills/reproduce/tests/_lib.sh
+++ b/.claude/skills/reproduce/tests/_lib.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Shared grader helpers for the reproduce-skill evals. Mounted into each task's
+# workspace as ./_lib.sh and sourced by <task>/grader.sh.
+#
+#   source "$(dirname "$0")/_lib.sh"
+#   load_output            # asserts output.json exists and parses
+#   check name 'jq-expr'   # registers one predicate
+#   emit_result            # prints {"score":..., "details":..., "checks":[...]}
+
+OUT="${OUT:-output.json}"
+declare -a _CHECKS=()
+declare -i _PASSED=0
+declare -i _TOTAL=0
+
+load_output() {
+    if [[ ! -f "$OUT" ]]; then
+        echo "{\"score\":0,\"details\":\"$OUT missing — agent did not produce expected output file\",\"checks\":[{\"name\":\"output-exists\",\"passed\":false,\"message\":\"$OUT not found\"}]}"
+        exit 0
+    fi
+    if ! jq -e . "$OUT" >/dev/null 2>&1; then
+        echo "{\"score\":0,\"details\":\"$OUT is not valid JSON\",\"checks\":[{\"name\":\"output-parses\",\"passed\":false,\"message\":\"jq parse failed\"}]}"
+        exit 0
+    fi
+}
+
+check() {
+    local name="$1" expr="$2"
+    _TOTAL=$((_TOTAL + 1))
+    if jq -e "$expr" "$OUT" >/dev/null 2>&1; then
+        _PASSED=$((_PASSED + 1))
+        _CHECKS+=("$(jq -cn --arg n "$name" '{name:$n, passed:true, message:"ok"}')")
+    else
+        _CHECKS+=("$(jq -cn --arg n "$name" --arg e "$expr" '{name:$n, passed:false, message:("predicate failed: " + $e)}')")
+    fi
+}
+
+# analysis.json (the repro plan) shape per references/SCHEMA.md.
+check_schema_analysis() {
+    check "schema-version-1" '.schema_version == "1"'
+    check "layer-valid"      '.layer as $l | ["service","store-api","admin-api","storefront-ui","admin-ui"] | index($l) != null'
+    check "executor-valid"   '.executor as $e | ["direct","http","playwright"] | index($e) != null'
+    check "executor-matches-layer" '
+        (.layer | test("-ui$")) as $ui
+        | (.layer | test("-api$") or . == "store-api") as $api
+        | (.executor == "playwright" and $ui)
+          or (.executor == "http" and $api)
+          or (.executor == "direct" and .layer == "service")'
+    check "build-profile-object" '(.build_profile | type) == "object"'
+    check "targets-valid"    '(.targets // []) | (type == "array") and (all(.[]; . == "reported" or . == "trunk"))'
+}
+
+emit_result() {
+    local score
+    if (( _TOTAL == 0 )); then score="0.00"
+    else score=$(awk "BEGIN {printf \"%.2f\", $_PASSED/$_TOTAL}"); fi
+    local checks_arr
+    checks_arr=$(printf '%s\n' "${_CHECKS[@]}" | jq -cs '.')
+    jq -cn --argjson score "$score" --arg details "$_PASSED/$_TOTAL checks passed" --argjson checks "$checks_arr" \
+        '{score:$score, details:$details, checks:$checks}'
+}

--- a/.claude/skills/reproduce/tests/analyze/16511/grader.sh
+++ b/.claude/skills/reproduce/tests/analyze/16511/grader.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Bug #16511: out-of-range store-api product-listing returns 200 instead of 404.
+# Fix #16575's regression test asserts 404 + PRODUCT__LISTING_PAGE_OUT_OF_RANGE.
+#
+# A correct Analyze derives: store-api/http, the verbatim request (product-listing
+# + p=99), the HEALTHY assertion (404 or the OUT_OF_RANGE error code), reported
+# version 6.7.9.0, no asset build, minimal fixtures (demodata:false).
+set -uo pipefail
+
+source "$(dirname "$0")/_lib.sh"
+load_output
+check_schema_analysis
+
+check "layer-store-api"      '.layer == "store-api"'
+check "executor-http"        '.executor == "http"'
+check "version-reported"     '.version == "6.7.9.0"'
+check "request-is-listing"   '(.request.path // "") | test("product-listing")'
+check "request-out-of-range" '(.request.path // "") | test("p=99")'
+check "request-method-post"  '(.request.method // "") | ascii_upcase == "POST"'
+# expect = HEALTHY value: either 404 (status) or the OUT_OF_RANGE error code (field).
+check "assertion-healthy" '
+    (.assertion.kind == "http_status" and (.assertion.expect | tostring) == "404")
+    or (.assertion.kind == "response_field" and ((.assertion.expect // "") | test("OUT_OF_RANGE")))'
+check "no-asset-build"       '[.build_profile.admin_build, .build_profile.storefront_build, .build_profile.theme_build] | all(. == false)'
+check "minimal-fixtures"     '.fixtures.demodata == false'
+check "derived-from-test"    '(.derived_from // "") | test("16575|ProductListing|OUT_OF_RANGE")'
+
+emit_result

--- a/.claude/skills/reproduce/tests/analyze/16511/input.json
+++ b/.claude/skills/reproduce/tests/analyze/16511/input.json
@@ -1,0 +1,10 @@
+{
+  "mode": "analyze",
+  "issue": 16511,
+  "title": "Out-of-range pagination on category/listing pages returns HTTP 200 instead of a redirect or 404",
+  "version": "6.7.9.0",
+  "body_path": "issue.md",
+  "regression_test_path": "regression-test.php",
+  "regression_test_ref": "PR#16575 ProductListingRouteTest::testReturnsHttpNotFoundWhenRequestedPageExceedsLastPage",
+  "note": "Self-contained fixture: the issue body and the fix PR's regression test are provided as files so the eval is deterministic (no live gh fetch, no issue drift)."
+}

--- a/.claude/skills/reproduce/tests/analyze/16511/issue.md
+++ b/.claude/skills/reproduce/tests/analyze/16511/issue.md
@@ -1,0 +1,27 @@
+# Out-of-range pagination on category/listing pages returns HTTP 200 instead of a redirect or 404 (SEO issue)
+
+## Shopware Version
+
+6.7.9.0
+
+## Affected area / extension
+
+Platform (Default)
+
+## Actual behaviour
+
+When a category or listing page is requested with a `p` query parameter that
+exceeds the number of available pages for the current criteria (e.g.
+`/Damen/?p=99` on a category with only 3 pages), Shopware responds with
+**HTTP 200 OK** and renders the listing template with no products. From a search
+engine's perspective the URL is a valid, indexable, empty page — the classic
+"soft 404".
+
+The store-api equivalent (`POST /store-api/product-listing/{categoryId}?p=99`)
+likewise returns 200 with an empty listing.
+
+## Expected behaviour
+
+When the requested `p` is outside the valid range (`p < 1` or `p > lastPage`),
+the server must respond with a non-200 status — for the store-api, **HTTP 404**
+with error code `PRODUCT__LISTING_PAGE_OUT_OF_RANGE`.

--- a/.claude/skills/reproduce/tests/analyze/16511/regression-test.php
+++ b/.claude/skills/reproduce/tests/analyze/16511/regression-test.php
@@ -1,0 +1,25 @@
+<?php
+// Excerpt from the fix PR #16575 regression test:
+// tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+//
+// createData() seeds a category + 6 products in the default Storefront sales
+// channel. The out-of-range symptom fires with ANY product count, so a minimal
+// repro needs only 1 product in 1 category (not the test's 6, and not demodata).
+
+public function testReturnsHttpNotFoundWhenRequestedPageExceedsLastPage(): void
+{
+    $this->createData();
+
+    $this->browser->request(
+        'POST',
+        '/store-api/product-listing/' . $this->ids->get('category') . '?p=99'
+    );
+
+    $response = $this->browser->getResponse();
+
+    static::assertSame(404, $response->getStatusCode());
+
+    $payload = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+    static::assertArrayHasKey('errors', $payload);
+    static::assertSame('PRODUCT__LISTING_PAGE_OUT_OF_RANGE', $payload['errors'][0]['code']);
+}

--- a/.claude/skills/reproduce/tests/eval.yaml
+++ b/.claude/skills/reproduce/tests/eval.yaml
@@ -1,0 +1,39 @@
+version: "1"
+
+skill: ..
+
+defaults:
+    agent: claude
+    provider: local
+    trials: 1
+    timeout: 900
+    threshold: 0.8
+
+_anchors:
+    - &skill_runner |
+        You are testing the Shopware `reproduce` skill's Analyze phase.
+
+        1. Read input.json (a Shopware bug report) and the provided regression
+           test file `regression-test.php` (the fix PR's test — your source of
+           truth for the failing assertion and fixtures). DERIVE from it; do not
+           guess.
+        2. Invoke the reproduce skill (Skill tool, name "reproduce") to produce
+           the repro plan. references/SCHEMA.md is authoritative for the shape.
+        3. Write the skill's analysis.json output verbatim to a file called
+           output.json in the current directory.
+        4. No prose, no markdown fence. The grader reads output.json only.
+    - &lib { src: _lib.sh, dest: _lib.sh }
+
+tasks:
+    # Derive a store-api/http plan from a real bug (#16511) whose fix (#16575)
+    # added a regression test asserting HTTP 404 + PRODUCT__LISTING_PAGE_OUT_OF_RANGE.
+    - name: analyze-16511-listing-pagination
+      instruction: *skill_runner
+      workspace:
+          - { src: analyze/16511/input.json, dest: input.json }
+          - { src: analyze/16511/issue.md, dest: issue.md }
+          - { src: analyze/16511/regression-test.php, dest: regression-test.php }
+          - { src: analyze/16511/grader.sh, dest: grader.sh }
+          - *lib
+      graders:
+          - { type: deterministic, run: bash grader.sh, weight: 1.0 }

--- a/.claude/skills/reproduce/tests/smoke.sh
+++ b/.claude/skills/reproduce/tests/smoke.sh
@@ -48,4 +48,24 @@ check "single-leg trunk clean -> not_repro"    not_reproducible "$(verdict null 
 check "inconclusive -> needs_human_review"     needs_human_review "$(verdict inconclusive not_reproduced)"
 check "low-confidence plan -> needs_human"     needs_human_review "$(verdict reproduced reproduced true)"
 
+# --- fix-verify verdict map: drive the REAL bin/verdict.sh (MODE=fix-verify) ---
+# legs: base (fix absent) , head (fix present). Builds a temp artifacts dir and runs the script.
+VS="$(cd "$(dirname "$0")/../../../../.github/actions/repro/bin" && pwd)/verdict.sh"
+fv () { # fv <base_status> <head_status> [conf]
+  local d; d=$(mktemp -d)
+  mkdir -p "$d/repro-base" "$d/repro-head" "$d/analysis"
+  [ "$1" != "-" ] && echo "{\"status\":\"$1\"}" > "$d/repro-base/result.json"
+  [ "$2" != "-" ] && echo "{\"status\":\"$2\"}" > "$d/repro-head/result.json"
+  echo "{\"confidence\":${3:-0.9}}" > "$d/analysis/analysis.json"
+  MODE=fix-verify ART="$d" bash "$VS" 2>/dev/null | grep '^verdict=' | cut -d= -f2
+}
+echo "fix-verify verdict map (real bin/verdict.sh):"
+check "base repro, head clean -> fix_verified"      fix_verified        "$(fv reproduced not_reproduced)"
+check "both reproduced -> fix_ineffective"          fix_ineffective     "$(fv reproduced reproduced)"
+check "both clean -> test_does_not_guard"           test_does_not_guard "$(fv not_reproduced not_reproduced)"
+check "base clean, head repro -> introduces"        introduces_symptom  "$(fv not_reproduced reproduced)"
+check "any blocked -> blocked"                       blocked             "$(fv blocked not_reproduced)"
+check "inconclusive -> needs_human_review"           needs_human_review  "$(fv inconclusive not_reproduced)"
+check "low confidence -> needs_human_review"         needs_human_review  "$(fv reproduced not_reproduced 0.5)"
+
 [ "$fail" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/.claude/skills/reproduce/tests/smoke.sh
+++ b/.claude/skills/reproduce/tests/smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Smoke test for the reproduce pipeline's decision logic.
+#
+# Tests the two pure contracts from references/SCHEMA.md that are most likely to
+# regress: the target matrix (dedup + "not on manual rerun") and the verdict map.
+# No GitHub, no Docker — just bash. Run: bash .claude/skills/reproduce/tests/smoke.sh
+set -euo pipefail
+
+fail=0
+check () { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "  ok   $1"; else echo "  FAIL $1: expected '$2' got '$3'"; fail=1; fi
+}
+
+# --- target matrix: one leg if manual OR reported == trunk, else two ---
+targets () { # targets <skip_reported> <reported_version> <trunk_version>
+  if [ "$1" = "true" ] || [ "$2" = "$3" ]; then echo '["trunk"]'; else echo '["reported","trunk"]'; fi
+}
+echo "matrix (dedup + not-on-manual-rerun):"
+check "normal -> two legs"        '["reported","trunk"]' "$(targets false 6.6.10.0 trunk)"
+check "skip_reported -> one leg"   '["trunk"]'            "$(targets true  6.6.10.0 trunk)"
+check "reported==trunk -> one leg" '["trunk"]'           "$(targets false trunk    trunk)"
+
+# --- verdict map (first match wins); single-leg runs have reported == null ---
+# unsure = analyze flagged a weak/blocked plan (blocked_reason or 0.4 <= confidence < 0.7;
+# below 0.4 bails before provision, so the verdict job never sees it).
+verdict () { # verdict <reported_status> <trunk_status> [unsure]
+  local rep="$1" tru="$2" unsure="${3:-false}"
+  if   [ "$rep" = blocked ] || [ "$tru" = blocked ];               then echo blocked
+  elif [ "$unsure" = true ];                                       then echo needs_human_review
+  elif [ "$rep" = inconclusive ] || [ "$tru" = inconclusive ];     then echo needs_human_review
+  elif [ "$rep" = reproduced ]     && [ "$tru" = reproduced ];     then echo live_bug
+  elif [ "$rep" = reproduced ]     && [ "$tru" = not_reproduced ]; then echo fixed_on_trunk
+  elif [ "$rep" = not_reproduced ] && [ "$tru" = reproduced ];     then echo regression
+  elif [ "$rep" = not_reproduced ] && [ "$tru" = not_reproduced ]; then echo not_reproducible
+  elif [ "$rep" = null ] && [ "$tru" = reproduced ];               then echo live_bug
+  elif [ "$rep" = null ] && [ "$tru" = not_reproduced ];           then echo not_reproducible
+  else echo needs_human_review; fi
+}
+echo "verdict map:"
+check "both reproduced -> live_bug"            live_bug         "$(verdict reproduced reproduced)"
+check "reported only -> fixed_on_trunk"        fixed_on_trunk   "$(verdict reproduced not_reproduced)"
+check "regression (trunk only) -> regression"  regression       "$(verdict not_reproduced reproduced)"
+check "neither -> not_reproducible"            not_reproducible "$(verdict not_reproduced not_reproduced)"
+check "any blocked -> blocked"                 blocked          "$(verdict blocked reproduced)"
+check "blocked beats unsure"                   blocked          "$(verdict blocked reproduced true)"
+check "single-leg trunk repro -> live_bug"     live_bug         "$(verdict null reproduced)"
+check "single-leg trunk clean -> not_repro"    not_reproducible "$(verdict null not_reproduced)"
+check "inconclusive -> needs_human_review"     needs_human_review "$(verdict inconclusive not_reproduced)"
+check "low-confidence plan -> needs_human"     needs_human_review "$(verdict reproduced reproduced true)"
+
+[ "$fail" = 0 ] && echo "PASS" || { echo "FAILURES"; exit 1; }

--- a/.github/actions/repro/README.md
+++ b/.github/actions/repro/README.md
@@ -1,0 +1,79 @@
+# Bug-reproduction pipeline
+
+Automatically reproduces a reported bug issue **on the reported version and on trunk in
+parallel**, then posts the verdict + evidence back to the issue. The agent owns only the
+thin slices (read the issue → derive a repro plan → write the report); provisioning,
+building and running are deterministic CI jobs. The guiding principle is **derive, don't
+discover**: the repro is derived from the linked fix PR's regression test, not searched
+for by trial and error.
+
+## How to enable
+
+1. Add an `ANTHROPIC_API_KEY` repository secret (used only by the Analyze job). Without
+   it the workflow **hard-fails** rather than fabricating a plan.
+2. Trigger a run by either:
+   - applying the `ci:reproduce` label to an issue, **or**
+   - `gh workflow run reproduce.yml -f issue_number=<N> -f post_comment=true`
+3. The workflow reads the issue, reproduces, and (when triggered by a label, or with
+   `post_comment=true`) comments the verdict. Manual runs default to job-summary-only.
+
+## Phases
+
+```
+gate ─▶ analyze ─▶ reproduce (matrix: reported ‖ trunk) ─▶ verdict ─▶ report
+```
+
+- **gate** — deterministic checks (a real "Steps to reproduce" section must exist) before
+  any agent runs; cheap rejection of under-specified issues.
+- **analyze** — the only AI step. Emits `analysis.json`: the cheapest faithful `layer`,
+  minimal `build_profile`, `fixtures`, and an `assertion` derived from the fix PR's
+  regression test. Pinned to a bounded turn budget.
+- **reproduce** — one parallel leg per target version. The `executor` is chosen by layer.
+- **verdict / report** — deterministic merge + verdict map, then the issue comment.
+
+## Executors (cheapest faithful layer first)
+
+| Executor | Layer | Use when | Evidence |
+|---|---|---|---|
+| `http` | `*-api` | the bug surfaces on a store-/admin-API response | the resolved `curl` script + HAR |
+| `playwright` | `*-ui` | a genuine UI/storefront bug | the spec + screenshot/video/trace |
+| `direct` | `service` | the bug lives in an internal service/indexer/calculation that store-api or the UI can't faithfully exercise (license-gated, heavy domain setup) | the generated PHPUnit integration test |
+
+`expect = healthy`: the generated test asserts the *fixed* behaviour, so it **fails on the
+buggy version** (`reproduced`) and **passes when healthy** (`not_reproduced`).
+
+## Verdict states
+
+| Verdict | reported | trunk | Meaning |
+|---|---|---|---|
+| `live_bug` | reproduced | reproduced | still broken on trunk |
+| `fixed_on_trunk` | reproduced | not_reproduced | fixed; cites the backport candidate |
+| `regression` | not_reproduced | reproduced | newly broken on trunk |
+| `not_reproducible` | not_reproduced | not_reproduced | cannot reproduce as described |
+| `needs_info` | — | — | issue lacks usable repro steps (asked, not run) |
+| `needs_human_review` | — | — | mid-confidence plan or an indeterminate leg |
+| `blocked` | — | — | provisioning/seeding failed (infra, not a verdict) |
+
+## Cost discipline
+
+- **Match env to surface** — `direct`/`http` legs build neither storefront nor theme.
+- **Confidence bands** — a plan the analyzer doesn't trust (`< 0.4`) is **not run**; it
+  asks a human to confirm the draft first, rather than provisioning two installs to test
+  a guess. `0.4–0.7` runs but routes to `needs_human_review`.
+- **Fail fast, never yield mid-build** — one-shot provision, poll until READY.
+
+See [`../../../.claude/skills/reproduce/references/SCHEMA.md`](../../../.claude/skills/reproduce/references/SCHEMA.md)
+for the full JSON contracts.
+
+## Layout
+
+```
+.github/workflows/reproduce.yml        orchestrator (gate→analyze→reproduce→verdict→report)
+.github/workflows/reproduce-eval.yml   skillgrade eval for the Analyze phase
+.github/actions/repro/provision/       setup-shopware + server-ready poll
+.github/actions/repro/bin/run-http.sh        http executor
+.github/actions/repro/bin/run-playwright.sh  playwright executor
+.github/actions/repro/bin/run-direct.sh      direct (PHPUnit) executor
+.github/actions/repro/bin/seed.sh            minimal fixtures via the admin sync API
+.claude/skills/reproduce/              the interactive skill + JSON contracts + tests
+```

--- a/.github/actions/repro/bin/report.sh
+++ b/.github/actions/repro/bin/report.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Render the GitHub comment (-> $OUT, default comment.md) and, when $GITHUB_STEP_SUMMARY is
+# set, the job summary. Shared by reproduce + fix-verify; MODE selects leg names, the
+# headline, and the verdict callouts. Reads leg statuses straight from the artifacts.
+#
+# Env: MODE(reproduce|fix-verify, default reproduce), ART(default artifacts), ISSUE,
+#      VERDICT, FIX, UNSURE, RUN_URL, OUT(default comment.md).
+set -euo pipefail
+
+MODE=${MODE:-reproduce}; ART=${ART:-artifacts}; OUT=${OUT:-comment.md}
+VERDICT=${VERDICT:-needs_human_review}; FIX=${FIX:-}; UNSURE=${UNSURE:-}; RUN_URL=${RUN_URL:-}
+case "$MODE" in
+  reproduce)  A=reported; B=trunk; SUBJECT="Reproduction — Issue #${ISSUE}" ;;
+  fix-verify) A=base;     B=head;  SUBJECT="Fix verification — PR #${ISSUE}" ;;
+  *) echo "::error::unknown MODE '$MODE'"; exit 1 ;;
+esac
+AF="$ART/repro-$A/result.json"; BF="$ART/repro-$B/result.json"
+AN="$ART/analysis/analysis.json"; ATTR="$ART/attribution/attribution.json"
+LAYER=$(jq -r .layer "$AN" 2>/dev/null || echo unknown)
+have_a=0; [ -f "$AF" ] && have_a=1
+have_b=0; [ -f "$BF" ] && have_b=1
+as="null"; [ -f "$AF" ] && as=$(jq -r .status "$AF")
+bs="null"; [ -f "$BF" ] && bs=$(jq -r .status "$BF")
+
+# Dedup: the generated script is identical across legs for direct/playwright (authored ONCE)
+# and usually http; only http can vary (per-leg resolved ids). Show it once when they match.
+same=0; maxlines=0
+for f in "$AF" "$BF"; do [ -f "$f" ] || continue
+  n=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' '); [ "$n" -gt "$maxlines" ] && maxlines=$n; done
+if [ "$have_a" = 1 ] && [ "$have_b" = 1 ]; then
+  cmp -s <(jq -r '.evidence.script // ""' "$AF") <(jq -r '.evidence.script // ""' "$BF") && same=1; fi
+
+emit_script () { # <result.json> <label-suffix> <mode: comment|full>
+  local f="$1" label="$2" mode="$3" lang nlines
+  lang=$(jq -r '.evidence.script_lang // "sh"' "$f")
+  nlines=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' ')
+  [ "$nlines" -gt 0 ] || return 0
+  echo "**Repro script${label}** (\`${lang}\`)"
+  if [ "$mode" = comment ] && [ "$nlines" -gt 60 ]; then
+    echo "_${nlines} lines — in the \`repro-*\` run [artifact](${RUN_URL})._"
+  else echo "\`\`\`${lang}"; jq -r .evidence.script "$f"; echo '```'; fi
+}
+render_scripts () { # <mode: comment|full>
+  local mode="$1"
+  if   [ "$have_a" = 1 ] && [ "$have_b" = 1 ] && [ "$same" = 1 ]; then emit_script "$AF" " (run unchanged on both legs)" "$mode"
+  elif [ "$have_a" = 1 ] && [ "$have_b" = 1 ]; then emit_script "$AF" " — $A" "$mode"; echo; emit_script "$BF" " — $B" "$mode"
+  elif [ "$have_a" = 1 ]; then emit_script "$AF" "" "$mode"
+  elif [ "$have_b" = 1 ]; then emit_script "$BF" "" "$mode"; fi
+}
+leg_section () { # <leg name>
+  local t="$1" f st br ex ac
+  f="$ART/repro-$t/result.json"; [ -f "$f" ] || return 0
+  st=$(jq -r .status "$f"); br=$(jq -r '.blocked_reason // ""' "$f")
+  echo
+  if [ -n "$br" ] && [ "$br" != "null" ]; then echo "### ${t} — \`${st}\`"; echo; echo "> ⚠️ ${br}"
+  else ex=$(jq -r .assertion.expect "$f"); ac=$(jq -r .assertion.actual "$f"); echo "### ${t} — \`${st}\` (expected ${ex}, got ${ac})"; fi
+  echo "Reporter: \`$(jq -r .evidence.reporter_output "$f")\`"
+  [ "$(jq -r .executor "$f")" = playwright ] && echo "📊 Interactive Playwright report + trace/video: \`repro-${t}\` artifact of the [run](${RUN_URL}) — open \`playwright-report/index.html\`."
+}
+
+{
+  echo "## ${SUBJECT}: \`${VERDICT}\`"; echo
+  echo "Layer \`${LAYER}\` · ${A}: \`${as}\` · ${B}: \`${bs}\` · [run](${RUN_URL})"; echo
+  if jq -e '.scenario | arrays and length > 0' "$AN" >/dev/null 2>&1; then
+    echo "**Scenario**"; jq -r '.scenario[] | "1. " + .' "$AN"; echo; fi
+  case "$VERDICT" in
+    fixed_on_trunk)      [ -n "$FIX" ] && echo "**Likely fix (backport candidate):** ${FIX}" ;;
+    fix_verified)        echo "> ✅ **Fix verified**: the symptom is present on \`base\` (without the fix) and gone on \`head\` (with it).${FIX:+ Derived from ${FIX}.}" ;;
+    fix_ineffective)     echo "> ❌ **Fix ineffective**: the symptom still reproduces on \`head\` (with the fix applied) — the change does not remove it." ;;
+    test_does_not_guard) echo "> ⚠️ **Test does not guard the bug**: the repro passes even on \`base\` (without the fix), so it would NOT catch a regression. Strengthen the test, or the symptom isn't actually being exercised." ;;
+    introduces_symptom)  echo "> ❌ **Introduces the symptom**: \`head\` reproduces a symptom that \`base\` does not." ;;
+    regression)          echo "> ⚠️ **Regression**: not reproduced on the reported version but reproduced on trunk. Confirm the reported leg actually exercised the symptom (a missing fixture can cause a false negative)." ;;
+    needs_human_review)  echo "> 🟡 **Needs human review**: the verdict is not trusted automatically${UNSURE:+ — ${UNSURE}}. The leg evidence below is informative but unconfirmed; confirm against the steps before acting." ;;
+  esac
+  if [ -f "$ATTR" ]; then KIND=$(jq -r .kind "$ATTR"); CMT=$(jq -r .likely_commit "$ATTR"); RSN=$(jq -r .reasoning "$ATTR"); echo "**Likely ${KIND} commit:** \`${CMT}\` — ${RSN}"; fi
+  leg_section "$A"; leg_section "$B"
+  echo
+  render_scripts comment
+} > "$OUT"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  { cat "$OUT"
+    if [ "$maxlines" -gt 60 ]; then echo; echo "<details><summary>Full generated repro script</summary>"; echo; render_scripts full; echo; echo "</details>"; fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+cat "$OUT"

--- a/.github/actions/repro/bin/run-direct.sh
+++ b/.github/actions/repro/bin/run-direct.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# `direct` executor. Runs a generated PHPUnit integration test that instantiates the
+# service/route directly — for bugs that can't fire faithfully through store-api or the
+# UI (license-gated, internal services, heavy domain setup; your multi-warehouse class).
+#
+# expect = HEALTHY: the test asserts the FIXED behaviour, so it FAILS on the buggy
+# version (=> reproduced) and PASSES when healthy (=> not_reproduced). A test that
+# ERRORS (can't bootstrap/compile — e.g. the reported version lacks an API the test
+# uses) => inconclusive (cross-version mismatch), never a bogus reproduced.
+#
+# Env: ANALYSIS, OUT, TARGET (req), SHOP_DIR (default shop),
+#      PHPUNIT_REPORT (advanced/testing: parse this report instead of running phpunit)
+set -euo pipefail
+
+ANALYSIS=${ANALYSIS:-analysis.json}
+OUT=${OUT:-result.json}
+: "${TARGET:?TARGET is required}"
+SHOP=${SHOP_DIR:-shop}
+VERSION=$(jq -r '.version // "unknown"' "$ANALYSIS")
+SPEC=$(jq -r '.script_path // "ReproTest.php"' "$ANALYSIS")
+SCRIPT=""; [ -f "$SPEC" ] && SCRIPT=$(cat "$SPEC")
+
+REPORT=$(mktemp); trap 'rm -f "$REPORT"' EXIT
+if [ -n "${PHPUNIT_REPORT:-}" ]; then
+  cp "$PHPUNIT_REPORT" "$REPORT"
+else
+  [ -f "$SPEC" ] || { echo "::error::generated test '$SPEC' not found"; exit 1; }
+  # Place the test where Shopware's PSR-4 autoload-dev (Shopware\Tests\Integration\) finds it.
+  mkdir -p "$SHOP/tests/integration/Repro"
+  cp "$SPEC" "$SHOP/tests/integration/Repro/ReproTest.php"
+  set +e
+  ( cd "$SHOP" && APP_ENV=test php vendor/bin/phpunit --colors=never \
+      tests/integration/Repro/ReproTest.php ) >"$REPORT" 2>&1
+  set -e
+fi
+TAIL=$(tail -c 1500 "$REPORT" | tr -d '\r' | tr -s ' ')
+
+# Map the PHPUnit summary. OK => healthy; FAILURES => symptom; ERRORS/fatal/no-tests =>
+# the test couldn't run (likely a cross-version API mismatch) => inconclusive.
+if grep -qE '^OK( |\()' "$REPORT"; then
+  STATUS="not_reproduced"; MATCHED="true"; REASON_TEXT=""; REPORTER="PHPUnit OK (healthy)"
+elif grep -q 'FAILURES!' "$REPORT"; then
+  STATUS="reproduced"; MATCHED="false"; REASON_TEXT=""
+  REPORTER=$(grep -m1 -E '^[0-9]+\)' "$REPORT" | head -c 300); [ -n "$REPORTER" ] || REPORTER="assertion failed (symptom present)"
+elif grep -qE 'ERRORS!|No tests executed|Fatal error|PHP Fatal|Uncaught' "$REPORT"; then
+  STATUS="inconclusive"; MATCHED="null"
+  REASON_TEXT="PHPUnit could not run the test (bootstrap/compile error — likely a cross-version API mismatch): $TAIL"
+  REPORTER="PHPUnit errored (test could not run)"
+else
+  STATUS="blocked"; MATCHED="null"
+  REASON_TEXT="PHPUnit produced no recognisable result: $TAIL"
+  REPORTER="PHPUnit produced no result"
+fi
+
+jq -n \
+  --argjson issue "$(jq -r '.issue' "$ANALYSIS")" \
+  --arg target "$TARGET" --arg version "$VERSION" --arg status "$STATUS" \
+  --argjson matched "$MATCHED" --arg script "$SCRIPT" --arg reporter "$REPORTER" \
+  --arg reason_text "$REASON_TEXT" '{
+    schema_version: "1", issue: $issue, target: $target, version: $version, executor: "direct",
+    status: $status,
+    assertion: { expect: "test passes (healthy)", actual: $reporter, matched: $matched },
+    duration_s: 0,
+    evidence: { script: $script, script_lang: "php", reporter_output: $reporter,
+      http: [], artifacts: [{ kind: "phpunit-test", name: "ReproTest.php" }], truncated: false },
+    blocked_reason: (if $reason_text == "" then null else $reason_text end)
+  }' > "$OUT"
+
+echo "status=$STATUS  ($REPORTER)"

--- a/.github/actions/repro/bin/run-http.sh
+++ b/.github/actions/repro/bin/run-http.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# `http` executor (v2). Reads the plan (analysis.json), runs the request — or a
+# request SEQUENCE — against the running shop, and asserts on the FINAL response.
+#
+# Supports:
+#  - install-specific placeholders in path/body/headers, resolved against the shop:
+#    {{SC}} {{NAV_CAT}} {{COUNTRY}} {{SALUTATION}} {{SALUTATION2}} {{TAX}} {{CURRENCY}}
+#    {{LANGUAGE}} {{STOREFRONT_URL}} {{SW_ACCESS_KEY}} {{SW_CONTEXT_TOKEN}}
+#  - multi-step: `requests: [...]`; sw-context-token is captured and carried forward;
+#    a non-final setup request that isn't 2xx => blocked.
+#  - false-positive guard: an unparseable/empty response_field on a non-2xx response
+#    => inconclusive (NOT a bogus "reproduced").
+#
+# expect = HEALTHY value: actual != expect => reproduced; actual == expect => not_reproduced.
+#
+# Env: ANALYSIS, OUT, APP_URL (req), TARGET (req), SW_ACCESS_KEY, ADMIN_USER, ADMIN_PASS
+set -euo pipefail
+
+ANALYSIS=${ANALYSIS:-analysis.json}
+OUT=${OUT:-result.json}
+: "${APP_URL:?APP_URL is required}"
+: "${TARGET:?TARGET is required}"
+BASE=${APP_URL%/}
+ACCESS_KEY=${SW_ACCESS_KEY:-}
+ADMIN_USER=${ADMIN_USER:-admin}
+ADMIN_PASS=${ADMIN_PASS:-shopware}
+
+VERSION=$(jq -r '.version // "unknown"' "$ANALYSIS")
+KIND=$(jq -r '.assertion.kind' "$ANALYSIS")
+EXPECT=$(jq -r '.assertion.expect | tostring' "$ANALYSIS")
+FIELD=$(jq -r '.assertion.field // ""' "$ANALYSIS")
+# A single `request` is treated as a one-element sequence.
+REQS=$(jq -c 'if .requests then .requests else [.request] end' "$ANALYSIS")
+NREQ=$(echo "$REQS" | jq 'length')
+
+# Plain vars (no associative array → portable to bash 3.2 + the CI's bash 5).
+SW_ACCESS_KEY_V="$ACCESS_KEY"; STOREFRONT_URL="$BASE"
+SC=""; NAV_CAT=""; COUNTRY=""; SALUTATION=""; SALUTATION2=""; TAX=""; CURRENCY=""; LANGUAGE=""
+
+# Resolve install-specific ids only if the plan references {{...}} beyond the free ones (admin API).
+NEED=$(echo "$REQS" | grep -oE '\{\{[A-Z0-9_]+\}\}' | sort -u | tr -d '{}' || true)
+if echo "$NEED" | grep -qvE '^(SW_ACCESS_KEY|STOREFRONT_URL|SW_CONTEXT_TOKEN)?$'; then
+  TOKEN=$(curl -sS --max-time 30 -X POST "$BASE/api/oauth/token" -H 'Content-Type: application/json' \
+    -d "{\"grant_type\":\"password\",\"client_id\":\"administration\",\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\",\"scopes\":\"write\"}" \
+    | jq -r '.access_token // empty')
+  [ -n "$TOKEN" ] || { echo "::error::admin token failed (needed to resolve request ids)"; exit 1; }
+  A=(-H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -H 'Accept: application/json')
+  q() { curl -sS --max-time 30 -X POST "$BASE/api/search/$1" "${A[@]}" -d "$2"; }
+  SCJ=$(q sales-channel '{"limit":1,"filter":[{"type":"equals","field":"active","value":true}]}')
+  SC=$(echo "$SCJ" | jq -r '.data[0].id // empty')
+  NAV_CAT=$(echo "$SCJ" | jq -r '.data[0].navigationCategoryId // empty')
+  # storefrontUrl must be a registered SC domain (a basic-setup default SC is headless,
+  # domain "default.headlessN"), NOT APP_URL. Resolve the real domain when present.
+  SCDOM=$(q sales-channel-domain '{"limit":1}' | jq -r '.data[0].url // empty')
+  [ -n "$SCDOM" ] && STOREFRONT_URL="$SCDOM"
+  COUNTRY=$(q country '{"limit":1,"filter":[{"type":"equals","field":"active","value":true}]}' | jq -r '.data[0].id // empty')
+  SALS=$(q salutation '{"limit":2}')
+  SALUTATION=$(echo "$SALS" | jq -r '.data[0].id // empty')
+  SALUTATION2=$(echo "$SALS" | jq -r '.data[1].id // .data[0].id // empty')
+  TAX=$(q tax '{"limit":1}' | jq -r '.data[0].id // empty')
+  CURRENCY=$(q currency '{"limit":1,"filter":[{"type":"equals","field":"isoCode","value":"EUR"}]}' | jq -r '.data[0].id // empty')
+  LANGUAGE=$(q language '{"limit":1}' | jq -r '.data[0].id // empty')
+fi
+
+CTX=""                       # sw-context-token, carried across the sequence
+HEAD=$(mktemp); BODYF=$(mktemp); trap 'rm -f "$HEAD" "$BODYF"' EXIT
+SCRIPT=""; CODE=""; blocked=""
+
+resolve() { # substitute {{KEY}} placeholders (SALUTATION2 before SALUTATION)
+  local s="$1"
+  s="${s//\{\{SW_ACCESS_KEY\}\}/$SW_ACCESS_KEY_V}"
+  s="${s//\{\{STOREFRONT_URL\}\}/$STOREFRONT_URL}"
+  s="${s//\{\{SC\}\}/$SC}"
+  s="${s//\{\{NAV_CAT\}\}/$NAV_CAT}"
+  s="${s//\{\{COUNTRY\}\}/$COUNTRY}"
+  s="${s//\{\{SALUTATION2\}\}/$SALUTATION2}"
+  s="${s//\{\{SALUTATION\}\}/$SALUTATION}"
+  s="${s//\{\{TAX\}\}/$TAX}"
+  s="${s//\{\{CURRENCY\}\}/$CURRENCY}"
+  s="${s//\{\{LANGUAGE\}\}/$LANGUAGE}"
+  s="${s//\{\{SW_CONTEXT_TOKEN\}\}/$CTX}"
+  printf '%s' "$s"
+}
+
+# assertion.expect may itself reference a resolved id (e.g. {{SALUTATION2}}).
+EXPECT=$(resolve "$EXPECT")
+
+for i in $(seq 0 $((NREQ - 1))); do
+  R=$(echo "$REQS" | jq -c ".[$i]")
+  M=$(echo "$R" | jq -r '.method // "GET"')
+  P=$(resolve "$(echo "$R" | jq -r '.path // ""')")
+  B=$(resolve "$(echo "$R" | jq -r '.body // ""')")
+  CURL=(curl -sS --max-time 30 -o "$BODYF" -D "$HEAD" -w '%{http_code}' -X "$M" "$BASE$P")
+  [ -n "$ACCESS_KEY" ] && CURL+=(-H "sw-access-key: $ACCESS_KEY")
+  [ -n "$CTX" ] && CURL+=(-H "sw-context-token: $CTX")
+  DISP_H=""; [ -n "$ACCESS_KEY" ] && DISP_H=" -H \"sw-access-key: [REDACTED_KEY]\""
+  # plan headers (resolved); drop any sw-access-key the agent added (the executor injects it).
+  has_ct=0
+  while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    case "$h" in sw-access-key:*) continue;; esac
+    case "$(printf '%s' "$h" | tr 'A-Z' 'a-z')" in content-type:*) has_ct=1;; esac
+    h=$(resolve "$h"); CURL+=(-H "$h"); DISP_H+=" -H \"$h\""
+  done < <(echo "$R" | jq -r '.headers // {} | to_entries[] | "\(.key): \(.value)"')
+  # store-api/admin-api are JSON: default Content-Type when a body is present and the plan
+  # omitted it — otherwise curl sends form-encoded and every field reads as blank (400).
+  if [ -n "$B" ] && [ "$has_ct" = 0 ]; then CURL+=(-H "Content-Type: application/json"); DISP_H+=" -H \"Content-Type: application/json\""; fi
+  DISP_B=""; [ -n "$B" ] && { CURL+=(--data "$B"); DISP_B=" --data '$B'"; }
+  SCRIPT="${SCRIPT}curl -sS -X $M \"\$APP_URL$P\"${DISP_H}${DISP_B}"$'\n'
+
+  if ! CODE=$("${CURL[@]}" 2>/dev/null); then blocked="request $((i + 1)) ($M $P) — transport failure"; break; fi
+  T=$(grep -i '^sw-context-token:' "$HEAD" 2>/dev/null | tail -1 | tr -d '\r' | sed 's/^[^:]*:[[:space:]]*//' || true)
+  [ -n "$T" ] && CTX="$T"
+  # a non-final SETUP request must succeed, else the repro can't proceed
+  if [ "$i" -lt $((NREQ - 1)) ] && ! [[ "$CODE" =~ ^2 ]]; then
+    blocked="setup request $((i + 1)) ($M $P) returned HTTP $CODE — $(head -c 1500 "$BODYF" 2>/dev/null | tr -d '\r\n' | tr -s ' ')"; break
+  fi
+done
+
+if [ -n "$blocked" ]; then
+  STATUS="blocked"; MATCHED="null"; ACTUAL="null"; REASON_TEXT="$blocked"; REPORTER="$blocked"
+else
+  REASON_TEXT=""
+  case "$KIND" in
+    http_status) ACTUAL_RAW="$CODE"; REPORTER="HTTP $CODE (expected $EXPECT)" ;;
+    response_field)
+      ACTUAL_RAW=$(jq -r "$FIELD" "$BODYF" 2>/dev/null || true); [ -n "$ACTUAL_RAW" ] || ACTUAL_RAW="<unparseable>"
+      REPORTER="$FIELD = '$ACTUAL_RAW' (expected '$EXPECT'); HTTP $CODE" ;;
+    *) ACTUAL_RAW="$CODE"; REPORTER="HTTP $CODE (unknown assertion kind '$KIND')" ;;
+  esac
+  # Guard: a missing field on a non-2xx response means the call was malformed/failed,
+  # not that the symptom occurred → inconclusive, never a bogus "reproduced".
+  if [ "$KIND" = "response_field" ] && { [ "$ACTUAL_RAW" = "<unparseable>" ] || [ "$ACTUAL_RAW" = "null" ]; } && ! [[ "$CODE" =~ ^2 ]]; then
+    STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"$ACTUAL_RAW\""
+    REASON_TEXT="final request returned HTTP $CODE, asserted field absent (likely malformed) — body: $(head -c 1500 "$BODYF" 2>/dev/null | tr -d '\r\n' | tr -s ' ')"
+  elif [ "$ACTUAL_RAW" = "$EXPECT" ]; then
+    STATUS="not_reproduced"; MATCHED="true"; ACTUAL="\"$ACTUAL_RAW\""
+  else
+    STATUS="reproduced"; MATCHED="false"; ACTUAL="\"$ACTUAL_RAW\""
+  fi
+fi
+
+{ echo '#!/usr/bin/env bash'; echo '# Reproduction request(s) — set $APP_URL (executor injects sw-access-key / sw-context-token).'; printf '%s' "$SCRIPT"; } > repro.sh
+
+jq -n \
+  --argjson issue "$(jq -r '.issue' "$ANALYSIS")" \
+  --arg target "$TARGET" --arg version "$VERSION" --arg status "$STATUS" \
+  --arg expect "$EXPECT" --argjson actual "$ACTUAL" --argjson matched "$MATCHED" \
+  --arg script "$SCRIPT" --arg reporter "$REPORTER" --argjson code "${CODE:-0}" \
+  --arg reason_text "$REASON_TEXT" '{
+    schema_version: "1", issue: $issue, target: $target, version: $version, executor: "http",
+    status: $status,
+    assertion: { expect: $expect, actual: ($actual | if . == null then null else tostring end), matched: $matched },
+    duration_s: 0,
+    evidence: { script: $script, script_lang: "sh", reporter_output: $reporter,
+      http: [{ status: $code }], artifacts: [], truncated: false },
+    blocked_reason: (if $reason_text == "" then null else $reason_text end)
+  }' > "$OUT"
+
+echo "status=$STATUS  ($REPORTER)"

--- a/.github/actions/repro/bin/run-playwright.sh
+++ b/.github/actions/repro/bin/run-playwright.sh
@@ -49,7 +49,8 @@ else
   SKIPPED=$(jq -r '.stats.skipped // 0' "$REPORT")
   REASON="null"
   # Every failed/timed-out test's error message — used to classify WHY it failed.
-  ERRS=$(jq -r '[.. | objects | select(.status?=="failed" or .status?=="timedOut") | .error?.message // empty] | join(" || ")' "$REPORT")
+  # Strip ANSI colour codes Playwright embeds, else they leak into the rendered comment.
+  ERRS=$(jq -r '[.. | objects | select(.status?=="failed" or .status?=="timedOut") | .error?.message // empty] | join(" || ")' "$REPORT" | perl -pe 's/\e\[[0-9;]*m//g')
   MSG=$(printf '%s' "$ERRS" | tr -s ' \n' '  ' | head -c 300)
   if [ "$EXPECTED" = 0 ] && [ "$UNEXPECTED" = 0 ] && [ "$SKIPPED" = 0 ]; then
     STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"no tests ran\""

--- a/.github/actions/repro/bin/run-playwright.sh
+++ b/.github/actions/repro/bin/run-playwright.sh
@@ -31,9 +31,10 @@ if [ -z "${PW_REPORT:-}" ]; then
   # collected — a spec at the workspace root is silently ignored (0 tests => "no tests ran").
   # Place it next to the config (mirrors run-direct.sh dropping ReproTest.php under the shop).
   cp "$SPEC" "$(dirname "$CONFIG")/repro.spec.ts"
+  # No --reporter on the CLI: that would OVERRIDE the config and suppress the html report.
+  # Let the config's reporters run — json → $REPORT (pw-report.json), html → playwright-report/.
   set +e
-  APP_URL="$APP_URL" npx playwright test \
-    --config "$CONFIG" --reporter=json >"$REPORT" 2>pw-stderr.txt
+  APP_URL="$APP_URL" npx playwright test --config "$CONFIG" >pw-stdout.txt 2>pw-stderr.txt
   set -e
 fi
 

--- a/.github/actions/repro/bin/run-playwright.sh
+++ b/.github/actions/repro/bin/run-playwright.sh
@@ -42,13 +42,41 @@ if ! jq -e . "$REPORT" >/dev/null 2>&1; then
 else
   EXPECTED=$(jq -r '.stats.expected // 0' "$REPORT")
   UNEXPECTED=$(jq -r '.stats.unexpected // 0' "$REPORT")
+  SKIPPED=$(jq -r '.stats.skipped // 0' "$REPORT")
   REASON="null"
-  if [ "$EXPECTED" = 0 ] && [ "$UNEXPECTED" = 0 ]; then
+  # Every failed/timed-out test's error message — used to classify WHY it failed.
+  ERRS=$(jq -r '[.. | objects | select(.status?=="failed" or .status?=="timedOut") | .error?.message // empty] | join(" || ")' "$REPORT")
+  MSG=$(printf '%s' "$ERRS" | tr -s ' \n' '  ' | head -c 300)
+  if [ "$EXPECTED" = 0 ] && [ "$UNEXPECTED" = 0 ] && [ "$SKIPPED" = 0 ]; then
     STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"no tests ran\""
-    REPORTER="no tests executed"
+    REPORTER="no tests executed"; REASON="\"playwright ran no tests\""
   elif [ "$UNEXPECTED" -gt 0 ]; then
-    STATUS="reproduced"; MATCHED="false"; ACTUAL="\"$UNEXPECTED failing\""
-    REPORTER=$(jq -r '[.. | objects | select(.status?=="failed") | .error?.message // empty] | first // "assertion failed"' "$REPORT" | head -c 300)
+    # A failure is the SYMPTOM (=> reproduced) ONLY when it's a real value assertion on an
+    # element that was found. The SAME spec runs on both versions, so a failure because the
+    # page/control the repro depends on is ABSENT on this version (cross-version UI drift)
+    # must NOT masquerade as the symptom => inconclusive. Precedence: explicit precondition
+    # marker, then navigation/connection failure, then a genuine expect() assertion, else
+    # an unrecognised locator/timeout failure (a drive failure, not a reproduction).
+    if printf '%s' "$ERRS" | grep -q 'PRECONDITION_NOT_FOUND'; then
+      STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"precondition missing on $VERSION\""
+      REPORTER="precondition absent on this version (UI differs) — $MSG"
+      REASON="\"a precondition element the spec depends on is absent on $VERSION (likely cross-version UI drift); the symptom could not be exercised, so this is not a reproduction\""
+    elif printf '%s' "$ERRS" | grep -qiE 'net::ERR|ERR_CONNECTION|page\.goto|waiting for navigation|Navigation to .* failed'; then
+      STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"could not load the page on $VERSION\""
+      REPORTER="navigation/connection failure — $MSG"
+      REASON="\"the spec could not load the target page on $VERSION; the symptom cannot be judged\""
+    elif printf '%s' "$ERRS" | grep -qE 'expect|Expected:|toBe|toHave|toContain|toEqual'; then
+      STATUS="reproduced"; MATCHED="false"; ACTUAL="\"$UNEXPECTED failing\""
+      REPORTER=$([ -n "$MSG" ] && printf '%s' "$MSG" || echo "assertion failed")
+    else
+      STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"$UNEXPECTED failing (non-assertion)\""
+      REPORTER="failure was not a value assertion (likely a missing/changed element) — $MSG"
+      REASON="\"the failure was a locator/timeout error, not an assertion on a found element; cannot confirm the symptom on $VERSION\""
+    fi
+  elif [ "$SKIPPED" -gt 0 ] && [ "$EXPECTED" = 0 ]; then
+    STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"$SKIPPED skipped\""
+    REPORTER="spec skipped (precondition not met on this version)"
+    REASON="\"the spec skipped itself (test.skip): the repro's precondition is not met on $VERSION\""
   else
     STATUS="not_reproduced"; MATCHED="true"; ACTUAL="\"$EXPECTED passing\""
     REPORTER="all $EXPECTED test(s) passed (healthy)"

--- a/.github/actions/repro/bin/run-playwright.sh
+++ b/.github/actions/repro/bin/run-playwright.sh
@@ -24,12 +24,16 @@ VERSION=$(jq -r '.version // "unknown"' "$ANALYSIS")
 SPEC=$(jq -r '.script_path // "repro.spec.ts"' "$ANALYSIS")
 REPORT=${PW_REPORT:-pw-report.json}
 
+CONFIG=.github/actions/repro/repro.playwright.config.ts
 if [ -z "${PW_REPORT:-}" ]; then
   [ -f "$SPEC" ] || { echo "::error::generated spec '$SPEC' not found"; exit 1; }
-  # one-shot run; the config's baseURL reads $APP_URL.
+  # Playwright's testDir is the config's directory, so the spec must live THERE to be
+  # collected — a spec at the workspace root is silently ignored (0 tests => "no tests ran").
+  # Place it next to the config (mirrors run-direct.sh dropping ReproTest.php under the shop).
+  cp "$SPEC" "$(dirname "$CONFIG")/repro.spec.ts"
   set +e
-  APP_URL="$APP_URL" npx playwright test "$SPEC" \
-    --config .github/actions/repro/repro.playwright.config.ts --reporter=json >"$REPORT" 2>pw-stderr.txt
+  APP_URL="$APP_URL" npx playwright test \
+    --config "$CONFIG" --reporter=json >"$REPORT" 2>pw-stderr.txt
   set -e
 fi
 

--- a/.github/actions/repro/bin/run-playwright.sh
+++ b/.github/actions/repro/bin/run-playwright.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Real `playwright` executor. Runs the spec Analyze generated ONCE (repro.spec.ts,
+# reused by both legs) against the leg's APP_URL, then maps the result to a verdict.
+#
+# expect = healthy: the spec asserts the FIXED behaviour, so it FAILS on the buggy
+# version (=> reproduced) and PASSES when healthy (=> not_reproduced).
+#
+# Evidence: the verbatim spec + the Playwright JSON summary; screenshots/video/trace
+# are written under test-results/ and uploaded by the workflow.
+#
+# Env:
+#   ANALYSIS     analysis.json                         (default: analysis.json)
+#   OUT          result.json                           (default: result.json)
+#   APP_URL      base URL of the running shop          (required)
+#   TARGET       reported | trunk                      (required)
+#   PW_REPORT    parse this existing JSON report instead of running (testing hook)
+set -euo pipefail
+
+ANALYSIS=${ANALYSIS:-analysis.json}
+OUT=${OUT:-result.json}
+: "${APP_URL:?APP_URL is required}"
+: "${TARGET:?TARGET is required}"
+VERSION=$(jq -r '.version // "unknown"' "$ANALYSIS")
+SPEC=$(jq -r '.script_path // "repro.spec.ts"' "$ANALYSIS")
+REPORT=${PW_REPORT:-pw-report.json}
+
+if [ -z "${PW_REPORT:-}" ]; then
+  [ -f "$SPEC" ] || { echo "::error::generated spec '$SPEC' not found"; exit 1; }
+  # one-shot run; the config's baseURL reads $APP_URL.
+  set +e
+  APP_URL="$APP_URL" npx playwright test "$SPEC" \
+    --config .github/actions/repro/repro.playwright.config.ts --reporter=json >"$REPORT" 2>pw-stderr.txt
+  set -e
+fi
+
+SCRIPT=""; [ -f "$SPEC" ] && SCRIPT=$(cat "$SPEC")
+
+# Map via the JSON reporter's stats: unexpected = failing tests.
+if ! jq -e . "$REPORT" >/dev/null 2>&1; then
+  STATUS="blocked"; MATCHED="null"; ACTUAL="null"; REASON="\"playwright produced no parseable report (env not READY?)\""
+  REPORTER="runner error: $(tail -1 pw-stderr.txt 2>/dev/null || echo unknown)"
+else
+  EXPECTED=$(jq -r '.stats.expected // 0' "$REPORT")
+  UNEXPECTED=$(jq -r '.stats.unexpected // 0' "$REPORT")
+  REASON="null"
+  if [ "$EXPECTED" = 0 ] && [ "$UNEXPECTED" = 0 ]; then
+    STATUS="inconclusive"; MATCHED="null"; ACTUAL="\"no tests ran\""
+    REPORTER="no tests executed"
+  elif [ "$UNEXPECTED" -gt 0 ]; then
+    STATUS="reproduced"; MATCHED="false"; ACTUAL="\"$UNEXPECTED failing\""
+    REPORTER=$(jq -r '[.. | objects | select(.status?=="failed") | .error?.message // empty] | first // "assertion failed"' "$REPORT" | head -c 300)
+  else
+    STATUS="not_reproduced"; MATCHED="true"; ACTUAL="\"$EXPECTED passing\""
+    REPORTER="all $EXPECTED test(s) passed (healthy)"
+  fi
+fi
+
+jq -n \
+  --argjson issue "$(jq -r '.issue' "$ANALYSIS")" \
+  --arg target "$TARGET" --arg version "$VERSION" --arg status "$STATUS" \
+  --argjson matched "$MATCHED" --argjson actual "$ACTUAL" \
+  --arg script "$SCRIPT" --arg reporter "$REPORTER" --argjson reason "$REASON" '{
+    schema_version: "1",
+    issue: $issue,
+    target: $target,
+    version: $version,
+    executor: "playwright",
+    status: $status,
+    assertion: { expect: "spec passes (healthy)", actual: $actual, matched: $matched },
+    duration_s: 0,
+    evidence: {
+      script: $script,
+      script_lang: "ts",
+      reporter_output: $reporter,
+      http: [],
+      artifacts: [{ kind: "playwright-results", name: "test-results/", run_artifact: ("repro-" + $target) }],
+      truncated: false
+    },
+    blocked_reason: $reason
+  }' > "$OUT"
+
+echo "status=$STATUS  ($REPORTER)"

--- a/.github/actions/repro/bin/seed.sh
+++ b/.github/actions/repro/bin/seed.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Seed exactly the entities a repro needs, via the admin sync API. NO demodata.
+#
+# Reads the plan's sync payload (entities the Analyze agent derived), resolves the
+# install-specific placeholders ({{SC}}/{{NAV_CAT}}/{{TAX}}/{{CURRENCY}}) against the
+# running shop, and POSTs /api/_action/sync. Idempotent upsert.
+#
+# Env:
+#   APP_URL     base URL of the running shop          (required)
+#   PAYLOAD     path to the sync payload JSON          (default: fixtures.json)
+#   ADMIN_USER  admin username (default-install: admin)
+#   ADMIN_PASS  admin password (default-install: shopware)
+set -euo pipefail
+
+: "${APP_URL:?APP_URL is required}"
+PAYLOAD="${PAYLOAD:-fixtures.json}"
+BASE=${APP_URL%/}
+USER="${ADMIN_USER:-admin}"
+PASS="${ADMIN_PASS:-shopware}"
+
+# A plan with no fixtures is valid (e.g. demodata:false + the bug needs no seed data).
+if [ ! -f "$PAYLOAD" ]; then
+  echo "no fixtures payload ($PAYLOAD) — nothing to seed"
+  exit 0
+fi
+
+# 1. Admin token via the first-party password grant (works on a default install).
+TOKEN=$(curl -sS --max-time 30 -X POST "$BASE/api/oauth/token" \
+  -H 'Content-Type: application/json' \
+  -d "{\"grant_type\":\"password\",\"client_id\":\"administration\",\"username\":\"$USER\",\"password\":\"$PASS\",\"scopes\":\"write\"}" \
+  | jq -r '.access_token // empty')
+[ -n "$TOKEN" ] || { echo "::error::admin token request failed"; exit 1; }
+# Accept: application/json → flat response (id + navigationCategoryId at top level);
+# without it /api/search returns JSON:API where nested fields live under .attributes.
+AUTH=(-H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -H 'Accept: application/json')
+
+# 2. Resolve install-specific ids referenced by the payload as placeholders.
+# NOTE: keep this set in sync with run-http.sh's resolver (the two diverged once).
+search () { curl -sS --max-time 30 -X POST "$BASE/api/search/$1" "${AUTH[@]}" -d "$2"; }
+SC_JSON=$(search sales-channel '{"limit":1,"filter":[{"type":"equals","field":"active","value":true}]}')
+SC=$(echo "$SC_JSON"  | jq -r '.data[0].id // empty')
+NAV=$(echo "$SC_JSON" | jq -r '.data[0].navigationCategoryId // empty')
+TAX=$(search tax '{"limit":1}'      | jq -r '.data[0].id // empty')
+CUR=$(search currency '{"limit":1,"filter":[{"type":"equals","field":"isoCode","value":"EUR"}]}' | jq -r '.data[0].id // empty')
+COUNTRY=$(search country '{"limit":1,"filter":[{"type":"equals","field":"active","value":true}]}' | jq -r '.data[0].id // empty')
+SALS=$(search salutation '{"limit":2}')
+SAL=$(echo "$SALS"  | jq -r '.data[0].id // empty')
+SAL2=$(echo "$SALS" | jq -r '.data[1].id // .data[0].id // empty')
+LANG=$(search language '{"limit":1}' | jq -r '.data[0].id // empty')
+
+# Fail loud if a referenced placeholder resolved to EMPTY (else we'd POST an empty UUID).
+for kv in "SC:$SC" "NAV_CAT:$NAV" "TAX:$TAX" "CURRENCY:$CUR" "COUNTRY:$COUNTRY" "SALUTATION:$SAL" "SALUTATION2:$SAL2" "LANGUAGE:$LANG"; do
+  k=${kv%%:*}; v=${kv#*:}
+  if grep -q "{{$k}}" "$PAYLOAD" && [ -z "$v" ]; then
+    echo "::error::could not resolve {{$k}} (admin search returned empty)"; exit 1
+  fi
+done
+
+OUT=$(mktemp)
+sed -e "s/{{SC}}/$SC/g" -e "s/{{NAV_CAT}}/$NAV/g" -e "s/{{TAX}}/$TAX/g" -e "s/{{CURRENCY}}/$CUR/g" \
+    -e "s/{{COUNTRY}}/$COUNTRY/g" -e "s/{{SALUTATION2}}/$SAL2/g" -e "s/{{SALUTATION}}/$SAL/g" -e "s/{{LANGUAGE}}/$LANG/g" "$PAYLOAD" > "$OUT"
+
+# Fail loud if any placeholder is still unresolved (would seed broken entities).
+if grep -q '{{' "$OUT"; then
+  echo "::error::unresolved placeholder(s) in sync payload:"; grep -o '{{[^}]*}}' "$OUT" | sort -u
+  exit 1
+fi
+
+# 3. Upsert the entities.
+RESP=$(mktemp)
+CODE=$(curl -sS --max-time 60 -o "$RESP" -w '%{http_code}' -X POST "$BASE/api/_action/sync" "${AUTH[@]}" --data @"$OUT")
+if [ "$CODE" != "200" ] && [ "$CODE" != "204" ]; then
+  echo "::error::sync failed (HTTP $CODE)"; cat "$RESP"; exit 1
+fi
+echo "seeded OK (sync HTTP $CODE; SC=$SC nav=$NAV tax=$TAX cur=$CUR)"

--- a/.github/actions/repro/bin/verdict.sh
+++ b/.github/actions/repro/bin/verdict.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Deterministic verdict from two leg results + the analyze plan's confidence. No agent.
+# Shared by the reproduce and fix-verify workflows; MODE selects the leg names + verdict map.
+#
+#   MODE=reproduce   legs: reported (A) , trunk (B)
+#     reproduced/reproduced → live_bug · reproduced/not_reproduced → fixed_on_trunk
+#     not_reproduced/reproduced → regression · not_reproduced/not_reproduced → not_reproducible
+#   MODE=fix-verify  legs: base (A) , head (B)   (A = fix ABSENT, B = fix PRESENT)
+#     reproduced/not_reproduced → fix_verified · reproduced/reproduced → fix_ineffective
+#     not_reproduced/not_reproduced → test_does_not_guard · not_reproduced/reproduced → introduces_symptom
+#
+# Precedence (both modes): any blocked → blocked; unsure plan (blocked_reason or
+# confidence < 0.7) → needs_human_review; any inconclusive → needs_human_review; else the map.
+#
+# Env: MODE (default reproduce), ART (artifacts dir, default "artifacts").
+# Emits KEY=VALUE to $GITHUB_OUTPUT when set (always also to stdout): has_results, verdict,
+#   <A_NAME>, <B_NAME>, fix_candidate, unsure_reason.
+set -euo pipefail
+
+MODE=${MODE:-reproduce}
+ART=${ART:-artifacts}
+case "$MODE" in
+  reproduce)  A_NAME=reported; B_NAME=trunk ;;
+  fix-verify) A_NAME=base;     B_NAME=head  ;;
+  *) echo "::error::unknown MODE '$MODE'"; exit 1 ;;
+esac
+AF="$ART/repro-$A_NAME/result.json"
+BF="$ART/repro-$B_NAME/result.json"
+
+out () { [ -n "${GITHUB_OUTPUT:-}" ] && echo "$1=$2" >> "$GITHUB_OUTPUT"; echo "$1=$2"; }
+
+# No leg produced a result → no verdict, no comment downstream.
+if [ ! -f "$AF" ] && [ ! -f "$BF" ]; then
+  out has_results false
+  echo "::warning::No $MODE leg produced a result (aborted/cancelled/failed)."
+  exit 0
+fi
+out has_results true
+
+a="null"; b="null"
+[ -f "$AF" ] && a=$(jq -r .status "$AF")
+[ -f "$BF" ] && b=$(jq -r .status "$BF")
+out "$A_NAME" "$a"
+out "$B_NAME" "$b"
+
+AN="$ART/analysis/analysis.json"
+CONF=$(jq -r '.confidence // 1' "$AN" 2>/dev/null || echo 1)
+BLOCKED=$(jq -r '.blocked_reason // ""' "$AN" 2>/dev/null || echo "")
+DERIVED=$(jq -r '.derived_from // ""' "$AN" 2>/dev/null || echo "")
+CONF_REASON=$(jq -r '.confidence_reason // ""' "$AN" 2>/dev/null || echo "")
+
+# Mid-band plan (0.4–0.7; below 0.4 bailed before provision) or a blocked_reason → don't
+# trust the verdict even if the legs ran; route to a human with the reason captured.
+unsure=false; UNSURE_REASON=""
+[ -n "$BLOCKED" ] && [ "$BLOCKED" != null ] && { unsure=true; UNSURE_REASON="$BLOCKED"; }
+awk "BEGIN{exit !($CONF < 0.7)}" && { unsure=true; [ -n "$CONF_REASON" ] && UNSURE_REASON="$CONF_REASON"; }
+out unsure_reason "$UNSURE_REASON"
+
+# Precedence: infra → unreliable-plan → indeterminate leg → mode-specific core combos.
+V="needs_human_review"
+if   [ "$a" = "blocked" ] || [ "$b" = "blocked" ];           then V="blocked"
+elif [ "$unsure" = "true" ];                                 then V="needs_human_review"
+elif [ "$a" = "inconclusive" ] || [ "$b" = "inconclusive" ]; then V="needs_human_review"
+elif [ "$MODE" = "reproduce" ]; then
+  if   [ "$a" = "reproduced" ]     && [ "$b" = "reproduced" ];     then V="live_bug"
+  elif [ "$a" = "reproduced" ]     && [ "$b" = "not_reproduced" ]; then V="fixed_on_trunk"
+  elif [ "$a" = "not_reproduced" ] && [ "$b" = "reproduced" ];     then V="regression"
+  elif [ "$a" = "not_reproduced" ] && [ "$b" = "not_reproduced" ]; then V="not_reproducible"
+  elif [ "$a" = "null" ]           && [ "$b" = "reproduced" ];     then V="live_bug"
+  elif [ "$a" = "null" ]           && [ "$b" = "not_reproduced" ]; then V="not_reproducible"
+  fi
+else  # fix-verify: A = base (fix absent), B = head (fix present)
+  if   [ "$a" = "reproduced" ]     && [ "$b" = "not_reproduced" ]; then V="fix_verified"
+  elif [ "$a" = "reproduced" ]     && [ "$b" = "reproduced" ];     then V="fix_ineffective"
+  elif [ "$a" = "not_reproduced" ] && [ "$b" = "not_reproduced" ]; then V="test_does_not_guard"
+  elif [ "$a" = "not_reproduced" ] && [ "$b" = "reproduced" ];     then V="introduces_symptom"
+  fi
+fi
+out verdict "$V"
+
+# fixed_on_trunk / fix_verified: the fixing PR/commit is often already known (derived_from).
+FIX=""; { [ "$V" = "fixed_on_trunk" ] || [ "$V" = "fix_verified" ]; } && FIX="$DERIVED"
+out fix_candidate "$FIX"
+echo "MODE=$MODE verdict=$V $A_NAME=$a $B_NAME=$b unsure=$unsure"

--- a/.github/actions/repro/demo/ReproTest.php
+++ b/.github/actions/repro/demo/ReproTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Repro;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ *
+ * DEMO wiring smoke for the `direct` executor — used ONLY by the workflow's dry-run
+ * demo (dry_run=true, demo_layer=direct). Not a real reproduction.
+ */
+class ReproTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCoreServiceIsAvailable(): void
+    {
+        // Healthy: the product repository resolves from the container. Passing => the
+        // executor maps OK => not_reproduced, which proves the whole direct path runs:
+        // provision -> place test under tests/integration/Repro -> phpunit -> parse -> report.
+        static::assertNotNull(static::getContainer()->get('product.repository'));
+    }
+}

--- a/.github/actions/repro/demo/repro.spec.ts
+++ b/.github/actions/repro/demo/repro.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+// DEMO wiring smoke for the `playwright` executor — used ONLY by the workflow's dry-run
+// demo (dry_run=true, demo_layer=playwright). Not a real reproduction.
+test('admin entry point renders', async ({ page }) => {
+  // PRECONDITION + SYMPTOM (healthy): the admin entry point loads and the page renders.
+  // Passing => not_reproduced, which proves the whole playwright path runs: provision ->
+  // copy spec under the config's testDir -> playwright run -> parse stats -> report.
+  await page.goto('/admin');
+  await expect(page.locator('body')).toBeVisible();
+});

--- a/.github/actions/repro/provision/action.yaml
+++ b/.github/actions/repro/provision/action.yaml
@@ -1,0 +1,102 @@
+name: "Reproduce — provision"
+description: >
+  Boot a Shopware instance at a specific version, building only the surface the
+  bug lives on (build_profile). Outputs APP_URL and a store-api access key.
+  Reuses shopware/setup-shopware; mirrors the server-start flow of .github/actions/ats.
+
+inputs:
+  version:
+    description: "Shopware ref: 'trunk' for the checked-out branch, or a tag like 'v6.6.10.0' for the reported version"
+    required: true
+  repository:
+    description: "Shopware repository"
+    required: false
+    default: "shopware/shopware"
+  php-version:
+    required: false
+    default: "8.4"
+  path:
+    description: "Subdir to install the shop into (keeps the workspace root tooling/analysis intact)"
+    required: false
+    default: "shop"
+  storefront-build:
+    description: "Build storefront assets (only needed for storefront-ui layer)"
+    required: false
+    default: "false"
+  admin-build:
+    description: "Build admin assets (only needed for admin-ui layer)"
+    required: false
+    default: "false"
+
+outputs:
+  app_url:
+    description: "Base URL of the running shop"
+    value: ${{ steps.serve.outputs.app_url }}
+  access_key:
+    description: "store-api sales-channel access key"
+    value: ${{ steps.access-key.outputs.key }}
+
+runs:
+  using: "composite"
+  steps:
+    # Install only what the surface needs. http/direct → no JS build at all.
+    - name: Setup Shopware
+      uses: shopware/setup-shopware@main
+      with:
+        shopware-version: ${{ inputs.version }}
+        shopware-repository: ${{ inputs.repository }}
+        path: ${{ inputs.path }}
+        php-version: ${{ inputs.php-version }}
+        mysql-version: "builtin"
+        install: "true"
+        install-admin: ${{ inputs.admin-build }}
+        install-storefront: ${{ inputs.storefront-build }}
+        skip-js-build: ${{ (inputs.admin-build == 'false' && inputs.storefront-build == 'false') && 'true' || 'false' }}
+        allow-insecure-versions: "true" # reported version may be an old release
+        env: "prod"
+
+    - name: Define minimal environment
+      shell: bash
+      run: |
+        echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> "$GITHUB_ENV"
+        echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> "$GITHUB_ENV"
+        echo "BLUE_GREEN_DEPLOYMENT=1" >> "$GITHUB_ENV"
+
+    - name: Start webserver and wait until READY
+      id: serve
+      shell: bash
+      working-directory: ${{ inputs.path }}
+      env:
+        SYMFONY_DAEMON: "1"
+        SYMFONY_NO_TLS: "1"
+        SYMFONY_ALLOW_HTTP: "1"
+        SYMFONY_PORT: "8000"
+        SYMFONY_ALLOW_ALL_IP: "1"
+      run: |
+        set -euo pipefail
+        symfony server:start
+        APP_URL="http://localhost:8000"
+        # one-shot start, then poll until READY (never yield mid-build).
+        # READY = the web server responds at all; ANY HTTP status counts (the
+        # executor probes the real endpoint). Do not require 2xx here.
+        ready=0
+        for i in $(seq 1 60); do
+          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$APP_URL/admin" || echo 000)
+          if [ "$code" != "000" ]; then echo "server responding (HTTP $code) after ${i}s"; ready=1; break; fi
+          sleep 1
+        done
+        [ "$ready" = 1 ] || { echo "::error::shop not READY after 60s"; exit 1; }
+        echo "app_url=$APP_URL" >> "$GITHUB_OUTPUT"
+
+    - name: Resolve store-api access key
+      id: access-key
+      shell: bash
+      run: |
+        set -euo pipefail
+        # DATABASE_URL is exported by setup-shopware. Read the default sales channel key.
+        eval "$(php -r '$u=parse_url(getenv("DATABASE_URL")); printf("DBH=%s DBP=%s DBU=%s DBPW=%s DBN=%s",
+          $u["host"]??"127.0.0.1", $u["port"]??3306, $u["user"]??"root", $u["pass"]??"", ltrim($u["path"]??"/","/"));')"
+        KEY=$(mysql -h"$DBH" -P"$DBP" -u"$DBU" ${DBPW:+-p"$DBPW"} "$DBN" -N -e \
+          "SELECT access_key FROM sales_channel WHERE active=1 ORDER BY created_at LIMIT 1;")
+        echo "::add-mask::$KEY"
+        echo "key=$KEY" >> "$GITHUB_OUTPUT"

--- a/.github/actions/repro/repro.playwright.config.ts
+++ b/.github/actions/repro/repro.playwright.config.ts
@@ -15,7 +15,13 @@ export default defineConfig({
     // is too short and aborts mid-flow; give the whole test room.
     timeout: 120_000,
     outputDir: `${cwd()}/test-results`,
-    reporter: [['json', { outputFile: 'pw-report.json' }]],
+    // json → machine verdict (run-playwright.sh reads it); html → the rich interactive
+    // report (trace/screenshots/steps) uploaded with the leg so a human can open it.
+    // open:'never' so CI never tries to launch a browser to serve it.
+    reporter: [
+        ['json', { outputFile: `${cwd()}/pw-report.json` }],
+        ['html', { outputFolder: `${cwd()}/playwright-report`, open: 'never' }],
+    ],
     use: {
         baseURL: process.env['APP_URL'],
         trace: 'on',

--- a/.github/actions/repro/repro.playwright.config.ts
+++ b/.github/actions/repro/repro.playwright.config.ts
@@ -10,6 +10,10 @@ import { cwd } from 'node:process';
 export default defineConfig({
     testDir: '.',
     testIgnore: '**/demo/**',
+    // A repro is a multi-step flow against a freshly-provisioned shop (login + navigate +
+    // interact), with generous per-locator waits. Playwright's 30s default per-test timeout
+    // is too short and aborts mid-flow; give the whole test room.
+    timeout: 120_000,
     outputDir: `${cwd()}/test-results`,
     reporter: [['json', { outputFile: 'pw-report.json' }]],
     use: {

--- a/.github/actions/repro/repro.playwright.config.ts
+++ b/.github/actions/repro/repro.playwright.config.ts
@@ -5,9 +5,11 @@ import { cwd } from 'node:process';
 // directory — run-playwright.sh copies the generated spec here so it is the only spec
 // collected (a spec left at the workspace root is NOT discovered). baseURL comes from the
 // leg's running shop; outputDir is pinned to the workspace root so the workflow uploads the
-// trace/video/screenshot evidence.
+// trace/video/screenshot evidence. testIgnore excludes the committed dry-run demo fixtures
+// under demo/ — testDir recurses, so without this a real run would ALSO collect demo/.
 export default defineConfig({
     testDir: '.',
+    testIgnore: '**/demo/**',
     outputDir: `${cwd()}/test-results`,
     reporter: [['json', { outputFile: 'pw-report.json' }]],
     use: {

--- a/.github/actions/repro/repro.playwright.config.ts
+++ b/.github/actions/repro/repro.playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+// Minimal config for a single generated repro spec. baseURL comes from the leg's
+// running shop; trace/video/screenshot are captured as evidence (config-only options).
+export default defineConfig({
+    testDir: '.',
+    outputDir: 'test-results',
+    reporter: [['json', { outputFile: 'pw-report.json' }]],
+    use: {
+        baseURL: process.env['APP_URL'],
+        trace: 'on',
+        video: 'on',
+        screenshot: 'on',
+    },
+});

--- a/.github/actions/repro/repro.playwright.config.ts
+++ b/.github/actions/repro/repro.playwright.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from '@playwright/test';
+import { cwd } from 'node:process';
 
-// Minimal config for a single generated repro spec. baseURL comes from the leg's
-// running shop; trace/video/screenshot are captured as evidence (config-only options).
+// Minimal config for a single generated repro spec. `testDir: '.'` is the config's OWN
+// directory — run-playwright.sh copies the generated spec here so it is the only spec
+// collected (a spec left at the workspace root is NOT discovered). baseURL comes from the
+// leg's running shop; outputDir is pinned to the workspace root so the workflow uploads the
+// trace/video/screenshot evidence.
 export default defineConfig({
     testDir: '.',
-    outputDir: 'test-results',
+    outputDir: `${cwd()}/test-results`,
     reporter: [['json', { outputFile: 'pw-report.json' }]],
     use: {
         baseURL: process.env['APP_URL'],

--- a/.github/workflows/fix-verify.yml
+++ b/.github/workflows/fix-verify.yml
@@ -1,0 +1,406 @@
+name: Verify Fix
+
+# Sibling of reproduce.yml — the SAME engine pointed at a PR. Instead of {reported version,
+# trunk} it provisions the PR's {base (fix ABSENT), head (fix PRESENT)} from source, runs ONE
+# derived repro on both, and confirms the symptom is present on base and gone on head.
+#
+#   gate ─▶ analyze ─▶ verify (matrix: base ‖ head) ─▶ verdict ─▶ report
+#
+# Verdict map (bin/verdict.sh MODE=fix-verify):
+#   base=reproduced  head=not_reproduced → fix_verified         (the fix works)
+#   base=reproduced  head=reproduced     → fix_ineffective      (fix doesn't remove it)
+#   base=not_repro   head=not_repro      → test_does_not_guard  (repro passes without the fix)
+#   base=not_repro   head=reproduced     → introduces_symptom
+# Shares provision/, bin/run-*.sh, seed.sh, verdict.sh, report.sh, and the skill contracts
+# with reproduce.yml.
+
+on:
+  pull_request_target:
+    types: [labeled] # maintainer applies `ci:verify-fix` (only collaborators can label → authz)
+  issue_comment:
+    types: [created] # `/verify-fix` on a PR, trusted authors only
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to verify"
+        required: true
+        type: number
+      post_comment:
+        description: "Post the result as a PR comment (otherwise job summary only)"
+        required: false
+        default: false
+        type: boolean
+      max_turns:
+        description: "Cap on the Analyze agent's turns (cost control; default 35)"
+        required: false
+        default: "35"
+        type: string
+
+concurrency:
+  group: fix-verify-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  pull-requests: write # comment on the PR, guarded by the gate
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Gate: decide whether to run + who is allowed, and resolve the PR's base/head
+  # refs. SECURITY: pull_request_target runs in the base-repo context (secrets
+  # present) but we build/run PR HEAD code, so only TRUSTED triggers proceed.
+  # --------------------------------------------------------------------------
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      pr: ${{ steps.decide.outputs.pr }}
+      post: ${{ steps.decide.outputs.post }}
+      base_repo: ${{ steps.decide.outputs.base_repo }}
+      base_sha: ${{ steps.decide.outputs.base_sha }}
+      head_repo: ${{ steps.decide.outputs.head_repo }}
+      head_sha: ${{ steps.decide.outputs.head_sha }}
+      linked_issue: ${{ steps.decide.outputs.linked_issue }}
+    steps:
+      - id: decide
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const LABEL = 'ci:verify-fix';
+            const CMD = '/verify-fix';
+            const TRUSTED = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const ev = context.eventName;
+            let run = false, pr = '', post = false;
+
+            if (ev === 'workflow_dispatch') {
+              run = true; // dispatch already requires write access
+              pr = String(context.payload.inputs.pr_number);
+              post = String(context.payload.inputs.post_comment) === 'true';
+            } else if (ev === 'pull_request_target' && context.payload.action === 'labeled') {
+              // only collaborators can apply labels → the label itself is the authz.
+              if (context.payload.label && context.payload.label.name === LABEL) {
+                run = true; post = true;
+                pr = String(context.payload.pull_request.number);
+              }
+            } else if (ev === 'issue_comment' && context.payload.action === 'created') {
+              const c = context.payload.comment;
+              const onPR = !!context.payload.issue.pull_request; // PRs only
+              const body = (c.body || '').trim();
+              if (onPR && body.startsWith(CMD) && TRUSTED.includes(c.author_association)) {
+                run = true; post = true;
+                pr = String(context.payload.issue.number);
+              }
+            }
+
+            let baseRepo = '', baseSha = '', headRepo = '', headSha = '', linked = '';
+            if (run && pr) {
+              const { owner, repo } = context.repo;
+              try {
+                const { data } = await github.rest.pulls.get({ owner, repo, pull_number: Number(pr) });
+                baseRepo = data.base.repo.full_name; baseSha = data.base.sha;
+                headRepo = data.head.repo.full_name; headSha = data.head.sha;
+                const m = (data.body || '').match(/(?:fix(?:es|ed)?|close[sd]?|resolve[sd]?)\s+#(\d+)/i);
+                linked = m ? m[1] : '';
+              } catch (e) { core.warning('could not resolve PR refs: ' + e.message); run = false; }
+            }
+
+            core.setOutput('run', String(run));
+            core.setOutput('pr', pr);
+            core.setOutput('post', String(post));
+            core.setOutput('base_repo', baseRepo);
+            core.setOutput('base_sha', baseSha);
+            core.setOutput('head_repo', headRepo);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('linked_issue', linked);
+            core.info(`run=${run} pr=${pr} base=${baseRepo}@${baseSha} head=${headRepo}@${headSha} linked=#${linked} post=${post}`);
+
+  # --------------------------------------------------------------------------
+  # Analyze: derive a STANDALONE repro from the bug this PR fixes (its linked
+  # issue + this PR's regression test). It must run on the BASE ref, which lacks
+  # the PR's test file — so it must NOT import that test.
+  # --------------------------------------------------------------------------
+  analyze:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+    outputs:
+      ready: ${{ steps.matrix.outputs.ready }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - id: mode
+        env:
+          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          if [ "$HAS_KEY" = "true" ]; then echo "mode=real" >> "$GITHUB_OUTPUT"
+          else echo "::error::Verify-fix requires ANTHROPIC_API_KEY. Refusing to fabricate a plan."; exit 1; fi
+
+      # Prefetch: the bug = the PR's linked issue (or the PR body); the regression test = this PR's diff.
+      - name: Prefetch context
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ needs.gate.outputs.pr }}
+          LINKED: ${{ needs.gate.outputs.linked_issue }}
+        run: |
+          set -euo pipefail
+          if [ -n "$LINKED" ]; then
+            gh issue view "$LINKED" --repo "$GITHUB_REPOSITORY" --json title,body,comments \
+              --jq '"# " + .title + "\n\n" + (.body // "") + "\n\n## Comments\n\n" + ([.comments[]? | select(((.body // "") | contains("## Reproduction")) | not) | "**@" + (.author.login // "?") + ":** " + (.body // "")] | join("\n\n"))' \
+              > issue.md 2>/dev/null || echo "(linked issue unavailable)" > issue.md
+          else
+            gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json title,body \
+              --jq '"# " + .title + "\n\n" + (.body // "")' > issue.md 2>/dev/null || echo "(PR unavailable)" > issue.md
+          fi
+          head -c 60000 issue.md > issue.cap && mv issue.cap issue.md
+          # This PR's diff carries the fix + the regression test.
+          { echo "# PR #$PR (the fix under verification)"; gh pr diff "$PR" --repo "$GITHUB_REPOSITORY" 2>/dev/null | head -c 60000; } > fixpr.diff
+
+      - name: Analyze (agent)
+        id: analyze
+        if: steps.mode.outputs.mode == 'real'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          prompt: |
+            Run the `reproduce` skill's Analyze phase to verify the fix in PR
+            #${{ needs.gate.outputs.pr }} of ${{ github.repository }}.
+            The bug the PR fixes (its linked issue, or the PR description) is in `./issue.md`;
+            the PR's own diff — fix AND its regression test — is in `./fixpr.diff`. READ BOTH
+            FIRST. Derive the cheapest faithful, SELF-CONTAINED repro of the bug that runs on a
+            ref that does NOT contain this PR's changes (the `base` leg) — so it must NOT
+            import or depend on the test file THIS PR adds; reproduce the symptom independently
+            (derive the assertion from the linked issue + the PR's test, but author your own
+            script/test). It asserts the HEALTHY (fixed) behaviour, so on base (fix absent) it
+            fails → reproduced, and on head (fix present) it passes → not_reproduced.
+            BE ECONOMICAL: your VERY FIRST Write must be a complete best-effort analysis.json
+            (plus its spec/test); refine only if turns remain; never finish without it. If the
+            PR has no derivable, CI-reproducible symptom, write analysis.json as
+            {"schema_version":"1","issue":${{ needs.gate.outputs.pr }},"needs_info":"<one
+            question>"} and stop. `confidence` (0..1) measures repro fidelity (not whether a
+            fix exists); set `confidence_reason` if < 0.7.
+            Pick the cheapest faithful `layer` (service < *-api < *-ui) and its `executor`
+            (service→direct, *-api→http, *-ui→playwright). THEN READ
+            `.claude/skills/reproduce/references/executors/<executor>.md` and FOLLOW it
+            (http → request/requests in analysis.json; playwright → repro.spec.ts; direct →
+            ReproTest.php; set script_path). Write analysis.json per
+            `.claude/skills/reproduce/references/SCHEMA.md`. If seeding is needed, write
+            fixtures.json (hex UUIDs + {{SC}}/{{NAV_CAT}}/{{TAX}}/{{CURRENCY}} placeholders).
+            Include `scenario` (numbered Given/When/Then). Comment every step. Emit only the
+            file(s) — no prose, no markdown fence.
+          claude_args: >-
+            --model claude-sonnet-4-6 --max-turns ${{ github.event.inputs.max_turns || '35' }}
+            --allowedTools "Read,Glob,Grep,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(gh api:*),Bash(rg:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git blame:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(jq:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(sed:*),Bash(wc:*)"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: analysis
+          path: |
+            analysis.json
+            fixtures.json
+            repro.spec.ts
+            ReproTest.php
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - id: matrix
+        env:
+          PR: ${{ needs.gate.outputs.pr }}
+          POST: ${{ needs.gate.outputs.post }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # No plan / needs_info / low confidence → don't provision two from-source builds.
+          if [ ! -f analysis.json ]; then
+            echo "::warning::analyze produced no analysis.json"
+            [ "$POST" = "true" ] && gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+              --body "## Fix verification — could not analyze"$'\n\n'"The analyzer did not produce a plan within its budget. A human can review, or re-trigger."
+            echo "ready=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          cat analysis.json
+          NEEDS=$(jq -r '.needs_info // empty' analysis.json)
+          if [ -n "$NEEDS" ]; then
+            echo "::warning::needs info: $NEEDS"
+            [ "$POST" = "true" ] && gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+              --body "## Fix verification — needs info"$'\n\n'"$NEEDS"
+            echo "ready=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          CONF=$(jq -r '.confidence // 1' analysis.json)
+          if awk "BEGIN{exit !($CONF < 0.4)}"; then
+            REASON=$(jq -r '.confidence_reason // "low confidence"' analysis.json)
+            SCEN=$(jq -r '(.scenario // []) | map("- " + .) | join("\n")' analysis.json)
+            echo "::warning::low confidence ($CONF) — not run: $REASON"
+            [ "$POST" = "true" ] && gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" \
+              --body "## Fix verification — low confidence, not run"$'\n\n'"confidence \`$CONF\` — not run (building two installs from source to test a guess is wasteful)."$'\n\n'"**Why:** $REASON"$'\n\n'"**Draft scenario:**"$'\n'"$SCEN"
+            echo "ready=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+  # --------------------------------------------------------------------------
+  # Verify: one parallel leg per ref. base = fix ABSENT, head = fix PRESENT.
+  # Both build Shopware FROM SOURCE at the leg's SHA (setup-shopware checks out
+  # shopware-version as a git ref), then run the SAME derived repro.
+  # --------------------------------------------------------------------------
+  verify:
+    needs: [gate, analyze]
+    if: needs.gate.outputs.run == 'true' && needs.analyze.outputs.ready == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40 # build-from-source is heavier than installing a release
+    strategy:
+      fail-fast: false
+      matrix:
+        leg: [base, head]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: analysis
+      - id: plan
+        env:
+          LEG: ${{ matrix.leg }}
+          BASE_REPO: ${{ needs.gate.outputs.base_repo }}
+          BASE_SHA: ${{ needs.gate.outputs.base_sha }}
+          HEAD_REPO: ${{ needs.gate.outputs.head_repo }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$LEG" = "base" ]; then echo "repo=$BASE_REPO" >> "$GITHUB_OUTPUT"; echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          else echo "repo=$HEAD_REPO" >> "$GITHUB_OUTPUT"; echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"; fi
+          echo "executor=$(jq -r .executor analysis.json)" >> "$GITHUB_OUTPUT"
+          echo "admin_build=$(jq -r .build_profile.admin_build analysis.json)" >> "$GITHUB_OUTPUT"
+          echo "storefront_build=$(jq -r .build_profile.storefront_build analysis.json)" >> "$GITHUB_OUTPUT"
+
+      # Provision the leg's ref FROM SOURCE — version=<sha>, repository=<repo> are forwarded to
+      # setup-shopware, which checks them out via actions/checkout (accepts any ref/fork).
+      - id: provision
+        if: steps.plan.outputs.executor == 'http' || steps.plan.outputs.executor == 'playwright' || steps.plan.outputs.executor == 'direct'
+        continue-on-error: true
+        uses: ./.github/actions/repro/provision
+        with:
+          version: ${{ steps.plan.outputs.sha }}
+          repository: ${{ steps.plan.outputs.repo }}
+          admin-build: ${{ steps.plan.outputs.admin_build }}
+          storefront-build: ${{ steps.plan.outputs.storefront_build }}
+
+      - name: Seed fixtures
+        id: seed
+        if: steps.provision.outcome == 'success'
+        continue-on-error: true
+        env:
+          APP_URL: ${{ steps.provision.outputs.app_url }}
+        run: PAYLOAD=fixtures.json bash .github/actions/repro/bin/seed.sh
+
+      - name: Mark leg blocked (provision/seed failed)
+        if: steps.provision.outcome != 'success' || steps.seed.outcome != 'success'
+        run: |
+          set -euo pipefail
+          jq -n --argjson issue "$(jq -r .issue analysis.json)" --arg leg "${{ matrix.leg }}" \
+            --arg version "$(jq -r .version analysis.json)" --arg executor "$(jq -r .executor analysis.json)" '{
+              schema_version:"1", issue:$issue, target:$leg, version:$version, executor:$executor,
+              status:"blocked", assertion:{expect:null,actual:null,matched:null}, duration_s:0,
+              evidence:{script:"",script_lang:"sh",reporter_output:"provision/seed failed",http:[],artifacts:[],truncated:false},
+              blocked_reason:"environment not READY (provision or seed failed) for the '"${{ matrix.leg }}"' leg" }' > result.json
+
+      - name: Run executor
+        if: steps.provision.outcome == 'success' && steps.seed.outcome == 'success'
+        env:
+          APP_URL: ${{ steps.provision.outputs.app_url }}
+          TARGET: ${{ matrix.leg }}
+        run: |
+          set -euo pipefail
+          EXECUTOR=$(jq -r .executor analysis.json)
+          case "$EXECUTOR" in
+            http)       ANALYSIS=analysis.json OUT=result.json bash .github/actions/repro/bin/run-http.sh ;;
+            playwright) ANALYSIS=analysis.json OUT=result.json bash .github/actions/repro/bin/run-playwright.sh ;;
+            direct)     ANALYSIS=analysis.json OUT=result.json SHOP_DIR=shop bash .github/actions/repro/bin/run-direct.sh ;;
+            *) echo "::warning::unknown executor"; jq -n '{schema_version:"1",status:"inconclusive",blocked_reason:"unknown executor"}' > result.json ;;
+          esac
+          cat result.json
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: repro-${{ matrix.leg }}
+          path: |
+            result.json
+            repro.sh
+            repro.spec.ts
+            ReproTest.php
+            test-results/
+            playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Verdict + report: shared scripts, MODE=fix-verify.
+  # --------------------------------------------------------------------------
+  verdict:
+    needs: [gate, analyze, verify]
+    if: always() && needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      has_results: ${{ steps.v.outputs.has_results }}
+      verdict: ${{ steps.v.outputs.verdict }}
+      base: ${{ steps.v.outputs.base }}
+      head: ${{ steps.v.outputs.head }}
+      fix_candidate: ${{ steps.v.outputs.fix_candidate }}
+      unsure_reason: ${{ steps.v.outputs.unsure_reason }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+      - id: v
+        run: MODE=fix-verify ART=artifacts bash .github/actions/repro/bin/verdict.sh
+
+  report:
+    needs: [gate, analyze, verify, verdict]
+    if: always() && needs.gate.outputs.run == 'true' && needs.verdict.outputs.has_results == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+      - id: render
+        env:
+          MODE: fix-verify
+          ISSUE: ${{ needs.gate.outputs.pr }}
+          VERDICT: ${{ needs.verdict.outputs.verdict }}
+          FIX: ${{ needs.verdict.outputs.fix_candidate }}
+          UNSURE: ${{ needs.verdict.outputs.unsure_reason }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/actions/repro/bin/report.sh
+      - name: Post comment
+        if: needs.gate.outputs.post == 'true' && needs.verdict.outputs.verdict != 'blocked'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ needs.gate.outputs.pr }}'),
+              body: fs.readFileSync('comment.md', 'utf8'),
+            });

--- a/.github/workflows/reproduce-eval.yml
+++ b/.github/workflows/reproduce-eval.yml
@@ -1,0 +1,50 @@
+name: Reproduce Skill Eval
+
+# Manually-run skillgrade eval for the `reproduce` skill's Analyze phase.
+# workflow_dispatch → pick any branch in "Run workflow"; it runs THAT branch's
+# fixtures (once this file exists on the default branch so it's dispatchable).
+# Cost-intensive: each task spawns a real agent run. Needs ANTHROPIC_API_KEY.
+
+on:
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "skillgrade --eval task (blank = all tasks)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Require API key (no silent skip)
+        env:
+          KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          [ -n "$KEY" ] || { echo "::error::ANTHROPIC_API_KEY secret is required to run the eval."; exit 1; }
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install skillgrade + claude CLI
+        run: npm i -g skillgrade zod @anthropic-ai/claude-code
+
+      - name: Run eval
+        working-directory: .claude/skills/reproduce/tests
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_MODEL: claude-sonnet-4-6 # bounded task; avoid the Opus default
+        run: |
+          set -euo pipefail
+          ARGS="--provider=local --agent=claude --ci --threshold=0.8"
+          if [ -n "${{ github.event.inputs.task }}" ]; then ARGS="$ARGS --eval=${{ github.event.inputs.task }}"; fi
+          skillgrade $ARGS

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -558,7 +558,8 @@ jobs:
             repro.spec.ts
             ReproTest.php
             test-results/
-          if-no-files-found: ignore # the runnable script (repro.sh|repro.spec.ts|ReproTest.php) + test-results/ vary by executor
+            playwright-report/
+          if-no-files-found: ignore # script (repro.sh|repro.spec.ts|ReproTest.php) + test-results/ + playwright-report/ vary by executor
           retention-days: 7
 
   # --------------------------------------------------------------------------
@@ -796,6 +797,10 @@ jobs:
                 echo "### ${t} — \`${st}\` (expected ${ex}, got ${ac})"
               fi
               echo "Reporter: \`$(jq -r .evidence.reporter_output "$f")\`"
+              # playwright legs ship the interactive HTML report (+ trace/video/screenshot).
+              if [ "$(jq -r .executor "$f")" = playwright ]; then
+                echo "📊 Interactive Playwright report + trace/video: \`repro-${t}\` artifact of the [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})  — open \`playwright-report/index.html\`."
+              fi
             done
             # The script is shared by both legs (shown once) unless http resolved differently.
             echo

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -578,57 +578,16 @@ jobs:
       fix_candidate: ${{ steps.v.outputs.fix_candidate }}
       unsure_reason: ${{ steps.v.outputs.unsure_reason }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+      # Shared, mode-parameterized verdict map (see bin/verdict.sh). Emits has_results,
+      # reported, trunk, verdict, fix_candidate, unsure_reason to the step outputs.
       - id: v
-        run: |
-          set -euo pipefail
-          REP="artifacts/repro-reported/result.json"
-          TRU="artifacts/repro-trunk/result.json"
-          # No leg produced a result → no verdict, no comment downstream.
-          if [ ! -f "$REP" ] && [ ! -f "$TRU" ]; then
-            echo "has_results=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No reproduce leg produced a result (aborted/cancelled/failed)."
-            exit 0
-          fi
-          echo "has_results=true" >> "$GITHUB_OUTPUT"
-          rep="null"; tru="null"
-          [ -f "$REP" ] && rep=$(jq -r .status "$REP")
-          [ -f "$TRU" ] && tru=$(jq -r .status "$TRU")
-          echo "reported=$rep" >> "$GITHUB_OUTPUT"
-          echo "trunk=$tru" >> "$GITHUB_OUTPUT"
-
-          A=artifacts/analysis/analysis.json
-          CONF=$(jq -r '.confidence // 1' "$A" 2>/dev/null || echo 1)
-          BLOCKED=$(jq -r '.blocked_reason // ""' "$A" 2>/dev/null || echo "")
-          DERIVED=$(jq -r '.derived_from // ""' "$A" 2>/dev/null || echo "")
-          CONF_REASON=$(jq -r '.confidence_reason // ""' "$A" 2>/dev/null || echo "")
-          # Mid-band plan (0.4–0.7; below 0.4 bailed before provision) → don't trust the
-          # verdict even if the legs ran; route to a human with the reason. Capture WHY so
-          # the report says "uncertain: <reason>" not just a number.
-          unsure=false; UNSURE_REASON=""
-          [ -n "$BLOCKED" ] && { unsure=true; UNSURE_REASON="$BLOCKED"; }
-          awk "BEGIN{exit !($CONF < 0.7)}" && { unsure=true; [ -n "$CONF_REASON" ] && UNSURE_REASON="$CONF_REASON"; }
-          echo "unsure_reason=$UNSURE_REASON" >> "$GITHUB_OUTPUT"
-
-          # Precedence: infra → unreliable-plan → indeterminate leg → core combos.
-          if   [ "$rep" = "blocked" ] || [ "$tru" = "blocked" ];               then V="blocked"
-          elif [ "$unsure" = "true" ];                                         then V="needs_human_review"
-          elif [ "$rep" = "inconclusive" ] || [ "$tru" = "inconclusive" ];     then V="needs_human_review"
-          elif [ "$rep" = "reproduced" ]     && [ "$tru" = "reproduced" ];     then V="live_bug"
-          elif [ "$rep" = "reproduced" ]     && [ "$tru" = "not_reproduced" ]; then V="fixed_on_trunk"
-          elif [ "$rep" = "not_reproduced" ] && [ "$tru" = "reproduced" ];     then V="regression"
-          elif [ "$rep" = "not_reproduced" ] && [ "$tru" = "not_reproduced" ]; then V="not_reproducible"
-          elif [ "$rep" = "null" ]           && [ "$tru" = "reproduced" ];     then V="live_bug"
-          elif [ "$rep" = "null" ]           && [ "$tru" = "not_reproduced" ]; then V="not_reproducible"
-          else V="needs_human_review"
-          fi
-          echo "verdict=$V" >> "$GITHUB_OUTPUT"
-          # fixed_on_trunk: the fixing PR/commit is often already known (Analyze's derived_from).
-          FIX=""; [ "$V" = "fixed_on_trunk" ] && FIX="$DERIVED"
-          echo "fix_candidate=$FIX" >> "$GITHUB_OUTPUT"
-          echo "verdict=$V reported=$rep trunk=$tru unsure=$unsure fix='$FIX'"
+        run: MODE=reproduce ART=artifacts bash .github/actions/repro/bin/verdict.sh
 
   # --------------------------------------------------------------------------
   # Attribute (AGENT, gated): on a diverging verdict, name the commit that fixed
@@ -698,124 +657,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+      # Shared, mode-parameterized renderer (see bin/report.sh): writes comment.md and the
+      # collapsible job summary, with the script dedup + playwright HTML-report pointer.
       - id: render
         env:
+          MODE: reproduce
           ISSUE: ${{ needs.gate.outputs.issue }}
           VERDICT: ${{ needs.verdict.outputs.verdict }}
-          REP: ${{ needs.verdict.outputs.reported }}
-          TRU: ${{ needs.verdict.outputs.trunk }}
           FIX: ${{ needs.verdict.outputs.fix_candidate }}
           UNSURE: ${{ needs.verdict.outputs.unsure_reason }}
-        run: |
-          set -euo pipefail
-          LAYER=$(jq -r .layer artifacts/analysis/analysis.json 2>/dev/null || echo "unknown")
-          ATTR="artifacts/attribution/attribution.json"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          RF="artifacts/repro-reported/result.json"; TF="artifacts/repro-trunk/result.json"
-          have_r=0; [ -f "$RF" ] && have_r=1
-          have_t=0; [ -f "$TF" ] && have_t=1
-          # The generated script is identical across legs for direct/playwright (authored
-          # ONCE and reused) and usually for http; only http can vary (per-leg resolved
-          # ids/tokens). Decide once whether to show it a single time or per-leg, so we don't
-          # list two copies of the same script.
-          same=0; maxlines=0
-          for f in "$RF" "$TF"; do
-            [ -f "$f" ] || continue
-            n=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' ')
-            [ "$n" -gt "$maxlines" ] && maxlines=$n
-          done
-          if [ "$have_r" = 1 ] && [ "$have_t" = 1 ]; then
-            cmp -s <(jq -r '.evidence.script // ""' "$RF") <(jq -r '.evidence.script // ""' "$TF") && same=1
-          fi
-          # emit_script <result.json> <label-suffix> <mode: comment|full>
-          emit_script () {
-            local f="$1" label="$2" mode="$3" lang nlines
-            lang=$(jq -r '.evidence.script_lang // "sh"' "$f")
-            nlines=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' ')
-            [ "$nlines" -gt 0 ] || return 0
-            echo "**Repro script${label}** (\`${lang}\`)"
-            if [ "$mode" = comment ] && [ "$nlines" -gt 60 ]; then
-              echo "_${nlines} lines — in the \`repro-*\` run [artifact](${RUN_URL})._"
-            else
-              echo "\`\`\`${lang}"; jq -r .evidence.script "$f"; echo '```'
-            fi
-          }
-          # Show one script when the legs match (direct/playwright/most http); both only when
-          # http resolved to genuinely different ids. mode picks comment (trim long) vs full.
-          render_scripts () {
-            local mode="$1"
-            if [ "$have_r" = 1 ] && [ "$have_t" = 1 ] && [ "$same" = 1 ]; then
-              emit_script "$RF" " (run unchanged on both legs)" "$mode"
-            elif [ "$have_r" = 1 ] && [ "$have_t" = 1 ]; then
-              emit_script "$RF" " — reported" "$mode"; echo; emit_script "$TF" " — trunk" "$mode"
-            elif [ "$have_r" = 1 ]; then emit_script "$RF" "" "$mode"
-            elif [ "$have_t" = 1 ]; then emit_script "$TF" "" "$mode"
-            fi
-          }
-          {
-            echo "## Reproduction — Issue #${ISSUE}: \`${VERDICT}\`"
-            echo
-            echo "Layer \`${LAYER}\` · reported: \`${REP}\` · trunk: \`${TRU}\` · [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            echo
-            # Scenario (human-readable intent) before the per-leg scripts.
-            if jq -e '.scenario | arrays and length > 0' artifacts/analysis/analysis.json >/dev/null 2>&1; then
-              echo "**Scenario**"
-              jq -r '.scenario[] | "1. " + .' artifacts/analysis/analysis.json
-              echo
-            fi
-            if [ "$VERDICT" = "fixed_on_trunk" ] && [ -n "$FIX" ]; then
-              echo "**Likely fix (backport candidate):** ${FIX}"
-            fi
-            if [ "$VERDICT" = "regression" ]; then
-              echo "> ⚠️ **Regression**: not reproduced on the reported version but reproduced on trunk. Confirm the reported leg actually exercised the symptom (a missing fixture can cause a false negative)."
-            fi
-            if [ "$VERDICT" = "needs_human_review" ]; then
-              # The legs ran but the plan was mid-confidence (0.4–0.7) or a leg was indeterminate.
-              # Show the evidence below; flag WHY a human should adjudicate rather than trust the legs.
-              echo "> 🟡 **Needs human review**: the verdict is not trusted automatically${UNSURE:+ — ${UNSURE}}. The leg evidence below is informative but unconfirmed; confirm against the steps before acting."
-            fi
-            if [ -f "$ATTR" ]; then
-              KIND=$(jq -r .kind "$ATTR"); CMT=$(jq -r .likely_commit "$ATTR"); RSN=$(jq -r .reasoning "$ATTR")
-              echo "**Likely ${KIND} commit:** \`${CMT}\` — ${RSN}"
-            fi
-            # Per-leg verdicts — these legitimately differ between the two versions.
-            for t in reported trunk; do
-              f="artifacts/repro-${t}/result.json"
-              [ -f "$f" ] || continue
-              st=$(jq -r .status "$f"); br=$(jq -r '.blocked_reason // ""' "$f")
-              echo
-              if [ -n "$br" ] && [ "$br" != "null" ]; then
-                # blocked/inconclusive: the assertion never ran — show WHY (incl. the failing response body)
-                echo "### ${t} — \`${st}\`"
-                echo
-                echo "> ⚠️ ${br}"
-              else
-                ex=$(jq -r .assertion.expect "$f"); ac=$(jq -r .assertion.actual "$f")
-                echo "### ${t} — \`${st}\` (expected ${ex}, got ${ac})"
-              fi
-              echo "Reporter: \`$(jq -r .evidence.reporter_output "$f")\`"
-              # playwright legs ship the interactive HTML report (+ trace/video/screenshot).
-              if [ "$(jq -r .executor "$f")" = playwright ]; then
-                echo "📊 Interactive Playwright report + trace/video: \`repro-${t}\` artifact of the [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})  — open \`playwright-report/index.html\`."
-              fi
-            done
-            # The script is shared by both legs (shown once) unless http resolved differently.
-            echo
-            render_scripts comment
-          } > comment.md
-          # Job summary mirrors the comment; if the comment trimmed a long script to a pointer,
-          # append the full script (collapsed) so it stays visible on the run page too.
-          {
-            cat comment.md
-            if [ "$maxlines" -gt 60 ]; then
-              echo; echo "<details><summary>Full generated repro script</summary>"; echo
-              render_scripts full
-              echo; echo "</details>"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash .github/actions/repro/bin/report.sh
       - name: Post comment
         # 'blocked' = the repro env/seed failed (infra), not a bug verdict → keep it in the
         # job summary, don't post public noise on the issue. Real verdicts still post.

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -267,22 +267,26 @@ jobs:
             below 0.4 is NOT executed (a human is asked to confirm the draft first), so the
             reason is what they act on. For a playwright
             layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE,
-            semantic locators — getByRole(role, {name}) / getByText / getByPlaceholder with
-            case-insensitive regex and user-visible/accessible names. For form inputs (login,
-            search) prefer getByRole('textbox'|'combobox', {name}) or getByPlaceholder; do NOT
-            use getByLabel for inputs — Shopware's custom admin/storefront fields have no
-            associated <label>, so getByLabel silently matches nothing (a real bug we hit: a
-            "Username" field is reachable as getByRole('textbox', {name:/username/i}), not
-            getByLabel). NEVER use CSS classes, data-test ids, or attribute selectors — not
-            even as a fallback; an element no semantic locator can reach IS a
-            PRECONDITION_NOT_FOUND. The admin SPA is slow to bootstrap (especially on a mobile
-            viewport) — wait robustly (locator.waitFor visible) for the login field and the
-            dashboard, don't use an instant isVisible() right after goto. The SAME spec runs on
-            BOTH the reported and trunk versions, so it must tolerate UI drift. Structure it in
-            two parts: (1) NAVIGATION/PRECONDITION
-            — reach the state and verify each element the repro depends on EXISTS; if a
-            required element is absent, `throw new Error('PRECONDITION_NOT_FOUND: <what>')`
-            (or test.skip) so a changed-UI version is reported inconclusive, NOT as a false
+            semantic locators — getByRole(role, {name}) / getByLabel / getByText /
+            getByPlaceholder with case-insensitive regex and user-visible/accessible names.
+            For form inputs, getByRole('textbox'|'combobox', {name}) AND getByLabel both work
+            (getByLabel resolves aria-label / aria-labelledby / associated <label>, all of
+            which Shopware's mt-* fields expose as the accessible name). NEVER use CSS classes,
+            data-test ids, or attribute selectors — not even as a fallback; an element no
+            semantic locator can reach IS a PRECONDITION_NOT_FOUND.
+            CRITICAL — gate EVERY precondition on a WAITING check: `await
+            expect(locator).toBeVisible({timeout})` or `locator.waitFor({state:'visible',
+            timeout})`, then treat the timeout as PRECONDITION_NOT_FOUND. NEVER use
+            `isVisible()`/`isHidden()` to decide a precondition — they return the element's
+            CURRENT state immediately and IGNORE any timeout option, so right after
+            `page.goto('/admin')` (the admin SPA is still bootstrapping) they return false in
+            milliseconds and throw a FALSE PRECONDITION_NOT_FOUND (this is exactly the #6 miss
+            — the getByLabel locator was correct; the un-waiting isVisible was the bug).
+            The SAME spec runs on BOTH the reported and trunk versions, so it must tolerate UI
+            drift. Structure it in two parts: (1) NAVIGATION/PRECONDITION
+            — reach the state and wait for each element the repro depends on to be visible; if
+            it never appears, `throw new Error('PRECONDITION_NOT_FOUND: <what>')` (or
+            test.skip) so a changed-UI version is reported inconclusive, NOT as a false
             reproduction; (2) exactly ONE symptom assertion of the HEALTHY behaviour via
             expect(). Do NOT read storefront templates/JS to hunt exact selectors; emit the
             spec immediately. Treat this as a hard budget: do not exceed ~15 tool calls

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -265,65 +265,22 @@ jobs:
             "symptom is timing/environment-dependent and may not reproduce in CI" or "symptom
             under-specified: no concrete expected value to assert") — never "no fix PR". A run
             below 0.4 is NOT executed (a human is asked to confirm the draft first), so the
-            reason is what they act on. For a playwright
-            layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE
-            semantic locators — getByRole(role,{name}) / getByLabel / getByText /
-            getByPlaceholder with case-insensitive regex and accessible/visible names
-            (getByRole and getByLabel both resolve aria-label/aria-labelledby/<label>, which
-            Shopware's mt-* fields expose). Scope locators inside the relevant landmark and use
-            SPECIFIC names to avoid strict-mode ambiguity (e.g.
-            getByRole('navigation').getByRole('link',{name:/^Products$/i}), NOT a broad regex
-            with .first()). NEVER use CSS classes, data-test ids, or attribute selectors, even
-            as a fallback; an element no semantic locator can reach IS a PRECONDITION_NOT_FOUND.
-            The SAME spec runs on BOTH the reported and trunk versions, so it must tolerate UI
-            drift. Structure it in two parts:
-            (1) NAVIGATION/PRECONDITION — reach the state and WAIT for each element the repro
-            depends on: `await locator.waitFor({state:'visible',timeout}).catch(() => { throw
-            new Error('PRECONDITION_NOT_FOUND: <what>') })`. NEVER gate a precondition on
-            isVisible()/isHidden() (they return the CURRENT state immediately and IGNORE the
-            timeout, so right after page.goto they false-negative while the SPA is still
-            loading — the #6 miss) and NEVER on expect()/toBeVisible() (a precondition that
-            times out would be misread as the SYMPTOM => false `reproduced`). Do NOT wait via
-            waitForLoadState('networkidle') (the admin SPA long-polls and never settles) or
-            waitForURL() on a pattern already true before the action — wait for a concrete
-            post-action element instead.
-            (2) exactly ONE SYMPTOM assertion of the HEALTHY behaviour via `await expect(...)` —
-            this is the ONLY failure that may mean `reproduced`, so give it a generous timeout.
-            For a hidden/closed/collapsed/off-canvas symptom use
-            `await expect(locator).not.toBeInViewport()` or assert explicit state
-            (toHaveAttribute('aria-hidden','true')) — NOT not.toBeVisible(): an element moved
-            off-screen via transform/translate is still "visible" to Playwright, so toBeVisible
-            would fail on BOTH versions and FAKE a reproduction. Do NOT read storefront templates/JS to hunt exact selectors; emit the
-            spec immediately. Treat this as a hard budget: do not exceed ~15 tool calls
-            before writing the file(s).
-            Write the analysis.json object (per
-            .claude/skills/reproduce/references/SCHEMA.md) to `analysis.json` in the
-            workspace root. If the repro needs seeded entities, ALSO write the admin
-            sync payload to `fixtures.json` (the path in fixtures.sync_payload_path),
-            using {{SC}}/{{NAV_CAT}}/{{TAX}}/{{CURRENCY}} placeholders for install-specific
-            ids. Every entity id you mint MUST be a 32-char lowercase-hex Shopware UUID
-            (e.g. 0192f3c4a5b67890abcdef0123456789) — never a human-readable string like
-            "repro-1" (the sync API rejects non-UUIDs). For http, use `request` or
-            `requests` (a multi-step array; the executor carries sw-context-token and
-            injects sw-access-key — never add those); reference PRE-EXISTING install ids via
-            {{SC}}/{{COUNTRY}}/{{SALUTATION}}/{{SALUTATION2}}/{{STOREFRONT_URL}} placeholders
-            the executor resolves. For a `playwright` (UI) layer, ALSO generate the test as `repro.spec.ts`
-            (referenced by script_path) — it must assert the HEALTHY behaviour and use
-            relative paths (baseURL is injected). For a `direct`/`service` layer (a bug that
-            can't fire faithfully through store-api or the UI — license-gated, an internal
-            service, or heavy domain setup), ALSO generate a minimal PHPUnit integration test
-            as `ReproTest.php` (referenced by script_path): namespace
-            `Shopware\Tests\Integration\Repro`, class `ReproTest extends TestCase` using
-            `IntegrationTestBehaviour` + `KernelTestBehaviour`, services from
-            `$this->getContainer()`. REUSE the fix PR's regression-test setup where it exists
-            (./fixpr.diff) — do NOT reinvent the bootstrap. The single test method must ASSERT
-            THE HEALTHY (fixed) behaviour so it fails on the buggy version. Prefer STABLE
-            service/DAL APIs so the same test also runs on the reported version; if it can
-            only compile on trunk, that is fine (the reported leg reports `inconclusive`,
-            never a bogus pass). Include `scenario` in analysis.json: a
-            plain-English, numbered Given/When/Then list of the repro steps. Comment EVERY
-            step of the generated script (curl or spec) explaining what it does and what it
-            asserts. Emit only those file(s) — no prose, no markdown fence. Do not comment or label.
+            reason is what they act on.
+            Pick the cheapest faithful `layer` (service < *-api < *-ui; escalate only when a
+            cheaper layer cannot fire the symptom) and its matching `executor`: service →
+            direct, *-api → http, *-ui → playwright. THEN READ
+            `.claude/skills/reproduce/references/executors/<executor>.md` and FOLLOW that
+            file's authoring contract for the script that executor needs (http → `request`/
+            `requests` in analysis.json, no separate file; playwright → `repro.spec.ts`;
+            direct → `ReproTest.php`; set `script_path` accordingly). Write analysis.json (per
+            `.claude/skills/reproduce/references/SCHEMA.md`) to `analysis.json` in the
+            workspace root. If the repro needs seeded entities, ALSO write the admin sync
+            payload to `fixtures.json` (fixtures.sync_payload_path): mint 32-char
+            lowercase-hex UUIDs for entities you create and use {{SC}}/{{NAV_CAT}}/{{TAX}}/
+            {{CURRENCY}} placeholders for install ids (never human-readable ids — the sync API
+            rejects them). Include `scenario`: a plain-English, numbered Given/When/Then list
+            of the repro steps. Comment every step of the generated script. Emit only the
+            file(s) — no prose, no markdown fence. Do not comment or label.
           # Pin Sonnet (bounded task) + cap turns (bounds cost when the agent can't find
           # context, e.g. off-repo). Widen the READ-ONLY allowlist so the agent stops
           # thrashing on denied tools (denials burn turns -> $). Matches triage's pins.

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -267,11 +267,19 @@ jobs:
             below 0.4 is NOT executed (a human is asked to confirm the draft first), so the
             reason is what they act on. For a playwright
             layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE,
-            semantic locators (getByRole / getByLabel / getByText with case-insensitive
-            regex, ARIA roles, user-visible text) — NEVER CSS classes, data-test ids, or DOM
-            structure, which churn between versions and would make the reported leg fail for
-            the WRONG reason. The SAME spec runs on BOTH the reported and trunk versions, so
-            it must tolerate UI drift. Structure it in two parts: (1) NAVIGATION/PRECONDITION
+            semantic locators — getByRole(role, {name}) / getByText / getByPlaceholder with
+            case-insensitive regex and user-visible/accessible names. For form inputs (login,
+            search) prefer getByRole('textbox'|'combobox', {name}) or getByPlaceholder; do NOT
+            use getByLabel for inputs — Shopware's custom admin/storefront fields have no
+            associated <label>, so getByLabel silently matches nothing (a real bug we hit: a
+            "Username" field is reachable as getByRole('textbox', {name:/username/i}), not
+            getByLabel). NEVER use CSS classes, data-test ids, or attribute selectors — not
+            even as a fallback; an element no semantic locator can reach IS a
+            PRECONDITION_NOT_FOUND. The admin SPA is slow to bootstrap (especially on a mobile
+            viewport) — wait robustly (locator.waitFor visible) for the login field and the
+            dashboard, don't use an instant isVisible() right after goto. The SAME spec runs on
+            BOTH the reported and trunk versions, so it must tolerate UI drift. Structure it in
+            two parts: (1) NAVIGATION/PRECONDITION
             — reach the state and verify each element the repro depends on EXISTS; if a
             required element is absent, `throw new Error('PRECONDITION_NOT_FOUND: <what>')`
             (or test.skip) so a changed-UI version is reported inconclusive, NOT as a false

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -266,29 +266,34 @@ jobs:
             under-specified: no concrete expected value to assert") — never "no fix PR". A run
             below 0.4 is NOT executed (a human is asked to confirm the draft first), so the
             reason is what they act on. For a playwright
-            layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE,
-            semantic locators — getByRole(role, {name}) / getByLabel / getByText /
-            getByPlaceholder with case-insensitive regex and user-visible/accessible names.
-            For form inputs, getByRole('textbox'|'combobox', {name}) AND getByLabel both work
-            (getByLabel resolves aria-label / aria-labelledby / associated <label>, all of
-            which Shopware's mt-* fields expose as the accessible name). NEVER use CSS classes,
-            data-test ids, or attribute selectors — not even as a fallback; an element no
-            semantic locator can reach IS a PRECONDITION_NOT_FOUND.
-            CRITICAL — gate EVERY precondition on a WAITING check: `await
-            expect(locator).toBeVisible({timeout})` or `locator.waitFor({state:'visible',
-            timeout})`, then treat the timeout as PRECONDITION_NOT_FOUND. NEVER use
-            `isVisible()`/`isHidden()` to decide a precondition — they return the element's
-            CURRENT state immediately and IGNORE any timeout option, so right after
-            `page.goto('/admin')` (the admin SPA is still bootstrapping) they return false in
-            milliseconds and throw a FALSE PRECONDITION_NOT_FOUND (this is exactly the #6 miss
-            — the getByLabel locator was correct; the un-waiting isVisible was the bug).
+            layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE
+            semantic locators — getByRole(role,{name}) / getByLabel / getByText /
+            getByPlaceholder with case-insensitive regex and accessible/visible names
+            (getByRole and getByLabel both resolve aria-label/aria-labelledby/<label>, which
+            Shopware's mt-* fields expose). Scope locators inside the relevant landmark and use
+            SPECIFIC names to avoid strict-mode ambiguity (e.g.
+            getByRole('navigation').getByRole('link',{name:/^Products$/i}), NOT a broad regex
+            with .first()). NEVER use CSS classes, data-test ids, or attribute selectors, even
+            as a fallback; an element no semantic locator can reach IS a PRECONDITION_NOT_FOUND.
             The SAME spec runs on BOTH the reported and trunk versions, so it must tolerate UI
-            drift. Structure it in two parts: (1) NAVIGATION/PRECONDITION
-            — reach the state and wait for each element the repro depends on to be visible; if
-            it never appears, `throw new Error('PRECONDITION_NOT_FOUND: <what>')` (or
-            test.skip) so a changed-UI version is reported inconclusive, NOT as a false
-            reproduction; (2) exactly ONE symptom assertion of the HEALTHY behaviour via
-            expect(). Do NOT read storefront templates/JS to hunt exact selectors; emit the
+            drift. Structure it in two parts:
+            (1) NAVIGATION/PRECONDITION — reach the state and WAIT for each element the repro
+            depends on: `await locator.waitFor({state:'visible',timeout}).catch(() => { throw
+            new Error('PRECONDITION_NOT_FOUND: <what>') })`. NEVER gate a precondition on
+            isVisible()/isHidden() (they return the CURRENT state immediately and IGNORE the
+            timeout, so right after page.goto they false-negative while the SPA is still
+            loading — the #6 miss) and NEVER on expect()/toBeVisible() (a precondition that
+            times out would be misread as the SYMPTOM => false `reproduced`). Do NOT wait via
+            waitForLoadState('networkidle') (the admin SPA long-polls and never settles) or
+            waitForURL() on a pattern already true before the action — wait for a concrete
+            post-action element instead.
+            (2) exactly ONE SYMPTOM assertion of the HEALTHY behaviour via `await expect(...)` —
+            this is the ONLY failure that may mean `reproduced`, so give it a generous timeout.
+            For a hidden/closed/collapsed/off-canvas symptom use
+            `await expect(locator).not.toBeInViewport()` or assert explicit state
+            (toHaveAttribute('aria-hidden','true')) — NOT not.toBeVisible(): an element moved
+            off-screen via transform/translate is still "visible" to Playwright, so toBeVisible
+            would fail on BOTH versions and FAKE a reproduction. Do NOT read storefront templates/JS to hunt exact selectors; emit the
             spec immediately. Treat this as a hard budget: do not exceed ~15 tool calls
             before writing the file(s).
             Write the analysis.json object (per

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -223,7 +223,7 @@ jobs:
         # complete analysis.json (written before the cap) still counts. The matrix
         # step fails cleanly if no analysis.json was produced.
         continue-on-error: true
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Use the default token so the action skips the Claude GitHub App token
@@ -704,7 +704,7 @@ jobs:
       - name: Attribute (agent)
         if: steps.mode.outputs.real == 'true'
         continue-on-error: true # enrichment only — a failed attribution must not red the run
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@11ba60486e4aec9ddfeafcf4bb3f00b028ac2c16 # v1.0.142
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ github.token }}

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -239,14 +239,24 @@ jobs:
             budget: do the MINIMUM investigation to fill the plan (a few targeted searches,
             NOT a full code tour), then WRITE the output file(s) immediately as your top
             priority. If still uncertain after a handful of tool calls, emit a best-effort
-            plan with a lower `confidence` rather than exploring further. `confidence` is how
-            faithful you believe the plan is (0..1); a plan derived from a linked fix PR's
-            regression test is high (~0.95), one where you had to infer the repro steps with
-            NO fix PR to anchor on is low. Whenever `confidence` < 0.7 you MUST also set
-            `confidence_reason` to one short sentence saying what makes it uncertain (e.g.
-            "no linked fix PR; repro steps inferred from the issue body") — a run below 0.4 is
-            NOT executed (a human is asked to confirm the draft first), so the reason is what
-            they act on. For a playwright
+            plan with a lower `confidence` rather than exploring further. `confidence` (0..1)
+            measures how FAITHFULLY the plan reproduces the reported symptom — NOT whether a
+            fix exists. It is HIGH when the symptom can be asserted deterministically (clear
+            expected-vs-actual, a stable endpoint/field/locator) AND the environment is
+            faithfully reproducible in CI. It is LOW when the symptom is vague or
+            non-deterministic, depends on environment CI can't reproduce (specific
+            timing/network/hardware/third-party state), or the failing layer is unclear.
+            A linked fix PR's regression test is the PREFERRED SOURCE to derive the assertion
+            from (derive, don't discover) and makes a confident plan easy — but its ABSENCE is
+            NEUTRAL: derive the assertion from the issue's described symptom and stay confident
+            if that symptom is concrete and reproducible. Do NOT lower confidence merely
+            because there is no fix PR — open, unfixed, clearly-described bugs are exactly what
+            this pipeline should reproduce. Whenever `confidence` < 0.7 you MUST also set
+            `confidence_reason` to the FAITHFULNESS obstacle in one short sentence (e.g.
+            "symptom is timing/environment-dependent and may not reproduce in CI" or "symptom
+            under-specified: no concrete expected value to assert") — never "no fix PR". A run
+            below 0.4 is NOT executed (a human is asked to confirm the draft first), so the
+            reason is what they act on. For a playwright
             layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE,
             semantic locators (getByRole / getByLabel / getByText with case-insensitive
             regex, ARIA roles, user-visible text) — NEVER CSS classes, data-test ids, or DOM

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -5,8 +5,8 @@ name: Reproduce Issue
 #   gate ─▶ analyze ─▶ reproduce (matrix: reported ‖ trunk, parallel) ─▶ report
 #
 # Status: analyze = real claude-code-action agent (explicit dry_run demo / hard-fail
-# if no key); reproduce(http) = real provision + executor; reproduce(direct|playwright)
-# = stubs (emit inconclusive). All JSON conforms to
+# if no key); reproduce = real provision + executor for all three layers
+# (http / playwright / direct). All JSON conforms to
 # .claude/skills/reproduce/references/SCHEMA.md.
 
 on:

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -389,7 +389,10 @@ jobs:
   # --------------------------------------------------------------------------
   reproduce:
     needs: [gate, analyze]
-    if: needs.gate.outputs.run == 'true'
+    # Skip cleanly (don't fail the run) when there are no targets — analyze emitted an
+    # empty matrix for needs_info or a < 0.4 low-confidence bail-out. An empty fromJSON('[]')
+    # matrix would otherwise error on expansion and turn a correct no-op run red.
+    if: needs.gate.outputs.run == 'true' && needs.analyze.outputs.targets != '[]' && needs.analyze.outputs.targets != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # No explicit name: the matrix is a list of version strings, so GitHub's default

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -247,11 +247,19 @@ jobs:
             "no linked fix PR; repro steps inferred from the issue body") — a run below 0.4 is
             NOT executed (a human is asked to confirm the draft first), so the reason is what
             they act on. For a playwright
-            layer, write the spec straight FROM THE ISSUE'S STEPS using resilient
-            role/text locators (getByRole / getByText / getByLabel) — do NOT read
-            storefront templates/JS to hunt exact selectors. A simple, imperfect spec is
-            fine (the trace shows what happened); emit it immediately. Treat this as a hard
-            budget: do not exceed ~15 tool calls before writing the file(s).
+            layer, write the spec straight FROM THE ISSUE'S STEPS using VERSION-STABLE,
+            semantic locators (getByRole / getByLabel / getByText with case-insensitive
+            regex, ARIA roles, user-visible text) — NEVER CSS classes, data-test ids, or DOM
+            structure, which churn between versions and would make the reported leg fail for
+            the WRONG reason. The SAME spec runs on BOTH the reported and trunk versions, so
+            it must tolerate UI drift. Structure it in two parts: (1) NAVIGATION/PRECONDITION
+            — reach the state and verify each element the repro depends on EXISTS; if a
+            required element is absent, `throw new Error('PRECONDITION_NOT_FOUND: <what>')`
+            (or test.skip) so a changed-UI version is reported inconclusive, NOT as a false
+            reproduction; (2) exactly ONE symptom assertion of the HEALTHY behaviour via
+            expect(). Do NOT read storefront templates/JS to hunt exact selectors; emit the
+            spec immediately. Treat this as a hard budget: do not exceed ~15 tool calls
+            before writing the file(s).
             Write the analysis.json object (per
             .claude/skills/reproduce/references/SCHEMA.md) to `analysis.json` in the
             workspace root. If the repro needs seeded entities, ALSO write the admin

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -31,10 +31,16 @@ on:
         default: false
         type: boolean
       dry_run:
-        description: "DEMO: skip the Analyze agent and emit a canned plan (smoke-test the wiring without an API key)"
+        description: "DEMO: skip the Analyze agent and emit a canned plan (smoke-test the wiring without an API key, $0)"
         required: false
         default: false
         type: boolean
+      demo_layer:
+        description: "DEMO (dry_run only): which executor to smoke-test end-to-end"
+        required: false
+        default: "http"
+        type: choice
+        options: [http, direct, playwright]
       branch:
         description: "Branch/ref the trunk leg reproduces against (defaults to trunk)"
         required: false
@@ -309,23 +315,54 @@ jobs:
             --allowedTools "Read,Glob,Grep,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(gh api:*),Bash(rg:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git blame:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(jq:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(sed:*),Bash(wc:*)"
 
       # DEMO only: canned plan, reached solely via dry_run=true.
+      # DEMO: a canned plan per layer so the WHOLE pipeline (provision → executor → verdict
+      # → report) can be smoke-tested for $0 — no agent, no API key. confidence is 1.0 so the
+      # < 0.4 bail-out doesn't suppress the run; derived_from + the ::warning:: mark it fake.
       - name: Analyze (dry-run demo)
         if: steps.mode.outputs.mode == 'dry_run'
         env:
           ISSUE: ${{ needs.gate.outputs.issue }}
+          DEMO_LAYER: ${{ github.event.inputs.demo_layer || 'http' }}
         run: |
           set -euo pipefail
-          echo "::warning::DEMO dry-run — emitting a canned plan, NOT a real analysis."
-          jq -n --argjson issue "$ISSUE" '{
-            schema_version: "1", issue: $issue, layer: "store-api", executor: "http",
-            version: "6.6.10.0",
-            scenario: ["Given a running shop", "When POST /store-api/checkout/cart with an empty body", "Then a healthy shop returns HTTP 400"],
-            build_profile: { admin_build: false, storefront_build: false, theme_build: false },
-            fixtures: { demodata: false, sync_payload_path: "fixtures.json" },
-            request: { method: "POST", path: "/store-api/checkout/cart", headers: { "Content-Type": "application/json" }, body: "{}" },
-            assertion: { kind: "http_status", expect: "400", field: null, locator: "/store-api/checkout/cart" },
-            derived_from: "DEMO (dry-run)", confidence: 0.0, blocked_reason: null
-          }' > analysis.json
+          echo "::warning::DEMO dry-run ($DEMO_LAYER) — canned plan, NOT a real analysis."
+          case "$DEMO_LAYER" in
+            http)
+              jq -n --argjson issue "$ISSUE" '{
+                schema_version:"1", issue:$issue, layer:"store-api", executor:"http", version:"6.6.10.0",
+                scenario:["Given a running shop","When POST /store-api/checkout/cart with an empty body","Then a healthy shop returns HTTP 400"],
+                build_profile:{admin_build:false,storefront_build:false,theme_build:false},
+                fixtures:{demodata:false,sync_payload_path:"fixtures.json"},
+                request:{method:"POST",path:"/store-api/checkout/cart",headers:{"Content-Type":"application/json"},body:"{}"},
+                assertion:{kind:"http_status",expect:"400",field:null,locator:"/store-api/checkout/cart"},
+                derived_from:"DEMO (dry-run)", confidence:1.0, blocked_reason:null
+              }' > analysis.json
+              ;;
+            direct)
+              jq -n --argjson issue "$ISSUE" '{
+                schema_version:"1", issue:$issue, layer:"service", executor:"direct", version:"6.6.10.0",
+                scenario:["Given a provisioned shop","When a PHPUnit integration test resolves a core service","Then the service is available (healthy)"],
+                build_profile:{admin_build:false,storefront_build:false,theme_build:false},
+                fixtures:{demodata:false,sync_payload_path:"fixtures.json"},
+                script_path:"ReproTest.php",
+                derived_from:"DEMO (dry-run)", confidence:1.0, blocked_reason:null
+              }' > analysis.json
+              cp .github/actions/repro/demo/ReproTest.php ReproTest.php
+              ;;
+            playwright)
+              jq -n --argjson issue "$ISSUE" '{
+                schema_version:"1", issue:$issue, layer:"admin-ui", executor:"playwright", version:"6.6.10.0",
+                scenario:["Given a provisioned shop with the admin built","When the admin entry point is opened","Then the page renders (healthy)"],
+                build_profile:{admin_build:true,storefront_build:false,theme_build:false},
+                fixtures:{demodata:false,sync_payload_path:"fixtures.json"},
+                script_path:"repro.spec.ts",
+                derived_from:"DEMO (dry-run)", confidence:1.0, blocked_reason:null
+              }' > analysis.json
+              cp .github/actions/repro/demo/repro.spec.ts repro.spec.ts
+              ;;
+            *) echo "::error::unknown demo_layer '$DEMO_LAYER'"; exit 1 ;;
+          esac
+          cat analysis.json
 
       # Capture the agent transcript (tool calls, denials, per-turn breakdown) for cost
       # analysis. Fork/dev only — gate behind debug before the real shopware PR (tool

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -1,0 +1,784 @@
+name: Reproduce Issue
+
+# Hand-written orchestrator for the bug-reproduction pipeline.
+#
+#   gate ─▶ analyze ─▶ reproduce (matrix: reported ‖ trunk, parallel) ─▶ report
+#
+# Status: analyze = real claude-code-action agent (explicit dry_run demo / hard-fail
+# if no key); reproduce(http) = real provision + executor; reproduce(direct|playwright)
+# = stubs (emit inconclusive). All JSON conforms to
+# .claude/skills/reproduce/references/SCHEMA.md.
+
+on:
+  issues:
+    types: [labeled] # initial trigger: apply the `ci:reproduce` label
+  issue_comment:
+    types: [created] # initial trigger: comment `/reproduce`
+  workflow_dispatch: # on-demand run (BOTH legs by default; opt into trunk-only via skip_reported)
+    inputs:
+      issue_number:
+        description: "Issue number to reproduce"
+        required: true
+        type: number
+      skip_reported:
+        description: "Re-check trunk only (skip the reported-version leg)"
+        required: false
+        default: false
+        type: boolean
+      post_comment:
+        description: "Post the result as an issue comment (otherwise job summary only)"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "DEMO: skip the Analyze agent and emit a canned plan (smoke-test the wiring without an API key)"
+        required: false
+        default: false
+        type: boolean
+      branch:
+        description: "Branch/ref the trunk leg reproduces against (defaults to trunk)"
+        required: false
+        default: "trunk"
+        type: string
+      max_turns:
+        description: "Cap on the Analyze agent's turns (cost control; default 35)"
+        required: false
+        default: "35"
+        type: string
+
+concurrency:
+  group: reproduce-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+env:
+  # shopware/setup-shopware pulls node20 sub-actions (runs-on/action, setup-php, cache,
+  # checkout@v4); force them onto node24 to silence the deprecation warning we don't own.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  issues: write # comment + label, guarded by the gate job
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Decide whether to run, who is allowed, and which issue. One source of truth
+  # for downstream `if:` guards.
+  # --------------------------------------------------------------------------
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      issue: ${{ steps.decide.outputs.issue }}
+      is_manual: ${{ steps.decide.outputs.is_manual }}
+      post: ${{ steps.decide.outputs.post }}
+      skip_reported: ${{ steps.decide.outputs.skip_reported }}
+      needs_info: ${{ steps.decide.outputs.needs_info }}
+    steps:
+      - id: decide
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const LABEL = 'ci:reproduce';
+            const CMD = '/reproduce';
+            const TRUSTED = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const ev = context.eventName;
+            let run = false, issue = '', isManual = false, post = false, skipReported = false;
+
+            if (ev === 'workflow_dispatch') {
+              // dispatch already requires write access → trusted. Runs BOTH legs unless
+              // skip_reported is set (then it's a trunk-only re-check).
+              run = true;
+              isManual = true;
+              skipReported = String(context.payload.inputs.skip_reported) === 'true';
+              issue = String(context.payload.inputs.issue_number);
+              post = String(context.payload.inputs.post_comment) === 'true';
+            } else if (ev === 'issues' && context.payload.action === 'labeled') {
+              // only collaborators can apply labels → the label itself is the authz.
+              if (context.payload.label && context.payload.label.name === LABEL) {
+                run = true; post = true; // labeling an issue should post the verdict
+                issue = String(context.payload.issue.number);
+              }
+            } else if (ev === 'issue_comment' && context.payload.action === 'created') {
+              const c = context.payload.comment;
+              const onIssue = !context.payload.issue.pull_request; // issues only, not PRs
+              const body = (c.body || '').trim();
+              if (onIssue && body.startsWith(CMD) && TRUSTED.includes(c.author_association)) {
+                run = true; post = true; // /reproduce should post the verdict
+                issue = String(context.payload.issue.number);
+              }
+            }
+
+            // Dumb pre-check (no agent): the issue must have usable "Steps to reproduce".
+            // If not, ask for them and abort — don't spend an agent/provision on a vague issue.
+            let needsInfo = false;
+            if (run && issue) {
+              const { owner, repo } = context.repo;
+              let body = '';
+              try {
+                const { data } = await github.rest.issues.get({ owner, repo, issue_number: Number(issue) });
+                body = data.body || '';
+              } catch (e) { core.warning('could not fetch issue body: ' + e.message); }
+              const m = body.match(/steps to reproduce[:\s]*([\s\S]*?)(?=\n\s*#{1,6}\s|$)/i);
+              const steps = m ? m[1].replace(/[\s>*#-]/g, ' ').trim() : '';
+              if (steps.length < 15) {
+                needsInfo = true; run = false;
+                core.warning('no usable "Steps to reproduce" — requesting info, aborting');
+                if (post) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: Number(issue),
+                    body: "## Reproduction — needs info\n\nI couldn't find usable **Steps to reproduce** in this issue. Please add a clear, numbered reproduction and the affected Shopware version, then re-apply the `ci:reproduce` label." });
+                }
+              }
+            }
+
+            core.setOutput('run', String(run));
+            core.setOutput('issue', issue);
+            core.setOutput('is_manual', String(isManual));
+            core.setOutput('post', String(post));
+            core.setOutput('skip_reported', String(skipReported));
+            core.setOutput('needs_info', String(needsInfo));
+            core.info(`event=${ev} run=${run} issue=${issue} manual=${isManual} post=${post} skip_reported=${skipReported} needs_info=${needsInfo}`);
+
+  # --------------------------------------------------------------------------
+  # Analyze: emit the repro plan (analysis.json) and the target matrix.
+  # The matrix encodes BOTH dedup (reported == trunk) and "not on manual rerun".
+  # --------------------------------------------------------------------------
+  analyze:
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15 # the agent reads the issue + fix-PR test + schema
+    permissions:
+      contents: read # checkout
+      issues: write # agent reads the issue + posts a clarifying question when info is missing
+      id-token: write # claude-code-action fetches a GitHub token via OIDC
+    outputs:
+      targets: ${{ steps.matrix.outputs.targets }}
+    steps:
+      # Codebase available so the agent can read the DAL schema + the fix PR's test.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Decide the mode ONCE. Never silently fabricate: missing key + not dry-run = fail.
+      - id: mode
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          set -euo pipefail
+          if [ "$DRY_RUN" = "true" ]; then m=dry_run
+          elif [ "$HAS_KEY" = "true" ]; then m=real
+          else m=fail; fi
+          echo "mode=$m" >> "$GITHUB_OUTPUT"
+          echo "analyze mode: $m"
+
+      # Production safety: no key and not an explicit demo → fail loud, BEFORE provisioning.
+      - name: Guard — refuse to fabricate
+        if: steps.mode.outputs.mode == 'fail'
+        run: |
+          echo "::error::Analyze requires ANTHROPIC_API_KEY. Refusing to emit a fabricated plan."
+          echo "::error::Set the secret, or dispatch with dry_run=true for a clearly-labelled demo."
+          exit 1
+
+      # Real Analyze agent. Emits analysis.json per references/SCHEMA.md.
+      # Prefetch the issue + (best-effort) the linked fix PR's diff with cheap gh calls,
+      # so the agent reads them directly instead of spending turns searching/fetching.
+      - name: Prefetch context
+        if: steps.mode.outputs.mode == 'real'
+        env:
+          ISSUE: ${{ needs.gate.outputs.issue }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Issue title + body + COMMENTS — comments often hold the real repro steps,
+          # affected version, and the "closed by #PR" cross-reference. EXCLUDE our own
+          # prior verdict comments (they all start with "## Reproduction") to avoid a
+          # feedback loop / wasted context — free jq filter, the gh call is the same.
+          gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json title,body,comments \
+            --jq '"# " + .title + "\n\n" + (.body // "") + "\n\n## Comments\n\n" + ([.comments[]? | select(((.body // "") | contains("## Reproduction")) | not) | "**@" + (.author.login // "?") + ":** " + (.body // "")] | join("\n\n"))' \
+            > issue.md 2>/dev/null || echo "(issue unavailable)" > issue.md
+          head -c 60000 issue.md > issue.cap && mv issue.cap issue.md   # bound context
+
+          # First #-referenced number (in body OR comments) that is a real upstream PR →
+          # its title + body + diff (the diff carries the regression test). Best-effort.
+          for n in $(grep -oE '#[0-9]{3,}' issue.md | tr -d '#' | sort -un); do
+            if gh pr view "$n" --repo shopware/shopware --json title,body >/tmp/pv 2>/dev/null; then
+              { echo "# Fix PR shopware/shopware#$n"; jq -r '.title + "\n\n" + (.body // "")' /tmp/pv;
+                echo; echo "## Diff"; gh pr diff "$n" --repo shopware/shopware 2>/dev/null | head -c 40000; } > fixpr.diff
+              echo "prefetched fix PR shopware/shopware#$n"; break
+            fi
+          done
+
+      - name: Analyze (agent)
+        id: analyze
+        if: steps.mode.outputs.mode == 'real'
+        # Hitting --max-turns is a hard error in the action; tolerate it so a
+        # complete analysis.json (written before the cap) still counts. The matrix
+        # step fails cleanly if no analysis.json was produced.
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use the default token so the action skips the Claude GitHub App token
+          # exchange (the App is installed on shopware/shopware, but not everywhere).
+          github_token: ${{ github.token }}
+          prompt: |
+            Run the `reproduce` skill's Analyze phase for issue
+            #${{ needs.gate.outputs.issue }} in repository ${{ github.repository }}.
+            The issue (title, body AND comments) is ALREADY fetched to `./issue.md`, and if
+            a linked fix PR was found, its description + diff (with the regression test) is
+            in `./fixpr.diff` — READ THOSE FIRST and do not re-fetch/search when they suffice
+            (saves turns). Follow any OTHER linked issue/PR only if these are insufficient
+            (use `--repo shopware/shopware`). The working directory is a shopware checkout —
+            read it for code/DAL schema only as needed. If the issue is too vague,
+            contradictory, or missing essentials to derive a FAITHFUL plan, do NOT guess —
+            write analysis.json as {"schema_version":"1","issue":N,"needs_info":"<one
+            specific clarifying question>"} and stop (the pipeline will ask and abort).
+            Otherwise derive the cheapest faithful plan. BE ECONOMICAL — you have a limited turn
+            budget: do the MINIMUM investigation to fill the plan (a few targeted searches,
+            NOT a full code tour), then WRITE the output file(s) immediately as your top
+            priority. If still uncertain after a handful of tool calls, emit a best-effort
+            plan with a lower `confidence` rather than exploring further. `confidence` is how
+            faithful you believe the plan is (0..1); a plan derived from a linked fix PR's
+            regression test is high (~0.95), one where you had to infer the repro steps with
+            NO fix PR to anchor on is low. Whenever `confidence` < 0.7 you MUST also set
+            `confidence_reason` to one short sentence saying what makes it uncertain (e.g.
+            "no linked fix PR; repro steps inferred from the issue body") — a run below 0.4 is
+            NOT executed (a human is asked to confirm the draft first), so the reason is what
+            they act on. For a playwright
+            layer, write the spec straight FROM THE ISSUE'S STEPS using resilient
+            role/text locators (getByRole / getByText / getByLabel) — do NOT read
+            storefront templates/JS to hunt exact selectors. A simple, imperfect spec is
+            fine (the trace shows what happened); emit it immediately. Treat this as a hard
+            budget: do not exceed ~15 tool calls before writing the file(s).
+            Write the analysis.json object (per
+            .claude/skills/reproduce/references/SCHEMA.md) to `analysis.json` in the
+            workspace root. If the repro needs seeded entities, ALSO write the admin
+            sync payload to `fixtures.json` (the path in fixtures.sync_payload_path),
+            using {{SC}}/{{NAV_CAT}}/{{TAX}}/{{CURRENCY}} placeholders for install-specific
+            ids. Every entity id you mint MUST be a 32-char lowercase-hex Shopware UUID
+            (e.g. 0192f3c4a5b67890abcdef0123456789) — never a human-readable string like
+            "repro-1" (the sync API rejects non-UUIDs). For http, use `request` or
+            `requests` (a multi-step array; the executor carries sw-context-token and
+            injects sw-access-key — never add those); reference PRE-EXISTING install ids via
+            {{SC}}/{{COUNTRY}}/{{SALUTATION}}/{{SALUTATION2}}/{{STOREFRONT_URL}} placeholders
+            the executor resolves. For a `playwright` (UI) layer, ALSO generate the test as `repro.spec.ts`
+            (referenced by script_path) — it must assert the HEALTHY behaviour and use
+            relative paths (baseURL is injected). For a `direct`/`service` layer (a bug that
+            can't fire faithfully through store-api or the UI — license-gated, an internal
+            service, or heavy domain setup), ALSO generate a minimal PHPUnit integration test
+            as `ReproTest.php` (referenced by script_path): namespace
+            `Shopware\Tests\Integration\Repro`, class `ReproTest extends TestCase` using
+            `IntegrationTestBehaviour` + `KernelTestBehaviour`, services from
+            `$this->getContainer()`. REUSE the fix PR's regression-test setup where it exists
+            (./fixpr.diff) — do NOT reinvent the bootstrap. The single test method must ASSERT
+            THE HEALTHY (fixed) behaviour so it fails on the buggy version. Prefer STABLE
+            service/DAL APIs so the same test also runs on the reported version; if it can
+            only compile on trunk, that is fine (the reported leg reports `inconclusive`,
+            never a bogus pass). Include `scenario` in analysis.json: a
+            plain-English, numbered Given/When/Then list of the repro steps. Comment EVERY
+            step of the generated script (curl or spec) explaining what it does and what it
+            asserts. Emit only those file(s) — no prose, no markdown fence. Do not comment or label.
+          # Pin Sonnet (bounded task) + cap turns (bounds cost when the agent can't find
+          # context, e.g. off-repo). Widen the READ-ONLY allowlist so the agent stops
+          # thrashing on denied tools (denials burn turns -> $). Matches triage's pins.
+          claude_args: >-
+            --model claude-sonnet-4-6 --max-turns ${{ github.event.inputs.max_turns || '35' }}
+            --allowedTools "Read,Glob,Grep,Write,Bash(gh issue view:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr diff:*),Bash(gh search:*),Bash(gh api:*),Bash(rg:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git blame:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(jq:*),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(sed:*),Bash(wc:*)"
+
+      # DEMO only: canned plan, reached solely via dry_run=true.
+      - name: Analyze (dry-run demo)
+        if: steps.mode.outputs.mode == 'dry_run'
+        env:
+          ISSUE: ${{ needs.gate.outputs.issue }}
+        run: |
+          set -euo pipefail
+          echo "::warning::DEMO dry-run — emitting a canned plan, NOT a real analysis."
+          jq -n --argjson issue "$ISSUE" '{
+            schema_version: "1", issue: $issue, layer: "store-api", executor: "http",
+            version: "6.6.10.0",
+            scenario: ["Given a running shop", "When POST /store-api/checkout/cart with an empty body", "Then a healthy shop returns HTTP 400"],
+            build_profile: { admin_build: false, storefront_build: false, theme_build: false },
+            fixtures: { demodata: false, sync_payload_path: "fixtures.json" },
+            request: { method: "POST", path: "/store-api/checkout/cart", headers: { "Content-Type": "application/json" }, body: "{}" },
+            assertion: { kind: "http_status", expect: "400", field: null, locator: "/store-api/checkout/cart" },
+            derived_from: "DEMO (dry-run)", confidence: 0.0, blocked_reason: null
+          }' > analysis.json
+
+      # Capture the agent transcript (tool calls, denials, per-turn breakdown) for cost
+      # analysis. Fork/dev only — gate behind debug before the real shopware PR (tool
+      # outputs can be sensitive on a public repo).
+      - name: Upload agent transcript (debug)
+        if: always() && steps.analyze.outputs.execution_file != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: analyze-transcript
+          path: ${{ steps.analyze.outputs.execution_file }}
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Compute the target matrix from the produced plan (dedup + not-on-manual-rerun).
+      - id: matrix
+        env:
+          SKIP_REPORTED: ${{ needs.gate.outputs.skip_reported }}
+          BRANCH: ${{ github.event.inputs.branch || 'trunk' }}
+          ISSUE: ${{ needs.gate.outputs.issue }}
+          POST: ${{ needs.gate.outputs.post }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [ -f analysis.json ] || { echo "::error::no analysis.json produced"; exit 1; }
+          cat analysis.json
+          # Analyze judged the issue too ambiguous to reproduce faithfully → ask, don't guess.
+          NEEDS=$(jq -r '.needs_info // empty' analysis.json)
+          if [ -n "$NEEDS" ]; then
+            echo "::warning::analyze needs info: $NEEDS"
+            [ "$POST" = "true" ] && gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+              --body "## Reproduction — needs info"$'\n\n'"$NEEDS"
+            echo "targets=[]" >> "$GITHUB_OUTPUT"   # no legs → reproduce/report skip
+            exit 0
+          fi
+          # Pre-provision bail-out: a plan the agent itself doesn't trust (< 0.4) is almost
+          # always a guess (no fix PR to derive from). Provisioning two installs to test a
+          # guess wastes the expensive part of the run, so ask a human to confirm the draft
+          # plan FIRST rather than spend it. (0.4–0.7 still runs → needs_human_review.)
+          CONF=$(jq -r '.confidence // 1' analysis.json)
+          if awk "BEGIN{exit !($CONF < 0.4)}"; then
+            REASON=$(jq -r '.confidence_reason // .blocked_reason // "no reason given"' analysis.json)
+            SCEN=$(jq -r '(.scenario // []) | map("- " + .) | join("\n")' analysis.json)
+            echo "::warning::analyze low confidence ($CONF) — bailing before provision: $REASON"
+            [ "$POST" = "true" ] && gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+              --body "## Reproduction — low confidence, not run"$'\n\n'"The analyzer produced a draft plan it is not confident is faithful (confidence \`$CONF\`), so the reproduction was **not** run (to avoid provisioning two installs to test a guess)."$'\n\n'"**Why:** $REASON"$'\n\n'"**Draft scenario it would have tried:**"$'\n'"$SCEN"$'\n\n'"_Confirm or correct the steps above and re-trigger to run it._"
+            echo "targets=[]" >> "$GITHUB_OUTPUT"   # no legs → reproduce/report skip
+            exit 0
+          fi
+          VERSION=$(jq -r '.version' analysis.json)
+          # Each leg carries role (reported|trunk) + the ref to display/provision. The
+          # trunk leg uses $BRANCH (default trunk) so you can reproduce against a fix branch.
+          # Trunk-only when explicitly requested (skip_reported) or reported == the branch.
+          if [ "$SKIP_REPORTED" = "true" ] || [ "$VERSION" = "$BRANCH" ]; then
+            TARGETS=$(jq -nc --arg b "$BRANCH" '[$b]')
+          else
+            TARGETS=$(jq -nc --arg v "$VERSION" --arg b "$BRANCH" '[$v,$b]')
+          fi
+          echo "targets=$TARGETS" >> "$GITHUB_OUTPUT"
+          echo "Computed targets: $TARGETS"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: analysis
+          path: |
+            analysis.json
+            fixtures.json
+            repro.spec.ts
+            ReproTest.php
+          if-no-files-found: ignore # fixtures.json / repro.spec.ts / ReproTest.php are optional (seed / playwright / direct only)
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Reproduce: one parallel leg per target. fail-fast:false so one dead leg
+  # never kills the other. Executor is chosen by analysis.layer (here: http).
+  # --------------------------------------------------------------------------
+  reproduce:
+    needs: [gate, analyze]
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # No explicit name: the matrix is a list of version strings, so GitHub's default
+    # label is "reproduce (6.7.9.0)" when it runs and a clean "reproduce" when skipped
+    # (an explicit name template would render the raw ${{ }} on a skipped matrix job).
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.analyze.outputs.targets) }}
+    steps:
+      # repro tooling (this workflow's repo) at root; the shop is installed under ./shop
+      # so setup-shopware's checkout never clobbers analysis.json or the scripts.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: analysis
+      - id: plan
+        env:
+          LEG_VERSION: ${{ matrix.version }}
+          BRANCH: ${{ github.event.inputs.branch || 'trunk' }}
+        run: |
+          set -euo pipefail
+          # role derived: the leg whose version is the branch is "trunk", else "reported".
+          if [ "$LEG_VERSION" = "$BRANCH" ]; then ROLE=trunk; else ROLE=reported; fi
+          echo "role=$ROLE" >> "$GITHUB_OUTPUT"
+          EXECUTOR=$(jq -r .executor analysis.json)
+          echo "executor=$EXECUTOR" >> "$GITHUB_OUTPUT"
+          # trunk leg provisions the branch ref as-is (default trunk); reported leg pins the
+          # exact released tag (v-prefixed).
+          if [ "$ROLE" = "trunk" ]; then
+            echo "version=$LEG_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=v$LEG_VERSION" >> "$GITHUB_OUTPUT"
+          fi
+          echo "admin_build=$(jq -r .build_profile.admin_build analysis.json)" >> "$GITHUB_OUTPUT"
+          echo "storefront_build=$(jq -r .build_profile.storefront_build analysis.json)" >> "$GITHUB_OUTPUT"
+
+      # Provision only when an executor needs a live shop (http/playwright). Build only the surface.
+      # continue-on-error: a dead env blocks THIS leg, it must not kill the run (the other leg + report still go).
+      - id: provision
+        if: steps.plan.outputs.executor == 'http' || steps.plan.outputs.executor == 'playwright' || steps.plan.outputs.executor == 'direct'
+        continue-on-error: true
+        uses: ./.github/actions/repro/provision
+        with:
+          version: ${{ steps.plan.outputs.version }}
+          admin-build: ${{ steps.plan.outputs.admin_build }}
+          storefront-build: ${{ steps.plan.outputs.storefront_build }}
+
+      # Seed exactly the entities the plan needs (admin sync, demodata:false).
+      # No-ops when the plan ships no fixtures.json. Runs once per leg, before the executor.
+      - name: Seed fixtures
+        id: seed
+        if: steps.provision.outcome == 'success'
+        continue-on-error: true
+        env:
+          APP_URL: ${{ steps.provision.outputs.app_url }}
+        run: PAYLOAD=fixtures.json bash .github/actions/repro/bin/seed.sh
+
+      # Playwright legs need node + the browser (gated; http/direct skip this cost).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: steps.plan.outputs.executor == 'playwright' && steps.provision.outcome == 'success' && steps.seed.outcome == 'success'
+        with:
+          node-version: 22
+      - name: Install Playwright
+        if: steps.plan.outputs.executor == 'playwright' && steps.provision.outcome == 'success' && steps.seed.outcome == 'success'
+        run: |
+          npm init -y >/dev/null
+          npm i -D @playwright/test
+          npx playwright install --with-deps chromium
+
+      # Dead env (provision or seed failed) → emit a blocked result for this leg, skip the executor.
+      - name: Mark leg blocked
+        if: steps.provision.outcome == 'failure' || steps.seed.outcome == 'failure'
+        env:
+          TARGET: ${{ steps.plan.outputs.role }}
+        run: |
+          set -euo pipefail
+          FAILED=provision; [ "${{ steps.seed.outcome }}" = "failure" ] && FAILED=seed
+          jq -n --argjson issue "$(jq -r .issue analysis.json)" --arg target "$TARGET" \
+            --arg version "$(jq -r .version analysis.json)" --arg executor "$(jq -r .executor analysis.json)" --arg failed "$FAILED" '{
+              schema_version:"1", issue:$issue, target:$target, version:$version, executor:$executor,
+              status:"blocked", assertion:{expect:null,actual:null,matched:null}, duration_s:0,
+              evidence:{script:"", script_lang:"sh", reporter_output:($failed+" failed for this leg"),
+                http:[], artifacts:[], truncated:false},
+              blocked_reason:($failed+" step failed (dead env)") }' > result.json
+          cat result.json
+
+      - name: Run executor
+        if: steps.provision.outcome != 'failure' && steps.seed.outcome != 'failure'
+        env:
+          TARGET: ${{ steps.plan.outputs.role }}
+          EXECUTOR: ${{ steps.plan.outputs.executor }}
+          APP_URL: ${{ steps.provision.outputs.app_url }}
+          SW_ACCESS_KEY: ${{ steps.provision.outputs.access_key }}
+        run: |
+          set -euo pipefail
+          case "$EXECUTOR" in
+            http)
+              ANALYSIS=analysis.json OUT=result.json \
+                bash .github/actions/repro/bin/run-http.sh
+              ;;
+            playwright)
+              ANALYSIS=analysis.json OUT=result.json \
+                bash .github/actions/repro/bin/run-playwright.sh
+              ;;
+            direct)
+              ANALYSIS=analysis.json OUT=result.json SHOP_DIR=shop \
+                bash .github/actions/repro/bin/run-direct.sh
+              ;;
+            *)
+              echo "::warning::unknown executor '$EXECUTOR'; emitting inconclusive"
+              jq -n --argjson issue "$(jq -r .issue analysis.json)" --arg target "$TARGET" \
+                --arg version "$(jq -r .version analysis.json)" --arg executor "$EXECUTOR" '{
+                  schema_version:"1", issue:$issue, target:$target, version:$version, executor:$executor,
+                  status:"inconclusive", assertion:{expect:null,actual:null,matched:null}, duration_s:0,
+                  evidence:{script:"", script_lang:"sh", reporter_output:("unknown executor "+$executor),
+                    http:[], artifacts:[], truncated:false},
+                  blocked_reason:("unknown executor "+$executor) }' > result.json
+              ;;
+          esac
+          cat result.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always() # capture evidence even when a leg fails
+        with:
+          name: repro-${{ steps.plan.outputs.role }}
+          path: |
+            result.json
+            repro.sh
+            repro.spec.ts
+            ReproTest.php
+            test-results/
+          if-no-files-found: ignore # the runnable script (repro.sh|repro.spec.ts|ReproTest.php) + test-results/ vary by executor
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Verdict: deterministic decision from leg statuses + Analyze confidence. No agent.
+  # --------------------------------------------------------------------------
+  verdict:
+    needs: [gate, analyze, reproduce]
+    if: always() && needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      has_results: ${{ steps.v.outputs.has_results }}
+      verdict: ${{ steps.v.outputs.verdict }}
+      reported: ${{ steps.v.outputs.reported }}
+      trunk: ${{ steps.v.outputs.trunk }}
+      fix_candidate: ${{ steps.v.outputs.fix_candidate }}
+      unsure_reason: ${{ steps.v.outputs.unsure_reason }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+      - id: v
+        run: |
+          set -euo pipefail
+          REP="artifacts/repro-reported/result.json"
+          TRU="artifacts/repro-trunk/result.json"
+          # No leg produced a result → no verdict, no comment downstream.
+          if [ ! -f "$REP" ] && [ ! -f "$TRU" ]; then
+            echo "has_results=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No reproduce leg produced a result (aborted/cancelled/failed)."
+            exit 0
+          fi
+          echo "has_results=true" >> "$GITHUB_OUTPUT"
+          rep="null"; tru="null"
+          [ -f "$REP" ] && rep=$(jq -r .status "$REP")
+          [ -f "$TRU" ] && tru=$(jq -r .status "$TRU")
+          echo "reported=$rep" >> "$GITHUB_OUTPUT"
+          echo "trunk=$tru" >> "$GITHUB_OUTPUT"
+
+          A=artifacts/analysis/analysis.json
+          CONF=$(jq -r '.confidence // 1' "$A" 2>/dev/null || echo 1)
+          BLOCKED=$(jq -r '.blocked_reason // ""' "$A" 2>/dev/null || echo "")
+          DERIVED=$(jq -r '.derived_from // ""' "$A" 2>/dev/null || echo "")
+          CONF_REASON=$(jq -r '.confidence_reason // ""' "$A" 2>/dev/null || echo "")
+          # Mid-band plan (0.4–0.7; below 0.4 bailed before provision) → don't trust the
+          # verdict even if the legs ran; route to a human with the reason. Capture WHY so
+          # the report says "uncertain: <reason>" not just a number.
+          unsure=false; UNSURE_REASON=""
+          [ -n "$BLOCKED" ] && { unsure=true; UNSURE_REASON="$BLOCKED"; }
+          awk "BEGIN{exit !($CONF < 0.7)}" && { unsure=true; [ -n "$CONF_REASON" ] && UNSURE_REASON="$CONF_REASON"; }
+          echo "unsure_reason=$UNSURE_REASON" >> "$GITHUB_OUTPUT"
+
+          # Precedence: infra → unreliable-plan → indeterminate leg → core combos.
+          if   [ "$rep" = "blocked" ] || [ "$tru" = "blocked" ];               then V="blocked"
+          elif [ "$unsure" = "true" ];                                         then V="needs_human_review"
+          elif [ "$rep" = "inconclusive" ] || [ "$tru" = "inconclusive" ];     then V="needs_human_review"
+          elif [ "$rep" = "reproduced" ]     && [ "$tru" = "reproduced" ];     then V="live_bug"
+          elif [ "$rep" = "reproduced" ]     && [ "$tru" = "not_reproduced" ]; then V="fixed_on_trunk"
+          elif [ "$rep" = "not_reproduced" ] && [ "$tru" = "reproduced" ];     then V="regression"
+          elif [ "$rep" = "not_reproduced" ] && [ "$tru" = "not_reproduced" ]; then V="not_reproducible"
+          elif [ "$rep" = "null" ]           && [ "$tru" = "reproduced" ];     then V="live_bug"
+          elif [ "$rep" = "null" ]           && [ "$tru" = "not_reproduced" ]; then V="not_reproducible"
+          else V="needs_human_review"
+          fi
+          echo "verdict=$V" >> "$GITHUB_OUTPUT"
+          # fixed_on_trunk: the fixing PR/commit is often already known (Analyze's derived_from).
+          FIX=""; [ "$V" = "fixed_on_trunk" ] && FIX="$DERIVED"
+          echo "fix_candidate=$FIX" >> "$GITHUB_OUTPUT"
+          echo "verdict=$V reported=$rep trunk=$tru unsure=$unsure fix='$FIX'"
+
+  # --------------------------------------------------------------------------
+  # Attribute (AGENT, gated): on a diverging verdict, name the commit that fixed
+  # or introduced the symptom. Only runs for regression, or fixed_on_trunk with no
+  # known fix PR. Enrichment only — skips (does not fail) when no API key.
+  # --------------------------------------------------------------------------
+  attribute:
+    needs: [gate, analyze, reproduce, verdict]
+    if: >
+      always() && needs.gate.outputs.run == 'true' && needs.verdict.outputs.has_results == 'true' &&
+      ( needs.verdict.outputs.verdict == 'regression' ||
+        ( needs.verdict.outputs.verdict == 'fixed_on_trunk' && needs.verdict.outputs.fix_candidate == '' ) )
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read # full history for the git log range
+      issues: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # need v<reported>..trunk history + tags
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: analysis
+      - id: mode
+        env:
+          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: echo "real=$HAS_KEY" >> "$GITHUB_OUTPUT"
+      - name: Attribute (agent)
+        if: steps.mode.outputs.real == 'true'
+        continue-on-error: true # enrichment only — a failed attribution must not red the run
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          claude_args: >-
+            --model claude-sonnet-4-6 --max-turns 20
+            --allowedTools "Read,Glob,Grep,Write,Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git blame:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(rg:*),Bash(cat:*),Bash(ls:*),Bash(jq:*)"
+          prompt: |
+            The reproduce pipeline returned verdict "${{ needs.verdict.outputs.verdict }}" for issue
+            #${{ needs.gate.outputs.issue }}. Read analysis.json for the reported version and the
+            implicated code paths/symptom. Inspect `git log v<reported-version>..trunk` restricted to
+            those paths and find the single commit that most likely
+            ${{ needs.verdict.outputs.verdict == 'regression' && 'INTRODUCED' || 'FIXED' }} the symptom
+            (the one whose diff touches the asserted behaviour). Write ONLY this JSON to
+            attribution.json — no prose, no fence:
+            {"schema_version":"1","kind":"${{ needs.verdict.outputs.verdict == 'regression' && 'regression' || 'fix' }}","likely_commit":"<sha>","pr":"<#-or-null>","reasoning":"<1-2 sentences>","confidence":0.0}
+      - name: Skipped (no key)
+        if: steps.mode.outputs.real != 'true'
+        run: echo "::warning::No API key — skipping commit attribution (enrichment only)."
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: hashFiles('attribution.json') != ''
+        with:
+          name: attribution
+          path: attribution.json
+          retention-days: 7
+
+  # --------------------------------------------------------------------------
+  # Report: render a self-contained comment from the verdict + per-leg evidence
+  # + (optional) attribution. No agent. Posts only when a result exists.
+  # --------------------------------------------------------------------------
+  report:
+    needs: [gate, analyze, reproduce, verdict, attribute]
+    if: always() && needs.gate.outputs.run == 'true' && needs.verdict.outputs.has_results == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+      - id: render
+        env:
+          ISSUE: ${{ needs.gate.outputs.issue }}
+          VERDICT: ${{ needs.verdict.outputs.verdict }}
+          REP: ${{ needs.verdict.outputs.reported }}
+          TRU: ${{ needs.verdict.outputs.trunk }}
+          FIX: ${{ needs.verdict.outputs.fix_candidate }}
+          UNSURE: ${{ needs.verdict.outputs.unsure_reason }}
+        run: |
+          set -euo pipefail
+          LAYER=$(jq -r .layer artifacts/analysis/analysis.json 2>/dev/null || echo "unknown")
+          ATTR="artifacts/attribution/attribution.json"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          RF="artifacts/repro-reported/result.json"; TF="artifacts/repro-trunk/result.json"
+          have_r=0; [ -f "$RF" ] && have_r=1
+          have_t=0; [ -f "$TF" ] && have_t=1
+          # The generated script is identical across legs for direct/playwright (authored
+          # ONCE and reused) and usually for http; only http can vary (per-leg resolved
+          # ids/tokens). Decide once whether to show it a single time or per-leg, so we don't
+          # list two copies of the same script.
+          same=0; maxlines=0
+          for f in "$RF" "$TF"; do
+            [ -f "$f" ] || continue
+            n=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' ')
+            [ "$n" -gt "$maxlines" ] && maxlines=$n
+          done
+          if [ "$have_r" = 1 ] && [ "$have_t" = 1 ]; then
+            cmp -s <(jq -r '.evidence.script // ""' "$RF") <(jq -r '.evidence.script // ""' "$TF") && same=1
+          fi
+          # emit_script <result.json> <label-suffix> <mode: comment|full>
+          emit_script () {
+            local f="$1" label="$2" mode="$3" lang nlines
+            lang=$(jq -r '.evidence.script_lang // "sh"' "$f")
+            nlines=$(jq -r '.evidence.script // ""' "$f" | wc -l | tr -d ' ')
+            [ "$nlines" -gt 0 ] || return 0
+            echo "**Repro script${label}** (\`${lang}\`)"
+            if [ "$mode" = comment ] && [ "$nlines" -gt 60 ]; then
+              echo "_${nlines} lines — in the \`repro-*\` run [artifact](${RUN_URL})._"
+            else
+              echo "\`\`\`${lang}"; jq -r .evidence.script "$f"; echo '```'
+            fi
+          }
+          # Show one script when the legs match (direct/playwright/most http); both only when
+          # http resolved to genuinely different ids. mode picks comment (trim long) vs full.
+          render_scripts () {
+            local mode="$1"
+            if [ "$have_r" = 1 ] && [ "$have_t" = 1 ] && [ "$same" = 1 ]; then
+              emit_script "$RF" " (run unchanged on both legs)" "$mode"
+            elif [ "$have_r" = 1 ] && [ "$have_t" = 1 ]; then
+              emit_script "$RF" " — reported" "$mode"; echo; emit_script "$TF" " — trunk" "$mode"
+            elif [ "$have_r" = 1 ]; then emit_script "$RF" "" "$mode"
+            elif [ "$have_t" = 1 ]; then emit_script "$TF" "" "$mode"
+            fi
+          }
+          {
+            echo "## Reproduction — Issue #${ISSUE}: \`${VERDICT}\`"
+            echo
+            echo "Layer \`${LAYER}\` · reported: \`${REP}\` · trunk: \`${TRU}\` · [run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            echo
+            # Scenario (human-readable intent) before the per-leg scripts.
+            if jq -e '.scenario | arrays and length > 0' artifacts/analysis/analysis.json >/dev/null 2>&1; then
+              echo "**Scenario**"
+              jq -r '.scenario[] | "1. " + .' artifacts/analysis/analysis.json
+              echo
+            fi
+            if [ "$VERDICT" = "fixed_on_trunk" ] && [ -n "$FIX" ]; then
+              echo "**Likely fix (backport candidate):** ${FIX}"
+            fi
+            if [ "$VERDICT" = "regression" ]; then
+              echo "> ⚠️ **Regression**: not reproduced on the reported version but reproduced on trunk. Confirm the reported leg actually exercised the symptom (a missing fixture can cause a false negative)."
+            fi
+            if [ "$VERDICT" = "needs_human_review" ]; then
+              # The legs ran but the plan was mid-confidence (0.4–0.7) or a leg was indeterminate.
+              # Show the evidence below; flag WHY a human should adjudicate rather than trust the legs.
+              echo "> 🟡 **Needs human review**: the verdict is not trusted automatically${UNSURE:+ — ${UNSURE}}. The leg evidence below is informative but unconfirmed; confirm against the steps before acting."
+            fi
+            if [ -f "$ATTR" ]; then
+              KIND=$(jq -r .kind "$ATTR"); CMT=$(jq -r .likely_commit "$ATTR"); RSN=$(jq -r .reasoning "$ATTR")
+              echo "**Likely ${KIND} commit:** \`${CMT}\` — ${RSN}"
+            fi
+            # Per-leg verdicts — these legitimately differ between the two versions.
+            for t in reported trunk; do
+              f="artifacts/repro-${t}/result.json"
+              [ -f "$f" ] || continue
+              st=$(jq -r .status "$f"); br=$(jq -r '.blocked_reason // ""' "$f")
+              echo
+              if [ -n "$br" ] && [ "$br" != "null" ]; then
+                # blocked/inconclusive: the assertion never ran — show WHY (incl. the failing response body)
+                echo "### ${t} — \`${st}\`"
+                echo
+                echo "> ⚠️ ${br}"
+              else
+                ex=$(jq -r .assertion.expect "$f"); ac=$(jq -r .assertion.actual "$f")
+                echo "### ${t} — \`${st}\` (expected ${ex}, got ${ac})"
+              fi
+              echo "Reporter: \`$(jq -r .evidence.reporter_output "$f")\`"
+            done
+            # The script is shared by both legs (shown once) unless http resolved differently.
+            echo
+            render_scripts comment
+          } > comment.md
+          # Job summary mirrors the comment; if the comment trimmed a long script to a pointer,
+          # append the full script (collapsed) so it stays visible on the run page too.
+          {
+            cat comment.md
+            if [ "$maxlines" -gt 60 ]; then
+              echo; echo "<details><summary>Full generated repro script</summary>"; echo
+              render_scripts full
+              echo; echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Post comment
+        # 'blocked' = the repro env/seed failed (infra), not a bug verdict → keep it in the
+        # job summary, don't post public noise on the issue. Real verdicts still post.
+        if: needs.gate.outputs.post == 'true' && needs.verdict.outputs.verdict != 'blocked'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number('${{ needs.gate.outputs.issue }}'),
+              body: fs.readFileSync('comment.md', 'utf8'),
+            });

--- a/.github/workflows/reproduce.yml
+++ b/.github/workflows/reproduce.yml
@@ -237,9 +237,12 @@ jobs:
             specific clarifying question>"} and stop (the pipeline will ask and abort).
             Otherwise derive the cheapest faithful plan. BE ECONOMICAL — you have a limited turn
             budget: do the MINIMUM investigation to fill the plan (a few targeted searches,
-            NOT a full code tour), then WRITE the output file(s) immediately as your top
-            priority. If still uncertain after a handful of tool calls, emit a best-effort
-            plan with a lower `confidence` rather than exploring further. `confidence` (0..1)
+            NOT a full code tour). Your VERY FIRST Write MUST be a complete best-effort
+            analysis.json (plus its spec/test file) within the first few tool calls — treat
+            "produce the files" as turn 1, not the finale. Refine them afterwards ONLY if turns
+            remain; NEVER finish (or hit the turn cap) without having written analysis.json. If
+            still uncertain after a handful of tool calls, keep the best-effort plan with a
+            lower `confidence` rather than exploring further. `confidence` (0..1)
             measures how FAITHFULLY the plan reproduces the reported symptom — NOT whether a
             fix exists. It is HIGH when the symptom can be asserted deterministically (clear
             expected-vs-actual, a stable endpoint/field/locator) AND the environment is
@@ -346,7 +349,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          [ -f analysis.json ] || { echo "::error::no analysis.json produced"; exit 1; }
+          # No plan file: the agent errored or exceeded its turn budget without writing one.
+          # Degrade gracefully (visible comment + clean skip) instead of an opaque red run.
+          if [ ! -f analysis.json ]; then
+            echo "::warning::analyze produced no analysis.json (agent error or exceeded turn budget)"
+            [ "$POST" = "true" ] && gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" \
+              --body "## Reproduction — could not analyze"$'\n\n'"The analyzer did not produce a repro plan within its turn budget (likely an over-exploring UI/playwright analysis). No reproduction was run. A human can review the issue, or re-trigger to retry."
+            echo "targets=[]" >> "$GITHUB_OUTPUT"   # no legs → reproduce/report skip
+            exit 0
+          fi
           cat analysis.json
           # Analyze judged the issue too ambiguous to reproduce faithfully → ask, don't guess.
           NEEDS=$(jq -r '.needs_info // empty' analysis.json)

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,11 @@ Thumbs.db
 yalc.lock
 
 # AI/LLM Development Tools
-.claude/
+# Ignore everything in .claude/ EXCEPT .claude/skills/ — that path holds shared,
+# portable Agent Skills that all AI runtimes (Claude Code, opencode, Codex CLI,
+# Cursor, etc.) auto-load. Skills are project content, not user-local config.
+.claude/*
+!.claude/skills/
 .codex/
 .cursor/
 .cursorrules


### PR DESCRIPTION
> ⚠️ **Stacked on #17348 (reproduce RFC).** Cross-fork PRs can't base on another fork branch, so **this diff currently also contains #17348's commits** — review #17348 first. Once #17348 merges to trunk, this PR auto-reduces to just the fix-verify delta (5 files). The clean, fix-verify-only diff is visible in the fork-internal PR vienthuong/shopware#8.

> **Stacked on #17348** (the reproduce RFC). Base branch is `rfc/bug-reproduction-pipeline`, so this PR shows only the fix-verify delta. Review/merge after the reproduce PR.

## What this is
`fix-verify` is the **reproduce engine pointed at a PR**. Instead of `{reported version, trunk}` it provisions the PR's **base** (fix absent) and **head** (fix present) *from source*, runs **one derived repro** on both, and confirms the symptom is present on base and gone on head.

```
gate → analyze → verify (matrix: base ‖ head) → verdict → report
```

It answers *"does this PR's fix actually work?"* — and, as a bonus, *"is the regression test a real guard?"* (a repro that passes on base means the test wouldn't catch the bug).

## Verdict map
| base (no fix) | head (fix) | verdict |
|---|---|---|
| reproduced | not_reproduced | ✅ `fix_verified` |
| reproduced | reproduced | ❌ `fix_ineffective` |
| not_reproduced | not_reproduced | ⚠️ `test_does_not_guard` |
| not_reproduced | reproduced | ❌ `introduces_symptom` |
| any blocked/inconclusive, or confidence < 0.7 | — | `needs_human_review` |

## How it reuses the reproduce engine
This PR **extracts** the verdict map and report renderer into shared, `MODE`-parameterized scripts (`bin/verdict.sh`, `bin/report.sh`) and rewires `reproduce.yml` to call them (behaviour-preserving). `fix-verify.yml` then reuses those + `provision/`, `bin/run-*.sh`, `bin/seed.sh`, and the skill's analyze prompt + executor contracts. New surface ≈ a PR-trigger gate, base/head leg selection, and the fix-verify verdict map.

## Key design points
- **Provision from source, no new action:** `setup-shopware` checks out `shopware-version` as a git ref via `actions/checkout`, so each leg builds the exact base/head SHA (incl. fork heads) — zero provision-action changes.
- **Standalone repro:** the analyze prompt requires a repro that runs on a ref *lacking this PR's test* (it derives the assertion from the linked issue + the PR's test but authors its own). Verified locally on PR#15526 — the generated `ReproTest.php` had zero references to the PR's test file.
- **Security:** `pull_request_target` runs with secrets but we build/run PR head code, so the gate is **maintainer-trusted only** (label by a collaborator / trusted comment author / dispatch). The API key is scoped to the analyze job; the build/execute legs don't get it.

## Verification ($0, local-rehearsal loop)
- `bin/verdict.sh` unit-tested across **both** full truth tables; `smoke.sh` extended with the fix-verify cases (all green).
- `bin/report.sh` renders reproduce mode byte-compatibly and fix-verify with the right labels/callouts.
- Local fix-verify analyze rehearsal on PR#15526 → standalone `ReproTest.php`, php-valid, would yield `fix_verified`.

## Honest status
- The **two-ref from-source build** is CI-only (like reproduce's provision) — heavier than installing a release (two source builds per run). Not yet exercised in a real CI run; the decision logic + analyze are locally proven.
- `pull_request_target`/`issue_comment` only fire from a repo's **default branch**, so (like reproduce) this is inert until adopted onto a shopware branch; `workflow_dispatch` works for trials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
