### PR TITLE
fix: escape restrict-delete meta field alias for MariaDB

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -247,10 +247,10 @@ class EntityForeignKeyResolver implements ResetInterface
                 }
 
                 $query->addSelect(\sprintf(
-                    '%s.%s as _%s',
+                    '%s.%s as %s',
                     EntityDefinitionQueryHelper::escape($root->getEntityName()),
                     EntityDefinitionQueryHelper::escape($field->getStorageName()),
-                    $field->getPropertyName()
+                    EntityDefinitionQueryHelper::escape('_' . $field->getPropertyName())
                 ));
             }
         }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -3,8 +3,10 @@
 namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\DocumentDefinition;
@@ -117,6 +119,46 @@ class EntityForeignKeyResolverTest extends TestCase
                 ],
             ],
         ], $result);
+    }
+
+    #[TestDox('Restrict-delete meta field aliases are backtick-escaped so the query stays valid on MariaDB')]
+    public function testRestrictDeleteMetaFieldAliasesAreEscaped(): void
+    {
+        $capturedQueries = [];
+
+        $emptyResult = $this->createMock(Result::class);
+        $emptyResult->method('fetchAllAssociative')->willReturn([]);
+
+        // getSQL() needs a platform to render the query; use MariaDB, the engine that rejects the alias.
+        $this->connection->method('getDatabasePlatform')->willReturn(new MariaDBPlatform());
+
+        $this->connection->method('executeQuery')->willReturnCallback(
+            function (string $query) use (&$capturedQueries, $emptyResult): Result {
+                $capturedQueries[] = $query;
+
+                return $emptyResult;
+            }
+        );
+
+        $this->resolver->getAffectedDeleteRestrictions(
+            $this->buildRegistry(),
+            [['id' => Uuid::randomHex()]],
+            Context::createDefaultContext(),
+            true
+        );
+
+        $queries = implode("\n", $capturedQueries);
+
+        static::assertNotEmpty($capturedQueries);
+
+        // The meta field aliases must be backtick-escaped. An unescaped leading-underscore alias
+        // (e.g. `as _fileName`) is parsed by MariaDB as a charset introducer and fails with
+        // "ERROR 1064 ... near '_fileName'" (regression from #17329).
+        static::assertStringContainsString('as `_id`', $queries);
+        static::assertStringContainsString('as `_fileName`', $queries);
+        static::assertStringContainsString('as `_fileExtension`', $queries);
+        static::assertStringNotContainsString('as _fileName', $queries);
+        static::assertStringNotContainsString('as _fileExtension', $queries);
     }
 
     private function buildRegistry(): MediaDefinition


### PR DESCRIPTION
### 1. Why is this change necessary?

Discovered on Nightly failures on trunk since 16/06/26

  This is a regression from #17329 ("make media delete restricted exception more verbose").
  That PR added, in one commit, both:
  - an unescaped alias in `EntityForeignKeyResolver`'s RestrictDelete query (`'%s.%s as _%s'`)
  - `MediaDefinition::getRestrictDeleteMetaFields()` returning `['id', 'fileName', 'fileExtension']`.

  Together these emit `` `media`.`file_name` as _fileName ``. MariaDB parses the leading-underscore bareword as a charset introducer and rejects it: `ERROR 1064 ... near '_fileName'`. 
As a result, every restrict-delete check on `media` (the `productDownloads` RESTRICT association has existed since 2023) fails on MariaDB, breaking all MariaDB integration tests that delete media. 
It only surfaced at nightly because integration tests run on MariaDB only in the nightly matrix (PRs use MySQL).

See https://github.com/shopware/shopware/actions/workflows/nightly.yml failing since #17329  on all integration jobs using MariaDB 

  ### 2. What does this change do, exactly?

Escapes the alias via `EntityDefinitionQueryHelper::escape('_' . $field->getPropertyName())`, producing `` as `_fileName` ``, which is valid on both MySQL and MariaDB. 
The 2 table identifiers were already escaped, only the alias introduced by #17329 was not. 
The result-set key remains `_fileName`, so the verbose restrict-delete exception message is unaffected.

Adds a unit test as safe guard with a stub around MariaDB connector to prevent further failures on this resolver.

  ### 3. Describe each step to reproduce the issue or behaviour.

  - Run the new unit test without Resolver changes, this will fail 

or:
  - On MariaDB: `SELECT 1 as _fileName` → `ERROR 1064 ... near '_fileName'`; `SELECT 1 as `_fileName`` → succeeds.
  - Before the fix, deleting a `media` entity on MariaDB throws `SyntaxErrorException` from  `EntityForeignKeyResolver` (e.g. the Storefront theme/media integration tests at nightly).
  - After the fix, the same delete succeeds on MariaDB; MySQL behaviour is unchanged.

⚠️ Note on CI:

We cannot just run all integration jobs with MariaDB out of Nightly flow, this would be massive on development/merge pipeline. 

This can be tested with running Nightly against this branch, or run locally integration jobs with MariaDB, or with the new unit test.

https://github.com/shopware/shopware/actions/runs/27677093895 => forced Nightly to run against the branch, to verify integration jobs are passing with MariaDB (other jobs are not that relevant)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
