### PR TITLE
fix: promotion calculator with non stackable line items

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -284,8 +284,10 @@ class PromotionCalculator
 
         $splitItems = [];
         foreach ($calculatedCart->getLineItems() as $split) {
+            $isStackable = $split->isStackable();
             $split->setStackable(true);
             $splitItems[$split->getId()] = $this->lineItemQuantitySplitter->split($split, $shouldSplit ? 1 : $split->getQuantity(), $context);
+            $split->setStackable($isStackable);
         }
 
         $packages = $this->enrichPackagesWithCartData($packages, $splitItems);

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -328,6 +328,46 @@ class PromotionCalculatorTest extends TestCase
         static::assertSame(10.0, $thirdCalculatedCard->getPrice()->getTotalPrice());
     }
 
+    public function testCustomLineItemNotStackableBecomesStackable(): void
+    {
+        $promotionId = $this->getPromotionId();
+        $discountItem = $this->getDiscountItem($promotionId);
+
+        $discountItems = new LineItemCollection([$discountItem]);
+        $original = new Cart(Uuid::randomHex());
+
+        $productLineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $productLineItem->setPrice(new CalculatedPrice(90.0, 90.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+        $productLineItem->setStackable(true);
+
+        $customLineItem = new LineItem(Uuid::randomHex(), LineItem::CUSTOM_LINE_ITEM_TYPE);
+        $customLineItem->setPrice(new CalculatedPrice(10.0, 10.0, new CalculatedTaxCollection(), new TaxRuleCollection()));
+        $customLineItem->setStackable(false);
+
+        $toCalculate = new Cart(Uuid::randomHex());
+        $toCalculate->add($productLineItem);
+        $toCalculate->add($customLineItem);
+        $toCalculate->setPrice(new CartPrice(84.03, 100.0, 100.0, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS));
+
+        $this->promotionCalculator->calculate($discountItems, $original, $toCalculate, $this->salesChannelContext, new CartBehavior());
+        static::assertCount(3, $toCalculate->getLineItems());
+        $promotionLineItems = $toCalculate->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE);
+        static::assertCount(1, $promotionLineItems);
+
+        $promotionLineItem = $promotionLineItems->first();
+
+        static::assertNotNull($promotionLineItem);
+        static::assertNotNull($promotionLineItem->getPrice());
+
+        static::assertSame(-10.0, $promotionLineItem->getPrice()->getTotalPrice());
+
+        // Ensure that non-stackable items are still not stackable!
+        //  Right now they become stackable after each calculation.
+        $customLineItem = $toCalculate->get($customLineItem->getId());
+        self::assertNotNull($customLineItem);
+        self::assertFalse($customLineItem->isStackable());
+    }
+
     private function getPromotionId(bool $preventCombination = false, int $priority = 1, bool $useCodes = true, string $type = PromotionDiscountEntity::TYPE_ABSOLUTE): string
     {
         $promotionId = Uuid::randomHex();

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -363,8 +363,8 @@ class PromotionCalculatorTest extends TestCase
 
         // Ensure that non-stackable items are still not stackable!
         $customLineItem = $toCalculate->get($customLineItem->getId());
-        self::assertNotNull($customLineItem);
-        self::assertFalse($customLineItem->isStackable());
+        static::assertNotNull($customLineItem);
+        static::assertFalse($customLineItem->isStackable());
     }
 
     private function getPromotionId(bool $preventCombination = false, int $priority = 1, bool $useCodes = true, string $type = PromotionDiscountEntity::TYPE_ABSOLUTE): string

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionCalculatorTest.php
@@ -362,7 +362,6 @@ class PromotionCalculatorTest extends TestCase
         static::assertSame(-10.0, $promotionLineItem->getPrice()->getTotalPrice());
 
         // Ensure that non-stackable items are still not stackable!
-        //  Right now they become stackable after each calculation.
         $customLineItem = $toCalculate->get($customLineItem->getId());
         self::assertNotNull($customLineItem);
         self::assertFalse($customLineItem->isStackable());


### PR DESCRIPTION
https://github.com/shopware/shopware/pull/17417