### PR TITLE
fix: make Migration1773329152AddAgenticAiSalesChannelType idempotent

### DIFF
--- a/src/Core/Migration/V6_7/Migration1773329152AddAgenticAiSalesChannelType.php
+++ b/src/Core/Migration/V6_7/Migration1773329152AddAgenticAiSalesChannelType.php
@@ -22,6 +22,14 @@ class Migration1773329152AddAgenticAiSalesChannelType extends MigrationStep
     public function update(Connection $connection): void
     {
         $salesChannelTypeId = Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE);
+
+        if ($connection->fetchOne(
+            'SELECT 1 FROM `sales_channel_type` WHERE `id` = :id',
+            ['id' => $salesChannelTypeId]
+        ) !== false) {
+            return;
+        }
+
         $defaultLanguageIds = $this->fetchDefaultLanguageIds($connection);
         $systemLanguageId = Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM);
 

--- a/tests/migration/Core/V6_7/Migration1773329152AddAgenticAiSalesChannelTypeTest.php
+++ b/tests/migration/Core/V6_7/Migration1773329152AddAgenticAiSalesChannelTypeTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1773329152AddAgenticAiSalesChannelType;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1773329152AddAgenticAiSalesChannelType::class)]
+class Migration1773329152AddAgenticAiSalesChannelTypeTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1773329152, (new Migration1773329152AddAgenticAiSalesChannelType())->getCreationTimestamp());
+    }
+
+    public function testUpdateIsIdempotent(): void
+    {
+        $migration = new Migration1773329152AddAgenticAiSalesChannelType();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertSame(
+            1,
+            (int) $this->connection->fetchOne(
+                'SELECT COUNT(*) FROM `sales_channel_type` WHERE `id` = :id',
+                ['id' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE)]
+            )
+        );
+    }
+
+    public function testUpdateInsertsTypeAndTranslations(): void
+    {
+        $id = Uuid::fromHexToBytes(Defaults::SALES_CHANNEL_TYPE_AGENTIC_COMMERCE);
+
+        $this->connection->executeStatement(
+            'DELETE FROM `sales_channel` WHERE `type_id` = :id',
+            ['id' => $id]
+        );
+        $this->connection->executeStatement(
+            'DELETE FROM `sales_channel_type` WHERE `id` = :id',
+            ['id' => $id]
+        );
+
+        (new Migration1773329152AddAgenticAiSalesChannelType())->update($this->connection);
+
+        $row = $this->connection->fetchAssociative(
+            'SELECT `icon_name` FROM `sales_channel_type` WHERE `id` = :id',
+            ['id' => $id]
+        );
+        static::assertIsArray($row);
+        static::assertSame('regular-sparkle', $row['icon_name']);
+
+        $translations = $this->connection->fetchAllKeyValue(
+            'SELECT loc.code, sctt.name
+             FROM sales_channel_type_translation sctt
+             INNER JOIN language lang ON lang.id = sctt.language_id
+             INNER JOIN locale loc   ON loc.id  = lang.locale_id
+             WHERE sctt.sales_channel_type_id = :id',
+            ['id' => $id]
+        );
+        static::assertNotEmpty($translations);
+        static::assertContains('Agentic Commerce', $translations);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`Migration1773329152AddAgenticAiSalesChannelType` (shipped in 6.7.10) uses bare `$connection->insert()` calls with no idempotency guard. On any installation where the Agentic Commerce plugin ran its own migration on 6.5.x or 6.6.x, upgrading to 6.7.10+ causes `system:update:finish` to fail with a duplicate-key exception — the `sales_channel_type` row for the Agentic Commerce channel type already exists and the migration has no way to detect this.

### 2. What does this change do, exactly?

Adds a `fetchOne` existence check at the top of `update()`. If the `sales_channel_type` row is already present, the method returns immediately without attempting any inserts. A new test class `Migration1773329152AddAgenticAiSalesChannelTypeTest` is added covering the creation timestamp, double-run idempotency on an existing row, and the full insert path (type row and translations).

### 3. Describe each step to reproduce the issue or behaviour.

Install Agentic Commerce on a Shopware 6.5.x or 6.6.x installation, then upgrade the platform to 6.7.10+ and run `bin/console system:update:finish`. The migration runner executes `Migration1773329152AddAgenticAiSalesChannelType::update()`, which attempts to insert a row that already exists and throws a DBAL exception.

Alternatively, run the new test without the fix — `testUpdateIsIdempotent` fails because the second `update()` call throws.

### 4. Please link to the relevant issues (if any).

Fixes #17591

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes in `UPGRADE.md`
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them