### PR TITLE
chore: only allow services to uninstall themselves

### DIFF
--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -101,16 +101,20 @@ class ServiceController
         name: 'api.service.uninstall',
         defaults: [
             'auth_required' => true,
-            PlatformRequest::ATTRIBUTE_ACL => ['api_service_toggle'],
         ],
         methods: [Request::METHOD_POST]
     )]
     public function uninstall(string $serviceName, Context $context): JsonResponse
     {
-        $this->extractIntegrationIdOrFail($context);
+        $integrationId = $this->extractIntegrationIdOrFail($context);
+        $service = $this->serviceStorage->findByNameAndIntegrationId($serviceName, $integrationId, $context);
 
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
-            $this->serviceLifecycle->uninstall($serviceName, $context);
+        if (!$service) {
+            throw ServiceException::notFound('name', $serviceName);
+        }
+
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
+            $this->serviceLifecycle->uninstall($service->name, $context);
         });
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/src/Core/Service/ServiceStorage.php
+++ b/src/Core/Service/ServiceStorage.php
@@ -35,6 +35,18 @@ class ServiceStorage
         return $this->wrap($this->repository->search($criteria, $context)->getEntities()->first());
     }
 
+    public function findByNameAndIntegrationId(string $name, string $integrationId, Context $context): ?Service
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('selfManaged', true));
+        $criteria->addAssociation('app.acl_role');
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        $criteria->addFilter(new EqualsFilter('integrationId', $integrationId));
+        $criteria->setLimit(1);
+
+        return $this->wrap($this->repository->search($criteria, $context)->getEntities()->first());
+    }
+
     public function findByIntegrationId(string $integrationId, Context $context): ?Service
     {
         $criteria = new Criteria();

--- a/tests/unit/Core/Framework/App/Command/UninstallAppCommandTest.php
+++ b/tests/unit/Core/Framework/App/Command/UninstallAppCommandTest.php
@@ -26,7 +26,7 @@ class UninstallAppCommandTest extends TestCase
             ->willReturn(null);
 
         $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
-        $appLifecycle->expects($this->never())->method('delete');
+        $appLifecycle->expects($this->never())->method(static::anything());
 
         $command = new UninstallAppCommand($appLifecycle, $appStorage);
 

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -232,7 +232,7 @@ class ServiceControllerTest extends TestCase
     {
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
-        $source = new AdminApiSource('AABB', 'EEFF');
+        $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
 
         $this->serviceLifecycle->expects($this->once())->method('uninstall')->with('MyCoolService', $context);


### PR DESCRIPTION
Trunk's security fix (dcdbb98c228 — a service may only uninstall itself, matched by `integrationId`) has no equivalent in this branch's new `ServiceStorage` abstraction, and the two implementations conflict when merging trunk.

This adds `ServiceStorage::findByNameAndIntegrationId()` (filters `name` + `integrationId` + `selfManaged`) and uses it in `ServiceController::uninstall` before delegating to `ServiceLifecycle`, so the branch carries the same security behaviour as trunk.