### PR TITLE
fix(bootstrap): remove hard-coded headline margin

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -33,6 +33,10 @@ Content can be provided in two ways:
 
 The auto-generated `sizes` attribute produced by `thumbnail.html.twig` now includes a value for the XXL breakpoint. The `xxl` key is the open-ended top (`container / columns`), and `xl` is a closed range bounded by `breakpoint.xxl - 1`, matching the pattern used by smaller breakpoints. Templates that pass a manual `sizes` map to `sw_thumbnails` should add an `xxl` entry to keep parity.
 
+### Use Bootstrap variable for headings spacing
+
+The hard-coded headline `margin-bottom` from H1-H6 were removed. The bootstrap variable `$headings-margin-bottom` can now be used to set the bottom spacing of headlines.
+
 ### Storefront XHR login failures now keep HTTP 403
 
 Storefront requests that require a logged-in customer no longer redirect to the login page for XMLHttpRequests when the customer session is no longer valid.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -35,7 +35,7 @@ The auto-generated `sizes` attribute produced by `thumbnail.html.twig` now inclu
 
 ### Use Bootstrap variable for headings spacing
 
-The hard-coded headline `margin-bottom` from H1-H6 were removed. The bootstrap variable `$headings-margin-bottom` can now be used to set the bottom spacing of headlines.
+The hard-coded CSS `margin-bottom` was removed from HTML headlines H1-H6. The bootstrap variable `$headings-margin-bottom` can now be used to set the bottom spacing of headlines.
 
 ### Storefront XHR login failures now keep HTTP 403
 

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
@@ -76,6 +76,7 @@ $nav-link-font-size: $font-size-base !default;
 
 $headings-font-weight: 700 !default;
 $headings-font-family: $sw-font-family-headline !default;
+$headings-margin-bottom: 1rem !default;
 
 $link-decoration: underline !default;
 $link-hover-decoration: underline !default;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/base/_typography.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/base/_typography.scss
@@ -9,21 +9,6 @@ https://getbootstrap.com/docs/5.2/content/typography
 */
 
 h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
-    margin-bottom: 1rem;
-}
-
-h1,
 .h1 {
     line-height: 2.5rem;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

* Headlines (`h1`-`h6` and `.h1`-`.h6`) use hard-coded margin in our skin SCSS.
* This is not needed because Bootstrap already offers a variable for this.
* It created unnecessary CSS cascade and can also prevent spacing tooling classes from working.

### 2. What does this change do, exactly?

Use `$headings-margin-bottom` variable instead of custom CSS override.

### 3. Describe each step to reproduce the issue or behaviour.

No visual difference.

Developer test:
* Go to the product detail page.
* In the inspector, apply a `mb-0` class to the product name H1.
* The class should work as expected and remove the spacing.

### 4. Please link to the relevant issues (if any).
- closes #8460 