### PR TITLE
fix: Disable storefront cache for affiliate tracking URLs

### DIFF
--- a/src/Storefront/Framework/AffiliateTracking/AffiliateTrackingListener.php
+++ b/src/Storefront/Framework/AffiliateTracking/AffiliateTrackingListener.php
@@ -3,11 +3,13 @@
 namespace Shopware\Storefront\Framework\AffiliateTracking;
 
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
+use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\KernelListenerPriorities;
 use Shopware\Core\PlatformRequest;
 use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -23,10 +25,20 @@ class AffiliateTrackingListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
+            HttpCacheKeyEvent::class => 'disableCacheForAffiliateTracking',
             KernelEvents::CONTROLLER => [
                 ['checkAffiliateTracking', KernelListenerPriorities::KERNEL_CONTROLLER_EVENT_SCOPE_VALIDATE_POST],
             ],
         ];
+    }
+
+    public function disableCacheForAffiliateTracking(HttpCacheKeyEvent $event): void
+    {
+        if (!$this->hasAffiliateTracking($event->request)) {
+            return;
+        }
+
+        $event->isCacheable = false;
     }
 
     public function checkAffiliateTracking(ControllerEvent $event): void
@@ -39,6 +51,10 @@ class AffiliateTrackingListener implements EventSubscriberInterface
         // Only process storefront routes
         if (!\in_array(StorefrontRouteScope::ID, $scopes, true)) {
             return;
+        }
+
+        if ($this->hasAffiliateTracking($request)) {
+            $request->attributes->set(PlatformRequest::ATTRIBUTE_NO_STORE, true);
         }
 
         if (!$request->hasSession()) {
@@ -56,5 +72,11 @@ class AffiliateTrackingListener implements EventSubscriberInterface
         if ($campaignCode) {
             $session->set(self::CAMPAIGN_CODE_KEY, $campaignCode);
         }
+    }
+
+    private function hasAffiliateTracking(Request $request): bool
+    {
+        return (bool) $request->query->get(self::AFFILIATE_CODE_KEY)
+            || (bool) $request->query->get(self::CAMPAIGN_CODE_KEY);
     }
 }

--- a/tests/unit/Storefront/Framework/AffiliateTracking/AffiliateTrackingListenerTest.php
+++ b/tests/unit/Storefront/Framework/AffiliateTracking/AffiliateTrackingListenerTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\AffiliateTracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent;
+use Shopware\Core\Framework\Routing\KernelListenerPriorities;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Shopware\Storefront\Framework\AffiliateTracking\AffiliateTrackingListener;
+use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @internal
+ */
+#[CoversClass(AffiliateTrackingListener::class)]
+class AffiliateTrackingListenerTest extends TestCase
+{
+    public function testSubscribedEvents(): void
+    {
+        static::assertSame([
+            HttpCacheKeyEvent::class => 'disableCacheForAffiliateTracking',
+            KernelEvents::CONTROLLER => [
+                ['checkAffiliateTracking', KernelListenerPriorities::KERNEL_CONTROLLER_EVENT_SCOPE_VALIDATE_POST],
+            ],
+        ], AffiliateTrackingListener::getSubscribedEvents());
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    #[DataProvider('trackingParameterProvider')]
+    public function testDisablesCacheForAffiliateTracking(array $query): void
+    {
+        $event = new HttpCacheKeyEvent(new Request(query: $query));
+
+        (new AffiliateTrackingListener())->disableCacheForAffiliateTracking($event);
+
+        static::assertFalse($event->isCacheable);
+    }
+
+    public function testDoesNotDisableCacheWithoutAffiliateTracking(): void
+    {
+        $event = new HttpCacheKeyEvent(new Request(query: ['foo' => 'bar']));
+
+        (new AffiliateTrackingListener())->disableCacheForAffiliateTracking($event);
+
+        static::assertTrue($event->isCacheable);
+    }
+
+    public function testStoresAffiliateTrackingInSession(): void
+    {
+        $request = $this->createStorefrontRequest([
+            AffiliateTrackingListener::AFFILIATE_CODE_KEY => 'affiliate-code',
+            AffiliateTrackingListener::CAMPAIGN_CODE_KEY => 'campaign-code',
+        ]);
+
+        (new AffiliateTrackingListener())->checkAffiliateTracking($this->createControllerEvent($request));
+
+        static::assertSame('affiliate-code', $request->getSession()->get(AffiliateTrackingListener::AFFILIATE_CODE_KEY));
+        static::assertSame('campaign-code', $request->getSession()->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY));
+        static::assertTrue($request->attributes->getBoolean(PlatformRequest::ATTRIBUTE_NO_STORE));
+    }
+
+    public function testDoesNotStoreAffiliateTrackingOutsideStorefrontScope(): void
+    {
+        $request = new Request(query: [
+            AffiliateTrackingListener::AFFILIATE_CODE_KEY => 'affiliate-code',
+        ]);
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StoreApiRouteScope::ID]);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        (new AffiliateTrackingListener())->checkAffiliateTracking($this->createControllerEvent($request));
+
+        static::assertFalse($request->getSession()->has(AffiliateTrackingListener::AFFILIATE_CODE_KEY));
+        static::assertFalse($request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE));
+    }
+
+    public function testDoesNotStoreAffiliateTrackingWithoutAffiliateTracking(): void
+    {
+        $request = $this->createStorefrontRequest(['foo' => 'bar']);
+
+        (new AffiliateTrackingListener())->checkAffiliateTracking($this->createControllerEvent($request));
+
+        static::assertFalse($request->getSession()->has(AffiliateTrackingListener::AFFILIATE_CODE_KEY));
+        static::assertFalse($request->getSession()->has(AffiliateTrackingListener::CAMPAIGN_CODE_KEY));
+        static::assertFalse($request->attributes->has(PlatformRequest::ATTRIBUTE_NO_STORE));
+    }
+
+    public static function trackingParameterProvider(): \Generator
+    {
+        yield 'affiliate code' => [[AffiliateTrackingListener::AFFILIATE_CODE_KEY => 'affiliate-code']];
+        yield 'campaign code' => [[AffiliateTrackingListener::CAMPAIGN_CODE_KEY => 'campaign-code']];
+        yield 'affiliate and campaign code' => [[
+            AffiliateTrackingListener::AFFILIATE_CODE_KEY => 'affiliate-code',
+            AffiliateTrackingListener::CAMPAIGN_CODE_KEY => 'campaign-code',
+        ]];
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function createStorefrontRequest(array $query): Request
+    {
+        $request = new Request(query: $query);
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [StorefrontRouteScope::ID]);
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        return $request;
+    }
+
+    private function createControllerEvent(Request $request): ControllerEvent
+    {
+        return new ControllerEvent(
+            $this->createMock(HttpKernelInterface::class),
+            static fn () => null,
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+}


### PR DESCRIPTION
resolves #5790

Affiliate and campaign tracking codes can be lost when storefront pages are served from cache. In that case, the tracking request may not reach the regular storefront controller flow, so the affiliate or campaign code is not stored in the customer session.

### 2. What does this change do, exactly?

This change disables the Shopware HTTP cache key for requests containing `affiliateCode` or `campaignCode`.

It also marks storefront requests with affiliate tracking parameters as `no-store`, so cache headers are adjusted for proxy-based cache handling when the request reaches the storefront application.

Unit tests were added for:

  - disabling the HTTP cache key for affiliate and campaign tracking parameters
  - keeping normal requests cacheable
  - storing affiliate and campaign tracking codes in the session
  - ignoring non-storefront route scopes
  - not setting `no-store` when no tracking parameters are present