### PR TITLE
fix: flaky controller rate limiter test clock mock

### DIFF
--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -53,6 +53,7 @@ use Shopware\Storefront\Page\GenericPageLoader;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\Clock\NativeClock;
+use Symfony\Component\Clock\Test\ClockSensitiveTrait;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -70,6 +71,7 @@ class ControllerRateLimiterTest extends TestCase
     use OrderFixture;
     use RateLimiterTestTrait;
     use StorefrontControllerTestBehaviour;
+    use ClockSensitiveTrait;
 
     private Context $context;
 
@@ -117,8 +119,11 @@ class ControllerRateLimiterTest extends TestCase
 
     public function testGenerateAccountRecoveryRateLimit(): void
     {
+        $now = new \DateTimeImmutable('2026-01-01 00:00:00');
+        static::mockTime($now);
+
         $passwordRecoveryMailRoute = $this->createMock(SendPasswordRecoveryMailRoute::class);
-        $passwordRecoveryMailRoute->method('sendRecoveryMail')->willThrowException(new RateLimitExceededException(time() + 10));
+        $passwordRecoveryMailRoute->method('sendRecoveryMail')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 10));
 
         $controller = new AuthController(
             static::getContainer()->get(AccountLoginPageLoader::class),
@@ -221,8 +226,11 @@ class ControllerRateLimiterTest extends TestCase
 
     public function testFormControllerRateLimit(): void
     {
+        $now = new \DateTimeImmutable('2026-01-01 00:00:00');
+        static::mockTime($now);
+
         $contactFormRoute = $this->createMock(AbstractContactFormRoute::class);
-        $contactFormRoute->method('load')->willThrowException(new RateLimitExceededException(time() + 5));
+        $contactFormRoute->method('load')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
 
         $controller = new FormController(
             $contactFormRoute,
@@ -252,8 +260,11 @@ class ControllerRateLimiterTest extends TestCase
 
     public function testNewsletterSubscribeFormControllerRateLimit(): void
     {
+        $now = new \DateTimeImmutable('2026-01-01 00:00:00');
+        static::mockTime($now);
+
         $newsletterRequestRoute = $this->createMock(AbstractNewsletterSubscribeRoute::class);
-        $newsletterRequestRoute->method('subscribe')->willThrowException(new RateLimitExceededException(time() + 5));
+        $newsletterRequestRoute->method('subscribe')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
 
         $controller = new FormController(
             static::getContainer()->get(ContactFormRoute::class),
@@ -282,8 +293,11 @@ class ControllerRateLimiterTest extends TestCase
 
     public function testNewsletterUnsubscribeFormControllerRateLimit(): void
     {
+        $now = new \DateTimeImmutable('2026-01-01 00:00:00');
+        static::mockTime($now);
+
         $newsletterRequestRoute = $this->createMock(NewsletterUnsubscribeRoute::class);
-        $newsletterRequestRoute->method('unsubscribe')->willThrowException(new RateLimitExceededException(time() + 5));
+        $newsletterRequestRoute->method('unsubscribe')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
 
         $controller = new FormController(
             static::getContainer()->get(ContactFormRoute::class),
@@ -312,8 +326,11 @@ class ControllerRateLimiterTest extends TestCase
 
     public function testRevocationRequestFormControllerRateLimit(): void
     {
+        $now = new \DateTimeImmutable('2026-01-01 00:00:00');
+        static::mockTime($now);
+
         $abstractRevocationRequestRoute = $this->createMock(AbstractRevocationRequestRoute::class);
-        $abstractRevocationRequestRoute->method('request')->willThrowException(new RateLimitExceededException(time() + 5));
+        $abstractRevocationRequestRoute->method('request')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
 
         $controller = new FormController(
             static::getContainer()->get(ContactFormRoute::class),

--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -67,11 +67,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Group('slow')]
 class ControllerRateLimiterTest extends TestCase
 {
+    use ClockSensitiveTrait;
     use CustomerTestTrait;
     use OrderFixture;
     use RateLimiterTestTrait;
     use StorefrontControllerTestBehaviour;
-    use ClockSensitiveTrait;
 
     private Context $context;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`ControllerRateLimiterTest` uses `time()` directly when constructing `RateLimitExceededException`, making several tests sensitive to wall-clock timing. Under CI jitter, the elapsed time can fall just short of the exact-second threshold, causing intermittent failures unrelated to the actual code under test.

### 2. What does this change do, exactly?

Replaces `time()` calls in five rate-limiter tests with Symfony's `ClockSensitiveTrait::mockTime()`. Each test now pins a fixed `DateTimeImmutable` timestamp (`2026-01-01 00:00:00`) and uses that frozen time to construct the `RateLimitExceededException` retry-after value. This eliminates any dependency on the real wall clock during test execution.

  Affected tests:
  - `testGenerateAccountRecoveryRateLimit`
  - `testFormControllerRateLimit`
  - `testNewsletterSubscribeFormControllerRateLimit`
  - `testNewsletterUnsubscribeFormControllerRateLimit`
  - `testRevocationRequestFormControllerRateLimit`

 ### 3. Describe each step to reproduce the issue or behaviour.

  Run the following test multiple times in a resource-constrained environment (e.g. CI):

```bash
  ./vendor/bin/phpunit tests/integration/Storefront/Controller/ControllerRateLimiterTest.php --filter testFormControllerRateLimit
```

  Under timing jitter the test will occasionally report "waited 4s instead of expected 5s" and fail, even though no rate-limiting logic changed.

### 4. Please link to the relevant issues (if any).

  - closes #17454

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
