### PR TITLE
chore: bump php-cs-fixer to 3.95.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,7 +190,7 @@
         "bamarni/composer-bin-plugin": "^1.8.2",
         "dominikb/composer-license-checker": "^2.5",
         "ergebnis/phpunit-slow-test-detector": "^2.4",
-        "friendsofphp/php-cs-fixer": "3.94.2",
+        "friendsofphp/php-cs-fixer": "3.95.8",
         "jdorn/sql-formatter": "^1.2.17",
         "league/flysystem-async-aws-s3": "^3.29.0",
         "league/flysystem-google-cloud-storage": "^3.10.3",


### PR DESCRIPTION
  ### 1. Why is this change necessary?
`friendsofphp/php-cs-fixer` is pinned to `3.94.2`, whose `sebastian/diff` constraint caps at `^8.0`. 
PHPUnit 13 requires `sebastian/diff ^9.0`, so the current pin is one of the two dependency blockers preventing a durable upgraded exploration job.

<details> <summary>Scope of internal changes from v3.94.2 to v3.95.8</summary>

From https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/compare/v3.94.2...v3.95.8

#### New Rule Adjustments & Reformatting
Match-Arm Alignment: Changes introduced in the 3.95 sequence enforce stricter whitespace alignment rules around the fat arrow (=>) in match expressions. Running the fixer on this version can trigger immediate repo-wide formatting updates to existing codebases.

#### User-Visible Bug 
FixesMultilinePromotedPropertiesFixer: Added critical fixes handling the new keyword within constructor property initializers.
MethodArgumentSpaceFixer: Resolved an issue where nested or multi-line arguments were being incorrectly collapsed when configuring specific on_multiline single-line behaviors.
NoRedundantReadonlyPropertyFixer: Fixed an engine-level TypeError crashing the fixer when a trait incorporated an anonymous class.
PhpdocLineSpanFixer: Reordered execution priority so it now systematically runs after NoSuperfluousPhpdocTagsFixer to prevent broken docblock modifications.

#### New Runtime DependenciesAgent Detection: 

Version 3.95 incorporates ergebnis/agent-detector as a formal package dependency, which modifies output reporting styles if it senses execution by an automated AI pipeline or agent.

</details>

  ### 2. What does this change do, exactly?

Bumps `friendsofphp/php-cs-fixer` from `3.94.2` to `3.95.8` in the root `composer.json`. 3.95.8 widens its `sebastian/diff` constraint to include `^9.0`.

No impact on our src files.
No significant changes on performance either (memory, speed).

  ### 3. Describe each step to reproduce the issue or behaviour.

  - `composer update friendsofphp/php-cs-fixer` resolves to `v3.95.8` (pulls in `ergebnis/agent-detector`).
  - `composer show friendsofphp/php-cs-fixer` shows the `sebastian/diff` constraint now lists `… || ^9.0`.
  - `./vendor/bin/php-cs-fixer fix --dry-run` runs unchanged against the project config 
  -  no change either in CI lint job (no formatting diff).

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
