### PR TITLE
chore: Fix INI-dependent installer tests

### DIFF
--- a/src/Core/Installer/Database/DatabaseMigrator.php
+++ b/src/Core/Installer/Database/DatabaseMigrator.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Installer\Requirements\IniConfigReader;
 use Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter;
 
 /**
@@ -18,6 +19,7 @@ class DatabaseMigrator
         private readonly SetupDatabaseAdapter $adapter,
         private readonly MigrationCollectionFactory $migrationFactory,
         private readonly string $version,
+        private readonly IniConfigReader $iniConfigReader,
         private readonly ClockInterface $clock
     ) {
     }
@@ -37,8 +39,9 @@ class DatabaseMigrator
             $coreMigrations->sync();
         }
 
-        // use 7 s as max execution time, so the UI stays responsive
-        $maxExecutionTime = min(\ini_get('max_execution_time'), 7);
+        // Use 7s as request cap so the UI stays responsive; 0/-1 mean unlimited PHP runtime.
+        $configuredMaxExecutionTime = (int) $this->iniConfigReader->get('max_execution_time');
+        $maxExecutionTime = $configuredMaxExecutionTime <= 0 ? 7 : min($configuredMaxExecutionTime, 7);
         $startTime = (float) $this->clock->now()->format(Defaults::MICROTIME_FORMAT);
         $executedMigrations = $offset;
 

--- a/src/Core/Installer/DependencyInjection/services.xml
+++ b/src/Core/Installer/DependencyInjection/services.xml
@@ -264,6 +264,7 @@
             <argument type="service" id="Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter"/>
             <argument type="service" id="Shopware\Core\Installer\Database\MigrationCollectionFactory"/>
             <argument type="string">%kernel.shopware_version%</argument>
+            <argument type="service" id="Shopware\Core\Installer\Requirements\IniConfigReader"/>
             <argument type="service" id="Psr\Clock\ClockInterface"/>
         </service>
 

--- a/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
+++ b/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Unit\Core\Installer\Database;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Installer\Database\DatabaseMigrator;
 use Shopware\Core\Installer\Database\MigrationCollectionFactory;
+use Shopware\Core\Installer\Requirements\IniConfigReader;
 use Shopware\Core\Kernel;
 use Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter;
 use Symfony\Component\Clock\NativeClock;
@@ -25,6 +27,10 @@ class DatabaseMigratorTest extends TestCase
     private Connection&MockObject $connection;
 
     private MockObject&MigrationCollection $migrationCollection;
+
+    private MockObject&IniConfigReader $iniConfigReader;
+
+    private string $maxExecutionTime = '10';
 
     private DatabaseMigrator $databaseMigrator;
 
@@ -47,10 +53,17 @@ class DatabaseMigratorTest extends TestCase
             ->with($this->connection)
             ->willReturn($migrationLoader);
 
+        $this->iniConfigReader = $this->createMock(IniConfigReader::class);
+        $this->iniConfigReader
+            ->method('get')
+            ->with('max_execution_time')
+            ->willReturnCallback(fn (): string => $this->maxExecutionTime);
+
         $this->databaseMigrator = new DatabaseMigrator(
             $this->setupAdapter,
             $migrationCollectorFactory,
             Kernel::SHOPWARE_FALLBACK_VERSION,
+            $this->iniConfigReader,
             new NativeClock()
         );
     }
@@ -80,11 +93,7 @@ class DatabaseMigratorTest extends TestCase
             ->method('getExecutableDestructiveMigrations')
             ->willReturn(['migration']);
 
-        \ini_set('max_execution_time', '10');
-
         $result = $this->databaseMigrator->migrate(0, $this->connection);
-
-        \ini_restore('max_execution_time');
 
         static::assertSame([
             'offset' => 1,
@@ -126,11 +135,7 @@ class DatabaseMigratorTest extends TestCase
             ->method('getExecutableDestructiveMigrations')
             ->willReturn(['migration']);
 
-        \ini_set('max_execution_time', '10');
-
         $result = $this->databaseMigrator->migrate(1, $this->connection);
-
-        \ini_restore('max_execution_time');
 
         static::assertSame([
             'offset' => 3,
@@ -139,8 +144,11 @@ class DatabaseMigratorTest extends TestCase
         ], $result);
     }
 
-    public function testFinishedMigration(): void
+    #[DataProvider('maxExecutionTimeProvider')]
+    public function testFinishedMigration(string $maxExecutionTime): void
     {
+        $this->maxExecutionTime = $maxExecutionTime;
+
         $this->setupAdapter->expects($this->never())
             ->method('initializeShopwareDb')
             ->with($this->connection);
@@ -174,17 +182,20 @@ class DatabaseMigratorTest extends TestCase
             ->method('getExecutableDestructiveMigrations')
             ->willReturn([]);
 
-        \ini_set('max_execution_time', '10');
-
         $result = $this->databaseMigrator->migrate(6, $this->connection);
-
-        \ini_restore('max_execution_time');
 
         static::assertSame([
             'offset' => 10,
             'total' => 10,
             'isFinished' => true,
         ], $result);
+    }
+
+    public static function maxExecutionTimeProvider(): \Generator
+    {
+        yield 'configured above installer cap' => ['10'];
+        yield 'unlimited php runtime' => ['0'];
+        yield 'unlimited php runtime from cli option' => ['-1'];
     }
 
     /**

--- a/tests/unit/Core/Installer/Requirements/IniConfigReaderTest.php
+++ b/tests/unit/Core/Installer/Requirements/IniConfigReaderTest.php
@@ -14,34 +14,26 @@ use Shopware\Core\Installer\Requirements\IniConfigReader;
 class IniConfigReaderTest extends TestCase
 {
     #[DataProvider('configProvider')]
-    public function testGet(string $key, string|false $configValue, string $expectedValue): void
+    public function testGet(string $key): void
     {
-        \ini_set($key, (string) $configValue);
-
         $reader = new IniConfigReader();
-        static::assertSame($expectedValue, $reader->get($key));
 
-        \ini_restore($key);
+        // The cast is intentional: ini_get() returns false for unknown keys, matching IniConfigReader's empty-string result.
+        static::assertSame((string) \ini_get($key), $reader->get($key));
     }
 
     public static function configProvider(): \Generator
     {
         yield 'max_execution_time' => [
             'max_execution_time',
-            '30',
-            '30',
         ];
 
         yield 'memory_limit' => [
             'memory_limit',
-            '512M',
-            '512M',
         ];
 
         yield 'not set value' => [
-            'max_execution_time',
-            false,
-            '',
+            'not_existing_ini_value',
         ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The unit suite had tests that depended on mutable process-global PHP INI state. `IniConfigReaderTest` could fail when `memory_limit` was forced below current process memory, and `DatabaseMigratorTest` had to mutate `max_execution_time` because production code read the global INI value directly.

### 2. What does this change do, exactly?

- Injects `IniConfigReader` into `DatabaseMigrator` so tests can provide `max_execution_time` without mutating global INI state.
- Treats `max_execution_time` values `0` and `-1` as unlimited PHP runtime while keeping the installer request cap at 7 seconds.
- Changes `IniConfigReaderTest` to compare against current `ini_get()` values instead of overwriting them.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run the unit suite with `php -d memory_limit=-1 vendor/bin/phpunit --testsuite unit --coverage-cobertura coverage.xml --log-junit junit.xml`.
2. Let PHPUnit memory usage grow beyond `512M` before `IniConfigReaderTest::testGet` runs.
3. The test attempts to set `memory_limit` to `512M`, PHP keeps `-1`, and the assertion fails.

### 4. Please link to the relevant issues (if any).

- Related CI run: https://github.com/shopware/shopware/actions/runs/27756723371/job/82120329384

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers: not relevant, internal installer/unit-test stability fix
- [x] I have written or adjusted the documentation according to my changes: not relevant, no external docs impact
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

Validation:

- `docker compose -p codex-876f run --rm --no-deps web php -d memory_limit=-1 vendor/bin/phpunit --bootstrap vendor/autoload.php tests/unit/Core/Installer/Database/DatabaseMigratorTest.php tests/unit/Core/Installer/Requirements/IniConfigReaderTest.php`
- `git diff --check`
