### PR TITLE
fix: remove api_service_toggle from uninstall endpoint

### DIFF
--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -124,10 +124,7 @@ class ServiceController
     #[Route(
         path: '/api/service/uninstall/{serviceName}',
         name: 'api.service.uninstall',
-        defaults: [
-            'auth_required' => true,
-            PlatformRequest::ATTRIBUTE_ACL => ['api_service_toggle'],
-        ],
+        defaults: ['auth_required' => true],
         methods: [Request::METHOD_POST]
     )]
     public function uninstall(string $serviceName, Context $context): JsonResponse

--- a/tests/integration/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/integration/Core/Service/Api/ServiceControllerTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Service\Api;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+class ServiceControllerTest extends TestCase
+{
+    use AdminApiTestBehaviour;
+    use IntegrationTestBehaviour;
+
+    public function testUninstallDoesNotRequireApiServiceTogglePrivilege(): void
+    {
+        $integrationId = Uuid::randomHex();
+        $browser = $this->getBrowserAuthenticatedWithIntegration($integrationId);
+        $connection = static::getContainer()->get(Connection::class);
+
+        $connection->update('integration', [
+            'admin' => 0,
+        ], [
+            'id' => Uuid::fromHexToBytes($integrationId),
+        ]);
+
+        $this->createServiceApp($integrationId);
+
+        $browser->request('POST', '/api/service/uninstall/TestService');
+
+        static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode());
+        static::assertSame(0, (int) $connection->fetchOne('SELECT COUNT(*) FROM app WHERE name = :name', [
+            'name' => 'TestService',
+        ]));
+    }
+
+    public function testUninstallRequiresIntegrationAuthentication(): void
+    {
+        $this->getBrowser()->request('POST', '/api/service/uninstall/TestService');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $this->getBrowser()->getResponse()->getStatusCode());
+
+        $response = json_decode((string) $this->getBrowser()->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame('SERVICE__UPDATE_REQUIRES_INTEGRATION', $response['errors'][0]['code']);
+    }
+
+    private function createServiceApp(string $integrationId): void
+    {
+        /** @var EntityRepository<AppCollection> $appRepository */
+        $appRepository = static::getContainer()->get('app.repository');
+
+        $appRepository->create([[
+            'name' => 'TestService',
+            'path' => __DIR__ . '/../../Framework/App/Command/_fixtures/withoutPermissions',
+            'version' => '0.9.0',
+            'label' => 'Test service',
+            'accessToken' => 'test',
+            'integrationId' => $integrationId,
+            'selfManaged' => true,
+            'aclRole' => [
+                'name' => 'TestService',
+                'privileges' => [],
+            ],
+        ]], Context::createDefaultContext());
+    }
+}


### PR DESCRIPTION
This pull request updates the uninstall endpoint for services and introduces new integration tests to ensure correct privilege and authentication handling. The main changes are the removal of a specific privilege requirement from the uninstall route and the addition of comprehensive tests to verify the new behavior.

**API endpoint changes:**

* Removed the `api_service_toggle` privilege requirement from the `/api/service/uninstall/{serviceName}` route in `ServiceController`, so uninstalling a service now only requires authentication, not a specific ACL privilege.

**Testing improvements:**

* Added a new integration test class `ServiceControllerTest` to verify that:
  - The uninstall endpoint no longer requires the `api_service_toggle` privilege, only authentication.
  - Uninstalling a service without integration authentication returns the correct error code and message.
  - Helper method to create a test service app for use in these tests.