### PR TITLE
fix: promotion calculator with non stackable line items

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -271,8 +271,10 @@ class PromotionCalculator
 
         $splitItems = [];
         foreach ($calculatedCart->getLineItems() as $split) {
+            $isStackable = $split->isStackable();
             $split->setStackable(true);
             $splitItems[$split->getId()] = $this->lineItemQuantitySplitter->split($split, $shouldSplit ? 1 : $split->getQuantity(), $context);
+            $split->setStackable($isStackable);
         }
 
         $packages = $this->enrichPackagesWithCartData($packages, $splitItems);

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -328,6 +328,46 @@ class PromotionCalculatorTest extends TestCase
         static::assertSame(10.0, $thirdCalculatedCard->getPrice()->getTotalPrice());
     }
 
+    public function testCustomLineItemNotStackableBecomesStackable(): void
+    {
+        $promotionId = $this->getPromotionId();
+        $discountItem = $this->getDiscountItem($promotionId);
+
+        $discountItems = new LineItemCollection([$discountItem]);
+        $original = new Cart(Uuid::randomHex());
+
+        $productLineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $productLineItem->setPrice(new CalculatedPrice(90.0, 90.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+        $productLineItem->setStackable(true);
+
+        $customLineItem = new LineItem(Uuid::randomHex(), LineItem::CUSTOM_LINE_ITEM_TYPE);
+        $customLineItem->setPrice(new CalculatedPrice(10.0, 10.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+        $customLineItem->setStackable(false);
+
+        $toCalculate = new Cart(Uuid::randomHex());
+        $toCalculate->add($productLineItem);
+        $toCalculate->add($customLineItem);
+        $toCalculate->setPrice(new CartPrice(84.03, 100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS));
+
+        $this->promotionCalculator->calculate($discountItems, $original, $toCalculate, $this->salesChannelContext, new CartBehavior());
+        static::assertCount(3, $toCalculate->getLineItems());
+        $promotionLineItems = $toCalculate->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE);
+        static::assertCount(1, $promotionLineItems);
+
+        $promotionLineItem = $promotionLineItems->first();
+
+        static::assertNotNull($promotionLineItem);
+        static::assertNotNull($promotionLineItem->getPrice());
+
+        static::assertSame(-10.0, $promotionLineItem->getPrice()->getTotalPrice());
+
+        // Ensure that non-stackable items are still not stackable!
+        //  Right now they become stackable after each calculation.
+        $customLineItem = $toCalculate->get($customLineItem->getId());
+        self::assertNotNull($customLineItem);
+        self::assertFalse($customLineItem->isStackable());
+    }
+
     private function getPromotionId(bool $preventCombination = false, int $priority = 1, bool $useCodes = true, string $type = PromotionDiscountEntity::TYPE_ABSOLUTE): string
     {
         $promotionId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -362,7 +362,6 @@ class PromotionCalculatorTest extends TestCase
         static::assertSame(-10.0, $promotionLineItem->getPrice()->getTotalPrice());
 
         // Ensure that non-stackable items are still not stackable!
-        //  Right now they become stackable after each calculation.
         $customLineItem = $toCalculate->get($customLineItem->getId());
         self::assertNotNull($customLineItem);
         self::assertFalse($customLineItem->isStackable());


### PR DESCRIPTION
Thank you @mromeike 

### 1. Why is this change necessary?
PromotionCalculator sets stackable first so splitting into unit-priced/package-priced calculation items cannot fail, but fails to restore the stackable flag to its original state.

### 2. What does this change do, exactly?
Restore thh stackable flag to its original value.

### 3. Describe each step to reproduce the issue or behaviour.
Test verifies the case.

### 4. Please link to the relevant issues (if any).
Closes https://github.com/shopware/shopware/issues/17316