### PR TITLE
fix: add XXL thumbnail sizes to product boxes

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/product/card/box.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box.html.twig
@@ -11,7 +11,8 @@
         sm: '315px',
         md: '390px',
         lg: '350px',
-        xl: '280px'
+        xl: '280px',
+        xxl: '280px'
     } %}
 
     {% if layout == 'image' %}
@@ -20,7 +21,8 @@
             sm: '500px',
             md: '390px',
             lg: '350px',
-            xl: '280px'
+            xl: '280px',
+            xxl: '280px'
         } %}
     {% endif %}
 

--- a/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Framework\Twig;
 
 use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollection;
@@ -140,9 +141,53 @@ class ThumbnailExtensionTest extends TestCase
         // Every breakpoint entry in the auto-generated sizes attribute must carry
         // a non-empty value. Before the fix the xxl entry was missing and produced
         // "(min-width: ...px) ," in the rendered output.
-        static::assertSame(1, preg_match('/\ssizes="(?P<sizes>[^"]+)"/', $result, $matches), 'sizes attribute is missing');
+        $sizes = self::getSizesAttribute($result);
 
-        $entries = array_map('trim', explode(',', $matches['sizes']));
+        self::assertSizesAttributeHasValueForEveryBreakpoint($sizes);
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws \Throwable
+     * @throws Exception
+     * @throws RuntimeError
+     * @throws LoaderError
+     */
+    #[DataProvider('productBoxLayoutProvider')]
+    public function testProductBoxThumbnailSizesContainXxlBreakpointValue(string $layout): void
+    {
+        $result = $this->renderTemplate('@Storefront/storefront/product-box-thumbnail-sizes.html.twig', [
+            'layout' => $layout,
+            'media' => $this->createExampleMediaWithThumbnails([280, 400, 800, 1920]),
+            'context' => Generator::generateSalesChannelContext(),
+        ]);
+
+        $sizes = self::getSizesAttribute($result);
+
+        self::assertSizesAttributeHasValueForEveryBreakpoint($sizes);
+        static::assertStringContainsString('(min-width: 1400px) 280px', $sizes);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function productBoxLayoutProvider(): iterable
+    {
+        yield 'standard layout' => ['standard'];
+        yield 'image layout' => ['image'];
+    }
+
+    private static function getSizesAttribute(string $result): string
+    {
+        static::assertSame(1, preg_match('/\ssizes="(?P<sizes>[^"]+)"/', $result, $matches), 'sizes attribute is missing');
+        static::assertIsString($matches['sizes']);
+
+        return $matches['sizes'];
+    }
+
+    private static function assertSizesAttributeHasValueForEveryBreakpoint(string $sizes): void
+    {
+        $entries = array_map('trim', explode(',', $sizes));
         $fallback = array_pop($entries);
 
         static::assertNotEmpty($fallback, 'sizes fallback entry is empty');

--- a/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/component/product/card/box-image.html.twig
+++ b/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/component/product/card/box-image.html.twig
@@ -1,0 +1,4 @@
+{% sw_thumbnails 'product-box-image-thumbnail-sizes' with {
+    media: media,
+    sizes: sizes
+} %}

--- a/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -1,0 +1,4 @@
+{% sw_thumbnails 'product-box-standard-thumbnail-sizes' with {
+    media: media,
+    sizes: sizes
+} %}

--- a/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/product-box-thumbnail-sizes.html.twig
+++ b/tests/integration/Storefront/Framework/Twig/fixtures/Storefront/Resources/views/storefront/product-box-thumbnail-sizes.html.twig
@@ -1,0 +1,3 @@
+{% sw_include '@Storefront/storefront/component/product/card/box.html.twig' with {
+    layout: layout
+} %}


### PR DESCRIPTION
Fixes #17438

Adds the missing `xxl` value to the thumbnail `sizes` map used by product boxes.

## Why?

Product boxes define explicit thumbnail sizes in `box.html.twig`. Because those maps did not include an `xxl` entry, `sw_thumbnails` rendered an empty value for the XXL breakpoint, e.g. `(min-width: 1400px) ,`.

## How?

- Add `xxl: '280px'` for standard product boxes.
- Add `xxl: '280px'` for image product boxes.
- Add a Twig regression test covering both product box layouts.

The new `xxl` value intentionally reuses the existing `xl` value of `280px`. Before the `xxl` breakpoint was added to the thumbnail breakpoint map, the `xl` entry was the largest configured size and therefore also applied to viewports above `1400px`. Reusing `280px` restores that previous behavior while fixing the empty XXL `sizes` entry.
