### PR TITLE
perf: reduce storefront cache hash language permutations

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,11 @@
 
 ## Storefront
 
+### Storefront cache hash no longer varies by language
+
+The HTTP cache hash no longer includes the language id for storefront requests, because the storefront language is derived from the resolved domain URL.
+Store API requests still include the language id in the cache hash, as the same Store API URL can return different languages via the `sw-language-id` header.
+
 ### Central extension point for content before/after list prices
 
 A new template `@Storefront/storefront/component/product/list-price-affix.html.twig` is rendered inside every list price display (product box, product detail buy widget, advanced pricing table). It replaces the deprecated `listing.beforeListPrice` / `listing.afterListPrice` snippets as the single place to inject content around list prices.

--- a/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\Cache\Http\Extension\CacheHashRequiredExtens
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -99,10 +100,15 @@ class CacheHeadersService
             HttpCacheCookieEvent::RULE_IDS => $ruleIds,
             HttpCacheCookieEvent::VERSION_ID => $context->getVersionId(),
             HttpCacheCookieEvent::CURRENCY_ID => $context->getCurrencyId(),
-            HttpCacheCookieEvent::LANGUAGE_ID => $context->getLanguageId(),
             HttpCacheCookieEvent::TAX_STATE => $context->getTaxState(),
             HttpCacheCookieEvent::LOGGED_IN_STATE => $context->getCustomer() ? 'logged-in' : 'not-logged-in',
         ];
+
+        // Storefront language is already encoded in the resolved domain URL, while Store API
+        // can serve different languages for the same URL through the sw-language-id header.
+        if ($this->isStoreApi($request)) {
+            $parts[HttpCacheCookieEvent::LANGUAGE_ID] = $context->getLanguageId();
+        }
 
         foreach ($this->cookies as $cookie) {
             if ($request->cookies->has($cookie)) {
@@ -141,5 +147,14 @@ class CacheHeadersService
         }
 
         return false;
+    }
+
+    private function isStoreApi(Request $request): bool
+    {
+        return \in_array(
+            StoreApiRouteScope::ID,
+            (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
+            true
+        );
     }
 }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
@@ -153,7 +153,7 @@ class CacheHeadersService
     {
         return \in_array(
             StoreApiRouteScope::ID,
-            (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
+            $request->attributes->all(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE),
             true
         );
     }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
@@ -153,7 +153,7 @@ class CacheHeadersService
     {
         return \in_array(
             StoreApiRouteScope::ID,
-            (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
+            $request->attributes->all(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
             true
         );
     }

--- a/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheHeadersService.php
@@ -153,7 +153,7 @@ class CacheHeadersService
     {
         return \in_array(
             StoreApiRouteScope::ID,
-            $request->attributes->all(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
+            (array) $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []),
             true
         );
     }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\Framework\Test\TestCaseBase\EventDispatcherBehaviour;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -140,6 +141,32 @@ class CacheHeadersServiceTest extends TestCase
         // all logged in customer should share the same cache hash if no rules match
         yield 'Test with logged in customer' => [$customer, $emptyCart, true, 'logged-in'];
         yield 'Test with filled cart and logged in customer' => [$customer, $filledCart, true, 'logged-in'];
+    }
+
+    public function testStorefrontCacheHashDoesNotContainLanguageId(): void
+    {
+        $event = $this->cacheHeadersService->applyCacheHash(
+            new Request(attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => ['storefront']]),
+            $this->createCacheHashContext('language-a'),
+            $this->createFilledCart(),
+            new Response()
+        );
+
+        static::assertInstanceOf(HttpCacheCookieEvent::class, $event);
+        static::assertNull($event->get(HttpCacheCookieEvent::LANGUAGE_ID));
+    }
+
+    public function testStoreApiCacheHashContainsLanguageId(): void
+    {
+        $event = $this->cacheHeadersService->applyCacheHash(
+            new Request(attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]]),
+            $this->createCacheHashContext('language-a'),
+            $this->createFilledCart(),
+            new Response()
+        );
+
+        static::assertInstanceOf(HttpCacheCookieEvent::class, $event);
+        static::assertSame('language-a', $event->get(HttpCacheCookieEvent::LANGUAGE_ID));
     }
 
     public function testCurrencyChangeLeadsToDifferentCacheHash(): void
@@ -312,5 +339,27 @@ class CacheHeadersServiceTest extends TestCase
         $secondHash = $cookies[0]->getValue();
         // assert cache hash is different when custom cookie is different
         static::assertNotSame($firstHash, $secondHash);
+    }
+
+    private function createCacheHashContext(string $languageId): SalesChannelContext
+    {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCustomer')->willReturn(null);
+        $salesChannelContext->method('getRuleIds')->willReturn([]);
+        $salesChannelContext->method('getRuleIdsByAreas')->willReturn([]);
+        $salesChannelContext->method('getVersionId')->willReturn(Defaults::LIVE_VERSION);
+        $salesChannelContext->method('getCurrencyId')->willReturn(Defaults::CURRENCY);
+        $salesChannelContext->method('getLanguageId')->willReturn($languageId);
+        $salesChannelContext->method('getTaxState')->willReturn('gross');
+
+        return $salesChannelContext;
+    }
+
+    private function createFilledCart(): Cart
+    {
+        $cart = new Cart('filled');
+        $cart->add(new LineItem('test', 'test', 'test'));
+
+        return $cart;
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheHeadersServiceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\EventDispatcherBehaviour;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Storefront\Framework\Routing\StorefrontRouteScope;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -146,7 +147,7 @@ class CacheHeadersServiceTest extends TestCase
     public function testStorefrontCacheHashDoesNotContainLanguageId(): void
     {
         $event = $this->cacheHeadersService->applyCacheHash(
-            new Request(attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => ['storefront']]),
+            new Request(attributes: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID]]),
             $this->createCacheHashContext('language-a'),
             $this->createFilledCart(),
             new Response()


### PR DESCRIPTION
### 1. Why is this change necessary?

The cache rework uses `sw-cache-hash` to separate context permutations. For storefront pages, the language is already derived from the resolved sales-channel domain URL, so including the language id in the hash creates additional cache fragmentation without adding separation that the URL does not already provide.

Store API requests are different because the same endpoint URL can return different languages through the `sw-language-id` header.

### 2. What does this change do, exactly?

`CacheHeadersService` now adds `language-id` to the cache hash only for Store API route scope requests.

Storefront cache hashes keep the other context dimensions, but no longer vary by language id. Store API cache hashes continue to include the language id.

A focused unit test covers both Storefront and Store API behavior, and the developer-facing release info mentions the changed cache-hash behavior.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use a storefront request where a cache hash is required, for example a cart-filled, logged-in, non-default-currency, or cache-relevant-cookie context.
2. Compare otherwise equivalent storefront requests across language domains or language URL prefixes.
3. Before this change, the URL and the cache hash both varied by language; after this change, the storefront URL provides the language separation and the hash no longer adds a second language dimension.
4. For Store API requests, call the same Store API URL with different `sw-language-id` values; the cache hash still includes the language id.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
