### PR TITLE
fix: remove fixed item price option for shipping cost discounts

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -135,11 +135,14 @@ export default {
                     key: DiscountTypes.PERCENTAGE,
                     name: this.$t('sw-promotion.detail.main.discounts.valueTypePercentage'),
                 },
-                {
+            ];
+
+            if (!this.shippingScope) {
+                availableTypes.push({
                     key: DiscountTypes.FIXED_UNIT,
                     name: this.$t('sw-promotion.detail.main.discounts.valueTypeFixedUnit'),
-                },
-            ];
+                });
+            }
 
             // do not allow a fixed-total price for cart. this would mean the whole
             // cart is sold for price X.
@@ -423,11 +426,13 @@ export default {
             });
 
             this.loadRestrictedRules();
+            this.normalizeDiscountTypeForScope(this.discount.scope);
         },
 
         onDiscountScopeChanged(value) {
             this.cartScope = value === DiscountScopes.CART;
             this.shippingScope = value === DiscountScopes.DELIVERY;
+            this.normalizeDiscountTypeForScope(value);
 
             if (value === DiscountScopes.DELIVERY) {
                 this.discount.considerAdvancedRules = false;
@@ -447,6 +452,14 @@ export default {
             if (this.isPickingModeVisible) {
                 this.discount.pickerKey = this.pickerKeys[0];
             }
+        },
+
+        normalizeDiscountTypeForScope(scope) {
+            if (scope !== DiscountScopes.DELIVERY || this.discount.type !== DiscountTypes.FIXED_UNIT) {
+                return;
+            }
+
+            this.discount.type = DiscountTypes.FIXED;
         },
 
         // This function verifies the currently set value

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/sw-promotion-discount-component.spec.js
@@ -5,7 +5,7 @@ import { mount } from '@vue/test-utils';
 
 const { Criteria, EntityCollection } = Shopware.Data;
 
-async function createWrapper() {
+async function createWrapper(propOverrides = {}) {
     return mount(
         await wrapTestComponent('sw-promotion-discount-component', {
             sync: true,
@@ -143,6 +143,7 @@ async function createWrapper() {
                         new Criteria(1, 25),
                     ),
                 },
+                ...propOverrides,
             },
         },
     );
@@ -227,5 +228,67 @@ describe('src/module/sw-promotion-v2/component/sw-promotion-discount-component',
         expect(wrapper.vm.discount.promotionDiscountPrices).toHaveLength(1);
         expect(wrapper.vm.discount.promotionDiscountPrices[0].currencyId).toBe('currencyId');
         expect(wrapper.vm.discount.promotionDiscountPrices[0].price).toBe(9);
+    });
+
+    it('should not offer fixed item price for shipping costs discounts', async () => {
+        const wrapper = await createWrapper({
+            discount: {
+                isNew: () => false,
+                promotionId: 'promotionId',
+                scope: 'delivery',
+                type: 'absolute',
+                value: 100,
+                considerAdvancedRules: false,
+                maxValue: null,
+                sorterKey: 'PRICE_ASC',
+                applierKey: 'ALL',
+                usageKey: 'ALL',
+                apiAlias: null,
+                id: 'discountId',
+                discountRules: new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25)),
+                promotionDiscountPrices: new EntityCollection(
+                    '',
+                    'promotion_discount_prices',
+                    Shopware.Context.api,
+                    new Criteria(1, 25),
+                ),
+            },
+        });
+
+        expect(wrapper.vm.discountTypeOptions.map(({ value }) => value)).toEqual([
+            'absolute',
+            'percentage',
+            'fixed',
+        ]);
+    });
+
+    it('should normalize fixed item price to fixed price for shipping costs discounts', async () => {
+        const wrapper = await createWrapper({
+            discount: {
+                isNew: () => false,
+                promotionId: 'promotionId',
+                scope: 'delivery',
+                type: 'fixed_unit',
+                value: 100,
+                considerAdvancedRules: false,
+                maxValue: null,
+                sorterKey: 'PRICE_ASC',
+                applierKey: 'ALL',
+                usageKey: 'ALL',
+                apiAlias: null,
+                id: 'discountId',
+                discountRules: new EntityCollection('', 'rule', Shopware.Context.api, new Criteria(1, 25)),
+                promotionDiscountPrices: new EntityCollection(
+                    '',
+                    'promotion_discount_prices',
+                    Shopware.Context.api,
+                    new Criteria(1, 25),
+                ),
+            },
+        });
+
+        await flushPromises();
+
+        expect(wrapper.vm.discount.type).toBe('fixed');
     });
 });


### PR DESCRIPTION
- remove the `fixed item price` option for promotion discounts with shipping-cost scope

fixes: https://github.com/shopware/shopware/issues/9535

after:
<img width="580" height="534" alt="Screenshot 2026-06-15 at 18 49 33" src="https://github.com/user-attachments/assets/90fa9b2e-db2b-4170-9e50-381f79ec495f" />
