### PR TITLE
ci: warm trunk PHPStan result cache after each merge

### DIFF
--- a/.github/workflows/phpstan-cache-warm.yml
+++ b/.github/workflows/phpstan-cache-warm.yml
@@ -1,22 +1,8 @@
 name: PHPStan cache warm (trunk)
 
-# Keeps trunk's PHPStan result cache fresh after every merge.
-#
-# Why: the php.yml "PHPStan" job restores its result cache via the
-# "phpstan-result-cache-" key prefix, but that cache is only refreshed by the
-# nightly run -- so by mid-day it is up to ~24h stale and PRs restore a cache
-# whose metadata (config / Symfony container / composer) no longer matches the
-# current tree. PHPStan then discards the whole cache and re-analyses from
-# scratch (~13 min, the PR pipeline's long pole). Measured: ~64% of PHPStan
-# runs over a 7-day window were cold.
-#
-# This workflow re-runs PHPStan on trunk after each merge and saves the cache
-# under the SAME key prefix php.yml restores from. PRs based on current trunk
-# (that do not themselves change config/DI/dependencies) then restore a
-# minutes-old, matching cache and reuse it incrementally (~15-100s).
-#
-# It is purely additive: no change to php.yml and no code change. Each warm run
-# restores the previous warm cache, so it is itself incremental and cheap.
+# Refreshes trunk's PHPStan result cache after every merge so PRs restore a
+# current cache instead of the up-to-24h-old nightly one. Saves under the same
+# "phpstan-result-cache-" key the php.yml PHPStan job reads from.
 
 on:
   push:

--- a/.github/workflows/phpstan-cache-warm.yml
+++ b/.github/workflows/phpstan-cache-warm.yml
@@ -1,0 +1,62 @@
+name: PHPStan cache warm (trunk)
+
+# Keeps trunk's PHPStan result cache fresh after every merge.
+#
+# Why: the php.yml "PHPStan" job restores its result cache via the
+# "phpstan-result-cache-" key prefix, but that cache is only refreshed by the
+# nightly run -- so by mid-day it is up to ~24h stale and PRs restore a cache
+# whose metadata (config / Symfony container / composer) no longer matches the
+# current tree. PHPStan then discards the whole cache and re-analyses from
+# scratch (~13 min, the PR pipeline's long pole). Measured: ~64% of PHPStan
+# runs over a 7-day window were cold.
+#
+# This workflow re-runs PHPStan on trunk after each merge and saves the cache
+# under the SAME key prefix php.yml restores from. PRs based on current trunk
+# (that do not themselves change config/DI/dependencies) then restore a
+# minutes-old, matching cache and reuse it incrementally (~15-100s).
+#
+# It is purely additive: no change to php.yml and no code change. Each warm run
+# restores the previous warm cache, so it is itself incremental and cheap.
+
+on:
+  push:
+    branches:
+      - trunk
+  workflow_dispatch:
+
+concurrency:
+  group: phpstan-cache-warm
+  cancel-in-progress: false # let each warm run finish saving its cache
+
+jobs:
+  warm:
+    if: github.repository == 'shopware/shopware'
+    runs-on: ubuntu-24.04
+    name: "PHPStan cache warm"
+    steps:
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+
+      - name: Generate Schema
+        run: composer run framework:schema:dump
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: var/cache/phpstan
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
+
+      - name: PHPStan
+        run: composer run phpstan -- --error-format=table --no-progress
+
+      - name: "Save result cache"
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        if: always()
+        with:
+          path: var/cache/phpstan
+          key: "phpstan-result-cache-${{ github.run_id }}"


### PR DESCRIPTION
## Problem

PHPStan is the slowest job in the PR pipeline — about 13 minutes on a cold run.

PHPStan caches its analysis results between runs. To reuse that cache it first checks the environment still matches (PHP/PHPStan version, the resolved config, the Symfony container, and the installed dependencies). If anything differs, it discards the whole cache and re-analyses every file from scratch.

The cache is only rebuilt once a day, by the nightly run. By the time most PRs run, trunk has moved on, so the cache a PR downloads no longer matches and gets thrown away. Over the last 7 days (765 runs), ~64% of PHPStan runs were cold (~11 min each); only ~36% reused the cache.

## What this PR does

Adds a small workflow that re-runs PHPStan on trunk after every merge and saves its cache under the same key PR runs already read from. PRs then download a fresh, matching cache and PHPStan only re-checks the files the PR changed.

- The warm run reuses the previous one's cache, so it's fast itself (usually 15–100s).
- Cost is one extra PHPStan run per merge to trunk — free on our public runners.

## Expected effect

- PHPStan runs cold on far fewer PRs (roughly 60% → 30%).
- On the PRs that benefit, the pipeline drops from ~13 min to ~4.5 min.

## What it deliberately doesn't fix

If a PR genuinely changes a service definition, the PHPStan config/baseline, or `composer.json`, the cache can't be reused and that run stays cold. That's about half of today's cold runs and it's expected — there's no safe way around it here.

## How to verify (after merge)

The benefit only appears once this runs on trunk. A few days after merging:

1. **Warming is live** — `phpstan-cache-warm.yml` runs on each trunk merge and succeeds; after the first run its log shows `Result cache restored` (the cache is staying fresh).
2. **PRs reuse it** — sample PHPStan job times over ~5 weekdays. A PHPStan step under ~250s = cache hit; ~650–800s = cold. Expect cold runs to roughly halve (was ~64%).
3. **The remaining cold runs are the expected ones** — look at what the PRs that are still cold actually changed. They should only be PRs that changed a service definition, the PHPStan config/baseline, or `composer.json` (those can't reuse the cache — see above). If PRs that changed none of those are still cold, the warm cache isn't reaching them.
