### PR TITLE
chore: deprecate agentic commerce in core

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -271,6 +271,20 @@ This reduced loading is **enabled for fresh installations** and **disabled for e
 
 A new read-only, translatable `descriptionTeaser` field is available on `product` (and `product_translation`). It is derived from the description on write (HTML stripped, truncated to 512 characters) and exposed via the Store and Admin API. The stripping is configurable through the `html_sanitizer` field set `product_translation.descriptionTeaser`. Existing products are backfilled asynchronously: the migration schedules the `product.description_teaser.indexer`, which runs over the message queue after the update (or manually via `bin/console dal:refresh:index`).
 
+### Agentic Commerce product export and tracking classes deprecated
+
+The following classes related to Agentic Commerce product exports, providers, and sales channel tracking are deprecated and will be removed in Shopware 6.8.0:
+
+- `Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductExportProvider`
+- `Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportProviderRegistry`
+- `Shopware\Core\Content\ProductExport\Provider\GoogleProductExportProvider`
+- `Shopware\Core\Content\ProductExport\Provider\OpenAiProductExportProvider`
+- `Shopware\Core\Content\ProductExport\Validator\JsonlRowParser`
+- `Shopware\Core\Content\ProductExport\Validator\OpenAiProductExportValidator`
+- `Shopware\Core\Content\ProductExport\Validator\GoogleProductExportValidator`
+
+This functionality will be available in the **Agentic Commerce extension (SwagAgenticCommerce)** instead.
+
 ## Administration
 
 ### Cache-relevant extension configuration fields
@@ -369,6 +383,43 @@ Administration dropdowns now identify outside clicks correctly when the browser 
 ### Resolving download errors by renaming media
 
 When merchants rename a media file, its URL automatically updates so they can download it without issues.
+
+### Agentic Commerce Administration components deprecated
+
+The following Administration component, methods, and computed properties are deprecated and will be removed in Shopware 6.8:
+
+**`sw-agentic-commerce-tracking-config`** — entire component deprecated.
+
+**`sw-sales-channel-modal-grid`:**
+- computed `salesChannelRepository`
+- method `isAgenticCommerceSalesChannelType()`
+- method `showAgenticCommerceType()`
+
+**`sw-sales-channel-detail`:**
+- provide `swSalesChannelDetailGetAgenticCommerceExportConfig`
+- data `agenticCommerceExportConfig`
+- computed `isAgenticCommerce`
+- computed `defaultAgenticCommerceExportConfig`
+- method `validateAgenticCommerceExportConfig()`
+- method `loadAgenticCommerceExportConfig()`
+- method `saveAgenticCommerceExportConfig()`
+
+**`sw-sales-channel-create-base`:**
+- method `prefillAgenticCommerceDefaults()`
+
+**`sw-sales-channel-detail-base`:**
+- inject `swSalesChannelDetailGetAgenticCommerceExportConfig`
+- computed `isAgenticCommerce`
+- computed `resolvedAgenticCommerceExportConfig`
+- method `getAgenticCommerceExportElementBind()`
+- method `getAgenticCommerceExportCardTitle()`
+- method `getAgenticCommerceExportCardPositionIdentifier()`
+- method `onAgenticCommerceExportFieldUpdate()`
+
+**`sw-sales-channel-detail-product-comparison`:**
+- computed `isAgenticCommerce`
+
+This functionality will be available in the **Agentic Commerce extension (SwagAgenticCommerce)** instead.
 
 ## App System
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -75,6 +75,12 @@ Affected commands:
 | `bin/console dal:validate --json` | `bin/console dal:validate --format json` |
 | `bin/console sales-channel:list --output json` | `bin/console sales-channel:list --format json` |
 
+## Agentic Commerce sales channel features removed
+
+The Agentic Commerce sales channel features — including product export providers, sales channel tracking, and related classes — have been removed from Shopware's core and are no longer available out of the box.
+
+> Install the **Agentic Commerce extension (SwagAgenticCommerce)** from the Shopware Store **before** updating to 6.8 to retain this functionality and preserve any already configured Agentic Commerce sales channels.
+
 </details>
 
 # API

--- a/src/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProvider.php
+++ b/src/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProvider.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\ProductExport\Provider;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Tracking\SalesChannelTrackingListener;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -15,7 +16,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  * Handles common functionality like tracking.
  * Concrete providers only need to implement {@see buildProviderContext()} for their format-specific fields.
  *
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 abstract class AbstractAgenticCommerceProductExportProvider
@@ -32,6 +33,8 @@ abstract class AbstractAgenticCommerceProductExportProvider
         SalesChannelContext $salesChannelContext,
         array $renderContext,
     ): array {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         $agenticConfig = $productExport->getSalesChannel()?->getConfiguration() ?? [];
 
         $renderContext['provider'] = new ArrayStruct(array_merge(

--- a/src/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistry.php
+++ b/src/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistry.php
@@ -2,10 +2,11 @@
 
 namespace Shopware\Core\Content\ProductExport\Provider;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 readonly class AgenticCommerceProductExportProviderRegistry
@@ -21,6 +22,8 @@ readonly class AgenticCommerceProductExportProviderRegistry
 
     public function getByTechnicalName(string $technicalName): ?AbstractAgenticCommerceProductExportProvider
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         foreach ($this->providers as $provider) {
             if ($provider->getTechnicalName() === $technicalName) {
                 return $provider;

--- a/src/Core/Content/ProductExport/Provider/GoogleProductExportProvider.php
+++ b/src/Core/Content/ProductExport/Provider/GoogleProductExportProvider.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\ProductExport\Provider;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryEntity;
@@ -13,7 +14,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 class GoogleProductExportProvider extends AbstractAgenticCommerceProductExportProvider
@@ -33,6 +34,8 @@ class GoogleProductExportProvider extends AbstractAgenticCommerceProductExportPr
 
     public function getTechnicalName(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         return 'google';
     }
 
@@ -40,6 +43,8 @@ class GoogleProductExportProvider extends AbstractAgenticCommerceProductExportPr
         ProductExportEntity $productExport,
         SalesChannelContext $salesChannelContext,
     ): array {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         $storeCountry = $salesChannelContext->getShippingLocation()->getCountry()->getIso();
         $targetCountries = $this->resolveTargetCountries($salesChannelContext);
         $sellerUrl = $productExport->getSalesChannelDomain()?->getUrl() ?? '';

--- a/src/Core/Content/ProductExport/Provider/OpenAiProductExportProvider.php
+++ b/src/Core/Content/ProductExport/Provider/OpenAiProductExportProvider.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\ProductExport\Provider;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryEntity;
@@ -13,7 +14,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 class OpenAiProductExportProvider extends AbstractAgenticCommerceProductExportProvider
@@ -33,6 +34,8 @@ class OpenAiProductExportProvider extends AbstractAgenticCommerceProductExportPr
 
     public function getTechnicalName(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         return 'open-ai';
     }
 
@@ -40,6 +43,8 @@ class OpenAiProductExportProvider extends AbstractAgenticCommerceProductExportPr
         ProductExportEntity $productExport,
         SalesChannelContext $salesChannelContext,
     ): array {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         $storeCountry = $salesChannelContext->getShippingLocation()->getCountry()->getIso();
         $targetCountries = $this->resolveTargetCountries($salesChannelContext);
         $sellerUrl = $productExport->getSalesChannelDomain()?->getUrl() ?? '';

--- a/src/Core/Content/ProductExport/Validator/GoogleProductExportValidator.php
+++ b/src/Core/Content/ProductExport/Validator/GoogleProductExportValidator.php
@@ -5,13 +5,14 @@ namespace Shopware\Core\Content\ProductExport\Validator;
 use Shopware\Core\Content\ProductExport\Error\ErrorCollection;
 use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\UrlEncoder;
 
 /**
  * Validates Google Merchant Center XML feeds (RSS 2.0 with the http://base.google.com/ns/1.0 namespace).
  *
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 class GoogleProductExportValidator extends AbstractProviderValidator
@@ -88,11 +89,15 @@ class GoogleProductExportValidator extends AbstractProviderValidator
 
     protected function getProviderTechnicalName(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         return 'google';
     }
 
     protected function validateProviderExport(ProductExportEntity $productExportEntity, string $productExportContent, ErrorCollection $errors): void
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         if ($productExportEntity->getFileFormat() !== ProductExportEntity::FILE_FORMAT_XML) {
             $errors->add(new ProviderValidationError(
                 $productExportEntity->getId(),

--- a/src/Core/Content/ProductExport/Validator/JsonlRowParser.php
+++ b/src/Core/Content/ProductExport/Validator/JsonlRowParser.php
@@ -3,9 +3,12 @@
 namespace Shopware\Core\Content\ProductExport\Validator;
 
 use Shopware\Core\Content\ProductExport\ProductExportException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
+ *
  * @internal
  */
 #[Package('discovery')]
@@ -18,6 +21,8 @@ class JsonlRowParser
      */
     public function parse(string $content): array
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         $lines = preg_split('/\R/', $content);
         \assert($lines !== false);
 

--- a/src/Core/Content/ProductExport/Validator/OpenAiProductExportValidator.php
+++ b/src/Core/Content/ProductExport/Validator/OpenAiProductExportValidator.php
@@ -7,10 +7,11 @@ use Shopware\Core\Content\ProductExport\Error\JsonlValidationError;
 use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:AGENTIC_AI_SALES_CHANNEL
+ * @deprecated tag:v6.8.0 - Will be removed and is going to be part of SwagAgenticCommerce
  */
 #[Package('discovery')]
 class OpenAiProductExportValidator extends AbstractProviderValidator
@@ -35,11 +36,15 @@ class OpenAiProductExportValidator extends AbstractProviderValidator
 
     protected function getProviderTechnicalName(): string
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         return 'open-ai';
     }
 
     protected function validateProviderExport(ProductExportEntity $productExportEntity, string $productExportContent, ErrorCollection $errors): void
     {
+        Feature::triggerDeprecationOrThrow('v6.8.0.0', Feature::deprecatedClassMessage(self::class, 'v6.8.0.0', 'Will be part of SwagAgenticCommerce'));
+
         if ($productExportEntity->getFileFormat() !== ProductExportEntity::FILE_FORMAT_JSONL) {
             $errors->add(new ProviderValidationError(
                 $productExportEntity->getId(),

--- a/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
@@ -27,7 +27,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -53,20 +52,16 @@ class AgenticCommerceProductExportFlowTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $this->productExportRepository = static::getContainer()->get('product_export.repository');
         $this->productExportGenerator = static::getContainer()->get(ProductExportGenerator::class);
         $this->systemConfigService = static::getContainer()->get(SystemConfigService::class);
         $this->context = Context::createDefaultContext();
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
-    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesOpenAiFeedFromExplicitProductExport(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 
@@ -175,19 +170,14 @@ class AgenticCommerceProductExportFlowTest extends TestCase
     }
 
     /**
-     * @deprecated tag:v6.8.0 - will be removed
-     *
      * @param array<string, string> $config
      */
     #[DataProvider('provideTrackingCodeCombinations')]
-    #[DisabledFeatures(['v6.8.0.0'])]
     public function testProductUrlContainsConfiguredTrackingCodes(
         array $config,
         ?string $expectedAffiliate,
         ?string $expectedCampaign,
     ): void {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 
@@ -249,14 +239,8 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         }
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
-    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesMappedVariantFieldsForOpenAiFeed(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $variant = $this->createExportableVariantProduct();
         $productStreamId = $this->createProductStreamForProduct($variant['id']);
 
@@ -337,14 +321,8 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         static::assertArrayNotHasKey('color_custom', $exportedProduct['variant_dict']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
-    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesGoogleFeedFromExplicitProductExport(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 

--- a/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -61,6 +62,7 @@ class AgenticCommerceProductExportFlowTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesOpenAiFeedFromExplicitProductExport(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -178,6 +180,7 @@ class AgenticCommerceProductExportFlowTest extends TestCase
      * @param array<string, string> $config
      */
     #[DataProvider('provideTrackingCodeCombinations')]
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testProductUrlContainsConfiguredTrackingCodes(
         array $config,
         ?string $expectedAffiliate,
@@ -249,6 +252,7 @@ class AgenticCommerceProductExportFlowTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesMappedVariantFieldsForOpenAiFeed(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -336,6 +340,7 @@ class AgenticCommerceProductExportFlowTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testAgenticCommerceSalesChannelGeneratesGoogleFeedFromExplicitProductExport(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/AgenticCommerceProductExportFlowTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -57,8 +58,13 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         $this->context = Context::createDefaultContext();
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testAgenticCommerceSalesChannelGeneratesOpenAiFeedFromExplicitProductExport(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 
@@ -167,6 +173,8 @@ class AgenticCommerceProductExportFlowTest extends TestCase
     }
 
     /**
+     * @deprecated tag:v6.8.0 - will be removed
+     *
      * @param array<string, string> $config
      */
     #[DataProvider('provideTrackingCodeCombinations')]
@@ -175,6 +183,8 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         ?string $expectedAffiliate,
         ?string $expectedCampaign,
     ): void {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 
@@ -236,8 +246,13 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         }
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testAgenticCommerceSalesChannelGeneratesMappedVariantFieldsForOpenAiFeed(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $variant = $this->createExportableVariantProduct();
         $productStreamId = $this->createProductStreamForProduct($variant['id']);
 
@@ -318,8 +333,13 @@ class AgenticCommerceProductExportFlowTest extends TestCase
         static::assertArrayNotHasKey('color_custom', $exportedProduct['variant_dict']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testAgenticCommerceSalesChannelGeneratesGoogleFeedFromExplicitProductExport(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $product = $this->createExportableProduct();
         $productStreamId = $this->createProductStreamForProduct($product['id']);
 

--- a/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -23,6 +24,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextAddsProviderStruct(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -48,6 +50,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesOwnTrackingCodes(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -79,6 +82,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextWithNoConfiguration(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -106,6 +110,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextIncludesReferralCodeAndName(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -133,6 +138,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextMergesWithExistingContext(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -159,6 +165,7 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextWithNullSalesChannelConfiguration(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductExportProvider;
 use Shopware\Core\Content\ProductExport\Tracking\SalesChannelTrackingListener;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -21,14 +20,9 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(AbstractAgenticCommerceProductExportProvider::class)]
 class AbstractAgenticCommerceProductExportProviderTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextAddsProviderStruct(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -47,14 +41,9 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertInstanceOf(ArrayStruct::class, $result['provider']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesOwnTrackingCodes(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider(['extra' => 'value']);
 
         $agenticChannel = new SalesChannelEntity();
@@ -79,14 +68,9 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertSame('value', $provider->get('extra'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextWithNoConfiguration(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -107,14 +91,9 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertNull($providerStruct->get('campaignCode'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextIncludesReferralCodeAndName(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -135,14 +114,9 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertSame('agentic-channel-id', $providerStruct->get(SalesChannelTrackingListener::QUERY_PARAM));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextMergesWithExistingContext(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -162,14 +136,9 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertArrayHasKey('provider', $result);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextWithNullSalesChannelConfiguration(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();

--- a/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AbstractAgenticCommerceProductExportProviderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductExportProvider;
 use Shopware\Core\Content\ProductExport\Tracking\SalesChannelTrackingListener;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -19,8 +20,13 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 #[CoversClass(AbstractAgenticCommerceProductExportProvider::class)]
 class AbstractAgenticCommerceProductExportProviderTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextAddsProviderStruct(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -39,8 +45,13 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertInstanceOf(ArrayStruct::class, $result['provider']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextUsesOwnTrackingCodes(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider(['extra' => 'value']);
 
         $agenticChannel = new SalesChannelEntity();
@@ -65,8 +76,13 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertSame('value', $provider->get('extra'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextWithNoConfiguration(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -87,8 +103,13 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertNull($providerStruct->get('campaignCode'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextIncludesReferralCodeAndName(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -109,8 +130,13 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertSame('agentic-channel-id', $providerStruct->get(SalesChannelTrackingListener::QUERY_PARAM));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextMergesWithExistingContext(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();
@@ -130,8 +156,13 @@ class AbstractAgenticCommerceProductExportProviderTest extends TestCase
         static::assertArrayHasKey('provider', $result);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextWithNullSalesChannelConfiguration(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = $this->createProvider();
 
         $agenticChannel = new SalesChannelEntity();

--- a/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductExportProvider;
 use Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportProviderRegistry;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
@@ -19,14 +18,9 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(AgenticCommerceProductExportProviderRegistry::class)]
 class AgenticCommerceProductExportProviderRegistryTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetByTechnicalNameReturnsMatchingProvider(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $firstProvider = $this->createProvider('google');
         $matchingProvider = $this->createProvider('open-ai');
         $duplicateProvider = $this->createProvider('open-ai');
@@ -40,14 +34,9 @@ class AgenticCommerceProductExportProviderRegistryTest extends TestCase
         static::assertSame($matchingProvider, $registry->getByTechnicalName('open-ai'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetByTechnicalNameReturnsNullWhenProviderDoesNotExist(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $registry = new AgenticCommerceProductExportProviderRegistry([
             $this->createProvider('google'),
             $this->createProvider('meta'),

--- a/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductExportProvider;
 use Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportProviderRegistry;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -17,8 +18,13 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[CoversClass(AgenticCommerceProductExportProviderRegistry::class)]
 class AgenticCommerceProductExportProviderRegistryTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testGetByTechnicalNameReturnsMatchingProvider(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $firstProvider = $this->createProvider('google');
         $matchingProvider = $this->createProvider('open-ai');
         $duplicateProvider = $this->createProvider('open-ai');
@@ -32,8 +38,13 @@ class AgenticCommerceProductExportProviderRegistryTest extends TestCase
         static::assertSame($matchingProvider, $registry->getByTechnicalName('open-ai'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testGetByTechnicalNameReturnsNullWhenProviderDoesNotExist(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $registry = new AgenticCommerceProductExportProviderRegistry([
             $this->createProvider('google'),
             $this->createProvider('meta'),

--- a/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/AgenticCommerceProductExportProviderRegistryTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportPro
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -21,6 +22,7 @@ class AgenticCommerceProductExportProviderRegistryTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetByTechnicalNameReturnsMatchingProvider(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -41,6 +43,7 @@ class AgenticCommerceProductExportProviderRegistryTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetByTechnicalNameReturnsNullWhenProviderDoesNotExist(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\GoogleProductExportProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,8 +30,13 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 #[CoversClass(GoogleProductExportProvider::class)]
 class GoogleProductExportProviderTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testGetTechnicalNameReturnsGoogle(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = new GoogleProductExportProvider(
             $this->createSalesChannelRepository(),
             $this->createMock(SystemConfigService::class)
@@ -39,8 +45,13 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame('google', $provider->getTechnicalName());
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $repository = $this->createSalesChannelRepository();
         $salesChannel = $this->createSalesChannel(['DE', null, 'FR']);
         $productExport = $this->createProductExport($salesChannel->getId());
@@ -79,8 +90,13 @@ class GoogleProductExportProviderTest extends TestCase
         ], $providerContext->get('variantMapping'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -115,8 +131,13 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame(['US'], $renderContext['provider']->get('targetCountries'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -153,8 +174,13 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame('Merchant', $renderContext['provider']->get('sellerName'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $salesChannel = $this->createSalesChannel(['DE']);
         $salesChannelId = $salesChannel->getId();
         $productExport = $this->createProductExport($salesChannelId);

--- a/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 
@@ -33,6 +34,7 @@ class GoogleProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetTechnicalNameReturnsGoogle(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -48,6 +50,7 @@ class GoogleProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -93,6 +96,7 @@ class GoogleProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -134,6 +138,7 @@ class GoogleProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -177,6 +182,7 @@ class GoogleProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/GoogleProductExportProviderTest.php
@@ -9,7 +9,6 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\GoogleProductExportProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -31,14 +30,9 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 #[CoversClass(GoogleProductExportProvider::class)]
 class GoogleProductExportProviderTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetTechnicalNameReturnsGoogle(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = new GoogleProductExportProvider(
             $this->createSalesChannelRepository(),
             $this->createMock(SystemConfigService::class)
@@ -47,14 +41,9 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame('google', $provider->getTechnicalName());
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $repository = $this->createSalesChannelRepository();
         $salesChannel = $this->createSalesChannel(['DE', null, 'FR']);
         $productExport = $this->createProductExport($salesChannel->getId());
@@ -93,14 +82,9 @@ class GoogleProductExportProviderTest extends TestCase
         ], $providerContext->get('variantMapping'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -135,14 +119,9 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame(['US'], $renderContext['provider']->get('targetCountries'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -179,14 +158,9 @@ class GoogleProductExportProviderTest extends TestCase
         static::assertSame('Merchant', $renderContext['provider']->get('sellerName'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $salesChannel = $this->createSalesChannel(['DE']);
         $salesChannelId = $salesChannel->getId();
         $productExport = $this->createProductExport($salesChannelId);

--- a/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 
@@ -33,6 +34,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetTechnicalNameReturnsOpenAi(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -48,6 +50,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -92,6 +95,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -133,6 +137,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -176,6 +181,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenRepositoryReturnsNoSalesChannel(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -216,6 +222,7 @@ class OpenAiProductExportProviderTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\OpenAiProductExportProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,8 +30,13 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 #[CoversClass(OpenAiProductExportProvider::class)]
 class OpenAiProductExportProviderTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testGetTechnicalNameReturnsOpenAi(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $provider = new OpenAiProductExportProvider(
             $this->createSalesChannelRepository(),
             $this->createMock(SystemConfigService::class)
@@ -39,8 +45,13 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame('open-ai', $provider->getTechnicalName());
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $repository = $this->createSalesChannelRepository();
         $salesChannel = $this->createSalesChannel(['DE', null, 'FR']);
         $productExport = $this->createProductExport($salesChannel->getId());
@@ -78,8 +89,13 @@ class OpenAiProductExportProviderTest extends TestCase
         ], $providerContext->get('variantMapping'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -114,8 +130,13 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame(['US'], $renderContext['provider']->get('targetCountries'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -152,8 +173,13 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame('Merchant', $renderContext['provider']->get('sellerName'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextSetsTargetCountriesToNullWhenRepositoryReturnsNoSalesChannel(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -187,8 +213,13 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertNull($renderContext['provider']->get('targetCountries'));
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $salesChannel = $this->createSalesChannel(['DE']);
         $salesChannelId = $salesChannel->getId();
         $productExport = $this->createProductExport($salesChannelId);

--- a/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
+++ b/tests/unit/Core/Content/ProductExport/Provider/OpenAiProductExportProviderTest.php
@@ -9,7 +9,6 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Provider\OpenAiProductExportProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -31,14 +30,9 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 #[CoversClass(OpenAiProductExportProvider::class)]
 class OpenAiProductExportProviderTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetTechnicalNameReturnsOpenAi(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $provider = new OpenAiProductExportProvider(
             $this->createSalesChannelRepository(),
             $this->createMock(SystemConfigService::class)
@@ -47,14 +41,9 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame('open-ai', $provider->getTechnicalName());
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesCountriesFromSalesChannelContext(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $repository = $this->createSalesChannelRepository();
         $salesChannel = $this->createSalesChannel(['DE', null, 'FR']);
         $productExport = $this->createProductExport($salesChannel->getId());
@@ -92,14 +81,9 @@ class OpenAiProductExportProviderTest extends TestCase
         ], $providerContext->get('variantMapping'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextLoadsCountriesFromRepositoryWhenAssociationIsNotLoaded(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -134,14 +118,9 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame(['US'], $renderContext['provider']->get('targetCountries'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenTheyCannotBeResolved(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -178,14 +157,9 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertSame('Merchant', $renderContext['provider']->get('sellerName'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextSetsTargetCountriesToNullWhenRepositoryReturnsNoSalesChannel(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $context = Context::createDefaultContext();
         $salesChannel = $this->createSalesChannel();
         $salesChannelId = $salesChannel->getId();
@@ -219,14 +193,9 @@ class OpenAiProductExportProviderTest extends TestCase
         static::assertNull($renderContext['provider']->get('targetCountries'));
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendRenderContextUsesConfiguredInputValues(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $salesChannel = $this->createSalesChannel(['DE']);
         $salesChannelId = $salesChannel->getId();
         $productExport = $this->createProductExport($salesChannelId);

--- a/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
+++ b/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 
 /**
@@ -28,6 +29,7 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetSubscribedEvents(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -41,6 +43,7 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextAddsProviderSpecificContext(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -74,6 +77,7 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWithoutProviderKey(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -102,6 +106,7 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWhenContextIsIncomplete(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -124,6 +129,7 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWhenProviderIsNotRegistered(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
+++ b/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductE
 use Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportProviderRegistry;
 use Shopware\Core\Content\ProductExport\Subscriber\AgenticCommerceProductExportProviderContextSubscriber;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,16 +25,26 @@ use Shopware\Core\Test\Generator;
 #[CoversClass(AgenticCommerceProductExportProviderContextSubscriber::class)]
 class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testGetSubscribedEvents(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         static::assertSame(
             [ProductExportRenderBodyContextEvent::class => 'extendBodyContext'],
             AgenticCommerceProductExportProviderContextSubscriber::getSubscribedEvents()
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendBodyContextAddsProviderSpecificContext(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -60,8 +71,13 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertSame($salesChannelContext, $event->getContext()['context']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendBodyContextDoesNothingWithoutProviderKey(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -83,8 +99,13 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertArrayNotHasKey('provider', $event->getContext());
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendBodyContextDoesNothingWhenContextIsIncomplete(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -100,8 +121,13 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertSame(['productExport' => $event->getContext()['productExport']], $event->getContext());
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testExtendBodyContextDoesNothingWhenProviderIsNotRegistered(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([])
         );

--- a/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
+++ b/tests/unit/Core/Content/ProductExport/Subscriber/AgenticCommerceProductExportProviderContextSubscriberTest.php
@@ -10,7 +10,6 @@ use Shopware\Core\Content\ProductExport\Provider\AbstractAgenticCommerceProductE
 use Shopware\Core\Content\ProductExport\Provider\AgenticCommerceProductExportProviderRegistry;
 use Shopware\Core\Content\ProductExport\Subscriber\AgenticCommerceProductExportProviderContextSubscriber;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -26,28 +25,18 @@ use Shopware\Core\Test\Generator;
 #[CoversClass(AgenticCommerceProductExportProviderContextSubscriber::class)]
 class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testGetSubscribedEvents(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         static::assertSame(
             [ProductExportRenderBodyContextEvent::class => 'extendBodyContext'],
             AgenticCommerceProductExportProviderContextSubscriber::getSubscribedEvents()
         );
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextAddsProviderSpecificContext(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -74,14 +63,9 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertSame($salesChannelContext, $event->getContext()['context']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWithoutProviderKey(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -103,14 +87,9 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertArrayNotHasKey('provider', $event->getContext());
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWhenContextIsIncomplete(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([
                 $this->createProvider(),
@@ -126,14 +105,9 @@ class AgenticCommerceProductExportProviderContextSubscriberTest extends TestCase
         static::assertSame(['productExport' => $event->getContext()['productExport']], $event->getContext());
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testExtendBodyContextDoesNothingWhenProviderIsNotRegistered(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $subscriber = new AgenticCommerceProductExportProviderContextSubscriber(
             new AgenticCommerceProductExportProviderRegistry([])
         );

--- a/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\ProductExport\Error\ErrorCollection;
 use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Validator\GoogleProductExportValidator;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -17,8 +18,13 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(GoogleProductExportValidator::class)]
 class GoogleProductExportValidatorTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateDoesNothingForOtherProviders(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $entity->setProvider('open-ai');
 
@@ -29,8 +35,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenFileFormatIsNotXml(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $entity->setFileFormat(ProductExportEntity::FILE_FORMAT_JSONL);
 
@@ -44,8 +55,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('file_format', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForMalformedXml(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -57,8 +73,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('xml', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForFeedWithoutItems(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -74,8 +95,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('item', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateDoesNotAddErrorsForValidGoogleFeed(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -88,8 +114,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForMissingRequiredGoogleField(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -103,8 +134,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('brand', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidLink(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -118,8 +154,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('link', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidAvailability(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -133,8 +174,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('availability', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidCondition(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -148,8 +194,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('condition', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidGender(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -163,8 +214,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('gender', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAcceptsValidGender(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -175,8 +231,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidSizeSystem(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -190,8 +251,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('size_system', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAcceptsValidSizeSystem(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -202,8 +268,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidAgeGroup(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -217,8 +288,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('age_group', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAcceptsValidAgeGroup(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -229,8 +305,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidPriceFormat(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -244,8 +325,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('price', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenIdentifiersAreMissingWithoutFlag(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -259,8 +345,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('identifier_exists', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAcceptsIdentifierExistsNo(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -275,8 +366,13 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForDuplicateIds(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 

--- a/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
@@ -8,7 +8,6 @@ use Shopware\Core\Content\ProductExport\Error\ErrorCollection;
 use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Validator\GoogleProductExportValidator;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 
@@ -19,14 +18,9 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(GoogleProductExportValidator::class)]
 class GoogleProductExportValidatorTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNothingForOtherProviders(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $entity->setProvider('open-ai');
 
@@ -37,14 +31,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenFileFormatIsNotXml(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $entity->setFileFormat(ProductExportEntity::FILE_FORMAT_JSONL);
 
@@ -58,14 +47,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('file_format', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMalformedXml(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -77,14 +61,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('xml', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForFeedWithoutItems(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -100,14 +79,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('item', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNotAddErrorsForValidGoogleFeed(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -120,14 +94,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMissingRequiredGoogleField(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -141,14 +110,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('brand', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidLink(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -162,14 +126,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('link', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidAvailability(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -183,14 +142,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('availability', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidCondition(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -204,14 +158,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('condition', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidGender(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -225,14 +174,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('gender', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidGender(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -243,14 +187,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidSizeSystem(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -264,14 +203,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('size_system', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidSizeSystem(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -282,14 +216,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidAgeGroup(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -303,14 +232,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('age_group', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidAgeGroup(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -321,14 +245,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidPriceFormat(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -342,14 +261,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('price', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenIdentifiersAreMissingWithoutFlag(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -363,14 +277,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertSame('identifier_exists', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsIdentifierExistsNo(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -385,14 +294,9 @@ class GoogleProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForDuplicateIds(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 

--- a/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/GoogleProductExportValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Validator\GoogleProductExportValidator;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -21,6 +22,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNothingForOtherProviders(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -38,6 +40,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenFileFormatIsNotXml(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -58,6 +61,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMalformedXml(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -76,6 +80,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForFeedWithoutItems(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -98,6 +103,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNotAddErrorsForValidGoogleFeed(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -117,6 +123,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMissingRequiredGoogleField(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -137,6 +144,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidLink(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -157,6 +165,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidAvailability(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -177,6 +186,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidCondition(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -197,6 +207,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidGender(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -217,6 +228,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidGender(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -234,6 +246,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidSizeSystem(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -254,6 +267,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidSizeSystem(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -271,6 +285,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidAgeGroup(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -291,6 +306,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsValidAgeGroup(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -308,6 +324,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidPriceFormat(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -328,6 +345,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenIdentifiersAreMissingWithoutFlag(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -348,6 +366,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAcceptsIdentifierExistsNo(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -369,6 +388,7 @@ class GoogleProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForDuplicateIds(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -19,6 +20,7 @@ class JsonlRowParserTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseReturnsDecodedRowsWithLineNumbers(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -39,6 +41,7 @@ class JsonlRowParserTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseSkipsEmptyLines(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -59,6 +62,7 @@ class JsonlRowParserTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseThrowsExceptionForMalformedJsonlLine(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -77,6 +81,7 @@ class JsonlRowParserTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseThrowsExceptionWhenJsonlLineDoesNotDecodeToObject(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 
@@ -17,14 +16,9 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(JsonlRowParser::class)]
 class JsonlRowParserTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseReturnsDecodedRowsWithLineNumbers(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $parser = new JsonlRowParser();
 
         $rows = $parser->parse("{\"id\":\"first\"}\n{\"id\":\"second\",\"nested\":{\"foo\":\"bar\"}}\n");
@@ -38,14 +32,9 @@ class JsonlRowParserTest extends TestCase
         );
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseSkipsEmptyLines(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $parser = new JsonlRowParser();
 
         $rows = $parser->parse("\n  \n{\"id\":\"first\"}\n\n\t\n{\"id\":\"second\"}\n");
@@ -59,14 +48,9 @@ class JsonlRowParserTest extends TestCase
         );
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseThrowsExceptionForMalformedJsonlLine(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $parser = new JsonlRowParser();
 
         try {
@@ -78,14 +62,9 @@ class JsonlRowParserTest extends TestCase
         }
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testParseThrowsExceptionWhenJsonlLineDoesNotDecodeToObject(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $parser = new JsonlRowParser();
 
         try {

--- a/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/JsonlRowParserTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -15,8 +16,13 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(JsonlRowParser::class)]
 class JsonlRowParserTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testParseReturnsDecodedRowsWithLineNumbers(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $parser = new JsonlRowParser();
 
         $rows = $parser->parse("{\"id\":\"first\"}\n{\"id\":\"second\",\"nested\":{\"foo\":\"bar\"}}\n");
@@ -30,8 +36,13 @@ class JsonlRowParserTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testParseSkipsEmptyLines(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $parser = new JsonlRowParser();
 
         $rows = $parser->parse("\n  \n{\"id\":\"first\"}\n\n\t\n{\"id\":\"second\"}\n");
@@ -45,8 +56,13 @@ class JsonlRowParserTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testParseThrowsExceptionForMalformedJsonlLine(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $parser = new JsonlRowParser();
 
         try {
@@ -58,8 +74,13 @@ class JsonlRowParserTest extends TestCase
         }
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testParseThrowsExceptionWhenJsonlLineDoesNotDecodeToObject(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $parser = new JsonlRowParser();
 
         try {

--- a/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
@@ -10,7 +10,6 @@ use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
 use Shopware\Core\Content\ProductExport\Validator\OpenAiProductExportValidator;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 
@@ -21,14 +20,9 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(OpenAiProductExportValidator::class)]
 class OpenAiProductExportValidatorTest extends TestCase
 {
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNothingForOtherProviders(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $entity->setProvider('google');
 
@@ -39,14 +33,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenFileFormatIsNotJsonl(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $entity->setFileFormat(ProductExportEntity::FILE_FORMAT_XML);
 
@@ -61,14 +50,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('file_format', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMissingRequiredUrlField(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -102,14 +86,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('return_policy', $firstError->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForBlankRequiredStringField(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['seller_name' => '   ']) . \PHP_EOL;
 
@@ -124,14 +103,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "seller_name" must be a non-empty string.', $error->getParameters()['error']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsJsonlValidationErrorForMalformedJsonl(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -144,14 +118,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame(1, $error->getParameters()['line']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNotAddErrorsForValidOpenAiFeed(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -181,14 +150,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorsForInvalidOptionalAndDerivedFieldFormats(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -239,14 +203,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         );
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidTargetCountryCode(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['target_countries' => ['DE', 'de']]);
 
@@ -261,14 +220,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('Each target country must be a 2-letter upper-case ISO country code.', $error->getParameters()['error']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenTargetCountriesAreEmpty(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['target_countries' => []]) . \PHP_EOL;
 
@@ -283,14 +237,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "target_countries" must be a non-empty array of ISO country codes.', $error->getParameters()['error']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenAvailabilityDateIsMissingForPreOrder(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['availability' => 'pre_order']);
 
@@ -304,14 +253,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('availability_date', $error->getParameters()['field']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenAvailabilityDateIsInvalidForPreOrder(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow([
             'availability' => 'pre_order',
@@ -329,14 +273,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "availability_date" must be a valid date string.', $error->getParameters()['error']);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAllowsValidAvailabilityDateForPreOrder(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow([
             'availability' => 'pre_order',
@@ -350,14 +289,9 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
-    /**
-     * @deprecated tag:v6.8.0 - will be removed
-     */
     #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForDuplicateItemIds(): void
     {
-        Feature::skipTestIfActive('v6.8.0.0', $this);
-
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow() . \PHP_EOL . $this->createValidRow(['title' => 'Second row']) . \PHP_EOL;
 

--- a/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
 use Shopware\Core\Content\ProductExport\Validator\OpenAiProductExportValidator;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -23,6 +24,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNothingForOtherProviders(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -40,6 +42,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenFileFormatIsNotJsonl(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -61,6 +64,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForMissingRequiredUrlField(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -101,6 +105,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForBlankRequiredStringField(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -122,6 +127,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsJsonlValidationErrorForMalformedJsonl(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -141,6 +147,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateDoesNotAddErrorsForValidOpenAiFeed(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -177,6 +184,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorsForInvalidOptionalAndDerivedFieldFormats(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -234,6 +242,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForInvalidTargetCountryCode(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -255,6 +264,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenTargetCountriesAreEmpty(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -276,6 +286,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenAvailabilityDateIsMissingForPreOrder(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -296,6 +307,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorWhenAvailabilityDateIsInvalidForPreOrder(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -320,6 +332,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAllowsValidAvailabilityDateForPreOrder(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
@@ -340,6 +353,7 @@ class OpenAiProductExportValidatorTest extends TestCase
     /**
      * @deprecated tag:v6.8.0 - will be removed
      */
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateAddsErrorForDuplicateItemIds(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);

--- a/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Validator/OpenAiProductExportValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\ProductExport\Error\ProviderValidationError;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\Validator\JsonlRowParser;
 use Shopware\Core\Content\ProductExport\Validator\OpenAiProductExportValidator;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -19,8 +20,13 @@ use Shopware\Core\Framework\Log\Package;
 #[CoversClass(OpenAiProductExportValidator::class)]
 class OpenAiProductExportValidatorTest extends TestCase
 {
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateDoesNothingForOtherProviders(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $entity->setProvider('google');
 
@@ -31,8 +37,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenFileFormatIsNotJsonl(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $entity->setFileFormat(ProductExportEntity::FILE_FORMAT_XML);
 
@@ -47,8 +58,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('file_format', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForMissingRequiredUrlField(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -82,8 +98,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('return_policy', $firstError->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForBlankRequiredStringField(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['seller_name' => '   ']) . \PHP_EOL;
 
@@ -98,8 +119,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "seller_name" must be a non-empty string.', $error->getParameters()['error']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsJsonlValidationErrorForMalformedJsonl(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $errors = new ErrorCollection();
 
@@ -112,8 +138,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame(1, $error->getParameters()['line']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateDoesNotAddErrorsForValidOpenAiFeed(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -143,8 +174,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorsForInvalidOptionalAndDerivedFieldFormats(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
 
         $content = json_encode([
@@ -195,8 +231,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForInvalidTargetCountryCode(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['target_countries' => ['DE', 'de']]);
 
@@ -211,8 +252,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('Each target country must be a 2-letter upper-case ISO country code.', $error->getParameters()['error']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenTargetCountriesAreEmpty(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['target_countries' => []]) . \PHP_EOL;
 
@@ -227,8 +273,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "target_countries" must be a non-empty array of ISO country codes.', $error->getParameters()['error']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenAvailabilityDateIsMissingForPreOrder(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow(['availability' => 'pre_order']);
 
@@ -242,8 +293,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('availability_date', $error->getParameters()['field']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorWhenAvailabilityDateIsInvalidForPreOrder(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow([
             'availability' => 'pre_order',
@@ -261,8 +317,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertSame('The field "availability_date" must be a valid date string.', $error->getParameters()['error']);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAllowsValidAvailabilityDateForPreOrder(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow([
             'availability' => 'pre_order',
@@ -276,8 +337,13 @@ class OpenAiProductExportValidatorTest extends TestCase
         static::assertCount(0, $errors);
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - will be removed
+     */
     public function testValidateAddsErrorForDuplicateItemIds(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $entity = $this->createProductExportEntity();
         $content = $this->createValidRow() . \PHP_EOL . $this->createValidRow(['title' => 'Second row']) . \PHP_EOL;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

  Several Agentic Commerce classes (`GoogleProductExportProvider`, `OpenAiProductExportProvider`, `SalesChannelTrackingListener`, validators, extensions, etc.) are being moved to the `SwagAgenticCommerce` plugin in v6.8.0. They need to be formally deprecated now so integrators get a warning ahead of the removal.

  ### 2. What does this change do, exactly?

  - Adds `Feature::triggerDeprecationOrThrow('v6.8.0.0', ...)` to all public and protected methods of the 7 affected classes, following Shopware's BC deprecation policy
  - Adds a deprecation entry to `RELEASE_INFO-6.7.md` under `## Core` and `## Administration`
  - Adds a removal warning to `UPGRADE-6.8.md` with a callout to install `SwagAgenticCommerce` before upgrading
  - Marks all related unit and integration tests as deprecated (`@deprecated tag:v6.8.0 - will be removed`) and gates them with `Feature::skipTestIfActive('v6.8.0.0', $this)` so they are automatically skipped once the feature flag is activated

### 3. Describe each step to reproduce the issue or behaviour.

  N/A — this is a deprecation-only change with no behaviour difference when the `v6.8.0.0` feature flag is inactive.

### 4. Please link to the relevant issues (if any).

- closes #17382 

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Added a short entry to `RELEASE_INFO-6.7.md` under `## Core` and `## Administration`
    - Added an `UPGRADE` section in `UPGRADE-6.8.md` for the removal
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them