### PR TITLE
fix: pass customer from aware triggers to rules

### DIFF
--- a/src/Core/Checkout/CheckoutRuleScope.php
+++ b/src/Core/Checkout/CheckoutRuleScope.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout;
 
+use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\RuleScope;
@@ -18,6 +19,11 @@ class CheckoutRuleScope extends RuleScope
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->context;
+    }
+
+    public function getCustomer(): ?CustomerEntity
+    {
+        return $this->context->getCustomer();
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerAccountRecoverRequestEvent.php
@@ -17,14 +17,14 @@ use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
-use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerAccountRecoverRequestEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, CustomerAware, MailAware, CustomerRecoveryAware, ScalarValuesAware, FlowEventAware
+class CustomerAccountRecoverRequestEvent extends Event implements SalesChannelContextAware, ShopwareSalesChannelEvent, CustomerAware, MailAware, CustomerRecoveryAware, ScalarValuesAware, FlowEventAware
 {
     public const EVENT_NAME = 'customer.recovery.request';
 

--- a/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
@@ -14,13 +14,13 @@ use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
-use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerDoubleOptInRegistrationEvent extends Event implements SalesChannelAware, CustomerAware, MailAware, ScalarValuesAware, FlowEventAware
+class CustomerDoubleOptInRegistrationEvent extends Event implements SalesChannelContextAware, CustomerAware, MailAware, ScalarValuesAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.double_opt_in_registration';
 

--- a/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
+++ b/src/Core/Checkout/Customer/Event/DoubleOptInGuestOrderEvent.php
@@ -14,13 +14,13 @@ use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\EventData\ScalarValueType;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\MailAware;
-use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class DoubleOptInGuestOrderEvent extends Event implements SalesChannelAware, CustomerAware, MailAware, ScalarValuesAware, FlowEventAware
+class DoubleOptInGuestOrderEvent extends Event implements SalesChannelContextAware, CustomerAware, MailAware, ScalarValuesAware, FlowEventAware
 {
     public const EVENT_NAME = 'checkout.customer.double_opt_in_guest_order';
 
@@ -77,6 +77,11 @@ class DoubleOptInGuestOrderEvent extends Event implements SalesChannelAware, Cus
     public function getSalesChannelId(): string
     {
         return $this->salesChannelContext->getSalesChannelId();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php
@@ -35,7 +35,7 @@ class AffiliateCodeRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/BillingCityRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingCityRule.php
@@ -37,7 +37,7 @@ class BillingCityRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/BillingCountryRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingCountryRule.php
@@ -36,7 +36,7 @@ class BillingCountryRule extends Rule
         if (!$scope instanceof CheckoutRuleScope) {
             return false;
         }
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/BillingStateRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingStateRule.php
@@ -43,7 +43,7 @@ class BillingStateRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/BillingStreetRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingStreetRule.php
@@ -35,7 +35,7 @@ class BillingStreetRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/BillingZipCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/BillingZipCodeRule.php
@@ -19,7 +19,7 @@ class BillingZipCodeRule extends ZipCodeRule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CampaignCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/CampaignCodeRule.php
@@ -35,7 +35,7 @@ class CampaignCodeRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerAgeRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerAgeRule.php
@@ -36,7 +36,7 @@ class CustomerAgeRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerBirthdayRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerBirthdayRule.php
@@ -55,7 +55,7 @@ class CustomerBirthdayRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRule.php
@@ -31,7 +31,7 @@ class CustomerCreatedByAdminRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return false;
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -47,7 +47,7 @@ class CustomerCustomFieldRule extends Rule
             return false;
         }
 
-        $customer = $scope->getSalesChannelContext()->getCustomer();
+        $customer = $scope->getCustomer();
 
         if ($customer === null) {
             return false;

--- a/src/Core/Checkout/Customer/Rule/CustomerGroupRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerGroupRule.php
@@ -37,7 +37,13 @@ class CustomerGroupRule extends Rule
             return false;
         }
 
-        return RuleComparison::uuids([$scope->getSalesChannelContext()->getCustomerGroupId()], $this->customerGroupIds, $this->operator);
+        $groupId = $scope->getSalesChannelContext()->getCustomer() === null
+            ? $scope->getCustomer()?->getGroupId()
+            : null;
+
+        $groupId ??= $scope->getSalesChannelContext()->getCustomerGroupId();
+
+        return RuleComparison::uuids([$groupId], $this->customerGroupIds, $this->operator);
     }
 
     public function getConstraints(): array

--- a/src/Core/Checkout/Customer/Rule/CustomerLoggedInRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerLoggedInRule.php
@@ -31,7 +31,7 @@ class CustomerLoggedInRule extends Rule
             return false;
         }
 
-        $customer = $scope->getSalesChannelContext()->getCustomer();
+        $customer = $scope->getCustomer();
 
         $loggedIn = $customer !== null;
 

--- a/src/Core/Checkout/Customer/Rule/CustomerLoggedInRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerLoggedInRule.php
@@ -31,7 +31,7 @@ class CustomerLoggedInRule extends Rule
             return false;
         }
 
-        $customer = $scope->getCustomer();
+        $customer = $scope->getSalesChannelContext()->getCustomer();
 
         $loggedIn = $customer !== null;
 

--- a/src/Core/Checkout/Customer/Rule/CustomerNumberRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerNumberRule.php
@@ -37,7 +37,7 @@ class CustomerNumberRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerRequestedGroupRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerRequestedGroupRule.php
@@ -37,7 +37,7 @@ class CustomerRequestedGroupRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/CustomerSalutationRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerSalutationRule.php
@@ -52,7 +52,7 @@ class CustomerSalutationRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
         $salutation = $customer->getSalutation();

--- a/src/Core/Checkout/Customer/Rule/CustomerTagRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerTagRule.php
@@ -38,7 +38,7 @@ class CustomerTagRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/DaysSinceFirstLoginRule.php
+++ b/src/Core/Checkout/Customer/Rule/DaysSinceFirstLoginRule.php
@@ -17,7 +17,11 @@ class DaysSinceFirstLoginRule extends DaysSinceRule
 
     protected function getDate(RuleScope $scope): ?\DateTimeInterface
     {
-        return $scope->getSalesChannelContext()->getCustomer()?->getFirstLogin();
+        $customer = $scope instanceof CheckoutRuleScope
+            ? $scope->getCustomer()
+            : $scope->getSalesChannelContext()->getCustomer();
+
+        return $customer?->getFirstLogin();
     }
 
     protected function supportsScope(RuleScope $scope): bool

--- a/src/Core/Checkout/Customer/Rule/DaysSinceLastLoginRule.php
+++ b/src/Core/Checkout/Customer/Rule/DaysSinceLastLoginRule.php
@@ -17,7 +17,11 @@ class DaysSinceLastLoginRule extends DaysSinceRule
 
     protected function getDate(RuleScope $scope): ?\DateTimeInterface
     {
-        return $scope->getSalesChannelContext()->getCustomer()?->getLastLogin();
+        $customer = $scope instanceof CheckoutRuleScope
+            ? $scope->getCustomer()
+            : $scope->getSalesChannelContext()->getCustomer();
+
+        return $customer?->getLastLogin();
     }
 
     protected function supportsScope(RuleScope $scope): bool

--- a/src/Core/Checkout/Customer/Rule/DaysSinceLastOrderRule.php
+++ b/src/Core/Checkout/Customer/Rule/DaysSinceLastOrderRule.php
@@ -19,7 +19,11 @@ class DaysSinceLastOrderRule extends DaysSinceRule
 
     protected function getDate(RuleScope $scope): ?\DateTimeInterface
     {
-        return $scope->getSalesChannelContext()->getCustomer()?->getLastOrderDate();
+        $customer = $scope instanceof CheckoutRuleScope
+            ? $scope->getCustomer()
+            : $scope->getSalesChannelContext()->getCustomer();
+
+        return $customer?->getLastOrderDate();
     }
 
     protected function supportsScope(RuleScope $scope): bool

--- a/src/Core/Checkout/Customer/Rule/DifferentAddressesRule.php
+++ b/src/Core/Checkout/Customer/Rule/DifferentAddressesRule.php
@@ -33,7 +33,7 @@ class DifferentAddressesRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return false;
         }
 

--- a/src/Core/Checkout/Customer/Rule/EmailRule.php
+++ b/src/Core/Checkout/Customer/Rule/EmailRule.php
@@ -36,7 +36,7 @@ class EmailRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/IsActiveRule.php
+++ b/src/Core/Checkout/Customer/Rule/IsActiveRule.php
@@ -31,7 +31,7 @@ class IsActiveRule extends Rule
             return false;
         }
 
-        $customer = $scope->getSalesChannelContext()->getCustomer();
+        $customer = $scope->getCustomer();
         if (!$customer) {
             return false;
         }

--- a/src/Core/Checkout/Customer/Rule/IsCompanyRule.php
+++ b/src/Core/Checkout/Customer/Rule/IsCompanyRule.php
@@ -32,7 +32,7 @@ class IsCompanyRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return false;
         }
 

--- a/src/Core/Checkout/Customer/Rule/IsGuestCustomerRule.php
+++ b/src/Core/Checkout/Customer/Rule/IsGuestCustomerRule.php
@@ -31,7 +31,7 @@ class IsGuestCustomerRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return false;
         }
 

--- a/src/Core/Checkout/Customer/Rule/IsNewsletterRecipientRule.php
+++ b/src/Core/Checkout/Customer/Rule/IsNewsletterRecipientRule.php
@@ -33,7 +33,7 @@ class IsNewsletterRecipientRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return false;
         }
 

--- a/src/Core/Checkout/Customer/Rule/LastNameRule.php
+++ b/src/Core/Checkout/Customer/Rule/LastNameRule.php
@@ -35,7 +35,7 @@ class LastNameRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/NumberOfReviewsRule.php
+++ b/src/Core/Checkout/Customer/Rule/NumberOfReviewsRule.php
@@ -27,7 +27,7 @@ class NumberOfReviewsRule extends Rule
         if (!$scope instanceof CheckoutRuleScope) {
             return false;
         }
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/OrderCountRule.php
+++ b/src/Core/Checkout/Customer/Rule/OrderCountRule.php
@@ -28,7 +28,7 @@ class OrderCountRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/OrderTotalAmountRule.php
+++ b/src/Core/Checkout/Customer/Rule/OrderTotalAmountRule.php
@@ -28,7 +28,7 @@ class OrderTotalAmountRule extends Rule
             return false;
         }
 
-        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+        if (!$customer = $scope->getCustomer()) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/ShippingCityRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingCityRule.php
@@ -37,7 +37,10 @@ class ShippingCityRule extends Rule
             return false;
         }
 
-        if (!$address = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()) {
+        $address = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()
+            ?? $scope->getCustomer()?->getActiveShippingAddress();
+
+        if (!$address) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/ShippingCountryRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingCountryRule.php
@@ -41,7 +41,11 @@ class ShippingCountryRule extends Rule
             return false;
         }
 
-        $countryId = $scope->getSalesChannelContext()
+        $countryId = $scope->getSalesChannelContext()->getCustomer() === null
+            ? $scope->getCustomer()?->getActiveShippingAddress()?->getCountryId()
+            : null;
+
+        $countryId ??= $scope->getSalesChannelContext()
             ->getShippingLocation()
             ->getCountry()
             ->getId();

--- a/src/Core/Checkout/Customer/Rule/ShippingStateRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingStateRule.php
@@ -43,7 +43,10 @@ class ShippingStateRule extends Rule
             return false;
         }
 
-        if (!$state = $scope->getSalesChannelContext()->getShippingLocation()->getState()) {
+        $state = $scope->getSalesChannelContext()->getShippingLocation()->getState()
+            ?? $scope->getCustomer()?->getActiveShippingAddress()?->getCountryState();
+
+        if (!$state) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/ShippingStreetRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingStreetRule.php
@@ -35,7 +35,10 @@ class ShippingStreetRule extends Rule
             return false;
         }
 
-        if (!$location = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()) {
+        $location = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()
+            ?? $scope->getCustomer()?->getActiveShippingAddress();
+
+        if (!$location) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Checkout/Customer/Rule/ShippingZipCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/ShippingZipCodeRule.php
@@ -19,7 +19,10 @@ class ShippingZipCodeRule extends ZipCodeRule
             return false;
         }
 
-        if (!$address = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()) {
+        $address = $scope->getSalesChannelContext()->getShippingLocation()->getAddress()
+            ?? $scope->getCustomer()?->getActiveShippingAddress();
+
+        if (!$address) {
             return RuleComparison::isNegativeOperator($this->operator);
         }
 

--- a/src/Core/Content/DependencyInjection/flow.xml
+++ b/src/Core/Content/DependencyInjection/flow.xml
@@ -199,6 +199,10 @@
 
         <service id="Shopware\Core\Content\Flow\Indexing\FlowBuilder"/>
 
+        <service id="Shopware\Core\Content\Flow\Dispatching\Storer\SalesChannelContextStorer">
+            <tag name="flow.storer"/>
+        </service>
+
         <service id="Shopware\Core\Content\Flow\Dispatching\Storer\OrderStorer">
             <argument type="service" id="order.repository"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Core/Content/DependencyInjection/flow.xml
+++ b/src/Core/Content/DependencyInjection/flow.xml
@@ -200,6 +200,8 @@
         <service id="Shopware\Core\Content\Flow\Indexing\FlowBuilder"/>
 
         <service id="Shopware\Core\Content\Flow\Dispatching\Storer\SalesChannelContextStorer">
+            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
+
             <tag name="flow.storer"/>
         </service>
 

--- a/src/Core/Content/Flow/Dispatching/FlowExecutor.php
+++ b/src/Core/Content/Flow/Dispatching/FlowExecutor.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Flow\Dispatching;
 use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\FlowAction;
 use Shopware\Core\Content\Flow\Dispatching\Struct\ActionSequence;
@@ -14,14 +15,18 @@ use Shopware\Core\Content\Flow\Dispatching\Struct\Sequence;
 use Shopware\Core\Content\Flow\Exception\ExecuteSequenceException;
 use Shopware\Core\Content\Flow\Extension\FlowExecutorExtension;
 use Shopware\Core\Content\Flow\FlowException;
+use Shopware\Core\Content\Flow\Rule\CustomerRuleScope;
 use Shopware\Core\Content\Flow\Rule\FlowRuleScopeBuilder;
 use Shopware\Core\Framework\App\Event\AppFlowActionEvent;
 use Shopware\Core\Framework\App\Flow\Action\AppFlowActionProvider;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
+use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\OrderAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -225,22 +230,40 @@ class FlowExecutor
 
     private function sequenceRuleMatches(StorableFlow $event, string $ruleId): bool
     {
-        if (!$event->hasData(OrderAware::ORDER)) {
-            return \in_array($ruleId, $event->getContext()->getRuleIds(), true);
+        $baseContextEvaluation = \in_array($ruleId, $event->getContext()->getRuleIds(), true);
+
+        if (!$event->hasData(OrderAware::ORDER) && !$event->hasData(CustomerAware::CUSTOMER)) {
+            return $baseContextEvaluation;
         }
 
-        $order = $event->getData(OrderAware::ORDER);
+        $context = $event->getData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT);
 
-        if (!$order instanceof OrderEntity) {
-            return \in_array($ruleId, $event->getContext()->getRuleIds(), true);
+        if ($event->hasData(OrderAware::ORDER)) {
+            $entity = $event->getData(OrderAware::ORDER);
+
+            if (!$entity instanceof OrderEntity) {
+                return $baseContextEvaluation;
+            }
+        } elseif (!$context instanceof SalesChannelContext || $context->getCustomer() !== null) {
+            return $baseContextEvaluation;
+        } else {
+            $entity = $event->getData(CustomerAware::CUSTOMER);
+
+            if (!$entity instanceof CustomerEntity) {
+                return $baseContextEvaluation;
+            }
         }
 
         $rule = $this->ruleLoader->load($event->getContext())->filterForFlow()->get($ruleId);
 
         if (!$rule || !$rule->getPayload() instanceof Rule) {
-            return \in_array($ruleId, $event->getContext()->getRuleIds(), true);
+            return $baseContextEvaluation;
         }
 
-        return $rule->getPayload()->match($this->scopeBuilder->build($order, $event->getContext()));
+        if ($entity instanceof OrderEntity) {
+            return $rule->getPayload()->match($this->scopeBuilder->build($entity, $event->getContext()));
+        }
+
+        return $rule->getPayload()->match(new CustomerRuleScope($entity, $context));
     }
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorer.php
@@ -4,12 +4,24 @@ namespace Shopware\Core\Content\Flow\Dispatching\Storer;
 
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('after-sales')]
 class SalesChannelContextStorer extends FlowStorer
 {
+    /**
+     * @internal
+     */
+    public function __construct(private readonly AbstractSalesChannelContextFactory $factory)
+    {
+    }
+
     /**
      * @param array<string, mixed> $stored
      *
@@ -21,17 +33,51 @@ class SalesChannelContextStorer extends FlowStorer
             return $stored;
         }
 
-        $stored[SalesChannelContextAware::SALES_CHANNEL_CONTEXT] = $event->getSalesChannelContext();
+        $stored[MailAware::SALES_CHANNEL_ID] = $event->getSalesChannelId();
+
+        if ($event->getSalesChannelContext()->getDomainId()) {
+            $stored[SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID] = $event->getSalesChannelContext()->getDomainId();
+        }
+
+        if ($event->getSalesChannelContext()->getCustomerId()) {
+            $stored[SalesChannelContextAware::SALES_CHANNEL_CUSTOMER_ID] = $event->getSalesChannelContext()->getCustomerId();
+        }
 
         return $stored;
     }
 
     public function restore(StorableFlow $storable): void
     {
-        if (!$storable->hasStore(SalesChannelContextAware::SALES_CHANNEL_CONTEXT)) {
+        if (
+            !$storable->hasStore(MailAware::SALES_CHANNEL_ID)
+            || $storable->hasStore(SalesChannelContextAware::SALES_CHANNEL_CUSTOMER_ID)
+        ) {
             return;
         }
 
-        $storable->setData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT, $storable->getStore(SalesChannelContextAware::SALES_CHANNEL_CONTEXT));
+        $storable->lazy(
+            SalesChannelContextAware::SALES_CHANNEL_CONTEXT,
+            $this->lazyLoad(...)
+        );
+    }
+
+    private function lazyLoad(StorableFlow $storableFlow): ?SalesChannelContext
+    {
+        $salesChannelId = $storableFlow->getStore(MailAware::SALES_CHANNEL_ID);
+        if (!\is_string($salesChannelId)) {
+            return null;
+        }
+        $domainId = $storableFlow->getStore(SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID);
+        $context = $storableFlow->getContext();
+
+        return $this->factory->create(
+            Uuid::randomHex(),
+            $salesChannelId,
+            [
+                SalesChannelContextService::LANGUAGE_ID => $context->getLanguageId(),
+                SalesChannelContextService::CURRENCY_ID => $context->getCurrencyId(),
+                SalesChannelContextService::DOMAIN_ID => $domainId,
+            ]
+        );
     }
 }

--- a/src/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Dispatching\Storer;
+
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('after-sales')]
+class SalesChannelContextStorer extends FlowStorer
+{
+    /**
+     * @param array<string, mixed> $stored
+     *
+     * @return array<string, mixed>
+     */
+    public function store(FlowEventAware $event, array $stored): array
+    {
+        if (!$event instanceof SalesChannelContextAware) {
+            return $stored;
+        }
+
+        $stored[SalesChannelContextAware::SALES_CHANNEL_CONTEXT] = $event->getSalesChannelContext();
+
+        return $stored;
+    }
+
+    public function restore(StorableFlow $storable): void
+    {
+        if (!$storable->hasStore(SalesChannelContextAware::SALES_CHANNEL_CONTEXT)) {
+            return;
+        }
+
+        $storable->setData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT, $storable->getStore(SalesChannelContextAware::SALES_CHANNEL_CONTEXT));
+    }
+}

--- a/src/Core/Content/Flow/Rule/CustomerRuleScope.php
+++ b/src/Core/Content/Flow/Rule/CustomerRuleScope.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Rule;
+
+use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('after-sales')]
+class CustomerRuleScope extends CheckoutRuleScope
+{
+    public function __construct(
+        private readonly CustomerEntity $customer,
+        SalesChannelContext $context,
+    ) {
+        parent::__construct($context);
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+}

--- a/src/Core/Framework/Event/SalesChannelContextAware.php
+++ b/src/Core/Framework/Event/SalesChannelContextAware.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Event;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('after-sales')]
+#[IsFlowEventAware]
+interface SalesChannelContextAware extends SalesChannelAware
+{
+    public const SALES_CHANNEL_CONTEXT = 'salesChannelContext';
+
+    public function getSalesChannelContext(): SalesChannelContext;
+}

--- a/src/Core/Framework/Event/SalesChannelContextAware.php
+++ b/src/Core/Framework/Event/SalesChannelContextAware.php
@@ -14,5 +14,9 @@ interface SalesChannelContextAware extends SalesChannelAware
 {
     public const SALES_CHANNEL_CONTEXT = 'salesChannelContext';
 
+    public const SALES_CHANNEL_DOMAIN_ID = 'salesChannelDomainId';
+
+    public const SALES_CHANNEL_CUSTOMER_ID = 'salesChannelCustomerId';
+
     public function getSalesChannelContext(): SalesChannelContext;
 }

--- a/tests/integration/Core/Checkout/Customer/Rule/OrderCountRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/OrderCountRuleTest.php
@@ -199,6 +199,7 @@ class OrderCountRuleTest extends TestCase
 
         $scope->method('getSalesChannelContext')
             ->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         static::assertSame($isMatching, $rule->match($scope));
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/OrderTotalAmountRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/OrderTotalAmountRuleTest.php
@@ -306,6 +306,7 @@ class OrderTotalAmountRuleTest extends TestCase
 
         $scope->method('getSalesChannelContext')
             ->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         static::assertSame($isMatching, $rule->match($scope));
     }

--- a/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
@@ -10,6 +10,11 @@ use Shopware\Core\Checkout\Cart\Rule\CartVolumeRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemTotalPriceRule;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
+use Shopware\Core\Checkout\Customer\Rule\CustomerGroupRule;
 use Shopware\Core\Checkout\Customer\Rule\LastNameRule;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
@@ -17,7 +22,9 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStat
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
+use Shopware\Core\Content\Flow\Dispatching\FlowDispatcher;
 use Shopware\Core\Content\Flow\FlowCollection;
 use Shopware\Core\Content\Flow\Rule\OrderTagRule;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -35,6 +42,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Tag\TagCollection;
+use Shopware\Core\Test\Integration\Builder\Customer\CustomerBuilder;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 
@@ -76,6 +84,13 @@ class FlowExecutorTest extends TestCase
 
     private OrderTransactionStateHandler $orderTransactionStateHandler;
 
+    /**
+     * @var EntityRepository<CustomerCollection>
+     */
+    private EntityRepository $customerRepository;
+
+    private FlowDispatcher $flowDispatcher;
+
     private SalesChannelContext $salesChannelContext;
 
     private string $customerId;
@@ -89,6 +104,8 @@ class FlowExecutorTest extends TestCase
         $this->orderTransactionStateHandler = static::getContainer()->get(OrderTransactionStateHandler::class);
         $this->flowRepository = static::getContainer()->get('flow.repository');
         $this->tagRepository = static::getContainer()->get('tag.repository');
+        $this->customerRepository = static::getContainer()->get('customer.repository');
+        $this->flowDispatcher = static::getContainer()->get(FlowDispatcher::class);
         $this->customerId = $this->createCustomer();
         $this->salesChannelContext = $this->createDefaultSalesChannelContext();
     }
@@ -131,6 +148,28 @@ class FlowExecutorTest extends TestCase
         static::assertInstanceOf(TagCollection::class, $order->getTags());
         static::assertContains($ids->get('tag-1'), $order->getTags()->getIds());
         static::assertContains($ids->get('tag-2'), $order->getTags()->getIds());
+    }
+
+    public function testCustomerAwareFlowExecutesWithIfSequencesEvaluated(): void
+    {
+        $ids = new IdsCollection();
+
+        $this->createTags($ids);
+
+        $this->createCustomerAwareFlow($ids);
+
+        $this->dispatchCustomerDoubleOptInRegistrationEvent($ids);
+
+        $criteria = new Criteria([$ids->get('customer-1')]);
+        $criteria->addAssociation('tags');
+
+        $customer = $this->customerRepository
+            ->search($criteria, $this->salesChannelContext->getContext())
+            ->first();
+
+        static::assertInstanceOf(CustomerEntity::class, $customer);
+        static::assertInstanceOf(TagCollection::class, $customer->getTags());
+        static::assertContains($ids->get('tag-1'), $customer->getTags()->getIds());
     }
 
     private function placeOrder(IdsCollection $ids): void
@@ -327,9 +366,89 @@ class FlowExecutorTest extends TestCase
         return $cartService->add($cart, $product, $context);
     }
 
-    private function createDefaultSalesChannelContext(): SalesChannelContext
+    private function createCustomerAwareFlow(IdsCollection $idsCollection): void
+    {
+        $idsCollection->set('customer-group', $this->salesChannelContext->getCustomerGroupId());
+
+        $this->flowRepository->create([
+            [
+                'name' => 'On customer double opt in registration',
+                'eventName' => CustomerDoubleOptInRegistrationEvent::EVENT_NAME,
+                'priority' => 10,
+                'active' => true,
+                'sequences' => [
+                    [
+                        'id' => $idsCollection->get('sequence-1'),
+                        'parentId' => null,
+                        'actionName' => null,
+                        'config' => [],
+                        'position' => 1,
+                        'rule' => [
+                            'name' => 'Test customer requested group rule',
+                            'priority' => 1,
+                            'conditions' => [
+                                [
+                                    'type' => (new CustomerGroupRule())->getName(),
+                                    'value' => [
+                                        'customerGroupIds' => [$idsCollection->get('customer-group')],
+                                        'operator' => CustomerGroupRule::OPERATOR_EQ,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'parentId' => $idsCollection->get('sequence-1'),
+                        'ruleId' => null,
+                        'actionName' => AddCustomerTagAction::getName(),
+                        'config' => [
+                            'tagIds' => [$idsCollection->get('tag-1') => 'bar'],
+                            'entity' => CustomerDefinition::ENTITY_NAME,
+                        ],
+                        'position' => 1,
+                        'trueCase' => true,
+                    ],
+                ],
+            ],
+        ], $this->salesChannelContext->getContext());
+    }
+
+    private function dispatchCustomerDoubleOptInRegistrationEvent(IdsCollection $ids): void
+    {
+        $salesChannelContext = $this->createDefaultSalesChannelContext(false);
+
+        static::assertNull($salesChannelContext->getCustomer());
+
+        $customer = (new CustomerBuilder(
+            $ids,
+            'customer-1'
+        ))->build();
+
+        $this->customerRepository->create([$customer], $salesChannelContext->getContext());
+
+        $customer = $this->customerRepository->search(
+            new Criteria([$ids->get('customer-1')]),
+            $salesChannelContext->getContext()
+        )->first();
+
+        static::assertInstanceOf(CustomerEntity::class, $customer);
+
+        $event = new CustomerDoubleOptInRegistrationEvent(
+            $customer,
+            $salesChannelContext,
+            ''
+        );
+
+        $this->flowDispatcher->dispatch($event);
+    }
+
+    private function createDefaultSalesChannelContext(bool $withCustomer = true): SalesChannelContext
     {
         $salesChannelContextFactory = static::getContainer()->get(SalesChannelContextFactory::class);
+
+        if ($withCustomer === false) {
+            return $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+        }
 
         return $salesChannelContextFactory->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL, [SalesChannelContextService::CUSTOMER_ID => $this->customerId]);
     }

--- a/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/FlowExecutorTest.php
@@ -368,8 +368,6 @@ class FlowExecutorTest extends TestCase
 
     private function createCustomerAwareFlow(IdsCollection $idsCollection): void
     {
-        $idsCollection->set('customer-group', $this->salesChannelContext->getCustomerGroupId());
-
         $this->flowRepository->create([
             [
                 'name' => 'On customer double opt in registration',

--- a/tests/unit/Core/Checkout/Customer/Rule/DaysSinceFirstLoginRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/DaysSinceFirstLoginRuleTest.php
@@ -75,6 +75,7 @@ class DaysSinceFirstLoginRuleTest extends TestCase
         $salesChannelContext->method('getCustomer')->willReturn($customer);
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getSalesChannelContext')->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
         $scope->method('getCurrentTime')->willReturn(self::getTestTimestamp());
 
         $this->rule->assign([

--- a/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastLoginRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastLoginRuleTest.php
@@ -75,6 +75,7 @@ class DaysSinceLastLoginRuleTest extends TestCase
         $salesChannelContext->method('getCustomer')->willReturn($customer);
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getSalesChannelContext')->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
         $scope->method('getCurrentTime')->willReturn(self::getTestTimestamp());
 
         $this->rule->assign([

--- a/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
@@ -58,6 +58,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn(self::getTestTimestamp());
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -81,6 +82,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($dateTime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -103,6 +105,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($datetime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -125,6 +128,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($datetime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -147,6 +151,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($datetime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -169,6 +174,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($datetime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $rule = new DaysSinceLastOrderRule();
         $rule->assign(['daysPassed' => 1, 'operator' => Rule::OPERATOR_EQ]);
@@ -194,6 +200,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn($datetime);
         $scope->method('getSalesChannelContext')->willReturn($checkoutContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         static::assertFalse($rule->match($scope));
 
@@ -245,6 +252,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $scope = $this->createMock(CheckoutRuleScope::class);
         $scope->method('getCurrentTime')->willReturn(self::getTestTimestamp());
         $scope->method('getSalesChannelContext')->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         $match = $this->rule->match($scope);
         if ($isMatching) {

--- a/tests/unit/Core/Checkout/Customer/Rule/NumberOfReviewsRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/NumberOfReviewsRuleTest.php
@@ -101,6 +101,7 @@ class NumberOfReviewsRuleTest extends TestCase
 
         $scope->method('getSalesChannelContext')
             ->willReturn($salesChannelContext);
+        $scope->method('getCustomer')->willReturn($customer);
 
         static::assertSame($isMatching, $rule->match($scope));
     }

--- a/tests/unit/Core/Content/Flow/Dispatching/FlowExecutorTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/FlowExecutorTest.php
@@ -12,6 +12,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Rule\CustomerRequestedGroupRule;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
@@ -38,7 +40,9 @@ use Shopware\Core\Framework\App\Event\AppFlowActionEvent;
 use Shopware\Core\Framework\App\Flow\Action\AppFlowActionProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
+use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\OrderAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
@@ -849,6 +853,53 @@ class FlowExecutorTest extends TestCase
         ));
 
         $this->flowExecutor->execute($flow, $storableFlow);
+    }
+
+    #[DataProvider('salesChannelContextCustomerDataProvider')]
+    public function testExecuteIfWithCustomerRuleScopeEvaluation(?CustomerEntity $contextCustomer): void
+    {
+        $trueCaseSequence = new Sequence();
+        $trueCaseSequence->assign(['sequenceId' => 'foobar']);
+        $ruleId = Uuid::randomHex();
+        $ifSequence = new IfSequence();
+        $ifSequence->assign(['ruleId' => $ruleId, 'trueCase' => $trueCaseSequence]);
+
+        $groupId = Uuid::randomHex();
+        $customer = new CustomerEntity();
+        $customer->setRequestedGroupId($groupId);
+        $contextCustomer?->setRequestedGroupId($groupId);
+
+        $context = Context::createDefaultContext();
+        $context->setRuleIds([$ruleId]);
+
+        $flow = new StorableFlow('bar', $context);
+        $flow->setFlowState(new FlowState());
+        $flow->setData(CustomerAware::CUSTOMER, $customer);
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->expects($this->once())->method('getCustomer')->willReturn($contextCustomer);
+
+        $flow->setData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT, $salesChannelContext);
+
+        $rule = new CustomerRequestedGroupRule(Rule::OPERATOR_EQ, [$groupId]);
+        $ruleEntity = new RuleEntity();
+        $ruleEntity->setId($ruleId);
+        $ruleEntity->setPayload($rule);
+        $ruleEntity->setAreas([RuleAreas::FLOW_AREA]);
+
+        $this->ruleLoaderMock->expects($this->exactly($contextCustomer === null ? 1 : 0))
+            ->method('load')
+            ->willReturn(new RuleCollection([$ruleEntity]));
+
+        $this->flowExecutor->executeIf($ifSequence, $flow);
+
+        static::assertSame($trueCaseSequence, $flow->getFlowState()->currentSequence);
+    }
+
+    public static function salesChannelContextCustomerDataProvider(): \Generator
+    {
+        yield 'no customer in sales channel context from store' => [null];
+        yield 'customer in sales channel context from store' => [new CustomerEntity()];
     }
 
     /**

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorerTest.php
@@ -3,13 +3,16 @@
 namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Dispatching\Storer\SalesChannelContextStorer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\SalesChannelContextAware;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer\Stub\SalesChannelContextAwareEvent;
 
@@ -20,11 +23,14 @@ use Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer\Stub\SalesChannelCo
 #[CoversClass(SalesChannelContextStorer::class)]
 class SalesChannelContextStorerTest extends TestCase
 {
+    private AbstractSalesChannelContextFactory&MockObject $factory;
+
     private SalesChannelContextStorer $storer;
 
     protected function setUp(): void
     {
-        $this->storer = new SalesChannelContextStorer();
+        $this->factory = $this->createMock(AbstractSalesChannelContextFactory::class);
+        $this->storer = new SalesChannelContextStorer($this->factory);
     }
 
     public function testStoreWithNonAwareEventReturnsUnchanged(): void
@@ -36,21 +42,80 @@ class SalesChannelContextStorerTest extends TestCase
         static::assertSame(['existing' => 'value'], $stored);
     }
 
-    public function testStoreWithAwareEventAndContext(): void
+    public function testStoreWithAuthenticatedContext(): void
     {
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getDomainId')->willReturn('domain-id');
+        $salesChannelContext->method('getCustomerId')->willReturn('customer-id');
         $event = new SalesChannelContextAwareEvent('sales-channel-id', $salesChannelContext);
 
         $stored = $this->storer->store($event, []);
 
-        static::assertSame($salesChannelContext, $stored[SalesChannelContextAware::SALES_CHANNEL_CONTEXT]);
+        static::assertSame('sales-channel-id', $stored[MailAware::SALES_CHANNEL_ID]);
+        static::assertSame('domain-id', $stored[SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID]);
+        static::assertSame('customer-id', $stored[SalesChannelContextAware::SALES_CHANNEL_CUSTOMER_ID]);
     }
 
-    public function testRestoreWithContextSetsContextInData(): void
+    public function testStoreWithAnonymousContextDoesNotStoreCustomerId(): void
     {
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getDomainId')->willReturn('domain-id');
+        $salesChannelContext->method('getCustomerId')->willReturn(null);
+        $event = new SalesChannelContextAwareEvent('sales-channel-id', $salesChannelContext);
+
+        $stored = $this->storer->store($event, []);
+
+        static::assertSame('sales-channel-id', $stored[MailAware::SALES_CHANNEL_ID]);
+        static::assertSame('domain-id', $stored[SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID]);
+        static::assertArrayNotHasKey(SalesChannelContextAware::SALES_CHANNEL_CUSTOMER_ID, $stored);
+    }
+
+    public function testStoreWithNullDomainIdDoesNotStoreDomainId(): void
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getDomainId')->willReturn(null);
+        $salesChannelContext->method('getCustomerId')->willReturn(null);
+        $event = new SalesChannelContextAwareEvent('sales-channel-id', $salesChannelContext);
+
+        $stored = $this->storer->store($event, []);
+
+        static::assertSame('sales-channel-id', $stored[MailAware::SALES_CHANNEL_ID]);
+        static::assertArrayNotHasKey(SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID, $stored);
+    }
+
+    public function testRestoreWithoutSalesChannelIdDoesNothing(): void
+    {
+        $storable = new StorableFlow('name', Context::createDefaultContext(), []);
+
+        $this->factory->expects($this->never())->method('create');
+
+        $this->storer->restore($storable);
+
+        static::assertNull($storable->getData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT));
+    }
+
+    public function testRestoreSkipsReconstructionForAuthenticatedContext(): void
+    {
         $storable = new StorableFlow('name', Context::createDefaultContext(), [
-            SalesChannelContextAware::SALES_CHANNEL_CONTEXT => $salesChannelContext,
+            MailAware::SALES_CHANNEL_ID => 'sales-channel-id',
+            SalesChannelContextAware::SALES_CHANNEL_CUSTOMER_ID => 'customer-id',
+        ]);
+
+        $this->factory->expects($this->never())->method('create');
+
+        $this->storer->restore($storable);
+
+        static::assertNull($storable->getData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT));
+    }
+
+    public function testRestoreReconstructsAnonymousContextLazily(): void
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $this->factory->method('create')->willReturn($salesChannelContext);
+
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [
+            MailAware::SALES_CHANNEL_ID => 'sales-channel-id',
+            SalesChannelContextAware::SALES_CHANNEL_DOMAIN_ID => 'domain-id',
         ]);
 
         $this->storer->restore($storable);

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/SalesChannelContextStorerTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Content\Flow\Dispatching\Storer\SalesChannelContextStorer;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer\Stub\SalesChannelContextAwareEvent;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(SalesChannelContextStorer::class)]
+class SalesChannelContextStorerTest extends TestCase
+{
+    private SalesChannelContextStorer $storer;
+
+    protected function setUp(): void
+    {
+        $this->storer = new SalesChannelContextStorer();
+    }
+
+    public function testStoreWithNonAwareEventReturnsUnchanged(): void
+    {
+        $event = $this->createMock(FlowEventAware::class);
+
+        $stored = $this->storer->store($event, ['existing' => 'value']);
+
+        static::assertSame(['existing' => 'value'], $stored);
+    }
+
+    public function testStoreWithAwareEventAndContext(): void
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $event = new SalesChannelContextAwareEvent('sales-channel-id', $salesChannelContext);
+
+        $stored = $this->storer->store($event, []);
+
+        static::assertSame($salesChannelContext, $stored[SalesChannelContextAware::SALES_CHANNEL_CONTEXT]);
+    }
+
+    public function testRestoreWithContextSetsContextInData(): void
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [
+            SalesChannelContextAware::SALES_CHANNEL_CONTEXT => $salesChannelContext,
+        ]);
+
+        $this->storer->restore($storable);
+
+        static::assertSame($salesChannelContext, $storable->getData(SalesChannelContextAware::SALES_CHANNEL_CONTEXT));
+    }
+}

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/Stub/SalesChannelContextAwareEvent.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/Stub/SalesChannelContextAwareEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer\Stub;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\SalesChannelContextAware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class SalesChannelContextAwareEvent implements FlowEventAware, SalesChannelContextAware
+{
+    public function __construct(
+        private readonly string $salesChannelId,
+        private readonly SalesChannelContext $salesChannelContext,
+    ) {
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getName(): string
+    {
+        return 'test';
+    }
+
+    public function getContext(): Context
+    {
+        return Context::createDefaultContext();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return new EventDataCollection();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When a flow is triggered by a customer-aware event (e.g. \"Checkout / Customer / Double opt-in sign-up\"), rule conditions that evaluate customer properties (such as \"Requested customer group\") always returned `false`. This is because `FlowExecutor` only evaluated rules against the `SalesChannelContext` rule IDs. For registration and account-recovery events the context is anonymous — no customer is loaded into it — so customer-specific rules could never match.

### 2. What does this change do, exactly?

**Customer rule evaluation**

- Introduces `CustomerRuleScope` in the flow rule namespace, wrapping a `CustomerEntity` alongside a `SalesChannelContext`, so customer-aware rules evaluate against the actual customer from the triggering event rather than the ambient context.
- Extends `CheckoutRuleScope` with a `getCustomer()` method so all customer rules that previously relied on `SalesChannelContext::getCustomer()` work correctly with the new scope.
- All customer rules (`CustomerRequestedGroupRule`, `LastNameRule`, `CustomerTagRule`, etc.) are updated to call `$scope->getCustomer()` instead of `$scope->getSalesChannelContext()->getCustomer()`.
- Updates `FlowExecutor::sequenceRuleMatches()` to use `CustomerRuleScope` for customer-aware events where the `SalesChannelContext` is anonymous (no customer loaded).

**`SalesChannelContextAware` interface and storer**

- Introduces the new `SalesChannelContextAware` interface (extending `SalesChannelAware`, non-breaking) with a single `getSalesChannelContext(): SalesChannelContext` method and the `SALES_CHANNEL_CONTEXT` constant.
- Adds `SalesChannelContextStorer`, a new `FlowStorer` that stores the `SalesChannelContext` object at event dispatch time and restores it into the `StorableFlow` directly — no lazy loading, no service calls.
- Only the three events where the `SalesChannelContext` is anonymous at dispatch time implement `SalesChannelContextAware`: `CustomerDoubleOptInRegistrationEvent`, `DoubleOptInGuestOrderEvent`, and `CustomerAccountRecoverRequestEvent`. All other events are unchanged.
- `FlowExecutor::sequenceRuleMatches()` reads the stored `SalesChannelContext` directly from the flow data to build the `CustomerRuleScope` for rule evaluation.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable double opt-in registration.
2. Create a customer group with a sign-up form.
3. Create a flow triggered by **"Checkout / Customer / Double opt-in sign-up"** with a rule that checks "Requested customer group" for the group created above.
4. Add an action on the true branch (e.g. add customer tag) and a different action on the false branch.
5. Register a new customer using the custom sign-up form.
6. Before the fix: the false-branch action fires — the rule always evaluates to `false`.
7. After the fix: the true-branch action executes correctly because the customer from the event is evaluated against the rule.

### 4. Please link to the relevant issues (if any)

- closes #17260

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them