### PR TITLE
chore: add inheritance aware to support inherit in the attribute entity

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Attribute/Entity.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/Entity.php
@@ -27,6 +27,7 @@ final class Entity
         public ?string $since = null,
         public string $collectionClass = EntityCollection::class,
         public string $hydratorClass = EntityHydrator::class,
+        public bool $inheritanceAware = false,
     ) {
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -173,6 +173,7 @@ class AttributeEntityCompiler
             'type' => 'entity',
             'since' => $instance->since,
             'parent' => $instance->parent,
+            'inheritance_aware' => $instance->inheritanceAware,
             'entity_class' => $class,
             'entity_name' => $instance->name,
             'hydrator_class' => $instance->hydratorClass,

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
@@ -52,6 +52,11 @@ class AttributeEntityDefinition extends EntityDefinition
         return $this->meta['hydrator_class'];
     }
 
+    public function isInheritanceAware(): bool
+    {
+        return (bool) ($this->meta['inheritance_aware'] ?? false);
+    }
+
     protected function getParentDefinitionClass(): ?string
     {
         return $this->meta['parent'] ?? null;

--- a/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/AttributeEntityCompilerTest.php
@@ -389,6 +389,7 @@ class AttributeEntityCompilerTest extends TestCase
                 'type' => 'entity',
                 'since' => '6.6.3.0',
                 'parent' => null,
+                'inheritance_aware' => false,
                 'entity_class' => AttributeEntity::class,
                 'entity_name' => 'attribute_entity',
                 'hydrator_class' => EntityHydrator::class,


### PR DESCRIPTION
### Why this platform change is needed

Sub Organization Units need to use Shopware DAL inheritance for inherited fields and associations such as addresses, payment methods, shipping methods, default addresses, and IndividualPricing assignments.

For explicit entity definitions this is already possible by overriding `EntityDefinition::isInheritanceAware()`. However, attribute-based entities are generated through `AttributeEntityDefinition`, and before this change there was no way for an attribute entity to opt into DAL inheritance. Even if fields are marked with `#[Inherited]`, the DAL read/write/query/hydration logic only activates inheritance when the entity definition returns `isInheritanceAware() = true`.

This change adds a minimal opt-in flag to the attribute entity metadata:

- `#[Entity(..., inheritanceAware: true)]`
- `AttributeEntityCompiler` stores the flag as definition metadata.
- `AttributeEntityDefinition::isInheritanceAware()` reads that metadata.

The default remains `false`, so existing attribute entities keep their current behavior. Explicit entity definitions are also unaffected.

This allows an attribute entity to participate in the existing DAL inheritance mechanism without introducing custom definition classes or new platform-specific parent/child attributes.