### PR TITLE
fix: consider footer navigation tree children as page urls

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -61,10 +61,16 @@
 
                                     {# Check footer navigation #}
                                     {% if footer.navigation and footer.navigation.tree %}
-                                        {% for footerItem in footer.navigation.tree %}
-                                            {% if footerItem.category.cmsPageId == contactCmsPageId and footerItem.category.seoUrl %}
-                                                {% set contactUrl = footerItem.category.seoUrl %}
+                                        {% for root in footer.navigation.tree %}
+                                            {% if root.category.cmsPageId == contactCmsPageId and root.category.seoUrl %}
+                                                {% set contactUrl = root.category.seoUrl %}
                                             {% endif %}
+
+                                            {% for footerItem in root.children %}
+                                                {% if footerItem.category.cmsPageId == contactCmsPageId and footerItem.category.seoUrl %}
+                                                    {% set contactUrl = footerItem.category.seoUrl %}
+                                                {% endif %}
+                                            {% endfor %}
                                         {% endfor %}
                                     {% endif %}
 
@@ -91,10 +97,16 @@
 
                                     {# Check footer navigation #}
                                     {% if footer.navigation and footer.navigation.tree %}
-                                        {% for footerItem in footer.navigation.tree %}
-                                            {% if footerItem.category.cmsPageId == revocationRequestCmsPageId and footerItem.category.seoUrl %}
-                                                {% set revocationRequestUrl = footerItem.category.seoUrl %}
+                                        {% for root in footer.navigation.tree %}
+                                            {% if root.category.cmsPageId == revocationRequestCmsPageId and root.category.seoUrl %}
+                                                {% set revocationRequestUrl = root.category.seoUrl %}
                                             {% endif %}
+
+                                            {% for footerItem in root.children %}
+                                                {% if footerItem.category.cmsPageId == revocationRequestCmsPageId and footerItem.category.seoUrl %}
+                                                    {% set revocationRequestUrl = footerItem.category.seoUrl %}
+                                                {% endif %}
+                                            {% endfor %}
                                         {% endfor %}
                                     {% endif %}
 
@@ -281,10 +293,16 @@
 
                         {# Check footer navigation #}
                         {% if footer.navigation and footer.navigation.tree %}
-                            {% for footerItem in footer.navigation.tree %}
-                                {% if footerItem.category.cmsPageId == shippingCmsPageId and footerItem.category.seoUrl %}
-                                    {% set shippingUrl = footerItem.category.seoUrl %}
+                            {% for root in footer.navigation.tree %}
+                                {% if root.category.cmsPageId == shippingCmsPageId and root.category.seoUrl %}
+                                    {% set shippingUrl = root.category.seoUrl %}
                                 {% endif %}
+
+                                {% for footerItem in root.children %}
+                                    {% if footerItem.category.cmsPageId == shippingCmsPageId and footerItem.category.seoUrl %}
+                                        {% set shippingUrl = footerItem.category.seoUrl %}
+                                    {% endif %}
+                                {% endfor %}
                             {% endfor %}
                         {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
At the moment, navigation tree children are not considered when looking for page urls of contact, revocation and shipping pages.

### 2. What does this change do, exactly?
Handle children of footer navigation tree when looking for page urls.

### 3. Describe each step to reproduce the issue or behaviour.
Add a footer menu with a category child using the shipping cms page. The shipping link in the bottom footer is expected to use the seoUrl of the shipping category, but the generated route path is used instead.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #16744

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
