### PR TITLE
chore: bump acceptance suite v12.13.1

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "2.1.2",
-        "@shopware-ag/acceptance-test-suite": "12.13.0",
+        "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -59,15 +59,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1205,8 +1196,8 @@
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
       "version": "12.13.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.13.0.tgz",
-      "integrity": "sha512-HbrF/TfQv4ygGtZqtwvUsWJuruKYfXcfLL3MWxoD0iJoqbdlPAag67M0+vU3YXk+fDrB1ZZL3COif/+6ezk4ew==",
+      "resolved": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
+      "integrity": "sha512-kN6sIoZzbWWZ0+6B51gFdwig4NMHgDcAWqInJVGOIxntzgdfjL/X6I95CHLRYnXgdEJOKV9tzmsF+5x0162WNg==",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",
@@ -1214,7 +1205,7 @@
         "@shopware/api-client": "1.4.0",
         "axe-html-reporter": "2.2.11",
         "compare-versions": "6.1.1",
-        "i18next": "25.8.3",
+        "i18next": "26.3.1",
         "image-js": "1.3.0",
         "uuid": "14.0.0"
       },
@@ -3717,29 +3708,26 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.8.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.3.tgz",
-      "integrity": "sha512-IC/pp2vkczdu1sBheq1eC92bLavN6fM5jH61c7Xa23PGio5ePEd+EP+re1IkO7KEM9eyeJHUxvIRxsaYTlsSyQ==",
+      "version": "26.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.3.1.tgz",
+      "integrity": "sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
+          "url": "https://www.locize.com/i18next"
         },
         {
           "type": "individual",
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4"
-      },
       "peerDependencies": {
-        "typescript": "^5"
+        "typescript": "^5 || ^6"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "2.1.2",
-        "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
+        "@shopware-ag/acceptance-test-suite": "12.13.1",
         "@shopware/api-client": "1.4.0",
         "lighthouse": "12.8.2",
         "playwright-lighthouse": "4.0.0"
@@ -1195,9 +1195,9 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "12.13.0",
-      "resolved": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
-      "integrity": "sha512-kN6sIoZzbWWZ0+6B51gFdwig4NMHgDcAWqInJVGOIxntzgdfjL/X6I95CHLRYnXgdEJOKV9tzmsF+5x0162WNg==",
+      "version": "12.13.1",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-12.13.1.tgz",
+      "integrity": "sha512-cQk3IFiHAkM8DXT7f6A9Pu8faDs+WgIHRtp5xCyhxx5BfvTUwCekPGWovxln9+NmYy3mtBAuv13Wu72lFWmbeA==",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.11.1",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "2.1.2",
-    "@shopware-ag/acceptance-test-suite": "12.13.0",
+    "@shopware-ag/acceptance-test-suite": "12.13.1",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "2.1.2",
-    "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
+    "@shopware-ag/acceptance-test-suite": "12.13.0",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "2.1.2",
-    "@shopware-ag/acceptance-test-suite": "12.13.0",
+    "@shopware-ag/acceptance-test-suite": "https://pkg.pr.new/shopware/acceptance-test-suite/@shopware-ag/acceptance-test-suite@642",
     "@shopware/api-client": "1.4.0",
     "lighthouse": "12.8.2",
     "playwright-lighthouse": "4.0.0"


### PR DESCRIPTION
Updated this PR to use the released `@shopware-ag/acceptance-test-suite@12.13.1` instead of the `pkg.pr.new` tarball.

Local checks after the update:

- `npm i @shopware-ag/acceptance-test-suite@12.13.1 --save-exact --package-lock-only --ignore-scripts` completed successfully in `tests/acceptance`.
- `npm ls @shopware-ag/acceptance-test-suite` resolves `@shopware-ag/acceptance-test-suite@12.13.1` in the original working tree.
- `git diff --check -- tests/acceptance/package.json tests/acceptance/package-lock.json` passed.
- `npm run lint` still fails on the same existing acceptance-test lint issues (`playwright/no-networkidle`, `playwright/no-skipped-test`, and unused-variable warnings).