### PR TITLE
fix: media field popover clipped in modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/index.js
@@ -98,7 +98,7 @@ export default {
             }
 
             const inModal = !!this.$el.closest('.mt-modal');
-            return inModal ? { targetSelector: '.mt-modal__content-inner' } : {};
+            return inModal ? { targetSelector: '.mt-modal' } : {};
         },
 
         mediaFieldClasses() {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.scss
@@ -147,6 +147,16 @@ $sw-media-field-color-unlink: $color-crimson-500;
     }
 }
 
+.mt-modal:has(.sw-popover__wrapper.sw-media-field__expanded-content) {
+    overflow: visible;
+
+    .mt-modal__header,
+    .mt-modal__content,
+    .mt-modal__footer {
+        overflow-x: hidden;
+    }
+}
+
 .sw-popover__wrapper.sw-media-field__expanded-content.--placement-bottom-outside {
     transform: translate(calc(-100% + 45px), calc(-100% - 50px));
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.spec.js
@@ -139,7 +139,7 @@ describe('src/app/component/media/sw-media-field', () => {
 
         const config = wrapper.vm.$options.computed.popoverConfig.call(wrapper.vm);
         expect(config).toEqual({
-            targetSelector: '.mt-modal__content-inner',
+            targetSelector: '.mt-modal',
         });
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When `sw-media-field` is used inside an `mt-modal`, its picker popover is clipped and partially or fully invisible. `mt-modal` has `overflow: hidden` on its root element and uses the CSS `translate` property for centering (`translate: -50% -50%`). Per the CSS spec, a `translate` (or any transform) on an ancestor establishes a new containing block for all positioned descendants — including `position: fixed` — and `overflow: hidden` clips everything within it. No CSS positioning strategy can escape this boundary from inside the modal.

### 2. What does this change do, exactly?

Two small changes to `sw-media-field`:

**`index.js`** — when the component detects it is inside `.mt-modal`, the `popoverConfig` now uses `targetSelector: '.mt-modal'` (the modal root) instead of `'.mt-modal__content-inner'`. This appends the popover as a direct child of `.mt-modal` rather than deep inside the scrollable content wrapper, giving it the correct positioning context.

  **`sw-media-field.scss`** — adds a CSS `:has()` rule:

  ```css
  .mt-modal:has(.sw-popover__wrapper.sw-media-field__expanded-content) {
      overflow: visible;

      .mt-modal__header,
      .mt-modal__content,
      .mt-modal__footer {
          overflow-x: hidden;
      }
  }
  ```

This sets `overflow: visible` on `.mt-modal` only while the picker popover is present in the DOM, allowing it to extend outside the modal's bounds. The child sections retain `overflow-x: hidden` so the modal's internal layout is unaffected.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Open any view that renders `sw-media-field` inside an `mt-modal`.
  2. Click the media picker button.
  3. **Before:** the picker popover is clipped by the modal — the search field and/or media list are cut off and unreachable.
  4. **After:** the full picker popover is visible and usable.

### 4. Please link to the relevant issues (if any).

  - closes #15213

### 5. Checklist

  - [ ] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them