### PR TITLE
fix: gate service scripts by services env

### DIFF
--- a/src/Core/Framework/App/ActiveAppsLoader.php
+++ b/src/Core/Framework/App/ActiveAppsLoader.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\Service\ResetInterface;
 #[Package('framework')]
 class ActiveAppsLoader implements ResetInterface
 {
+    private const SERVICES_ENABLED_AUTO = 'auto';
+
     /**
      * @var array<App>|null
      */
@@ -27,7 +29,9 @@ class ActiveAppsLoader implements ResetInterface
     public function __construct(
         private readonly Connection $connection,
         private readonly AppLoader $appLoader,
-        private readonly string $projectDir
+        private readonly string $projectDir,
+        private readonly string $servicesEnabled = self::SERVICES_ENABLED_AUTO,
+        private readonly string $appEnv = 'prod',
     ) {
     }
 
@@ -41,6 +45,19 @@ class ActiveAppsLoader implements ResetInterface
         }
 
         return $this->activeApps;
+    }
+
+    public function isActive(string $appName): bool
+    {
+        foreach ($this->getActiveApps() as $app) {
+            if ($app['name'] !== $appName) {
+                continue;
+            }
+
+            return !$app['selfManaged'] || $this->servicesEnabled();
+        }
+
+        return false;
     }
 
     public function reset(): void
@@ -86,5 +103,14 @@ class ActiveAppsLoader implements ResetInterface
                 'selfManaged' => false,
             ], $this->appLoader->load());
         }
+    }
+
+    private function servicesEnabled(): bool
+    {
+        if ($this->servicesEnabled === self::SERVICES_ENABLED_AUTO) {
+            return $this->appEnv === 'prod';
+        }
+
+        return filter_var($this->servicesEnabled, \FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -200,6 +200,8 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLoader"/>
             <argument>%kernel.project_dir%</argument>
+            <argument>%env(ENABLE_SERVICES)%</argument>
+            <argument>%kernel.environment%</argument>
 
             <tag name="kernel.reset" method="reset"/>
             <tag name="kernel.event_listener" event="console.terminate" method="reset"/>

--- a/src/Core/Framework/DependencyInjection/script.xml
+++ b/src/Core/Framework/DependencyInjection/script.xml
@@ -17,6 +17,7 @@
 
         <service id="Shopware\Core\Framework\Script\Execution\ScriptExecutor" public="true">
             <argument type="service" id="Shopware\Core\Framework\Script\Execution\ScriptLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\App\ActiveAppsLoader"/>
             <argument type="service" id="Shopware\Core\Framework\Script\Debugging\ScriptTraces"/>
             <argument type="service" id="service_container"/>
             <argument type="service" id="Shopware\Core\Framework\Script\Execution\ScriptEnvironmentFactory"/>
@@ -72,4 +73,3 @@
         </service>
     </services>
 </container>
-

--- a/src/Core/Framework/Script/Execution/ScriptExecutor.php
+++ b/src/Core/Framework/Script/Execution/ScriptExecutor.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Script\Execution;
 
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Event\Hooks\AppLifecycleHook;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Api\AclFacadeHookFactory;
@@ -38,6 +39,7 @@ class ScriptExecutor
      */
     public function __construct(
         private readonly ScriptLoader $loader,
+        private readonly ActiveAppsLoader $activeAppsLoader,
         private readonly ScriptTraces $traces,
         private readonly ContainerInterface $container,
         private readonly ScriptEnvironmentFactory $scriptEnvironmentFactory,
@@ -60,8 +62,14 @@ class ScriptExecutor
                 continue;
             }
 
-            if (!$hook instanceof AppLifecycleHook && !$script->isActive()) {
-                continue;
+            if (!$hook instanceof AppLifecycleHook) {
+                if (!$script->isActive()) {
+                    continue;
+                }
+
+                if ($scriptAppInfo && !$this->activeAppsLoader->isActive($scriptAppInfo->getAppName())) {
+                    continue;
+                }
             }
 
             try {

--- a/tests/integration/Core/Content/Product/Hook/ProductPricingHookTest.php
+++ b/tests/integration/Core/Content/Product/Hook/ProductPricingHookTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Cart\Facade\ScriptPriceStubs;
 use Shopware\Core\Content\Product\Hook\Pricing\ProductPricingHook;
 use Shopware\Core\Content\Product\Hook\Pricing\ProductProxy;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -95,6 +96,7 @@ class ProductPricingHookTest extends TestCase
 
         $executor = new ScriptExecutor(
             $loader,
+            static::getContainer()->get(ActiveAppsLoader::class),
             $traces,
             static::getContainer(),
             static::getContainer()->get(ScriptEnvironmentFactory::class),

--- a/tests/unit/Core/Framework/App/ActiveAppsLoaderTest.php
+++ b/tests/unit/Core/Framework/App/ActiveAppsLoaderTest.php
@@ -91,4 +91,64 @@ class ActiveAppsLoaderTest extends TestCase
 
         static::assertSame($expected, $activeAppsLoader->getActiveApps());
     }
+
+    public function testIsActiveChecksServicesEnvForSelfManagedApps(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'name' => 'regular-app',
+                    'path' => 'regular-app',
+                    'author' => 'test',
+                    'self_managed' => 0,
+                ],
+                [
+                    'name' => 'service-app',
+                    'path' => 'service-app',
+                    'author' => 'test',
+                    'self_managed' => 1,
+                ],
+            ]);
+
+        $activeAppsLoader = new ActiveAppsLoader(
+            $connection,
+            $this->createMock(AppLoader::class),
+            '/',
+            'false',
+            'prod'
+        );
+
+        static::assertTrue($activeAppsLoader->isActive('regular-app'));
+        static::assertFalse($activeAppsLoader->isActive('service-app'));
+        static::assertFalse($activeAppsLoader->isActive('missing-app'));
+    }
+
+    public function testIsActiveUsesProdForAutoServicesEnv(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                [
+                    'name' => 'service-app',
+                    'path' => 'service-app',
+                    'author' => 'test',
+                    'self_managed' => 1,
+                ],
+            ]);
+
+        $activeAppsLoader = new ActiveAppsLoader(
+            $connection,
+            $this->createMock(AppLoader::class),
+            '/',
+            'auto',
+            'dev'
+        );
+
+        static::assertFalse($activeAppsLoader->isActive('service-app'));
+    }
 }

--- a/tests/unit/Core/Framework/Script/Execution/ScriptExecutorTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptExecutorTest.php
@@ -4,8 +4,13 @@ namespace Shopware\Tests\Unit\Core\Framework\Script\Execution;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Script\Api\ApiHook;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Script\Execution\InterfaceHook;
+use Shopware\Core\Framework\Script\Execution\Script;
+use Shopware\Core\Framework\Script\Execution\ScriptAppInformation;
 use Shopware\Core\Framework\Script\Execution\ScriptEnvironmentFactory;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Script\Execution\ScriptLoader;
@@ -22,6 +27,7 @@ class ScriptExecutorTest extends TestCase
     {
         $scriptExecutor = new ScriptExecutor(
             $this->createMock(ScriptLoader::class),
+            $this->createMock(ActiveAppsLoader::class),
             $this->createMock(ScriptTraces::class),
             $this->createMock(ContainerInterface::class),
             $this->createMock(ScriptEnvironmentFactory::class),
@@ -32,5 +38,44 @@ class ScriptExecutorTest extends TestCase
         } catch (ScriptException $e) {
             static::assertSame(ScriptException::INTERFACE_HOOK_EXECUTION_NOT_ALLOWED, $e->getErrorCode());
         }
+    }
+
+    public function testSkipsScriptWhenAppIsNotActive(): void
+    {
+        $loader = $this->createMock(ScriptLoader::class);
+        $loader
+            ->expects($this->once())
+            ->method('get')
+            ->with('api-service-endpoint')
+            ->willReturn([
+                new Script(
+                    'service-script.twig',
+                    '',
+                    new \DateTimeImmutable(),
+                    new ScriptAppInformation('app-id', 'SwagService', '1.0.0', 'integration-id'),
+                ),
+            ]);
+
+        $activeAppsLoader = $this->createMock(ActiveAppsLoader::class);
+        $activeAppsLoader
+            ->expects($this->once())
+            ->method('isActive')
+            ->with('SwagService')
+            ->willReturn(false);
+
+        $scriptEnvironmentFactory = $this->createMock(ScriptEnvironmentFactory::class);
+        $scriptEnvironmentFactory
+            ->expects($this->never())
+            ->method('initEnv');
+
+        $scriptExecutor = new ScriptExecutor(
+            $loader,
+            $activeAppsLoader,
+            $this->createMock(ScriptTraces::class),
+            $this->createMock(ContainerInterface::class),
+            $scriptEnvironmentFactory,
+        );
+
+        $scriptExecutor->execute(new ApiHook('service-endpoint', [], Context::createDefaultContext()));
     }
 }


### PR DESCRIPTION
## Summary
- Track the resolved `ENABLE_SERVICES` state in system config
- Sync env-state changes on main requests
- Uninstall services when the env kill switch flips off and schedule install when it flips back on
