### PR TITLE
fix: use OAuth client repository interface for MCP auth

### DIFF
--- a/src/Core/Framework/Mcp/Authentication/McpAuthenticationListener.php
+++ b/src/Core/Framework/Mcp/Authentication/McpAuthenticationListener.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Mcp\Authentication;
 
-use Shopware\Core\Framework\Api\OAuth\ClientRepository;
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\McpException;
@@ -38,7 +38,7 @@ class McpAuthenticationListener implements EventSubscriberInterface
      * @internal
      */
     public function __construct(
-        private readonly ClientRepository $clientRepository,
+        private readonly ClientRepositoryInterface $clientRepository,
         private readonly RateLimiter $rateLimiter,
     ) {
     }

--- a/tests/unit/Core/Framework/Mcp/Authentication/McpAuthenticationListenerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Authentication/McpAuthenticationListenerTest.php
@@ -2,9 +2,9 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Mcp\Authentication;
 
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Api\OAuth\ClientRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\Authentication\McpAuthenticationListener;
 use Shopware\Core\Framework\Mcp\McpException;
@@ -40,7 +40,7 @@ class McpAuthenticationListenerTest extends TestCase
 
     public function testSkipsNonMcpRoutes(): void
     {
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->expects($this->never())->method('validateClient');
 
         $listener = new McpAuthenticationListener($clientRepository, $this->createMock(RateLimiter::class));
@@ -53,7 +53,7 @@ class McpAuthenticationListenerTest extends TestCase
 
     public function testFallsThroughWhenNoAccessKeyHeaders(): void
     {
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->expects($this->never())->method('validateClient');
 
         $listener = new McpAuthenticationListener($clientRepository, $this->createMock(RateLimiter::class));
@@ -66,7 +66,7 @@ class McpAuthenticationListenerTest extends TestCase
 
     public function testFallsThroughToBearerJwtWhenNoAccessKeyHeaders(): void
     {
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->expects($this->never())->method('validateClient');
 
         $listener = new McpAuthenticationListener($clientRepository, $this->createMock(RateLimiter::class));
@@ -82,7 +82,7 @@ class McpAuthenticationListenerTest extends TestCase
     public function testRejectsUnsupportedKeyType(): void
     {
         $listener = new McpAuthenticationListener(
-            static::createStub(ClientRepository::class),
+            static::createStub(ClientRepositoryInterface::class),
             static::createStub(RateLimiter::class),
         );
 
@@ -99,7 +99,7 @@ class McpAuthenticationListenerTest extends TestCase
 
     public function testRejectsInvalidCredentialsAndDoesNotResetRateLimiter(): void
     {
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->method('validateClient')
             ->with('SWIAvalidintegrationkey12', 'wrong-secret', 'client_credentials')
             ->willReturn(false);
@@ -131,7 +131,7 @@ class McpAuthenticationListenerTest extends TestCase
             ->willThrowException($expected);
 
         $listener = new McpAuthenticationListener(
-            static::createStub(ClientRepository::class),
+            static::createStub(ClientRepositoryInterface::class),
             $rateLimiter,
         );
 
@@ -150,7 +150,7 @@ class McpAuthenticationListenerTest extends TestCase
         $accessKey = 'SWIAvalidintegrationkey12';
         $secret = 'my-secret-key';
 
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->method('validateClient')
             ->with($accessKey, $secret, 'client_credentials')
             ->willReturn(true);
@@ -180,7 +180,7 @@ class McpAuthenticationListenerTest extends TestCase
         $accessKey = 'SWUAvaliduseraccesskey123';
         $secret = 'my-secret-key';
 
-        $clientRepository = $this->createMock(ClientRepository::class);
+        $clientRepository = $this->createMock(ClientRepositoryInterface::class);
         $clientRepository->method('validateClient')
             ->with($accessKey, $secret, 'client_credentials')
             ->willReturn(true);


### PR DESCRIPTION
### 1. Why is this change necessary?

`McpAuthenticationListener` type-hints the concrete OAuth `ClientRepository`, but plugins can replace that service with another implementation of `ClientRepositoryInterface`. That causes a `TypeError` during container instantiation when the replacement does not extend the concrete Shopware class.

### 2. What does this change do, exactly?

The MCP authentication listener now depends on `League\OAuth2\Server\Repositories\ClientRepositoryInterface`, which is the contract that provides `validateClient()`. The existing service wiring can keep resolving the `ClientRepository::class` service id, including plugin replacements.

The unit test now mocks the interface to cover the supported dependency contract.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install Shopware with the `MCP_SERVER` feature enabled.
2. Install a plugin that replaces `Shopware\Core\Framework\Api\OAuth\ClientRepository` with a `ClientRepositoryInterface` implementation that does not extend the concrete class.
3. Compile the container or trigger `McpAuthenticationListener` instantiation.
4. The listener constructor rejects the replacement service with a `TypeError`.

### 4. Please link to the relevant issues (if any).

- closes #17505

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them