### PR TITLE
fix: service can uninstall itself without permissions, and only itself

### DIFF
--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -126,14 +126,13 @@ class ServiceController
         name: 'api.service.uninstall',
         defaults: [
             'auth_required' => true,
-            PlatformRequest::ATTRIBUTE_ACL => ['api_service_toggle'],
         ],
         methods: [Request::METHOD_POST]
     )]
     public function uninstall(string $serviceName, Context $context): JsonResponse
     {
-        $this->extractIntegrationIdOrFail($context);
-        $service = $this->loadServiceByName($serviceName, $context);
+        $integrationId = $this->extractIntegrationIdOrFail($context);
+        $service = $this->loadServiceByNameAndIntegrationId($serviceName, $integrationId, $context);
 
         if (!$service) {
             throw ServiceException::notFound('name', $serviceName);
@@ -265,6 +264,17 @@ class ServiceController
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->addFilter(new EqualsFilter('selfManaged', true));
+        $criteria->setLimit(1);
+
+        return $this->appRepository->search($criteria, $context)->getEntities()->first();
+    }
+
+    private function loadServiceByNameAndIntegrationId(string $name, string $integrationId, Context $context): ?AppEntity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->addFilter(new EqualsFilter('integrationId', $integrationId));
         $criteria->addFilter(new EqualsFilter('selfManaged', true));
         $criteria->setLimit(1);
 

--- a/tests/integration/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/integration/Core/Service/Api/ServiceControllerTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Service\Api;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+class ServiceControllerTest extends TestCase
+{
+    use AdminFunctionalTestBehaviour;
+
+    /**
+     * @var EntityRepository<AppCollection>
+     */
+    private EntityRepository $appRepository;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->appRepository = static::getContainer()->get('app.repository');
+        $this->connection = static::getContainer()->get(Connection::class);
+    }
+
+    public function testServiceCanUninstallItself(): void
+    {
+        $serviceName = 'RemoteUninstall' . Uuid::randomHex();
+        $integrationId = Uuid::randomHex();
+
+        $browser = $this->getBrowserAuthenticatedWithIntegration($integrationId);
+        $appId = $this->createServiceApp($serviceName, $integrationId);
+
+        $browser->jsonRequest('POST', '/api/service/uninstall/' . $serviceName);
+
+        static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+        static::assertNull($this->appRepository->search(new Criteria([$appId]), Context::createDefaultContext())->first());
+    }
+
+    public function testServiceCannotUninstallAnotherService(): void
+    {
+        $ownServiceName = 'RemoteUninstallOwn' . Uuid::randomHex();
+        $otherServiceName = 'RemoteUninstallOther' . Uuid::randomHex();
+        $integrationId = Uuid::randomHex();
+
+        $browser = $this->getBrowserAuthenticatedWithIntegration($integrationId);
+        $this->createServiceApp($ownServiceName, $integrationId);
+        $otherAppId = $this->createServiceApp($otherServiceName, $this->createIntegration());
+
+        $browser->jsonRequest('POST', '/api/service/uninstall/' . $otherServiceName);
+
+        static::assertSame(Response::HTTP_NOT_FOUND, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
+        static::assertNotNull($this->appRepository->search(new Criteria([$otherAppId]), Context::createDefaultContext())->first());
+    }
+
+    /**
+     * @return string the app id
+     */
+    private function createServiceApp(string $serviceName, string $integrationId): string
+    {
+        $appId = Uuid::randomHex();
+
+        $app = [
+            'id' => $appId,
+            'name' => $serviceName,
+            'path' => __DIR__ . '/../../Framework/App/Command/_fixtures/withoutPermissions',
+            'version' => '1.0.0',
+            'label' => $serviceName,
+            'active' => true,
+            'accessToken' => 'test',
+            'selfManaged' => true,
+            'integrationId' => $integrationId,
+            'aclRole' => [
+                'name' => $serviceName,
+                'privileges' => [],
+            ],
+        ];
+
+        $this->appRepository->create([$app], Context::createDefaultContext());
+
+        return $appId;
+    }
+
+    private function createIntegration(): string
+    {
+        $integrationId = Uuid::randomHex();
+
+        $this->connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'label' => 'test integration',
+            'access_key' => AccessKeyHelper::generateAccessKey('integration'),
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        return $integrationId;
+    }
+}

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -236,7 +236,7 @@ class ServiceControllerTest extends TestCase
     {
         $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
 
-        $source = new AdminApiSource('AABB', 'EEFF');
+        $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
 
         $this->appLifecycle->expects($this->once())->method('delete')->with($this->appId, ['id' => $this->appId], $context);


### PR DESCRIPTION
### 1. Why is this change necessary?

Services need a permission to be uninstalled, but that permission maybe not be granted. If a service can be installed, it should be able to uninstall itself.

Also, services could uninstall others services, as long as it had the permission.

### 2. What does this change do, exactly?

The uninstall route now loads the service by both service name and caller integration id before deleting it. The route keeps authentication but drops the toggle ACL. We drop the toggle because: we can install services, therefore, we should be able to remove them, in the event of a faulty release. We should be able to do this without merchant accepting services consent.

Note: eventually this should use `ServiceStorage` instead of manually loading via `app.repository`

### 3. Describe each step to reproduce the issue or behaviour.

1. Authenticate as service integration A.
2. Call `/api/service/uninstall/{serviceName}` for service B.
3. The request must not delete service B.

### 4. Please link to the relevant issues (if any).

Relates to https://github.com/shopware/service-enablement/issues/96

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have read the contribution requirements and fulfilled them