### PR TITLE
fix: elasticsearch bulk refresh test flakiness

### DIFF
--- a/src/Elasticsearch/DependencyInjection/Configuration.php
+++ b/src/Elasticsearch/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('enabled')->end()
                 ->booleanNode('indexing_enabled')->end()
                 ->integerNode('indexing_batch_size')->defaultValue(100)->end()
+                ->booleanNode('refresh_after_bulk')->defaultFalse()->end()
                 ->scalarNode('hosts')->end()
                 ->scalarNode('index_prefix')->end()
                 ->scalarNode('throw_exception')->end()

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -41,7 +41,8 @@ class ElasticsearchIndexer
         private readonly LoggerInterface $logger,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly int $indexingBatchSize,
-        private readonly ClockInterface $clock
+        private readonly ClockInterface $clock,
+        private readonly bool $refreshAfterBulk = false,
     ) {
     }
 
@@ -276,6 +277,10 @@ class ElasticsearchIndexer
             'index' => $index,
             'body' => $documents,
         ];
+
+        if ($this->refreshAfterBulk) {
+            $arguments['refresh'] = true;
+        }
 
         $result = $this->client->bulk($arguments);
 

--- a/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/elasticsearch.yaml
@@ -125,6 +125,7 @@ elasticsearch:
         exclude_source: "%env(bool:SHOPWARE_ES_EXCLUDE_SOURCE)%"
     ssl:
         verify_server_cert: true
+    refresh_after_bulk: false
     index_settings:
         number_of_shards: '%env(int-or-null:SHOPWARE_ES_NUMBER_OF_SHARDS)%'
         number_of_replicas: '%env(int-or-null:SHOPWARE_ES_NUMBER_OF_REPLICAS)%'

--- a/src/Elasticsearch/Resources/config/packages/test/elasticsearch.yaml
+++ b/src/Elasticsearch/Resources/config/packages/test/elasticsearch.yaml
@@ -1,4 +1,5 @@
 elasticsearch:
+    refresh_after_bulk: true
     index_settings:
         number_of_shards: 1
         number_of_replicas: 0

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -383,6 +383,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument>%elasticsearch.indexing_batch_size%</argument>
             <argument type="service" id="Psr\Clock\ClockInterface"/>
+            <argument>%elasticsearch.refresh_after_bulk%</argument>
 
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Elasticsearch/Test/ElasticsearchTestTestBehaviour.php
+++ b/src/Elasticsearch/Test/ElasticsearchTestTestBehaviour.php
@@ -50,8 +50,6 @@ trait ElasticsearchTestTestBehaviour
             ->run(new ArrayInput([]), new NullOutput());
 
         $this->runWorker();
-
-        $this->refreshIndex();
     }
 
     public function refreshIndex(): void

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -234,8 +234,6 @@ class ElasticsearchProductTest extends TestCase
                     ->build(),
             ], $context);
 
-            $this->refreshIndex();
-
             $criteria = new Criteria();
             $criteria->addState(Criteria::STATE_ELASTICSEARCH_AWARE);
             $criteria->addFilter(new EqualsFilter('productNumber', 'u7'));
@@ -247,7 +245,6 @@ class ElasticsearchProductTest extends TestCase
 
             $this->productRepository->delete([['id' => $ids->get('u7')]], $context);
 
-            $this->refreshIndex();
             $result = $searcher->search($this->productDefinition, $criteria, $context);
             static::assertCount(0, $result->getIds());
         } catch (\Exception $e) {

--- a/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php
@@ -333,8 +333,6 @@ class ProductSearchQueryBuilderTest extends TestCase
         $ids = new IdsCollection();
         $this->createData($ids);
 
-        $this->refreshIndex();
-
         return $ids;
     }
 

--- a/tests/integration/Elasticsearch/Product/ProductSortingStreamSearchTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSortingStreamSearchTest.php
@@ -554,8 +554,6 @@ class ProductSortingStreamSearchTest extends TestCase
             ]
         );
 
-        $this->refreshIndex();
-
         $index = $this->helper->getIndexName($this->productDefinition);
 
         $exists = $this->client->indices()->exists(['index' => $index]);

--- a/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/unit/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -422,7 +422,8 @@ class ElasticsearchIndexerTest extends TestCase
             $logger,
             $eventDispatcher,
             1,
-            new NativeClock()
+            new NativeClock(),
+            true
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`ElasticsearchProductTest::testTermAlgorithm` and `testEntityAggregationWithTermQuery` fail intermittently across unrelated PRs because freshly bulk-indexed documents are not guaranteed to be query-visible when assertions run. After the worker drains the indexing queue and `indices()->refresh()` is called, OpenSearch can still return 0 hits under CI load — the write is in the translog but the segment hasn't been made searchable yet.

### 2. What does this change do, exactly?

Adds a `refresh_after_bulk` configuration option to `ElasticsearchIndexer`. When enabled, `'refresh' => true` is passed directly to every `bulk()` call, instructing OpenSearch to block the HTTP response until the indexed documents are visible to search. This makes the guarantee server-side and deterministic rather than relying on a post-hoc `indices()->refresh()` call.

The option defaults to `false` (no behaviour change in production). It is set to `true` in `src/Elasticsearch/Resources/config/packages/test/elasticsearch.yaml`, so all test environments automatically get immediate document visibility after every bulk operation — including incremental writes via `updateIds()` that are triggered by repository events.

As a consequence, the now-redundant explicit `refreshIndex()` calls that followed bulk operations in the storefront product test files are removed.

  **Changed files:**
  - `src/Elasticsearch/DependencyInjection/Configuration.php` — register `refresh_after_bulk` bool node (default `false`)
  - `src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php` — accept `$refreshAfterBulk` constructor param; inject `'refresh' => true` into `bulk()` arguments when set
  - `src/Elasticsearch/Resources/config/services.xml` — wire `%elasticsearch.refresh_after_bulk%` as the final constructor argument
  - `src/Elasticsearch/Resources/config/packages/test/elasticsearch.yaml` — set `refresh_after_bulk: true`
  - `src/Elasticsearch/Test/ElasticsearchTestTestBehaviour.php` — remove now-redundant `refreshIndex()` from `indexElasticSearch()`
  - `tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php` — remove redundant `refreshIndex()` calls after `upsert`/`delete`
  - `tests/integration/Elasticsearch/Product/ProductSortingStreamSearchTest.php` — remove redundant `refreshIndex()` after `updateIds()`
  - `tests/integration/Elasticsearch/Product/ProductSearchQueryBuilderTest.php` — remove redundant `refreshIndex()` after `createData()`

### 3. Describe each step to reproduce the issue or behaviour.

The flakiness is timing-dependent and most visible under CI load, but can be reproduced with a pinned seed via the `ci/reproduce-es-product-flaky` branch. Without this fix, `testTermAlgorithm` searches for `spachtelmasse` and returns 0 results; `testEntityAggregationWithTermQuery` returns an aggregation of size 0 instead of 2.

  ### 4. Please link to the relevant issues (if any).

  - closes #17445

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them