### PR TITLE
chore: disable agentic commerce sales channel type button without the extension

### DIFF
--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -442,7 +442,6 @@ const missingTests = [
     'src/module/sw-property/page/sw-property-create/index.js',
     'src/module/sw-review/index.js',
     'src/module/sw-sales-channel/component/sw-sales-channel-modal-detail/index.js',
-    'src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js',
     'src/module/sw-sales-channel/default-search-configuration.js',
     'src/module/sw-sales-channel/index.js',
     'src/module/sw-sales-channel/agentic-product-export-templates/index.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -91,23 +91,23 @@ export default {
         },
 
         getTooltip(item) {
-            const isDisabledAgenticCommerceType = !this.showAgenticCommerceType() &&
-                this.isAgenticCommerceSalesChannelType(item.id);
-            const messageKey = isDisabledAgenticCommerceType ?
-                'sw-sales-channel.modal.messageAgenticCommerce' :
-                'sw-sales-channel.modal.messageNoProductStreams';
+            const isDisabledAgenticCommerceType =
+                !this.showAgenticCommerceType() && this.isAgenticCommerceSalesChannelType(item.id);
+            const messageKey = isDisabledAgenticCommerceType
+                ? 'sw-sales-channel.modal.messageAgenticCommerce'
+                : 'sw-sales-channel.modal.messageNoProductStreams';
 
             return {
                 message: this.$t(messageKey),
                 showOnDisabledElements: true,
-                disabled: !this.isDisabled(item)
+                disabled: !this.isDisabled(item),
             };
         },
 
         isDisabled(item) {
-            return this.addChannelAction.disabled(item.id) || (
-                !this.showAgenticCommerceType() &&
-                this.isAgenticCommerceSalesChannelType(item.id)
+            return (
+                this.addChannelAction.disabled(item.id) ||
+                (!this.showAgenticCommerceType() && this.isAgenticCommerceSalesChannelType(item.id))
             );
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -47,11 +47,6 @@ export default {
     },
 
     computed: {
-        /** @deprecated tag:v6.8.0 - Will be removed */
-        salesChannelRepository() {
-            return this.repositoryFactory.create('sales_channel');
-        },
-
         salesChannelTypeRepository() {
             return this.repositoryFactory.create('sales_channel_type');
         },
@@ -70,23 +65,10 @@ export default {
             };
             const criteria = new Criteria(1, 500);
 
-            /**
-             * @deprecated tag:v6.8.0 - keep only the type search of the promise callback.
-             *
-             * Only show the option to create a new agentic commerce sales channel
-             * if one had been created using a previous release and still exists
-             * OR the SwagAgenticCommerce plugin is installed
-             */
-            this.showAgenticCommerceType().then((showAgenticCommerceType) => {
-                if (!showAgenticCommerceType) {
-                    criteria.addFilter(Criteria.not('AND', [Criteria.equals('id', Defaults.agenticCommerceTypeId)]));
-                }
-
-                this.salesChannelTypeRepository.search(criteria, context).then((response) => {
-                    this.total = response.total;
-                    this.salesChannelTypes = response;
-                    this.isLoading = false;
-                });
+            this.salesChannelTypeRepository.search(criteria, context).then((response) => {
+                this.total = response.total;
+                this.salesChannelTypes = response;
+                this.isLoading = false;
             });
         },
 
@@ -108,17 +90,30 @@ export default {
             return salesChannelTypeId === Defaults.productComparisonTypeId;
         },
 
+        getTooltip(item) {
+            const isDisabledAgenticCommerceType = !this.showAgenticCommerceType() &&
+                this.isAgenticCommerceSalesChannelType(item.id);
+            const messageKey = isDisabledAgenticCommerceType ?
+                'sw-sales-channel.modal.messageAgenticCommerce' :
+                'sw-sales-channel.modal.messageNoProductStreams';
+
+            return {
+                message: this.$t(messageKey),
+                showOnDisabledElements: true,
+                disabled: !this.isDisabled(item)
+            };
+        },
+
+        isDisabled(item) {
+            return this.addChannelAction.disabled(item.id) || (
+                !this.showAgenticCommerceType() &&
+                this.isAgenticCommerceSalesChannelType(item.id)
+            );
+        },
+
         /** @deprecated tag:v6.8.0 - Will be removed */
         showAgenticCommerceType() {
-            if (Shopware.Context.app.config.bundles?.SwagAgenticCommerce) {
-                return Promise.resolve(true);
-            }
-
-            const criteria = new Criteria(1, 1);
-            criteria.addAssociation('type');
-            criteria.addFilter(Criteria.equals('type.id', Defaults.agenticCommerceTypeId));
-
-            return this.salesChannelRepository.searchIds(criteria).then((response) => Promise.resolve(response.total > 0));
+            return !!Shopware.Context.app.config.bundles?.SwagAgenticCommerce;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.html.twig
@@ -74,16 +74,12 @@
             label="actions"
         >
             <mt-button
-                v-tooltip="{
-                    message: $t('sw-sales-channel.modal.messageNoProductStreams'),
-                    showOnDisabledElements: true,
-                    disabled: !addChannelAction.disabled(item.id)
-                }"
+                v-tooltip="getTooltip(item)"
                 class="sw-sales-channel-modal__add-channel-action"
                 size="small"
                 variant="primary"
                 :is-loading="addChannelAction.loading(item.id)"
-                :disabled="addChannelAction.disabled(item.id)"
+                :disabled="isDisabled(item)"
                 data-analytics-id="sw_sales_channel.modal_grid.sales_channel_add"
                 :data-analytics-sales-channel-type-id="item.id"
                 @click="onAddChannel(item.id)"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.js
@@ -1,0 +1,164 @@
+/**
+ * @sw-package discovery
+ */
+
+import { mount } from '@vue/test-utils';
+
+const PRODUCT_COMPARISON_TYPE_ID = Shopware.Defaults.productComparisonTypeId;
+const AGENTIC_COMMERCE_TYPE_ID = Shopware.Defaults.agenticCommerceTypeId;
+
+const mockSalesChannelTypes = [
+    { id: PRODUCT_COMPARISON_TYPE_ID, iconName: 'comparison-icon', translated: { name: 'Product Comparison', description: 'A comparison feed' } },
+    { id: AGENTIC_COMMERCE_TYPE_ID, iconName: 'agentic-icon', translated: { name: 'Agentic Commerce', description: 'Agentic Commerce' } },
+];
+
+function createAddChannelAction({ disabled = () => false, loading = () => false } = {}) {
+    return { disabled, loading };
+}
+
+async function createWrapper({ addChannelAction = createAddChannelAction(), productStreamsExist = true } = {}) {
+    const mockSearch = jest.fn().mockResolvedValue(
+        Object.assign([...mockSalesChannelTypes], { total: mockSalesChannelTypes.length }),
+    );
+
+    return mount(await wrapTestComponent('sw-sales-channel-modal-grid', { sync: true }), {
+        props: {
+            addChannelAction,
+            productStreamsExist,
+        },
+        global: {
+            stubs: {
+                'sw-grid': {
+                    template: '<div class="sw-grid"><slot name="columns" v-for="item in items" :item="item" /></div>',
+                    props: ['items', 'selectable', 'header', 'table'],
+                },
+                'sw-grid-column': {
+                    template: '<div class="sw-grid-column"><slot /></div>',
+                    props: ['flex', 'align', 'label', 'dataIndex'],
+                },
+                'mt-button': {
+                    template: '<button :disabled="disabled || undefined" @click="$emit(\'click\')"><slot /></button>',
+                    props: ['disabled', 'isLoading', 'size', 'variant'],
+                    emits: ['click'],
+                },
+                'mt-icon': {
+                    template: '<span class="mt-icon" />',
+                    props: ['name'],
+                },
+                'mt-promo-badge': {
+                    template: '<span class="mt-promo-badge" />',
+                    props: ['variant', 'size'],
+                },
+                'sw-loader': true,
+                'sw-extension-teaser-sales-channel': true,
+            },
+            directives: {
+                tooltip: {},
+            },
+            provide: {
+                repositoryFactory: {
+                    create: () => ({
+                        search: mockSearch,
+                    }),
+                },
+            },
+        },
+    });
+}
+
+describe('sw-sales-channel-modal-grid', () => {
+    it('renders a button for each sales channel type after loading', async () => {
+        const wrapper = await createWrapper();
+
+        const buttons = wrapper.findAll('.sw-sales-channel-modal__add-channel-action');
+        expect(buttons).toHaveLength(mockSalesChannelTypes.length);
+    });
+
+    it('emits grid-channel-add with the type id when add button is clicked', async () => {
+        const wrapper = await createWrapper();
+
+        const buttons = wrapper.findAll('.sw-sales-channel-modal__add-channel-action');
+        await buttons[0].trigger('click');
+
+        expect(wrapper.emitted('grid-channel-add')).toBeTruthy();
+        expect(wrapper.emitted('grid-channel-add')[0][0]).toBe(PRODUCT_COMPARISON_TYPE_ID);
+    });
+
+    it('emits grid-detail-open with the type when description is clicked', async () => {
+        const wrapper = await createWrapper();
+
+        const buttons = wrapper.findAll('.sw-sales-channel-modal-grid__item-description');
+        await buttons[0].trigger('click');
+
+        expect(wrapper.emitted('grid-detail-open')).toBeTruthy();
+        expect(wrapper.emitted('grid-detail-open')[0][0]).toEqual(mockSalesChannelTypes[0]);
+    });
+
+    it('disables the add button when addChannelAction.disabled returns true', async () => {
+        const wrapper = await createWrapper({
+            addChannelAction: createAddChannelAction({ disabled: (id) => id === AGENTIC_COMMERCE_TYPE_ID }),
+        });
+
+        const buttons = wrapper.findAll('.sw-sales-channel-modal__add-channel-action');
+
+        expect(buttons[0].attributes('disabled')).toBeUndefined();
+        expect(buttons[1].attributes('disabled')).toBeDefined();
+    });
+
+    it('disables the add button for agentic commerce type', async () => {
+        const wrapper = await createWrapper();
+
+        const buttons = wrapper.findAll('.sw-sales-channel-modal__add-channel-action');
+        const agenticIndex = mockSalesChannelTypes.findIndex((t) => t.id === AGENTIC_COMMERCE_TYPE_ID);
+        expect(buttons[agenticIndex].attributes('disabled')).toBeDefined();
+    });
+
+    describe('getTooltip', () => {
+        it('uses the agentic commerce message key for the agentic commerce type', async () => {
+            const wrapper = await createWrapper();
+
+            const agenticItem = mockSalesChannelTypes.find((t) => t.id === AGENTIC_COMMERCE_TYPE_ID);
+            const tooltip = wrapper.vm.getTooltip(agenticItem);
+
+            expect(tooltip.message).toBe(wrapper.vm.$t('sw-sales-channel.modal.messageAgenticCommerce'));
+        });
+
+        it('uses the no-product-streams message key for the product comparison type', async () => {
+            const wrapper = await createWrapper({
+                addChannelAction: createAddChannelAction({ disabled: (id) => id === PRODUCT_COMPARISON_TYPE_ID }),
+            });
+
+            const comparisonItem = mockSalesChannelTypes.find((t) => t.id === PRODUCT_COMPARISON_TYPE_ID);
+            const tooltip = wrapper.vm.getTooltip(comparisonItem);
+
+            expect(tooltip.message).toBe(wrapper.vm.$t('sw-sales-channel.modal.messageNoProductStreams'));
+        });
+    });
+
+    describe('isDisabled', () => {
+        it('returns false for a regular type when addChannelAction.disabled is false', async () => {
+            const wrapper = await createWrapper();
+
+            const regularItem = mockSalesChannelTypes[0];
+            expect(wrapper.vm.isDisabled(regularItem)).toBe(false);
+        });
+
+        it('returns true when addChannelAction.disabled returns true', async () => {
+            const wrapper = await createWrapper({
+                addChannelAction: createAddChannelAction({ disabled: () => true }),
+            });
+
+            const regularItem = mockSalesChannelTypes[0];
+            expect(wrapper.vm.isDisabled(regularItem)).toBe(true);
+        });
+
+        it('returns true for agentic commerce type regardless of addChannelAction', async () => {
+            const wrapper = await createWrapper({
+                addChannelAction: createAddChannelAction({ disabled: () => false }),
+            });
+
+            const agenticItem = mockSalesChannelTypes.find((t) => t.id === AGENTIC_COMMERCE_TYPE_ID);
+            expect(wrapper.vm.isDisabled(agenticItem)).toBe(true);
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.spec.js
@@ -8,8 +8,16 @@ const PRODUCT_COMPARISON_TYPE_ID = Shopware.Defaults.productComparisonTypeId;
 const AGENTIC_COMMERCE_TYPE_ID = Shopware.Defaults.agenticCommerceTypeId;
 
 const mockSalesChannelTypes = [
-    { id: PRODUCT_COMPARISON_TYPE_ID, iconName: 'comparison-icon', translated: { name: 'Product Comparison', description: 'A comparison feed' } },
-    { id: AGENTIC_COMMERCE_TYPE_ID, iconName: 'agentic-icon', translated: { name: 'Agentic Commerce', description: 'Agentic Commerce' } },
+    {
+        id: PRODUCT_COMPARISON_TYPE_ID,
+        iconName: 'comparison-icon',
+        translated: { name: 'Product Comparison', description: 'A comparison feed' },
+    },
+    {
+        id: AGENTIC_COMMERCE_TYPE_ID,
+        iconName: 'agentic-icon',
+        translated: { name: 'Agentic Commerce', description: 'Agentic Commerce' },
+    },
 ];
 
 function createAddChannelAction({ disabled = () => false, loading = () => false } = {}) {
@@ -17,9 +25,9 @@ function createAddChannelAction({ disabled = () => false, loading = () => false 
 }
 
 async function createWrapper({ addChannelAction = createAddChannelAction(), productStreamsExist = true } = {}) {
-    const mockSearch = jest.fn().mockResolvedValue(
-        Object.assign([...mockSalesChannelTypes], { total: mockSalesChannelTypes.length }),
-    );
+    const mockSearch = jest
+        .fn()
+        .mockResolvedValue(Object.assign([...mockSalesChannelTypes], { total: mockSalesChannelTypes.length }));
 
     return mount(await wrapTestComponent('sw-sales-channel-modal-grid', { sync: true }), {
         props: {
@@ -30,15 +38,30 @@ async function createWrapper({ addChannelAction = createAddChannelAction(), prod
             stubs: {
                 'sw-grid': {
                     template: '<div class="sw-grid"><slot name="columns" v-for="item in items" :item="item" /></div>',
-                    props: ['items', 'selectable', 'header', 'table'],
+                    props: [
+                        'items',
+                        'selectable',
+                        'header',
+                        'table',
+                    ],
                 },
                 'sw-grid-column': {
                     template: '<div class="sw-grid-column"><slot /></div>',
-                    props: ['flex', 'align', 'label', 'dataIndex'],
+                    props: [
+                        'flex',
+                        'align',
+                        'label',
+                        'dataIndex',
+                    ],
                 },
                 'mt-button': {
                     template: '<button :disabled="disabled || undefined" @click="$emit(\'click\')"><slot /></button>',
-                    props: ['disabled', 'isLoading', 'size', 'variant'],
+                    props: [
+                        'disabled',
+                        'isLoading',
+                        'size',
+                        'variant',
+                    ],
                     emits: ['click'],
                 },
                 'mt-icon': {
@@ -47,7 +70,10 @@ async function createWrapper({ addChannelAction = createAddChannelAction(), prod
                 },
                 'mt-promo-badge': {
                     template: '<span class="mt-promo-badge" />',
-                    props: ['variant', 'size'],
+                    props: [
+                        'variant',
+                        'size',
+                    ],
                 },
                 'sw-loader': true,
                 'sw-extension-teaser-sales-channel': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de.json
@@ -38,6 +38,7 @@
             "buttonShowDetails": "Details",
             "buttonBack": "Zurück",
             "titleDescription": "Informationen",
+            "messageAgenticCommerce": "Um Agentic-Commerce-Vertriebskanäle zu erstellen, installiere bitte die Agentic Commerce Erweiterung aus dem Shopware Store.",
             "messageNoProductStreams": "Um Produktvergleiche oder Agentic-Commerce-Vertriebskanäle zu erstellen, musst Du zunächst eine dynamische Produktgruppe erstellen."
         },
         "detail": {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en.json
@@ -38,6 +38,7 @@
             "buttonShowDetails": "Show details",
             "buttonBack": "Back",
             "titleDescription": "Information",
+            "messageAgenticCommerce": "In order to create agentic commerce sales channels, please install the Agentic Commerce extension from the Shopware Store.",
             "messageNoProductStreams": "In order to use product comparisons or agentic commerce sales channels, a dynamic product group has to be created first."
         },
         "detail": {


### PR DESCRIPTION
### 1. Why is this change necessary?

The Agentic Commerce sales channel type should only be available for creation when the `SwagAgenticCommerce` plugin is installed. Previously, the type was still offered in the sales channel creation dialog if an agentic channel had been created in a prior release and still existed — even without the plugin. This was a regression from the original intent, as the type should always require the plugin to be present.

### 2. What does this change do, exactly?

  - Removes the deprecated async `showAgenticCommerceType()` logic that checked for an existing agentic sales channel via an API call, replacing it with a simple synchronous check of `Shopware.Context.app.config.bundles?.SwagAgenticCommerce`.
  - The "Agentic Commerce" type button in the sales channel creation modal is now always disabled when the plugin is not installed, regardless of whether agentic channels already exist.
  - A dedicated tooltip (`messageAgenticCommerce`) is shown when the button is disabled due to the missing plugin, directing users to install the extension from the Shopware Store.
  - The tooltip logic is extracted into a new `getTooltip(item)` method, and a new `isDisabled(item)` method encapsulates both the existing product-stream disabled state and the new agentic commerce disabled state.
  - Adds unit tests for the `sw-sales-channel-modal-grid` component.
  - Removes `sw-sales-channel-modal-grid/index.js` from the missing-tests baseline, as it is now covered.

### 3. Describe each step to reproduce the issue or behaviour.

  1. Install Shopware without the `SwagAgenticCommerce` plugin.
  2. Create at least one Agentic Commerce sales channel using a release that previously allowed it.
  3. Remove / do not install the `SwagAgenticCommerce` plugin.
  4. Open **Sales Channels → Add sales channel**.
  5. **Before this fix:** The "Agentic Commerce" type button was enabled, allowing creation.
  6. **After this fix:** The button is disabled and shows a tooltip: *"In order to create agentic commerce sales channels, please install the Agentic Commerce extension from the Shopware Store."*
  7. Install the `SwagAgenticCommerce` plugin → the button becomes enabled again.

  ### 4. Please link to the relevant issues (if any).

  - closes #17383

  ### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them