### PR TITLE
fix: exclude export sales channels from sales channel rule condition

### DIFF
--- a/src/Core/Framework/Rule/SalesChannelRule.php
+++ b/src/Core/Framework/Rule/SalesChannelRule.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Rule;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
@@ -42,6 +43,33 @@ class SalesChannelRule extends Rule
     {
         return (new RuleConfig())
             ->operatorSet(RuleConfig::OPERATOR_SET_STRING, false, true)
-            ->entitySelectField('salesChannelIds', SalesChannelDefinition::ENTITY_NAME, true);
+            ->entitySelectField(
+                'salesChannelIds',
+                SalesChannelDefinition::ENTITY_NAME,
+                true,
+                [
+                    'criteria' => [
+                        'associations' => [
+                            'type',
+                        ],
+                        'filters' => [
+                            [
+                                'type' => 'not',
+                                'operator' => 'AND',
+                                'queries' => [
+                                    [
+                                        'type' => 'equalsAny',
+                                        'field' => 'type.id',
+                                        'value' => [
+                                            Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON,
+                                            Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ]
+            );
     }
 }

--- a/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
+++ b/tests/unit/Core/System/SalesChannel/Rule/SalesChannelRuleTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleConstraints;
@@ -85,6 +86,56 @@ class SalesChannelRuleTest extends TestCase
             null,
             false,
         ];
+    }
+
+    public function testItGetsConfig(): void
+    {
+        $salesChannelRule = new SalesChannelRule(Rule::OPERATOR_EQ, []);
+
+        $config = $salesChannelRule->getConfig();
+
+        static::assertSame(
+            [
+                'operatorSet' => [
+                    'operators' => [
+                        '=',
+                        '!=',
+                    ],
+                    'isMatchAny' => true,
+                ],
+                'fields' => [
+                    'salesChannelIds' => [
+                        'name' => 'salesChannelIds',
+                        'type' => 'multi-entity-id-select',
+                        'config' => [
+                            'entity' => 'sales_channel',
+                            'criteria' => [
+                                'associations' => [
+                                    'type',
+                                ],
+                                'filters' => [
+                                    [
+                                        'type' => 'not',
+                                        'operator' => 'AND',
+                                        'queries' => [
+                                            [
+                                                'type' => 'equalsAny',
+                                                'field' => 'type.id',
+                                                'value' => [
+                                                    Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON,
+                                                    Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $config->getData()
+        );
     }
 
     public function testProvidesConstraints(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The **Sales Channel** rule condition currently shows all sales channel types in its selector, including **Product Export** (product comparison) and **Agentic Commerce** channels. These channel types are not customer-facing storefront channels — they are used for automated exports or API-driven commerce. Including them in the rule condition selector is misleading because the condition is intended to match a customer's active storefront session, and selecting these types will never produce a meaningful match in that context.

### 2. What does this change do, exactly?

Adds a criteria filter to the `SalesChannelRule::getConfig()` entity select field so that sales channels of type `SALES_CHANNEL_TYPE_PRODUCT_COMPARISON` and `SALES_CHANNEL_TYPE_AGENTIC_COMMERCE` are excluded from the dropdown when configuring the Sales Channel rule condition in the administration. The filter is applied via the `criteria` config option on the `entitySelectField`, using a `not`/`equalsAny` filter on `type.id`.

A unit test covering the exact config shape (including the exclusion filter) has been added to `SalesChannelRuleTest`.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Navigate to **Settings → Rule Builder** and create or edit a rule.
  2. Add a condition of type **Sales Channel**.
  3. Open the Sales Channel selector dropdown.
  4. Without this fix: Product Export and Agentic Commerce sales channels appear in the list, making them selectable for a condition where they will never match.
  5. With this fix: those channel types are filtered out and no longer appear in the selector.

### 4. Please link to the relevant issues (if any).

  - closes #6180
  - relates https://github.com/shopware/shopware/pull/17271

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them