### PR TITLE
fix: emit mapping after inline order address creation

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
@@ -231,6 +231,8 @@ export default {
 
             return this.customerRepository.save(this.customer).then(() => {
                 this.currentAddress = null;
+
+                this.onAddressChange(address.id);
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/sw-order-address-selection.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/sw-order-address-selection.spec.js
@@ -280,6 +280,40 @@ describe('src/module/sw-order/component/sw-order-address-selection', () => {
         expect(wrapper.find('.sw-customer-address-form')).toBeTruthy();
     });
 
+    it('should select a newly created address after saving it', async () => {
+        wrapper = await createWrapper({
+            type: 'shipping',
+        });
+
+        await flushPromises();
+
+        wrapper.vm.createNewCustomerAddress();
+        Object.assign(wrapper.vm.currentAddress, {
+            id: 'newCustomerAddressId',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            street: 'Example Street 1',
+            zipcode: '12345',
+            city: 'Example City',
+            countryId: 'countryId',
+        });
+
+        wrapper.vm.isValidAddress = jest.fn(() => true);
+
+        await wrapper.vm.onSaveAddress();
+
+        expect(wrapper.emitted('change-address')).toEqual([
+            [
+                {
+                    orderAddressId: '38e8895864a649a1b2ec806dad02ab87',
+                    customerAddressId: 'newCustomerAddressId',
+                    type: 'shipping',
+                    edited: false,
+                },
+            ],
+        ]);
+    });
+
     it('should be able to get the options with props', async () => {
         const addressSelection = wrapper.find('.sw-order-address-selection');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Because newly created inline addresses were saved as customer addresses but not emitted as the selected order address, so the order save payload could miss `customerAddressId` or `type` and fail backend validation.

### 2. What does this change do, exactly?
After saving a newly created/edited customer address in the order address selector, it emits the normal `change-address` event with the saved address id and selector type, so the order detail page sends a complete address mapping.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open a order in the administration
2. Switch to the "Details" tab
3. In the billing or shipping address select, click "Add new address"
4. Fill in the address form and confirm
5. Select the newly created address in the dropdown
6. Click "Save"

### 4. Please link to the relevant issues (if any).
- Fixes https://github.com/shopware/shopware/issues/16802

### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
