### PR TITLE
fix: hide rental notice for cancelled Store extension subscriptions

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/index.js
@@ -50,8 +50,13 @@ export default {
             });
         },
 
-        isRent() {
-            return this.extension?.storeLicense?.variant === this.shopwareExtensionService.EXTENSION_VARIANT_TYPES.RENT;
+        hasActiveRentLicense() {
+            const storeLicense = this.extension?.storeLicense;
+
+            return (
+                storeLicense?.variant === this.shopwareExtensionService.EXTENSION_VARIANT_TYPES.RENT &&
+                storeLicense.expirationDate === null
+            );
         },
 
         headline() {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.html.twig
@@ -22,7 +22,7 @@
     {% endblock %}
 
     {% block sw_extension_adding_failed_licence_cancellation %}
-    <template v-if="isRent">
+    <template v-if="hasActiveRentLicense">
         <p class="sw-extension-adding-failed__text-licence-cancellation">
             {{ $t('sw-extension-store.component.sw-extension-adding-failed.installationFailed.notificationLicense') }}
         </p>

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.spec.js
@@ -1,6 +1,8 @@
 import { mount } from '@vue/test-utils';
 import ShopwareExtensionService from 'src/module/sw-extension/service/shopware-extension.service';
 
+const licenceCancellationTextSelector = '.sw-extension-adding-failed__text-licence-cancellation';
+
 async function createWrapper() {
     const shopwareExtensionService = new ShopwareExtensionService();
 
@@ -58,21 +60,38 @@ describe('src/module/sw-extension-component/sw-extension-adding-failed', () => {
         expect(wrapper.emitted().close).toBeTruthy();
     });
 
-    it('renders all information if extension is rent', async () => {
+    it('renders all information if extension has an active rent license', async () => {
         Shopware.Store.get('shopwareExtensions').setMyExtensions([
             {
                 name: 'test-app',
                 storeLicense: {
                     variant: 'rent',
+                    expirationDate: null,
                 },
             },
         ]);
 
         const wrapper = await createWrapper();
 
-        expect(wrapper.get('.sw-extension-adding-failed__text-licence-cancellation').text()).toBe(
+        expect(wrapper.get(licenceCancellationTextSelector).text()).toBe(
             'sw-extension-store.component.sw-extension-adding-failed.installationFailed.notificationLicense',
         );
+    });
+
+    it('does not render additional information if the rent license is cancelled', async () => {
+        Shopware.Store.get('shopwareExtensions').setMyExtensions([
+            {
+                name: 'test-app',
+                storeLicense: {
+                    variant: 'rent',
+                    expirationDate: '2025-08-01T03:30:35+01:00',
+                },
+            },
+        ]);
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find(licenceCancellationTextSelector).exists()).toBe(false);
     });
 
     it('does not render additional information if the license is not a subscription', async () => {
@@ -87,7 +106,7 @@ describe('src/module/sw-extension-component/sw-extension-adding-failed', () => {
 
         const wrapper = await createWrapper();
 
-        expect(wrapper.find('.sw-extension-installation-failed__text-licence-cancellation').exists()).toBe(false);
+        expect(wrapper.find(licenceCancellationTextSelector).exists()).toBe(false);
         expect(wrapper.find('h3').text()).toBe(
             'sw-extension-store.component.sw-extension-adding-failed.installationFailed.titleFailure',
         );
@@ -101,7 +120,7 @@ describe('src/module/sw-extension-component/sw-extension-adding-failed', () => {
 
         const wrapper = await createWrapper();
 
-        expect(wrapper.find('.sw-extension-installation-failed__text-licence-cancellation').exists()).toBe(false);
+        expect(wrapper.find(licenceCancellationTextSelector).exists()).toBe(false);
         expect(wrapper.find('h3').text()).toBe('sw-extension-store.component.sw-extension-adding-failed.titleFailure');
         expect(wrapper.find('p').text()).toBe('sw-extension-store.component.sw-extension-adding-failed.textProblem');
     });


### PR DESCRIPTION
Closes #17526

he failed installation modal for Store extensions still showed the rental notice even when the subscription had already been cancelled.

This is misleading because the notice says that the rental remains active, although cancelled rental subscriptions already have an `expirationDate`.

### 2. What does this change do, exactly?

The modal now only shows the rental notice when the extension has an active rental license.

A rental license is treated as active for this notice when:

- `variant` is `rent`
- `expirationDate` is `null`

Cancelled rental licenses have an `expirationDate`, so the notice is hidden for them.

The Administration unit test was adjusted to cover both active and cancelled rental licenses.