### PR TITLE
fix: wishlist local storage race condition

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/wishlist/local-wishlist.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/wishlist/local-wishlist.plugin.js
@@ -26,11 +26,13 @@ export default class WishlistLocalStoragePlugin extends BaseWishlistStoragePlugi
      */
     // eslint-disable-next-line no-unused-vars
     add(productId, router = null) {
+        this.load();
         super.add(productId);
         this._save();
     }
 
     remove(productId) {
+        this.load();
         super.remove(productId);
 
         this._save();
@@ -42,10 +44,6 @@ export default class WishlistLocalStoragePlugin extends BaseWishlistStoragePlugi
     _fetch() {
         if (window.useDefaultCookieConsent && !CookieStorageHelper.getItem(this.cookieEnabledName)) {
             this.storage.removeItem(this._getStorageKey());
-        }
-
-        if (this.getCurrentCounter() > 0) {
-            return this.products;
         }
 
         const productStr = this.storage.getItem(this._getStorageKey());


### PR DESCRIPTION
### 1. Why is this change necessary?

  The guest wishlist (`WishlistLocalStoragePlugin`) has a race condition that causes products to be silently lost when a user adds items from multiple browser tabs. Two compounding bugs are responsible:

  1. `add()` and `remove()` operate on a stale in-memory `this.products` snapshot captured at page load — they never re-read `localStorage` before writing, so any change made in another tab is overwritten.
  2. `_fetch()` had an early-return guard (`if (this.getCurrentCounter() > 0) return this.products`) that prevented re-reading `localStorage` once products were already in memory, making it impossible for a tab to pick up changes from other tabs.

### 2. What does this change do, exactly?

  - Adds a `this.load()` call at the start of both `add()` and `remove()` so that both methods always refresh `this.products` from `localStorage` before mutating it.
  - Removes the `getCurrentCounter() > 0` early-return from `_fetch()` so every invocation reads the current `localStorage` value instead of returning the cached in-memory state.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Enable the wishlist feature; ensure the user is **not** logged in.
  2. Open **Tab A** and **Tab B** on different product listing pages.
  3. Add Product 1 from Tab A.
  4. Add Product 2 from Tab B (without reloading Tab A).
  5. Add Product 3 from Tab A (without reloading).
  6. Open the wishlist page — before this fix only 2 products appear; after this fix all 3 are present.

  ### 4. Please link to the relevant issues (if any).

  - closes #14671

  ### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them