### PR TITLE
fix: keep product slider configured ids order

### DIFF
--- a/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
+++ b/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
@@ -77,6 +77,16 @@ class StaticProductProcessor extends AbstractProductSliderProcessor
             $products = $this->filterOutOutOfStockHiddenCloseoutProducts($products);
         }
 
+        $criteriaIds = array_unique($searchResult->getCriteria()->getIds());
+        if (\count($criteriaIds) > 0) {
+            $configuredIds = $slot->getFieldConfig()->get('products')?->getArrayValue() ?? [];
+            usort(
+                $criteriaIds,
+                static fn (string $a, string $b): int => array_search($a, $configuredIds, true) <=> array_search($b, $configuredIds, true)
+            );
+            $products->sortByIdArray($criteriaIds);
+        }
+
         $slider = new ProductSliderStruct();
         $slider->setProducts($products);
 

--- a/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
+++ b/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
@@ -78,7 +78,7 @@ class StaticProductProcessor extends AbstractProductSliderProcessor
         }
 
         $criteriaIds = array_unique($searchResult->getCriteria()->getIds());
-        if (\count($criteriaIds) > 0) {
+        if (\count($criteriaIds) > 0 && \count($searchResult->getCriteria()->getSorting()) === 0) {
             $configuredIds = $slot->getFieldConfig()->get('products')?->getArrayValue() ?? [];
             usort(
                 $criteriaIds,

--- a/tests/unit/Core/Content/Product/Cms/ProductSlider/StaticProductProcessorTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSlider/StaticProductProcessorTest.php
@@ -113,6 +113,7 @@ class StaticProductProcessorTest extends TestCase
     {
         $this->hideUnavailableProducts(false);
 
+        $this->config->add(new FieldConfig('products', FieldConfig::SOURCE_STATIC, ['product-1', 'product-2']));
         $slot = $this->getSlot();
         $resolverContext = $this->getResolverContext();
 
@@ -134,10 +135,41 @@ class StaticProductProcessorTest extends TestCase
         static::assertTrue($products->has('product-2'));
     }
 
+    public function testEnrichRestoresConfiguredProductOrder(): void
+    {
+        $this->hideUnavailableProducts(false);
+
+        // Configure the slot with products in order [product-2, product-1]
+        $this->config->add(new FieldConfig('products', FieldConfig::SOURCE_STATIC, ['product-2', 'product-1']));
+        $slot = $this->getSlot();
+        $resolverContext = $this->getResolverContext();
+
+        // Simulate the DB returning products in a different order (e.g. as merged from another slider)
+        $products = $this->getProducts(); // returns [product-1, product-2]
+        $searchResult = $this->getEntitySearchResult($products);
+        $searchResult->assign(['criteria' => new Criteria(['product-1', 'product-2', 'product-2', 'product-1'])]);
+
+        $data = new ElementDataCollection();
+        $data->add('product-slider_id', $searchResult);
+
+        $this->getProcessor()->enrich($slot, $data, $resolverContext);
+
+        $enrichedData = $slot->getData();
+        static::assertInstanceOf(ProductSliderStruct::class, $enrichedData);
+
+        $enrichedProducts = $enrichedData->getProducts();
+        static::assertInstanceOf(ProductCollection::class, $enrichedProducts);
+        static::assertCount(2, $enrichedProducts);
+
+        $ids = array_values($enrichedProducts->getIds());
+        static::assertSame(['product-2', 'product-1'], $ids, 'Products must be in the configured slider order, not DB order');
+    }
+
     public function testEnrichHideUnavailableProducts(): void
     {
         $this->hideUnavailableProducts(true);
 
+        $this->config->add(new FieldConfig('products', FieldConfig::SOURCE_STATIC, ['product-1', 'product-2']));
         $slot = $this->getSlot();
         $resolverContext = $this->getResolverContext();
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When a CMS page contains two or more static product sliders that share one or more products, all affected sliders display their products in the order of whichever slider was resolved first — ignoring the individual configured order of every subsequent slider.

The root cause is the criteria merging optimisation in `CmsSlotsDataResolver::optimizeCriteriaObjects()`. ID-only criteria (no filters, sorting, or limit) from all product sliders on the page are merged into a single DB query. When the results are distributed back to each slot in `mapEntities()`, the `filter()` call preserves the DB-returned order rather than each slider's own configured product order.

### 2. What does this change do, exactly?

After the merged search result is retrieved and optionally filtered for out-of-stock closeout products, `StaticProductProcessor::enrich()` now re-sorts the product collection by the configured product IDs from the slot's field config using `ProductCollection::sortByIdArray()`.

This mirrors the approach already used in `ProductStreamProcessor` for product stream results and ensures each slider renders its products in the independently configured order regardless of how many sliders share the same products.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Create a CMS page with two static product sliders.
  2. In both sliders, manually select the same products but in a different order (e.g. slider A: P1 → P2 → P3; slider B: P3 → P2 → P1).
  3. Assign the CMS page to a product and open the product detail page in the storefront.
  4. Both sliders show products in the same order (P1, P2, P3) — slider B's configured order is ignored.

  After this fix, slider A shows P1 → P2 → P3 and slider B shows P3 → P2 → P1.

### 4. Please link to the relevant issues (if any).

  - closes #17357

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them