### PR TITLE
fix: decouple storefront routes from core

### DIFF
--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -42,7 +43,8 @@ class CategoryBreadcrumbBuilder
     public function __construct(
         private readonly EntityRepository $categoryRepository,
         private readonly SalesChannelRepository $productRepository,
-        private readonly Connection $connection
+        private readonly Connection $connection,
+        private readonly EntityRouteResolver $entityRouteResolver,
     ) {
     }
 
@@ -298,8 +300,8 @@ class CategoryBreadcrumbBuilder
         $query->andWhere('seo_url.language_id = :languageId');
         $query->andWhere('seo_url.sales_channel_id = :salesChannelId');
         $query->andWhere('seo_url.foreign_key IN (:categoryIds)');
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $query->setParameter('routeName', 'frontend.navigation.page');
+        $routeName = $this->entityRouteResolver->getRouteNameForEntityName(CategoryDefinition::ENTITY_NAME);
+        $query->setParameter('routeName', $routeName);
         $query->setParameter('languageId', Uuid::fromHexToBytes($context->getLanguageId()));
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($salesChannel->getId()));
         $query->setParameter('categoryIds', Uuid::fromHexToBytesList($categoryIds), ArrayParameterType::BINARY);

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Content\Category\Service;
 
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -15,7 +17,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
     /**
      * @internal
      */
-    public function __construct(private readonly SeoUrlPlaceholderHandlerInterface $seoUrlReplacer)
+    public function __construct(private readonly EntityRouteResolver $entityRouteResolver)
     {
     }
 
@@ -31,8 +33,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
         }
 
         if ($category->getType() !== CategoryDefinition::TYPE_LINK) {
-            /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-            return $this->seoUrlReplacer->generate('frontend.navigation.page', ['navigationId' => $category->getId()]);
+            return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $category->getId()]);
         }
 
         $linkType = $category->getTranslation('linkType');
@@ -44,21 +45,18 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
 
         switch ($linkType) {
             case CategoryDefinition::LINK_TYPE_PRODUCT:
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.detail.page', ['productId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, ['productId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
                 if ($salesChannel !== null && $internalLink === $salesChannel->getNavigationCategoryId()) {
                     /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                    return $this->seoUrlReplacer->generate('frontend.home.page');
+                    return $this->entityRouteResolver->generateSeoUrlPlaceholder('frontend.home.page');
                 }
 
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.navigation.page', ['navigationId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                return $this->seoUrlReplacer->generate('frontend.landing.page', ['landingPageId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, ['landingPageId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_EXTERNAL:
             default:

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -48,12 +48,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
                 return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, ['productId' => $internalLink]);
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
-                if ($salesChannel !== null && $internalLink === $salesChannel->getNavigationCategoryId()) {
-                    /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                    return $this->entityRouteResolver->generateSeoUrlPlaceholder('frontend.home.page');
-                }
-
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $internalLink], $salesChannel);
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
                 return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, ['landingPageId' => $internalLink]);

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -9,7 +9,6 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('discovery')]
@@ -34,10 +33,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
         }
 
         if ($category->getType() !== CategoryDefinition::TYPE_LINK) {
-            return $this->entityRouteResolver->generateSeoUrlPlaceholder(
-                CategoryDefinition::ENTITY_NAME,
-                new ArrayStruct(['navigationId' => $category->getId()])
-            );
+            return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, [$category->getId()]);
         }
 
         $linkType = $category->getTranslation('linkType');
@@ -49,22 +45,13 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
 
         switch ($linkType) {
             case CategoryDefinition::LINK_TYPE_PRODUCT:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
-                    ProductDefinition::ENTITY_NAME,
-                    new ArrayStruct(['productId' => $internalLink])
-                );
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, [$internalLink]);
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
-                    CategoryDefinition::ENTITY_NAME,
-                    new ArrayStruct(['navigationId' => $internalLink])
-                );
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, [$internalLink]);
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
-                    LandingPageDefinition::ENTITY_NAME,
-                    new ArrayStruct(['landingPageId' => $internalLink])
-                );
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, [$internalLink]);
 
             case CategoryDefinition::LINK_TYPE_EXTERNAL:
             default:

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -33,7 +33,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
         }
 
         if ($category->getType() !== CategoryDefinition::TYPE_LINK) {
-            return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, [$category->getId()]);
+            return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, $category->getId());
         }
 
         $linkType = $category->getTranslation('linkType');
@@ -45,13 +45,13 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
 
         switch ($linkType) {
             case CategoryDefinition::LINK_TYPE_PRODUCT:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, [$internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, $internalLink);
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, [$internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, $internalLink);
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, [$internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, $internalLink);
 
             case CategoryDefinition::LINK_TYPE_EXTERNAL:
             default:

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -57,8 +57,7 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
             case CategoryDefinition::LINK_TYPE_CATEGORY:
                 return $this->entityRouteResolver->generateSeoUrlPlaceholder(
                     CategoryDefinition::ENTITY_NAME,
-                    new ArrayStruct(['navigationId' => $internalLink]),
-                    $salesChannel
+                    new ArrayStruct(['navigationId' => $internalLink])
                 );
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:

--- a/src/Core/Content/Category/Service/CategoryUrlGenerator.php
+++ b/src/Core/Content/Category/Service/CategoryUrlGenerator.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('discovery')]
@@ -33,7 +34,10 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
         }
 
         if ($category->getType() !== CategoryDefinition::TYPE_LINK) {
-            return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $category->getId()]);
+            return $this->entityRouteResolver->generateSeoUrlPlaceholder(
+                CategoryDefinition::ENTITY_NAME,
+                new ArrayStruct(['navigationId' => $category->getId()])
+            );
         }
 
         $linkType = $category->getTranslation('linkType');
@@ -45,13 +49,23 @@ class CategoryUrlGenerator extends AbstractCategoryUrlGenerator
 
         switch ($linkType) {
             case CategoryDefinition::LINK_TYPE_PRODUCT:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(ProductDefinition::ENTITY_NAME, ['productId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
+                    ProductDefinition::ENTITY_NAME,
+                    new ArrayStruct(['productId' => $internalLink])
+                );
 
             case CategoryDefinition::LINK_TYPE_CATEGORY:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(CategoryDefinition::ENTITY_NAME, ['navigationId' => $internalLink], $salesChannel);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
+                    CategoryDefinition::ENTITY_NAME,
+                    new ArrayStruct(['navigationId' => $internalLink]),
+                    $salesChannel
+                );
 
             case CategoryDefinition::LINK_TYPE_LANDING_PAGE:
-                return $this->entityRouteResolver->generateSeoUrlPlaceholder(LandingPageDefinition::ENTITY_NAME, ['landingPageId' => $internalLink]);
+                return $this->entityRouteResolver->generateSeoUrlPlaceholder(
+                    LandingPageDefinition::ENTITY_NAME,
+                    new ArrayStruct(['landingPageId' => $internalLink])
+                );
 
             case CategoryDefinition::LINK_TYPE_EXTERNAL:
             default:

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -92,10 +92,11 @@
             <argument type="service" id="category.repository"/>
             <argument type="service" id="sales_channel.product.repository"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator">
-            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface" />
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Validation\EntryPointValidator">

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -50,7 +50,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
-            <argument type="service" id="router"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver"/>
             <argument type="service" id="event_dispatcher"/>
 
             <tag name="shopware.sitemap_url_provider"/>
@@ -67,7 +67,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
-            <argument type="service" id="router"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="event_dispatcher"/>
 
@@ -77,7 +77,7 @@
         <service id="Shopware\Core\Content\Sitemap\Provider\LandingPageUrlProvider">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\ConfigHandler"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="router"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver"/>
             <argument type="service" id="event_dispatcher"/>
 
             <tag name="shopware.sitemap_url_provider"/>

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
@@ -17,7 +17,7 @@ class SeoUrlRouteConfigException extends SeoException
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY,
-            'Missing parameter key for primary key of entity "{{ entityName }}".',
+            'Missing parameter key for primary key in route config of entity "{{ entityName }}".',
             ['entityName' => $entityName]
         );
     }

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\Exception;
+
+use Shopware\Core\Content\Seo\SeoException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('discovery')]
+class SeoUrlRouteConfigException extends SeoException
+{
+    public const ROUTE_PARAMETERS_MISMATCHING = 'FRAMEWORK__ROUTE_PARAMETERS_MISMATCHING';
+    public const ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME = 'FRAMEWORK__ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME';
+
+    /**
+     * @param list<string> $required
+     * @param list<string> $given
+     */
+    public static function routeParametersMismatching(array $required, array $given): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::ROUTE_PARAMETERS_MISMATCHING,
+            'Mismatch between required route parameters and given values.',
+            ['required' => $required, 'given' => $given]
+        );
+    }
+
+    public static function routeConfigNotFoundForEntityName(string $entityName): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME,
+            'No route config found for given entity name.',
+            ['entityName' => $entityName]
+        );
+    }
+}

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
@@ -9,14 +9,14 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('discovery')]
 class SeoUrlRouteConfigException extends SeoException
 {
-    public const ROUTE_CONFIG_MISSING_PRIMARY_KEY = 'FRAMEWORK__ROUTE_PARAMETERS_MISMATCHING';
+    public const ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY = 'FRAMEWORK__ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY';
     public const ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME = 'FRAMEWORK__ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME';
 
-    public static function routeConfigMissingPrimaryKey(string $entityName): self
+    public static function routeConfigMissingParameterKeyForPrimaryKey(string $entityName): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
-            self::ROUTE_CONFIG_MISSING_PRIMARY_KEY,
+            self::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY,
             'Missing key for primary key.',
             ['entityName' => $entityName]
         );

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
@@ -17,7 +17,7 @@ class SeoUrlRouteConfigException extends SeoException
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY,
-            'Missing key for primary key.',
+            'Missing parameter key for primary key of entity "{{ entityName }}".',
             ['entityName' => $entityName]
         );
     }
@@ -27,7 +27,7 @@ class SeoUrlRouteConfigException extends SeoException
         return new self(
             Response::HTTP_BAD_REQUEST,
             self::ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME,
-            'No route config found for given entity name.',
+            'No route config found for given entity name "{{ entityName }}".',
             ['entityName' => $entityName]
         );
     }

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteConfigException.php
@@ -9,20 +9,16 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('discovery')]
 class SeoUrlRouteConfigException extends SeoException
 {
-    public const ROUTE_PARAMETERS_MISMATCHING = 'FRAMEWORK__ROUTE_PARAMETERS_MISMATCHING';
+    public const ROUTE_CONFIG_MISSING_PRIMARY_KEY = 'FRAMEWORK__ROUTE_PARAMETERS_MISMATCHING';
     public const ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME = 'FRAMEWORK__ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME';
 
-    /**
-     * @param list<string> $required
-     * @param list<string> $given
-     */
-    public static function routeParametersMismatching(array $required, array $given): self
+    public static function routeConfigMissingPrimaryKey(string $entityName): self
     {
         return new self(
             Response::HTTP_BAD_REQUEST,
-            self::ROUTE_PARAMETERS_MISMATCHING,
-            'Mismatch between required route parameters and given values.',
-            ['required' => $required, 'given' => $given]
+            self::ROUTE_CONFIG_MISSING_PRIMARY_KEY,
+            'Missing key for primary key.',
+            ['entityName' => $entityName]
         );
     }
 

--- a/src/Core/Content/Seo/HreflangLoader.php
+++ b/src/Core/Content/Seo/HreflangLoader.php
@@ -32,8 +32,7 @@ class HreflangLoader implements HreflangLoaderInterface
 
         $domains = $this->fetchSalesChannelDomains($salesChannelContext->getSalesChannelId());
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        if ($parameter->getRoute() === 'frontend.home.page') {
+        if ($parameter->isHomepage()) {
             return $this->getHreflangForHomepage($domains, $salesChannelContext->getSalesChannel()->getHreflangDefaultDomainId());
         }
 

--- a/src/Core/Content/Seo/HreflangLoaderParameter.php
+++ b/src/Core/Content/Seo/HreflangLoaderParameter.php
@@ -15,6 +15,7 @@ class HreflangLoaderParameter
         protected string $route,
         protected array $routeParameters,
         protected SalesChannelContext $salesChannelContext,
+        private readonly bool $homepage = false,
     ) {
     }
 
@@ -34,5 +35,10 @@ class HreflangLoaderParameter
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->salesChannelContext;
+    }
+
+    public function isHomepage(): bool
+    {
+        return $this->homepage;
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRoute.php
@@ -24,7 +24,7 @@ class CategoryStoreApiUrlRoute implements EntitySeoUrlRouteInterface
             self::ROUTE_NAME,
             '',
             true,
-            ['navigationId']
+            'navigationId'
         );
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRoute.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\SeoUrlRoute;
+
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+class CategoryStoreApiUrlRoute implements EntitySeoUrlRouteInterface
+{
+    final public const ROUTE_NAME = 'store-api.category.detail';
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly CategoryDefinition $categoryDefinition)
+    {
+    }
+
+    public function getConfig(): SeoUrlRouteConfig
+    {
+        return new SeoUrlRouteConfig(
+            $this->categoryDefinition,
+            self::ROUTE_NAME,
+            '',
+            true,
+            ['navigationId']
+        );
+    }
+}

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -2,9 +2,9 @@
 
 namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
+use Shopware\Core\Content\Seo\SeoException;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Symfony\Component\Routing\RouterInterface;
 
 #[Package('inventory')]
@@ -12,47 +12,66 @@ class EntityRouteResolver
 {
     /**
      * @internal
+     *
+     * @param iterable<EntitySeoUrlRouteInterface> $storeApiSeoUrlRoutes
      */
     public function __construct(
         private readonly SeoUrlRouteRegistry $registry,
         private readonly SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
         private readonly RouterInterface $router,
+        private readonly iterable $storeApiSeoUrlRoutes = [],
     ) {
     }
 
     public function getRouteNameForEntityName(string $entityName): string
     {
-        $routes = $this->registry->findByDefinition($entityName);
-        $key = array_key_first($routes);
-        $route = $key !== null ? $routes[$key] : null;
-        $config = $route?->getConfig();
-
-        if ($config) {
-            return $config->getRouteName();
-        }
-
-        return \sprintf('store-api.%s.detail', str_replace('_', '-', $entityName));
+        return $this->getRouteConfig($entityName)->getRouteName();
     }
 
     /**
      * Generates a SEO URL placeholder for the given entity.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
+     *
+     * @param list<string> $values
      */
-    public function generateSeoUrlPlaceholder(string $entityName, ArrayStruct $parameters = new ArrayStruct()): string
+    public function generateSeoUrlPlaceholder(string $entityName, array $values = []): string
     {
-        $routeName = $this->getRouteNameForEntityName($entityName);
+        $config = $this->getRouteConfig($entityName);
 
-        return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters->getVars());
+        return $this->seoUrlPlaceholderHandler->generate($config->getRouteName(), $config->getParameterKeyValuePairs($values));
     }
 
     /**
      * Generates a concrete URL for the given entity via the Symfony router.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
+     *
+     * @param list<string> $values
      */
-    public function generateUrl(string $entityName, ArrayStruct $parameters = new ArrayStruct()): string
+    public function generateUrl(string $entityName, array $values = []): string
     {
-        $routeName = $this->getRouteNameForEntityName($entityName);
+        $config = $this->getRouteConfig($entityName);
 
-        return $this->router->generate($routeName, $parameters->getVars());
+        return $this->router->generate($config->getRouteName(), $config->getParameterKeyValuePairs($values));
+    }
+
+    private function getRouteConfig(string $entityName): SeoUrlRouteConfig
+    {
+        $routes = $this->registry->findByDefinition($entityName);
+        $key = array_key_first($routes);
+        $route = $key !== null ? $routes[$key] : null;
+
+        if ($route) {
+            return $route->getConfig();
+        }
+
+        foreach ($this->storeApiSeoUrlRoutes as $storeApiSeoUrlRoute) {
+            $config = $storeApiSeoUrlRoute->getConfig();
+
+            if ($config->getDefinition()->getEntityName() === $entityName) {
+                return $config;
+            }
+        }
+
+        throw SeoException::seoUrlRouteNotFound($entityName);
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
 #[Package('inventory')]
@@ -19,18 +20,25 @@ class EntityRouteResolver
     ) {
     }
 
-    public function getRouteNameForEntityName(string $entityName): string
-    {
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function getRouteNameForEntityName(
+        string $entityName,
+        array $parameters = [],
+        ?SalesChannelEntity $salesChannel = null
+    ): string {
         $routes = $this->registry->findByDefinition($entityName);
-        $route = \array_key_exists(0, $routes) ? $routes[0]->getConfig()->getRouteName() : null;
+        $route = $routes[0] ?? null;
+        $config = $route?->getConfig();
 
-        if ($route) {
-            return $route;
+        if ($config) {
+            return $salesChannel
+                ? $config->getRouteBySalesChannel($salesChannel, $parameters)
+                : $config->getRouteName();
         }
 
-        $fallback = \sprintf('store-api.%s.detail', str_replace('_', '-', $entityName));
-
-        return $this->router->getRouteCollection()->get($fallback) !== null ? $fallback : $entityName;
+        return \sprintf('store-api.%s.detail', str_replace('_', '-', $entityName));
     }
 
     /**
@@ -39,9 +47,12 @@ class EntityRouteResolver
      *
      * @param array<string, mixed> $parameters
      */
-    public function generateSeoUrlPlaceholder(string $entityName, array $parameters = []): string
-    {
-        $routeName = $this->getRouteNameForEntityName($entityName);
+    public function generateSeoUrlPlaceholder(
+        string $entityName,
+        array $parameters = [],
+        ?SalesChannelEntity $salesChannel = null,
+    ): string {
+        $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
 
         return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters);
     }
@@ -52,9 +63,12 @@ class EntityRouteResolver
      *
      * @param array<string, mixed> $parameters
      */
-    public function generateUrl(string $entityName, array $parameters = []): string
-    {
-        $routeName = $this->getRouteNameForEntityName($entityName);
+    public function generateUrl(
+        string $entityName,
+        array $parameters = [],
+        ?SalesChannelEntity $salesChannel = null,
+    ): string {
+        $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
 
         return $this->router->generate($routeName, $parameters);
     }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
-use Shopware\Core\Content\Seo\SeoException;
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Routing\RouterInterface;
@@ -72,6 +72,6 @@ class EntityRouteResolver
             }
         }
 
-        throw SeoException::seoUrlRouteNotFound($entityName);
+        throw SeoUrlRouteConfigException::routeConfigNotFoundForEntityName($entityName);
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -31,27 +31,23 @@ class EntityRouteResolver
     /**
      * Generates a SEO URL placeholder for the given entity.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
-     *
-     * @param list<string> $values
      */
-    public function generateSeoUrlPlaceholder(string $entityName, array $values = []): string
+    public function generateSeoUrlPlaceholder(string $entityName, string $primaryKey): string
     {
         $config = $this->getRouteConfig($entityName);
 
-        return $this->seoUrlPlaceholderHandler->generate($config->getRouteName(), $config->getParameterKeyValuePairs($values));
+        return $this->seoUrlPlaceholderHandler->generate($config->getRouteName(), $config->getPrimaryKeyParameter($primaryKey));
     }
 
     /**
      * Generates a concrete URL for the given entity via the Symfony router.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
-     *
-     * @param list<string> $values
      */
-    public function generateUrl(string $entityName, array $values = []): string
+    public function generateUrl(string $entityName, string $primaryKey): string
     {
         $config = $this->getRouteConfig($entityName);
 
-        return $this->router->generate($config->getRouteName(), $config->getParameterKeyValuePairs($values));
+        return $this->router->generate($config->getRouteName(), $config->getPrimaryKeyParameter($primaryKey));
     }
 
     private function getRouteConfig(string $entityName): SeoUrlRouteConfig

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -20,16 +21,14 @@ class EntityRouteResolver
     ) {
     }
 
-    /**
-     * @param array<string, mixed> $parameters
-     */
     public function getRouteNameForEntityName(
         string $entityName,
-        array $parameters = [],
+        ArrayStruct $parameters = new ArrayStruct(),
         ?SalesChannelEntity $salesChannel = null
     ): string {
         $routes = $this->registry->findByDefinition($entityName);
-        $route = $routes[0] ?? null;
+        $key = array_key_first($routes);
+        $route = $key !== null ? $routes[$key] : null;
         $config = $route?->getConfig();
 
         if ($config) {
@@ -44,32 +43,28 @@ class EntityRouteResolver
     /**
      * Generates a SEO URL placeholder for the given entity.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
-     *
-     * @param array<string, mixed> $parameters
      */
     public function generateSeoUrlPlaceholder(
         string $entityName,
-        array $parameters = [],
+        ArrayStruct $parameters = new ArrayStruct(),
         ?SalesChannelEntity $salesChannel = null,
     ): string {
         $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
 
-        return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters);
+        return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters->getVars());
     }
 
     /**
      * Generates a concrete URL for the given entity via the Symfony router.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
-     *
-     * @param array<string, mixed> $parameters
      */
     public function generateUrl(
         string $entityName,
-        array $parameters = [],
+        ArrayStruct $parameters = new ArrayStruct(),
         ?SalesChannelEntity $salesChannel = null,
     ): string {
         $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
 
-        return $this->router->generate($routeName, $parameters);
+        return $this->router->generate($routeName, $parameters->getVars());
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -52,11 +52,9 @@ class EntityRouteResolver
 
     private function getRouteConfig(string $entityName): SeoUrlRouteConfig
     {
-        $routes = $this->registry->findByDefinition($entityName);
-        $key = array_key_first($routes);
-        $route = $key !== null ? $routes[$key] : null;
+        $route = array_first($this->registry->findByDefinition($entityName));
 
-        if ($route) {
+        if ($route instanceof EntitySeoUrlRouteInterface) {
             return $route->getConfig();
         }
 

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
 #[Package('inventory')]
@@ -21,20 +20,15 @@ class EntityRouteResolver
     ) {
     }
 
-    public function getRouteNameForEntityName(
-        string $entityName,
-        ArrayStruct $parameters = new ArrayStruct(),
-        ?SalesChannelEntity $salesChannel = null
-    ): string {
+    public function getRouteNameForEntityName(string $entityName): string
+    {
         $routes = $this->registry->findByDefinition($entityName);
         $key = array_key_first($routes);
         $route = $key !== null ? $routes[$key] : null;
         $config = $route?->getConfig();
 
         if ($config) {
-            return $salesChannel
-                ? $config->getRouteBySalesChannel($salesChannel, $parameters)
-                : $config->getRouteName();
+            return $config->getRouteName();
         }
 
         return \sprintf('store-api.%s.detail', str_replace('_', '-', $entityName));
@@ -44,12 +38,9 @@ class EntityRouteResolver
      * Generates a SEO URL placeholder for the given entity.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
      */
-    public function generateSeoUrlPlaceholder(
-        string $entityName,
-        ArrayStruct $parameters = new ArrayStruct(),
-        ?SalesChannelEntity $salesChannel = null,
-    ): string {
-        $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
+    public function generateSeoUrlPlaceholder(string $entityName, ArrayStruct $parameters = new ArrayStruct()): string
+    {
+        $routeName = $this->getRouteNameForEntityName($entityName);
 
         return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters->getVars());
     }
@@ -58,12 +49,9 @@ class EntityRouteResolver
      * Generates a concrete URL for the given entity via the Symfony router.
      * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
      */
-    public function generateUrl(
-        string $entityName,
-        ArrayStruct $parameters = new ArrayStruct(),
-        ?SalesChannelEntity $salesChannel = null,
-    ): string {
-        $routeName = $this->getRouteNameForEntityName($entityName, $parameters, $salesChannel);
+    public function generateUrl(string $entityName, ArrayStruct $parameters = new ArrayStruct()): string
+    {
+        $routeName = $this->getRouteNameForEntityName($entityName);
 
         return $this->router->generate($routeName, $parameters->getVars());
     }

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\SeoUrlRoute;
+
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Routing\RouterInterface;
+
+#[Package('inventory')]
+class EntityRouteResolver
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly SeoUrlRouteRegistry $registry,
+        private readonly SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    public function getRouteNameForEntityName(string $entityName): string
+    {
+        $routes = $this->registry->findByDefinition($entityName);
+        $route = \array_key_exists(0, $routes) ? $routes[0]->getConfig()->getRouteName() : null;
+
+        if ($route) {
+            return $route;
+        }
+
+        $fallback = \sprintf('store-api.%s.detail', str_replace('_', '-', $entityName));
+
+        return $this->router->getRouteCollection()->get($fallback) !== null ? $fallback : $entityName;
+    }
+
+    /**
+     * Generates a SEO URL placeholder for the given entity.
+     * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
+     *
+     * @param array<string, mixed> $parameters
+     */
+    public function generateSeoUrlPlaceholder(string $entityName, array $parameters = []): string
+    {
+        $routeName = $this->getRouteNameForEntityName($entityName);
+
+        return $this->seoUrlPlaceholderHandler->generate($routeName, $parameters);
+    }
+
+    /**
+     * Generates a concrete URL for the given entity via the Symfony router.
+     * Returns store-api route when no route is registered for the entity type (e.g. headless setups).
+     *
+     * @param array<string, mixed> $parameters
+     */
+    public function generateUrl(string $entityName, array $parameters = []): string
+    {
+        $routeName = $this->getRouteNameForEntityName($entityName);
+
+        return $this->router->generate($routeName, $parameters);
+    }
+}

--- a/src/Core/Content/Seo/SeoUrlRoute/EntitySeoUrlRouteInterface.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntitySeoUrlRouteInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\SeoUrlRoute;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+interface EntitySeoUrlRouteInterface
+{
+    public function getConfig(): SeoUrlRouteConfig;
+}

--- a/src/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRoute.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\SeoUrlRoute;
+
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+class LandingPageStoreApiUrlRoute implements EntitySeoUrlRouteInterface
+{
+    final public const ROUTE_NAME = 'store-api.landing-page.detail';
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly LandingPageDefinition $landingPageDefinition)
+    {
+    }
+
+    public function getConfig(): SeoUrlRouteConfig
+    {
+        return new SeoUrlRouteConfig(
+            $this->landingPageDefinition,
+            self::ROUTE_NAME,
+            '',
+            true,
+            ['landingPageId']
+        );
+    }
+}

--- a/src/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRoute.php
@@ -24,7 +24,7 @@ class LandingPageStoreApiUrlRoute implements EntitySeoUrlRouteInterface
             self::ROUTE_NAME,
             '',
             true,
-            ['landingPageId']
+            'landingPageId'
         );
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRoute.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo\SeoUrlRoute;
+
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+class ProductStoreApiUrlRoute implements EntitySeoUrlRouteInterface
+{
+    final public const ROUTE_NAME = 'store-api.product.detail';
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly ProductDefinition $productDefinition)
+    {
+    }
+
+    public function getConfig(): SeoUrlRouteConfig
+    {
+        return new SeoUrlRouteConfig(
+            $this->productDefinition,
+            self::ROUTE_NAME,
+            '',
+            true,
+            ['productId']
+        );
+    }
+}

--- a/src/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRoute.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRoute.php
@@ -24,7 +24,7 @@ class ProductStoreApiUrlRoute implements EntitySeoUrlRouteInterface
             self::ROUTE_NAME,
             '',
             true,
-            ['productId']
+            'productId'
         );
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -4,13 +4,14 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
 class SeoUrlRouteConfig
 {
     /**
-     * @param \Closure(SalesChannelEntity, array<string, mixed>): string|null $routeBySalesChannelGetter
+     * @param \Closure(SalesChannelEntity, ArrayStruct): string|null $routeBySalesChannelGetter
      */
     public function __construct(
         private readonly EntityDefinition $definition,
@@ -51,11 +52,10 @@ class SeoUrlRouteConfig
         $this->skipInvalid = $skipInvalid;
     }
 
-    /**
-     * @param array<string, mixed> $parameters
-     */
-    public function getRouteBySalesChannel(SalesChannelEntity $salesChannelEntity, array $parameters = []): string
-    {
+    public function getRouteBySalesChannel(
+        SalesChannelEntity $salesChannelEntity,
+        ArrayStruct $parameters = new ArrayStruct()
+    ): string {
         if ($this->routeBySalesChannelGetter) {
             return ($this->routeBySalesChannelGetter)($salesChannelEntity, $parameters);
         }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -8,11 +8,15 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 class SeoUrlRouteConfig
 {
+    /**
+     * @param list<string> $parameterKeys
+     */
     public function __construct(
         private readonly EntityDefinition $definition,
         private readonly string $routeName,
         private string $template,
         private bool $skipInvalid = true,
+        private array $parameterKeys = [],
     ) {
     }
 
@@ -44,5 +48,15 @@ class SeoUrlRouteConfig
     public function setSkipInvalid(bool $skipInvalid): void
     {
         $this->skipInvalid = $skipInvalid;
+    }
+
+    /**
+     * @param list<string> $values
+     *
+     * @return array<string, string>
+     */
+    public function getParameterKeyValuePairs(array $values): array
+    {
+        return array_combine($this->parameterKeys, $values);
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -4,21 +4,15 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\ArrayStruct;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
 class SeoUrlRouteConfig
 {
-    /**
-     * @param \Closure(SalesChannelEntity, ArrayStruct): string|null $routeBySalesChannelGetter
-     */
     public function __construct(
         private readonly EntityDefinition $definition,
         private readonly string $routeName,
         private string $template,
         private bool $skipInvalid = true,
-        private readonly ?\Closure $routeBySalesChannelGetter = null,
     ) {
     }
 
@@ -50,16 +44,5 @@ class SeoUrlRouteConfig
     public function setSkipInvalid(bool $skipInvalid): void
     {
         $this->skipInvalid = $skipInvalid;
-    }
-
-    public function getRouteBySalesChannel(
-        SalesChannelEntity $salesChannelEntity,
-        ArrayStruct $parameters = new ArrayStruct()
-    ): string {
-        if ($this->routeBySalesChannelGetter) {
-            return ($this->routeBySalesChannelGetter)($salesChannelEntity, $parameters);
-        }
-
-        return $this->getRouteName();
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -4,15 +4,20 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
 class SeoUrlRouteConfig
 {
+    /**
+     * @param \Closure(SalesChannelEntity, array<string, mixed>): string|null $routeBySalesChannelGetter
+     */
     public function __construct(
         private readonly EntityDefinition $definition,
         private readonly string $routeName,
         private string $template,
-        private bool $skipInvalid = true
+        private bool $skipInvalid = true,
+        private readonly ?\Closure $routeBySalesChannelGetter = null,
     ) {
     }
 
@@ -44,5 +49,17 @@ class SeoUrlRouteConfig
     public function setSkipInvalid(bool $skipInvalid): void
     {
         $this->skipInvalid = $skipInvalid;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function getRouteBySalesChannel(SalesChannelEntity $salesChannelEntity, array $parameters = []): string
+    {
+        if ($this->routeBySalesChannelGetter) {
+            return ($this->routeBySalesChannelGetter)($salesChannelEntity, $parameters);
+        }
+
+        return $this->getRouteName();
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
 
@@ -57,6 +58,10 @@ class SeoUrlRouteConfig
      */
     public function getParameterKeyValuePairs(array $values): array
     {
-        return array_combine($this->parameterKeys, $values);
+        try {
+            return array_combine($this->parameterKeys, $values);
+        } catch (\ValueError) {
+            throw SeoUrlRouteConfigException::routeParametersMismatching($this->parameterKeys, $values);
+        }
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -54,7 +54,7 @@ class SeoUrlRouteConfig
     public function getPrimaryKeyParameter(string $primaryKey): array
     {
         if ($this->primaryKeyParameterKey === null) {
-            throw SeoUrlRouteConfigException::routeConfigMissingPrimaryKey($this->definition->getEntityName());
+            throw SeoUrlRouteConfigException::routeConfigMissingParameterKeyForPrimaryKey($this->definition->getEntityName());
         }
 
         return [$this->primaryKeyParameterKey => $primaryKey];

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfig.php
@@ -9,15 +9,12 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('inventory')]
 class SeoUrlRouteConfig
 {
-    /**
-     * @param list<string> $parameterKeys
-     */
     public function __construct(
         private readonly EntityDefinition $definition,
         private readonly string $routeName,
         private string $template,
         private bool $skipInvalid = true,
-        private array $parameterKeys = [],
+        private readonly ?string $primaryKeyParameterKey = null,
     ) {
     }
 
@@ -52,16 +49,14 @@ class SeoUrlRouteConfig
     }
 
     /**
-     * @param list<string> $values
-     *
      * @return array<string, string>
      */
-    public function getParameterKeyValuePairs(array $values): array
+    public function getPrimaryKeyParameter(string $primaryKey): array
     {
-        try {
-            return array_combine($this->parameterKeys, $values);
-        } catch (\ValueError) {
-            throw SeoUrlRouteConfigException::routeParametersMismatching($this->parameterKeys, $values);
+        if ($this->primaryKeyParameterKey === null) {
+            throw SeoUrlRouteConfigException::routeConfigMissingPrimaryKey($this->definition->getEntityName());
         }
+
+        return [$this->primaryKeyParameterKey => $primaryKey];
     }
 }

--- a/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteInterface.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteInterface.php
@@ -8,10 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
-interface SeoUrlRouteInterface
+interface SeoUrlRouteInterface extends EntitySeoUrlRouteInterface
 {
-    public function getConfig(): SeoUrlRouteConfig;
-
     public function prepareCriteria(Criteria $criteria, SalesChannelEntity $salesChannel): void;
 
     public function getMapping(Entity $entity, ?SalesChannelEntity $salesChannel): SeoUrlMapping;

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -100,10 +99,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$category['id']])) {
                 $newUrl->setLoc($seoUrls[$category['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(
-                    CategoryDefinition::ENTITY_NAME,
-                    new ArrayStruct(['navigationId' => $category['id']])
-                ));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(CategoryDefinition::ENTITY_NAME, [$category['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -99,7 +99,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$category['id']])) {
                 $newUrl->setLoc($seoUrls[$category['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(CategoryDefinition::ENTITY_NAME, [$category['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(CategoryDefinition::ENTITY_NAME, $category['id']));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -99,7 +100,10 @@ class CategoryUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$category['id']])) {
                 $newUrl->setLoc($seoUrls[$category['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(CategoryDefinition::ENTITY_NAME, ['navigationId' => $category['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(
+                    CategoryDefinition::ENTITY_NAME,
+                    new ArrayStruct(['navigationId' => $category['id']])
+                ));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -19,7 +20,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class CategoryUrlProvider extends AbstractUrlProvider
@@ -36,7 +36,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         private readonly Connection $connection,
         private readonly CategoryDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router,
+        private readonly EntityRouteResolver $entityRouteResolver,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -80,8 +80,8 @@ class CategoryUrlProvider extends AbstractUrlProvider
             static fn (array $category) => $categoryIdsFetchedEvent->hasId($category['id'])
         );
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls($categoryIdsFetchedEvent->getIds(), 'frontend.navigation.page', $context, $this->connection);
+        $routeName = $this->entityRouteResolver->getRouteNameForEntityName(CategoryDefinition::ENTITY_NAME);
+        $seoUrls = $this->getSeoUrls($categoryIdsFetchedEvent->getIds(), $routeName, $context, $this->connection);
 
         /** @var array<string, array{seo_path_info: string}> $seoUrls */
         $seoUrls = FetchModeHelper::groupUnique($seoUrls);
@@ -99,8 +99,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$category['id']])) {
                 $newUrl->setLoc($seoUrls[$category['id']]['seo_path_info']);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $newUrl->setLoc($this->router->generate('frontend.navigation.page', ['navigationId' => $category['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(CategoryDefinition::ENTITY_NAME, ['navigationId' => $category['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -15,6 +15,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -75,7 +76,10 @@ class LandingPageUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$landingPage['id']])) {
                 $url->setLoc($seoUrls[$landingPage['id']]['seo_path_info']);
             } else {
-                $url->setLoc($this->entityRouteResolver->generateUrl(LandingPageDefinition::ENTITY_NAME, ['landingPageId' => $landingPage['id']]));
+                $url->setLoc($this->entityRouteResolver->generateUrl(
+                    LandingPageDefinition::ENTITY_NAME,
+                    new ArrayStruct(['landingPageId' => $landingPage['id']])
+                ));
             }
 
             $lastMod = $landingPage['updated_at'] ?: $landingPage['created_at'];

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -75,7 +75,7 @@ class LandingPageUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$landingPage['id']])) {
                 $url->setLoc($seoUrls[$landingPage['id']]['seo_path_info']);
             } else {
-                $url->setLoc($this->entityRouteResolver->generateUrl(LandingPageDefinition::ENTITY_NAME, [$landingPage['id']]));
+                $url->setLoc($this->entityRouteResolver->generateUrl(LandingPageDefinition::ENTITY_NAME, $landingPage['id']));
             }
 
             $lastMod = $landingPage['updated_at'] ?: $landingPage['created_at'];

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -4,7 +4,9 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -16,7 +18,6 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class LandingPageUrlProvider extends AbstractUrlProvider
@@ -31,7 +32,7 @@ class LandingPageUrlProvider extends AbstractUrlProvider
     public function __construct(
         private readonly ConfigHandler $configHandler,
         private readonly Connection $connection,
-        private readonly RouterInterface $router,
+        private readonly EntityRouteResolver $entityRouteResolver,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -61,8 +62,8 @@ class LandingPageUrlProvider extends AbstractUrlProvider
 
         $ids = array_column($landingPages, 'id');
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls($ids, 'frontend.landing.page', $context, $this->connection);
+        $routeName = $this->entityRouteResolver->getRouteNameForEntityName(LandingPageDefinition::ENTITY_NAME);
+        $seoUrls = $this->getSeoUrls($ids, $routeName, $context, $this->connection);
 
         /** @var array<string, array{seo_path_info: string}> $seoUrls */
         $seoUrls = FetchModeHelper::groupUnique($seoUrls);
@@ -74,8 +75,7 @@ class LandingPageUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$landingPage['id']])) {
                 $url->setLoc($seoUrls[$landingPage['id']]['seo_path_info']);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $url->setLoc($this->router->generate('frontend.landing.page', ['landingPageId' => $landingPage['id']]));
+                $url->setLoc($this->entityRouteResolver->generateUrl(LandingPageDefinition::ENTITY_NAME, ['landingPageId' => $landingPage['id']]));
             }
 
             $lastMod = $landingPage['updated_at'] ?: $landingPage['created_at'];

--- a/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/LandingPageUrlProvider.php
@@ -15,7 +15,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -76,10 +75,7 @@ class LandingPageUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$landingPage['id']])) {
                 $url->setLoc($seoUrls[$landingPage['id']]['seo_path_info']);
             } else {
-                $url->setLoc($this->entityRouteResolver->generateUrl(
-                    LandingPageDefinition::ENTITY_NAME,
-                    new ArrayStruct(['landingPageId' => $landingPage['id']])
-                ));
+                $url->setLoc($this->entityRouteResolver->generateUrl(LandingPageDefinition::ENTITY_NAME, [$landingPage['id']]));
             }
 
             $lastMod = $landingPage['updated_at'] ?: $landingPage['created_at'];

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -92,10 +91,7 @@ class ProductUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$product['id']])) {
                 $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(
-                    ProductDefinition::ENTITY_NAME,
-                    new ArrayStruct(['productId' => $product['id']])
-                ));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(ProductDefinition::ENTITY_NAME, [$product['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -91,7 +92,10 @@ class ProductUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$product['id']])) {
                 $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(ProductDefinition::ENTITY_NAME, ['productId' => $product['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(
+                    ProductDefinition::ENTITY_NAME,
+                    new ArrayStruct(['productId' => $product['id']])
+                ));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Sitemap\Event\SitemapQueryEvent;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -20,7 +21,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 #[Package('discovery')]
 class ProductUrlProvider extends AbstractUrlProvider
@@ -41,7 +41,7 @@ class ProductUrlProvider extends AbstractUrlProvider
         private readonly Connection $connection,
         private readonly ProductDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router,
+        private readonly EntityRouteResolver $entityRouteResolver,
         private readonly SystemConfigService $systemConfigService,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
@@ -72,8 +72,8 @@ class ProductUrlProvider extends AbstractUrlProvider
 
         $keys = FetchModeHelper::keyPair($products);
 
-        /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-        $seoUrls = $this->getSeoUrls(array_values($keys), 'frontend.detail.page', $context, $this->connection);
+        $routeName = $this->entityRouteResolver->getRouteNameForEntityName(ProductDefinition::ENTITY_NAME);
+        $seoUrls = $this->getSeoUrls(array_values($keys), $routeName, $context, $this->connection);
 
         /** @var array<string, array{seo_path_info: string}> $seoUrls */
         $seoUrls = FetchModeHelper::groupUnique($seoUrls);
@@ -91,8 +91,7 @@ class ProductUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$product['id']])) {
                 $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
             } else {
-                /** @phpstan-ignore shopware.storefrontRouteUsage (Do not use Storefront routes in the core. Will be fixed with https://github.com/shopware/shopware/issues/12970) */
-                $newUrl->setLoc($this->router->generate('frontend.detail.page', ['productId' => $product['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(ProductDefinition::ENTITY_NAME, ['productId' => $product['id']]));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -91,7 +91,7 @@ class ProductUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$product['id']])) {
                 $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->entityRouteResolver->generateUrl(ProductDefinition::ENTITY_NAME, [$product['id']]));
+                $newUrl->setLoc($this->entityRouteResolver->generateUrl(ProductDefinition::ENTITY_NAME, $product['id']));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -45,6 +45,12 @@
             <argument type="tagged_iterator" tag="shopware.seo_url.route"/>
         </service>
 
+        <service id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver">
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry"/>
+            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
+            <argument type="service" id="router"/>
+        </service>
+
         <service id="Shopware\Core\Content\Seo\EmptyPathInfoResolver" public="true" decorates="Shopware\Core\Content\Seo\SeoResolver" decoration-priority="-2000">
             <argument type="service" id="Shopware\Core\Content\Seo\EmptyPathInfoResolver.inner"/>
         </service>

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -45,10 +45,26 @@
             <argument type="tagged_iterator" tag="shopware.seo_url.route"/>
         </service>
 
+        <service id="Shopware\Core\Content\Seo\SeoUrlRoute\ProductStoreApiUrlRoute">
+            <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
+            <tag name="shopware.entity.seo_url.route"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Seo\SeoUrlRoute\CategoryStoreApiUrlRoute">
+            <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
+            <tag name="shopware.entity.seo_url.route"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Seo\SeoUrlRoute\LandingPageStoreApiUrlRoute">
+            <argument type="service" id="Shopware\Core\Content\LandingPage\LandingPageDefinition"/>
+            <tag name="shopware.entity.seo_url.route"/>
+        </service>
+
         <service id="Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver">
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
             <argument type="service" id="router"/>
+            <argument type="tagged_iterator" tag="shopware.entity.seo_url.route"/>
         </service>
 
         <service id="Shopware\Core\Content\Seo\EmptyPathInfoResolver" public="true" decorates="Shopware\Core\Content\Seo\SeoResolver" decoration-priority="-2000">

--- a/src/Storefront/DependencyInjection/seo.xml
+++ b/src/Storefront/DependencyInjection/seo.xml
@@ -33,5 +33,11 @@
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry"/>
             <tag name="shopware.api.enum_provider" />
         </service>
+
+        <service id="Shopware\Storefront\Framework\Seo\StorefrontCategoryUrlGenerator"
+                 decorates="Shopware\Core\Content\Category\Service\CategoryUrlGenerator">
+            <argument type="service" id="Shopware\Storefront\Framework\Seo\StorefrontCategoryUrlGenerator.inner"/>
+            <argument type="service" id="router"/>
+        </service>
     </services>
 </container>

--- a/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
+++ b/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
@@ -50,7 +50,7 @@ class TemplateDataSubscriber implements EventSubscriberInterface
 
         $routeParams = $request->attributes->get('_route_params', []);
         $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
-        $parameter = new HreflangLoaderParameter($route, $routeParams, $salesChannelContext);
+        $parameter = new HreflangLoaderParameter($route, $routeParams, $salesChannelContext, $route === 'frontend.home.page');
         $event->setParameter('hrefLang', $this->hreflangLoader->load($parameter));
     }
 

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
@@ -32,7 +32,8 @@ class LandingPageSeoUrlRoute implements SeoUrlRouteInterface
             $this->landingPageDefinition,
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
-            true
+            true,
+            ['landingPageId']
         );
     }
 
@@ -52,7 +53,7 @@ class LandingPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $landingPage,
-            ['landingPageId' => $landingPage->getId()],
+            $this->getConfig()->getParameterKeyValuePairs([$landingPage->getId()]),
             [
                 'landingPage' => $landingPageJson,
             ]

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
@@ -33,7 +33,7 @@ class LandingPageSeoUrlRoute implements SeoUrlRouteInterface
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
             true,
-            ['landingPageId']
+            'landingPageId'
         );
     }
 
@@ -53,7 +53,7 @@ class LandingPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $landingPage,
-            $this->getConfig()->getParameterKeyValuePairs([$landingPage->getId()]),
+            $this->getConfig()->getPrimaryKeyParameter($landingPage->getId()),
             [
                 'landingPage' => $landingPageJson,
             ]

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -37,7 +37,8 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
             $this->categoryDefinition,
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
-            true
+            true,
+            ['navigationId']
         );
     }
 
@@ -71,7 +72,7 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $category,
-            ['navigationId' => $category->getId()],
+            $this->getConfig()->getParameterKeyValuePairs([$category->getId()]),
             [
                 'category' => $categoryJson,
             ],

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -38,7 +38,7 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
             true,
-            ['navigationId']
+            'navigationId'
         );
     }
 
@@ -72,7 +72,7 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $category,
-            $this->getConfig()->getParameterKeyValuePairs([$category->getId()]),
+            $this->getConfig()->getPrimaryKeyParameter($category->getId()),
             [
                 'category' => $categoryJson,
             ],

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -21,6 +21,7 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
 {
     final public const ROUTE_NAME = 'frontend.navigation.page';
     final public const DEFAULT_TEMPLATE = '{% for part in category.seoBreadcrumb %}{{ part }}/{% endfor %}';
+    final public const HOME_PAGE_ROUTE_NAME = 'frontend.home.page';
 
     /**
      * @internal
@@ -37,7 +38,16 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
             $this->categoryDefinition,
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
-            true
+            true,
+            static function (SalesChannelEntity $salesChannel, array $parameters): string {
+                $navigationId = $parameters['navigationId'] ?? null;
+
+                if ($salesChannel->getNavigationCategoryId() === $navigationId) {
+                    return self::HOME_PAGE_ROUTE_NAME;
+                }
+
+                return self::ROUTE_NAME;
+            },
         );
     }
 

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -14,7 +14,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
@@ -22,7 +21,6 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
 {
     final public const ROUTE_NAME = 'frontend.navigation.page';
     final public const DEFAULT_TEMPLATE = '{% for part in category.seoBreadcrumb %}{{ part }}/{% endfor %}';
-    final public const HOME_PAGE_ROUTE_NAME = 'frontend.home.page';
 
     /**
      * @internal
@@ -39,18 +37,7 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
             $this->categoryDefinition,
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
-            true,
-            static function (SalesChannelEntity $salesChannel, ArrayStruct $parameters): string {
-                $navigationId = $parameters->get('navigationId');
-
-                if ($salesChannel->getNavigationCategoryId() === $navigationId) {
-                    $parameters->offsetUnset('navigationId');
-
-                    return self::HOME_PAGE_ROUTE_NAME;
-                }
-
-                return self::ROUTE_NAME;
-            },
+            true
         );
     }
 

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 #[Package('inventory')]
@@ -39,10 +40,12 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
             true,
-            static function (SalesChannelEntity $salesChannel, array $parameters): string {
-                $navigationId = $parameters['navigationId'] ?? null;
+            static function (SalesChannelEntity $salesChannel, ArrayStruct $parameters): string {
+                $navigationId = $parameters->get('navigationId');
 
                 if ($salesChannel->getNavigationCategoryId() === $navigationId) {
+                    $parameters->offsetUnset('navigationId');
+
                     return self::HOME_PAGE_ROUTE_NAME;
                 }
 

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
@@ -36,7 +36,7 @@ class ProductPageSeoUrlRoute implements SeoUrlRouteInterface
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
             true,
-            ['productId']
+            'productId'
         );
     }
 
@@ -66,7 +66,7 @@ class ProductPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $product,
-            $this->getConfig()->getParameterKeyValuePairs([$product->getId()]),
+            $this->getConfig()->getPrimaryKeyParameter($product->getId()),
             [
                 'product' => $productJson,
             ]

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
@@ -35,7 +35,8 @@ class ProductPageSeoUrlRoute implements SeoUrlRouteInterface
             $this->productDefinition,
             self::ROUTE_NAME,
             self::DEFAULT_TEMPLATE,
-            true
+            true,
+            ['productId']
         );
     }
 
@@ -65,7 +66,7 @@ class ProductPageSeoUrlRoute implements SeoUrlRouteInterface
 
         return new SeoUrlMapping(
             $product,
-            ['productId' => $product->getId()],
+            $this->getConfig()->getParameterKeyValuePairs([$product->getId()]),
             [
                 'product' => $productJson,
             ]

--- a/src/Storefront/Framework/Seo/StorefrontCategoryUrlGenerator.php
+++ b/src/Storefront/Framework/Seo/StorefrontCategoryUrlGenerator.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
+/**
+ * @internal
+ */
 #[Package('discovery')]
 class StorefrontCategoryUrlGenerator extends AbstractCategoryUrlGenerator
 {

--- a/src/Storefront/Framework/Seo/StorefrontCategoryUrlGenerator.php
+++ b/src/Storefront/Framework/Seo/StorefrontCategoryUrlGenerator.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Seo;
+
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\Routing\RouterInterface;
+
+#[Package('discovery')]
+class StorefrontCategoryUrlGenerator extends AbstractCategoryUrlGenerator
+{
+    private const HOME_PAGE_ROUTE = 'frontend.home.page';
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly AbstractCategoryUrlGenerator $decorated,
+        private readonly RouterInterface $router,
+    ) {
+    }
+
+    public function getDecorated(): AbstractCategoryUrlGenerator
+    {
+        return $this->decorated;
+    }
+
+    public function generate(CategoryEntity $category, ?SalesChannelEntity $salesChannel): ?string
+    {
+        if ($salesChannel !== null && $this->isHomePageLink($category, $salesChannel)) {
+            return $this->router->generate(self::HOME_PAGE_ROUTE);
+        }
+
+        return $this->getDecorated()->generate($category, $salesChannel);
+    }
+
+    private function isHomePageLink(CategoryEntity $category, SalesChannelEntity $salesChannel): bool
+    {
+        if (
+            $category->getType() !== CategoryDefinition::TYPE_LINK
+            || $category->getTranslation('linkType') !== CategoryDefinition::LINK_TYPE_CATEGORY
+        ) {
+            return false;
+        }
+
+        return $category->getTranslation('internalLink') === $salesChannel->getNavigationCategoryId();
+    }
+}

--- a/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
+++ b/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
@@ -370,7 +370,7 @@ class HreflangLoaderTest extends TestCase
         ], $this->salesChannelContext->getContext());
 
         $links = $this->hreflangLoader->load(
-            new HreflangLoaderParameter('frontend.home.page', [], $this->salesChannelContext)
+            new HreflangLoaderParameter('frontend.home.page', [], $this->salesChannelContext, true)
         );
 
         static::assertCount(2, $links);
@@ -424,7 +424,7 @@ class HreflangLoaderTest extends TestCase
         ], $this->salesChannelContext->getContext());
 
         $links = $this->hreflangLoader->load(
-            new HreflangLoaderParameter('frontend.home.page', [], $this->salesChannelContext)
+            new HreflangLoaderParameter('frontend.home.page', [], $this->salesChannelContext, true)
         );
 
         static::assertCount(3, $links);

--- a/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -36,10 +36,10 @@ class EntityRouteResolverTest extends TestCase
         $resolver = $this->getContainer()->get(EntityRouteResolver::class);
         static::assertInstanceOf(EntityRouteResolver::class, $resolver);
 
-        static::assertSame($expectedPath, $resolver->generateUrl($entityName, [$id]));
+        static::assertSame($expectedPath, $resolver->generateUrl($entityName, $id));
         static::assertSame(
             SeoUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . $expectedPath . '#',
-            $resolver->generateSeoUrlPlaceholder($entityName, [$id])
+            $resolver->generateSeoUrlPlaceholder($entityName, $id)
         );
     }
 
@@ -74,10 +74,10 @@ class EntityRouteResolverTest extends TestCase
             ],
         );
 
-        static::assertSame($expectedPath, $resolver->generateUrl($entityName, [$id]));
+        static::assertSame($expectedPath, $resolver->generateUrl($entityName, $id));
         static::assertSame(
             SeoUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . $expectedPath . '#',
-            $resolver->generateSeoUrlPlaceholder($entityName, [$id])
+            $resolver->generateSeoUrlPlaceholder($entityName, $id)
         );
     }
 

--- a/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandler;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\SeoUrlRoute\CategoryStoreApiUrlRoute;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Content\Seo\SeoUrlRoute\LandingPageStoreApiUrlRoute;
+use Shopware\Core\Content\Seo\SeoUrlRoute\ProductStoreApiUrlRoute;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+class EntityRouteResolverTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    #[DataProvider('storefrontUrlProvider')]
+    public function testGenerateStorefrontUrl(string $entityName, string $expectedPath, string $id): void
+    {
+        if (!static::getContainer()->has(NavigationPageSeoUrlRoute::class)) {
+            static::markTestSkipped('Storefront seo url tests need storefront bundle to be installed');
+        }
+
+        $resolver = $this->getContainer()->get(EntityRouteResolver::class);
+        static::assertInstanceOf(EntityRouteResolver::class, $resolver);
+
+        static::assertSame($expectedPath, $resolver->generateUrl($entityName, [$id]));
+        static::assertSame(
+            SeoUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . $expectedPath . '#',
+            $resolver->generateSeoUrlPlaceholder($entityName, [$id])
+        );
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function storefrontUrlProvider(): iterable
+    {
+        $id = Uuid::randomHex();
+
+        yield 'product' => [ProductDefinition::ENTITY_NAME, '/detail/' . $id, $id];
+        yield 'landing page' => [LandingPageDefinition::ENTITY_NAME, '/landingPage/' . $id, $id];
+        yield 'category' => [CategoryDefinition::ENTITY_NAME, '/navigation/' . $id, $id];
+    }
+
+    #[DataProvider('storeApiUrlProvider')]
+    public function testGenerateStoreApiUrl(string $entityName, string $expectedPath, string $id): void
+    {
+        $seoUrlPlaceholderHandler = $this->getContainer()->get(SeoUrlPlaceholderHandlerInterface::class);
+        static::assertInstanceOf(SeoUrlPlaceholderHandlerInterface::class, $seoUrlPlaceholderHandler);
+        $router = $this->getContainer()->get('router');
+        static::assertInstanceOf(RouterInterface::class, $router);
+
+        $resolver = new EntityRouteResolver(
+            new SeoUrlRouteRegistry([]),
+            $seoUrlPlaceholderHandler,
+            $router,
+            [
+                $this->getContainer()->get(ProductStoreApiUrlRoute::class),
+                $this->getContainer()->get(CategoryStoreApiUrlRoute::class),
+                $this->getContainer()->get(LandingPageStoreApiUrlRoute::class),
+            ],
+        );
+
+        static::assertSame($expectedPath, $resolver->generateUrl($entityName, [$id]));
+        static::assertSame(
+            SeoUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . $expectedPath . '#',
+            $resolver->generateSeoUrlPlaceholder($entityName, [$id])
+        );
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string, 2: string}>
+     */
+    public static function storeApiUrlProvider(): iterable
+    {
+        $id = Uuid::randomHex();
+
+        yield 'product' => [ProductDefinition::ENTITY_NAME, '/store-api/product/' . $id, $id];
+        yield 'landing page' => [LandingPageDefinition::ENTITY_NAME, '/store-api/landing-page/' . $id, $id];
+        yield 'category' => [CategoryDefinition::ENTITY_NAME, '/store-api/category/' . $id, $id];
+    }
+}

--- a/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Sitemap\Provider\LandingPageUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -22,7 +23,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -122,7 +122,7 @@ class LandingPageUrlProviderTest extends TestCase
         $landingPageUrlProvider = new LandingPageUrlProvider(
             $configHandler,
             static::getContainer()->get(Connection::class),
-            static::getContainer()->get(RouterInterface::class),
+            static::getContainer()->get(EntityRouteResolver::class),
             static::getContainer()->get('event_dispatcher'),
         );
 

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryCollection;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -36,10 +37,15 @@ class CategoryBreadcrumbBuilderTest extends TestCase
 {
     protected SalesChannelContext $salesChannelContext;
 
+    private EntityRouteResolver $entityRouteResolver;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->salesChannelContext = $this->getSalesChannelContext();
+        $entityRouteResolver = static::createStub(EntityRouteResolver::class);
+        $entityRouteResolver->method('getRouteNameForEntityName')->willReturn('frontend.navigation.page');
+        $this->entityRouteResolver = $entityRouteResolver;
     }
 
     public function testGetProductSeoCategoryShouldReturnMainCategory(): void
@@ -54,7 +60,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -75,7 +82,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -90,7 +98,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -111,7 +120,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -131,7 +141,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
         $product = $this->getProductEntity($streamIds, []);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -151,7 +162,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $categoryRepositoryMock,
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
         $product = $this->getProductEntity([], $categoryIds);
 
@@ -208,7 +220,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c01', $this->salesChannelContext->getContext());
@@ -242,7 +255,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c02', $this->salesChannelContext->getContext());
@@ -276,7 +290,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c03', $this->salesChannelContext->getContext());
@@ -311,7 +326,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([$product], [$product]),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
 
         $result = $categoryBreadcrumbBuilder->getProductBreadcrumbUrls($product->getId(), '', $this->salesChannelContext)->getElements();
@@ -335,7 +351,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->entityRouteResolver,
         );
         $result = $categoryBreadcrumbBuilder->getProductSeoCategory($productEntity, $this->salesChannelContext);
 

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
@@ -23,15 +25,15 @@ class CategoryUrlGeneratorTest extends TestCase
 
     private CategoryUrlGenerator $urlGenerator;
 
-    private Stub&SeoUrlPlaceholderHandlerInterface $replacer;
+    private Stub&EntityRouteResolver $entityRouteResolver;
 
     private SalesChannelEntity $salesChannel;
 
     protected function setUp(): void
     {
-        $this->replacer = static::createStub(SeoUrlPlaceholderHandlerInterface::class);
-        $this->urlGenerator = new CategoryUrlGenerator($this->replacer);
-        $this->replacer->method('generate')->willReturnArgument(0);
+        $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
+        $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
+        $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnArgument(0);
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
     }
@@ -42,7 +44,7 @@ class CategoryUrlGeneratorTest extends TestCase
         $category->setId(Uuid::randomHex());
         $category->setType(CategoryDefinition::TYPE_PAGE);
 
-        static::assertSame('frontend.navigation.page', $this->urlGenerator->generate($category, $this->salesChannel));
+        static::assertSame(CategoryDefinition::ENTITY_NAME, $this->urlGenerator->generate($category, $this->salesChannel));
     }
 
     public function testFolder(): void
@@ -93,9 +95,9 @@ class CategoryUrlGeneratorTest extends TestCase
     public static function dataProviderLinkTypes(): array
     {
         return [
-            [CategoryDefinition::LINK_TYPE_PRODUCT, 'frontend.detail.page'],
-            [CategoryDefinition::LINK_TYPE_CATEGORY, 'frontend.navigation.page'],
-            [CategoryDefinition::LINK_TYPE_LANDING_PAGE, 'frontend.landing.page'],
+            [CategoryDefinition::LINK_TYPE_PRODUCT, ProductDefinition::ENTITY_NAME],
+            [CategoryDefinition::LINK_TYPE_CATEGORY, CategoryDefinition::ENTITY_NAME],
+            [CategoryDefinition::LINK_TYPE_LANDING_PAGE, LandingPageDefinition::ENTITY_NAME],
             [CategoryDefinition::LINK_TYPE_EXTERNAL, self::EXTERNAL_URL],
             [null, self::EXTERNAL_URL],
         ];

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -35,13 +35,7 @@ class CategoryUrlGeneratorTest extends TestCase
         $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
         $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnCallback(
-            static function (string $entityName, ArrayStruct $parameters, ?SalesChannelEntity $salesChannel): string {
-                if ($parameters->has('navigationId') && $salesChannel?->getNavigationCategoryId() === $parameters->get('navigationId')) {
-                    return 'frontend.home.page';
-                }
-
-                return $entityName;
-            }
+            static fn (string $entityName, ArrayStruct $parameters): string => $entityName
         );
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
@@ -62,22 +56,6 @@ class CategoryUrlGeneratorTest extends TestCase
         $category->setType(CategoryDefinition::TYPE_FOLDER);
 
         static::assertNull($this->urlGenerator->generate($category, $this->salesChannel));
-    }
-
-    public function testLinkCategoryHome(): void
-    {
-        $category = new CategoryEntity();
-        $category->setType(CategoryDefinition::TYPE_LINK);
-        $category->setLinkType(CategoryDefinition::LINK_TYPE_CATEGORY);
-        $category->addTranslated('linkType', CategoryDefinition::LINK_TYPE_CATEGORY);
-        $category->setInternalLink(Uuid::randomHex());
-
-        $internalLink = $category->getInternalLink();
-        static::assertIsString($internalLink);
-        $category->addTranslated('internalLink', $internalLink);
-        $this->salesChannel->setNavigationCategoryId($internalLink);
-
-        static::assertSame('frontend.home.page', $this->urlGenerator->generate($category, $this->salesChannel));
     }
 
     #[DataProvider('dataProviderLinkTypes')]

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
@@ -34,8 +35,8 @@ class CategoryUrlGeneratorTest extends TestCase
         $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
         $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnCallback(
-            static function (string $entityName, array $parameters, ?SalesChannelEntity $salesChannel): string {
-                if (isset($parameters['navigationId']) && $salesChannel?->getNavigationCategoryId() === $parameters['navigationId']) {
+            static function (string $entityName, ArrayStruct $parameters, ?SalesChannelEntity $salesChannel): string {
+                if ($parameters->has('navigationId') && $salesChannel?->getNavigationCategoryId() === $parameters->get('navigationId')) {
                     return 'frontend.home.page';
                 }
 

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -33,7 +33,15 @@ class CategoryUrlGeneratorTest extends TestCase
     {
         $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
-        $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnArgument(0);
+        $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnCallback(
+            static function (string $entityName, array $parameters, ?SalesChannelEntity $salesChannel): string {
+                if (isset($parameters['navigationId']) && $salesChannel?->getNavigationCategoryId() === $parameters['navigationId']) {
+                    return 'frontend.home.page';
+                }
+
+                return $entityName;
+            }
+        );
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
     }

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
@@ -35,7 +34,7 @@ class CategoryUrlGeneratorTest extends TestCase
         $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
         $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnCallback(
-            static fn (string $entityName, ArrayStruct $parameters): string => $entityName
+            static fn (string $entityName, array $values): string => $entityName
         );
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());

--- a/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryUrlGeneratorTest.php
@@ -33,9 +33,7 @@ class CategoryUrlGeneratorTest extends TestCase
     {
         $this->entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $this->urlGenerator = new CategoryUrlGenerator($this->entityRouteResolver);
-        $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnCallback(
-            static fn (string $entityName, array $values): string => $entityName
-        );
+        $this->entityRouteResolver->method('generateSeoUrlPlaceholder')->willReturnArgument(0);
         $this->salesChannel = new SalesChannelEntity();
         $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
     }

--- a/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
+++ b/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
@@ -21,7 +21,7 @@ class SeoUrlRouteConfigExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY, $exception->getErrorCode());
-        static::assertSame('Missing parameter key for primary key of entity "product".', $exception->getMessage());
+        static::assertSame('Missing parameter key for primary key in route config of entity "product".', $exception->getMessage());
         static::assertSame(['entityName' => 'product'], $exception->getParameters());
     }
 

--- a/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
+++ b/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
@@ -15,14 +15,14 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(SeoUrlRouteConfigException::class)]
 class SeoUrlRouteConfigExceptionTest extends TestCase
 {
-    public function testRouteParametersMismatching(): void
+    public function testRouteConfigMissingPrimaryKey(): void
     {
-        $exception = SeoUrlRouteConfigException::routeParametersMismatching(['productId'], ['abc123', 'extra']);
+        $exception = SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('product');
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertSame(SeoUrlRouteConfigException::ROUTE_PARAMETERS_MISMATCHING, $exception->getErrorCode());
-        static::assertSame('Mismatch between required route parameters and given values.', $exception->getMessage());
-        static::assertSame(['required' => ['productId'], 'given' => ['abc123', 'extra']], $exception->getParameters());
+        static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_MISSING_PRIMARY_KEY, $exception->getErrorCode());
+        static::assertSame('Missing key for primary key.', $exception->getMessage());
+        static::assertSame(['entityName' => 'product'], $exception->getParameters());
     }
 
     public function testRouteConfigNotFoundForEntityName(): void

--- a/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
+++ b/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
@@ -15,12 +15,12 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(SeoUrlRouteConfigException::class)]
 class SeoUrlRouteConfigExceptionTest extends TestCase
 {
-    public function testRouteConfigMissingPrimaryKey(): void
+    public function testRouteConfigMissingParameterKeyForPrimaryKey(): void
     {
-        $exception = SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('product');
+        $exception = SeoUrlRouteConfigException::routeConfigMissingParameterKeyForPrimaryKey('product');
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
-        static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_MISSING_PRIMARY_KEY, $exception->getErrorCode());
+        static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY, $exception->getErrorCode());
         static::assertSame('Missing key for primary key.', $exception->getMessage());
         static::assertSame(['entityName' => 'product'], $exception->getParameters());
     }

--- a/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
+++ b/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SeoUrlRouteConfigException::class)]
+class SeoUrlRouteConfigExceptionTest extends TestCase
+{
+    public function testRouteParametersMismatching(): void
+    {
+        $exception = SeoUrlRouteConfigException::routeParametersMismatching(['productId'], ['abc123', 'extra']);
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(SeoUrlRouteConfigException::ROUTE_PARAMETERS_MISMATCHING, $exception->getErrorCode());
+        static::assertSame('Mismatch between required route parameters and given values.', $exception->getMessage());
+        static::assertSame(['required' => ['productId'], 'given' => ['abc123', 'extra']], $exception->getParameters());
+    }
+
+    public function testRouteConfigNotFoundForEntityName(): void
+    {
+        $exception = SeoUrlRouteConfigException::routeConfigNotFoundForEntityName('product');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME, $exception->getErrorCode());
+        static::assertSame('No route config found for given entity name.', $exception->getMessage());
+        static::assertSame(['entityName' => 'product'], $exception->getParameters());
+    }
+}

--- a/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
+++ b/tests/unit/Core/Content/Seo/Exception/SeoUrlRouteConfigExceptionTest.php
@@ -21,7 +21,7 @@ class SeoUrlRouteConfigExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_MISSING_PARAMETER_KEY_FOR_PRIMARY_KEY, $exception->getErrorCode());
-        static::assertSame('Missing key for primary key.', $exception->getMessage());
+        static::assertSame('Missing parameter key for primary key of entity "product".', $exception->getMessage());
         static::assertSame(['entityName' => 'product'], $exception->getParameters());
     }
 
@@ -31,7 +31,7 @@ class SeoUrlRouteConfigExceptionTest extends TestCase
 
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
         static::assertSame(SeoUrlRouteConfigException::ROUTE_CONFIG_NOT_FOUND_FOR_ENTITY_NAME, $exception->getErrorCode());
-        static::assertSame('No route config found for given entity name.', $exception->getMessage());
+        static::assertSame('No route config found for given entity name "product".', $exception->getMessage());
         static::assertSame(['entityName' => 'product'], $exception->getParameters());
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRouteTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\CategoryStoreApiUrlRoute;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CategoryStoreApiUrlRoute::class)]
+class CategoryStoreApiUrlRouteTest extends TestCase
+{
+    public function testGetConfig(): void
+    {
+        $definition = new CategoryDefinition();
+        $config = (new CategoryStoreApiUrlRoute($definition))->getConfig();
+
+        static::assertSame($definition, $config->getDefinition());
+        static::assertSame(CategoryStoreApiUrlRoute::ROUTE_NAME, $config->getRouteName());
+        static::assertSame('store-api.category.detail', $config->getRouteName());
+        static::assertSame('', $config->getTemplate());
+        static::assertTrue($config->getSkipInvalid());
+        static::assertSame(['navigationId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/CategoryStoreApiUrlRouteTest.php
@@ -25,6 +25,6 @@ class CategoryStoreApiUrlRouteTest extends TestCase
         static::assertSame('store-api.category.detail', $config->getRouteName());
         static::assertSame('', $config->getTemplate());
         static::assertTrue($config->getSkipInvalid());
-        static::assertSame(['navigationId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+        static::assertSame(['navigationId' => 'abc123'], $config->getPrimaryKeyParameter('abc123'));
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -12,8 +12,6 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Struct\ArrayStruct;
-use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -46,38 +44,6 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('store-api.product.detail', $resolver->getRouteNameForEntityName('product'));
     }
 
-    public function testGetRouteNameUsesRouteBySalesChannelClosureWhenSalesChannelProvided(): void
-    {
-        $id = Uuid::randomHex();
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setNavigationCategoryId($id);
-        $parameters = new ArrayStruct(['navigationId' => $id]);
-
-        $resolver = $this->createResolverWithRoute(
-            'category',
-            'frontend.navigation.page',
-            static fn (SalesChannelEntity $sc, ArrayStruct $params): string => $sc->getNavigationCategoryId() === $params->get('navigationId')
-                ? 'frontend.home.page'
-                : 'frontend.navigation.page',
-        );
-
-        static::assertSame(
-            'frontend.home.page',
-            $resolver->getRouteNameForEntityName('category', $parameters, $salesChannel)
-        );
-    }
-
-    public function testGetRouteNameIgnoresSalesChannelClosureWhenNoSalesChannelProvided(): void
-    {
-        $resolver = $this->createResolverWithRoute(
-            'category',
-            'frontend.navigation.page',
-            static fn (SalesChannelEntity $sc, array $params): string => 'frontend.home.page',
-        );
-
-        static::assertSame('frontend.navigation.page', $resolver->getRouteNameForEntityName('category'));
-    }
-
     public function testGenerateSeoUrlPlaceholderPassesResolvedRouteAndParameters(): void
     {
         $this->placeholderHandler
@@ -104,32 +70,6 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('category'));
     }
 
-    public function testGenerateSeoUrlPlaceholderRespectsRouteBySalesChannelClosure(): void
-    {
-        $id = Uuid::randomHex();
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setNavigationCategoryId($id);
-
-        $this->placeholderHandler
-            ->expects($this->once())
-            ->method('generate')
-            ->with('frontend.home.page', ['navigationId' => $id])
-            ->willReturn('HOME_PLACEHOLDER');
-
-        $resolver = $this->createResolverWithRoute(
-            'category',
-            'frontend.navigation.page',
-            static fn (SalesChannelEntity $sc, ArrayStruct $params): string => $sc->getNavigationCategoryId() === $params->get('navigationId')
-                ? 'frontend.home.page'
-                : 'frontend.navigation.page',
-        );
-
-        static::assertSame(
-            'HOME_PLACEHOLDER',
-            $resolver->generateSeoUrlPlaceholder('category', new ArrayStruct(['navigationId' => $id]), $salesChannel)
-        );
-    }
-
     public function testGenerateUrlPassesResolvedRouteAndParameters(): void
     {
         $this->router
@@ -143,12 +83,12 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', new ArrayStruct(['productId' => 'abc123'])));
     }
 
-    private function createResolverWithRoute(string $entityName, string $routeName, ?\Closure $routeBySalesChannelGetter = null): EntityRouteResolver
+    private function createResolverWithRoute(string $entityName, string $routeName): EntityRouteResolver
     {
         $definition = static::createStub(EntityDefinition::class);
         $definition->method('getEntityName')->willReturn($entityName);
 
-        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true, $routeBySalesChannelGetter);
+        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true);
 
         $seoUrlRoute = static::createStub(SeoUrlRouteInterface::class);
         $seoUrlRoute->method('getConfig')->willReturn($config);

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -5,13 +5,13 @@ namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteNotFoundException;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -37,11 +37,25 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('frontend.detail.page', $resolver->getRouteNameForEntityName('product'));
     }
 
-    public function testGetRouteNameFallsBackToStoreApiRouteWhenNotRegistered(): void
+    public function testGetRouteNameResolvesViaConfiguredRouteWhenNotRegistered(): void
+    {
+        $resolver = new EntityRouteResolver(
+            new SeoUrlRouteRegistry([]),
+            $this->placeholderHandler,
+            $this->router,
+            [$this->createSeoUrlRoute('product', 'store-api.product.detail')],
+        );
+
+        static::assertSame('store-api.product.detail', $resolver->getRouteNameForEntityName('product'));
+    }
+
+    public function testGetRouteNameThrowsWhenEntityHasNoRoute(): void
     {
         $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
 
-        static::assertSame('store-api.product.detail', $resolver->getRouteNameForEntityName('product'));
+        $this->expectException(SeoUrlRouteNotFoundException::class);
+
+        $resolver->getRouteNameForEntityName('product');
     }
 
     public function testGenerateSeoUrlPlaceholderPassesResolvedRouteAndParameters(): void
@@ -52,9 +66,9 @@ class EntityRouteResolverTest extends TestCase
             ->with('frontend.detail.page', ['productId' => 'abc123'])
             ->willReturn('SEO_PLACEHOLDER');
 
-        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
 
-        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', new ArrayStruct(['productId' => 'abc123'])));
+        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', ['abc123']));
     }
 
     public function testGenerateSeoUrlPlaceholderUsesEmptyParametersByDefault(): void
@@ -78,25 +92,36 @@ class EntityRouteResolverTest extends TestCase
             ->with('frontend.detail.page', ['productId' => 'abc123'])
             ->willReturn('/product/some-product/abc123');
 
-        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
 
-        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', new ArrayStruct(['productId' => 'abc123'])));
+        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['abc123']));
     }
 
-    private function createResolverWithRoute(string $entityName, string $routeName): EntityRouteResolver
+    /**
+     * @param list<string> $parameterKeys
+     */
+    private function createResolverWithRoute(string $entityName, string $routeName, array $parameterKeys = []): EntityRouteResolver
+    {
+        return new EntityRouteResolver(
+            new SeoUrlRouteRegistry([$this->createSeoUrlRoute($entityName, $routeName, $parameterKeys)]),
+            $this->placeholderHandler,
+            $this->router,
+        );
+    }
+
+    /**
+     * @param list<string> $parameterKeys
+     */
+    private function createSeoUrlRoute(string $entityName, string $routeName, array $parameterKeys = []): SeoUrlRouteInterface
     {
         $definition = static::createStub(EntityDefinition::class);
         $definition->method('getEntityName')->willReturn($entityName);
 
-        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true);
+        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true, $parameterKeys);
 
         $seoUrlRoute = static::createStub(SeoUrlRouteInterface::class);
         $seoUrlRoute->method('getConfig')->willReturn($config);
 
-        return new EntityRouteResolver(
-            new SeoUrlRouteRegistry([$seoUrlRoute]),
-            $this->placeholderHandler,
-            $this->router,
-        );
+        return $seoUrlRoute;
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -11,8 +11,8 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
-use Symfony\Component\Routing\Route;
-use Symfony\Component\Routing\RouteCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -40,39 +40,40 @@ class EntityRouteResolverTest extends TestCase
 
     public function testGetRouteNameFallsBackToStoreApiRouteWhenNotRegistered(): void
     {
-        $routeCollection = static::createStub(RouteCollection::class);
-        $routeCollection->method('get')
-            ->willReturnMap([
-                ['store-api.product.detail', new Route('/store-api/product/{productId}')],
-            ]);
-        $this->router->method('getRouteCollection')->willReturn($routeCollection);
-
         $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
 
         static::assertSame('store-api.product.detail', $resolver->getRouteNameForEntityName('product'));
     }
 
-    public function testGetRouteNameConvertsUnderscoreToKebabCaseForStoreApiFallback(): void
+    public function testGetRouteNameUsesRouteBySalesChannelClosureWhenSalesChannelProvided(): void
     {
-        $routeCollection = static::createStub(RouteCollection::class);
-        $routeCollection->method('get')
-            ->willReturnCallback(static fn (string $name) => $name === 'store-api.landing-page.detail' ? new Route('/') : null);
-        $this->router->method('getRouteCollection')->willReturn($routeCollection);
+        $id = Uuid::randomHex();
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setNavigationCategoryId($id);
 
-        $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
+        $resolver = $this->createResolverWithRoute(
+            'category',
+            'frontend.navigation.page',
+            static fn (SalesChannelEntity $sc, array $params): string => $sc->getNavigationCategoryId() === ($params['navigationId'] ?? null)
+                ? 'frontend.home.page'
+                : 'frontend.navigation.page',
+        );
 
-        static::assertSame('store-api.landing-page.detail', $resolver->getRouteNameForEntityName('landing_page'));
+        static::assertSame(
+            'frontend.home.page',
+            $resolver->getRouteNameForEntityName('category', ['navigationId' => $id], $salesChannel)
+        );
     }
 
-    public function testGetRouteNameFallsBackToEntityNameWhenNothingMatches(): void
+    public function testGetRouteNameIgnoresSalesChannelClosureWhenNoSalesChannelProvided(): void
     {
-        $routeCollection = static::createStub(RouteCollection::class);
-        $routeCollection->method('get')->willReturn(null);
-        $this->router->method('getRouteCollection')->willReturn($routeCollection);
+        $resolver = $this->createResolverWithRoute(
+            'category',
+            'frontend.navigation.page',
+            static fn (SalesChannelEntity $sc, array $params): string => 'frontend.home.page',
+        );
 
-        $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
-
-        static::assertSame('unknown_entity', $resolver->getRouteNameForEntityName('unknown_entity'));
+        static::assertSame('frontend.navigation.page', $resolver->getRouteNameForEntityName('category'));
     }
 
     public function testGenerateSeoUrlPlaceholderPassesResolvedRouteAndParameters(): void
@@ -101,6 +102,32 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('category'));
     }
 
+    public function testGenerateSeoUrlPlaceholderRespectsRouteBySalesChannelClosure(): void
+    {
+        $id = Uuid::randomHex();
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setNavigationCategoryId($id);
+
+        $this->placeholderHandler
+            ->expects($this->once())
+            ->method('generate')
+            ->with('frontend.home.page', ['navigationId' => $id])
+            ->willReturn('HOME_PLACEHOLDER');
+
+        $resolver = $this->createResolverWithRoute(
+            'category',
+            'frontend.navigation.page',
+            static fn (SalesChannelEntity $sc, array $params): string => $sc->getNavigationCategoryId() === ($params['navigationId'] ?? null)
+                ? 'frontend.home.page'
+                : 'frontend.navigation.page',
+        );
+
+        static::assertSame(
+            'HOME_PLACEHOLDER',
+            $resolver->generateSeoUrlPlaceholder('category', ['navigationId' => $id], $salesChannel)
+        );
+    }
+
     public function testGenerateUrlPassesResolvedRouteAndParameters(): void
     {
         $this->router
@@ -114,12 +141,12 @@ class EntityRouteResolverTest extends TestCase
         static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['productId' => 'abc123']));
     }
 
-    private function createResolverWithRoute(string $entityName, string $routeName): EntityRouteResolver
+    private function createResolverWithRoute(string $entityName, string $routeName, ?\Closure $routeBySalesChannelGetter = null): EntityRouteResolver
     {
         $definition = static::createStub(EntityDefinition::class);
         $definition->method('getEntityName')->willReturn($entityName);
 
-        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}');
+        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true, $routeBySalesChannelGetter);
 
         $seoUrlRoute = static::createStub(SeoUrlRouteInterface::class);
         $seoUrlRoute->method('getConfig')->willReturn($config);

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Seo\Exception\SeoUrlRouteNotFoundException;
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
@@ -53,7 +53,7 @@ class EntityRouteResolverTest extends TestCase
     {
         $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
 
-        $this->expectException(SeoUrlRouteNotFoundException::class);
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigNotFoundForEntityName('product'));
 
         $resolver->getRouteNameForEntityName('product');
     }
@@ -95,6 +95,15 @@ class EntityRouteResolverTest extends TestCase
         $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
 
         static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['abc123']));
+    }
+
+    public function testThrowsExceptionOnRouteParameterMismatch(): void
+    {
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeParametersMismatching(['productId'], []));
+
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
+
+        $resolver->generateUrl('product', []);
     }
 
     /**

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -86,7 +86,7 @@ class EntityRouteResolverTest extends TestCase
 
     public function testThrowsExceptionWhenRouteHasNoPrimaryKeyConfigured(): void
     {
-        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('product'));
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingParameterKeyForPrimaryKey('product'));
 
         $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
 

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -66,22 +66,9 @@ class EntityRouteResolverTest extends TestCase
             ->with('frontend.detail.page', ['productId' => 'abc123'])
             ->willReturn('SEO_PLACEHOLDER');
 
-        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', 'productId');
 
-        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', ['abc123']));
-    }
-
-    public function testGenerateSeoUrlPlaceholderUsesEmptyParametersByDefault(): void
-    {
-        $this->placeholderHandler
-            ->expects($this->once())
-            ->method('generate')
-            ->with('frontend.navigation.page', [])
-            ->willReturn('SEO_PLACEHOLDER');
-
-        $resolver = $this->createResolverWithRoute('category', 'frontend.navigation.page');
-
-        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('category'));
+        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', 'abc123'));
     }
 
     public function testGenerateUrlPassesResolvedRouteAndParameters(): void
@@ -92,41 +79,35 @@ class EntityRouteResolverTest extends TestCase
             ->with('frontend.detail.page', ['productId' => 'abc123'])
             ->willReturn('/product/some-product/abc123');
 
-        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', 'productId');
 
-        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['abc123']));
+        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', 'abc123'));
     }
 
-    public function testThrowsExceptionOnRouteParameterMismatch(): void
+    public function testThrowsExceptionWhenRouteHasNoPrimaryKeyConfigured(): void
     {
-        $this->expectExceptionObject(SeoUrlRouteConfigException::routeParametersMismatching(['productId'], []));
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('product'));
 
-        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page', ['productId']);
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
 
-        $resolver->generateUrl('product', []);
+        $resolver->generateUrl('product', 'abc123');
     }
 
-    /**
-     * @param list<string> $parameterKeys
-     */
-    private function createResolverWithRoute(string $entityName, string $routeName, array $parameterKeys = []): EntityRouteResolver
+    private function createResolverWithRoute(string $entityName, string $routeName, ?string $primaryKeyParameterKey = null): EntityRouteResolver
     {
         return new EntityRouteResolver(
-            new SeoUrlRouteRegistry([$this->createSeoUrlRoute($entityName, $routeName, $parameterKeys)]),
+            new SeoUrlRouteRegistry([$this->createSeoUrlRoute($entityName, $routeName, $primaryKeyParameterKey)]),
             $this->placeholderHandler,
             $this->router,
         );
     }
 
-    /**
-     * @param list<string> $parameterKeys
-     */
-    private function createSeoUrlRoute(string $entityName, string $routeName, array $parameterKeys = []): SeoUrlRouteInterface
+    private function createSeoUrlRoute(string $entityName, string $routeName, ?string $primaryKeyParameterKey = null): SeoUrlRouteInterface
     {
         $definition = static::createStub(EntityDefinition::class);
         $definition->method('getEntityName')->willReturn($entityName);
 
-        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true, $parameterKeys);
+        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}', true, $primaryKeyParameterKey);
 
         $seoUrlRoute = static::createStub(SeoUrlRouteInterface::class);
         $seoUrlRoute->method('getConfig')->willReturn($config);

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(EntityRouteResolver::class)]
+class EntityRouteResolverTest extends TestCase
+{
+    private SeoUrlPlaceholderHandlerInterface&MockObject $placeholderHandler;
+
+    private RouterInterface&MockObject $router;
+
+    protected function setUp(): void
+    {
+        $this->placeholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+    }
+
+    public function testGetRouteNameReturnsRegisteredRoute(): void
+    {
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
+
+        static::assertSame('frontend.detail.page', $resolver->getRouteNameForEntityName('product'));
+    }
+
+    public function testGetRouteNameFallsBackToStoreApiRouteWhenNotRegistered(): void
+    {
+        $routeCollection = static::createStub(RouteCollection::class);
+        $routeCollection->method('get')
+            ->willReturnMap([
+                ['store-api.product.detail', new Route('/store-api/product/{productId}')],
+            ]);
+        $this->router->method('getRouteCollection')->willReturn($routeCollection);
+
+        $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
+
+        static::assertSame('store-api.product.detail', $resolver->getRouteNameForEntityName('product'));
+    }
+
+    public function testGetRouteNameConvertsUnderscoreToKebabCaseForStoreApiFallback(): void
+    {
+        $routeCollection = static::createStub(RouteCollection::class);
+        $routeCollection->method('get')
+            ->willReturnCallback(static fn (string $name) => $name === 'store-api.landing-page.detail' ? new Route('/') : null);
+        $this->router->method('getRouteCollection')->willReturn($routeCollection);
+
+        $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
+
+        static::assertSame('store-api.landing-page.detail', $resolver->getRouteNameForEntityName('landing_page'));
+    }
+
+    public function testGetRouteNameFallsBackToEntityNameWhenNothingMatches(): void
+    {
+        $routeCollection = static::createStub(RouteCollection::class);
+        $routeCollection->method('get')->willReturn(null);
+        $this->router->method('getRouteCollection')->willReturn($routeCollection);
+
+        $resolver = new EntityRouteResolver(new SeoUrlRouteRegistry([]), $this->placeholderHandler, $this->router);
+
+        static::assertSame('unknown_entity', $resolver->getRouteNameForEntityName('unknown_entity'));
+    }
+
+    public function testGenerateSeoUrlPlaceholderPassesResolvedRouteAndParameters(): void
+    {
+        $this->placeholderHandler
+            ->expects($this->once())
+            ->method('generate')
+            ->with('frontend.detail.page', ['productId' => 'abc123'])
+            ->willReturn('SEO_PLACEHOLDER');
+
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
+
+        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', ['productId' => 'abc123']));
+    }
+
+    public function testGenerateSeoUrlPlaceholderUsesEmptyParametersByDefault(): void
+    {
+        $this->placeholderHandler
+            ->expects($this->once())
+            ->method('generate')
+            ->with('frontend.navigation.page', [])
+            ->willReturn('SEO_PLACEHOLDER');
+
+        $resolver = $this->createResolverWithRoute('category', 'frontend.navigation.page');
+
+        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('category'));
+    }
+
+    public function testGenerateUrlPassesResolvedRouteAndParameters(): void
+    {
+        $this->router
+            ->expects($this->once())
+            ->method('generate')
+            ->with('frontend.detail.page', ['productId' => 'abc123'])
+            ->willReturn('/product/some-product/abc123');
+
+        $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
+
+        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['productId' => 'abc123']));
+    }
+
+    private function createResolverWithRoute(string $entityName, string $routeName): EntityRouteResolver
+    {
+        $definition = static::createStub(EntityDefinition::class);
+        $definition->method('getEntityName')->willReturn($entityName);
+
+        $config = new SeoUrlRouteConfig($definition, $routeName, '{{ entity.name }}');
+
+        $seoUrlRoute = static::createStub(SeoUrlRouteInterface::class);
+        $seoUrlRoute->method('getConfig')->willReturn($config);
+
+        return new EntityRouteResolver(
+            new SeoUrlRouteRegistry([$seoUrlRoute]),
+            $this->placeholderHandler,
+            $this->router,
+        );
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\Routing\RouterInterface;
@@ -50,18 +51,19 @@ class EntityRouteResolverTest extends TestCase
         $id = Uuid::randomHex();
         $salesChannel = new SalesChannelEntity();
         $salesChannel->setNavigationCategoryId($id);
+        $parameters = new ArrayStruct(['navigationId' => $id]);
 
         $resolver = $this->createResolverWithRoute(
             'category',
             'frontend.navigation.page',
-            static fn (SalesChannelEntity $sc, array $params): string => $sc->getNavigationCategoryId() === ($params['navigationId'] ?? null)
+            static fn (SalesChannelEntity $sc, ArrayStruct $params): string => $sc->getNavigationCategoryId() === $params->get('navigationId')
                 ? 'frontend.home.page'
                 : 'frontend.navigation.page',
         );
 
         static::assertSame(
             'frontend.home.page',
-            $resolver->getRouteNameForEntityName('category', ['navigationId' => $id], $salesChannel)
+            $resolver->getRouteNameForEntityName('category', $parameters, $salesChannel)
         );
     }
 
@@ -86,7 +88,7 @@ class EntityRouteResolverTest extends TestCase
 
         $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
 
-        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', ['productId' => 'abc123']));
+        static::assertSame('SEO_PLACEHOLDER', $resolver->generateSeoUrlPlaceholder('product', new ArrayStruct(['productId' => 'abc123'])));
     }
 
     public function testGenerateSeoUrlPlaceholderUsesEmptyParametersByDefault(): void
@@ -117,14 +119,14 @@ class EntityRouteResolverTest extends TestCase
         $resolver = $this->createResolverWithRoute(
             'category',
             'frontend.navigation.page',
-            static fn (SalesChannelEntity $sc, array $params): string => $sc->getNavigationCategoryId() === ($params['navigationId'] ?? null)
+            static fn (SalesChannelEntity $sc, ArrayStruct $params): string => $sc->getNavigationCategoryId() === $params->get('navigationId')
                 ? 'frontend.home.page'
                 : 'frontend.navigation.page',
         );
 
         static::assertSame(
             'HOME_PLACEHOLDER',
-            $resolver->generateSeoUrlPlaceholder('category', ['navigationId' => $id], $salesChannel)
+            $resolver->generateSeoUrlPlaceholder('category', new ArrayStruct(['navigationId' => $id]), $salesChannel)
         );
     }
 
@@ -138,7 +140,7 @@ class EntityRouteResolverTest extends TestCase
 
         $resolver = $this->createResolverWithRoute('product', 'frontend.detail.page');
 
-        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', ['productId' => 'abc123']));
+        static::assertSame('/product/some-product/abc123', $resolver->generateUrl('product', new ArrayStruct(['productId' => 'abc123'])));
     }
 
     private function createResolverWithRoute(string $entityName, string $routeName, ?\Closure $routeBySalesChannelGetter = null): EntityRouteResolver

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRouteTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\LandingPageStoreApiUrlRoute;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LandingPageStoreApiUrlRoute::class)]
+class LandingPageStoreApiUrlRouteTest extends TestCase
+{
+    public function testGetConfig(): void
+    {
+        $definition = new LandingPageDefinition();
+        $config = (new LandingPageStoreApiUrlRoute($definition))->getConfig();
+
+        static::assertSame($definition, $config->getDefinition());
+        static::assertSame(LandingPageStoreApiUrlRoute::ROUTE_NAME, $config->getRouteName());
+        static::assertSame('store-api.landing-page.detail', $config->getRouteName());
+        static::assertSame('', $config->getTemplate());
+        static::assertTrue($config->getSkipInvalid());
+        static::assertSame(['landingPageId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/LandingPageStoreApiUrlRouteTest.php
@@ -25,6 +25,6 @@ class LandingPageStoreApiUrlRouteTest extends TestCase
         static::assertSame('store-api.landing-page.detail', $config->getRouteName());
         static::assertSame('', $config->getTemplate());
         static::assertTrue($config->getSkipInvalid());
-        static::assertSame(['landingPageId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+        static::assertSame(['landingPageId' => 'abc123'], $config->getPrimaryKeyParameter('abc123'));
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRouteTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Seo\SeoUrlRoute\ProductStoreApiUrlRoute;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ProductStoreApiUrlRoute::class)]
+class ProductStoreApiUrlRouteTest extends TestCase
+{
+    public function testGetConfig(): void
+    {
+        $definition = new ProductDefinition();
+        $config = (new ProductStoreApiUrlRoute($definition))->getConfig();
+
+        static::assertSame($definition, $config->getDefinition());
+        static::assertSame(ProductStoreApiUrlRoute::ROUTE_NAME, $config->getRouteName());
+        static::assertSame('store-api.product.detail', $config->getRouteName());
+        static::assertSame('', $config->getTemplate());
+        static::assertTrue($config->getSkipInvalid());
+        static::assertSame(['productId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRouteTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/ProductStoreApiUrlRouteTest.php
@@ -25,6 +25,6 @@ class ProductStoreApiUrlRouteTest extends TestCase
         static::assertSame('store-api.product.detail', $config->getRouteName());
         static::assertSame('', $config->getTemplate());
         static::assertTrue($config->getSkipInvalid());
-        static::assertSame(['productId' => 'abc123'], $config->getParameterKeyValuePairs(['abc123']));
+        static::assertSame(['productId' => 'abc123'], $config->getPrimaryKeyParameter('abc123'));
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(SeoUrlRouteConfig::class)]
+class SeoUrlRouteConfigTest extends TestCase
+{
+    public function testConfig(): void
+    {
+        $entityDefinition = $this->createMock(EntityDefinition::class);
+        $config = new SeoUrlRouteConfig(
+            $entityDefinition,
+            'foo_bar',
+            '{{ foo.bar }}',
+            false,
+            static fn () => 'foo_bar_baz'
+        );
+
+        static::assertSame($entityDefinition, $config->getDefinition());
+        static::assertSame('foo_bar', $config->getRouteName());
+        static::assertSame('{{ foo.bar }}', $config->getTemplate());
+        static::assertFalse($config->getSkipInvalid());
+        static::assertSame('foo_bar_baz', $config->getRouteBySalesChannel(new SalesChannelEntity()));
+    }
+}

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\Seo\SeoUrlRoute;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Seo\Exception\SeoUrlRouteConfigException;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
@@ -23,7 +24,7 @@ class SeoUrlRouteConfigTest extends TestCase
             'foo_bar',
             '{{ foo.bar }}',
             false,
-            ['fooId', 'barId']
+            'fooId'
         );
 
         static::assertSame($entityDefinition, $config->getDefinition());
@@ -31,8 +32,24 @@ class SeoUrlRouteConfigTest extends TestCase
         static::assertSame('{{ foo.bar }}', $config->getTemplate());
         static::assertFalse($config->getSkipInvalid());
         static::assertSame(
-            ['fooId' => 'foo-value', 'barId' => 'bar-value'],
-            $config->getParameterKeyValuePairs(['foo-value', 'bar-value'])
+            ['fooId' => 'foo-value'],
+            $config->getPrimaryKeyParameter('foo-value')
         );
+    }
+
+    public function testGetPrimaryKeyParameterThrowsWhenNoKeyConfigured(): void
+    {
+        $defintion = $this->createMock(EntityDefinition::class);
+        $defintion->method('getEntityName')->willReturn('foo_bar');
+
+        $config = new SeoUrlRouteConfig(
+            $defintion,
+            'foo_bar',
+            '{{ foo.bar }}'
+        );
+
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('foo_bar'));
+
+        $config->getPrimaryKeyParameter('foo-value');
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 /**
  * @internal
@@ -23,14 +22,12 @@ class SeoUrlRouteConfigTest extends TestCase
             $entityDefinition,
             'foo_bar',
             '{{ foo.bar }}',
-            false,
-            static fn () => 'foo_bar_baz'
+            false
         );
 
         static::assertSame($entityDefinition, $config->getDefinition());
         static::assertSame('foo_bar', $config->getRouteName());
         static::assertSame('{{ foo.bar }}', $config->getTemplate());
         static::assertFalse($config->getSkipInvalid());
-        static::assertSame('foo_bar_baz', $config->getRouteBySalesChannel(new SalesChannelEntity()));
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -22,12 +22,17 @@ class SeoUrlRouteConfigTest extends TestCase
             $entityDefinition,
             'foo_bar',
             '{{ foo.bar }}',
-            false
+            false,
+            ['fooId', 'barId']
         );
 
         static::assertSame($entityDefinition, $config->getDefinition());
         static::assertSame('foo_bar', $config->getRouteName());
         static::assertSame('{{ foo.bar }}', $config->getTemplate());
         static::assertFalse($config->getSkipInvalid());
+        static::assertSame(
+            ['fooId' => 'foo-value', 'barId' => 'bar-value'],
+            $config->getParameterKeyValuePairs(['foo-value', 'bar-value'])
+        );
     }
 }

--- a/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
+++ b/tests/unit/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteConfigTest.php
@@ -48,7 +48,7 @@ class SeoUrlRouteConfigTest extends TestCase
             '{{ foo.bar }}'
         );
 
-        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingPrimaryKey('foo_bar'));
+        $this->expectExceptionObject(SeoUrlRouteConfigException::routeConfigMissingParameterKeyForPrimaryKey('foo_bar'));
 
         $config->getPrimaryKeyParameter('foo-value');
     }

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Event\SalesChannelCategoryIdsFetchedEvent;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
@@ -26,7 +27,6 @@ use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -43,7 +43,7 @@ class CategoryUrlProviderTest extends TestCase
 
     private readonly IteratorFactory&MockObject $iteratorFactory;
 
-    private readonly RouterInterface&MockObject $router;
+    private readonly EntityRouteResolver&MockObject $entityRouteResolver;
 
     private readonly EventDispatcher&MockObject $dispatcher;
 
@@ -59,7 +59,7 @@ class CategoryUrlProviderTest extends TestCase
         $this->connection = $this->createMock(Connection::class);
         $this->definition = $this->createMock(CategoryDefinition::class);
         $this->iteratorFactory = $this->createMock(IteratorFactory::class);
-        $this->router = $this->createMock(RouterInterface::class);
+        $this->entityRouteResolver = $this->createMock(EntityRouteResolver::class);
         $this->ids = new IdsCollection();
         $this->dispatcher = $this->createMock(EventDispatcher::class);
         $this->categoryResultIncrement = 0;
@@ -261,7 +261,8 @@ class CategoryUrlProviderTest extends TestCase
             ],
         ]);
 
-        $this->router->method('generate')->willReturn('category/2/detail');
+        $this->entityRouteResolver->method('getRouteNameForEntityName')->willReturn('frontend.navigation.page');
+        $this->entityRouteResolver->method('generateUrl')->willReturn('category/2/detail');
 
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->queryBuilder->method('executeQuery')->willReturn($categoryQueryResult);
@@ -281,7 +282,7 @@ class CategoryUrlProviderTest extends TestCase
             $this->connection,
             $this->definition,
             $this->iteratorFactory,
-            $this->router,
+            $this->entityRouteResolver,
             $this->dispatcher
         );
     }

--- a/tests/unit/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Sitemap\Provider;
+
+use Doctrine\DBAL\Cache\ArrayResult;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Content\Sitemap\Provider\LandingPageUrlProvider;
+use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
+use Shopware\Core\Content\Sitemap\Struct\Url;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LandingPageUrlProvider::class)]
+class LandingPageUrlProviderTest extends TestCase
+{
+    private readonly ConfigHandler&MockObject $configHandler;
+
+    private readonly Connection&MockObject $connection;
+
+    private readonly EntityRouteResolver&MockObject $entityRouteResolver;
+
+    private readonly EventDispatcher&MockObject $dispatcher;
+
+    private LandingPageUrlProvider $landingPageUrlProvider;
+
+    protected function setUp(): void
+    {
+        $this->configHandler = $this->createMock(ConfigHandler::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->entityRouteResolver = $this->createMock(EntityRouteResolver::class);
+        $this->dispatcher = $this->createMock(EventDispatcher::class);
+
+        $this->landingPageUrlProvider = new LandingPageUrlProvider(
+            $this->configHandler,
+            $this->connection,
+            $this->entityRouteResolver,
+            $this->dispatcher
+        );
+    }
+
+    public function testGetDecorated(): void
+    {
+        static::expectException(DecorationPatternException::class);
+        $this->landingPageUrlProvider->getDecorated();
+    }
+
+    public function testGetName(): void
+    {
+        $name = $this->landingPageUrlProvider->getName();
+        static::assertSame('landing_page', $name);
+    }
+
+    public function testGetLandingPageUrls(): void
+    {
+        $ids = new IdsCollection();
+        $queryResult = new Result(
+            new ArrayResult(
+                ['id', 'created_at', 'updated_at'],
+                [
+                    [Uuid::fromHexToBytes($ids->get('landing-page-1')), '2021-01-01 00:00:00', null],
+                    [Uuid::fromHexToBytes($ids->get('landing-page-2')), '2021-01-01 00:00:00', null],
+                ]
+            ),
+            $this->connection
+        );
+
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            [
+                'foreign_key' => $ids->get('landing-page-1'),
+                'seo_path_info' => 'landing-page/1/detail',
+            ],
+        ]);
+
+        $this->entityRouteResolver->method('getRouteNameForEntityName')->willReturn('frontend.landing.page');
+        $this->entityRouteResolver->method('generateUrl')->willReturn('landing-page/2/detail');
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->method('executeQuery')->willReturn($queryResult);
+
+        $this->connection->method('createQueryBuilder')->willReturn($queryBuilderMock);
+
+        $this->configHandler->method('get')
+            ->willReturn([
+                [
+                    'resource' => LandingPageEntity::class,
+                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'identifier' => $ids->get('landing-page-1'),
+                ],
+                [
+                    'resource' => LandingPageEntity::class,
+                    'salesChannelId' => Uuid::randomHex(),
+                    'identifier' => $ids->get('landing-page-2'),
+                ],
+            ]);
+
+        $context = Generator::generateSalesChannelContext();
+
+        $urlResult = $this->landingPageUrlProvider->getUrls($context, 2, 10);
+
+        $urls = $urlResult->getUrls();
+        static::assertCount(2, $urls);
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($ids->get('landing-page-1'), $url->getIdentifier());
+        static::assertSame('landing-page/1/detail', $url->getLoc());
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($ids->get('landing-page-2'), $url->getIdentifier());
+        static::assertSame('landing-page/2/detail', $url->getLoc());
+
+        static::assertSame(12, $urlResult->getNextOffset());
+    }
+}

--- a/tests/unit/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Sitemap\Provider;
+
+use Doctrine\DBAL\Cache\ArrayResult;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider;
+use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
+use Shopware\Core\Content\Sitemap\Struct\Url;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IterableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(ProductUrlProvider::class)]
+class ProductUrlProviderTest extends TestCase
+{
+    private readonly ConfigHandler&MockObject $configHandler;
+
+    private readonly Connection&MockObject $connection;
+
+    private readonly ProductDefinition&MockObject $definition;
+
+    private readonly IteratorFactory&MockObject $iteratorFactory;
+
+    private readonly EntityRouteResolver&MockObject $entityRouteResolver;
+
+    private readonly SystemConfigService&MockObject $systemConfigService;
+
+    private readonly EventDispatcher&MockObject $dispatcher;
+
+    private ProductUrlProvider $productUrlProvider;
+
+    protected function setUp(): void
+    {
+        $this->configHandler = $this->createMock(ConfigHandler::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->definition = $this->createMock(ProductDefinition::class);
+        $this->iteratorFactory = $this->createMock(IteratorFactory::class);
+        $this->entityRouteResolver = $this->createMock(EntityRouteResolver::class);
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->dispatcher = $this->createMock(EventDispatcher::class);
+
+        $this->productUrlProvider = new ProductUrlProvider(
+            $this->configHandler,
+            $this->connection,
+            $this->definition,
+            $this->iteratorFactory,
+            $this->entityRouteResolver,
+            $this->systemConfigService,
+            $this->dispatcher
+        );
+    }
+
+    public function testGetDecorated(): void
+    {
+        static::expectException(DecorationPatternException::class);
+        $this->productUrlProvider->getDecorated();
+    }
+
+    public function testGetName(): void
+    {
+        $name = $this->productUrlProvider->getName();
+        static::assertSame('product', $name);
+    }
+
+    public function testGetProductUrls(): void
+    {
+        $ids = new IdsCollection();
+        $queryResult = new Result(
+            new ArrayResult(
+                ['auto_increment', 'id', 'created_at', 'updated_at'],
+                [
+                    [1, $ids->get('product-1'), '2021-01-01 00:00:00', null],
+                    [2, $ids->get('product-2'), '2021-01-01 00:00:00', null],
+                ]
+            ),
+            $this->connection
+        );
+
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            [
+                'foreign_key' => $ids->get('product-1'),
+                'seo_path_info' => 'product/1/detail',
+            ],
+        ]);
+
+        $this->entityRouteResolver->method('getRouteNameForEntityName')->willReturn('frontend.detail.page');
+        $this->entityRouteResolver->method('generateUrl')->willReturn('product/2/detail');
+
+        $queryBuilderMock = $this->createMock(QueryBuilder::class);
+        $queryBuilderMock->method('executeQuery')->willReturn($queryResult);
+
+        $query = $this->createMock(IterableQuery::class);
+        $query->method('getQuery')->willReturn($queryBuilderMock);
+
+        $this->iteratorFactory->method('createIterator')->willReturn($query);
+        $this->configHandler->method('get')
+            ->willReturn([
+                [
+                    'resource' => ProductEntity::class,
+                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'identifier' => $ids->get('product-1'),
+                ],
+                [
+                    'resource' => ProductEntity::class,
+                    'salesChannelId' => Uuid::randomHex(),
+                    'identifier' => $ids->get('product-2'),
+                ],
+            ]);
+
+        $context = Generator::generateSalesChannelContext();
+
+        $urlResult = $this->productUrlProvider->getUrls($context, 100, 50);
+
+        $urls = $urlResult->getUrls();
+        static::assertCount(2, $urls);
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($ids->get('product-1'), $url->getIdentifier());
+        static::assertSame('product/1/detail', $url->getLoc());
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($ids->get('product-2'), $url->getIdentifier());
+        static::assertSame('product/2/detail', $url->getLoc());
+
+        static::assertSame(2, $urlResult->getNextOffset());
+    }
+}

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
 use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -64,16 +65,19 @@ class NavigationControllerTest extends TestCase
         $this->seoUrlReplacer = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
         $this->seoUrlReplacer->method('replace')
             ->willReturnCallback(static fn (string $url) => $url);
-        $this->seoUrlReplacer->method('generate')
-            ->willReturnCallback(static function (string $route, array $parameters) {
-                return match ($route) {
-                    'frontend.detail.page' => '/product/' . $parameters['productId'],
-                    'frontend.navigation.page' => '/navigation/' . $parameters['navigationId'],
+
+        $entityRouteResolver = static::createStub(EntityRouteResolver::class);
+        $entityRouteResolver->method('generateSeoUrlPlaceholder')
+            ->willReturnCallback(static function (string $entityName, array $parameters = []) {
+                return match ($entityName) {
+                    'product' => '/product/' . ($parameters['productId'] ?? ''),
+                    'category' => '/navigation/' . ($parameters['navigationId'] ?? ''),
+                    'landing_page' => '/landingPage/' . ($parameters['landingPageId'] ?? ''),
                     'frontend.home.page' => '/',
-                    default => '/' . $route,
+                    default => '/' . $entityName,
                 };
             });
-        $this->categoryUrlGenerator = new CategoryUrlGenerator($this->seoUrlReplacer);
+        $this->categoryUrlGenerator = new CategoryUrlGenerator($entityRouteResolver);
 
         $this->controller = new NavigationControllerTestClass(
             $this->pageLoader,

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Controller\NavigationController;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
@@ -68,12 +69,11 @@ class NavigationControllerTest extends TestCase
 
         $entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $entityRouteResolver->method('generateSeoUrlPlaceholder')
-            ->willReturnCallback(static function (string $entityName, array $parameters = []) {
+            ->willReturnCallback(static function (string $entityName, array $parameters = [], ?SalesChannelEntity $salesChannel = null) {
                 return match ($entityName) {
                     'product' => '/product/' . ($parameters['productId'] ?? ''),
                     'category' => '/navigation/' . ($parameters['navigationId'] ?? ''),
                     'landing_page' => '/landingPage/' . ($parameters['landingPageId'] ?? ''),
-                    'frontend.home.page' => '/',
                     default => '/' . $entityName,
                 };
             });

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -17,7 +17,6 @@ use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
-use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -69,11 +68,11 @@ class NavigationControllerTest extends TestCase
 
         $entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $entityRouteResolver->method('generateSeoUrlPlaceholder')
-            ->willReturnCallback(static function (string $entityName, ArrayStruct $parameters) {
+            ->willReturnCallback(static function (string $entityName, array $values) {
                 return match ($entityName) {
-                    'product' => '/product/' . $parameters->get('productId'),
-                    'category' => '/navigation/' . $parameters->get('navigationId'),
-                    'landing_page' => '/landingPage/' . $parameters->get('landingPageId'),
+                    'product' => '/product/' . $values[0],
+                    'category' => '/navigation/' . $values[0],
+                    'landing_page' => '/landingPage/' . $values[0],
                     default => '/' . $entityName,
                 };
             });

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Category\Service\CategoryUrlGenerator;
 use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -69,11 +70,11 @@ class NavigationControllerTest extends TestCase
 
         $entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $entityRouteResolver->method('generateSeoUrlPlaceholder')
-            ->willReturnCallback(static function (string $entityName, array $parameters = [], ?SalesChannelEntity $salesChannel = null) {
+            ->willReturnCallback(static function (string $entityName, ArrayStruct $parameters, ?SalesChannelEntity $salesChannel = null) {
                 return match ($entityName) {
-                    'product' => '/product/' . ($parameters['productId'] ?? ''),
-                    'category' => '/navigation/' . ($parameters['navigationId'] ?? ''),
-                    'landing_page' => '/landingPage/' . ($parameters['landingPageId'] ?? ''),
+                    'product' => '/product/' . $parameters->get('productId'),
+                    'category' => '/navigation/' . $parameters->get('navigationId'),
+                    'landing_page' => '/landingPage/' . $parameters->get('landingPageId'),
                     default => '/' . $entityName,
                 };
             });

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -21,7 +21,6 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Language\LanguageCollection;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Controller\NavigationController;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
@@ -70,7 +69,7 @@ class NavigationControllerTest extends TestCase
 
         $entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $entityRouteResolver->method('generateSeoUrlPlaceholder')
-            ->willReturnCallback(static function (string $entityName, ArrayStruct $parameters, ?SalesChannelEntity $salesChannel = null) {
+            ->willReturnCallback(static function (string $entityName, ArrayStruct $parameters) {
                 return match ($entityName) {
                     'product' => '/product/' . $parameters->get('productId'),
                     'category' => '/navigation/' . $parameters->get('navigationId'),

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -68,11 +68,11 @@ class NavigationControllerTest extends TestCase
 
         $entityRouteResolver = static::createStub(EntityRouteResolver::class);
         $entityRouteResolver->method('generateSeoUrlPlaceholder')
-            ->willReturnCallback(static function (string $entityName, array $values) {
+            ->willReturnCallback(static function (string $entityName, string $primaryKey) {
                 return match ($entityName) {
-                    'product' => '/product/' . $values[0],
-                    'category' => '/navigation/' . $values[0],
-                    'landing_page' => '/landingPage/' . $values[0],
+                    'product' => '/product/' . $primaryKey,
+                    'category' => '/navigation/' . $primaryKey,
+                    'landing_page' => '/landingPage/' . $primaryKey,
                     default => '/' . $entityName,
                 };
             });

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
@@ -11,6 +11,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
 
@@ -54,6 +56,29 @@ class NavigationPageSeoUrlRouteTest extends TestCase
 
         $notFilterQueries = $notFilter->getQueries();
         static::assertCount(2, $notFilterQueries);
+    }
+
+    public function testConfigRouteBySalesChannelClosure(): void
+    {
+        $navigationPageSeoUrlRoute = new NavigationPageSeoUrlRoute(
+            new CategoryDefinition(),
+            static::createStub(CategoryBreadcrumbBuilder::class)
+        );
+        $config = $navigationPageSeoUrlRoute->getConfig();
+        $categoryId = Uuid::randomHex();
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->assign(['navigationCategoryId' => $categoryId]);
+
+        $parameters = new ArrayStruct(['navigationId' => $categoryId]);
+        static::assertSame(
+            'frontend.home.page',
+            $config->getRouteBySalesChannel($salesChannel, $parameters)
+        );
+        static::assertFalse($parameters->has('navigationId'));
+        static::assertSame(
+            'frontend.navigation.page',
+            $config->getRouteBySalesChannel($salesChannel, $parameters)
+        );
     }
 
     private function assertEqualsFilter(

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
@@ -11,8 +11,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\ArrayStruct;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
 
@@ -56,29 +54,6 @@ class NavigationPageSeoUrlRouteTest extends TestCase
 
         $notFilterQueries = $notFilter->getQueries();
         static::assertCount(2, $notFilterQueries);
-    }
-
-    public function testConfigRouteBySalesChannelClosure(): void
-    {
-        $navigationPageSeoUrlRoute = new NavigationPageSeoUrlRoute(
-            new CategoryDefinition(),
-            static::createStub(CategoryBreadcrumbBuilder::class)
-        );
-        $config = $navigationPageSeoUrlRoute->getConfig();
-        $categoryId = Uuid::randomHex();
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->assign(['navigationCategoryId' => $categoryId]);
-
-        $parameters = new ArrayStruct(['navigationId' => $categoryId]);
-        static::assertSame(
-            'frontend.home.page',
-            $config->getRouteBySalesChannel($salesChannel, $parameters)
-        );
-        static::assertFalse($parameters->has('navigationId'));
-        static::assertSame(
-            'frontend.navigation.page',
-            $config->getRouteBySalesChannel($salesChannel, $parameters)
-        );
     }
 
     private function assertEqualsFilter(

--- a/tests/unit/Storefront/Framework/Seo/StorefrontCategoryUrlGeneratorTest.php
+++ b/tests/unit/Storefront/Framework/Seo/StorefrontCategoryUrlGeneratorTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Seo;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Service\AbstractCategoryUrlGenerator;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Storefront\Framework\Seo\StorefrontCategoryUrlGenerator;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(StorefrontCategoryUrlGenerator::class)]
+class StorefrontCategoryUrlGeneratorTest extends TestCase
+{
+    public function testGenerateHomePageLinkUsesRouter(): void
+    {
+        $navigationCategoryId = Uuid::randomHex();
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->once())
+            ->method('generate')
+            ->with('frontend.home.page')
+            ->willReturn('/');
+
+        $decorated = $this->createMock(AbstractCategoryUrlGenerator::class);
+        $decorated->expects($this->never())->method('generate');
+
+        $generator = new StorefrontCategoryUrlGenerator($decorated, $router);
+
+        $category = $this->createCategoryLink($navigationCategoryId);
+
+        static::assertSame('/', $generator->generate($category, $this->createSalesChannel($navigationCategoryId)));
+    }
+
+    public function testGenerateDelegatesWhenCategoryIsNotALink(): void
+    {
+        $navigationCategoryId = Uuid::randomHex();
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->never())->method('generate');
+
+        $decorated = $this->createMock(AbstractCategoryUrlGenerator::class);
+        $decorated->expects($this->once())
+            ->method('generate')
+            ->willReturn('DELEGATED');
+
+        $generator = new StorefrontCategoryUrlGenerator($decorated, $router);
+
+        $category = new CategoryEntity();
+        $category->setType(CategoryDefinition::TYPE_PAGE);
+        $category->setId($navigationCategoryId);
+
+        static::assertSame('DELEGATED', $generator->generate($category, $this->createSalesChannel($navigationCategoryId)));
+    }
+
+    public function testGenerateDelegatesForNonCategoryLinkType(): void
+    {
+        $internalLink = Uuid::randomHex();
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->never())->method('generate');
+
+        $decorated = $this->createMock(AbstractCategoryUrlGenerator::class);
+        $decorated->expects($this->once())
+            ->method('generate')
+            ->willReturn('DELEGATED');
+
+        $generator = new StorefrontCategoryUrlGenerator($decorated, $router);
+
+        $category = new CategoryEntity();
+        $category->setType(CategoryDefinition::TYPE_LINK);
+        $category->addTranslated('linkType', CategoryDefinition::LINK_TYPE_PRODUCT);
+        $category->addTranslated('internalLink', $internalLink);
+
+        static::assertSame('DELEGATED', $generator->generate($category, $this->createSalesChannel($internalLink)));
+    }
+
+    public function testGetDecoratedReturnsInner(): void
+    {
+        $decorated = $this->createMock(AbstractCategoryUrlGenerator::class);
+        $generator = new StorefrontCategoryUrlGenerator($decorated, $this->createMock(RouterInterface::class));
+
+        static::assertSame($decorated, $generator->getDecorated());
+    }
+
+    private function createCategoryLink(string $internalLink): CategoryEntity
+    {
+        $category = new CategoryEntity();
+        $category->setType(CategoryDefinition::TYPE_LINK);
+        $category->addTranslated('linkType', CategoryDefinition::LINK_TYPE_CATEGORY);
+        $category->addTranslated('internalLink', $internalLink);
+
+        return $category;
+    }
+
+    private function createSalesChannel(string $navigationCategoryId): SalesChannelEntity
+    {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setNavigationCategoryId($navigationCategoryId);
+
+        return $salesChannel;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Core bundles (`Content/Category`, `Content/Seo`, `Content/Sitemap`) were directly referencing Storefront route name strings such as `frontend.navigation.page`, `frontend.detail.page` and `frontend.home.page` (guarded by `@phpstan-ignore shopware.storefrontRouteUsage`). This created an implicit dependency on the Storefront bundle from Core, violating bundle separation and making Core unusable without Storefront (e.g. in headless setups).

### 2. What does this change do, exactly?

Introduces an `EntityRouteResolver` service in `Core/Content/Seo/SeoUrlRoute/` that centralises all entity-to-route-name resolution and URL generation, and removes the hardcoded Storefront route strings from Core. The resolver exposes:

  - `getRouteNameForEntityName(string $entityName)` — resolves the route name for an entity.
  - `generateSeoUrlPlaceholder(string $entityName, string $primaryKey)` — builds a SEO URL placeholder.
  - `generateUrl(string $entityName, string $primaryKey)` — builds a concrete URL via the Symfony router.

Resolution works as follows:

  1. Looks up the registered `SeoUrlRouteInterface` for the entity name via the existing `SeoUrlRouteRegistry` (populated by Storefront when present).
  2. Falls back to a `store-api.<entity>.detail` route when no Storefront route is registered (headless / API-only setups). New fallback routes `ProductStoreApiUrlRoute`, `CategoryStoreApiUrlRoute` and `LandingPageStoreApiUrlRoute` are injected into the resolver for this purpose.

Supporting changes:

  - **`EntitySeoUrlRouteInterface`** (new) — minimal interface exposing only `getConfig()`. `SeoUrlRouteInterface` now extends it, and the store-api fallback routes implement just this base interface (they only provide a config, no mapping/criteria).
  - **`SeoUrlRouteConfig`** — gains an optional `primaryKeyParameterKey` and a `getPrimaryKeyParameter(string $primaryKey)` method, centralising the mapping of an entity primary key to its route parameter (`navigationId`, `productId`, `landingPageId`). This replaces the per-route hardcoded route-parameter handling.
  - **`SeoUrlRouteConfigException`** (new) — `routeConfigNotFoundForEntityName()` and `routeConfigMissingParameterKeyForPrimaryKey()`.
  - **`StorefrontCategoryUrlGenerator`** (new, Storefront) — decorates the Core `CategoryUrlGenerator` to handle the home-page link special case (returns the `frontend.home.page` route). This keeps the `frontend.home.page` reference inside the Storefront bundle.

The following Core consumers now use `EntityRouteResolver` instead of hardcoded route strings / `SeoUrlPlaceholderHandlerInterface` / `RouterInterface`:

  - `CategoryUrlGenerator` — placeholder URLs for rich-text content links
  - `CategoryBreadcrumbBuilder` — resolves the navigation route name (drops a `shopware.storefrontRouteUsage` ignore)
  - `CategoryUrlProvider`, `ProductUrlProvider`, `LandingPageUrlProvider` (sitemap) — sitemap URL generation

`HreflangLoaderParameter` gains a `$homepage` boolean flag so `HreflangLoader` no longer compares against the literal `'frontend.home.page'` string (drops another `shopware.storefrontRouteUsage` ignore).

### 3. Describe each step to reproduce the issue or behaviour.

This is a refactoring change with no user-visible behaviour change. To verify:

  1. Run the unit tests — new coverage for `EntityRouteResolver`, `SeoUrlRouteConfig`, `SeoUrlRouteConfigException`, the store-api route classes and `StorefrontCategoryUrlGenerator`, including the headless fallback and missing-parameter-key error paths.
  2. Run the integration tests `EntityRouteResolverTest`, `LandingPageUrlProviderTest` and `HreflangLoaderTest`.
  3. Boot a Storefront instance and confirm sitemap generation, hreflang tags, and in-content category/product/landing-page links (including home-page links) still resolve correctly.
  4. Optionally boot with Storefront disabled and confirm the store-api fallback routes are used.

### 4. Please link to the relevant issues (if any).

  - closes #12970

### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them
