### PR TITLE
fix: treat unitless CMS image min-height as pixels

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/config.spec.js
@@ -126,6 +126,36 @@ describe('src/module/sw-cms/elements/image/config', () => {
         expect(wrapper.vm.element.config.minHeight.value).toBe('340px');
     });
 
+    it('should append px to a unitless min height value', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onChangeMinHeight('500');
+        expect(wrapper.vm.element.config.minHeight.value).toBe('500px');
+
+        wrapper.vm.onChangeMinHeight('260.5');
+        expect(wrapper.vm.element.config.minHeight.value).toBe('260.5px');
+    });
+
+    it('should keep an explicitly given unit on the min height value', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onChangeMinHeight('340px');
+        expect(wrapper.vm.element.config.minHeight.value).toBe('340px');
+
+        wrapper.vm.onChangeMinHeight('20rem');
+        expect(wrapper.vm.element.config.minHeight.value).toBe('20rem');
+    });
+
+    it('should clear the min height value when emptied', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onChangeMinHeight('');
+        expect(wrapper.vm.element.config.minHeight.value).toBe('');
+
+        wrapper.vm.onChangeMinHeight(null);
+        expect(wrapper.vm.element.config.minHeight.value).toBe('');
+    });
+
     it('should change the isDecorative value', async () => {
         const wrapper = await createWrapper();
         const isDecorativeSwitch = wrapper.find('.sw-cms-el-config-image__is-decorative input');

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -173,8 +173,11 @@ export default {
 
             const trimmed = String(value).trim();
 
-            // a plain number is interpreted as pixels so the resulting CSS stays valid
-            return /^\d+(\.\d+)?$/.test(trimmed) ? `${trimmed}px` : trimmed;
+            return this.isUnitlessNumber(trimmed) ? `${trimmed}px` : trimmed;
+        },
+
+        isUnitlessNumber(value) {
+            return /^\d+(\.\d+)?$/.test(value);
         },
 
         onChangeDisplayMode() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/index.js
@@ -162,8 +162,19 @@ export default {
         },
 
         onChangeMinHeight(value) {
-            this.element.config.minHeight.value = value === null ? '' : value;
+            this.element.config.minHeight.value = this.formatMinHeight(value);
             this.emitUpdate();
+        },
+
+        formatMinHeight(value) {
+            if (value === null || value === '') {
+                return '';
+            }
+
+            const trimmed = String(value).trim();
+
+            // a plain number is interpreted as pixels so the resulting CSS stays valid
+            return /^\d+(\.\d+)?$/.test(trimmed) ? `${trimmed}px` : trimmed;
         },
 
         onChangeDisplayMode() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -91,13 +91,14 @@
             field="minHeight"
             :element="element"
             :label="$t('sw-cms.elements.image.config.label.minHeight')"
-            @update:value="onChangeMinHeight"
         >
             <template #default="{ isInherited }">
                 <mt-text-field
                     v-model:model-value="element.config.minHeight.value"
                     :placeholder="$t('sw-cms.elements.image.config.placeholder.enterMinHeight')"
+                    :help-text="$t('sw-cms.elements.image.config.helpText.minHeight')"
                     :disabled="isInherited"
+                    @change="onChangeMinHeight"
                 />
             </template>
         </sw-cms-inherit-wrapper>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -266,7 +266,7 @@
           },
           "helpText": {
             "ariaLabel": "Dieser Text wird beim Auslesen des Links von Screenreadern vorgelesen.",
-            "minHeight": "Gib die Mindesthöhe in der gewünschten Einheit an. Zum Beispiel: 200px",
+            "minHeight": "Gib die Mindesthöhe an. Eine reine Zahl wird als Pixel interpretiert. Aus \"200\" wird zum Beispiel \"200px\".",
             "fetchPriorityHigh": "Setze diese Option, wenn das Bild das erste Bild auf der Seite ist. Diesem Bild wird dann das Attribut 'fetchpriority=\"high\"' hinzugefügt, was dem Browser mitteilt, dass das Bild mit höherer Priorität geladen werden soll, was den Largest Contentful Paint (LCP) verbessern kann.",
             "useFetchPriorityOnFirstItem": "Wenn diese Option eingeschaltet wird, wird das erste Bild mit einer höheren Priorität geladen. Dies kann die Geschwindigkeit des Aufbaus der Seite im Browser verbessern.",
             "isDecorative": "Wenn diese Option eingeschaltet ist, werden die Bildinformationen nicht von Screenreadern vorgelesen, das heißt der \"alt\"-Tag und \"title\"-Tag bleiben leer."

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
@@ -266,7 +266,7 @@
           },
           "helpText": {
             "ariaLabel": "This text will be read out by screen readers as link text.",
-            "minHeight": "Enter the minimum height with your desired unit. For example: 200px",
+            "minHeight": "Enter the minimum height. A plain number is treated as pixels. For example, \"200\" becomes \"200px\".",
             "fetchPriorityHigh": "Activate this option if the image is the first one on the page. The image will then be assigned the attribute 'fetchpriority=\"high\"', telling the browser to load it with higher priority. This can help improve the Largest Contentful Paint (LCP).",
             "useFetchPriorityOnFirstItem": "When this option is enabled, the first image is loaded with a higher priority. This can improve the speed at which the page is rendered in the browser.",
             "isDecorative": "When this option is enabled, the image information will not be read out by screen readers. This means that the \"alt\" and \"title\" tags will remain empty."


### PR DESCRIPTION
### 1. Why is this change necessary?

In the Shopping Experiences designer, the image element's "Min height" field accepts a plain number. Entering e.g. `500` stored `min-height: "500"`, which is invalid CSS (only `0` may be unitless), so the browser ignores it. In cover mode the container then has no height source and the image collapses to 0 — in both the admin preview and the storefront — and the collapsed element can no longer be selected in the editor. See #17588.

### 2. What does this change do, exactly?

- Normalizes the min-height value on change: a purely numeric input is treated as pixels (`500` becomes `500px`). Values that already carry a unit (`340px`, `20rem`, `50vh`) are left untouched, and an empty value is cleared.
- The field commits via `@change`, so the normalization happens on blur and is visible to the user (the field shows `500px`).
- Wires up the existing (previously unused) `helpText.minHeight` snippet on the field and clarifies its wording: "A plain number is treated as pixels. For example, \"200\" becomes \"200px\"." It intentionally does not advertise `%`, which resolves against an indefinite parent height in the default layout and collapses the image.

### 3. Describe each step to reproduce the issue or behaviour.

1. Shopping Experiences → add an image element → set display mode to "Cropped" (cover).
2. In "Min height" enter a bare number, e.g. `500`.
3. Before: stored as `500` → invalid CSS → image collapses (admin preview and storefront). After: normalized to `500px` and renders correctly.

### 4. Please link to the relevant issues (if any).

closes #17588

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them