### PR TITLE
fix: update Store extension error documentation link

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-error-handler.service.spec.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-error-handler.service.spec.ts
@@ -1,0 +1,58 @@
+import extensionErrorHandler from './extension-error-handler.service';
+
+const currentDownloadNotAllowedForDomainDocumentationLink =
+    'https://docs.shopware.com/en/shopware-6-en/extensions/error-messages#download-not-allowed-for-domain';
+const currentGermanDownloadNotAllowedForDomainDocumentationLink =
+    'https://docs.shopware.com/de/shopware-6-de/Erweiterungen/fehlermeldungen#download-not-allowed-for-domain';
+
+function createStoreApiError(documentationLink: string): StoreApiException {
+    return {
+        code: 'FRAMEWORK__STORE_ERROR',
+        status: '500',
+        title: 'Download not allowed',
+        detail: 'The download of the extension is not allowed for the selected shop.',
+        meta: {
+            documentationLink,
+        },
+    } as StoreApiException;
+}
+
+/**
+ * @sw-package checkout
+ */
+describe('src/module/sw-extension/service/extension-error-handler.service', () => {
+    it.each([
+        [
+            'https://docs.shopware.com/de/shopware-6-de/einstellungen/Erweiterungen/fehlermeldungen#download-not-allowed-for-domain',
+            currentGermanDownloadNotAllowedForDomainDocumentationLink,
+        ],
+        [
+            'https://docs.shopware.com/en/shopware-6-en/settings/extensions/error-messages#download-not-allowed-for-domain',
+            currentDownloadNotAllowedForDomainDocumentationLink,
+        ],
+    ])('maps the outdated download-not-allowed documentation link', (documentationLink, expectedDocumentationLink) => {
+        const mappedErrors = extensionErrorHandler.mapErrors([
+            createStoreApiError(documentationLink),
+        ]);
+
+        expect(mappedErrors).toEqual([
+            {
+                title: 'Download not allowed',
+                message: 'The download of the extension is not allowed for the selected shop.',
+                details: null,
+                parameters: {
+                    documentationLink: expectedDocumentationLink,
+                },
+            },
+        ]);
+    });
+
+    it('keeps unknown documentation links unchanged', () => {
+        const documentationLink = 'https://docs.shopware.com/en/shopware-6-en/extensions';
+        const mappedErrors = extensionErrorHandler.mapErrors([
+            createStoreApiError(documentationLink),
+        ]);
+
+        expect(mappedErrors[0]?.parameters?.documentationLink).toBe(documentationLink);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-error-handler.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-error-handler.service.ts
@@ -7,6 +7,17 @@ type MappedError = {
     };
 };
 
+const outdatedDocumentationLinks = new Map<string, string>([
+    [
+        'https://docs.shopware.com/de/shopware-6-de/einstellungen/Erweiterungen/fehlermeldungen#download-not-allowed-for-domain',
+        'https://docs.shopware.com/de/shopware-6-de/Erweiterungen/fehlermeldungen#download-not-allowed-for-domain',
+    ],
+    [
+        'https://docs.shopware.com/en/shopware-6-en/settings/extensions/error-messages#download-not-allowed-for-domain',
+        'https://docs.shopware.com/en/shopware-6-en/extensions/error-messages#download-not-allowed-for-domain',
+    ],
+]);
+
 class StoreError {
     constructor(
         public readonly title: string,
@@ -73,7 +84,7 @@ function mapErrorWithDocsLink({ title, detail: message, meta }: StoreApiExceptio
             message,
             details: null,
             parameters: {
-                documentationLink: meta.documentationLink,
+                documentationLink: outdatedDocumentationLinks.get(meta.documentationLink) ?? meta.documentationLink,
             },
         };
     }


### PR DESCRIPTION
Closes #17527

The failed installation modal for Store extensions can show a documentation link for the `download-not-allowed-for-domain` error that points to a 404 page.

### 2. What does this change do, exactly?

It maps the known outdated documentation links for `download-not-allowed-for-domain` to the current working Shopware Docs pages.

Unknown documentation links are kept unchanged.