### PR TITLE
fix: only remember an uninstalled app's secret when user data is kept

### DIFF
--- a/src/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriber.php
+++ b/src/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriber.php
@@ -39,6 +39,11 @@ readonly class RememberDeletedAppsSecretSubscriber implements EventSubscriberInt
 
     public function saveSecretFromDeletedApp(AppDeletedEvent $event): void
     {
+        // The old secret is only needed to re-register an app that kept its data; otherwise a re-install starts fresh.
+        if (!$event->keepUserData()) {
+            return;
+        }
+
         $criteria = new Criteria([$event->getAppId()]);
         $app = $this->appRepository->search($criteria, $event->getContext())->first();
 

--- a/tests/unit/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriberTest.php
+++ b/tests/unit/Core/Framework/App/DeletedApps/RememberDeletedAppsSecretSubscriberTest.php
@@ -59,7 +59,8 @@ class RememberDeletedAppsSecretSubscriberTest extends TestCase
         $appId = Uuid::randomHex();
         $event = new AppDeletedEvent(
             $appId,
-            Context::createDefaultContext()
+            Context::createDefaultContext(),
+            keepUserData: true
         );
 
         $foundApp = new AppEntity();
@@ -72,6 +73,28 @@ class RememberDeletedAppsSecretSubscriberTest extends TestCase
         $this->deletedAppsGateway->expects($this->once())
             ->method('insertSecretForDeletedApp')
             ->with('test-app', 'secret-123');
+
+        $this->subscriber->saveSecretFromDeletedApp($event);
+    }
+
+    public function testSecretIsNotSavedWhenUserDataIsNotKept(): void
+    {
+        $appId = Uuid::randomHex();
+        $event = new AppDeletedEvent(
+            $appId,
+            Context::createDefaultContext(),
+            keepUserData: false
+        );
+
+        $foundApp = new AppEntity();
+        $foundApp->setId($appId);
+        $foundApp->setName('test-app');
+        $foundApp->setAppSecret('secret-123');
+
+        $this->appRepository->searches = [[$foundApp]];
+
+        $this->deletedAppsGateway->expects($this->never())
+            ->method('insertSecretForDeletedApp');
 
         $this->subscriber->saveSecretFromDeletedApp($event);
     }


### PR DESCRIPTION
## Summary

`RememberDeletedAppsSecretSubscriber` persisted a deleted app's secret into `deleted_apps` on **every** uninstall, ignoring `keepUserData`. The stored secret exists for one purpose: to sign a later **re-registration** with the previous secret so the app server can verify continuity (`shopware-shop-signature-previous`, consumed in `AppManager::enrichInstallMetadata()`).

That guarantee only holds when both sides keep the secret. `AppDeletedEvent::getWebhookPayload()` already tells the app server `keepUserData` — on **`false`** the app server is asked to discard its data (incl. its secret). Keeping ours anyway means a re-install signs the handshake with a secret the app server no longer has → the continuity proof can't validate, and we retain a secret for an app whose data the merchant explicitly wiped.

- **Fix** — `saveSecretFromDeletedApp()` now early-returns when `!$event->keepUserData()`, so Shopware retains the secret **iff** it told the app server to retain its data. A `keepUserData=false` uninstall therefore re-installs **fresh**, which is the correct behaviour for a clean removal.

The flag was already threaded correctly (`UninstallAppCommand` → `AppLifecycle::uninstall` → `AppManager::uninstall` → `AppDeletedEvent`); only the subscriber ignored it, so the change is one guard clause. `AppDeletedEvent` is dispatched from just two sites — the real uninstall and `AppManager::removeAppData()`'s install/update rollback (always `keepUserData=false`); the shop-id-change strategies re-register via `AppSecretRotationService` and dispatch no `AppDeletedEvent`, so they are unaffected.

`vendor/bin/php-cs-fixer` (dry-run), `composer phpstan`, and the `RememberDeletedAppsSecretSubscriberTest` unit suite are green; the latter gains a regression test asserting nothing is stored when `keepUserData=false`.