### PR TITLE
test: stabilize order detail-details tab visual test

### DIFF
--- a/tests/acceptance/tests/Visual/Administration/OrderDetail.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/OrderDetail.spec.ts
@@ -29,6 +29,7 @@ test('Visual: Order Detail Page', { tag: '@Visual' }, async ({
         await AdminOrderDetail.detailsTabLink.click();
         await setViewport(AdminOrderDetail.page, {
             requestURL: '/api/search/custom-field-set',
+            contentHeight: 2666,
         });
 
         await replaceElements(AdminOrderDetail.page, [


### PR DESCRIPTION
### 1. Why is this change necessary?
Set viewport can not get screen height correcty each time and failing on pipeline. https://app.currents.dev/instance/c0d6adf6f9b181d7

The Order Detail visual test needs a stable viewport height for the Details tab screenshot.

### 2. What does this change do, exactly?

Adds an explicit `contentHeight` to the Details tab `setViewport` call in `OrderDetail.spec.ts`.

### 3. Describe each step to reproduce the issue or behaviour.

Run the Order Detail visual test and compare the Details tab screenshot capture.

