### PR TITLE
fix(docs): agent skills

### DIFF
--- a/coding-guidelines/core/agent-skills.md
+++ b/coding-guidelines/core/agent-skills.md
@@ -73,7 +73,7 @@ skills — never per-skill.
    security validation forbids importing files outside `.github/`. The
    interactive skill references the same file via its repo-root path; the
    gh aw policy fragment imports it via
-   `{{#runtime-import .github/aw/shared/<name>-policy.md}}`. See how the
+   <code v-pre>{{#runtime-import .github/aw/shared/&lt;name&gt;-policy.md}}</code>. See how the
    `triage` skill wires it up for the exact pattern.
 
 3. **Decide on the unattended path.** If the skill should also run in CI:


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This PR fixes syntax issue causing issues in the docs build process.

### 2. What does this change do, exactly?

It escapes Vue syntax in inline codeblock. See https://github.com/vuejs/vitepress/discussions/480#discussioncomment-2225141

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/docs/pull/2327
https://github.com/vuejs/vitepress/issues?q=is%3Aissue%20vue%20interpolation
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
