### PR TITLE
fix: adjust created by admin label positioning on customer detail

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.html.twig
@@ -8,14 +8,12 @@
         <h2>
             {{ salutation(customer) }}
         </h2>
-        <sw-label
+        <mt-badge
             v-if="customer?.createdById"
-            appearance="pill"
-            size="small"
             class="sw-customer-detail__created-by-admin-label"
         >
             {{ $t('sw-customer.detail.labelCreatedByAdmin') }}
-        </sw-label>
+        </mt-badge>
     </template>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-detail/sw-customer-detail.scss
@@ -37,8 +37,8 @@
         }
     }
 
-    &__created-by-admin-label {
-        margin: 0 10px;
+    .sw-customer-detail__created-by-admin-label {
+        margin: 1px 10px 0;
         text-align: center;
     }
 }


### PR DESCRIPTION
- fixed Created by admin label positioning on customer detail page header

after:
<img width="579" height="135" alt="Screenshot 2026-06-17 at 11 19 33" src="https://github.com/user-attachments/assets/447d8da2-be1f-482c-8c53-12448e19c9ee" />

fixes: https://github.com/shopware/shopware/issues/17328