### PR TITLE
fix: open configurable extensions from extension card

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -155,6 +155,19 @@ export default {
             );
         },
 
+        configLink() {
+            if (!this.extension.configurable) {
+                return null;
+            }
+
+            return {
+                name: 'sw.extension.config',
+                params: {
+                    namespace: this.extension.name,
+                },
+            };
+        },
+
         link() {
             if (this.openLink) {
                 return this.openLink;
@@ -169,7 +182,7 @@ export default {
                 };
             }
 
-            return null;
+            return this.configLink;
         },
 
         consentAffirmationModalActionLabel() {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -94,7 +94,7 @@
         </span>
         <router-link
             v-else-if="extension.configurable"
-            :to="{ name: 'sw.extension.config', params: { namespace: extension.name } }"
+            :to="configLink"
         >
             {{ $t('sw-extension-store.component.sw-extension-card-base.contextMenu.config') }}
         </router-link>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.spec.js
@@ -17,6 +17,7 @@ async function createWrapper(propsData = {}, provide = {}) {
                 'sw-extension-icon': true,
                 'sw-context-menu-item': {
                     name: 'sw-context-menu-item',
+                    props: ['routerLink'],
                     template: '<div class="sw-context-menu-item"><slot></slot></div>',
                 },
                 'sw-context-button': {
@@ -176,6 +177,29 @@ describe('src/module/sw-extension/component/sw-extension-card-base', () => {
 
         const state = wrapper.findAll('.sw-context-menu-item');
         expect(state).toHaveLength(1);
+    });
+
+    it('should use the extension config route as fallback open link', async () => {
+        const wrapper = await createWrapper({
+            extension: {
+                name: 'ExampleConfigurableExtension',
+                installedAt: '845618651',
+                active: true,
+                configurable: true,
+                permissions: {},
+            },
+        });
+
+        await flushPromises();
+
+        const openExtensionItem = wrapper.findComponent({ name: 'sw-context-menu-item' });
+
+        expect(openExtensionItem.props('routerLink')).toStrictEqual({
+            name: 'sw.extension.config',
+            params: {
+                namespace: 'ExampleConfigurableExtension',
+            },
+        });
     });
 
     it('should not show config menu item: not active and activated once', async () => {


### PR DESCRIPTION
Closes #17131

Configurable extensions can expose a plugin configuration without registering a dedicated extension entry route. In that case the extension card has a valid configuration target, but the context menu did not show "Open extension" because the computed open link returned `null`.

### 2. What does this change do, exactly?

The extension card now reuses the extension configuration route as fallback open link when an installed and active extension is configurable.

This also keeps the visible configuration link and the context menu open link aligned by using the same computed route object.
