### PR TITLE
refactor(administration): migrate legacy SCSS vars to Meteor tokens

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/assets/scss/directives/dragdrop.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/directives/dragdrop.scss
@@ -7,7 +7,7 @@
     user-focus: none;
     user-select: none;
     z-index: $z-index-dragdrop;
-    box-shadow: 0 0 4px 0 $color-shopware-brand-500;
+    box-shadow: 0 0 4px 0 var(--color-border-brand-default);
     overflow: hidden;
     cursor: grab;
 
@@ -22,11 +22,11 @@
     }
 
     &.is--valid-drag {
-        box-shadow: 0 0 4px 0 $color-emerald-500;
+        box-shadow: 0 0 4px 0 var(--color-border-positive-default);
     }
 
     &.is--invalid-drag {
-        box-shadow: 0 0 4px 0 $color-crimson-500;
+        box-shadow: 0 0 4px 0 var(--color-border-critical-default);
     }
 }
 
@@ -47,10 +47,10 @@
 }
 
 .is--dragging {
-    background: $color-gray-100;
-    border: 1px dashed $color-gray-300;
+    background: var(--color-background-secondary-default);
+    border: 1px dashed var(--color-border-secondary-default);
     box-shadow: none;
-    color: $color-gray-100;
+    color: var(--color-background-secondary-default);
     cursor: grab;
 
     & > * {

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/directives/tooltip.scss
@@ -1,20 +1,15 @@
 @import "~scss/variables";
 
 $sw-tooltip-z-index: $z-index-tooltip;
-$sw-tooltip-color-background: var(--color-elevation-surface-floating);
-$sw-tooltip-color: var(--color-text-inverse-default);
-$sw-tooltip-border-radius: var(--border-radius-overlay);
-$sw-tooltip-color-light: $color-darkgray-200;
-$sw-tooltip-border-color-light: $color-gray-300;
 
 .sw-tooltip {
     position: absolute;
     z-index: $sw-tooltip-z-index;
 
     &.sw-tooltip--dark {
-        background-color: var(--color-elevation-surface-floating);
+        background-color: var(--color-elevation-floating-default);
         border-radius: var(--border-radius-xs);
-        color: var(--color-text-inverse-default);
+        color: var(--color-text-primary-inverse);
         padding: var(--scale-size-12);
         font-size: var(--font-size-2xs);
         word-wrap: break-word;
@@ -25,7 +20,7 @@ $sw-tooltip-border-color-light: $color-gray-300;
             height: 8px;
             width: 8px;
             transform: rotate(45deg);
-            background: $sw-tooltip-color-background;
+            background: var(--color-elevation-floating-default);
         }
 
         &.sw-tooltip--top::before {
@@ -55,14 +50,14 @@ $sw-tooltip-border-color-light: $color-gray-300;
 
     &.sw-tooltip--light {
         pointer-events: none;
-        color: var(--color-text-inverse-default);
+        color: var(--color-text-primary-inverse);
         font-size: var(--font-size-2xs);
         font-weight: var(--font-weight-regular);
         line-height: var(--font-line-height-2xs);
         width: auto !important;
         height: auto !important;
         padding: 5px 10px;
-        background: var(--color-elevation-surface-floating);
+        background: var(--color-elevation-floating-default);
         box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
         border-radius: var(--border-radius-xs);
 

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -133,7 +133,7 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button, .mt-lin
 .mt-card__toolbar {
     flex-basis: 100%;
     padding: 30px;
-    background-color: var(--color-background-secondary-default);
+    background-color: var(--color-elevation-surface-sunken);
     border-bottom: 1px solid var(--color-border-primary-default);
 }
 

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/mixins.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/mixins.scss
@@ -95,7 +95,7 @@
     padding: 0;
     outline: none;
     line-height: unset;
-    color: $color-darkgray-200;
+    color: var(--color-text-primary-default);
     border: none;
     background: none;
     cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/pages/error.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/pages/error.scss
@@ -1,4 +1,3 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
 .sw-error-404 {
@@ -10,7 +9,7 @@
     // added duplicated height property, to center content vertically on iOS
     height: 100vh;
     height: 100svh;
-    background-color: $color-white;
+    background-color: var(--color-background-primary-default);
 
     &__content {
         display: flex;
@@ -24,7 +23,7 @@
     }
 
     &__title {
-        color: $color-darkgray-800;
+        color: var(--color-text-primary-default);
         position: absolute;
         top: 50%;
         left: 50%;
@@ -33,17 +32,17 @@
     }
 
     &__description {
-        color: $color-darkgray-800;
+        color: var(--color-text-primary-default);
         text-wrap: balance;
         max-width: 60ch;
         text-align: center;
         padding-block: 2rem;
-        line-height: $line-height-md;
+        line-height: var(--font-line-height-m);
     }
 
     &__icon {
         @include size(0.75rem);
 
-        fill: $color-white;
+        fill: var(--color-static-white);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-shop-id-change-modal/sw-app-shop-id-change-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-shop-id-change-modal/sw-app-shop-id-change-modal.scss
@@ -75,7 +75,7 @@
         }
 
         .sw-app-shop-id-change-modal__content-fingerprint-item {
-            border: 1px dashed var(--color-border-primary-default);
+            border: 1px dashed var(--color-border-secondary-default);
             border-radius: var(--border-radius-xs);
             background-color: var(--color-background-secondary-default);
             padding: var(--scale-size-16);

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/sw-app-topbar-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/sw-app-topbar-button.scss
@@ -1,12 +1,10 @@
-$topbar-button-text-color: #2d2e32;
-
 .sw-app-topbar-button {
     .mt-button {
-        background: #fff;
-        color: $topbar-button-text-color;
+        background: var(--color-background-primary-default);
+        color: var(--color-text-primary-default);
 
         svg {
-            color: $topbar-button-text-color;
+            color: var(--color-icon-primary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/sw-app-wrong-app-url-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-wrong-app-url-modal/sw-app-wrong-app-url-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-app-wrong-app-url-modal {
     .sw-app-wrong-app-url-modal__content-description {
         text-align: center;
@@ -14,6 +12,6 @@
     }
 
     .sw-app-wrong-app-url_modal__content-description-technical-details {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-alert-deprecated/sw-alert-deprecated.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-alert-deprecated/sw-alert-deprecated.scss
@@ -1,17 +1,16 @@
 @import "~scss/variables";
 
-$sw-alert-box-shadow: 1px 2px 5px rgba(0, 0, 0, 10%);
 $sw-alert-size-close: 40px;
 
 .sw-alert {
-    border: 1px solid $color-gray-300;
+    border: 1px solid var(--color-border-secondary-default);
     border-radius: $border-radius-default;
-    color: $color-darkgray-200;
-    background-color: $color-white;
+    color: var(--color-text-primary-default);
+    background-color: var(--color-background-primary-default);
     text-align: left;
     position: relative;
     margin: 0 auto 20px;
-    font-size: $font-size-s;
+    font-size: var(--font-size-s);
 
     &__body {
         padding: 24px 60px 24px 24px;
@@ -27,7 +26,7 @@ $sw-alert-size-close: 40px;
     }
 
     &__icon {
-        color: $color-gray-300;
+        color: var(--color-icon-secondary-default);
         position: absolute;
         display: block;
         left: 26px;
@@ -65,7 +64,7 @@ $sw-alert-size-close: 40px;
     }
 
     &__actions {
-        border-top: 1px solid $color-gray-300;
+        border-top: 1px solid var(--color-border-secondary-default);
         display: flex;
         flex-wrap: wrap;
 
@@ -77,53 +76,53 @@ $sw-alert-size-close: 40px;
             flex-basis: 0;
             flex-grow: 1;
             max-width: 100%;
-            font-weight: $font-weight-medium;
+            font-weight: var(--font-weight-medium);
 
             &:not(:last-child) {
-                border-right: 1px solid $color-gray-300;
+                border-right: 1px solid var(--color-border-secondary-default);
             }
 
             &:hover {
-                background-color: $color-white;
+                background-color: var(--color-background-primary-default);
             }
         }
     }
 
     &--notification {
-        box-shadow: $sw-alert-box-shadow;
-        border: 1px solid $color-gray-300;
-        border-left: 4px solid $color-gray-300;
-        background-color: $color-gray-100;
+        box-shadow: 1px 2px 5px var(--color-elevation-shadow-default);
+        border: 1px solid var(--color-border-secondary-default);
+        border-left: 4px solid var(--color-border-secondary-default);
+        background-color: var(--color-background-secondary-default);
 
         .sw-alert__actions {
-            border-color: $color-gray-300;
+            border-color: var(--color-border-secondary-default);
 
             .mt-button {
-                color: $color-shopware-brand-500;
-                border-color: $color-gray-300;
+                color: var(--color-text-brand-default);
+                border-color: var(--color-border-secondary-default);
 
                 &:hover {
-                    background-color: $color-gray-100;
+                    background-color: var(--color-background-secondary-default);
                 }
             }
         }
     }
 
     &--warning {
-        border-color: $color-pumpkin-spice-500;
-        background-color: $color-pumpkin-spice-50;
-        color: $color-pumpkin-spice-900;
+        border-color: var(--color-border-attention-default);
+        background-color: var(--color-background-attention-default);
+        color: var(--color-text-primary-default);
 
         &.sw-alert--notification {
-            background-color: $color-white;
-            border-color: $color-gray-300;
-            border-left-color: $color-pumpkin-spice-500;
-            color: $color-darkgray-200;
+            background-color: var(--color-background-primary-default);
+            border-color: var(--color-border-secondary-default);
+            border-left-color: var(--color-border-attention-default);
+            color: var(--color-text-primary-default);
         }
 
         .sw-alert__icon,
         .sw-alert__close {
-            color: $color-pumpkin-spice-900;
+            color: var(--color-icon-attention-default);
         }
     }
 
@@ -132,74 +131,74 @@ $sw-alert-size-close: 40px;
     }
 
     &--error {
-        border-color: $color-crimson-500;
-        background-color: $color-crimson-50;
+        border-color: var(--color-border-critical-default);
+        background-color: var(--color-background-critical-default);
 
         &.sw-alert--notification {
-            background-color: $color-white;
-            border-color: $color-gray-300;
-            border-left-color: $color-crimson-500;
+            background-color: var(--color-background-primary-default);
+            border-color: var(--color-border-secondary-default);
+            border-left-color: var(--color-border-critical-default);
         }
 
         .sw-alert__icon,
         .sw-alert__close {
-            color: $color-crimson-500;
+            color: var(--color-icon-critical-default);
         }
 
         .sw-alert__title {
-            color: $color-crimson-900;
+            color: var(--color-text-critical-default);
         }
 
         .sw-alert__message {
-            color: $color-crimson-900;
+            color: var(--color-text-critical-default);
         }
     }
 
     &--success {
-        border-color: $color-emerald-500;
-        background-color: $color-emerald-50;
+        border-color: var(--color-border-positive-default);
+        background-color: var(--color-background-positive-default);
 
         &.sw-alert--notification {
-            background-color: $color-white;
-            border-color: $color-gray-300;
-            border-left-color: $color-emerald-500;
+            background-color: var(--color-background-primary-default);
+            border-color: var(--color-border-secondary-default);
+            border-left-color: var(--color-border-positive-default);
         }
 
         .sw-alert__icon,
         .sw-alert__close {
-            color: $color-emerald-500;
+            color: var(--color-icon-positive-default);
         }
 
         .sw-alert__title {
-            color: $color-emerald-900;
+            color: var(--color-text-primary-default);
         }
 
         .sw-alert__message {
-            color: $color-emerald-900;
+            color: var(--color-text-primary-default);
         }
     }
 
     &--info {
-        border-color: $color-shopware-brand-500;
-        background-color: $color-shopware-brand-50;
+        border-color: var(--color-border-brand-default);
+        background-color: var(--color-background-brand-default);
 
         &.sw-alert--notification {
-            background-color: $color-white;
-            border-color: $color-gray-300;
-            border-left-color: $color-shopware-brand-500;
+            background-color: var(--color-background-primary-default);
+            border-color: var(--color-border-secondary-default);
+            border-left-color: var(--color-border-brand-default);
         }
 
         .sw-alert__icon,
         .sw-alert__close {
-            color: $color-shopware-brand-500;
+            color: var(--color-icon-brand-default);
         }
 
         .sw-alert__title {
-            color: $color-shopware-brand-500;
+            color: var(--color-text-brand-default);
         }
 
         .sw-alert__message {
-            color: $color-shopware-brand-500;
+            color: var(--color-text-brand-default);
         }
     }
 
@@ -235,17 +234,17 @@ $sw-alert-size-close: 40px;
     }
 
     &--neutral {
-        border-color: $color-gray-300;
-        background-color: $color-white;
+        border-color: var(--color-border-secondary-default);
+        background-color: var(--color-background-primary-default);
 
         &.sw-alert--notification {
-            background-color: $color-white;
-            border-color: $color-gray-300;
-            border-left-color: $color-gray-300;
+            background-color: var(--color-background-primary-default);
+            border-color: var(--color-border-secondary-default);
+            border-left-color: var(--color-border-secondary-default);
         }
 
         .sw-alert__icon {
-            color: $color-darkgray-200;
+            color: var(--color-icon-secondary-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/sw-avatar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-avatar/sw-avatar.scss
@@ -7,16 +7,16 @@ $sw-avatar-size-default: 40px;
     width: $sw-avatar-size-default;
     height: $sw-avatar-size-default;
     border-radius: 100%;
-    background: $color-gray-200 no-repeat center center;
+    background: var(--color-background-secondary-default) no-repeat center center;
     background-size: cover;
     text-align: center;
-    font-weight: $font-weight-semi-bold;
+    font-weight: var(--font-weight-semibold);
     text-transform: uppercase;
-    color: $color-white;
+    color: var(--color-static-white);
     user-select: none;
 
     .mt-icon {
-        color: $color-shopware-brand-500;
+        color: var(--color-icon-brand-default);
     }
 
     &.sw-avatar__square {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-button-deprecated/sw-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-button-deprecated/sw-button.scss
@@ -3,20 +3,18 @@
  */
 @import "~scss/variables";
 
-$sw-button-transition: all 0.15s ease-out;
-
 .sw-button {
-    border: 1px solid $color-gray-400;
-    background: $color-gray-50;
-    color: $color-darkgray-200;
-    transition: $sw-button-transition;
+    border: 1px solid var(--color-border-primary-default);
+    background: var(--color-interaction-secondary-default);
+    color: var(--color-text-primary-default);
+    transition: all 0.15s ease-out;
     display: inline-block;
     border-radius: $border-radius-default;
     padding: 2px 24px;
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 34px;
     outline: none;
-    font-weight: $font-weight-semi-bold;
+    font-weight: var(--font-weight-semibold);
     white-space: nowrap;
     text-overflow: ellipsis;
     vertical-align: middle;
@@ -43,70 +41,70 @@ $sw-button-transition: all 0.15s ease-out;
 
     &:hover:not(.sw-button--disabled),
     &:hover:not([disabled]) {
-        background: $color-gray-100;
+        background: var(--color-interaction-secondary-hover);
     }
 
     &:active:not(.sw-button--disabled) {
-        background: $color-gray-200;
-        border-color: $color-gray-400;
+        background: var(--color-interaction-secondary-pressed);
+        border-color: var(--color-border-primary-default);
     }
 
     &:disabled,
     &.sw-button--disabled {
-        color: $color-gray-500;
-        border-color: $color-gray-200;
+        color: var(--color-text-primary-disabled);
+        border-color: var(--color-border-primary-default);
         cursor: not-allowed;
 
         .mt-icon {
-            color: $color-gray-400;
+            color: var(--color-icon-primary-disabled);
         }
     }
 
     .mt-icon {
-        color: $color-gray-800;
+        color: var(--color-icon-primary-default);
     }
 
     .sw-loader .sw-loader-element div {
-        border-color: $color-gray-800 transparent transparent transparent;
+        border-color: var(--color-icon-primary-default) transparent transparent transparent;
     }
 
     &.sw-button--primary {
-        background: $color-shopware-brand-500;
-        color: $color-white;
+        background: var(--color-interaction-primary-default);
+        color: var(--color-static-white);
         line-height: 36px;
         border: 0 none;
 
         .mt-icon {
-            color: $color-white;
+            color: var(--color-static-white);
         }
 
         .sw-loader .sw-loader-element div {
-            border-color: $color-white transparent transparent transparent;
+            border-color: var(--color-static-white) transparent transparent transparent;
         }
 
         &.sw-button--x-small {
-            line-height: $line-height-sm;
+            line-height: var(--font-line-height-s);
         }
 
         &.sw-button--small {
-            line-height: $line-height-lg;
+            line-height: var(--font-line-height-l);
         }
 
         &:hover {
-            background: $color-shopware-brand-700;
+            background: var(--color-interaction-primary-hover);
         }
 
         &:active {
-            background: $color-shopware-brand-800;
+            background: var(--color-interaction-primary-pressed);
         }
 
         &:disabled,
         &.sw-button--disabled {
-            background: $color-shopware-brand-200;
+            background: var(--color-interaction-primary-disabled);
         }
 
         &.sw-button--square .mt-icon {
-            color: $color-white;
+            color: var(--color-static-white);
         }
     }
 
@@ -152,99 +150,99 @@ $sw-button-transition: all 0.15s ease-out;
     }
 
     &.sw-button--danger {
-        background: $color-crimson-500;
-        color: $color-white;
+        background: var(--color-interaction-critical-default);
+        color: var(--color-static-white);
         line-height: 36px;
         border: 0 none;
 
         .mt-icon {
-            color: $color-white;
+            color: var(--color-static-white);
         }
 
         .sw-loader .sw-loader-element div {
-            border-color: $color-white transparent transparent transparent;
+            border-color: var(--color-static-white) transparent transparent transparent;
         }
 
         &.sw-button--x-small {
-            line-height: $line-height-sm;
+            line-height: var(--font-line-height-s);
         }
 
         &.sw-button--small {
-            line-height: $line-height-lg;
+            line-height: var(--font-line-height-l);
         }
 
         &:hover {
-            background: $color-crimson-700;
+            background: var(--color-interaction-critical-hover);
         }
 
         &:active {
-            background: $color-crimson-800;
+            background: var(--color-interaction-critical-pressed);
         }
 
         &:disabled,
         &.sw-button--disabled {
-            background: $color-crimson-200;
+            background: var(--color-interaction-critical-disabled);
 
             .mt-icon {
-                color: $color-white;
+                color: var(--color-static-white);
             }
         }
     }
 
     &.sw-button--ghost {
         background-color: transparent;
-        border-color: $color-shopware-brand-500;
-        color: $color-shopware-brand-500;
+        border-color: var(--color-border-brand-default);
+        color: var(--color-text-brand-default);
 
         .mt-icon {
-            color: $color-shopware-brand-500;
+            color: var(--color-icon-brand-default);
         }
 
         .sw-loader .sw-loader-element div {
-            border-color: $color-shopware-brand-500 transparent transparent transparent;
+            border-color: var(--color-icon-brand-default) transparent transparent transparent;
         }
 
         &:hover {
-            background-color: $color-shopware-brand-50;
+            background-color: var(--color-background-brand-default);
         }
 
         &:active {
-            background-color: $color-shopware-brand-100;
+            background-color: var(--color-background-brand-default);
         }
 
         &:disabled,
         &.sw-button--disabled {
             background-color: transparent;
-            border-color: $color-shopware-brand-200;
-            color: $color-shopware-brand-200;
+            border-color: var(--color-border-brand-disabled);
+            color: var(--color-text-brand-disabled);
 
             .mt-icon {
-                color: $color-shopware-brand-200;
+                color: var(--color-icon-brand-disabled);
             }
         }
     }
 
     &.sw-button--ghost-danger {
         background: transparent;
-        border-color: $color-crimson-500;
-        color: $color-crimson-500;
+        border-color: var(--color-border-critical-default);
+        color: var(--color-text-critical-default);
 
         &:hover {
-            background: $color-crimson-50;
+            background: var(--color-background-critical-default);
         }
 
         &:active {
-            background: $color-crimson-100;
+            background: var(--color-background-critical-default);
         }
 
         &:disabled,
         &.sw-button--disabled {
             background-color: transparent;
-            border-color: $color-crimson-200;
-            color: $color-crimson-200;
+            border-color: var(--color-border-critical-disabled);
+            color: var(--color-text-critical-disabled);
 
             .mt-icon {
-                color: $color-crimson-200;
+                color: var(--color-icon-critical-disabled);
             }
         }
     }
@@ -252,18 +250,18 @@ $sw-button-transition: all 0.15s ease-out;
     &.sw-button--context {
         border: none;
         background-color: transparent;
-        color: $color-darkgray-800;
+        color: var(--color-text-primary-default);
 
         .mt-icon {
-            color: $color-darkgray-800;
+            color: var(--color-icon-primary-default);
         }
 
         .sw-loader .sw-loader-element div {
-            border-color: $color-darkgray-800 transparent transparent transparent;
+            border-color: var(--color-icon-primary-default) transparent transparent transparent;
         }
 
         &:hover {
-            background-color: $color-gray-100;
+            background-color: var(--color-interaction-secondary-hover);
         }
     }
 
@@ -275,8 +273,8 @@ $sw-button-transition: all 0.15s ease-out;
     &.sw-button--x-small {
         padding-left: 10px;
         padding-right: 10px;
-        font-size: $font-size-xxs;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-2xs);
+        line-height: var(--font-line-height-xs);
 
         &.sw-button--square {
             width: 24px;
@@ -286,7 +284,7 @@ $sw-button-transition: all 0.15s ease-out;
     &.sw-button--small {
         padding-left: 15px;
         padding-right: 15px;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 26px;
 
         &.sw-button--square {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card-deprecated/sw-card-deprecated.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card-deprecated/sw-card-deprecated.scss
@@ -99,7 +99,7 @@
         padding: 24px;
         padding-bottom: 20px;
         border-radius: $border-radius-lg $border-radius-lg 0 0;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-card__avatar {
@@ -122,15 +122,15 @@
 
     .sw-card__title {
         color: var(--color-text-primary-default);
-        font-size: $font-size-m;
-        font-weight: $font-weight-semi-bold;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-m);
+        font-weight: var(--font-weight-semibold);
+        line-height: var(--font-line-height-xs);
     }
 
     .sw-card__subtitle {
         color: var(--color-text-secondary-default);
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
     }
 
     .sw-card__titles-right-slot {
@@ -140,8 +140,8 @@
     .sw-card__toolbar {
         flex-basis: 100%;
         padding: 30px;
-        background-color: var(--color-background-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &.has--header {
@@ -177,7 +177,7 @@
         }
 
         h1 {
-            font-size: $font-size-xl;
+            font-size: var(--font-size-xl);
         }
 
         h2 {
@@ -185,13 +185,13 @@
         }
 
         h3 {
-            font-size: $font-size-l;
+            font-size: var(--font-size-l);
         }
 
         h4,
         h5,
         h6 {
-            font-size: $font-size-m;
+            font-size: var(--font-size-m);
         }
 
         a.sw-card__quick-link {
@@ -201,7 +201,7 @@
             align-items: center;
             text-decoration: none;
             color: var(--color-text-brand-default);
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
 
             &:hover {
                 color: var(--color-text-brand-hover);
@@ -228,12 +228,12 @@
             border-bottom-right-radius: 0;
 
             &:hover {
-                border-bottom-color: var(--color-border-primary-default);
+                border-bottom-color: var(--color-border-secondary-default);
             }
 
             &:focus {
                 background-color: var(--color-background-secondary-default);
-                border-bottom-color: var(--color-border-primary-default);
+                border-bottom-color: var(--color-border-secondary-default);
             }
 
             &:active {
@@ -256,7 +256,7 @@
     }
 
     & > .sw-tabs {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-lg $border-radius-lg 0 0;
         border-bottom: none;
         margin-bottom: 0;
@@ -284,7 +284,7 @@
             font-weight: normal;
 
             &.sw-tabs-item--active {
-                font-weight: $font-weight-semi-bold;
+                font-weight: var(--font-weight-semibold);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card-section/sw-card-section.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card-section/sw-card-section.scss
@@ -4,19 +4,19 @@
     padding: 30px;
 
     &.sw-card-section--divider-top {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &.sw-card-section--divider-right {
-        border-right: 1px solid var(--color-border-primary-default);
+        border-right: 1px solid var(--color-border-secondary-default);
     }
 
     &.sw-card-section--divider-bottom {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &.sw-card-section--divider-left {
-        border-left: 1px solid var(--color-border-primary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
     }
 
     &.sw-card-section--secondary {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart/index.js
@@ -268,7 +268,7 @@ export default {
                 stroke: {
                     width: '2',
                     curve: 'straight',
-                    colors: ['var(--color-border-brand-selected)'],
+                    colors: ['var(--color-border-brand-default)'],
                 },
 
                 title: {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-chart/sw-chart.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-chart/sw-chart.scss
@@ -3,8 +3,8 @@
 .apexcharts-canvas {
     .apexcharts-tooltip {
         box-shadow: var(--color-elevation-shadow-default) !important;
-        background-color: var(--color-elevation-surface-overlay) !important;
-        border: 1px solid var(--color-border-primary-default) !important;
+        background-color: var(--color-elevation-surface-raised) !important;
+        border: 1px solid var(--color-border-secondary-default) !important;
         border-radius: var(--border-radius-l) !important;
         color: var(--color-text-primary-default) !important;
 
@@ -17,21 +17,21 @@
             font-size: var(--font-size-xs) !important;
             font-weight: var(--font-weight-bold) !important;
             background: var(--color-interaction-secondary-default) !important;
-            border-bottom: 1px solid var(--color-border-primary-default) !important;
+            border-bottom: 1px solid var(--color-border-secondary-default) !important;
             padding: var(--scale-size-10) var(--scale-size-16) !important;
             margin-bottom: 0 !important;
         }
     }
 
     .apexcharts-xaxistooltip {
-        color: var(--color-text-inverse-default) !important;
-        background-color: var(--color-elevation-surface-floating) !important;
+        color: var(--color-text-primary-inverse) !important;
+        background-color: var(--color-elevation-floating-default) !important;
         border-radius: var(--border-radius-xs) !important;
     }
 
     .apexcharts-xaxistooltip::before,
     .apexcharts-xaxistooltip::after {
-        border-bottom-color: var(--color-elevation-surface-floating) !important;
+        border-bottom-color: var(--color-elevation-floating-default) !important;
     }
 
     .apexcharts-tooltip-marker::before {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-container/sw-container.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-container/sw-container.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-container {
     display: grid;
     width: 100%;
@@ -14,7 +12,7 @@
     }
 
     h1 {
-        font-size: $font-size-xl;
+        font-size: var(--font-size-xl);
     }
 
     h2 {
@@ -22,18 +20,18 @@
     }
 
     h3 {
-        font-size: $font-size-l;
+        font-size: var(--font-size-l);
     }
 
     h4,
     h5,
     h6 {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
     }
 
     p {
-        font-size: $font-size-xs;
-        line-height: $line-height-sm;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-s);
         color: var(--color-text-primary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-description-list/sw-description-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-description-list/sw-description-list.scss
@@ -1,15 +1,13 @@
-@import "~scss/variables";
-
 .sw-description-list {
-    line-height: $line-height-sm;
-    font-size: $font-size-xs;
+    line-height: var(--font-line-height-s);
+    font-size: var(--font-size-xs);
     display: grid;
     place-content: start;
 
     dt,
     dd {
         padding: 15px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         &:last-of-type {
             border-bottom-color: transparent;
@@ -17,7 +15,7 @@
     }
 
     dt {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         color: var(--color-text-primary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-label/sw-label.scss
@@ -30,7 +30,7 @@ $sw-label-pill-border-radius: 50px;
     }
 
     &.sw-label--dismissable:hover {
-        border-color: var(--color-border-brand-selected);
+        border-color: var(--color-border-brand-default);
         background: var(--color-background-brand-default);
 
         .sw-label__caption {
@@ -60,8 +60,8 @@ $sw-label-pill-border-radius: 50px;
         height: 100%;
         right: 10px;
         top: 0;
-        color: $color-darkgray-200;
-        background-color: $color-gray-50;
+        color: var(--color-icon-primary-default);
+        background-color: var(--color-background-secondary-default);
         border: 0 none;
         cursor: pointer;
         outline: none;
@@ -69,13 +69,13 @@ $sw-label-pill-border-radius: 50px;
 
     &.sw-label--ghost {
         background: transparent;
-        border-color: $color-gray-300;
+        border-color: var(--color-border-primary-default);
     }
 
     &.sw-label--appearance-badged {
         background: transparent;
         border: 0;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         padding: 4px 0;
         line-height: 22px;
 
@@ -107,9 +107,9 @@ $sw-label-pill-border-radius: 50px;
     &.sw-label--warning,
     &.sw-label--neutral {
         &.sw-label--small {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
             line-height: 14px;
-            font-size: $font-size-xxs;
+            font-size: var(--font-size-2xs);
             padding: 0 5px;
             padding-left: 15px;
             height: 16px;
@@ -138,7 +138,7 @@ $sw-label-pill-border-radius: 50px;
     &.sw-label--success:not(&--appearance-badged) {
         @include sw-label-variant(
             var(--color-background-positive-default),
-            var(--color-text-positive-default),
+            var(--color-text-primary-default),
             var(--color-border-positive-default),
             var(--color-border-positive-default)
         );
@@ -156,7 +156,7 @@ $sw-label-pill-border-radius: 50px;
     &.sw-label--warning:not(&--appearance-badged) {
         @include sw-label-variant(
             var(--color-background-attention-default),
-            var(--color-text-attention-default),
+            var(--color-text-primary-default),
             var(--color-border-attention-default),
             var(--color-border-attention-default)
         );
@@ -173,17 +173,17 @@ $sw-label-pill-border-radius: 50px;
 
     &.sw-label--neutral-reversed:not(&--appearance-badged) {
         @include sw-label-variant(
-            var(--color-elevation-surface-floating),
-            var(--color-text-inverse-default),
-            var(--color-elevation-surface-floating),
-            var(--color-elevation-surface-floating)
+            var(--color-elevation-floating-default),
+            var(--color-text-primary-inverse),
+            var(--color-elevation-floating-default),
+            var(--color-elevation-floating-default)
         );
     }
 
     &.sw-label--primary:not(&--appearance-badged) {
         @include sw-label-variant(
             var(--color-interaction-primary-default),
-            var(--color-text-static-default),
+            var(--color-static-white),
             var(--color-interaction-primary-hover),
             var(--color-interaction-primary-default)
         );

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
@@ -2,12 +2,7 @@
 @import "~scss/mixins";
 @import "~scss/variables";
 
-$sw-modal-color-backdrop: rgba(0, 0, 0, 40%);
 $sw-modal-gap: var(--scale-size-64);
-$sw-modal-loader-z-index: $z-index-modal + 1;
-$sw-modal-title-font-size: var(--font-size-m);
-$sw-modal-transition-duration: 0.4s;
-$sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
 
 .sw-modal {
     position: fixed;
@@ -19,7 +14,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
     width: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    background-color: $sw-modal-color-backdrop;
+    background-color: var(--color-elevation-backdrop-default);
     z-index: $z-index-modal;
     outline: none;
     display: flex;
@@ -33,6 +28,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
 
         background-color: var(--color-elevation-surface-raised);
         border-radius: var(--border-radius-card);
+        border: 1px solid var(--color-border-secondary-default);
         color: var(--color-text-primary-default);
         max-height: calc(100vh - #{$sw-modal-gap});
         min-height: 200px;
@@ -90,7 +86,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
     }
 
     .sw-modal__header {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         display: flex;
         flex-shrink: 0;
         flex-direction: row;
@@ -119,8 +115,8 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
         margin: 0;
         color: var(--color-text-secondary-default);
         font-size: var(--font-size-xs);
-        font-weight: var(--font-size-regular);
-        line-height: var(--line-height-xs);
+        font-weight: var(--font-weight-regular);
+        line-height: var(--font-line-height-xs);
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -147,7 +143,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
         }
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
     }
@@ -172,7 +168,7 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
     .sw-modal__footer {
         border-radius: 0 0 var(--border-radius-card) var(--border-radius-card);
         background-color: var(--color-elevation-surface-raised);
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
         display: grid;
         grid-auto-columns: min-content;
         grid-auto-flow: column;
@@ -185,17 +181,17 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
     }
 
     .sw-loader {
-        z-index: $sw-modal-loader-z-index;
+        z-index: $z-index-modal + 1;
     }
 }
 
 // Vue.js Transitions
 .sw-modal-fade-enter-active,
 .sw-modal-fade-leave-active {
-    transition: opacity $sw-modal-transition-duration $sw-modal-transition-timing-function;
+    transition: opacity 0.4s cubic-bezier(0.68, -0.55, 0.26, 1.55);
 
     .sw-modal__dialog {
-        transition: transform $sw-modal-transition-duration $sw-modal-transition-timing-function;
+        transition: transform 0.4s cubic-bezier(0.68, -0.55, 0.26, 1.55);
         transform: scale(1);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-product-image/sw-product-image.scss
@@ -3,10 +3,10 @@
 .sw-product-image {
     position: relative;
     border-radius: $border-radius-default;
-    border: 2px solid $color-gray-300;
+    border: 2px solid var(--color-border-secondary-default);
 
     &.is--placeholder {
-        border: 2px dashed $color-gray-300;
+        border: 2px dashed var(--color-border-primary-default);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -59,7 +59,7 @@
     }
 
     &:hover {
-        background-color: $color-gray-300;
+        background-color: var(--color-background-secondary-default);
 
         .sw-product-image__image {
             opacity: 0.7;
@@ -81,13 +81,13 @@
         visibility: hidden;
 
         .mt-icon {
-            color: $color-white;
+            color: var(--color-static-white);
             height: 100%;
         }
     }
 
     .sw-product-image__placeholder-icon {
-        color: $color-gray-300;
+        color: var(--color-icon-secondary-default);
     }
 
     &::after {
@@ -98,7 +98,7 @@
 
     &.is--cover {
         border-radius: $border-radius-default;
-        border: 2px solid $color-shopware-brand-500;
+        border: 2px solid var(--color-border-brand-default);
     }
 
     // @experimental stableVersion:v6.8.0 feature:SPATIAL_BASES

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/sw-property-search.scss
@@ -13,7 +13,7 @@
         .sw-property-search__tree-selection__group_grid {
             padding-top: 10px;
             border-radius: 0 0 0 $border-radius-default;
-            border-right: 1px solid $color-gray-300;
+            border-right: 1px solid var(--color-border-secondary-default);
         }
 
         .sw-grid-column .sw-grid__cell-content {
@@ -23,7 +23,7 @@
 
         .sw-grid-column.is-selected {
             .sw-grid__cell-content {
-                color: $color-shopware-brand-500;
+                color: var(--color-text-brand-default);
                 font-weight: 900;
             }
         }
@@ -37,7 +37,7 @@
         }
 
         .sw-grid-column {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
 
         .sw-grid-row {
@@ -72,7 +72,7 @@
         }
 
         .sw-grid__pagination {
-            background-color: $color-white;
+            background-color: var(--color-background-primary-default);
 
             .mt-icon {
                 margin: 0;
@@ -133,9 +133,9 @@
         position: absolute;
         z-index: $z-index-flyout;
         border-radius: $border-radius-default;
-        background-color: $color-white;
+        background-color: var(--color-elevation-surface-raised);
         background-clip: padding-box;
-        box-shadow: 0 1px 6px 0 lighten($color-darkgray-200, 30%);
+        box-shadow: 0 1px 6px 0 var(--color-elevation-shadow-default);
     }
 
     .sw-property-search__search-field {
@@ -143,8 +143,8 @@
 
         &-container {
             padding: 30px;
-            border-bottom: 1px solid #d8dde6;
-            background-color: $color-gray-100;
+            border-bottom: 1px solid var(--color-border-secondary-default);
+            background-color: var(--color-background-secondary-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-radio-panel/sw-radio-panel.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-radio-panel/sw-radio-panel.scss
@@ -2,7 +2,7 @@
 @import "~scss/mixins";
 
 .sw-radio-panel {
-    background: $color-white;
+    background: var(--color-background-primary-default);
     display: block;
     position: relative;
     max-width: 300px;
@@ -10,8 +10,8 @@
     .sw-radio-panel__image {
         width: 80px;
         height: 80px;
-        background-color: $color-shopware-brand-50;
-        color: $color-shopware-brand-100;
+        background-color: var(--color-background-brand-default);
+        color: var(--color-icon-brand-default);
         border-radius: 50%;
         margin: 0 auto 15px;
         display: flex;
@@ -21,10 +21,10 @@
 
     .sw-radio-panel__title {
         display: block;
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         font-weight: normal;
         margin: 0 0 12px;
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         transition: all 0.2s ease-in-out;
 
         &.is--truncate {
@@ -36,7 +36,7 @@
 
     .sw-radio-panel__description {
         display: block;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
 
         &.is--truncate {
             @include truncate;
@@ -49,7 +49,7 @@
         display: block;
         padding: 30px;
         height: 100%;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-primary-default);
         border-radius: $border-radius-default;
         text-align: center;
         cursor: pointer;
@@ -62,8 +62,8 @@
         right: 15px;
         width: 15px;
         height: 15px;
-        background-color: $color-gray-100;
-        border: 2px solid $color-gray-300;
+        background-color: var(--color-background-secondary-default);
+        border: 2px solid var(--color-border-primary-default);
         border-radius: 50%;
         transition: all 0.2s ease-in-out;
     }
@@ -75,26 +75,26 @@
         visibility: hidden;
 
         &:checked + .sw-radio-panel__body {
-            border-color: $color-shopware-brand-500;
+            border-color: var(--color-border-brand-default);
 
             .sw-radio-panel__title {
-                color: $color-shopware-brand-500;
+                color: var(--color-text-brand-default);
             }
 
             .sw-radio-panel__radio {
-                border: 5px solid $color-shopware-brand-500;
-                background-color: $color-white;
+                border: 5px solid var(--color-border-brand-default);
+                background-color: var(--color-background-primary-default);
             }
         }
     }
 
     &:hover {
         .sw-radio-panel__title {
-            color: $color-shopware-brand-500;
+            color: var(--color-text-brand-default);
         }
 
         .sw-radio-panel__body {
-            border-color: $color-shopware-brand-500;
+            border-color: var(--color-border-brand-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-deprecated/sw-tabs-deprecated.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-deprecated/sw-tabs-deprecated.scss
@@ -20,7 +20,7 @@
             bottom: 0;
             width: 100%;
             height: 1px;
-            background-color: var(--color-border-primary-default);
+            background-color: var(--color-border-secondary-default);
             pointer-events: none;
         }
 
@@ -35,7 +35,7 @@
         position: absolute;
         bottom: 0;
         height: 2px;
-        background-color: var(--color-border-brand-selected);
+        background-color: var(--color-border-brand-default);
 
         &.has--error {
             background-color: var(--color-border-critical-default);

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.scss
@@ -53,7 +53,7 @@ $sw-side-navigation-item-link-distance: 10px;
     }
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: -2px;
     }
 }
@@ -61,7 +61,7 @@ $sw-side-navigation-item-link-distance: 10px;
 .sw-tabs--vertical .sw-tabs-item {
     padding: $sw-side-navigation-item-link-distance;
     border-bottom: 0 none;
-    border-left: 1px solid var(--color-border-primary-default);
+    border-left: 1px solid var(--color-border-secondary-default);
 }
 
 .sw-tabs--vertical.sw-tabs--align-right .sw-tabs-item {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-user-card/sw-user-card.scss
@@ -1,15 +1,13 @@
-@import "~scss/variables";
-
 .sw-user-card {
     .sw-user-card__metadata-user-name {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-m;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-m);
         margin-bottom: 8px;
     }
 
     .sw-user-card__metadata-item {
         margin-bottom: 8px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-user-card__actions {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-version/sw-version.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-version/sw-version.scss
@@ -1,8 +1,6 @@
 @import "~scss/variables";
 @import "~scss/mixins";
 
-$sw-version-font-size-info: 12px;
-
 .sw-version {
     white-space: nowrap;
     width: 100%;
@@ -11,9 +9,9 @@ $sw-version-font-size-info: 12px;
         @include truncate;
 
         max-width: 200px;
-        color: $color-white;
-        font-size: $font-size-s;
-        font-weight: $font-weight-bold;
+        color: var(--color-static-white);
+        font-size: var(--font-size-s);
+        font-weight: var(--font-weight-bold);
         margin: 0;
         vertical-align: top;
     }
@@ -37,6 +35,6 @@ $sw-version-font-size-info: 12px;
 
         max-width: 200px;
         color: $color-gray-300;
-        font-size: $sw-version-font-size-info;
+        font-size: var(--font-size-2xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/sw-context-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/sw-context-button.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 $sw-context-button-color-text: var(--color-icon-primary-default);
 $sw-context-button-border-radius: var(--border-radius-xs);
 $sw-context-button-color-border: var(--color-border-primary-default);
@@ -11,7 +9,7 @@ $sw-context-button-color-disabled: var(--color-icon-primary-disabled);
     color: $sw-context-button-color-text;
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: var(--scale-size-2);
         border-radius: var(--border-radius-xs);
 
@@ -39,7 +37,7 @@ $sw-context-button-color-disabled: var(--color-icon-primary-disabled);
         border-radius: $sw-context-button-border-radius;
         cursor: pointer;
         height: var(--scale-size-24);
-        line-height: $line-height-sm;
+        line-height: var(--font-line-height-s);
         padding: 0 var(--scale-size-8);
         outline: none;
 

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-divider/sw-context-menu-divider.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-divider/sw-context-menu-divider.scss
@@ -1,9 +1,5 @@
-@import "~scss/variables";
-
-$sw-context-menu-color-border: var(--color-border-primary-default);
-
 .sw_context_menu_divider {
     border: none;
-    border-bottom: 1px solid $sw-context-menu-color-border;
+    border-bottom: 1px solid var(--color-border-secondary-default);
     margin: 5px -10px;
 }

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 $sw-context-menu-color-background-hover: var(--color-background-brand-default);
 $sw-context-menu-color-text: var(--color-text-primary-default);
 $sw-context-menu-color-active: var(--color-text-brand-default);
@@ -22,7 +20,7 @@ $sw-context-menu-color-warning: var(--color-text-attention-default);
     cursor: pointer;
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: var(--scale-size-2);
     }
 
@@ -97,7 +95,7 @@ $sw-context-menu-color-warning: var(--color-text-attention-default);
     }
 
     &.sw-context-menu-item--headline {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         cursor: default;
 
         &:hover {

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu/sw-context-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu/sw-context-menu.scss
@@ -1,6 +1,6 @@
 @import "~scss/variables";
 
-$sw-context-menu-color-border: var(--color-border-primary-default);
+$sw-context-menu-color-border: var(--color-border-secondary-default);
 $sw-context-menu-color-text: var(--color-text-primary-default);
 $sw-context-menu-color-active: var(--color-interaction-primary-default);
 $sw-context-menu-z-index: $z-index-context-menu;
@@ -28,7 +28,7 @@ $sw-context-menu-z-index: $z-index-context-menu;
         border: 1px solid $sw-context-menu-color-border;
         border-radius: 4px;
         text-align: left;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: $sw-context-menu-color-text;
         position: relative;
 

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-column-boolean/sw-data-grid-column-boolean.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-column-boolean/sw-data-grid-column-boolean.scss
@@ -1,8 +1,6 @@
-@import "~scss/variables";
-
 .sw-data-grid-column-boolean {
     .is--active {
-        color: $color-emerald-500;
+        color: var(--color-icon-positive-default);
 
         &.mt-icon {
             width: 16px;
@@ -15,7 +13,7 @@
     }
 
     .is--inactive {
-        color: $color-crimson-500;
+        color: var(--color-icon-critical-default);
 
         &.mt-icon {
             width: 16px;

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -36,7 +36,7 @@
         margin: 0;
         font-size: var(--font-size-xs);
         color: var(--color-text-primary-default);
-        border-right: 1px solid var(--color-border-primary-default);
+        border-right: 1px solid var(--color-border-secondary-default);
         overflow: hidden;
         background-color: var(--color-elevation-surface-default);
 
@@ -46,7 +46,7 @@
     }
 
     &.sw-data-grid--actions .sw-data-grid__cell {
-        border-right: 1px solid var(--color-border-primary-default);
+        border-right: 1px solid var(--color-border-secondary-default);
 
         &:last-child,
         &:nth-last-child(2) {
@@ -99,7 +99,7 @@
             text-decoration: none;
 
             &:focus-visible {
-                outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+                outline: var(--scale-size-2) solid var(--color-border-brand-default);
                 outline-offset: var(--scale-size-2);
                 border-radius: var(--border-radius-2xs);
             }
@@ -166,13 +166,13 @@
         bottom: 0;
         width: 0;
         height: 100%;
-        background-color: var(--color-border-primary-default);
+        background-color: var(--color-border-secondary-default);
         cursor: ew-resize;
         opacity: 0;
         transition: all 0.2s ease-in-out;
 
         &.is--column-resizing {
-            background-color: var(--color-border-brand-selected);
+            background-color: var(--color-border-brand-default);
         }
     }
 
@@ -197,14 +197,14 @@
         position: sticky;
         top: 0;
         background-clip: padding-box;
-        box-shadow: inset 0 -1px 0 var(--color-border-primary-default);
+        box-shadow: inset 0 -1px 0 var(--color-border-secondary-default);
         background-color: var(--color-elevation-surface-default);
         z-index: 6;
         overflow: visible;
 
         &.sw-data-grid__cell--selection {
             z-index: 7;
-            box-shadow: inset -1px -1px 0 0 var(--color-border-primary-default);
+            box-shadow: inset -1px -1px 0 0 var(--color-border-secondary-default);
         }
 
         .sw-data-grid__cell-content {
@@ -250,7 +250,7 @@
         min-width: 88px;
         max-width: 88px;
         border-right: 0;
-        box-shadow: inset -1px 0 0 var(--color-border-primary-default);
+        box-shadow: inset -1px 0 0 var(--color-border-secondary-default);
         overflow: visible;
         z-index: 5;
 
@@ -279,7 +279,7 @@
         right: 0;
         height: var(--scale-size-64);
         z-index: 7;
-        border-bottom: 1px inset var(--color-border-primary-default);
+        border-bottom: 1px inset var(--color-border-secondary-default);
         padding: 20px 12px 20px 100px;
     }
 
@@ -319,8 +319,8 @@
 
             .sw-data-grid__cell {
                 background-color: var(--color-background-brand-default);
-                border-top: 1px solid var(--color-border-brand-selected);
-                border-bottom: 1px solid var(--color-border-brand-selected);
+                border-top: 1px solid var(--color-border-brand-default);
+                border-bottom: 1px solid var(--color-border-brand-default);
             }
 
             .sw-data-grid__cell-content {
@@ -364,7 +364,7 @@
         width: 88px;
         min-width: 88px;
         max-width: 88px;
-        box-shadow: inset 1px 0 0 var(--color-border-primary-default);
+        box-shadow: inset 1px 0 0 var(--color-border-secondary-default);
         overflow: visible;
         z-index: 4;
 
@@ -394,7 +394,7 @@
         border-radius: var(--border-radius-xs);
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
 
@@ -421,7 +421,7 @@
         position: relative;
         width: 48px;
         height: 48px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
         background-color: var(--color-background-primary-default);
         margin-right: 15px;
@@ -445,7 +445,7 @@
     }
 
     .sw-data-grid__cell-settings {
-        box-shadow: inset 1px -1px 0 var(--color-border-primary-default);
+        box-shadow: inset 1px -1px 0 var(--color-border-secondary-default);
         z-index: 7;
     }
 
@@ -569,7 +569,7 @@
 
         .sw-data-grid__cell {
             border-right: 0 none;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
     }
 
@@ -578,10 +578,10 @@
     }
 
     .sw-data-grid__cell--header.sw-data-grid__cell--selection {
-        box-shadow: inset 0 -1px 0 0 var(--color-border-primary-default);
+        box-shadow: inset 0 -1px 0 0 var(--color-border-secondary-default);
     }
 
     .sw-data-grid__cell-settings {
-        box-shadow: inset 0 -1px 0 var(--color-border-primary-default);
+        box-shadow: inset 0 -1px 0 var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.scss
@@ -33,7 +33,7 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
     }
 
     .sw-category-tree-field__label-more .sw-category-tree-field__label-more-property {
-        color: $color-shopware-brand-500;
+        color: var(--color-text-brand-default);
     }
 
     .sw-category-tree-field__label-property {
@@ -76,7 +76,7 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
 
     &.is--disabled {
         .sw-block-field__block {
-            background-color: $color-gray-100;
+            background-color: var(--color-background-tertiary-default);
         }
     }
 }
@@ -85,9 +85,9 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
     overflow-x: hidden;
     height: 350px;
     z-index: 20;
-    border: 1px solid $color-gray-100;
+    border: 1px solid var(--color-border-secondary-default);
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 10%);
-    background-color: $color-white;
+    background-color: var(--color-elevation-surface-raised);
 
     &.sw-popover__wrapper.--placement-bottom-outside {
         transform: translate(0, calc(-100% - 90px));
@@ -125,11 +125,11 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
         }
 
         li.sw-category-tree-field__search-result:hover {
-            background-color: lighten($color-shopware-brand-500, 40);
+            background-color: var(--color-background-brand-default);
         }
 
         li.sw-category-tree-field__search-result.is--focus {
-            background-color: lighten($color-shopware-brand-500, 40);
+            background-color: var(--color-background-brand-default);
         }
 
         li .sw-category-tree-field__search-results-checkbox {
@@ -151,10 +151,10 @@ $sw-category-tree-field-transition-results: all ease-in-out 0.2s;
     }
 
     &.is--disabled {
-        background-color: $color-gray-100;
+        background-color: var(--color-background-tertiary-default);
 
         .sw-label {
-            background-color: $color-gray-100;
+            background-color: var(--color-background-tertiary-default);
         }
 
         &::after {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-many-to-many-assignment-card/sw-many-to-many-assignment-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-many-to-many-assignment-card/sw-many-to-many-assignment-card.scss
@@ -6,7 +6,7 @@
     }
 
     .sw-many-to-many-assignment-card__grid {
-        border-top: 1px solid $color-gray-300;
+        border-top: 1px solid var(--color-border-secondary-default);
         border-radius: 0 0 $border-radius-default $border-radius-default;
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-product-stream-grid-preview {
     &__toolbar {
         z-index: 10;
         height: 83px;
         padding: 25px 35px;
-        background-color: $color-gray-100;
-        border-top: 1px solid $color-gray-300;
+        background-color: var(--color-elevation-surface-sunken);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-sales-channel/sw-extension-teaser-sales-channel.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-sales-channel/sw-extension-teaser-sales-channel.scss
@@ -1,8 +1,6 @@
-@import "~scss/variables";
-
 .sw-extension-teaser-sales-channel {
     display: flex;
-    background: white;
+    background: var(--color-background-primary-default);
     align-items: center;
     justify-content: space-between;
     margin: 10px 0;
@@ -15,29 +13,29 @@
     }
 
     &__icon {
-        background: $color-gray-100;
+        background: var(--color-background-secondary-default);
         width: 64px;
         height: 64px;
         border-radius: 8px;
         margin-right: 30px;
 
         .mt-icon {
-            color: $color-gray-900;
+            color: var(--color-icon-primary-default);
             margin: 20px;
         }
     }
 
     &__item-name {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         margin-bottom: 0;
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         font-weight: normal;
         cursor: pointer;
     }
 
     &__item-description {
-        color: $color-darkgray-200;
-        font-size: $font-size-xs;
+        color: var(--color-text-primary-default);
+        font-size: var(--font-size-xs);
         margin-top: 5px;
         cursor: pointer;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/feedback/sw-ai-copilot-badge/sw-ai-copilot-badge.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/feedback/sw-ai-copilot-badge/sw-ai-copilot-badge.scss
@@ -15,8 +15,8 @@
 
     .sw-ai-copilot-badge__label {
         color: var(--color-text-brand-default);
-        font-size: $font-size-xs;
-        font-weight: $font-weight-medium;
-        line-height: $line-height-sm;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-medium);
+        line-height: var(--font-line-height-s);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/feedback/sw-ai-copilot-warning/sw-ai-copilot-warning.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/feedback/sw-ai-copilot-warning/sw-ai-copilot-warning.scss
@@ -1,8 +1,6 @@
-@import "~scss/variables";
-
 .sw-ai-copilot-warning {
-    font-size: $font-size-xs;
-    color: $color-gray-600;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary-default);
     display: flex;
     align-items: center;
     margin-bottom: 8px;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-range-filter {
     .sw-container {
         grid-template-columns: 1fr;
@@ -12,7 +10,7 @@
     }
 
     &__divider {
-        border-bottom: 1px solid $color-gray-400;
+        border-bottom: 1px solid var(--color-border-secondary-default);
         transform: translateY(calc(-43px / 2));
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/sw-sidebar-filter-panel.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/sw-sidebar-filter-panel.scss
@@ -7,7 +7,7 @@
         align-items: center;
         margin: 0;
         padding: 0 25px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         a {
             float: left;
@@ -23,7 +23,7 @@
         cursor: pointer;
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
             border-radius: var(--border-radius-xs);
         }

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-block-field/sw-block-field.scss
@@ -1,11 +1,8 @@
-@import "~scss/variables";
-
-$sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
-
 .sw-block-field {
     .sw-block-field__block {
         border: 1px solid var(--color-border-primary-default);
-        border-radius: $border-radius-default;
+        border-radius: var(--border-radius-xs);
+        background: var(--color-background-primary-default);
         overflow: hidden;
         height: 48px;
     }
@@ -22,10 +19,10 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
         min-width: 0;
         padding: 12px 16px;
         border: none;
-        background: var(--color-elevation-surface-raised);
+        background: var(--color-background-primary-default);
         font-size: var(--font-size-xs);
         line-height: var(--font-line-height-xs);
-        transition: $sw-field-transition;
+        transition: border-color 0.3s ease-out, background 0.3s ease;
         color: var(--color-text-primary-default);
         outline: none;
         -webkit-appearance: none;
@@ -38,7 +35,7 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
         }
 
         &:disabled {
-            background: var(--color-background-primary-disabled);
+            background: var(--color-background-tertiary-default);
             border-color: var(--color-border-primary-default);
             cursor: default !important;
         }
@@ -51,7 +48,7 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
     &.has--focus {
         .sw-block-field__block {
             outline-offset: var(--scale-size-2);
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
         }
     }
 
@@ -63,7 +60,7 @@ $sw-field-transition: border-color 0.3s ease-out, background 0.3s ease;
             input,
             textarea,
             select {
-                background: var(--color-background-critical);
+                background: var(--color-background-critical-default);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-contextual-field/sw-contextual-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-contextual-field/sw-contextual-field.scss
@@ -1,10 +1,6 @@
-@import "~scss/variables";
-
-$sw-field-transition: border-color 0.3s ease-out;
-
 .sw-contextual-field {
     input:-webkit-autofill {
-        -webkit-box-shadow: 0 0 0 1000px $color-white inset;
+        -webkit-box-shadow: 0 0 0 1000px var(--color-background-primary-default) inset;
     }
 
     .sw-block-field__block {
@@ -17,14 +13,14 @@ $sw-field-transition: border-color 0.3s ease-out;
         justify-content: center;
         align-items: center;
         min-width: 50px;
-        background: $color-gray-50;
-        border-left: 1px solid $color-gray-300;
+        background: var(--color-background-secondary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
         border-right: none;
         line-height: 22px;
         padding: 12px 15px;
-        font-size: $font-size-xs;
-        color: $color-darkgray-200;
-        transition: $sw-field-transition;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-primary-default);
+        transition: border-color 0.3s ease-out;
 
         .mt-icon {
             width: 16px;
@@ -32,14 +28,14 @@ $sw-field-transition: border-color 0.3s ease-out;
         }
 
         &.is--prefix {
-            border-right: 1px solid $color-gray-300;
+            border-right: 1px solid var(--color-border-secondary-default);
             border-left: none;
         }
     }
 
     &.is--disabled {
         .sw-field__addition {
-            background: $color-gray-100;
+            background: var(--color-background-tertiary-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-grouped-single-select/sw-grouped-single-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-grouped-single-select/sw-grouped-single-select.scss
@@ -5,7 +5,7 @@
         font-size: var(--font-size-xs);
         color: var(--color-text-primary-default);
         font-weight: var(--font-weight-medium);
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
 
         &:first-of-type {
             border: 0;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-select/sw-multi-tag-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-tag-select/sw-multi-tag-select.scss
@@ -34,9 +34,9 @@
 
 .sw-multi-tag-select-valid {
     cursor: pointer;
-    background: $color-shopware-brand-50;
+    background: var(--color-background-brand-default);
 }
 
 .sw-multi-tag-select-invalid {
-    background: $color-gray-50;
+    background: var(--color-background-tertiary-default);
 }

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.scss
@@ -4,7 +4,7 @@
     position: relative;
 
     .sw-block-field__block {
-        background-color: var(--color-elevation-surface-raised);
+        background-color: var(--color-background-primary-default);
         position: relative;
         overflow: visible;
     }
@@ -54,7 +54,7 @@
         border-radius: var(--border-radius-xs);
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
 
@@ -111,7 +111,7 @@
 
     &.is--disabled {
         .sw-block-field__block {
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
         }
 
         .sw-label,
@@ -126,7 +126,7 @@
         }
 
         input {
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.scss
@@ -1,7 +1,3 @@
-@import "~scss/variables";
-
-$sw-select-result-list-transition: all ease-in-out 0.2s;
-
 .sw-select-result-list {
     position: absolute;
     top: 0;
@@ -38,12 +34,12 @@ $sw-select-result-list-transition: all ease-in-out 0.2s;
     max-height: 250px;
     overflow-x: hidden;
     overflow-y: auto;
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
-    background-color: var(--color-elevation-surface-overlay);
+    background-color: var(--color-elevation-surface-raised);
     font-size: var(--font-size-xs);
     padding: var(--scale-size-8);
-    border-radius: var(--border-radius-overlay);
+    border-radius: var(--border-radius-xs);
 
     .sw-select-result-list__item-list {
         list-style: none;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
@@ -1,11 +1,3 @@
-@import "~scss/variables";
-
-$sw-select-result-active-color-background: var(--color-background-brand-default);
-$sw-select-result-active-color-text: var(--color-text-primary-default);
-$sw-select-result-color-border: var(--color-border-primary-default);
-$sw-select-result-color-icon: var(--color-text-primary-default);
-$sw-select-result-transition-item-icon: all ease-in-out 0.15s;
-$sw-select-result-disabled-color-background: var(--color-background-primary-disabled);
 $sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
 
 .sw-select-result {
@@ -49,11 +41,11 @@ $sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
     }
 
     &.is--active {
-        background: $sw-select-result-active-color-background;
-        color: $sw-select-result-active-color-text;
+        background: var(--color-background-brand-default);
+        color: var(--color-text-primary-default);
 
         .sw-select-result__result-item-text {
-            color: $sw-select-result-active-color-text;
+            color: var(--color-text-primary-default);
         }
     }
 
@@ -67,7 +59,7 @@ $sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
     }
 
     > .mt-icon {
-        color: $sw-select-result-color-icon;
+        color: var(--color-text-primary-default);
         margin-left: 10px;
         order: 4;
         justify-self: end;
@@ -115,7 +107,7 @@ $sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
         color: $sw-select-result-disabled-color-text;
 
         &.is--active {
-            background: $sw-select-result-disabled-color-background;
+            background: var(--color-background-tertiary-default);
             color: $sw-select-result-disabled-color-text;
             cursor: default;
         }
@@ -136,7 +128,7 @@ $sw-select-result-disabled-color-text: var(--color-text-primary-disabled);
     // Vue.js transitions
     .sw-select-result-appear-enter-active,
     .sw-select-result-appear-leave-active {
-        transition: $sw-select-result-transition-item-icon;
+        transition: all ease-in-out 0.15s;
         transform: translateY(0);
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-selection-list/sw-select-selection-list.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-select-selection-list {
     display: flex;
     flex-wrap: wrap;
@@ -21,7 +19,7 @@
         padding: var(--scale-size-8) var(--scale-size-12);
         margin: 0 var(--scale-size-6) 0 0;
         color: var(--color-text-brand-default);
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 14px;
         border-radius: var(--border-radius-xs);
         height: unset;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-advanced-selection-rule-disabled {
-    color: darken($color-gray-300, 15%);
+    color: var(--color-text-primary-disabled);
 }

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-entity-advanced-selection-modal {
     .sw-modal__body {
         padding: 0;
@@ -22,7 +20,7 @@
             }
 
             &__content {
-                border: 1px solid var(--color-border-primary-default);
+                border: 1px solid var(--color-border-secondary-default);
                 padding: 0;
             }
         }
@@ -49,11 +47,11 @@
         top: 0;
         right: 0;
         transform: translate(50%, -50%);
-        color: $color-white;
-        background-color: $color-shopware-brand-500;
-        font-size: $font-size-xxs;
+        color: var(--color-static-white);
+        background-color: var(--color-interaction-primary-default);
+        font-size: var(--font-size-2xs);
         font-style: normal;
-        font-weight: $font-weight-regular;
+        font-weight: var(--font-weight-regular);
         padding: 0;
         margin: 0;
         width: 16px;
@@ -89,20 +87,20 @@
     .sw-entity-advanced-selection-modal__filter-headline {
         padding: 16px 24px;
         margin: 0;
-        font-size: $font-size-s;
-        font-weight: $font-weight-bold;
-        border-bottom: 1px solid $color-gray-300;
+        font-size: var(--font-size-s);
+        font-weight: var(--font-weight-bold);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-entity-advanced-selection-modal__filter-footer {
-        background-color: $color-gray-100;
+        background-color: var(--color-background-secondary-default);
         padding: 20px 24px;
         text-align: right;
     }
 
     .sw-entity-advanced-selection-modal__filter-reset {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-xs);
     }
 
     .sw-data-grid__actions-menu {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field.scss
@@ -1,12 +1,3 @@
-@import "~scss/variables";
-
-$sw-field-color-text: $color-darkgray-200;
-$sw-field-color-focus: $color-shopware-brand-500;
-$sw-field-color-background: $color-white;
-$sw-field-color-border: $color-gray-300;
-$sw-field-color-error: $color-crimson-500;
-$sw-field-color-inherited: $color-module-purple-900;
-
 .sw-field--checkbox {
     margin-bottom: 22px;
 
@@ -23,7 +14,7 @@ $sw-field-color-inherited: $color-module-purple-900;
         &.is--bordered {
             margin-top: 24px;
             border-radius: 4px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             padding: 15px;
         }
     }
@@ -71,16 +62,16 @@ $sw-field-color-inherited: $color-module-purple-900;
             }
 
             &:disabled ~ .sw-field__checkbox-state {
-                background: $color-gray-100;
-                border-color: $color-gray-300;
-                color: lighten($sw-field-color-text, 40%);
+                background: var(--color-background-tertiary-default);
+                border-color: var(--color-border-primary-default);
+                color: var(--color-text-primary-disabled);
             }
 
             &:checked,
             &:indeterminate {
                 ~ .sw-field__checkbox-state {
-                    background: $sw-field-color-focus;
-                    border-color: $sw-field-color-focus;
+                    background: var(--color-interaction-primary-default);
+                    border-color: var(--color-interaction-primary-default);
 
                     /* stylelint-disable-next-line max-nesting-depth */
                     .mt-icon {
@@ -90,18 +81,18 @@ $sw-field-color-inherited: $color-module-purple-900;
             }
 
             &:checked:disabled ~ .sw-field__checkbox-state {
-                background: $color-gray-100;
-                border-color: $color-gray-300;
-                color: lighten($sw-field-color-text, 40%);
+                background: var(--color-background-tertiary-default);
+                border-color: var(--color-border-primary-default);
+                color: var(--color-text-primary-disabled);
 
                 .mt-icon {
                     display: inline-block;
-                    color: lighten($sw-field-color-text, 40%);
+                    color: var(--color-icon-primary-disabled);
                 }
             }
 
             &:focus ~ .sw-field__checkbox-state {
-                outline: 2px solid $sw-field-color-focus;
+                outline: 2px solid var(--color-border-brand-default);
                 outline-offset: 2px;
             }
         }
@@ -112,9 +103,9 @@ $sw-field-color-inherited: $color-module-purple-900;
             height: 100%;
             z-index: 1;
             text-align: center;
-            background: $sw-field-color-background;
-            color: $sw-field-color-text;
-            border: 1px solid $sw-field-color-border;
+            background: var(--color-background-primary-default);
+            color: var(--color-text-primary-default);
+            border: 1px solid var(--color-border-primary-default);
             border-radius: 4px;
 
             .mt-icon {
@@ -128,41 +119,41 @@ $sw-field-color-inherited: $color-module-purple-900;
                 position: absolute;
                 top: -1px;
                 left: -1px;
-                color: $sw-field-color-background;
+                color: var(--color-static-white);
             }
         }
     }
 
     &.has--error {
         .sw-field__checkbox-state {
-            border: 1px solid $sw-field-color-error;
+            border: 1px solid var(--color-interaction-critical-default);
         }
 
         input[type="checkbox"] {
             &:disabled ~ .sw-field__checkbox-state {
-                border: 1px solid $sw-field-color-error, 5%;
+                border: 1px solid var(--color-border-critical-disabled);
             }
 
             &:checked ~ .sw-field__checkbox-state {
-                border: 1px solid $sw-field-color-error;
-                background-color: $sw-field-color-error;
+                border: 1px solid var(--color-interaction-critical-default);
+                background-color: var(--color-interaction-critical-default);
             }
 
             &:checked:disabled ~ .sw-field__checkbox-state {
-                border: 1px solid $sw-field-color-error;
+                border: 1px solid var(--color-interaction-critical-default);
             }
         }
 
         .sw-field__label {
-            color: $color-crimson-500;
+            color: var(--color-text-critical-default);
         }
     }
 
     &.is--inherited {
         input[type="checkbox"] {
             &:checked ~ .sw-field__checkbox-state {
-                border-color: $sw-field-color-border;
-                background: $sw-field-color-border;
+                border-color: var(--color-border-primary-default);
+                background: var(--color-background-secondary-default);
             }
         }
     }
@@ -183,20 +174,20 @@ $sw-field-color-inherited: $color-module-purple-900;
 .sw-field--checkbox.sw-field__checkbox--ghost {
     .sw-field__checkbox input[type="checkbox"]:not(:checked) ~ .sw-field__checkbox-state {
         background-color: transparent;
-        border: 1px solid $color-shopware-brand-500;
+        border: 1px solid var(--color-border-brand-default);
 
         .mt-icon {
             display: inline-block;
-            color: $color-shopware-brand-500;
+            color: var(--color-icon-brand-default);
         }
     }
 
     &.is--disabled {
         .sw-field__checkbox input[type="checkbox"]:not(:checked) ~ .sw-field__checkbox-state {
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
 
             .mt-icon {
-                color: $color-gray-300;
+                color: var(--color-icon-primary-disabled);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-code-editor/sw-code-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-code-editor/sw-code-editor.scss
@@ -69,7 +69,7 @@
 
     &.is--disabled {
         .sw-code-editor__editor {
-            background-color: var(--color-gray-100);
+            background-color: var(--color-background-tertiary-default);
 
             &::after {
                 content: "";

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker-deprecated/sw-colorpicker.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable */
 @import '~scss/variables';
-@import '~scss/mixins';
 
 .sw-colorpicker {
     position: relative;
@@ -61,8 +60,8 @@
 
             &-label {
                 text-align: center;
-                color: $color-darkgray-200;
-                font-size: $font-size-xs;
+                color: var(--color-text-primary-default);
+                font-size: var(--font-size-xs);
                 margin-top: 2px;
                 user-select: none;
                 -moz-user-select: none;
@@ -93,10 +92,10 @@
     &__colorpicker {
         width: 260px;
         padding: 10px;
-        border: 1px solid $color-gray-300;
-        background-color: $color-white;
+        border: 1px solid var(--color-border-secondary-default);
+        background-color: var(--color-elevation-surface-raised);
         border-radius: $border-radius-default;
-        box-shadow: 0 3px 6px 0 rgba(120, 138, 155, 0.5);
+        box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
 
         &::before {
             content: '';
@@ -105,10 +104,10 @@
             height: 12px;
             top: -6px;
             left: 20px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-bottom: none;
             border-right: none;
-            background: $color-white;
+            background: var(--color-elevation-surface-raised);
             transform: rotate(45deg);
         }
 
@@ -127,7 +126,7 @@
             display: block;
             width: 238px;
             height: 150px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
             background-image: linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
                 linear-gradient(0deg, #000, rgba(0, 0, 0, 0) 50%),
@@ -141,7 +140,7 @@
             height: 18px;
             border: 3px solid #fff;
             border-radius: 50%;
-            box-shadow: 0 0 5px $color-shopware-brand-500;
+            box-shadow: 0 0 5px var(--color-border-brand-default);
             cursor: grab;
 
             &:active {
@@ -171,7 +170,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             -webkit-appearance: none;
             cursor: pointer;
@@ -181,7 +180,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             cursor: pointer;
         }
@@ -215,7 +214,7 @@
             display: inline-block;
             width: 58px;
             height: 58px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: $border-radius-default;
         }
 
@@ -224,7 +223,7 @@
             display: inline-block;
             width: 58px;
             height: 58px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: $border-radius-default;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 90 90' width='100%25' height='100%25'%3E%3Crect width='30' height='30' x='00' y='00' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='30' y='30' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='60' y='00' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='60' y='60' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='00' y='60' fill='%23cdd5db' /%3E%3C/svg%3E");
 
@@ -244,10 +243,10 @@
             min-width: 0;
             height: 32px;
             padding: 0 5px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
-            font-size: $font-size-xs;
-            color: $color-darkgray-200;
+            font-size: var(--font-size-xs);
+            color: var(--color-text-primary-default);
             outline: none;
 
             &[type='number'] {
@@ -268,7 +267,7 @@
             }
 
             &:focus {
-                border-color: $color-shopware-brand-500;
+                border-color: var(--color-border-brand-default);
             }
         }
     }
@@ -277,7 +276,7 @@
         width: 100%;
         height: 20px;
         margin-top: 10px;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-primary-default);
         border-radius: $border-radius-default;
         background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='100%25' height='100%25'%3E%3Crect width='10' height='10' x='00' y='00' fill='%23cdd5db' /%3E%3Crect width='10' height='10' x='10' y='10' fill='%23cdd5db' /%3E%3C/svg%3E");
         outline: none;
@@ -287,7 +286,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             -webkit-appearance: none;
             cursor: pointer;
@@ -296,7 +295,7 @@
         &::-moz-range-thumb {
             height: 26px;
             width: 8px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
             background: #fff;
             cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-colorpicker/sw-colorpicker.scss
@@ -1,6 +1,5 @@
 /* stylelint-disable */
 @import "~scss/variables";
-@import "~scss/mixins";
 
 .sw-colorpicker {
     position: relative;
@@ -57,8 +56,8 @@
 
             &-label {
                 text-align: center;
-                color: $color-darkgray-200;
-                font-size: $font-size-xs;
+                color: var(--color-text-primary-default);
+                font-size: var(--font-size-xs);
                 margin-top: 2px;
                 user-select: none;
                 -moz-user-select: none;
@@ -89,10 +88,10 @@
     &__colorpicker {
         width: 260px;
         padding: 10px;
-        border: 1px solid $color-gray-300;
-        background-color: $color-white;
+        border: 1px solid var(--color-border-secondary-default);
+        background-color: var(--color-elevation-surface-raised);
         border-radius: $border-radius-default;
-        box-shadow: 0 3px 6px 0 rgba(120, 138, 155, 0.5);
+        box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
 
         &::before {
             content: '';
@@ -101,10 +100,10 @@
             height: 12px;
             top: -6px;
             left: 20px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-bottom: none;
             border-right: none;
-            background: $color-white;
+            background: var(--color-elevation-surface-raised);
             transform: rotate(45deg);
         }
 
@@ -123,7 +122,7 @@
             display: block;
             width: 238px;
             height: 150px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
             background-image:
                 linear-gradient(180deg, #fff, rgba(255, 255, 255, 0) 50%),
@@ -138,7 +137,7 @@
             height: 18px;
             border: 3px solid #fff;
             border-radius: 50%;
-            box-shadow: 0 0 5px $color-shopware-brand-500;
+            box-shadow: 0 0 5px var(--color-border-brand-default);
             cursor: grab;
 
             &:active {
@@ -159,7 +158,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             -webkit-appearance: none;
             cursor: pointer;
@@ -169,7 +168,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             cursor: pointer;
         }
@@ -203,7 +202,7 @@
             display: inline-block;
             width: 58px;
             height: 58px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: $border-radius-default;
         }
 
@@ -212,7 +211,7 @@
             display: inline-block;
             width: 58px;
             height: 58px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: $border-radius-default;
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 90 90' width='100%25' height='100%25'%3E%3Crect width='30' height='30' x='00' y='00' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='30' y='30' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='60' y='00' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='60' y='60' fill='%23cdd5db' /%3E%3Crect width='30' height='30' x='00' y='60' fill='%23cdd5db' /%3E%3C/svg%3E");
 
@@ -232,10 +231,10 @@
             min-width: 0;
             height: 32px;
             padding: 0 5px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
-            font-size: $font-size-xs;
-            color: $color-darkgray-200;
+            font-size: var(--font-size-xs);
+            color: var(--color-text-primary-default);
             outline: none;
 
             &[type=number] {
@@ -256,7 +255,7 @@
             }
 
             &:focus {
-                border-color: $color-shopware-brand-500;
+                border-color: var(--color-border-brand-default);
             }
         }
     }
@@ -265,7 +264,7 @@
         width: 100%;
         height: 20px;
         margin-top: 10px;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-primary-default);
         border-radius: $border-radius-default;
         background-image: url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' width='100%25' height='100%25'%3E%3Crect width='10' height='10' x='00' y='00' fill='%23cdd5db' /%3E%3Crect width='10' height='10' x='10' y='10' fill='%23cdd5db' /%3E%3C/svg%3E");
         outline: none;
@@ -275,7 +274,7 @@
             height: 26px;
             width: 8px;
             border-radius: $border-radius-default;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             background: #fff;
             -webkit-appearance: none;
             cursor: pointer;
@@ -284,7 +283,7 @@
         &::-moz-range-thumb {
             height: 26px;
             width: 8px;
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $border-radius-default;
             background: #fff;
             cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-compact-colorpicker/sw-compact-colorpicker.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-compact-colorpicker/sw-compact-colorpicker.scss
@@ -1,6 +1,3 @@
-@import "~scss/variables";
-@import "~scss/mixins";
-
 .sw-field.sw-field--compact-colorpicker {
     margin-bottom: 0;
 
@@ -29,7 +26,7 @@
 
     .sw-colorpicker__previewWrapper {
         position: initial;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 2px;
         height: 16px;
         width: 16px;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker-deprecated/sw-datepicker.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker-deprecated/sw-datepicker.scss
@@ -1,16 +1,7 @@
-@import "~scss/variables";
-
-$sw-datepicker-color-border: $color-gray-300;
-$sw-datepicker-color-font: $color-darkgray-200;
-$sw-datepicker-color-disabled-font: #b3bfcc;
-$sw-datepicker-color-hover: $color-shopware-brand-500;
-$sw-datepicker-color-selected: #e6e6e6;
-$sw-datepicker-color-text-selected: $color-white;
-
 @mixin flatpickr-day-hovered {
-    color: $sw-datepicker-color-text-selected;
-    background-color: $sw-datepicker-color-hover;
-    border-color: $color-shopware-brand-500;
+    color: var(--color-static-white);
+    background-color: var(--color-interaction-primary-default);
+    border-color: var(--color-border-brand-default);
 }
 
 .sw-field--datepicker {
@@ -21,7 +12,7 @@ $sw-datepicker-color-text-selected: $color-white;
 
         .mt-icon {
             &:hover {
-                color: darken($sw-datepicker-color-font, 20%);
+                color: var(--color-icon-primary-default);
             }
         }
     }
@@ -54,9 +45,9 @@ $sw-datepicker-color-text-selected: $color-white;
 }
 
 .flatpickr-calendar {
-    color: $sw-datepicker-color-font;
-    box-shadow: 0 3px 6px 0 rgba(120, 138, 155, 30%);
-    border: 1px solid $sw-datepicker-color-border;
+    color: var(--color-text-primary-default);
+    box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
+    border: 1px solid var(--color-border-secondary-default);
     border-radius: 4px;
 
     &::before,
@@ -71,15 +62,15 @@ $sw-datepicker-color-text-selected: $color-white;
         .flatpickr-monthDropdown-months {
             padding-top: 2px;
             padding-bottom: 4px;
-            font-weight: $font-weight-semi-bold;
-            color: $color-darkgray-200;
+            font-weight: var(--font-weight-semibold);
+            color: var(--color-text-primary-default);
             text-align: right;
             -moz-appearance: none;
             -webkit-appearance: none;
             line-height: 1.2;
 
             option {
-                font-weight: $font-weight-regular;
+                font-weight: var(--font-weight-regular);
             }
         }
 
@@ -89,13 +80,13 @@ $sw-datepicker-color-text-selected: $color-white;
 
             &:hover {
                 svg {
-                    fill: $color-shopware-brand-500;
+                    fill: var(--color-icon-brand-default);
                 }
             }
         }
 
         .cur-year {
-            color: $color-darkgray-200;
+            color: var(--color-text-primary-default);
         }
     }
 
@@ -111,7 +102,7 @@ $sw-datepicker-color-text-selected: $color-white;
     .flatpickr-weekday {
         font-size: inherit;
         color: inherit;
-        font-weight: $font-weight-regular;
+        font-weight: var(--font-weight-regular);
     }
 
     .flatpickr-day {
@@ -119,7 +110,7 @@ $sw-datepicker-color-text-selected: $color-white;
         margin-bottom: 6px;
 
         &:not(.flatpickr-disabled) {
-            color: $sw-datepicker-color-font;
+            color: var(--color-text-primary-default);
         }
 
         &:hover {
@@ -127,8 +118,8 @@ $sw-datepicker-color-text-selected: $color-white;
         }
 
         &.selected {
-            background-color: $sw-datepicker-color-selected;
-            border-color: $sw-datepicker-color-border;
+            background-color: var(--color-background-secondary-default);
+            border-color: var(--color-border-secondary-default);
 
             &:hover {
                 @include flatpickr-day-hovered;
@@ -138,7 +129,7 @@ $sw-datepicker-color-text-selected: $color-white;
         &.prevMonthDay,
         &.nextMonthDay {
             &:not(.flatpickr-disabled) {
-                color: $sw-datepicker-color-disabled-font;
+                color: var(--color-text-secondary-default);
             }
 
             &:hover {
@@ -147,14 +138,14 @@ $sw-datepicker-color-text-selected: $color-white;
         }
 
         &.today {
-            border-color: $color-gray-300;
+            border-color: var(--color-border-secondary-default);
 
             &:hover {
                 @include flatpickr-day-hovered;
             }
 
             &.selected {
-                background-color: $sw-datepicker-color-selected;
+                background-color: var(--color-background-secondary-default);
 
                 &:hover {
                     @include flatpickr-day-hovered;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-modal.sw-maintain-currencies-modal {
     .sw-modal__dialog {
         max-width: 1170px;
@@ -7,7 +5,7 @@
 
     .sw-modal__body {
         padding: 0;
-        border-bottom: 1px solid $color-gray-300;
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-data-grid__cell--header {
             border-width: 0;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/sw-price-field.scss
@@ -1,10 +1,3 @@
-@import "~scss/variables";
-
-$sw-price-field-lock-color-default: $color-darkgray-200;
-$sw-price-field-lock-color-locked: $color-shopware-brand-500;
-$sw-price-field-suffix-font-size: 20px;
-$sw-price-field-suffix-font-weight: $font-weight-regular;
-
 .sw-price-field {
     .price-field-grid {
         display: grid;
@@ -17,16 +10,16 @@ $sw-price-field-suffix-font-weight: $font-weight-regular;
         height: 45px;
         background: none;
         border: none;
-        color: $sw-price-field-lock-color-default;
+        color: var(--color-icon-primary-default);
         outline: none;
         cursor: pointer;
 
         &.is--locked {
-            color: $sw-price-field-lock-color-locked;
+            color: var(--color-icon-brand-default);
         }
 
         &.is--disabled {
-            color: $color-gray-700;
+            color: var(--color-icon-primary-disabled);
             cursor: default;
         }
 
@@ -37,8 +30,8 @@ $sw-price-field-suffix-font-weight: $font-weight-regular;
 
     .sw-field {
         .sw-field__addition {
-            font-weight: $sw-price-field-suffix-font-weight;
-            font-size: $sw-price-field-suffix-font-size;
+            font-weight: var(--font-weight-regular);
+            font-size: var(--font-size-l);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.scss
@@ -43,7 +43,7 @@
 
     &.sw-field--radio-bordered .sw-field__radio-group {
         border-radius: var(--border-radius-xs);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         padding: var(--scale-size-12) var(--scale-size-16);
         margin-bottom: 0;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/sw-select-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-field-deprecated/sw-select-field.scss
@@ -1,13 +1,3 @@
-@import "~scss/variables";
-
-$sw-select-field-color-text: $color-darkgray-200;
-$sw-select-field-color-text-disabled: $color-gray-300;
-$sw-select-field-color-focus: $color-shopware-brand-500;
-$sw-select-field-border-radius: $border-radius-default;
-$sw-select-field-color-background: $color-white;
-$sw-select-field-color-border: $color-gray-300;
-$sw-select-field-color-error: $color-crimson-500;
-
 .sw-field.sw-field--select {
     .sw-block-field__block {
         width: 100%;
@@ -19,7 +9,7 @@ $sw-select-field-color-error: $color-crimson-500;
             top: calc(50% - 10px);
             right: 12px;
             text-align: center;
-            color: $sw-select-field-color-text;
+            color: var(--color-icon-primary-default);
             pointer-events: none;
 
             .mt-icon {
@@ -46,31 +36,31 @@ $sw-select-field-color-error: $color-crimson-500;
     }
 
     .sw-field--select__placeholder-option {
-        color: lighten($sw-select-field-color-text, 25);
+        color: var(--color-text-secondary-default);
     }
 
     select {
         padding-right: 30px;
 
         option {
-            color: $sw-select-field-color-text;
-            background-color: $sw-select-field-color-background;
+            color: var(--color-text-primary-default);
+            background-color: var(--color-background-primary-default);
         }
 
         option:disabled {
-            color: $sw-select-field-color-text-disabled;
+            color: var(--color-text-primary-disabled);
         }
 
         &.is--placeholder {
-            color: lighten($sw-select-field-color-text, 25%);
+            color: var(--color-text-secondary-default);
         }
     }
 
     .sw-field--select__load-placeholder {
         height: 45px;
-        border-radius: $sw-select-field-border-radius;
-        border: 1px solid $sw-select-field-color-border;
-        background: $sw-select-field-color-background;
+        border-radius: var(--border-radius-xs);
+        border: 1px solid var(--color-border-primary-default);
+        background: var(--color-background-primary-default);
         appearance: none;
         user-select: none;
         position: relative;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-select-option/sw-select-option.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-select-option/sw-select-option.scss
@@ -1,16 +1,6 @@
-@import "~scss/variables";
-
-$sw-select-option-active-color-background: lighten($color-shopware-brand-500, 40%);
-$sw-select-option-active-color-text: $color-shopware-brand-500;
-$sw-select-option-color-border: $color-gray-300;
-$sw-select-option-color-icon: darken($color-gray-100, 20%);
-$sw-select-option-transition-item-icon: all ease-in-out 0.15s;
-$sw-select-option-disabled-color-background: $color-gray-100;
-$sw-select-option-disabled-color-text: darken($color-gray-300, 15%);
-
 .sw-select-option {
     padding: 12px 15px;
-    border-bottom: 1px solid $sw-select-option-color-border;
+    border-bottom: 1px solid var(--color-border-secondary-default);
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -22,23 +12,23 @@ $sw-select-option-disabled-color-text: darken($color-gray-300, 15%);
     }
 
     .mt-icon {
-        color: $sw-select-option-color-icon;
+        color: var(--color-icon-secondary-default);
         flex-grow: 0;
         flex-shrink: 0;
         margin-left: 10px;
     }
 
     &.is--active {
-        background: $sw-select-option-active-color-background;
-        color: $sw-select-option-active-color-text;
+        background: var(--color-background-brand-default);
+        color: var(--color-text-primary-default);
     }
 
     &.is--disabled {
-        color: $sw-select-option-disabled-color-text;
+        color: var(--color-text-primary-disabled);
 
         &.is--active {
-            background: $sw-select-option-disabled-color-background;
-            color: $sw-select-option-disabled-color-text;
+            background: var(--color-background-tertiary-default);
+            color: var(--color-text-primary-disabled);
             cursor: default;
         }
     }
@@ -50,7 +40,7 @@ $sw-select-option-disabled-color-text: darken($color-gray-300, 15%);
     // Vue.js transitions
     .sw-select-option-appear-enter-active,
     .sw-select-option-appear-leave-active {
-        transition: $sw-select-option-transition-item-icon;
+        transition: all ease-in-out 0.15s;
         transform: translateY(0);
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-snippet-field {
     .sw-block-field input {
         padding-right: 32px;
@@ -18,7 +16,7 @@
         position: absolute;
         right: 16px;
         bottom: 16px;
-        color: $color-shopware-brand-500;
+        color: var(--color-icon-brand-default);
         cursor: pointer;
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.scss
@@ -1,9 +1,3 @@
-@import "~scss/variables";
-
-$sw-field--switch-color-border: var(--color-border-primary-default);
-$sw-field--switch-color-background: var(--color-icon-static-default);
-$sw-field--switch-color-text: var(--color-text-primary-default);
-$sw-field--switch-color-focus: var(--color-interaction-primary-default);
 $sw-field--switch-color-error: var(--color-interaction-critical-default);
 
 .sw-field--switch {
@@ -37,12 +31,12 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
         display: grid;
         grid-template-columns: 24px 1fr auto;
         align-items: center;
-        color: $sw-field--switch-color-text;
+        color: var(--color-text-primary-default);
     }
 
     &.sw-field--switch-bordered .sw-field--switch__content {
         border-radius: 4px;
-        border: 1px solid $sw-field--switch-color-border;
+        border: 1px solid var(--color-border-secondary-default);
         padding: 0 16px;
         min-height: 46px;
     }
@@ -84,7 +78,7 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
             }
 
             &:checked ~ .sw-field__switch-state {
-                background: $sw-field--switch-color-focus;
+                background: var(--color-interaction-primary-default);
 
                 .sw-field__switch-state-knob {
                     left: 10px;
@@ -112,7 +106,7 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
                 position: absolute;
                 top: 3px;
                 left: 3px;
-                background: $sw-field--switch-color-background;
+                background: var(--color-static-white);
                 border-radius: 7px;
             }
         }
@@ -161,7 +155,7 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
                 background: $sw-field--switch-color-error;
 
                 .sw-field__switch-state-knob {
-                    background: var(--color-icon-static-default);
+                    background: var(--color-static-white);
                 }
             }
 
@@ -196,7 +190,7 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
     &.is--inherited {
         input[type="checkbox"] {
             &:checked ~ .sw-field__switch-state {
-                background: $sw-field--switch-color-border;
+                background: var(--color-border-primary-default);
             }
         }
     }
@@ -204,7 +198,7 @@ $sw-field--switch-color-error: var(--color-interaction-critical-default);
     &:focus-within {
         .sw-field__switch-state {
             outline-offset: var(--scale-size-2);
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-table-toolbar/sw-text-editor-table-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-table-toolbar/sw-text-editor-table-toolbar.scss
@@ -7,7 +7,7 @@
         grid-auto-flow: column dense;
         height: 36px;
         user-select: none;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         grid-auto-columns: 32px;
 
         .sw-text-editor-table-toolbar__button {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.scss
@@ -43,7 +43,7 @@
     left: var(--flyoutLinkLeftOffset, 0);
     top: calc(100% + 6px);
     white-space: nowrap;
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
     z-index: 260;
 
@@ -56,8 +56,8 @@
         width: 8px;
         transform: rotate(45deg);
         background: var(--color-elevation-surface-raised);
-        border-top: 1px solid var(--color-border-primary-default);
-        border-left: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
     }
 
     &-inner-container {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-table-button/sw-text-editor-toolbar-table-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-table-button/sw-text-editor-toolbar-table-button.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-text-editor-toolbar-table-button {
     padding: 12px;
 
@@ -22,7 +20,7 @@
     .sw-text-editor-toolbar-table-button__grid-info {
         white-space: pre-wrap;
         color: var(--color-text-secondary-default);
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
     }
 
     .sw-text-editor-toolbar-table-button__table {
@@ -30,7 +28,7 @@
         cursor: pointer;
         border-radius: 2px;
         border-style: hidden;
-        box-shadow: 0 0 0 1px var(--color-border-primary-default);
+        box-shadow: 0 0 0 1px var(--color-border-secondary-default);
         margin-top: 22px;
 
         .sw-text-editor-toolbar-table-button__col-placeholder {
@@ -40,13 +38,13 @@
 
         .sw-text-editor-toolbar-table-button__table-head {
             .sw-text-editor-toolbar-table-button__col {
-                border: 1px solid var(--color-border-primary-default);
+                border: 1px solid var(--color-border-secondary-default);
                 background: var(--color-background-secondary-default);
             }
         }
 
         .sw-text-editor-toolbar-table-button__col {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
 
             &.is--selected {
                 background: var(--color-background-brand-default);

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/sw-text-editor-toolbar.scss
@@ -1,10 +1,8 @@
-$sw-text-editor-toolbar-item-color-boxed: var(--color-icon-secondary-default);
-
 .sw-text-editor-toolbar {
     padding: 0 6px;
     background: var(--color-elevation-floating-default);
     border-radius: 4px;
-    color: var(--color-icon-inverse-default);
+    color: var(--color-icon-primary-inverse);
     display: grid;
     grid-auto-flow: column dense;
     grid-auto-columns: min-content;
@@ -34,8 +32,8 @@ $sw-text-editor-toolbar-item-color-boxed: var(--color-icon-secondary-default);
         left: 0;
         position: initial;
         background: var(--color-background-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
-        color: $sw-text-editor-toolbar-item-color-boxed;
+        border-bottom: 1px solid var(--color-border-secondary-default);
+        color: var(--color-icon-secondary-default);
         display: grid;
         grid-template-columns: auto;
 
@@ -45,11 +43,11 @@ $sw-text-editor-toolbar-item-color-boxed: var(--color-icon-secondary-default);
 
         .sw-text-editor-buttons {
             &.is--middle {
-                border-left: 1px solid var(--color-border-primary-default);
+                border-left: 1px solid var(--color-border-secondary-default);
             }
 
             &.is--right {
-                border-left: 1px solid var(--color-border-primary-default);
+                border-left: 1px solid var(--color-border-secondary-default);
             }
         }
     }
@@ -63,12 +61,12 @@ $sw-text-editor-toolbar-item-color-boxed: var(--color-icon-secondary-default);
         }
 
         &.is--middle {
-            border-left: 1px solid var(--color-border-primary-default);
+            border-left: 1px solid var(--color-border-secondary-default);
             padding-left: 1px;
         }
 
         &.is--right {
-            border-left: 1px solid var(--color-border-primary-default);
+            border-left: 1px solid var(--color-border-secondary-default);
             padding-left: 1px;
             justify-self: end;
         }

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.scss
@@ -19,9 +19,9 @@
         display: inline-block;
         border-radius: $border-radius-default;
         padding: 2px 24px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         outline: none;
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         vertical-align: middle;
         text-decoration: none;
         user-select: none;
@@ -32,7 +32,7 @@
 
         &-primary {
             background-color: var(--color-interaction-primary-default);
-            color: var(--color-text-static-default);
+            color: var(--color-static-white);
         }
 
         &-secondary {
@@ -41,7 +41,7 @@
         }
 
         &-sm {
-            line-height: $line-height-lg;
+            line-height: var(--font-line-height-l);
         }
     }
 
@@ -57,7 +57,7 @@
         .sw-text-editor__label {
             display: block;
             line-height: 16px;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             margin-bottom: 8px;
             color: var(--color-text-secondary-default);
             user-select: none;
@@ -166,7 +166,7 @@
         h4,
         h5,
         h6 {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
             color: var(--color-text-primary-default);
             letter-spacing: 0;
             margin-bottom: 0;
@@ -179,49 +179,49 @@
         }
 
         h2 {
-            font-size: $font-size-3xl;
+            font-size: var(--font-size-2xl);
             line-height: 34px;
             margin-top: 30px;
         }
 
         h3 {
-            font-size: $font-size-xl;
+            font-size: var(--font-size-xl);
             line-height: 33px;
             margin-top: 28px;
         }
 
         h4 {
-            font-size: $font-size-l;
-            line-height: $line-height-md;
+            font-size: var(--font-size-l);
+            line-height: var(--font-line-height-m);
             margin-top: 24px;
         }
 
         h5 {
-            font-size: $font-size-s;
+            font-size: var(--font-size-s);
             line-height: 21px;
             margin-top: 22px;
         }
 
         h6 {
-            font-size: $font-size-xs;
-            line-height: $line-height-sm;
+            font-size: var(--font-size-xs);
+            line-height: var(--font-line-height-s);
             margin-top: 22px;
         }
 
         p,
         div {
             font-weight: normal;
-            font-size: $font-size-s;
-            line-height: $line-height-md;
+            font-size: var(--font-size-s);
+            line-height: var(--font-line-height-m);
             color: var(--color-text-primary-default);
             letter-spacing: 0;
             margin-top: 16px;
         }
 
         blockquote {
-            font-size: $font-size-s;
+            font-size: var(--font-size-s);
             font-style: italic;
-            line-height: $line-height-md;
+            line-height: var(--font-line-height-m);
             color: var(--color-text-primary-default);
             margin-left: 20px;
             position: relative;
@@ -246,8 +246,8 @@
 
             li {
                 font-weight: normal;
-                font-size: $font-size-s;
-                line-height: $line-height-md;
+                font-size: var(--font-size-s);
+                line-height: var(--font-line-height-m);
                 color: var(--color-text-primary-default);
                 margin-bottom: 8px;
             }
@@ -262,7 +262,7 @@
             margin-left: auto;
             margin-right: auto;
             margin-top: 16px;
-            border: 2px solid var(--color-border-primary-default);
+            border: 2px solid var(--color-border-secondary-default);
         }
 
         & > *:first-child {
@@ -299,7 +299,7 @@
 
     .sw-text-editor-table__row {
         .sw-text-editor-table__col {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             min-width: 15px;
             min-height: 15px;
             position: relative;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field.scss
@@ -1,7 +1,3 @@
-@import "~scss/variables";
-
-$sw-field-color-secure: $color-emerald-500;
-
 .sw-field {
     &__url-input__prefix {
         display: inline-flex;
@@ -11,7 +7,7 @@ $sw-field-color-secure: $color-emerald-500;
         padding: 12px 15px;
 
         &.is--ssl {
-            color: $sw-field-color-secure;
+            color: var(--color-text-positive-default);
         }
 
         .mt-icon {

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-pagination/sw-pagination.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-pagination/sw-pagination.scss
@@ -1,10 +1,7 @@
-@import "~scss/variables";
-
 $sw-pagination-color-background: var(--color-elevation-surface-raised);
-$sw-pagination-controls-color-border: var(--color-border-primary-default);
+$sw-pagination-controls-color-border: var(--color-border-secondary-default);
 $sw-pagination-controls-color-hover: var(--color-interaction-primary-default);
 $sw-pagination-controls-color-text: var(--color-text-primary-default);
-$sw-pagination-border-radius: var(--border-radius-xs);
 
 .sw-pagination {
     min-height: 64px;
@@ -86,7 +83,7 @@ $sw-pagination-border-radius: var(--border-radius-xs);
 
         &.is-active {
             background: $sw-pagination-controls-color-hover;
-            color: #fff;
+            color: var(--color-static-white);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-image-slider/sw-image-slider.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-image-slider/sw-image-slider.scss
@@ -28,11 +28,11 @@
         }
 
         &.is--bordered {
-            border: 1px solid #ccc;
+            border: 1px solid var(--color-border-secondary-default);
         }
 
         &.is--active {
-            border: 1px solid $color-shopware-brand-500;
+            border: 1px solid var(--color-border-brand-default);
             border-radius: $border-radius-default;
         }
     }
@@ -78,14 +78,14 @@
             margin: 12px 6px;
             border: 0 none;
             border-radius: 100%;
-            background: $color-gray-500;
+            background: var(--color-icon-secondary-default);
             transition: background 0.3s ease-out;
             outline: none;
             cursor: pointer;
             text-indent: -9999px;
 
             &.is--active {
-                background: $color-darkgray-100;
+                background: var(--color-icon-primary-default);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-add-thumbnail-form/sw-media-add-thumbnail-form.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-add-thumbnail-form/sw-media-add-thumbnail-form.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-media-add-thumbnail-form-lock-color-default: $color-darkgray-200;
-$sw-media-add-thumbnail-form-lock-color-locked: $color-shopware-brand-500;
-
 .sw-media-add-thumbnail-form {
     display: grid;
     grid-template-columns: 1fr auto;
@@ -33,12 +28,12 @@ $sw-media-add-thumbnail-form-lock-color-locked: $color-shopware-brand-500;
             height: 32px;
             background: none;
             border: none;
-            color: $sw-media-add-thumbnail-form-lock-color-default;
+            color: var(--color-icon-primary-default);
             outline: none;
             cursor: pointer;
 
             &.is--locked {
-                color: $sw-media-add-thumbnail-form-lock-color-locked;
+                color: var(--color-icon-brand-default);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -3,19 +3,14 @@
 
 $sw-media-base-item-color: var(--color-text-primary-default);
 $sw-media-base-item-border-radius: $border-radius-default;
-$sw-media-base-item-small-font-size: $font-size-xs;
-$sw-media-base-item-color-border: var(--color-border-primary-default);
-$sw-media-base-item-color-text-inline-input: var(--color-text-primary-default);
+$sw-media-base-item-color-border: var(--color-border-secondary-default);
 $sw-media-base-item-color-context-button: var(--color-elevation-surface-raised);
 $sw-media-base-item-color-loading-indicator: var(--color-text-primary-default);
 $sw-media-base-item-color-hover: var(--color-background-brand-default);
 $sw-media-base-item-color-metadata: var(--color-text-secondary-default);
 $sw-media-base-item-pseudo-padding: 33px;
-$sw-media-base-item-color-input-background: var(--color-elevation-surface-raised);
 $sw-media-base-item-color-input-border: var(--color-border-primary-default);
-$sw-media-base-item-border-radius-input: $border-radius-default;
 $sw-media-base-item-color-selected: var(--color-border-brand-default);
-$sw-media-base-item-color-checkmark: var(--color-static-white);
 $sw-media-base-item-color-input: var(--color-text-primary-default);
 $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
 
@@ -98,7 +93,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         max-width: 100%;
         margin: 15px 0 5px;
         text-align: center;
-        font-size: $sw-media-base-item-small-font-size;
+        font-size: var(--font-size-xs);
 
         .sw-media-base-item__name {
             @include truncate;
@@ -194,7 +189,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
             overflow: hidden;
             margin: 0;
             text-align: left;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
 
             .sw-media-base-item__name-field input {
                 text-align: unset;
@@ -202,7 +197,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-media-base-item__name {
-            line-height: $line-height-xs;
+            line-height: var(--font-line-height-xs);
         }
 
         .sw-media-base-item__metadata-container {
@@ -210,7 +205,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
             margin: -5px 0 0;
             text-align: left;
             color: $sw-media-base-item-color-metadata;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
 
         &:hover {
@@ -233,7 +228,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
             border-color: transparent;
 
             &:hover {
-                border-color: var(--color-border-primary-default);
+                border-color: var(--color-border-secondary-default);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.scss
@@ -4,7 +4,7 @@
     .sw-media-upload-v2__dropzone {
         min-height: unset;
         padding: 6px;
-        background-color: $color-gray-50;
+        background-color: var(--color-background-secondary-default);
     }
 
     .sw-media-upload-v2__button {
@@ -69,7 +69,7 @@
         .sw-context-button__button {
             border: 0 none;
             visibility: hidden;
-            color: $color-white;
+            color: var(--color-static-white);
         }
 
         &:hover {
@@ -109,9 +109,9 @@
     .sw-media-compact-upload-v2__label {
         display: block;
         line-height: 16px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 8px;
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         font-weight: normal;
         user-select: none;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.scss
@@ -1,16 +1,8 @@
 @import "~scss/variables";
 
-$sw-media-field-font-size-label: $font-size-xs;
-$sw-media-field-color-label: $color-darkgray-200;
 $sw-media-field-border-radius-input: $border-radius-default;
-$sw-media-field-border-color-input: $color-gray-300;
-$sw-media-field-border-color-input-active: $color-shopware-brand-500;
 $sw-media-field-border-radius-picker: $border-radius-default;
-$sw-media-field-border-color-picker: $color-gray-300;
-$sw-media-field-background-color-picker: $color-white;
-$sw-media-field-background-color-list-item-hover: $color-shopware-brand-50;
-$sw-media-field-color-picker-toggle: $color-shopware-brand-500;
-$sw-media-field-color-unlink: $color-crimson-500;
+$sw-media-field-border-color-picker: var(--color-border-secondary-default);
 
 .sw-media-field {
     position: relative;
@@ -19,8 +11,8 @@ $sw-media-field-color-unlink: $color-crimson-500;
 
     .sw-media-field__label {
         display: block;
-        font-size: $sw-media-field-font-size-label;
-        color: $sw-media-field-color-label;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-primary-default);
         margin-bottom: 8px;
         line-height: 16px;
         font-weight: normal;
@@ -36,8 +28,8 @@ $sw-media-field-color-unlink: $color-crimson-500;
 
         .sw-media-field__input {
             padding: 2px 2px 2px 8px;
-            background-color: $color-white;
-            border: 1px solid $sw-media-field-border-color-input;
+            background-color: var(--color-background-primary-default);
+            border: 1px solid var(--color-border-primary-default);
             border-radius: $sw-media-field-border-radius-input 0 0 $sw-media-field-border-radius-input;
         }
 
@@ -48,14 +40,14 @@ $sw-media-field-color-unlink: $color-crimson-500;
 
         .mt-button--square {
             border-radius: 0 $sw-media-field-border-radius-input $sw-media-field-border-radius-input 0;
-            border: 1px solid $sw-media-field-border-color-input;
+            border: 1px solid var(--color-border-primary-default);
             border-left: 0 none;
             width: 45px;
             height: 45px;
         }
 
         &.is--active .sw-media-field__input {
-            border: 1px solid $sw-media-field-border-color-input-active;
+            border: 1px solid var(--color-border-brand-default);
         }
     }
 
@@ -74,7 +66,7 @@ $sw-media-field-color-unlink: $color-crimson-500;
 .sw-media-field__expanded-content {
     width: 380px;
     padding: 30px;
-    background-color: $sw-media-field-background-color-picker;
+    background-color: var(--color-elevation-surface-raised);
     border: 1px solid $sw-media-field-border-color-picker;
     border-radius: $sw-media-field-border-radius-picker;
     transform: translate(calc(-100% + 45px), 6px);
@@ -88,7 +80,7 @@ $sw-media-field-color-unlink: $color-crimson-500;
 
         > .sw-media-field__suggestion-list-entry:hover {
             cursor: pointer;
-            background: $sw-media-field-background-color-list-item-hover;
+            background: var(--color-background-brand-default);
         }
     }
 
@@ -104,7 +96,7 @@ $sw-media-field-color-unlink: $color-crimson-500;
         height: 8px;
         width: 8px;
         transform: rotate(45deg);
-        background: $color-white;
+        background: var(--color-elevation-surface-raised);
         border-top: 1px solid $sw-media-field-border-color-picker;
         border-left: 1px solid $sw-media-field-border-color-picker;
         z-index: $z-index-context-menu;
@@ -121,21 +113,21 @@ $sw-media-field-color-unlink: $color-crimson-500;
         border: none;
         background: none;
         padding: 0;
-        color: $sw-media-field-color-picker-toggle;
+        color: var(--color-icon-brand-default);
         justify-self: start;
 
         &.is--remove {
-            color: $sw-media-field-color-unlink;
+            color: var(--color-icon-critical-default);
             justify-self: end;
         }
     }
 
     .sw-media-field__icon-add {
-        color: $sw-media-field-color-picker-toggle;
+        color: var(--color-icon-brand-default);
     }
 
     .sw-media-field__icon-remove {
-        color: $sw-media-field-color-unlink;
+        color: var(--color-icon-critical-default);
     }
 
     .sw-media-field__picker-loader {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/sw-media-folder-content.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/sw-media-folder-content.scss
@@ -1,18 +1,14 @@
 @import "~scss/variables";
 @import "~scss/mixins";
 
-$sw-media-folder-content-border-color-listing: $color-gray-300;
 $sw-media-folder-content-border-radius-listing: $border-radius-default;
 $sw-media-folder-content-border-radius-list-item: $border-radius-default;
-$sw-media-folder-content-color-buttons: $color-darkgray-200;
-$sw-media-folder-content-parent-color: $color-gray-300;
-$sw-media-folder-content-background-color: $color-white;
 
 .sw-media-folder-content {
     .sw-media-folder-content__folder-listing {
-        border: 1px solid $sw-media-folder-content-border-color-listing;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $sw-media-folder-content-border-radius-listing;
-        background-color: $sw-media-folder-content-background-color;
+        background-color: var(--color-background-primary-default);
         padding: 8px;
         list-style: none;
     }
@@ -27,15 +23,15 @@ $sw-media-folder-content-background-color: $color-white;
         cursor: pointer;
 
         &:hover {
-            background-color: $color-shopware-brand-50;
+            background-color: var(--color-background-brand-default);
 
             .sw-media-folder-content__folder-button {
-                color: $color-shopware-brand-500;
+                color: var(--color-text-brand-default);
             }
         }
 
         &.is--selected {
-            background-color: $color-shopware-brand-50;
+            background-color: var(--color-background-brand-default);
         }
     }
 
@@ -50,7 +46,7 @@ $sw-media-folder-content-background-color: $color-white;
         border: none;
         outline: none;
         padding: 8px;
-        color: $sw-media-folder-content-color-buttons;
+        color: var(--color-icon-primary-default);
     }
 
     .sw-media-folder-content__folder-button,

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.scss
@@ -1,10 +1,3 @@
-@import "~scss/variables";
-
-$sw-media-folder-item-background-color-preview: var(--color-elevation-surface-raised);
-$sw-media-folder-item-border-radius-preview: $border-radius-default;
-$sw-media-folder-item-border-color-preview: var(--color-border-primary-default);
-$sw-media-folder-item-border-color-highlighted-preview: var(--color-border-brand-default);
-
 .sw-media-folder-item {
     position: relative;
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-list-selection-item-v2/sw-media-list-selection-item-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-list-selection-item-v2/sw-media-list-selection-item-v2.scss
@@ -1,18 +1,14 @@
 @import "~scss/variables";
 
-$sw-media-list-selection-item-v2-color-white: $color-white;
-$sw-media-list-selection-item-v2-color-hover: $color-black;
-$sw-media-list-selection-item-v2-color-border: $color-gray-300;
 $sw-media-list-selection-item-v2-border-radius: $border-radius-default;
-$sw-media-list-selection-item-v2-placeholder-color: lighten($color-gray-300, 5%);
 
 .sw-media-list-selection-item-v2 {
     position: relative;
     border-radius: $sw-media-list-selection-item-v2-border-radius;
-    border: 2px solid $sw-media-list-selection-item-v2-placeholder-color;
+    border: 2px solid var(--color-border-secondary-default);
 
     &.is--placeholder {
-        border: 2px dashed $sw-media-list-selection-item-v2-placeholder-color;
+        border: 2px dashed var(--color-border-secondary-default);
         display: flex;
         align-items: center;
         justify-content: center;
@@ -44,7 +40,7 @@ $sw-media-list-selection-item-v2-placeholder-color: lighten($color-gray-300, 5%)
     }
 
     &:hover {
-        background-color: $sw-media-list-selection-item-v2-color-hover;
+        background-color: var(--color-static-black);
 
         .sw-media-list-selection-item-v2__image {
             opacity: 0.7;
@@ -66,13 +62,13 @@ $sw-media-list-selection-item-v2-placeholder-color: lighten($color-gray-300, 5%)
         visibility: hidden;
 
         .mt-icon {
-            color: $sw-media-list-selection-item-v2-color-white;
+            color: var(--color-static-white);
             height: 100%;
         }
     }
 
     .sw-media-list-selection-item-v2__placeholder-icon {
-        color: $sw-media-list-selection-item-v2-placeholder-color;
+        color: var(--color-icon-primary-default);
     }
 
     &.is--drag-element {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-list-selection-v2/sw-media-list-selection-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-list-selection-v2/sw-media-list-selection-v2.scss
@@ -3,7 +3,7 @@
 .sw-media-list-selection-v2 {
     .sw-media-list-selection-v2__grid {
         border-radius: $border-radius-default;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         display: grid;
         padding: 20px;
         grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.scss
@@ -1,10 +1,3 @@
-@import "~scss/variables";
-
-$sw-media-modal-folder-settings-color-switch-mode: $color-shopware-brand-500;
-$sw-media-modal-folder-settings-border-color: $color-gray-300;
-$sw-media-modal-folder-settings-color-disabled-switch-mode: $color-gray-300;
-$sw-media-modal-folder-settings-delete-color: $color-crimson-500;
-
 .sw-media-modal-folder-settings {
     .sw-tabs__bar {
         &.sw-tabs__bar-minimal {
@@ -20,7 +13,7 @@ $sw-media-modal-folder-settings-delete-color: $color-crimson-500;
     }
 
     .sw-media-modal-folder-settings__thumbnails-list-container {
-        border: 1px solid $sw-media-modal-folder-settings-border-color;
+        border: 1px solid var(--color-border-secondary-default);
         padding: 22px 24px 0;
     }
 
@@ -29,7 +22,7 @@ $sw-media-modal-folder-settings-delete-color: $color-crimson-500;
 
         &.is--editable {
             li {
-                border-bottom: 1px solid $sw-media-modal-folder-settings-border-color;
+                border-bottom: 1px solid var(--color-border-secondary-default);
             }
         }
 
@@ -49,13 +42,13 @@ $sw-media-modal-folder-settings-delete-color: $color-crimson-500;
             height: 16px;
             background: 0 none;
             border: 0 none;
-            color: $sw-media-modal-folder-settings-delete-color;
+            color: var(--color-text-critical-default);
             cursor: pointer;
             outline: none;
         }
 
         .sw-media-modal-folder-settings__delete-thumbnail[disabled] {
-            color: $color-gray-300;
+            color: var(--color-text-primary-disabled);
             cursor: not-allowed;
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-move/sw-media-modal-move.scss
@@ -1,16 +1,9 @@
-@import "~scss/variables";
 @import "~scss/mixins";
-
-$sw-media-modal-move-breadcrumbs-hover-background-color: $color-shopware-brand-50;
-$sw-media-modal-move-breadcrumbs-right-arrow-color: $color-darkgray-200;
-$sw-media-modal-move-breadcrumbs-default-color: $color-darkgray-200;
-$sw-media-modal-move-breadcrumbs-target-color: $color-shopware-brand-500;
-$sw-media-modal-move-breadcrumbs-parent-color: $color-gray-300;
 
 .sw-media-modal-move {
     .sw-media-modal-move-folder-breadcrumbs {
         display: flex;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         line-height: 22px;
         margin-bottom: 20px;
         align-items: center;
@@ -21,26 +14,26 @@ $sw-media-modal-move-breadcrumbs-parent-color: $color-gray-300;
         border: none;
         outline: none;
         padding: 8px 6px 8px 0;
-        color: $sw-media-modal-move-breadcrumbs-default-color;
+        color: var(--color-text-primary-default);
         max-width: 400px;
 
         @include truncate;
 
         &:hover {
-            background-color: $sw-media-modal-move-breadcrumbs-hover-background-color;
+            background-color: var(--color-background-brand-default);
         }
 
         &.--target {
-            color: $sw-media-modal-move-breadcrumbs-target-color;
+            color: var(--color-text-brand-default);
 
             .mt-icon {
-                color: $sw-media-modal-move-breadcrumbs-right-arrow-color;
+                color: var(--color-icon-primary-default);
             }
         }
 
         &.--parent {
             .mt-icon {
-                color: $sw-media-modal-move-breadcrumbs-right-arrow-color;
+                color: var(--color-icon-primary-default);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/sw-media-upload-v2.scss
@@ -1,12 +1,11 @@
 @import "~scss/variables";
 
 $sw-media-upload-v2-border-color: var(--color-border-primary-default);
-$sw-media-upload-v2-color-highlighted: var(--color-border-brand-selected);
+$sw-media-upload-v2-color-highlighted: var(--color-border-brand-default);
 $sw-media-upload-v2-color-switch-mode: var(--color-text-brand-default);
 $sw-media-upload-v2-border-radius: $border-radius-default;
 $sw-media-upload-v2-upload-background-color: var(--color-background-secondary-default);
 $sw-media-upload-v2-background-color-highlighted: var(--color-background-brand-default);
-$sw-media-upload-v2-caption-font-size: $font-size-m;
 $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
 
 .sw-media-upload-v2 {
@@ -25,7 +24,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
         flex-direction: row;
         line-height: 16px;
         min-height: 16px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-primary-default);
         font-weight: normal;
         user-select: none;
@@ -61,7 +60,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-                font-size: $font-size-xs;
+                font-size: var(--font-size-xs);
             }
         }
 
@@ -120,7 +119,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
         flex-shrink: 0;
         width: 96px;
         height: 96px;
-        border: 2px solid $sw-media-upload-v2-border-color;
+        border: 2px solid var(--color-border-secondary-default);
         border-radius: $sw-media-upload-v2-border-radius;
 
         &:not(.is--fallback) {
@@ -128,7 +127,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
         }
 
         &.is--fallback {
-            border: 2px dashed $sw-media-upload-v2-border-color;
+            border: 2px dashed var(--color-border-secondary-default);
         }
     }
 
@@ -147,7 +146,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
     }
 
     .sw-media-preview-v2 {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
 
         .sw-media-preview-v2__item {
             padding: 3px;
@@ -214,7 +213,7 @@ $sw-media-upload-v2-caption-icon-color: var(--color-icon-secondary-default);
     }
 
     .sw-media-upload-v2__upload-caption {
-        font-size: $sw-media-upload-v2-caption-font-size;
+        font-size: var(--font-size-m);
         text-align: center;
 
         .mt-icon {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor-collapse/sw-model-editor-collapse.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor-collapse/sw-model-editor-collapse.scss
@@ -1,20 +1,14 @@
-@import "~scss/variables";
-
-$sw-model-editor-collapse-color-divider: $color-gray-300;
-$sw-model-editor-collapse-color-title: $color-darkgray-200;
-$sw-model-editor-collapse-font-size-title: $font-size-s;
-
 .sw-model-editor .sw-collapse {
     .sw-model-editor-collapse__header {
         display: grid;
         grid-template-columns: 1fr auto;
         cursor: pointer;
         padding: 16px 25px 0;
-        color: $sw-model-editor-collapse-color-title;
+        color: var(--color-text-primary-default);
     }
 
     .sw-model-editor-collapse__title {
-        font-size: $sw-model-editor-collapse-font-size-title;
+        font-size: var(--font-size-s);
         font-weight: normal;
     }
 
@@ -26,5 +20,5 @@ $sw-model-editor-collapse-font-size-title: $font-size-s;
         padding: 0 25px 25px;
     }
 
-    border-bottom: 1px solid $sw-model-editor-collapse-color-divider;
+    border-bottom: 1px solid var(--color-border-secondary-default);
 }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-model-editor/sw-model-editor.scss
@@ -1,7 +1,4 @@
-@import "~scss/variables";
-
 $sw-model-editor-canvas-ui__button-size: 42px;
-$sw-model-editor-canvas-ui__orientation-size: $sw-model-editor-canvas-ui__button-size;
 $sw-model-editor-box-shadow: 0 2px 6px 0 #00000036;
 $sw-button-transition: all 0.15s ease-out;
 
@@ -26,10 +23,10 @@ $sw-button-transition: all 0.15s ease-out;
     display: flex;
     flex-direction: column;
     flex: 0 0 400px;
-    border-left: 1px solid var(--color-border-primary-default);
+    border-left: 1px solid var(--color-border-secondary-default);
 
     .sw-model-editor-sidebar-content-item {
-        border-bottom: 1px solid #d1d9e0;
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-model-editor-sidebar-content-item-header {
             display: grid;
@@ -67,15 +64,15 @@ $sw-button-transition: all 0.15s ease-out;
     border-radius: $sw-model-editor-canvas-ui__button-size;
     overflow: hidden;
     pointer-events: auto;
-    background: $color-white;
+    background: var(--color-background-primary-default);
     display: flex;
     box-shadow: $sw-model-editor-box-shadow;
 
     .sw-model-editor-canvas-ui__button {
         width: $sw-model-editor-canvas-ui__button-size;
         height: $sw-model-editor-canvas-ui__button-size;
-        background: $color-white;
-        color: $color-darkgray-200;
+        background: var(--color-background-primary-default);
+        color: var(--color-icon-primary-default);
         transition: $sw-button-transition;
         border: none;
         outline: none;
@@ -85,22 +82,22 @@ $sw-button-transition: all 0.15s ease-out;
         justify-content: center;
 
         &:disabled {
-            color: $color-gray-300;
+            color: var(--color-icon-primary-disabled);
 
             &:hover {
-                background: $color-white;
+                background: var(--color-background-primary-default);
             }
         }
 
         &:hover {
-            background: $color-gray-100;
+            background: var(--color-background-secondary-default);
         }
     }
 
     &.is--active {
         .sw-model-editor-canvas-ui__button {
-            color: $color-shopware-brand-500;
-            background: $color-shopware-brand-50;
+            color: var(--color-icon-brand-default);
+            background: var(--color-background-brand-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-vector-field {
     .sw-vector-field__input {
         display: flex;
@@ -10,7 +8,7 @@
 
     .mt-field__addition.is--prefix {
         min-width: 32px;
-        font-weight: $font-weight-bold;
+        font-weight: var(--font-weight-bold);
     }
 
     .sw-vector-field__lock-icon {
@@ -23,7 +21,7 @@
 
         &.is--disabled {
             cursor: default;
-            color: var(--color-gray-700);
+            color: var(--color-icon-primary-disabled);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/mt-text-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor-wrapper/mt-text-editor/mt-text-editor.scss
@@ -1,16 +1,14 @@
-@import "~scss/variables";
-
 .mt-text-editor {
     .mt-text-editor__content-editor {
         .btn {
-            background: $color-gray-50;
-            color: $color-darkgray-200;
+            background: var(--color-background-secondary-default);
+            color: var(--color-text-primary-default);
             display: inline-block;
-            border-radius: $border-radius-default;
+            border-radius: var(--border-radius-button);
             padding: 2px 24px;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             outline: none;
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
             vertical-align: middle;
             text-decoration: none;
             user-select: none;
@@ -20,17 +18,17 @@
             border: 0 none;
 
             &-primary {
-                background-color: $color-gray-900;
-                color: $color-white;
+                background-color: var(--color-interaction-primary-default);
+                color: var(--color-static-white);
             }
 
             &-secondary {
-                background-color: $color-gray-300;
-                color: $color-darkgray-200;
+                background-color: var(--color-interaction-secondary-default);
+                color: var(--color-text-primary-default);
             }
 
             &-sm {
-                line-height: $line-height-lg;
+                line-height: var(--font-line-height-l);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-card/sw-meteor-card.scss
@@ -24,16 +24,16 @@
             }
 
             .sw-meteor-card__title {
-                font-size: $font-size-m;
-                font-weight: $font-weight-semi-bold;
+                font-size: var(--font-size-m);
+                font-weight: var(--font-weight-semibold);
             }
         }
 
         .sw-meteor-card__toolbar {
             padding: 24px 32px;
-            background-color: var(--color-background-secondary-default);
-            border-top: 1px solid var(--color-border-primary-default);
-            border-bottom: 1px solid var(--color-border-primary-default);
+            background-color: var(--color-elevation-surface-sunken);
+            border-top: 1px solid var(--color-border-secondary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
 
             @media screen and (max-width: 960px) {
                 padding: 15px;
@@ -60,20 +60,20 @@
     }
 
     &.has--header .sw-meteor-card__content {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-meteor-card__content {
         position: relative;
         line-height: 22px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
 
         & > .sw-grid {
             border: none;
         }
 
         h1 {
-            font-size: $font-size-xl;
+            font-size: var(--font-size-xl);
         }
 
         h2 {
@@ -81,13 +81,13 @@
         }
 
         h3 {
-            font-size: $font-size-m;
+            font-size: var(--font-size-m);
         }
 
         h4,
         h5,
         h6 {
-            font-size: $font-size-s;
+            font-size: var(--font-size-s);
         }
 
         a.sw-meteor-card__quick-link {
@@ -97,7 +97,7 @@
             align-items: center;
             text-decoration: none;
             color: var(--color-text-brand-default);
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
 
             &:hover {
                 color: var(--color-text-brand-hover);
@@ -124,12 +124,12 @@
             border-bottom-right-radius: 0;
 
             &:hover {
-                border-bottom-color: var(--color-border-primary-default);
+                border-bottom-color: var(--color-border-secondary-default);
             }
 
             &:focus {
                 background-color: var(--color-background-secondary-default);
-                border-bottom-color: var(--color-border-primary-default);
+                border-bottom-color: var(--color-border-secondary-default);
             }
 
             &:active {
@@ -153,11 +153,11 @@
     }
 
     .sw-meteor-card__footer {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
         padding: 24px 32px;
         position: relative;
         line-height: 22px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
 
         @media screen and (max-width: 960px) {
             padding: 15px;
@@ -201,9 +201,9 @@
         .sw-tabs-item {
             padding: 19px 0 15px;
             margin-right: 14px;
-            font-weight: $font-weight-regular;
+            font-weight: var(--font-weight-regular);
             border-color: transparent;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
 
             @media screen and (max-width: 960px) {
                 padding: 15px 0 10px;
@@ -214,7 +214,7 @@
             }
 
             &.sw-tabs-item--active {
-                font-weight: $font-weight-semi-bold;
+                font-weight: var(--font-weight-semibold);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-navigation/sw-meteor-navigation.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-navigation/sw-meteor-navigation.scss
@@ -3,8 +3,8 @@
 .sw-meteor-navigation {
     display: flex;
     align-items: center;
-    color: $color-gray-500;
-    font-size: $font-size-xs;
+    color: var(--color-text-secondary-default);
+    font-size: var(--font-size-xs);
 
     .sw-meteor-navigation__back-arrow {
         margin-right: 8px;
@@ -14,8 +14,8 @@
     .sw-meteor-navigation__link {
         display: flex;
         align-items: center;
-        color: $color-gray-500;
-        font-weight: $font-weight-medium;
+        color: var(--color-text-secondary-default);
+        font-weight: var(--font-weight-medium);
         text-decoration: none;
         padding: 6px 10px;
         border-radius: $border-radius-md;
@@ -25,13 +25,13 @@
         &:focus,
         &:focus-within,
         &:focus-visible {
-            background-color: $color-gray-100;
-            color: $color-darkgray-800;
+            background-color: var(--color-background-secondary-default);
+            color: var(--color-text-primary-default);
         }
 
         &:active {
-            background-color: $color-gray-200;
-            color: $color-darkgray-900;
+            background-color: var(--color-background-secondary-default);
+            color: var(--color-text-primary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-page/sw-meteor-page.scss
@@ -66,7 +66,7 @@
         padding: 12px 12px 0;
         z-index: $z-index-page-header;
         margin-bottom: 48px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-meteor-page__smart-bar-navigation {
             margin-bottom: 12px;
@@ -109,7 +109,7 @@
             width: 100%;
             display: block;
             height: 1px;
-            background-color: var(--color-border-primary-default);
+            background-color: var(--color-border-secondary-default);
             transform: translate(0, 12px);
         }
     }
@@ -183,7 +183,7 @@
 
                 color: var(--color-text-primary-default);
                 line-height: 1.2;
-                font-size: $font-size-xl;
+                font-size: var(--font-size-xl);
                 margin-right: 8px;
                 margin-bottom: 0;
                 min-width: 20%;

--- a/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-single-select/sw-meteor-single-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/meteor/sw-meteor-single-select/sw-meteor-single-select.scss
@@ -1,22 +1,20 @@
-@import "~scss/variables";
-
 .sw-meteor-single-select {
     .sw-meteor-single-select__preview {
         display: flex;
         flex-wrap: nowrap;
         align-items: center;
-        background-color: $color-white;
+        background-color: var(--color-background-primary-default);
         padding: 6px 16px;
         border-radius: 20px;
-        border: 1px solid $color-gray-300;
-        font-size: $font-size-xs;
-        color: $color-darkgray-200;
+        border: 1px solid var(--color-border-primary-default);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-primary-default);
         cursor: pointer;
         transition: 0.1s all ease-in-out;
 
         &:hover {
-            border-color: $color-shopware-brand-500;
-            color: $color-shopware-brand-500;
+            border-color: var(--color-border-brand-default);
+            color: var(--color-text-brand-default);
         }
 
         .mt-icon {
@@ -32,7 +30,7 @@
     }
 
     .sw-meteor-single-select__label {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         padding-right: 4px;
     }
 
@@ -60,9 +58,9 @@
             position: sticky;
             top: 0;
             border-radius: 3px 3px 0 0;
-            border-bottom: 1px solid $color-gray-300;
+            border-bottom: 1px solid var(--color-border-secondary-default);
             padding: var(--search-field-padding);
-            background: $color-white;
+            background: var(--color-background-primary-default);
             margin: 0;
 
             .sw-simple-search-field__search-icon {

--- a/src/Administration/Resources/app/administration/src/app/component/modal/sw-image-preview-modal/sw-image-preview-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/modal/sw-image-preview-modal/sw-image-preview-modal.scss
@@ -35,9 +35,9 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
 
     .sw-image-preview-modal__button-action {
         padding: 8px 12px;
-        background: $color-gray-50;
+        background: var(--color-background-secondary-default);
         border: 1px solid transparent;
-        color: $color-gray-900;
+        color: var(--color-text-primary-default);
 
         &:first-child {
             border-top-left-radius: $border-radius-default;
@@ -72,11 +72,11 @@ $sw-modal-transition-timing-function: cubic-bezier(0.68, -0.55, 0.26, 1.55);
         bottom: 0;
         width: 100%;
         padding: 20px 0;
-        background: $color-white;
+        background: var(--color-background-primary-default);
     }
 
     .sw-image-preview-modal__divider {
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         position: absolute;
         bottom: 139px;
         left: 20px;

--- a/src/Administration/Resources/app/administration/src/app/component/modal/sw-search-preferences-modal/sw-search-preferences-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/modal/sw-search-preferences-modal/sw-search-preferences-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-search-preferences-modal {
     &.sw-modal .sw-modal__body {
         padding: 0;
@@ -11,12 +9,12 @@
 
     &__description {
         padding: 20px 32px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     &__description span {
         cursor: pointer;
-        color: rgb(24, 158, 255);
+        color: var(--color-text-brand-default);
         text-decoration: underline;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.scss
@@ -3,7 +3,7 @@
 
     &.container-condition-level__is--even {
         background-color: var(--color-elevation-surface-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
 
         &.is--disabled {
@@ -13,7 +13,7 @@
 
     &.container-condition-level__is--odd {
         background-color: var(--color-elevation-surface-sunken);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
 
         &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.scss
@@ -3,7 +3,7 @@
 
     &.container-condition-level__is--even {
         background-color: var(--color-elevation-surface-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
 
         &.is--disabled {
@@ -13,7 +13,7 @@
 
     &.container-condition-level__is--odd {
         background-color: var(--color-elevation-surface-sunken);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
 
         &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.scss
@@ -2,7 +2,7 @@
     align-self: center;
     margin-right: var(--scale-size-2);
     background-color: var(--color-interaction-secondary-default);
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     padding: var(--scale-size-6) var(--scale-size-12);
     font-size: var(--font-size-xs);
     border-radius: var(--border-radius-button);
@@ -27,7 +27,7 @@
 
     &__menu {
         background-color: var(--color-background-primary-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
         box-shadow: 0 3px 6px rgba(120, 138, 155, 25%);
         padding: var(--scale-size-8);

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-help-sidebar/sw-help-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-help-sidebar/sw-help-sidebar.html.twig
@@ -93,7 +93,7 @@
                         }"
                         class="sw-help-sidebar__shortcut-button"
                         :aria-label="$t('help-center.sidebar.ariaLabelButtonShortcut')"
-                        variant="secondary"
+                        variant="tertiary"
                         @click="openShortcutModal"
                     >
                         <mt-icon

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-help-sidebar/sw-help-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-help-sidebar/sw-help-sidebar.scss
@@ -18,7 +18,7 @@
         height: 100%;
         margin-left: auto;
         background: var(--color-elevation-surface-raised);
-        border-left: 1px solid var(--color-border-primary-defaul);
+        border-left: 1px solid var(--color-border-secondary-default);
 
         &:focus {
             outline: none;
@@ -31,7 +31,7 @@
         justify-content: space-between;
         height: var(--scale-size-80);
         padding: 0 var(--scale-size-24);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &__body {
@@ -44,8 +44,7 @@
         height: var(--scale-size-64);
         margin-top: auto;
         padding: 0 var(--scale-size-24);
-        border-top: 1px solid var(--color-border-primary-default);
-        background: var(--color-background-primary-disabled);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &__headline {
@@ -68,7 +67,7 @@
         }
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.scss
@@ -5,7 +5,7 @@
         justify-content: space-between;
         padding: var(--scale-size-16) var(--scale-size-24);
         color: var(--color-text-primary-default);
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &__title {

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-item/sw-sidebar-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-item/sw-sidebar-item.scss
@@ -3,7 +3,7 @@
     height: 100%;
     display: grid;
     grid-template-rows: var(--scale-size-64) 1fr;
-    border-left: 1px solid var(--color-border-primary-default);
+    border-left: 1px solid var(--color-border-secondary-default);
     overflow: hidden;
 
     &__headline {
@@ -40,7 +40,7 @@
         }
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-navigation-item/sw-sidebar-navigation-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-navigation-item/sw-sidebar-navigation-item.scss
@@ -9,7 +9,7 @@
     outline: none;
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: calc(var(--scale-size-2) * -1);
     }
 
@@ -37,7 +37,7 @@
         position: absolute;
         transform: translate(-30%, 70%);
         border-radius: var(--scale-size-18);
-        color: var(--color-text-static-default);
+        color: var(--color-static-white);
         font-size: var(--font-size-2xs);
         font-style: normal;
 

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar/sw-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar/sw-sidebar.scss
@@ -1,7 +1,7 @@
 .sw-sidebar {
     height: 100%;
     background-color: var(--color-elevation-surface-default);
-    border-left: 1px solid var(--color-border-primary-default);
+    border-left: 1px solid var(--color-border-secondary-default);
     display: grid;
     grid-template-columns: var(--scale-size-64) auto;
     width: var(--scale-size-64);

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
@@ -13,7 +13,6 @@ $sw-admin-menu-sub-menu-transition: 0.35s cubic-bezier(0.5, 0.32, 0.01, 1);
 $sw-admin-menu-flyout-transition: 0.2s cubic-bezier(0.5, 0.32, 0.01, 1);
 $sw-admin-menu-color-active: #172b4f;
 $sw-admin-menu-color-hover: #293f65;
-$sw-admin-menu-shop-status-ok: $color-emerald-500;
 $sw-admin-menu-background: #243758;
 $sw-admin-menu-background-hover: #293f65;
 $sw-admin-menu-divider: #344865;
@@ -150,8 +149,8 @@ $sw-admin-menu-active-text: $color-white;
         color: $sw-admin-menu-active-text;
         width: $sw-admin-menu-width-collapsed;
         transition: width $sw-admin-menu-transition;
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-xs);
         padding: 12px 30px;
         position: relative;
     }
@@ -214,11 +213,11 @@ $sw-admin-menu-active-text: $color-white;
         align-items: baseline;
         padding: 12px 30px;
         text-decoration: none;
-        font-size: $font-size-xs;
-        line-height: $line-height-md;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-m);
         cursor: pointer;
         position: relative;
-        font-weight: $font-weight-medium;
+        font-weight: var(--font-weight-medium);
 
         &:hover {
             color: #fff;
@@ -267,7 +266,7 @@ $sw-admin-menu-active-text: $color-white;
     .sw-admin-menu__sub-navigation-headline {
         color: $sw-admin-menu-color-text-primary;
         padding: 15px 30px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         font-weight: bold;
     }
 
@@ -276,8 +275,8 @@ $sw-admin-menu-active-text: $color-white;
         display: block;
         padding: 20px 32px;
         text-decoration: none;
-        font-size: $font-size-xs;
-        line-height: $line-height-md;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-m);
         width: 100%;
         cursor: pointer;
         white-space: nowrap;
@@ -365,15 +364,15 @@ $sw-admin-menu-active-text: $color-white;
 
     .sw-admin-menu__user-name {
         margin-top: 2px;
-        font-size: $font-size-xs;
-        font-weight: $font-weight-bold;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-bold);
         color: $sw-admin-menu-active-text;
     }
 
     .sw-admin-menu__user-type {
-        color: $color-pumpkin-spice-500;
-        font-size: $font-size-xs;
-        font-weight: $font-weight-medium;
+        color: var(--color-text-attention-default);
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-medium);
         margin-top: 2px;
     }
 
@@ -397,8 +396,8 @@ $sw-admin-menu-active-text: $color-white;
     .sw-admin-menu__user-actions-label {
         @include truncate;
 
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-xs);
         padding: 0 30px;
         height: 48px;
         line-height: 48px;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-error/sw-error.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-error/sw-error.scss
@@ -1,16 +1,13 @@
 @import "~scss/variables";
 
-$sw-error-background-stack: $color-gray-100;
 $sw-error-radius-stack: $border-radius-default;
-$sw-error-color: $color-darkgray-200;
-$sw-error-font-size-large: $font-size-m;
 
 .sw-error {
     display: grid;
     height: 100%;
     align-items: center;
     justify-items: center;
-    color: $sw-error-color;
+    color: var(--color-text-primary-default);
 
     .sw-error__container {
         display: grid;
@@ -37,7 +34,7 @@ $sw-error-font-size-large: $font-size-m;
 
     .sw-error__message {
         margin-bottom: 20px;
-        font-size: $sw-error-font-size-large;
+        font-size: var(--font-size-m);
     }
 
     .sw-error__stack {
@@ -48,8 +45,8 @@ $sw-error-font-size-large: $font-size-m;
         max-width: 450px;
         padding: 20px;
         overflow: auto;
-        background: $sw-error-background-stack;
-        border: 1px solid darken($sw-error-background-stack, 30%);
+        background: var(--color-background-secondary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $sw-error-radius-stack;
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-inheritance-warning/sw-inheritance-warning.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-inheritance-warning/sw-inheritance-warning.scss
@@ -20,8 +20,8 @@
     }
 
     p {
-        color: $color-darkgray-200;
-        font-size: $font-size-xs;
+        color: var(--color-text-primary-default);
+        font-size: var(--font-size-xs);
         line-height: 22px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-info/sw-language-info.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-language-info/sw-language-info.scss
@@ -1,19 +1,15 @@
 @import "~scss/variables";
 
-$sw-language-info-color-text: $color-darkgray-200;
-$sw-language-info-font-size: $font-size-xs;
-$sw-language-info-color-language: $color-shopware-brand-500;
-
 .sw-language-info {
     padding: 0;
     max-width: $content-width;
     margin: 0 auto 20px;
     height: 36px;
-    color: $sw-language-info-color-text;
-    font-size: $sw-language-info-font-size;
+    color: var(--color-text-primary-default);
+    font-size: var(--font-size-xs);
 
     .sw-language-info__link-parent {
-        color: $sw-language-info-color-language;
+        color: var(--color-text-brand-default);
         cursor: pointer;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -1,8 +1,8 @@
 @import "~scss/variables";
 
-$sw-page-smart-bar-border-color: var(--color-border-primary-default);
-$sw-page-separator-color: var(--color-border-primary-default);
-$sw-page-divider-background-color: var(--color-border-primary-default);
+$sw-page-smart-bar-border-color: var(--color-border-secondary-default);
+$sw-page-separator-color: var(--color-border-secondary-default);
+$sw-page-divider-background-color: var(--color-border-secondary-default);
 $sw-page-smart-bar-background-color: var(--color-elevation-surface-default);
 $sw-page-smart-bar-headline-color: var(--color-text-primary-default);
 $sw-page-side-content-default-width: 440px;
@@ -70,14 +70,14 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
     .smart-bar__back-btn {
         width: 54px;
         height: var(--scale-size-24);
-        line-height: $line-height-md;
+        line-height: var(--font-line-height-m);
         display: grid;
         grid-template-columns: 30px var(--scale-size-24);
         align-items: center;
         margin-left: 20px;
 
         .mt-icon.icon--regular-chevron-left-s {
-            line-height: $line-height-md;
+            line-height: var(--font-line-height-m);
             margin: auto;
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-request-consent-modal/sw-request-consent-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-request-consent-modal/sw-request-consent-modal.scss
@@ -1,7 +1,7 @@
 .sw-request-consent-modal__requestMessage {
     margin: var(--scale-size-16) 0;
     background-color: var(--color-elevation-surface-sunken);
-    border-radius: var(--border-radius-overlay);
+    border-radius: var(--border-radius-xs);
 
     ul {
         list-style: disc inside;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar-item/sw-search-bar-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar-item/sw-search-bar-item.scss
@@ -16,11 +16,11 @@ $sw-search-bar-item-label-hover-color-text: var(--color-text-brand-default);
         border-radius: $sw-search-bar-item-border-radius;
         display: flex;
         text-decoration: none;
-        line-height: $line-height-sm;
+        line-height: var(--font-line-height-s);
 
         &:focus-visible {
             outline-offset: var(--scale-size-2);
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
         }
     }
 
@@ -31,7 +31,7 @@ $sw-search-bar-item-label-hover-color-text: var(--color-text-brand-default);
 
     .sw-search-bar-item__label {
         color: $sw-search-bar-item-color-label;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -40,7 +40,7 @@ $sw-search-bar-item-label-hover-color-text: var(--color-text-brand-default);
 
     .sw-search-bar-item__type {
         color: $sw-search-bar-item-color-type;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         margin-left: auto;
     }
 
@@ -83,7 +83,7 @@ $sw-search-bar-item-label-hover-color-text: var(--color-text-brand-default);
 
             span {
                 padding: 0 4px;
-                font-size: $font-size-xxs;
+                font-size: var(--font-size-2xs);
             }
         }
 
@@ -98,7 +98,7 @@ $sw-search-bar-item-label-hover-color-text: var(--color-text-brand-default);
         }
 
         .sw-highlight-text:not(:first-child) {
-            color: $color-gray-500;
+            color: var(--color-text-secondary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/sw-search-bar.scss
@@ -2,16 +2,13 @@
 @import "~scss/variables";
 
 $sw-search-bar-border-color: var(--color-border-primary-default);
-$sw-search-bar-results-background-color: var(--color-elevation-surface-overlay);
+$sw-search-bar-results-background-color: var(--color-elevation-surface-raised);
 $sw-search-bar-border-radius: $border-radius-default;
 $sw-search-bar-results-box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
 $sw-search-bar-results-z-index: 800;
 $sw-search-bar-types-z-index: 900;
 $sw-search-bar-z-index: $z-index-search-bar-results;
-$sw-search-bar-button-color-text: $color-white;
 $sw-search-bar-mobile-box-shadow: 0 3px 3px rgba(0, 0, 0, 30%);
-$sw-search-bar-result-color-icon: darken($color-gray-100, 20%);
-$sw-search-bar-types-item-hover-color-background: lighten($color-shopware-brand-500, 40%);
 $sw-search-bar-types-item-border-radius: $border-radius-default;
 
 .sw-search-bar {
@@ -26,7 +23,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         line-height: 48px;
         display: block;
         background: 0 none;
-        color: $sw-search-bar-button-color-text;
+        color: var(--color-static-white);
         border: 0 none;
         outline: none;
         cursor: pointer;
@@ -70,7 +67,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         height: 50px;
 
         &.is--active {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
 
@@ -112,31 +109,31 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
     }
 
     .sw-search-bar__type {
-        background-color: darken($color-gray-100, 20%);
-        color: $color-white;
+        background-color: var(--color-background-tertiary-default);
+        color: var(--color-static-white);
         display: inline-block;
         padding: 5px 12px;
         border-radius: $sw-search-bar-border-radius;
         flex-shrink: 0;
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-xs);
     }
 
     &__type {
         &--v2 {
-            background-color: darken($color-gray-100, 20%);
-            color: $color-white;
+            background-color: var(--color-background-tertiary-default);
+            color: var(--color-static-white);
             display: flex;
             align-items: center;
             padding: 5px 12px;
             border-radius: $sw-search-bar-border-radius;
             flex-shrink: 0;
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-xs;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-xs);
 
             &:focus-visible {
                 outline-offset: var(--scale-size-2);
-                outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+                outline: var(--scale-size-2) solid var(--color-border-brand-default);
             }
 
             .mt-icon {
@@ -155,7 +152,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
     &__header {
         display: flex;
         justify-content: space-between;
-        background-color: var(--color-background-primary-disabled);
+        background-color: var(--color-background-tertiary-default);
         padding: 10px 24px;
     }
 
@@ -181,7 +178,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         outline: none;
 
         &::placeholder {
-            color: var(--color-text-tertiary-default);
+            color: var(--color-text-secondary-default);
         }
     }
 
@@ -226,7 +223,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         overflow-x: hidden;
         overflow-y: auto;
         background-color: $sw-search-bar-results-background-color;
-        border: 1px solid $sw-search-bar-border-color;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $sw-search-bar-border-radius;
         box-shadow: $sw-search-bar-results-box-shadow;
 
@@ -264,9 +261,9 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
 
                 span {
                     text-transform: uppercase;
-                    border: 1px solid var(--color-border-primary-default);
+                    border: 1px solid var(--color-border-secondary-default);
                     border-radius: 3px;
-                    background-color: var(--color-background-primary-disabled);
+                    background-color: var(--color-background-tertiary-default);
                     padding: 0 4px;
                     margin: 0 3px;
                 }
@@ -279,7 +276,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
             .sw-search-bar__results-column-header {
                 display: flex;
                 justify-content: space-between;
-                background-color: var(--color-background-primary-disabled);
+                background-color: var(--color-background-tertiary-default);
                 padding: 10px 24px;
                 margin: 0;
             }
@@ -308,7 +305,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         }
 
         .mt-icon {
-            color: $sw-search-bar-result-color-icon;
+            color: var(--color-icon-secondary-default);
             margin-right: 10px;
         }
     }
@@ -325,7 +322,7 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
         overflow-x: hidden;
         overflow-y: auto;
         background-color: $sw-search-bar-results-background-color;
-        border: 1px solid $sw-search-bar-border-color;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $sw-search-bar-border-radius;
         box-shadow: $sw-search-bar-results-box-shadow;
 
@@ -364,8 +361,8 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
             }
 
             &--filter {
-                font-size: $font-size-xs;
-                color: #b3bfcc;
+                font-size: var(--font-size-xs);
+                color: var(--color-text-secondary-default);
             }
         }
 
@@ -377,9 +374,9 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
 
             span {
                 text-transform: uppercase;
-                border: 1px solid var(--color-border-primary-default);
+                border: 1px solid var(--color-border-secondary-default);
                 border-radius: 3px;
-                background-color: var(--color-background-primary-disabled);
+                background-color: var(--color-background-tertiary-default);
                 padding: 0 4px;
                 margin: 0 3px;
             }
@@ -410,8 +407,8 @@ $sw-search-bar-types-item-border-radius: $border-radius-default;
     }
 
     &__shortcut-tip {
-        font-size: $font-size-xs;
-        color: lighten($color-darkgray-200, 25%);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary-default);
         margin: 20px 3px 0;
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-more-results/sw-search-more-results.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-search-more-results__link {
-    color: $color-shopware-brand-500;
+    color: var(--color-text-brand-default);
     margin-left: 5px;
 
     &--v2 {
-        font-size: $font-size-xs;
-        color: $color-gray-500;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary-default);
         text-decoration: none;
         margin-left: 10px;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
@@ -59,7 +59,7 @@
         top: 0;
         right: 0;
         bottom: 0;
-        border-left: 1px solid var(--color-border-primary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
         height: 100%;
         max-width: 90vw;
         transition: all 0.3s ease-in-out;
@@ -72,7 +72,7 @@
 
     &.is-overlay .sw-sidebar-renderer__overlay {
         box-shadow: -4px 0 16px rgba(0, 0, 0, 15%);
-        border-left: 1px solid var(--color-border-primary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
         border-radius: 8px 0 0 8px;
     }
 
@@ -115,7 +115,7 @@
         gap: 16px;
         flex-shrink: 0;
         align-self: stretch;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         background: var(--color-elevation-surface-raised);
         position: relative;
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.scss
@@ -12,7 +12,7 @@
     border-radius: var(--border-radius-round);
     border: 1px solid var(--color-border-primary-default);
     outline-offset: 2px;
-    outline: 2px solid var(--color-border-brand-selected);
+    outline: 2px solid var(--color-border-brand-default);
     padding: 0 16px;
     text-decoration: none;
     display: flex;

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -37,8 +37,8 @@
         box-shadow: 0 0 5px 1px var(--color-border-brand-default);
 
         .sw-tree-item__child-count {
-            background: var(--color-background-brand-default);
-            color: var(--color-text-primary-inverse);
+            background: var(--color-interaction-primary-default);
+            color: var(--color-static-white);
         }
 
         .sw-tree-item__actions {
@@ -73,7 +73,7 @@
         align-content: center;
         padding: 0;
         font-size: var(--font-size-xs);
-        line-height: var(--line-height-xs);
+        line-height: var(--font-line-height-xs);
         color: var(--color-text-primary-default);
         border-radius: var(--border-radius-xs);
 
@@ -249,7 +249,7 @@
     align-content: center;
     padding: 0;
     font-size: var(--font-size-xs);
-    line-height: var(--line-height-xs);
+    line-height: var(--font-line-height-xs);
     color: var(--color-text-primary-default);
     border-radius: var(--border-radius-xs);
 
@@ -276,8 +276,8 @@
         box-shadow: 0 0 5px 1px var(--color-border-brand-default);
 
         .sw-tree-item__child-count {
-            background: var(--color-background-brand-default);
-            color: var(--color-text-primary-inverse);
+            background: var(--color-interaction-primary-default);
+            color: var(--color-static-white);
         }
 
         .sw-tree-item__actions {

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -12,7 +12,7 @@
 
     .sw-tree__search {
         padding: var(--scale-size-10) var(--scale-size-20);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-tree-actions__headline {
@@ -52,7 +52,7 @@
 
             &::before {
                 content: "";
-                background: var(--color-border-primary-default);
+                background: var(--color-border-secondary-default);
                 position: absolute;
                 left: 15.5px;
                 top: 50%;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-duplicated-media-v2/sw-duplicated-media-v2.scss
@@ -1,14 +1,10 @@
-@import "~scss/variables";
 @import "~scss/mixins";
-
-$sw-duplicated-media-v2-separator-color: $color-gray-300;
-$sw-duplicated-media-v2-font-size-preview: $font-size-xs;
 
 .sw-duplicated-media-v2 {
     z-index: 1150;
 
     .sw-duplicated-media-v2__description {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 10px;
     }
 
@@ -22,11 +18,11 @@ $sw-duplicated-media-v2-font-size-preview: $font-size-xs;
 
     .sw-duplicated-media-v2__preview-separator {
         justify-self: center;
-        color: $sw-duplicated-media-v2-separator-color;
+        color: var(--color-icon-secondary-default);
     }
 
     .sw-duplicated-media-v2__options {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 0;
     }
 
@@ -46,7 +42,7 @@ $sw-duplicated-media-v2-font-size-preview: $font-size-xs;
         display: grid;
         grid-template-columns: auto 1fr;
         grid-column-gap: 10px;
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         padding: 8px;
     }
@@ -68,11 +64,11 @@ $sw-duplicated-media-v2-font-size-preview: $font-size-xs;
     .sw-duplicated-media-v2__target-label {
         @include truncate;
 
-        font-size: $sw-duplicated-media-v2-font-size-preview;
+        font-size: var(--font-size-xs);
     }
 
     .sw-duplicated-media-v2__target-details {
-        font-size: $font-size-xs;
-        color: $color-gray-300;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-external-link/sw-external-link.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-external-link/sw-external-link.scss
@@ -13,7 +13,7 @@
     }
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: var(--scale-size-2);
         border-radius: var(--border-radius-xs);
     }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-help-center/sw-help-center.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-help-center/sw-help-center.scss
@@ -19,7 +19,7 @@
         }
 
         &:focus-visible {
-            outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+            outline: var(--scale-size-2) solid var(--color-border-brand-default);
             outline-offset: var(--scale-size-2);
         }
     }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/sw-inherit-wrapper.scss
@@ -9,13 +9,13 @@
         display: flex;
         align-items: center;
         line-height: 16px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 8px;
         color: var(--color-text-primary-default);
 
         label {
             &.has--error {
-                color: $color-crimson-500;
+                color: var(--color-text-critical-default);
             }
 
             flex-grow: 1;
@@ -34,7 +34,7 @@
 
     &.is--required .sw-inherit-wrapper__toggle-wrapper label::after {
         content: "*";
-        color: $color-shopware-brand-500;
+        color: var(--color-text-brand-default);
     }
 
     .sw-inherit-wrapper__card-title {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-internal-link/sw-internal-link.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-internal-link/sw-internal-link.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-internal-link {
     display: flex;
     gap: 6px;
     align-items: center;
     text-decoration: underline;
     color: var(--color-text-brand-default);
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
 
     &:hover,
     &:focus {
@@ -18,6 +16,6 @@
     }
 
     &--disabled {
-        color: $color-gray-500;
+        color: var(--color-text-primary-disabled);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/sw-license-violation.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-license-violation-confirm-delete {
     z-index: 1300;
 }
@@ -8,7 +6,7 @@
     z-index: 1200;
 
     .sw-modal__body {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-license-violation__text {
@@ -21,7 +19,7 @@
         margin: 25px 0 0;
 
         tr {
-            border-bottom: 1px solid $color-gray-300;
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
 
         > :last-child {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader-deprecated/sw-loader.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-loader-deprecated/sw-loader.scss
@@ -1,6 +1,5 @@
 @import "~scss/variables";
 
-$sw-loader-element-color: $color-shopware-brand-500;
 $sw-loader-rotate-duration: 1.4s;
 $sw-loader-z-index: $z-index-loader;
 
@@ -33,7 +32,7 @@ $sw-loader-z-index: $z-index-loader;
             border-width: 4px;
             border-style: solid;
             border-radius: 50%;
-            border-color: $sw-loader-element-color transparent transparent transparent;
+            border-color: var(--color-icon-brand-default) transparent transparent transparent;
             animation: sw-loader-rotator $sw-loader-rotate-duration cubic-bezier(0.5, 0, 0.5, 1) infinite;
 
             &:nth-child(1) {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/sw-notification-center-item.scss
@@ -1,6 +1,6 @@
 .sw-notification-center-item {
     padding: var(--scale-size-18) var(--scale-size-24);
-    border-bottom: 1px solid var(--color-border-primary-default);
+    border-bottom: 1px solid var(--color-border-secondary-default);
 
     &:last-child {
         border-bottom: 0 none;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/sw-notification-center.scss
@@ -13,7 +13,7 @@
     }
 
     &:focus-visible {
-        outline: var(--scale-size-2) solid var(--color-border-brand-selected);
+        outline: var(--scale-size-2) solid var(--color-border-brand-default);
         outline-offset: var(--scale-size-2);
     }
 }
@@ -39,7 +39,7 @@
         .sw-notification-center__header {
             display: flex;
             justify-content: space-between;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
             padding: var(--scale-size-18) var(--scale-size-24);
         }
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/sw-notifications.scss
@@ -14,8 +14,8 @@ $sw-notifications-transition: 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     max-height: calc(100% - #{$sw-notifications-gap});
 
     .mt-banner {
-        background-color: var(--color-elevation-surface-overlay);
-        border-color: var(--color-border-primary-default);
+        background-color: var(--color-elevation-surface-raised);
+        border-color: var(--color-border-secondary-default);
         box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 6%);
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/sw-progress-bar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/sw-progress-bar.scss
@@ -1,8 +1,5 @@
 @use "sass:math";
-@import "~scss/variables";
 
-$sw-progress-bar-value-color: $color-shopware-brand-500;
-$sw-progress-bar-background-color: lighten($color-darkgray-200, 40%);
 $sw-progress-bar-height: 8px;
 
 .sw-progress-bar {
@@ -12,14 +9,14 @@ $sw-progress-bar-height: 8px;
     .sw-progress-bar__total {
         width: 100%;
         height: 100%;
-        background-color: $sw-progress-bar-background-color;
+        background-color: var(--color-background-secondary-default);
         border-radius: math.div($sw-progress-bar-height, 2);
     }
 
     .sw-progress-bar__value {
         transition: 1s width linear;
         height: 100%;
-        background-color: $sw-progress-bar-value-color;
+        background-color: var(--color-interaction-primary-default);
         border-radius: math.div($sw-progress-bar-height, 2);
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/sw-shortcut-overview-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/sw-shortcut-overview-item.scss
@@ -6,8 +6,8 @@
     kbd span {
         font-size: var(--font-size-xs);
         color: var(--color-text-primary-default);
-        border: 1px solid var(--color-border-primary-default);
-        background-color: var(--color-background-primary-disabled);
+        border: 1px solid var(--color-border-secondary-default);
+        background-color: var(--color-background-tertiary-default);
         padding: var(--scale-size-4) var(--scale-size-6);
         margin-right: var(--scale-size-8);
         cursor: default;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/sw-skeleton-bar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/sw-skeleton-bar.scss
@@ -3,7 +3,7 @@
 $sw-skeleton-bar-color: var(--color-border-primary-disabled);
 $sw-skeleton-bar-height: 32px;
 $sw-skeleton-shimmer-dark: var(--color-background-primary-default);
-$sw-skeleton-shimmer-light: var(--color-background-primary-disabled);
+$sw-skeleton-shimmer-light: var(--color-background-tertiary-default);
 
 .sw-skeleton-bar {
     height: $sw-skeleton-bar-height;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/sw-skeleton.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/sw-skeleton.scss
@@ -1,6 +1,4 @@
-@import "~scss/variables";
-
-$sw-skeleton-background: var(--color-background-primary-disabled);
+$sw-skeleton-background: var(--color-background-tertiary-default);
 
 .sw-skeleton {
     cursor: progress;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-status/sw-status.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-status/sw-status.scss
@@ -1,13 +1,11 @@
-@import "~scss/variables";
-
 .sw-status {
     display: flex;
     align-items: center;
     gap: 6px;
     padding: 4px 8px;
-    font-size: $font-size-xxs;
-    line-height: $font-size-xxs;
-    border-radius: $font-size-xxs * 2;
+    font-size: var(--font-size-2xs);
+    line-height: var(--font-size-2xs);
+    border-radius: var(--border-radius-round);
 
     .sw-color-badge {
         margin: 0;
@@ -15,7 +13,7 @@
 
     &--gray {
         background-color: var(--color-background-tertiary-default);
-        color: var(--color-text-secondary-default);
+        color: var(--color-text-primary-default);
 
         .sw-color-badge {
             background-color: var(--color-icon-secondary-default);
@@ -24,7 +22,7 @@
 
     &--blue {
         background-color: var(--color-background-brand-default);
-        color: var(--color-text-brand-default);
+        color: var(--color-text-primary-default);
 
         .sw-color-badge {
             background-color: var(--color-icon-brand-default);
@@ -33,7 +31,7 @@
 
     &--red {
         background-color: var(--color-background-critical-default);
-        color: var(--color-text-critical-default);
+        color: var(--color-text-primary-default);
 
         .sw-color-badge {
             background-color: var(--color-icon-critical-default);
@@ -42,7 +40,7 @@
 
     &--orange {
         background-color: var(--color-background-attention-default);
-        color: var(--color-text-attention-default);
+        color: var(--color-text-primary-default);
 
         .sw-color-badge {
             background-color: var(--color-icon-attention-default);
@@ -51,7 +49,7 @@
 
     &--green {
         background-color: var(--color-background-positive-default);
-        color: var(--color-text-positive-default);
+        color: var(--color-text-primary-default);
 
         .sw-color-badge {
             background-color: var(--color-icon-positive-default);

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/sw-text-preview.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/sw-text-preview.scss
@@ -1,14 +1,12 @@
-@import "~scss/variables";
-
 .sw-text-preview__expand-button::before {
-    height: $font-size-s * 1.25;
+    height: calc(var(--font-size-s) * 1.25);
     width: 50px;
     display: inline-block;
     position: absolute;
     left: -56px;
     content: "";
-    background: $color-white;
-    background: linear-gradient(90deg, transparent 0%, $color-white 100%);
+    background: var(--color-background-primary-default);
+    background: linear-gradient(90deg, transparent 0%, var(--color-background-primary-default) 100%);
 }
 
 .sw-text-preview__expand-button {

--- a/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/sw-wizard-dot-navigation.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/sw-wizard-dot-navigation.scss
@@ -1,10 +1,3 @@
-@import "~scss/variables";
-
-$dot-inactive-border-color: $color-gray-300;
-$dot-inactive-background-color: $color-white;
-$dot-active-border-color: $color-shopware-brand-500;
-$dot-active-background-color: $color-shopware-brand-500;
-
 .sw-wizard-dot-navigation {
     list-style: none;
     margin: 0;
@@ -14,16 +7,16 @@ $dot-active-background-color: $color-shopware-brand-500;
 
     .sw-wizard-dot-navigation__item {
         display: inline-block;
-        background: $dot-inactive-background-color;
+        background: var(--color-background-primary-default);
         width: 12px;
         height: 12px;
-        border: 1px solid $dot-inactive-border-color;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 100%;
         margin: 0 5px;
 
         &.is--active {
-            background: $dot-active-border-color;
-            border-color: $dot-active-background-color;
+            background: var(--color-interaction-primary-default);
+            border-color: var(--color-border-brand-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-custom-fields/sw-bulk-edit-custom-fields.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-custom-fields/sw-bulk-edit-custom-fields.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-bulk-edit__custom-fields {
     .sw-bulk-edit-custom-fields__change {
         display: flex;
@@ -15,7 +13,7 @@
             padding: 12px 32px;
 
             &:nth-child(even) {
-                background-color: $color-gray-100;
+                background-color: var(--color-background-secondary-default);
             }
 
             .sw-field,

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-document-generation-failed-list/sw-bulk-edit-document-generation-failed-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-document-generation-failed-list/sw-bulk-edit-document-generation-failed-list.scss
@@ -2,7 +2,7 @@
     width: 100%;
 
     .sw-data-grid {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.scss
@@ -19,14 +19,14 @@
             display: flex;
             justify-content: space-between;
             margin-bottom: 8px;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
 
         &__bar {
             position: relative;
             width: 100%;
             height: 8px;
-            background-color: $color-gray-100;
+            background-color: var(--color-background-secondary-default);
             border-radius: $border-radius-pill;
         }
 
@@ -35,7 +35,7 @@
             top: 0;
             left: 0;
             bottom: 0;
-            background-color: $color-emerald-500;
+            background-color: var(--color-background-positive-default);
             border-radius: $border-radius-pill;
             transition: width 0.15s ease-in-out;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/sw-bulk-edit-save-modal-success.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success/sw-bulk-edit-save-modal-success.scss
@@ -16,7 +16,7 @@
     &__document-generation-separator {
         width: 100%;
         margin: 24px 0;
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &__download-document-container {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal/sw-bulk-edit-save-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal/sw-bulk-edit-save-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-bulk-edit-save-modal {
     &.sw-modal .sw-modal__footer {
         justify-content: space-between;
@@ -7,7 +5,7 @@
     }
 
     &__help-text {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         padding-bottom: 20px;
         text-align: left;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-card/sw-category-entry-point-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-card/sw-category-entry-point-card.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-category-entry-point-card {
     &__navigation-list {
         margin: 12px 0 30px;
@@ -9,6 +7,6 @@
     }
 
     &__navigation-entry {
-        line-height: $line-height-md;
+        line-height: var(--font-line-height-m);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.scss
@@ -1,10 +1,8 @@
-@import "~scss/variables";
-
 .sw-category-entry-point-modal {
     .sw-category-entry-point-modal__layout-headline,
     .sw-category-entry-point-modal__seo-headline {
-        font-size: $font-size-m;
-        font-weight: $font-weight-regular;
+        font-size: var(--font-size-m);
+        font-weight: var(--font-weight-regular);
     }
 
     .sw-category-entry-point-modal__base-layout {
@@ -24,12 +22,12 @@
         align-items: baseline;
 
         .sw-category-entry-point-modal__desc-headline {
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-xs;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-xs);
         }
 
         .sw-category-entry-point-modal__desc-subheadline {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
 
         .sw-category-entry-point-modal__desc-headline.is--empty,
@@ -54,7 +52,7 @@
             justify-content: flex-end;
             color: var(--color-text-brand-default);
             text-decoration: none;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             margin-top: 8px;
 
             .mt-icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.scss
@@ -18,12 +18,12 @@
         margin: auto 0;
 
         .sw-category-layout-card__desc-headline {
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-xs;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-xs);
         }
 
         .sw-category-layout-card__desc-subheadline {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
 
         .sw-category-layout-card__desc-headline.is--empty,
@@ -50,7 +50,7 @@
             justify-content: flex-end;
             color: var(--color-text-brand-default);
             text-decoration: none;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             margin-top: 8px;
 
             .mt-icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-view/sw-category-view.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-view/sw-category-view.scss
@@ -7,7 +7,7 @@
     }
 
     .swag-category-view__column-info-header {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         margin-bottom: 10px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-landing-page-tree/sw-landing-page-tree.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-landing-page-tree/sw-landing-page-tree.scss
@@ -1,5 +1,3 @@
-$sw-tree-item-color-background: var(--color-background-secondary-default);
-
 .sw-landing-page-tree {
     height: 100%;
 
@@ -33,10 +31,10 @@ $sw-tree-item-color-background: var(--color-background-secondary-default);
             }
 
             &:hover {
-                background: $sw-tree-item-color-background;
+                background: var(--color-background-secondary-default);
 
                 .sw-tree-item__content {
-                    background: $sw-tree-item-color-background;
+                    background: var(--color-background-secondary-default);
                 }
             }
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-category {
     &__content {
         width: 100%;
@@ -16,7 +14,7 @@
 
     .sw-category-detail__collapse-headline,
     .sw-category-detail__collapse-selected-count {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
     }
 
     .sw-sidebar-collapse__actions {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-products/sw-category-detail-products.scss
@@ -23,6 +23,6 @@
     }
 
     .sw-product-stream-grid-preview__grid {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/category-heading/preview/sw-cms-preview-category-heading.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/category-heading/preview/sw-cms-preview-category-heading.scss
@@ -1,4 +1,3 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
 .sw-cms-preview-category-heading {
@@ -7,8 +6,8 @@
     &__name {
         @include flex-centering-vertical;
 
-        color: $color-darkgray-200;
-        font-size: $font-size-s;
-        font-weight: $font-weight-semi-bold;
+        color: var(--color-text-primary-default);
+        font-size: var(--font-size-s);
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/cross-selling/preview/sw-cms-preview-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/cross-selling/preview/sw-cms-preview-cross-selling.scss
@@ -1,13 +1,11 @@
-@import "~scss/variables";
-
 .sw-cms-sidebar__block-preview .sw-cms-block-preview-cross-selling {
     padding: 10px;
 
     h4 {
         display: inline-block;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 10px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 5px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/gallery-buybox/preview/sw-cms-preview-gallery-buybox.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/gallery-buybox/preview/sw-cms-preview-gallery-buybox.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-preview-gallery-buybox {
     display: grid;
     grid-template-columns: 7fr 5fr;
@@ -18,7 +16,7 @@
         grid-gap: 4px;
 
         img {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: 2px;
             display: block;
             object-fit: cover;
@@ -55,6 +53,6 @@
     }
 
     .sw-cms-el-preview-buy-box__price {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-description-reviews/preview/sw-cms-preview-product-description-reviews.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-description-reviews/preview/sw-cms-preview-product-description-reviews.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-sidebar__block-preview .sw-cms-block-preview-product-description-reviews {
     color: var(--color-text-primary-default);
     padding: 10px;
@@ -11,20 +9,20 @@
 
     &__tab-description,
     &__tab-reviews {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         margin: auto 10px auto 0;
         padding: 0 0 5px;
     }
 
     &__tab-description {
         color: var(--color-text-primary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &__content {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         color: var(--color-text-primary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-heading/preview/sw-cms-preview-product-heading.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-heading/preview/sw-cms-preview-product-heading.scss
@@ -11,8 +11,8 @@
         @include flex-centering-vertical;
 
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold);
     }
 
     &__logo {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-listing/preview/sw-cms-preview-product-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-listing/preview/sw-cms-preview-product-listing.scss
@@ -13,7 +13,7 @@
         width: 100%;
         padding: 5px;
         background: var(--color-background-tertiary-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 3px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/form/form/preview/sw-cms-preview-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/form/form/preview/sw-cms-preview-form.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-cms-preview-form {
     padding: 15px;
     overflow: auto;
 
     .sw-cms-preview-form-headline {
         margin-bottom: 10px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 10px;
     }
 
@@ -27,7 +25,7 @@
         margin-bottom: 10px;
         height: 1.7em;
         border-radius: 4px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-cms-preview-form-inputs__action {
@@ -36,7 +34,7 @@
         background: var(--color-background-tertiary-default);
         color: var(--color-text-primary-default);
         text-align: center;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 26px;
         border-radius: 3px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/preview/sw-cms-preview-image-gallery.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/preview/sw-cms-preview-image-gallery.scss
@@ -10,7 +10,7 @@
         grid-gap: 4px;
 
         img {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: 2px;
             display: block;
             object-fit: cover;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/category-navigation/preview/sw-cms-block-preview-category-navigation.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/category-navigation/preview/sw-cms-block-preview-category-navigation.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-cms-preview-category-navigation {
     width: 100%;
     background: var(--color-elevation-surface-raised);
     font-size: 22px;
     color: var(--color-text-primary-default);
-    font-weight: $font-weight-semi-bold;
+    font-weight: var(--font-weight-semibold);
     border-radius: 5px;
     padding: 20px;
 
@@ -23,6 +21,6 @@
     hr {
         max-width: 90%;
         margin: 10px auto;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/preview/sw-cms-block-preview-sidebar-filter.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/preview/sw-cms-block-preview-sidebar-filter.scss
@@ -8,7 +8,7 @@
 
     .sw-cms-block-preview-sidebar-filter__element {
         display: inline-block;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 3px;
         padding: 4px 6px;
         margin-right: 6px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-hero/component/sw-cms-block-text-hero.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-hero/component/sw-cms-block-text-hero.scss
@@ -2,6 +2,6 @@
     hr {
         max-width: 160px;
         margin: 0 auto 20px;
-        border: 2px solid var(--color-border-primary-default);
+        border: 2px solid var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.scss
@@ -14,7 +14,7 @@
     display: grid;
     grid-template-columns: 50% 50%;
     list-style: none;
-    border-bottom: 1px solid var(--color-border-primary-default);
+    border-bottom: 1px solid var(--color-border-secondary-default);
     padding-bottom: 24px;
     margin-bottom: 16px;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.scss
@@ -85,7 +85,7 @@
     }
 
     .sw-cms-create-wizard__page-preview {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         padding: 10px 10px 0;
         background: var(--color-elevation-surface-raised);
@@ -94,7 +94,7 @@
 
         .sw-cms-create-wizard__preview_image {
             background: center center no-repeat var(--color-elevation-surface-raised);
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: 4px;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/sw-cms-layout-assignment-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-layout-assignment-modal {
     .sw-modal__body {
         min-height: 550px;
@@ -7,12 +5,12 @@
 
     .sw-cms-layout-assignment-modal__headline {
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-cms-layout-assignment-modal__info-text {
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 20px;
     }
 
@@ -23,7 +21,7 @@
 
 .sw-modal.sw-cms-layout-assignment-modal__confirm-changes-modal {
     .sw-modal__body p {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
 
         &:not(:last-of-type) {
             margin-bottom: 14px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-cms-layout-modal {
     .sw-cms-layout-modal__header {
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 24px;
         padding: 24px 30px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-cms-layout-modal__actions-sorting {
             display: grid;
@@ -33,7 +31,7 @@
         }
 
         .sw-cms-layout-modal__header-title {
-            font-size: $font-size-m;
+            font-size: var(--font-size-m);
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-list-item {
     display: grid;
     grid-template-rows: 120px 40px;
@@ -24,7 +22,7 @@
 
         &:hover {
             cursor: not-allowed;
-            border-color: var(--color-border-primary-default);
+            border-color: var(--color-border-secondary-default);
         }
     }
 
@@ -34,7 +32,7 @@
         background-position: center;
         background-repeat: no-repeat;
         background-size: 90% 90%;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         height: 120px;
 
@@ -44,7 +42,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
     }
 
@@ -61,8 +59,8 @@
         position: absolute;
         bottom: 5px;
         left: 5px;
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xxs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-2xs);
         line-height: 16px;
         color: var(--color-static-white);
         padding: 4px 8px;
@@ -99,7 +97,7 @@
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-cms-list-item__options {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-mapping-field/sw-cms-mapping-field.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-mapping-field {
     .sw-cms-mapping-field__info {
         height: 20px;
@@ -13,7 +11,7 @@
     }
 
     .sw-cms-mapping-field__label {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         line-height: 16px;
         color: var(--color-text-primary-default);
         font-weight: normal;
@@ -28,7 +26,7 @@
         align-items: center;
         justify-content: end;
         justify-items: end;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-brand-default);
         cursor: pointer;
 
@@ -48,7 +46,7 @@
         align-items: center;
         justify-content: end;
         justify-items: end;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         cursor: pointer;
 
         &:hover {
@@ -66,13 +64,13 @@
         padding: 30px;
         text-align: center;
         background: var(--color-background-tertiary-default);
-        border: 1px dashed var(--color-border-primary-default);
+        border: 1px dashed var(--color-border-secondary-default);
         border-radius: 4px;
     }
 
     .sw-cms-mapping-field__preview {
         padding: 20px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         margin-top: 10px;
         margin-bottom: 22px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-missing-element-modal/sw-cms-missing-element-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-missing-element-modal/sw-cms-missing-element-modal.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-cms-missing-element-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
 
     &__title {
         span {
             text-transform: lowercase;
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
     }
 
@@ -15,7 +13,7 @@
     }
 
     &__paragraph {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     &__dont-remind {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
@@ -37,7 +37,7 @@
 
     .sw-cms-page-form__element-config {
         margin-bottom: 22px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         &:last-child {
             margin-bottom: 0;
@@ -128,7 +128,7 @@
 
     &__section-action-label {
         color: var(--color-text-primary-default);
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         line-height: 22px;
         width: 190px;
         word-wrap: break-word;
@@ -155,7 +155,7 @@
     &__section-type-icon {
         margin-right: 10px;
         color: var(--color-text-secondary-default);
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     &__section-divider {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-product-box-preview/sw-cms-product-box-preview.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-product-box-preview/sw-cms-product-box-preview.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-product-box-preview {
     height: 100%;
     display: grid;
@@ -34,21 +32,21 @@
     }
 
     .sw-cms-product-box-preview__name {
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
+        font-weight: var(--font-weight-semibold);
     }
 
     .sw-cms-product-box-preview__description {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 12px;
         margin-bottom: 8px;
     }
 
     .sw-cms-product-box-preview__price {
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
+        font-weight: var(--font-weight-semibold);
     }
 
     .sw-cms-product-box-preview__action {
@@ -56,7 +54,7 @@
         color: var(--color-text-primary-default);
         border-radius: 3px;
         text-align: center;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 26px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/sw-cms-section-config.scss
@@ -14,7 +14,7 @@
     display: grid;
     grid-template-columns: 50% 50%;
     list-style: none;
-    border-bottom: 1px solid var(--color-border-primary-default);
+    border-bottom: 1px solid var(--color-border-secondary-default);
     padding-bottom: 24px;
     margin-bottom: 16px;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
@@ -5,9 +5,9 @@
         background: var(--color-background-secondary-default) !important;
 
         .sw-cms-section__wrapper {
-            border: 30px solid var(--color-border-primary-default);
+            border: 30px solid var(--color-border-secondary-default);
             border-radius: 15px;
-            box-shadow: 0 0 0 1px var(--color-border-primary-default);
+            box-shadow: 0 0 0 1px var(--color-border-secondary-default);
         }
     }
 
@@ -47,8 +47,8 @@
     position: relative;
     background-repeat: no-repeat;
     background-position: center center;
-    border-top: 1px solid var(--color-border-primary-default);
-    border-bottom: 1px solid var(--color-border-primary-default);
+    border-top: 1px solid var(--color-border-secondary-default);
+    border-bottom: 1px solid var(--color-border-secondary-default);
     display: grid;
     grid-template-columns: 60px 1fr;
     align-items: center;
@@ -140,7 +140,7 @@
             align-items: center;
             flex-direction: column;
             border-radius: 10px;
-            border: 2px dashed var(--color-border-primary-default);
+            border: 2px dashed var(--color-border-secondary-default);
 
             &.is--valid-drop {
                 background-color: var(--color-background-brand-default);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/sw-cms-sidebar-nav-element.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/sw-cms-sidebar-nav-element.scss
@@ -5,7 +5,7 @@
     align-content: center;
     padding: 8px 4px 8px 14px;
     margin: 8px 0;
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     background: var(--color-background-tertiary-default);
     color: var(--color-text-primary-default);
     border-radius: 4px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-cms-sidebar {
     .sw-sidebar-item {
         .sw-sidebar-item__headline {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
             padding: 25px 25px 0;
             margin: 0;
         }
@@ -11,11 +9,11 @@
 
     .sw-cms-sidebar__navigator-section {
         padding: 12px 24px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-cms-sidebar__navigator-section-header {
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-s;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-s);
             color: var(--color-text-primary-default);
             margin: 12px 0;
             display: grid;
@@ -24,7 +22,7 @@
     }
 
     .sw-sidebar-collapse__title {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
     }
 
     .sw-cms-sidebar__settings {
@@ -44,7 +42,7 @@
 
     .sw-cms-sidebar__block-category {
         padding: 12px 24px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-field {
             margin: 0;
@@ -63,7 +61,7 @@
     }
 
     .sw-cms-sidebar__navigator-empty-element {
-        border: 1px dashed var(--color-border-primary-default);
+        border: 1px dashed var(--color-border-secondary-default);
         background-color: var(--color-background-primary-default);
         color: var(--color-text-secondary-default);
         padding: 8px 4px 8px 14px;
@@ -90,19 +88,19 @@
     .sw-cms-sidebar__layout-assignment-content,
     .sw-cms-sidebar__layout-set-as-default-content {
         padding: 25px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-cms-sidebar__layout-assignment-headline,
     .sw-cms-sidebar__layout-set-as-default-headline {
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-cms-sidebar__layout-assignment-info-text,
     .sw-cms-sidebar__layout-set-as-default-info-text {
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 20px;
     }
 
@@ -130,7 +128,7 @@
 .sw-cms-sidebar__block-preview {
     margin: 0 0 7px;
     background: var(--color-elevation-surface-raised);
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     border-radius: 5px;
     background-clip: padding-box;
     cursor: grab;
@@ -142,7 +140,7 @@
 
     &.is--dragging {
         box-shadow: none;
-        border: 1px dashed var(--color-border-primary-default);
+        border: 1px dashed var(--color-border-secondary-default);
         background-color: var(--color-background-tertiary-default);
 
         + .sw-cms-sidebar__block-favorite {
@@ -162,20 +160,20 @@
     h4,
     h5,
     h6 {
-        font-size: $font-size-s;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-s);
+        line-height: var(--font-line-height-xs);
         margin: 0 0 6px;
     }
 
     p {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 14px;
     }
 
     hr {
         max-width: 100px;
         margin: 0 auto 10px;
-        border: 2px solid var(--color-border-primary-default);
+        border: 2px solid var(--color-border-secondary-default);
     }
 
     img {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-section-selection/sw-cms-stage-section-selection.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-stage-section-selection/sw-cms-stage-section-selection.scss
@@ -37,7 +37,7 @@
     .sw-cms-stage-section-selection__default-preview-inner {
         height: 100%;
         width: 100%;
-        border: 1px dashed var(--color-border-primary-default);
+        border: 1px dashed var(--color-border-secondary-default);
         border-radius: $border-radius-default;
     }
 
@@ -49,7 +49,7 @@
         justify-content: center;
 
         .sw-cms-stage-section-selection__sidebar-preview-placeholder {
-            border: 1px dashed var(--color-border-primary-default);
+            border: 1px dashed var(--color-border-secondary-default);
             border-radius: $border-radius-default;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-toolbar/sw-cms-toolbar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-toolbar/sw-cms-toolbar.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-cms-toolbar {
     padding: 0 20px;
     min-height: 81px;
-    border-bottom: 2px solid var(--color-border-primary-default);
+    border-bottom: 2px solid var(--color-border-secondary-default);
     display: grid;
     grid-template-columns: 1fr 1fr auto auto auto;
     align-items: center;
@@ -26,8 +24,8 @@
 
     .sw-cms-toolbar__title h2 {
         color: var(--color-text-primary-default);
-        font-size: $font-size-m;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-m);
+        font-weight: var(--font-weight-semibold);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-visibility-config/sw-cms-visibility-config.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-visibility-config/sw-cms-visibility-config.scss
@@ -20,7 +20,7 @@
             justify-content: space-between;
             gap: 10px;
             padding: 16px 30px;
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: 4px;
             margin-bottom: 32px;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/sw-cms-el-buy-box.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/sw-cms-el-buy-box.scss
@@ -7,7 +7,7 @@
     height: 100%;
     width: 100%;
     pointer-events: none;
-    font-size: $font-size-xxs;
+    font-size: var(--font-size-2xs);
     color: var(--color-text-primary-default);
 
     &__placeholder {
@@ -61,7 +61,7 @@
     }
 
     &__variant-title {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     &__variants {
@@ -118,8 +118,8 @@
     &__buy-action {
         display: block;
         line-height: 40px;
-        font-size: $font-size-xs;
-        font-weight: $font-weight-bold;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-bold);
         text-align: center;
         text-decoration: none;
         color: var(--color-static-white);
@@ -129,7 +129,7 @@
 
     &__price {
         font-size: 26px;
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         margin-bottom: 16px;
     }
 
@@ -143,7 +143,7 @@
     }
 
     &__product-number-title {
-        font-weight: $font-weight-bold;
+        font-weight: var(--font-weight-bold);
     }
 
     &__product-number {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/preview/sw-cms-el-preview-buy-box.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/preview/sw-cms-el-preview-buy-box.scss
@@ -9,7 +9,7 @@
     justify-content: space-between;
 
     &__price {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
     }
 
     &__placeholders {
@@ -40,7 +40,7 @@
         color: var(--color-text-primary-default);
         border-radius: $border-radius-default;
         text-align: center;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 26px;
         width: 100%;
         margin-top: 4px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/category-name/component/sw-cms-el-category-name.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/category-name/component/sw-cms-el-category-name.scss
@@ -3,7 +3,7 @@
 .sw-cms-el-category-name {
     &__skeleton,
     &__placeholder {
-        background-color: $color-gray-100;
+        background-color: var(--color-background-secondary-default);
         height: 32px;
         border-radius: $border-radius-pill;
         margin-bottom: 16px;
@@ -11,7 +11,7 @@
     }
 
     &__placeholder {
-        color: $color-darkgray-200;
+        color: var(--color-text-primary-default);
         padding: 4px 12px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/sw-cms-el-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/component/sw-cms-el-cross-selling.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-cross-selling {
     width: 100%;
 
@@ -7,8 +5,8 @@
         display: inline-block;
         margin-bottom: 20px;
         padding-bottom: 5px;
-        border-bottom: 1px solid var(--color-border-primary-default);
-        font-size: $font-size-xs;
+        border-bottom: 1px solid var(--color-border-secondary-default);
+        font-size: var(--font-size-xs);
     }
 
     &__content {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/config/sw-cms-el-config-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/config/sw-cms-el-config-cross-selling.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-config-cross-selling {
     &__products {
         margin-bottom: 22px;
@@ -41,7 +39,7 @@
     }
 
     &__product-stream-preview-link {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         text-decoration: none;
 
         &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/preview/sw-cms-el-preview-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/cross-selling/preview/sw-cms-el-preview-cross-selling.scss
@@ -1,10 +1,8 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-cross-selling {
     h4 {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 10px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 5px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/sw-cms-el-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/sw-cms-el-form.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-form {
     width: 100%;
     user-select: none;
@@ -17,12 +15,12 @@
     }
 
     .sw-cms-el-form-headline {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 10px;
     }
 
     .sw-cms-el-form-note {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-cms-el-form__action {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/preview/sw-cms-el-preview-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/preview/sw-cms-el-preview-form.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-form {
     overflow: auto;
 
     .sw-cms-el--preview-form-headline {
         margin-bottom: 10px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 5px;
     }
 
@@ -26,7 +24,7 @@
         margin-bottom: 10px;
         height: 1em;
         border-radius: 4px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-cms-el-preview-form-inputs__action {
@@ -35,7 +33,7 @@
         background: var(--color-background-tertiary-default);
         color: var(--color-text-primary-default);
         text-align: center;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 26px;
         border-radius: 3px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/sw-cms-el-image-gallery.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/sw-cms-el-image-gallery.scss
@@ -58,7 +58,7 @@
     .sw-cms-el-image-gallery__item-placeholder,
     .sw-media-list-selection-item-v2 {
         border-radius: $border-radius-default;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         height: 64px;
         display: flex;
         align-items: center;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.scss
@@ -21,7 +21,7 @@
         height: 100%;
         width: 100%;
         border-radius: $border-radius-default;
-        border: 2px solid var(--color-border-primary-default);
+        border: 2px solid var(--color-border-secondary-default);
 
         img {
             border-radius: $border-radius-default;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/preview/sw-cms-el-preview-image-gallery.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/preview/sw-cms-el-preview-image-gallery.scss
@@ -9,7 +9,7 @@
         grid-gap: 4px;
 
         img {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             border-radius: 2px;
             display: block;
             object-fit: cover;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.scss
@@ -17,7 +17,7 @@
     .sw-cms-el-config-image-slider__settings-links {
         .sw-cms-el-config-image-slider__settings-link {
             margin-top: 8px;
-            border-top: 1px solid var(--color-border-primary-default);
+            border-top: 1px solid var(--color-border-secondary-default);
             padding-top: 20px;
 
             .sw-cms-el-config-image-slider__settings-link-prefix {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/manufacturer-logo/preview/sw-cms-el-preview-manufacturer-logo.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/manufacturer-logo/preview/sw-cms-el-preview-manufacturer-logo.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-manufacturer-logo {
     display: flex;
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: $color-gray-300;
+    color: var(--color-text-secondary-default);
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/component/sw-cms-el-product-box.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/component/sw-cms-el-product-box.scss
@@ -26,7 +26,7 @@
         flex-grow: 1;
         align-content: start;
         justify-content: center;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         position: relative;
         background: var(--color-elevation-surface-raised);
@@ -44,7 +44,7 @@
     .sw-cms-el-product-box__badge-new {
         padding: 4px 4px 4px 10px;
         margin-bottom: 10px;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         font-weight: bold;
         background: var(--color-interaction-primary-default);
         color: var(--color-static-white);
@@ -98,8 +98,8 @@
         display: block;
         height: 40px;
         margin-bottom: 10px;
-        font-size: $font-size-m;
-        line-height: $line-height-sm;
+        font-size: var(--font-size-m);
+        line-height: var(--font-line-height-s);
         overflow: hidden;
         text-decoration: none;
         color: var(--color-text-primary-default);
@@ -112,8 +112,8 @@
     .sw-cms-el-product-box__description {
         height: 72px;
         margin-top: 10px;
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
         overflow: hidden;
     }
 
@@ -123,24 +123,24 @@
 
     .sw-cms-el-product-box__price-unit {
         height: 36px;
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
         overflow: hidden;
     }
 
     .sw-cms-el-product-box__price-unit-reference {
         height: 18px;
-        font-size: $font-size-xs;
-        line-height: $line-height-xs;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-xs);
         overflow: hidden;
     }
 
     .sw-cms-el-product-box__price {
         height: 20px;
         margin-top: 10px;
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         font-weight: bold;
-        line-height: $line-height-sm;
+        line-height: var(--font-line-height-s);
         overflow: hidden;
         color: var(--color-text-primary-default);
     }
@@ -152,7 +152,7 @@
     .sw-cms-el-product-box__buy-action {
         display: block;
         line-height: 40px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         font-weight: bold;
         text-align: center;
         text-decoration: none;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/sw-cms-el-product-description-reviews.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/sw-cms-el-product-description-reviews.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-product-description-reviews {
     display: grid;
     align-content: flex-start;
@@ -13,16 +11,16 @@
 
     &__description-tab,
     &__reviews-tab {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
         margin: auto 10px auto 0;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding: 0 0 5px;
     }
 
     &__description-tab {
         color: var(--color-text-primary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &__placeholder > div {
@@ -83,11 +81,11 @@
 
     &__detail-item-label,
     &__detail-item-value {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         width: 50%;
     }
 
     &__detail-item-label {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/preview/sw-cms-el-preview-product-description-reviews.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/preview/sw-cms-el-preview-product-description-reviews.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-product-description-reviews {
     background: var(--color-elevation-surface-raised);
     color: var(--color-text-primary-default);
@@ -12,19 +10,19 @@
 
     &__description-tab,
     &__reviews-tab {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         margin: auto 10px auto 0;
         padding: 0 0 5px;
     }
 
     &__description-tab {
         color: var(--color-text-primary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     p {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/component/sw-cms-el-product-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/component/sw-cms-el-product-listing.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-product-listing {
     .sw-cms-el-product-listing__content {
         display: grid;
@@ -24,10 +22,10 @@
             display: grid;
             align-items: center;
             justify-content: center;
-            font-size: $font-size-s;
-            border-right: 1px solid var(--color-border-primary-default);
-            border-bottom: 1px solid var(--color-border-primary-default);
-            border-top: 1px solid var(--color-border-primary-default);
+            font-size: var(--font-size-s);
+            border-right: 1px solid var(--color-border-secondary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
+            border-top: 1px solid var(--color-border-secondary-default);
 
             .mt-icon {
                 color: var(--color-text-primary-default);
@@ -35,7 +33,7 @@
 
             &:first-of-type {
                 border-radius: 4px 0 0 4px;
-                border-left: 1px solid var(--color-border-primary-default);
+                border-left: 1px solid var(--color-border-secondary-default);
             }
 
             &:last-of-type {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/components/sw-cms-el-config-product-listing-config-sorting-grid/sw-cms-el-config-product-listing-config-sorting-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/components/sw-cms-el-config-product-listing-config-sorting-grid/sw-cms-el-config-product-listing-config-sorting-grid.scss
@@ -6,7 +6,7 @@
     }
 
     &__grid {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
         margin: 0 -30px -55px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-config-product-listing {
     &__content-info.mt-banner {
         margin-bottom: 0;
@@ -29,12 +27,12 @@
     .spacer {
         border: none;
         height: 1px;
-        background-color: var(--color-border-primary-default);
+        background-color: var(--color-border-secondary-default);
         margin: 20px 0;
     }
 
     div.sw-cms-el-config-product-listing-filter_properties_as_filter__description-text {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 20px;
         margin-left: 34px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/preview/sw-cms-el-preview-product-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/preview/sw-cms-el-preview-product-listing.scss
@@ -12,7 +12,7 @@
         width: 100%;
         padding: 5px;
         background: var(--color-background-tertiary-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 3px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/preview/sw-cms-el-preview-product-name.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-name/preview/sw-cms-el-preview-product-name.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-product-name {
     display: flex;
     align-items: center;
@@ -8,7 +6,7 @@
 
     &__heading {
         margin: 0;
-        font-size: $font-size-s;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-s);
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/component/sw-cms-el-product-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/component/sw-cms-el-product-slider.scss
@@ -60,7 +60,7 @@
 
     &.has--border {
         padding: 25px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-default;
 
         &.has--navigation-outside {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-config-product-slider {
     .sw-cms-el-config-product-slider__tabs {
         .sw-cms-el-config-product-slider__tab-content {
@@ -52,7 +50,7 @@
     }
 
     .sw-cms-el-config-product-slider__product-stream-preview-link {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         text-decoration: none;
 
         &.is--disabled {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-category-navigation/component/sw-cms-el-category-navigation.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-category-navigation/component/sw-cms-el-category-navigation.scss
@@ -1,6 +1,6 @@
 .sw-cms-el-category-navigation {
     width: 100%;
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     border-radius: 4px;
     background: var(--color-elevation-surface-raised);
     padding: 10px;
@@ -19,7 +19,7 @@
     hr {
         max-width: 90%;
         margin: 10px auto;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 
     h2 {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-category-navigation/preview/sw-cms-el-preview-category-navigation.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-category-navigation/preview/sw-cms-el-preview-category-navigation.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-category-navigation {
     width: 100%;
     background: var(--color-elevation-surface-raised);
     font-size: 22px;
     color: var(--color-text-primary-default);
-    font-weight: $font-weight-semi-bold;
+    font-weight: var(--font-weight-semibold);
 
     .sw-cms-el-category-placeholder-listing div {
         margin: 10px 0;
@@ -27,11 +25,11 @@
         margin: 10px auto;
         height: 1px;
         border: 0 none;
-        background-color: var(--color-border-primary-default);
+        background-color: var(--color-border-secondary-default);
     }
 
     p {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin: auto 10px auto 0;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/component/sw-cms-el-sidebar-filter.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/component/sw-cms-el-sidebar-filter.scss
@@ -7,7 +7,7 @@
 
     .sw-cms-element-sidebar-filter__element {
         display: inline-block;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 3px;
         padding: 8px 12px;
         margin-right: 12px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/preview/sw-cms-el-preview-sidebar-filter.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/sidebar-filter/preview/sw-cms-el-preview-sidebar-filter.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-element-preview-sidebar-filter {
     width: 100%;
     height: 100%;
@@ -8,14 +6,14 @@
     align-items: center;
 
     h3 {
-        font-size: $font-size-xs;
-        line-height: $line-height-sm;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-s);
         margin-bottom: 10px;
     }
 
     .sw-cms-element-preview-sidebar-filter__element {
         display: inline-block;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 3px;
         padding: 4px 6px;
         margin-right: 6px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.scss
@@ -21,7 +21,7 @@
         top: 1px;
         left: 0;
         background: var(--color-background-tertiary-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
 
         button {
             padding: 6px 8px;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/preview/sw-cms-el-preview-text.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/preview/sw-cms-el-preview-text.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-cms-el-preview-text {
     h1,
     h2,
@@ -7,13 +5,13 @@
     h4,
     h5,
     h6 {
-        font-size: $font-size-xs;
-        line-height: $line-height-sm;
+        font-size: var(--font-size-xs);
+        line-height: var(--font-line-height-s);
         margin: 0 0 6px;
     }
 
     p {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 15px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.scss
@@ -24,7 +24,7 @@
         padding-right: 20px;
         height: 80px;
         line-height: 80px;
-        border-right: 1px solid var(--color-border-primary-default);
+        border-right: 1px solid var(--color-border-secondary-default);
         color: var(--color-text-primary-default);
 
         &:hover {
@@ -49,8 +49,8 @@
     }
 
     .sw-cms-detail__page-defaults {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-xxs;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-2xs);
         line-height: 16px;
         color: var(--color-static-white);
         padding: 4px 8px;
@@ -104,7 +104,7 @@
                 padding: 8px 16px;
                 line-height: 22px;
                 height: 40px;
-                font-size: $font-size-xs;
+                font-size: var(--font-size-xs);
             }
         }
     }
@@ -164,7 +164,7 @@
 
             h2.sw-cms-detail__empty-stage-headline {
                 font-size: 32px;
-                font-weight: $font-weight-regular;
+                font-weight: var(--font-weight-regular);
                 margin-bottom: 5px;
             }
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.scss
@@ -49,7 +49,7 @@
         }
 
         h3 {
-            font-size: $font-size-3xl;
+            font-size: var(--font-size-2xl);
             font-weight: normal;
             margin: 0;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-generic-seo-general-card {
     .sw-generic-seo-general-card__google-preview-header {
         padding-bottom: 8px;
     }
 
     .sw-generic-seo-general-card__google-preview {
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         padding: 32px;
 
         &-link {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-generic-social-media-card {
     .sw-generic-social-media-card__media-preview {
         margin-top: 32px;
@@ -10,7 +8,7 @@
     }
 
     .sw-generic-social-media-card__media-preview-container {
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
 
         &.media-preview--sm {
             display: flex;

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/sw-dashboard-statistics.scss
@@ -30,7 +30,7 @@
         display: flex;
         justify-content: center;
         padding: var(--scale-size-24);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &__intro-stats-today-single-stat {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.scss
@@ -1,10 +1,8 @@
-@import "~scss/variables";
-
 .sw-extension-sdk-module {
     .sw-page__back-btn-container {
         a {
             margin-left: 20px;
-            color: $color-gray-700;
+            color: var(--color-text-primary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-extension-adding-failed {
     text-align: center;
 
@@ -8,12 +6,12 @@
     }
 
     h3 {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         margin-bottom: 0.5em;
     }
 
     p {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         line-height: 1.5;
         color: var(--color-text-secondary-default);
         margin-bottom: 8px;
@@ -25,7 +23,7 @@
     }
 
     &__text-licence-cancellation {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         color: var(--color-text-primary-default);
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-success/sw-extension-adding-success.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-success/sw-extension-adding-success.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-extension-adding-success {
     text-align: center;
 
@@ -8,12 +6,12 @@
     }
 
     h3 {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         margin-bottom: 0.5em;
     }
 
     p {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         line-height: 1.5;
         color: var(--color-text-secondary-default);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-app-module-error-page/sw-extension-app-module-error-page.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-app-module-error-page/sw-extension-app-module-error-page.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-extension-app-module-error-page {
     width: 100%;
     height: 100%;
@@ -13,7 +11,7 @@
 
         h3 {
             font-size: 32px;
-            font-weight: $font-weight-regular;
+            font-weight: var(--font-weight-regular);
             margin-block-end: 24px;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
@@ -1,18 +1,17 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
 .sw-extension-card-base {
     &.is--deactivated {
-        background: var(--color-background-primary-disabled);
+        background: var(--color-background-tertiary-default);
         box-shadow: none;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
 
         .sw-extension-card-base__extension-activation-switch {
             background: var(--color-background-secondary-default);
         }
 
         .sw-loader {
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
         }
     }
 
@@ -30,7 +29,7 @@
     &.is--not-installed {
         background-color: var(--color-background-secondary-default);
         box-shadow: none;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-loader {
@@ -52,7 +51,7 @@
         background-color: var(--color-background-secondary-default);
 
         &::after {
-            border-color: var(--color-border-primary-default);
+            border-color: var(--color-border-secondary-default);
         }
     }
 
@@ -68,18 +67,18 @@
     .sw-extension-card-base__info {
         margin-left: -8px;
         overflow: hidden;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
 
         .sw-extension-card-base__info-name {
             @include truncate;
 
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             color: var(--color-text-primary-default);
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
 
         .sw-extension-card-base__info-inactive {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
         }
     }
 
@@ -89,7 +88,7 @@
     }
 
     .sw-extension-card-base__meta-info {
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         text-align: right;
 
         a {
@@ -98,7 +97,7 @@
         }
 
         &-version {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
     }
 
@@ -107,7 +106,7 @@
         text-decoration: underline;
         color: var(--color-text-brand-default);
         transition: color 0.1s ease;
-        font-weight: $font-weight-medium;
+        font-weight: var(--font-weight-medium);
 
         &:hover {
             color: var(--color-text-brand-hover);

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-extension-card-bought {
     .sw-extension-card-bought__info-price-subscription {
         color: var(--color-text-primary-default);
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     .sw-extension-card-bought__info-price {
@@ -19,7 +17,7 @@
         display: inline-flex;
         align-items: center;
         margin-top: 2px;
-        font-weight: $font-weight-medium;
+        font-weight: var(--font-weight-medium);
 
         .mt-icon {
             margin-right: 4px;

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-deactivation-modal/sw-extension-deactivation-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-deactivation-modal/sw-extension-deactivation-modal.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-extension-deactivation-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 22px;
 
     .sw-extension-deactivation-modal__description {
@@ -9,7 +7,7 @@
     }
 
     .sw-extension-deactivation-modal__bold-paragraph {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     .sw-extension-deactivation-modal__hint-paragraph {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-domains-modal/sw-extension-domains-modal.scss
@@ -18,7 +18,7 @@
         padding: var(--scale-size-10) 0;
 
         &:not(:last-child) {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-details-modal/sw-extension-permissions-details-modal.scss
@@ -11,7 +11,7 @@
     border-collapse: collapse;
 
     .sw-extension-permissions-details-modal__operations {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         box-shadow: 0 3px 5px 0 var(--color-elevation-shadow-default);
         display: block;
         top: 0;
@@ -23,7 +23,7 @@
         padding: var(--scale-size-16) var(--scale-size-36);
 
         &:not(:last-child) {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
 
         &.sw-extension-permissions-details-modal__category {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
@@ -26,7 +26,7 @@
         padding: var(--scale-size-24) var(--scale-size-32);
 
         &:not(:last-child) {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
 
         .sw-extension-permissions-modal__category-label {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-privacy-policy-extensions-modal/sw-extension-privacy-policy-extensions-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-privacy-policy-extensions-modal/sw-extension-privacy-policy-extensions-modal.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-extension-privacy-policy-extensions-modal {
     .sw-extension-privacy-policy-extensions-modal__intro {
         margin-bottom: 24px;
     }
 
     .sw-extension-privacy-policy-extensions-modal__text {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         white-space: pre;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-extension-removal-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 22px;
 
     .sw-extension-removal-modal__bold-paragraph {
         margin-block-start: 1em;
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-uninstall-modal/sw-extension-uninstall-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-uninstall-modal/sw-extension-uninstall-modal.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-extension-uninstall-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 22px;
 
     .sw-extension-removal-modal__bold-paragraph {
         margin-block-start: 1em;
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-modal/sw-extension-rating-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-modal/sw-extension-rating-modal.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-modal.sw-extension-rating-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 22px;
 
     .sw-review-creation-inputs__review,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/sw-extension-rating-stars.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-rating-stars/sw-extension-rating-stars.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 $padding-star: 10%;
 
 .sw-extension-rating-stars {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-ratings-summary/sw-extension-ratings-summary.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-extension-ratings-summary {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     max-width: 450px;
 
     &__grid {
@@ -16,7 +14,7 @@
         grid-template-columns: auto 1fr;
         grid-gap: 12px;
         align-items: center;
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
 
         .mt-progress-bar {
             height: 4px;
@@ -27,7 +25,7 @@
             }
 
             .mt-progress-bar__track {
-                background: var(--color-background-primary-disabled);
+                background: var(--color-background-tertiary-default);
             }
 
             .mt-field-label,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-reply/sw-extension-review-reply.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-reply/sw-extension-review-reply.scss
@@ -12,7 +12,7 @@
     }
 
     &__producer-name {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
     }
 
     &__date {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review/sw-extension-review.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review/sw-extension-review.scss
@@ -1,10 +1,8 @@
-@import "~scss/variables";
-
 .sw-extension-review {
     margin-bottom: 20px;
 
     &__headline {
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         margin-bottom: 2px;
     }
 
@@ -18,7 +16,7 @@
 
     &__meta-data {
         color: var(--color-text-secondary-default);
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
     }
 
     &__comma:not(:last-child)::after {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.scss
@@ -8,14 +8,14 @@
     /* stylelint-disable-next-line max-line-length */
     .sw-meteor-page__smart-bar .sw-meteor-page__smart-bar-module-info .sw-meteor-page__smart-bar-header .sw-meteor-page__smart-bar-title {
         line-height: 36px;
-        font-size: $font-size-l;
+        font-size: var(--font-size-l);
     }
 
     .sw-meteor-page__smart-bar-content {
         margin-bottom: 24px;
 
         .sw-meteor-page__smart-bar-meta {
-            font-size: $font-size-xxs;
+            font-size: var(--font-size-2xs);
             color: var(--color-text-secondary-default);
             line-height: 12px;
         }
@@ -25,11 +25,11 @@
         width: 72px;
         height: 72px;
         border-radius: $border-radius-lg;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 
     &__producer-link {
         text-decoration: none;
-        font-weight: $font-weight-medium;
+        font-weight: var(--font-weight-medium);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-account/sw-extension-my-extensions-account.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-account/sw-extension-my-extensions-account.scss
@@ -51,7 +51,7 @@
     }
 
     .sw-extension-my-extensions-account__wrapper-content-login-status-id {
-        font-weight: $font-weight-bold;
+        font-weight: var(--font-weight-bold);
     }
 
     .sw-extension-my-extensions-account__wrapper-content-login-footer {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.scss
@@ -11,7 +11,7 @@
         display: flex;
         justify-content: center;
         background-color: var(--color-elevation-surface-raised);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
         text-align: center;
         padding: 44px;
@@ -36,7 +36,7 @@
         flex-direction: column;
 
         h2 {
-            font-size: $font-size-m;
+            font-size: var(--font-size-m);
         }
 
         p {
@@ -48,7 +48,7 @@
         color: var(--color-text-positive-default);
         background-color: var(--color-background-positive-default);
         border-radius: $border-radius-default;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         padding: 3px 5px;
         margin-bottom: 12px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/sw-first-run-wizard-mailer-selection.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-mailer-selection/sw-first-run-wizard-mailer-selection.scss
@@ -73,7 +73,7 @@
 
         p {
             font-size: var(--font-size-xs);
-            line-height: var(--line-height-xs);
+            line-height: var(--font-line-height-xs);
             color: var(--color-text-primary-default);
             transition: 0.3s color ease;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-app-action-modal/sw-flow-app-action-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-app-action-modal/sw-flow-app-action-modal.scss
@@ -1,7 +1,7 @@
 .sw-flow-app-action-modal {
     &__app-badge {
         background-color: var(--color-background-secondary-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-round);
         height: var(--scale-size-24);
         padding: var(--scale-size-4) var(--scale-size-10);

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/sw-flow-mail-send-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/sw-flow-mail-send-modal.scss
@@ -19,7 +19,7 @@
     }
 
     &__recipient-grid {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
         margin-bottom: var(--scale-size-32);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.scss
@@ -255,12 +255,12 @@
             position: absolute;
             top: -5px;
             right: -3px;
-            color: var(--color-border-primary-default);
+            color: var(--color-border-secondary-default);
         }
     }
 
     &__true-line {
-        border-top: 2px dashed var(--color-border-primary-default);
+        border-top: 2px dashed var(--color-border-secondary-default);
         width: calc(100% - var(--scale-size-6));
         position: absolute;
     }
@@ -272,7 +272,7 @@
         width: var(--scale-size-12);
         height: var(--scale-size-12);
         background: var(--color-elevation-surface-raised);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-round);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-condition/sw-flow-sequence-condition.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-condition/sw-flow-sequence-condition.scss
@@ -26,7 +26,7 @@
             position: absolute;
             top: -5px;
             right: -1.5px;
-            color: var(--color-border-primary-default);
+            color: var(--color-border-secondary-default);
         }
 
         &.is--disabled {
@@ -47,7 +47,7 @@
         width: var(--scale-size-12);
         height: var(--scale-size-12);
         background: var(--color-elevation-surface-raised);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-round);
     }
 
@@ -96,7 +96,7 @@
             position: absolute;
             bottom: -2px;
             left: -7px;
-            color: var(--color-border-primary-default);
+            color: var(--color-border-secondary-default);
         }
     }
 
@@ -160,13 +160,13 @@
     }
 
     &__true-line {
-        border-top: 2px dashed var(--color-border-primary-default);
+        border-top: 2px dashed var(--color-border-secondary-default);
         width: calc(100% - var(--scale-size-6));
         position: absolute;
     }
 
     &__false-line {
-        border-left: 2px dashed var(--color-border-primary-default);
+        border-left: 2px dashed var(--color-border-secondary-default);
         height: calc(100% - var(--scale-size-6));
         position: absolute;
         left: -2px;
@@ -303,7 +303,7 @@
         left: 360px;
         width: 20.5rem;
         padding: var(--scale-size-24);
-        border: 2px dashed var(--color-border-primary-default);
+        border: 2px dashed var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
         color: var(--color-text-primary-default);
 
@@ -324,7 +324,7 @@
 
 .sw-select-result-list-popover-wrapper {
     .sw-select-result__item-list {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: var(--scale-size-4);
         margin-bottom: var(--scale-size-4);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-selector/sw-flow-sequence-selector.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-selector/sw-flow-sequence-selector.scss
@@ -1,7 +1,7 @@
 .sw-flow-sequence-selector {
     width: 20.5rem;
     padding: var(--scale-size-24);
-    border: 2px dashed var(--color-border-primary-default);
+    border: 2px dashed var(--color-border-secondary-default);
     border-radius: var(--border-radius-card);
     margin-right: var(--scale-size-32);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/sw-flow-trigger.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/sw-flow-trigger.scss
@@ -11,7 +11,7 @@
     &.overlay .sw-flow-trigger__event-selection {
         z-index: 700;
         position: absolute;
-        background: var(--color-elevation-surface-overlay);
+        background: var(--color-elevation-surface-raised);
         background-clip: padding-box;
         border-radius: var(--border-radius-xs);
         box-shadow: 0 1px 6px 0 var(--color-elevation-shadow-default);

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
@@ -32,7 +32,7 @@
 
     &__trigger-explain {
         width: 26.25rem;
-        border: 2px dashed var(--color-border-primary-default);
+        border: 2px dashed var(--color-border-secondary-default);
         border-radius: var(--border-radius-card);
         padding: var(--scale-size-24);
         color: var(--color-text-primary-default);
@@ -59,7 +59,7 @@
         width: var(--scale-size-12);
         height: var(--scale-size-12);
         background: var(--color-elevation-surface-raised);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-round);
     }
 
@@ -89,8 +89,8 @@
             top: 64px;
             width: var(--scale-size-32);
             height: 54px;
-            border-bottom: 2px dashed var(--color-border-primary-default);
-            border-left: 2px dashed var(--color-border-primary-default);
+            border-bottom: 2px dashed var(--color-border-secondary-default);
+            border-left: 2px dashed var(--color-border-secondary-default);
             border-bottom-left-radius: 40px;
         }
 
@@ -109,7 +109,7 @@
             position: absolute;
             bottom: -7px;
             right: -10px;
-            color: var(--color-border-primary-default);
+            color: var(--color-border-secondary-default);
         }
 
         &:not(:last-child) .sw-flow-detail-flow__position-plus {
@@ -119,7 +119,7 @@
         &::before {
             content: "";
             display: block;
-            border-left: 2px dashed var(--color-border-primary-default);
+            border-left: 2px dashed var(--color-border-secondary-default);
             z-index: 1;
         }
 
@@ -127,7 +127,7 @@
             content: "";
             display: block;
             height: 165px;
-            border-left: 2px dashed var(--color-border-primary-default);
+            border-left: 2px dashed var(--color-border-secondary-default);
             z-index: 1;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/sw-import-export-entity-path-select.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-entity-path-select/sw-import-export-entity-path-select.scss
@@ -22,7 +22,7 @@
     }
 
     &__listing-seperator {
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
     }
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/sw-integration-mcp-allowlist.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/sw-integration-mcp-allowlist.scss
@@ -15,7 +15,7 @@
 
     &__type-section {
         background: var(--color-elevation-surface-default);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-bottom: none;
         overflow: hidden;
 
@@ -25,7 +25,7 @@
         }
 
         &:last-child {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
             border-bottom-right-radius: var(--border-radius-xs);
             border-bottom-left-radius: var(--border-radius-xs);
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-login/page/index/sw-login.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/page/index/sw-login.scss
@@ -245,7 +245,7 @@
             &::after {
                 flex: 1;
                 content: "";
-                border-top: 1px solid var(--color-border-primary-default);
+                border-top: 1px solid var(--color-border-secondary-default);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.scss
@@ -80,7 +80,7 @@
     &__attachments-info-grid {
         position: relative;
         margin-top: var(--scale-size-20);
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-folder-info/sw-media-folder-info.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-folder-info/sw-media-folder-info.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-media-quickinfo-border-color-preview: var(--color-border-primary-default);
-$sw-media-quickinfo-border-radius-preview: $border-radius-default;
-
 .sw-media-folder-info {
     .sw-media-sidebar__quickaction--disabled {
         opacity: 0.5;

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-metadata-item/sw-media-quickinfo-metadata-item.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-metadata-item/sw-media-quickinfo-metadata-item.scss
@@ -1,17 +1,14 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
-$sw-metadata-item-caption-color: var(--color-text-primary-default);
-
 .sw-media-quickinfo-metadata-item__term {
-    font-size: $font-size-xs;
-    color: $sw-metadata-item-caption-color;
+    font-size: var(--font-size-xs);
+    color: var(--color-text-primary-default);
 }
 
 .sw-media-quickinfo-metadata-item__description {
     @include truncate;
 
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
 
     @media screen and (max-width: 768px) {
         margin-bottom: 16px;

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.scss
@@ -1,5 +1,3 @@
-$sw-media-quickinfo-color-second-headline: var(--color-text-primary-default);
-
 .sw-media-quickinfo-multiple {
     .sw-media-sidebar__quickaction--disabled {
         opacity: 0.5;
@@ -14,5 +12,5 @@ $sw-media-quickinfo-color-second-headline: var(--color-text-primary-default);
 .sw-media-quickinfo-multiple .sw-media-quickinfo-multiple__second-headline {
     display: block;
     margin: 0 0 20px;
-    color: $sw-media-quickinfo-color-second-headline;
+    color: var(--color-text-primary-default);
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.scss
@@ -1,6 +1,3 @@
-$sw-media-quickinfo-usage-hover-color: var(--color-text-brand-default);
-$sw-media-quickinfo-usage-hover-background: var(--color-background-brand-default);
-
 .sw-media-quickinfo-usage {
     .sw-media-quickinfo-usage__loading-indicator {
         position: relative;
@@ -34,10 +31,10 @@ $sw-media-quickinfo-usage-hover-background: var(--color-background-brand-default
 
         &:hover {
             cursor: pointer;
-            background-color: $sw-media-quickinfo-usage-hover-background;
+            background-color: var(--color-background-brand-default);
 
             .sw-media-quickinfo-usage__label {
-                color: $sw-media-quickinfo-usage-hover-color;
+                color: var(--color-text-brand-default);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.scss
@@ -1,8 +1,5 @@
 @import "~scss/variables";
 
-$sw-media-quickinfo-border-color-preview: var(--color-border-primary-default);
-$sw-media-quickinfo-border-radius-preview: $border-radius-default;
-
 .sw-media-quickinfo {
     .sw-media-quickinfo__alert-file-missing {
         margin: 0 25px 25px;
@@ -21,8 +18,8 @@ $sw-media-quickinfo-border-radius-preview: $border-radius-default;
 
     .sw-media-quickinfo__media-preview {
         position: relative;
-        border: 1px solid $sw-media-quickinfo-border-color-preview;
-        border-radius: $sw-media-quickinfo-border-radius-preview;
+        border: 1px solid var(--color-border-secondary-default);
+        border-radius: $border-radius-default;
 
         &::after {
             content: "";

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-sidebar/sw-media-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-sidebar/sw-media-sidebar.scss
@@ -1,19 +1,11 @@
-@import "~scss/variables";
 @import "~scss/mixins";
-
-$sw-media-sidebar-z-index: $z-index-sidebar;
-$sw-media-sidebar-font-size-headline: $font-size-m;
-$sw-media-sidebar-color-headline: var(--color-text-primary-default);
-$sw-media-sidebar-border-color-headline: var(--color-border-primary-default);
-$sw-media-sidebar-color-quick-action: var(--color-text-brand-default);
-$sw-media-sidebar-color-quick-action-danger: var(--color-icon-critical-default);
 
 .sw-media-sidebar {
     display: grid;
     height: 100%;
     width: 400px;
     grid-template-rows: auto 1fr;
-    border-left: 1px solid var(--color-border-primary-default);
+    border-left: 1px solid var(--color-border-secondary-default);
 
     @media screen and (max-width: 768px) {
         width: 300px;
@@ -28,10 +20,10 @@ $sw-media-sidebar-color-quick-action-danger: var(--color-icon-critical-default);
 
         padding: 25px;
         margin: 0;
-        font-size: $sw-media-sidebar-font-size-headline;
+        font-size: var(--font-size-m);
         font-weight: normal;
-        color: $sw-media-sidebar-color-headline;
-        border-bottom: 1px solid $sw-media-sidebar-border-color-headline;
+        color: var(--color-text-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-media-sidebar__quickinfo-scroll-container {
@@ -95,22 +87,22 @@ $sw-media-sidebar-color-quick-action-danger: var(--color-icon-critical-default);
         margin-bottom: 16px;
 
         &:hover {
-            color: $sw-media-sidebar-color-quick-action;
+            color: var(--color-text-brand-default);
         }
 
         &:hover.is--danger {
-            color: $sw-media-sidebar-color-quick-action-danger;
+            color: var(--color-icon-critical-default);
         }
     }
 
     .sw-media-sidebar__quickactions-icon {
         position: relative;
         top: -2px;
-        color: $sw-media-sidebar-color-quick-action;
+        color: var(--color-text-brand-default);
         margin-right: 0.25rem;
 
         &.is--danger {
-            color: $sw-media-sidebar-color-quick-action-danger;
+            color: var(--color-icon-critical-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-breadcrumbs/sw-media-breadcrumbs.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-breadcrumbs/sw-media-breadcrumbs.scss
@@ -1,4 +1,3 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
 .sw-media-breadcrumbs {
@@ -13,7 +12,7 @@
     }
 
     .sw-media-breadcrumbs__entry {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         display: flex;
         align-items: center;
         margin-top: 5px;
@@ -39,6 +38,6 @@
     }
 
     &.is--small .sw-media-breadcrumbs__entry {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-collapse/sw-media-collapse.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-collapse/sw-media-collapse.scss
@@ -1,20 +1,14 @@
-@import "~scss/variables";
-
-$sw-media-collapse-color-divider: var(--color-border-primary-default);
-$sw-media-collapse-color-title: var(--color-text-primary-default);
-$sw-media-collapse-font-size-title: $font-size-s;
-
 .sw-media-sidebar .sw-collapse {
     .sw-media-collapse__header {
         display: grid;
         grid-template-columns: 1fr auto;
         cursor: pointer;
         padding: 16px 25px 0;
-        color: $sw-media-collapse-color-title;
+        color: var(--color-text-primary-default);
     }
 
     .sw-media-collapse__title {
-        font-size: $sw-media-collapse-font-size-title;
+        font-size: var(--font-size-s);
         font-weight: normal;
     }
 
@@ -26,5 +20,5 @@ $sw-media-collapse-font-size-title: $font-size-s;
         padding: 0 25px 25px;
     }
 
-    border-bottom: 1px solid $sw-media-collapse-color-divider;
+    border-bottom: 1px solid var(--color-border-secondary-default);
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.scss
@@ -1,14 +1,12 @@
 @import "~scss/variables";
 
-$sw-media-library-color-background: var(--color-elevation-surface-default);
-
 .sw-media-library {
     display: grid;
     grid-template-rows: auto 1fr;
     position: relative;
     width: 100%;
     height: 100%;
-    background-color: $sw-media-library-color-background;
+    background-color: var(--color-elevation-surface-default);
 
     .sw-media-library__options-container {
         padding: 0 24px 16px;
@@ -35,7 +33,7 @@ $sw-media-library-color-background: var(--color-elevation-surface-default);
 
     .sw-media-library__parent-folder {
         .sw-media-base-item__name-container {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
 
         &:hover .sw-media-base-item__selected-indicator {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-save-modal/sw-media-save-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-save-modal/sw-media-save-modal.scss
@@ -1,5 +1,3 @@
-$sw-media-modal-v2-non-grid-margin: 0 24px;
-
 .sw-modal.sw-media-save-modal.sw-modal--full {
     z-index: 1100;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.scss
@@ -1,10 +1,4 @@
-@import "~scss/variables";
 @import "~scss/mixins";
-
-$sw-media-index-font-size-navigation: $font-size-m;
-$sw-media-index-color-breadcrumb-icon: var(--color-text-brand-default);
-$sw-media-index-color-navigation-parent: var(--color-text-primary-default);
-$sw-media-index-page-background-color: var(--color-elevation-surface-default);
 
 .sw-media-index {
     .sw-media-index__navigation {
@@ -14,23 +8,23 @@ $sw-media-index-page-background-color: var(--color-elevation-surface-default);
         align-items: center;
         padding-left: 26px;
         min-width: 150px;
-        font-size: $sw-media-index-font-size-navigation;
+        font-size: var(--font-size-m);
     }
 
     .sw-media-index__navigation-breadcrumb {
-        color: $sw-media-index-color-breadcrumb-icon;
+        color: var(--color-text-brand-default);
         height: 28px;
     }
 
     .sw-media-index__navigation-label {
         @include truncate;
 
-        color: $sw-media-index-color-navigation-parent;
+        color: var(--color-text-primary-default);
         text-decoration: none;
     }
 
     .sw-media-index__page-content {
-        background: $sw-media-index-page-background-color;
+        background: var(--color-elevation-surface-default);
         display: grid;
         height: 100%;
         grid-template-columns: 1fr auto;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.scss
@@ -1,10 +1,3 @@
-@import "~scss/variables";
-
-$sw-order-address-modal-highlight: var(--color-background-brand-default);
-$sw-order-address-modal-link: var(--color-text-brand-default);
-$sw-order-address-modal-selected: var(--color-interaction-primary-default);
-$sw-order-address-modal-selected-text: var(--color-text-primary-inverse);
-
 .sw-order-address-modal {
     .sw-order-address-modal__entry {
         text-align: left;
@@ -14,18 +7,18 @@ $sw-order-address-modal-selected-text: var(--color-text-primary-inverse);
         border: none;
 
         &:hover {
-            background-color: $sw-order-address-modal-highlight;
-            color: $sw-order-address-modal-link;
+            background-color: var(--color-background-brand-default);
+            color: var(--color-text-brand-default);
         }
     }
 
     .sw-order-address-modal__entry__selected {
-        color: $sw-order-address-modal-selected-text;
-        background-color: $sw-order-address-modal-selected;
+        color: var(--color-static-white);
+        background-color: var(--color-interaction-primary-default);
 
         &:hover {
-            color: $sw-order-address-modal-selected-text;
-            background-color: $sw-order-address-modal-selected;
+            color: var(--color-static-white);
+            background-color: var(--color-interaction-primary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-address-modal/sw-order-create-address-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-address-modal/sw-order-create-address-modal.scss
@@ -1,8 +1,5 @@
 @import "~scss/variables";
 
-$sw-order-address-modal-highlight: var(--color-background-brand-default);
-$sw-order-address-modal-link: var(--color-text-brand-default);
-
 .sw-order-create-address-modal {
     &__card {
         text-align: left;
@@ -10,12 +7,12 @@ $sw-order-address-modal-link: var(--color-text-brand-default);
         line-height: 22px;
         padding: 15px;
         border: none;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         display: flex;
 
         &:hover {
-            background-color: $sw-order-address-modal-highlight;
-            color: $sw-order-address-modal-link;
+            background-color: var(--color-background-brand-default);
+            color: var(--color-text-brand-default);
 
             .sw-address {
                 &__body {
@@ -38,8 +35,8 @@ $sw-order-address-modal-link: var(--color-text-brand-default);
 
     &__card-label {
         color: var(--color-text-primary-default);
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-s;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-s);
     }
 
     &__card-body {
@@ -50,7 +47,7 @@ $sw-order-address-modal-link: var(--color-text-brand-default);
         display: inline-block;
         position: relative;
         margin: 0;
-        line-height: $font-size-m;
+        line-height: var(--font-size-m);
         color: var(--color-text-brand-default);
         cursor: pointer;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-order-create-general-info__summary {
     display: flex;
     flex-direction: column;
@@ -15,8 +13,8 @@
 
         &-header,
         &-total {
-            font-size: $font-size-s;
-            font-weight: $font-weight-semi-bold;
+            font-size: var(--font-size-s);
+            font-weight: var(--font-weight-semibold);
             line-height: 25px;
         }
 
@@ -36,7 +34,7 @@
 
         &-description,
         &-last-changed {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             line-height: 22px;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-invalid-promotion-modal/sw-order-create-invalid-promotion-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-invalid-promotion-modal/sw-order-create-invalid-promotion-modal.scss
@@ -1,8 +1,6 @@
-@import "~scss/variables";
-
 .sw-order-create-invalid-promotion-modal {
     &__description {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
         margin-bottom: 22px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-promotion-modal/sw-order-create-promotion-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-promotion-modal/sw-order-create-promotion-modal.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-order-create-promotion-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     color: var(--color-text-secondary-default);
 
     &.sw-modal--default .sw-modal__dialog {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/sw-order-customer-address-select.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/sw-order-customer-address-select.scss
@@ -8,7 +8,7 @@
 
 .sw-select-result-list-popover-wrapper {
     .sw-select-result__item-list {
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
         padding-bottom: 5px;
         margin-bottom: 5px;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.scss
@@ -1,13 +1,11 @@
-@import "~scss/variables";
-
 .sw-order-detail-state-card {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
 
     &__divider {
         margin: 32px 0;
         border: none;
         height: 1px;
-        background-color: var(--color-border-primary-default);
+        background-color: var(--color-border-secondary-default);
     }
 
     &__content {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-order-general-info__summary {
     display: flex;
     flex-direction: column;
@@ -16,8 +14,8 @@
         &-header,
         &-total,
         &-header-link {
-            font-size: $font-size-s;
-            font-weight: $font-weight-semi-bold;
+            font-size: var(--font-size-s);
+            font-weight: var(--font-weight-semibold);
             line-height: 25px;
         }
 
@@ -37,7 +35,7 @@
 
         &-description,
         &-last-changed {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             line-height: 22px;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.scss
@@ -1,18 +1,13 @@
-@import "~scss/variables";
-
-$sw-order-line-item-grid-trash: var(--color-icon-critical-default);
-$sw-order-line-item-border: var(--color-border-primary-default);
-
 .sw-order-line-items-grid {
     .sw-order-line-items-grid__actions-container {
         padding: 24px;
-        border-bottom: 1px solid $sw-order-line-item-border;
+        border-bottom: 1px solid var(--color-border-secondary-default);
         background: var(--color-background-tertiary-default);
 
         .sw-order-line-items-grid__delete-button {
             &.mt-button--square:not([disabled]) .mt-icon,
             &.mt-button--square:not(.mt-button--disabled) .mt-icon {
-                color: $sw-order-line-item-grid-trash;
+                color: var(--color-icon-critical-default);
             }
         }
     }
@@ -39,7 +34,7 @@ $sw-order-line-item-border: var(--color-border-primary-default);
     }
 
     .sw-order-line-items-grid__item-payload-options--group {
-        font-weight: $font-weight-bold;
+        font-weight: var(--font-weight-bold);
     }
 
     .mt-icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-modal/sw-order-nested-line-items-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-modal/sw-order-nested-line-items-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-modal__body:has(.sw-order-nested-line-items-modal__container) {
     overflow-x: scroll;
 }
@@ -18,8 +16,8 @@
     &__header-item {
         flex-grow: 1;
         padding: 10px;
-        border-bottom: 1px solid var(--color-border-primary-default);
-        font-weight: $font-weight-semi-bold;
+        border-bottom: 1px solid var(--color-border-secondary-default);
+        font-weight: var(--font-weight-semibold);
 
         &:first-child {
             padding-left: 30px;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-row/sw-order-nested-line-items-row.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-row/sw-order-nested-line-items-row.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-order-nested-line-items-row {
     &__content {
         display: flex;
     }
 
     &__nesting-level {
-        border-left: 1px solid var(--color-border-primary-default);
+        border-left: 1px solid var(--color-border-secondary-default);
         display: inline-block;
         height: 100%;
         padding: 0 8px 0 12px;
@@ -23,7 +21,7 @@
     &__item {
         flex-grow: 1;
         padding: 10px;
-        font-size: $font-size-s;
+        font-size: var(--font-size-s);
 
         &:first-child {
             padding: 0 0 0 30px;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-tag-field/sw-order-promotion-tag-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-tag-field/sw-order-promotion-tag-field.scss
@@ -1,19 +1,15 @@
-@import "~scss/variables";
-
-$promotion-tag-danger-border: var(--color-border-critical-default);
-
 .sw-order-promotion-tag-field {
     .sw-tagged-field__tag-list {
         background: var(--color-elevation-surface-raised);
 
         &--disabled {
-            background: var(--color-background-primary-disabled);
+            background: var(--color-background-tertiary-default);
         }
     }
 
     .sw-label {
         &.sw-label--danger {
-            border-color: $promotion-tag-danger-border;
+            border-color: var(--color-border-critical-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/sw-order-send-document-modal.scss
@@ -13,15 +13,15 @@
     }
 
     &__email-content-label {
-        line-height: $font-size-s;
-        font-size: $font-size-xs;
+        line-height: var(--font-size-s);
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
     }
 
     &__email-content {
         margin-top: 8px;
         padding: 15px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-default;
         overflow: scroll;
         background: var(--color-background-tertiary-default);

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card-entry/sw-order-state-history-card-entry.scss
@@ -1,11 +1,3 @@
-@import "~scss/variables";
-
-$sw-order-state-card-neutral: var(--color-icon-secondary-default);
-$sw-order-state-card-progress: var(--color-icon-brand-default);
-$sw-order-state-card-danger: var(--color-icon-critical-default);
-$sw-order-state-card-success: var(--color-icon-positive-default);
-$sw-order-state-card-warning: var(--color-icon-attention-default);
-
 .sw-order-state-history-card-entry {
     .sw-order-state-card__history-entry {
         display: block;
@@ -13,8 +5,8 @@ $sw-order-state-card-warning: var(--color-icon-attention-default);
 
         .sw-order-state-card__date {
             float: right;
-            line-height: $line-height-md;
-            font-size: $font-size-xxs;
+            line-height: var(--font-line-height-m);
+            font-size: var(--font-size-2xs);
         }
 
         .sw-order-state-card__text {
@@ -44,23 +36,23 @@ $sw-order-state-card-warning: var(--color-icon-attention-default);
         }
 
         .sw-order-state__neutral-icon {
-            color: $sw-order-state-card-neutral;
+            color: var(--color-icon-secondary-default);
         }
 
         .sw-order-state__progress-icon {
-            color: $sw-order-state-card-progress;
+            color: var(--color-icon-brand-default);
         }
 
         .sw-order-state__warning-icon {
-            color: $sw-order-state-card-warning;
+            color: var(--color-icon-attention-default);
         }
 
         .sw-order-state__danger-icon {
-            color: $sw-order-state-card-danger;
+            color: var(--color-icon-critical-default);
         }
 
         .sw-order-state__success-icon {
-            color: $sw-order-state-card-success;
+            color: var(--color-icon-positive-default);
         }
 
         .icon--regular-chevron-down-xxs {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-select-v2/sw-order-state-select-v2.scss
@@ -45,7 +45,7 @@
         }
 
         .sw-single-select__selection-text {
-            color: var(--color-text-brand-default);
+            color: var(--color-text-primary-default);
         }
 
         .sw-select__select-indicator {
@@ -66,7 +66,7 @@
         }
 
         .sw-single-select__selection-text {
-            color: var(--color-text-critical-default);
+            color: var(--color-text-primary-default);
         }
 
         .sw-select__select-indicator {
@@ -87,7 +87,7 @@
         }
 
         .sw-single-select__selection-text {
-            color: var(--color-text-positive-default);
+            color: var(--color-text-primary-default);
         }
 
         .sw-select__select-indicator {
@@ -108,7 +108,7 @@
         }
 
         .sw-single-select__selection-text {
-            color: var(--color-text-attention-default);
+            color: var(--color-text-primary-default);
         }
 
         .sw-select__select-indicator {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.scss
@@ -1,7 +1,3 @@
-@import "~scss/variables";
-
-$sw-order-user-card-link: var(--color-text-brand-default);
-
 .sw-order-user-card {
     .sw-order-user-card__container {
         padding-bottom: 24px;
@@ -9,8 +5,8 @@ $sw-order-user-card-link: var(--color-text-brand-default);
 
     .sw-order-user-card__metadata-user-name,
     .sw-order-user-card__metadata-price {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-m;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-m);
         margin-bottom: 8px;
     }
 
@@ -23,7 +19,7 @@ $sw-order-user-card-link: var(--color-text-brand-default);
 
     .sw-order-user-card__metadata-item {
         margin-bottom: 8px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     .sw-order-user-card__actions {
@@ -56,7 +52,7 @@ $sw-order-user-card-link: var(--color-text-brand-default);
         }
 
         dt {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
 
             &:not(:first-child),
             &:only-of-type {
@@ -68,7 +64,7 @@ $sw-order-user-card-link: var(--color-text-brand-default);
     .sw-description-list {
         .sw-order-user-card__address-edit-button,
         .sw-order-user-card__address-add-button {
-            color: $sw-order-user-card-link;
+            color: var(--color-text-brand-default);
             background: transparent;
             border: none;
             line-height: 10px;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/sw-order-create.scss
@@ -4,7 +4,6 @@
 $sw-field: ".sw-field";
 $sw-order-user-card: ".sw-order-user-card";
 $sw-highlight-text: ".sw-highlight-text";
-$font-weight-semi-bold: 600;
 $select-result-customer-item-last-width: 40px;
 $select-result-customer-item-gutter: 10px;
 
@@ -72,7 +71,7 @@ $select-result-customer-item-gutter: 10px;
         }
 
         #{$sw-field}__label {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
     }
 
@@ -80,8 +79,8 @@ $select-result-customer-item-gutter: 10px;
         display: flex;
         margin: 0 0 8px;
         color: var(--color-text-secondary-default);
-        font-size: $font-size-xs;
-        font-weight: $font-weight-semi-bold;
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold);
         line-height: 16px;
     }
 
@@ -90,7 +89,7 @@ $select-result-customer-item-gutter: 10px;
     }
 
     &__address-identical-text {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     &__address-identical-button {
@@ -116,7 +115,7 @@ $select-result-customer-item-gutter: 10px;
         }
 
         #{$sw-field}__label {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
     }
 }
@@ -126,7 +125,7 @@ $select-result-customer-item-gutter: 10px;
 
     .sw-order-create-summary__data {
         grid-area: summary;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         padding-right: 38px;
         display: grid;
         grid-template-columns: 1fr 1fr;
@@ -135,9 +134,9 @@ $select-result-customer-item-gutter: 10px;
         dd {
             padding: 0;
             line-height: 40px;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
             color: var(--color-text-secondary-default);
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             font-weight: normal;
             text-align: right;
         }
@@ -165,7 +164,7 @@ $select-result-customer-item-gutter: 10px;
     &.sw-order-create-details-header__customer-result {
         @include transition;
 
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         #{$this}__result-item-text {
             width: 100%;
@@ -188,7 +187,7 @@ $select-result-customer-item-gutter: 10px;
         padding: 0 5px;
         background: transparent;
         color: var(--color-text-brand-default);
-        font-size: $font-size-xxs;
+        font-size: var(--font-size-2xs);
         line-height: 12px;
         cursor: pointer;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.scss
@@ -26,9 +26,9 @@
         dt,
         dd {
             line-height: 40px;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
             color: var(--color-text-secondary-default);
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             font-weight: normal;
             text-align: right;
             padding: 0;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-order-list-color-error: var(--color-icon-critical-default);
-$sw-order-list-color-success: var(--color-icon-positive-default);
-
 .sw-order-list {
     .sw-order-list__content {
         width: 100%;
@@ -19,11 +14,11 @@ $sw-order-list-color-success: var(--color-icon-positive-default);
 
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
-            color: $sw-order-list-color-error;
+            color: var(--color-icon-critical-default);
         }
 
         .is--active {
-            color: $sw-order-list-color-success;
+            color: var(--color-icon-positive-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.scss
@@ -13,7 +13,7 @@
     &__field-hint {
         display: flex;
         line-height: var(--font-line-height-xs);
-        color: var(--color-text-tertiary-default);
+        color: var(--color-text-secondary-default);
         align-items: center;
         gap: var(--scale-size-8);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-add-properties-modal/sw-product-add-properties-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-add-properties-modal/sw-product-add-properties-modal.scss
@@ -63,8 +63,8 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     .sw-product-add-properties-modal__toolbar {
-        border-bottom: var(--scale-size-1) solid var(--color-border-primary-default);
-        background-color: var(--color-gray-100);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
+        background-color: var(--color-elevation-surface-sunken);
         grid-template-columns: 1fr auto;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-product-cross-selling-assignment {
     .sw-data-grid,
     .sw-product-cross-selling-assignment__option-list-empty-state {
-        border: var(--scale-size-1) solid var(--color-gray-300);
+        border: var(--scale-size-1) solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/sw-product-cross-selling-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/sw-product-cross-selling-form.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .product-detail-cross-selling-form {
     .sw-product-cross-selling-form__links .sw-card__quick-link {
         transition: color 0.3s ease;
 
         &.is--disabled {
             cursor: not-allowed;
-            color: var(--color-gray-500);
+            color: var(--color-text-primary-disabled);
             pointer-events: none;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/sw-product-download-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/sw-product-download-form.scss
@@ -6,7 +6,7 @@
 
     .sw-product-download-form__row {
         border-radius: var(--border-radius-xs);
-        border: var(--scale-size-1) solid var(--color-gray-300);
+        border: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-8) var(--scale-size-12) var(--scale-size-8) var(--scale-size-16);
         margin-top: var(--scale-size-16);
         height: auto;
@@ -28,7 +28,7 @@
         display: inline-flex;
         justify-self: end;
         align-items: center;
-        color: var(--color-gray-500);
+        color: var(--color-text-secondary-default);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-semibold);
         white-space: nowrap;
@@ -47,7 +47,7 @@
             content: "";
             width: var(--scale-size-4);
             height: var(--scale-size-4);
-            background-color: var(--color-gray-500);
+            background-color: var(--color-text-secondary-default);
             border-radius: 50%;
         }
     }
@@ -69,12 +69,12 @@
         right: 0;
         bottom: 0;
         left: 0;
-        background-color: var(--color-gray-100);
+        background-color: var(--color-background-tertiary-default);
         border-radius: var(--border-radius-xs);
         mix-blend-mode: multiply;
     }
 
     .sw-media-upload-v2.has--error .sw-media-upload-v2__dropzone {
-        border-color: var(--color-crimson-500);
+        border-color: var(--color-border-critical-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/sw-product-layout-assignment.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-layout-assignment/sw-product-layout-assignment.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-layout-assignment {
     display: grid;
     grid-template-columns: min-content 1fr;
@@ -18,7 +16,7 @@
 
         &.is--disabled {
             * {
-                color: var(--color-gray-500);
+                color: var(--color-text-primary-disabled);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/sw-product-media-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-media-form/sw-product-media-form.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-product-media-form {
     height: 100%;
 
     .sw-product-media-form__previews {
         border-radius: var(--border-radius-xs);
-        border: var(--scale-size-1) solid var(--color-gray-300);
+        border: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-20);
         margin-top: var(--scale-size-20);
         height: auto;
@@ -42,7 +40,7 @@
         height: calc(var(--scale-size-160) + var(--scale-size-16));
         max-height: 100%;
         max-width: 100%;
-        color: var(--color-gray-300);
+        color: var(--color-text-secondary-default);
         overflow: hidden;
         margin-bottom: var(--scale-size-10);
 
@@ -58,7 +56,7 @@
         }
 
         &.is--placeholder {
-            border: var(--scale-size-2) dashed var(--color-gray-300);
+            border: var(--scale-size-2) dashed var(--color-border-secondary-default);
             display: flex;
             align-items: center;
             justify-content: center;
@@ -71,19 +69,19 @@
 
     &.is--disabled {
         .mt-button {
-            background-color: var(--color-gray-100);
-            color: var(--color-gray-700);
+            background-color: var(--color-background-tertiary-default);
+            color: var(--color-text-primary-disabled);
         }
 
         .mt-button--ghost {
             background-color: transparent;
-            border-color: #7ec9ff;
-            color: var(--color-gray-800);
+            border-color: var(--color-border-brand-disabled);
+            color: var(--color-text-primary-disabled);
         }
 
         .mt-button--primary {
-            background: #7ec9ff;
-            color: var(--color-white);
+            background: var(--color-interaction-primary-disabled);
+            color: var(--color-static-white);
         }
 
         &::after {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.scss
@@ -16,7 +16,7 @@
                 right: 0;
                 bottom: 0;
                 left: 0;
-                background: var(--color-background-primary-disabled);
+                background: var(--color-background-tertiary-default);
                 mix-blend-mode: multiply;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.scss
@@ -1,12 +1,11 @@
 /* stylelint-disable max-nesting-depth */
-@import "~scss/variables";
 @import "~scss/mixins";
 
 $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
 
 .sw-product-variant-modal {
     &__main-product-link {
-        color: var(--color-shopware-brand-500);
+        color: var(--color-text-brand-default);
         text-decoration: none;
         font-size: var(--font-size-xs);
         cursor: pointer;
@@ -53,7 +52,7 @@ $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     &__variants {
-        color: var(--color-gray-600);
+        color: var(--color-text-secondary-default);
         margin-left: var(--scale-size-6);
     }
 
@@ -72,11 +71,11 @@ $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
 
     .mt-icon {
         &.is--inactive {
-            color: var(--color-crimson-500);
+            color: var(--color-icon-critical-default);
         }
 
         &.is--active {
-            color: var(--color-emerald-500);
+            color: var(--color-icon-positive-default);
         }
     }
 
@@ -85,7 +84,7 @@ $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     &__delete-modal-subline {
-        color: var(--color-gray-600);
+        color: var(--color-text-secondary-default);
         margin-top: var(--scale-size-8);
         font-size: var(--font-size-xs);
     }
@@ -95,11 +94,11 @@ $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     &__variant-options span {
-        color: var(--color-darkgray-200) !important;
+        color: var(--color-text-primary-default) !important;
     }
 
     &__variant-options:hover span {
-        color: var(--color-shopware-brand-500) !important;
+        color: var(--color-text-brand-default) !important;
     }
 
     &__media-inherited-icon {
@@ -111,8 +110,8 @@ $tree-base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     .sw-configuration-option-list__toolbar {
-        background-color: var(--color-background-secondary-default);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-26);
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-delivery/sw-product-modal-delivery.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-delivery/sw-product-modal-delivery.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-modal.sw-modal--default.sw-product-modal-delivery {
     .sw-modal__dialog {
         max-width: calc(var(--scale-size-224) * 5 + var(--scale-size-160));
@@ -20,12 +18,12 @@
             .sw-product-modal-delivery__sidebar {
                 padding: var(--scale-size-20) var(--scale-size-30);
                 flex-basis: calc(var(--scale-size-224) + var(--scale-size-56) + var(--scale-size-40) * 3);
-                border-right: var(--scale-size-1) solid var(--color-gray-300);
+                border-right: var(--scale-size-1) solid var(--color-border-secondary-default);
             }
         }
 
         .sw-modal__footer {
-            border-top: var(--scale-size-1) solid var(--color-gray-300);
+            border-top: var(--scale-size-1) solid var(--color-border-secondary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 /* stylelint-disable */
 .sw-product-modal-variant-generation__variant-amount {
     font-weight: var(--font-weight-bold);
@@ -9,8 +7,8 @@
     .sw-product-modal-variant-generation__toolbar {
         flex-basis: 100%;
         padding: var(--scale-size-30);
-        background-color: var(--color-gray-100);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
     }
 
     .sw-media-upload-v2__content {
@@ -28,13 +26,13 @@
         max-width: unset;
         margin-left: var(--scale-size-24);
         margin-right: var(--scale-size-24);
-        border: var(--scale-size-1) solid var(--color-gray-300);
+        border: var(--scale-size-1) solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-xs);
         filter: none;
 
         .sw-product-modal-variant-generation__card-title {
             padding: var(--scale-size-22) var(--scale-size-24);
-            border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+            border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
         }
 
         .sw-field--switch.sw-field--default {
@@ -42,7 +40,7 @@
         }
 
         .sw-product-modal-variant-generation__upload-all-container {
-            border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+            border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
             padding: var(--scale-size-8) var(--scale-size-24);
             display: flex;
             flex-wrap: wrap;
@@ -104,7 +102,7 @@
                         min-height: 0;
 
                         .sw-grid__pagination {
-                            background-color: var(--color-white);
+                            background-color: var(--color-background-primary-default);
                         }
 
                         .sw-grid__content,
@@ -124,12 +122,12 @@
             .sw-product-modal-variant-generation__sidebar {
                 padding: var(--scale-size-20) var(--scale-size-30);
                 max-width: calc(var(--scale-size-224) + var(--scale-size-56) + var(--scale-size-30));
-                border-right: var(--scale-size-1) solid var(--color-gray-300);
+                border-right: var(--scale-size-1) solid var(--color-border-secondary-default);
             }
         }
 
         .sw-modal__footer {
-            border-top: var(--scale-size-1) solid var(--color-gray-300);
+            border-top: var(--scale-size-1) solid var(--color-border-secondary-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-configurator-prices {
     height: 100%;
     display: flex;
@@ -22,7 +20,7 @@
         flex-basis: calc(var(--scale-size-224) + var(--scale-size-24) + var(--scale-size-22));
         height: 100%;
         overflow: auto;
-        border-right: var(--scale-size-1) solid var(--color-gray-300);
+        border-right: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-20) 0;
 
         .mt-icon {
@@ -40,11 +38,11 @@
         padding-left: var(--scale-size-20);
 
         &:hover {
-            background-color: #f0f8ff;
+            background-color: var(--color-interaction-secondary-hover);
         }
 
         &.is--selected {
-            background-color: var(--color-shopware-brand-50);
+            background-color: var(--color-background-brand-default);
         }
     }
 
@@ -55,7 +53,7 @@
         flex-direction: column;
 
         .sw-data-grid {
-            border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+            border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
         }
     }
 
@@ -66,7 +64,7 @@
 
     .sw-product-variants-configurator-prices__search {
         padding: var(--scale-size-26);
-        background-color: var(--color-background-secondary-default);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-restrictions/sw-product-variants-configurator-restrictions.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-restrictions/sw-product-variants-configurator-restrictions.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-configurator-restrictions {
     display: flex;
     flex-direction: column;
@@ -10,8 +8,8 @@
         grid-template-columns: 1fr calc(var(--scale-size-160) + var(--scale-size-40));
         grid-column-gap: var(--scale-size-16);
         padding: var(--scale-size-26);
-        background-color: var(--color-background-secondary-default);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
     }
 
     .sw-product-variants-configurator-restrictions__modal.sw-modal .sw-modal__body {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-selection/sw-product-variants-configurator-selection.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-property-search__search-field.sw-product-variants-configurator-selection-search__search-field {
     .sw-simple-search-field {
         margin: 0;
@@ -26,7 +24,7 @@
     }
 
     .generate-variant-progress-bar__description {
-        color: var(--color-darkgray-200);
+        color: var(--color-text-secondary-default);
         margin-top: var(--scale-size-20);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-price-field/sw-product-variants-price-field.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-price-field/sw-product-variants-price-field.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-price-field {
     display: grid;
     grid-template-columns: 1fr var(--scale-size-30) 1fr;
@@ -8,12 +6,12 @@
         height: var(--scale-size-32);
         background: none;
         border: none;
-        color: var(--color-darkgray-200);
+        color: var(--color-icon-secondary-default);
         outline: none;
         cursor: pointer;
 
         &.is--locked {
-            color: var(--color-shopware-brand-500);
+            color: var(--color-icon-brand-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-listing/sw-product-variants-delivery-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-listing/sw-product-variants-delivery-listing.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-delivery-listing {
     display: flex;
     flex-direction: column;
@@ -10,8 +8,8 @@
     }
 
     .sw-product-variants-delivery-listing-mode {
-        background-color: var(--color-gray-100);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
 
         .sw-field.sw-field--radio {
             margin: 0;
@@ -27,7 +25,7 @@
                 margin: 0;
 
                 &:nth-child(2) {
-                    border-left: var(--scale-size-1) solid var(--color-gray-300);
+                    border-left: var(--scale-size-1) solid var(--color-border-secondary-default);
                 }
             }
         }
@@ -49,11 +47,11 @@
             padding: var(--scale-size-30);
 
             &:nth-child(2) {
-                border-left: var(--scale-size-1) solid var(--color-gray-300);
+                border-left: var(--scale-size-1) solid var(--color-border-secondary-default);
             }
 
             &.is--disabled {
-                background-color: var(--color-gray-100);
+                background-color: var(--color-background-tertiary-default);
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-media/sw-product-variants-delivery-media.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-media/sw-product-variants-delivery-media.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-delivery-media {
     display: flex;
     height: 100%;
@@ -10,7 +8,7 @@
         flex-basis: calc(var(--scale-size-224) + var(--scale-size-24) + var(--scale-size-22));
         height: 100%;
         overflow: auto;
-        border-right: var(--scale-size-1) solid var(--color-gray-300);
+        border-right: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-20) 0;
 
         .mt-icon {
@@ -28,11 +26,11 @@
         padding-left: var(--scale-size-20);
 
         &:hover {
-            background-color: #f0f8ff;
+            background-color: var(--color-interaction-secondary-hover);
         }
 
         &.is--selected {
-            background-color: var(--color-background-secondary-default);
+            background-color: var(--color-background-brand-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-order/sw-product-variants-delivery-order.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-order/sw-product-variants-delivery-order.scss
@@ -6,15 +6,15 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     display: flex;
     height: 100%;
     padding: 0;
-    background-color: var(--color-gray-50);
+    background-color: var(--color-background-secondary-default);
 
     .sw-product-variants-delivery-order__groups {
-        background-color: var(--color-white);
+        background-color: var(--color-background-primary-default);
         font-size: var(--font-size-xs);
         flex-basis: calc(#{$base-size} + var(--scale-size-40) * 5 + var(--scale-size-20));
         height: 100%;
         overflow: auto;
-        border-right: var(--scale-size-1) solid var(--color-gray-300);
+        border-right: var(--scale-size-1) solid var(--color-border-secondary-default);
 
         .sw-tree {
             border-width: 0;

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-media-upload/sw-product-variants-media-upload.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-media-upload/sw-product-variants-media-upload.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-variants-media-upload.sw-media-upload-v2 {
     .sw-product-variants-media-upload {
         &__preview-images {
@@ -20,7 +18,7 @@
         &__cover-image::after {
             content: "";
             width: var(--scale-size-1);
-            background-color: var(--color-gray-300);
+            background-color: var(--color-border-secondary-default);
             position: absolute;
             left: calc(var(--scale-size-30) + var(--scale-size-8));
             height: var(--scale-size-32);
@@ -43,7 +41,7 @@
         min-height: 0;
         padding: var(--scale-size-8);
         width: calc(var(--scale-size-224) + var(--scale-size-56) + var(--scale-size-40) + var(--scale-size-10));
-        background: var(--color-gray-50);
+        background: var(--color-background-secondary-default);
 
         .sw-product-variants-media-upload__images {
             display: flex;
@@ -73,7 +71,7 @@
         &.is--cover {
             width: var(--scale-size-36);
             height: var(--scale-size-36);
-            border: var(--scale-size-1) solid var(--color-shopware-brand-500);
+            border: var(--scale-size-1) solid var(--color-border-brand-default);
         }
     }
 
@@ -124,14 +122,14 @@
 
     &:hover {
         .sw-media-upload-v2__preview {
-            background-color: var(--color-black);
+            background-color: var(--color-static-black);
             border: none;
 
             &.is--disabled {
                 background-color: unset;
 
                 &.is--cover {
-                    border: var(--scale-size-1) solid var(--color-shopware-brand-500);
+                    border: var(--scale-size-1) solid var(--color-border-brand-default);
                 }
 
                 .sw-media-preview-v2__item {
@@ -154,7 +152,7 @@
         visibility: hidden;
 
         .mt-icon {
-            color: var(--color-white);
+            color: var(--color-static-white);
             height: 100%;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-products-variants-overview.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-products-variants-overview.scss
@@ -5,8 +5,8 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
 
 .sw-product-variants-overview {
     .sw-configuration-option-list__toolbar {
-        background-color: var(--color-background-secondary-default);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
         padding: var(--scale-size-26);
 
         .mt-button {
@@ -34,7 +34,7 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
 
             .mt-icon {
                 opacity: 0;
-                color: var(--color-shopware-brand-500);
+                color: var(--color-icon-brand-default);
                 width: var(--scale-size-12);
                 height: var(--scale-size-12);
                 margin-right: var(--scale-size-6);
@@ -144,11 +144,11 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
     }
 
     .icon--regular-checkmark-xs {
-        color: var(--color-emerald-500);
+        color: var(--color-icon-positive-default);
     }
 
     .icon--regular-times-s {
-        color: var(--color-crimson-500);
+        color: var(--color-icon-critical-default);
     }
 
     .icon--regular-link-horizontal {
@@ -187,7 +187,7 @@ $base-size: calc(var(--scale-size-224) + var(--scale-size-56));
 
             opacity: 0;
             margin-right: var(--scale-size-6);
-            color: var(--color-shopware-brand-500);
+            color: var(--color-icon-brand-default);
         }
 
         .sw-data-grid.is--compact .sw-data-grid__body .sw-data-grid__cell-content {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-detail-context-prices {
     width: 100%;
     max-width: calc(var(--scale-size-224) * 5 + var(--scale-size-160) + var(--scale-size-40) + var(--scale-size-10));
@@ -28,8 +26,8 @@
 
     .sw-product-detail-context-prices__toolbar {
         padding: var(--scale-size-26);
-        background-color: var(--color-gray-100);
-        border-bottom: var(--scale-size-1) solid var(--color-gray-300);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
     }
 
     .sw-product-detail-context-prices__toolbar-selection {
@@ -106,7 +104,7 @@
         }
 
         .sw-product-detail-context-prices__parent-prices-link {
-            color: var(--color-shopware-brand-500);
+            color: var(--color-text-brand-default);
             margin-bottom: var(--scale-size-20);
         }
     }
@@ -117,7 +115,7 @@
         line-height: var(--scale-size-16);
         font-size: var(--font-size-xs);
         margin-bottom: var(--scale-size-20);
-        color: var(--color-darkgray-200);
+        color: var(--color-text-secondary-default);
 
         .sw-product-detail-context-prices__inheritance-icon {
             margin-right: var(--scale-size-8);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-detail-cross-selling {
     & &__restore-inheritance-btn.mt-button {
         display: block;
@@ -24,7 +22,7 @@
         line-height: var(--scale-size-16);
         font-size: var(--font-size-xs);
         margin: var(--scale-size-20) 0;
-        color: var(--color-darkgray-200);
+        color: var(--color-text-secondary-default);
 
         &.is--inherited {
             color: var(--color-module-purple-900);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-layout/sw-product-detail-layout.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-product-detail-layout {
     &__no-config.sw-card {
         text-align: center;
@@ -7,7 +5,7 @@
     }
 
     &__content-info {
-        color: var(--color-gray-500);
+        color: var(--color-text-secondary-default);
         font-size: var(--font-size-xs);
         margin-top: var(--scale-size-16);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-settings-discount-type/sw-promotion-v2-settings-discount-type.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-settings-discount-type/sw-promotion-v2-settings-discount-type.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-promotion-v2-settings-discount-type {
     .sw-promotion-v2-settings-discount-type__advanced-prices {
         display: block;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         cursor: pointer;
         text-align: right;
         margin-bottom: 15px;
-        color: $color-shopware-brand-500;
+        color: var(--color-text-brand-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-wizard-description/sw-promotion-v2-wizard-description.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/discount/sw-promotion-v2-wizard-description/sw-promotion-v2-wizard-description.scss
@@ -1,6 +1,4 @@
-@import "~scss/variables";
-
 .sw-promotion-v2-wizard-description {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     margin: 10px 0 30px;
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-promotion-v2-generate-codes-modal {
-    font-size: $font-size-xs;
+    font-size: var(--font-size-xs);
     line-height: 22px;
 
     &__description {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$color-state-positive: $color-emerald-500;
-$color-state-negative: $color-crimson-500;
-
 .sw-promotion-v2-individual-codes-behavior {
     margin: 0 -24px -24px;
 
@@ -17,18 +12,18 @@ $color-state-negative: $color-crimson-500;
     }
 
     &__description {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         line-height: 22px;
         margin-bottom: 24px;
     }
 
     &__redeemed-state {
         &.is--active {
-            color: $color-state-positive;
+            color: var(--color-text-positive-default);
         }
 
         &.is--inactive {
-            color: $color-state-negative;
+            color: var(--color-text-critical-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-cart-condition-form/sw-promotion-v2-cart-condition-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-cart-condition-form/sw-promotion-v2-cart-condition-form.scss
@@ -1,9 +1,7 @@
-@import "~scss/variables";
-
 .sw-promotion-v2-cart-condition-form {
     &__setgroup-card-title {
-        font-size: $font-size-m;
-        line-height: $line-height-md;
+        font-size: var(--font-size-m);
+        line-height: var(--font-line-height-m);
         margin-bottom: 32px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-empty-state-hero/sw-promotion-v2-empty-state-hero.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-empty-state-hero/sw-promotion-v2-empty-state-hero.scss
@@ -1,7 +1,5 @@
 // @deprecated tag:v6.8.0 - Will be removed
 
-@import "~scss/variables";
-
 .sw-promotion-v2-empty-state-hero {
     position: absolute;
     display: grid;
@@ -27,8 +25,8 @@
     }
 
     &__description {
-        color: $color-darkgray-200;
-        font-size: $font-size-xs;
+        color: var(--color-text-secondary-default);
+        font-size: var(--font-size-xs);
     }
 
     &__actions {

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-promotion-list-color-error: var(--color-icon-critical-default);
-$sw-promotion-list-color-success: var(--color-icon-positive-default);
-
 .sw-promotion-v2-list {
     &__content {
         width: 100%;
@@ -19,7 +14,7 @@ $sw-promotion-list-color-success: var(--color-icon-positive-default);
 
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
-            color: $sw-promotion-list-color-error;
+            color: var(--color-icon-critical-default);
 
             &.mt-icon {
                 width: 16px;
@@ -29,7 +24,7 @@ $sw-promotion-list-color-success: var(--color-icon-positive-default);
         }
 
         .is--active {
-            color: $sw-promotion-list-color-success;
+            color: var(--color-icon-positive-default);
 
             &.mt-icon {
                 width: 16px;

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-property-option-list {
     .sw-empty-state {
         position: static;
@@ -15,14 +13,14 @@
 
     .sw-property-option-list__toolbar {
         padding: 25px 35px;
-        background-color: $color-gray-100;
-        border-bottom: 1px solid $color-gray-300;
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-property-option-list__delete-button {
-            border-color: $color-crimson-500;
+            border-color: var(--color-border-critical-default);
 
             .mt-icon {
-                color: $color-crimson-500;
+                color: var(--color-icon-critical-default);
             }
 
             &.mt-button--disabled {

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-property-list-color-error: $color-crimson-500;
-$sw-property-list-color-success: $color-emerald-500;
-
 .sw-property-list {
     &__content {
         width: 100%;
@@ -19,7 +14,7 @@ $sw-property-list-color-success: $color-emerald-500;
 
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
-            color: $sw-property-list-color-error;
+            color: var(--color-icon-critical-default);
 
             &.mt-icon {
                 width: 16px;
@@ -29,7 +24,7 @@ $sw-property-list-color-success: $color-emerald-500;
         }
 
         .is--active {
-            color: $sw-property-list-color-success;
+            color: var(--color-icon-positive-default);
 
             &.mt-icon {
                 width: 16px;

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.scss
@@ -51,7 +51,7 @@
 
         &-review-title {
             font-weight: var(--font-weight-semibold);
-            font-size: var(--font-weight-m);
+            font-size: var(--font-size-m);
             margin-bottom: var(--scale-size-4);
             word-break: break-word;
         }
@@ -63,7 +63,7 @@
 
     .sw-review-base-info {
         font-size: var(--font-size-xs);
-        line-height: var(--line-height-xs);
+        line-height: var(--font-line-height-xs);
         margin-bottom: var(--scale-size-16);
 
         .sw-review-base-info-columns {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/sw-sales-channel-menu.scss
@@ -1,6 +1,3 @@
-@import "~scss/variables";
-@import "~scss/mixins";
-
 .sw-sales-channel-menu {
     .sw-sales-channel-menu-domain-link {
         margin-left: 16px;
@@ -39,8 +36,8 @@
         padding: 0 30px 12px;
 
         &-text {
-            font-size: $font-size-xs;
-            line-height: $line-height-md;
+            font-size: var(--font-size-xs);
+            line-height: var(--font-line-height-m);
             color: var(--color-text-secondary-default);
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-sales-channel-detail-domains {
     .sw-sales-channel-detail__button-domain-add {
         margin: 0 0 15px;
@@ -12,7 +10,7 @@
     .sw-sales-channel-detail-domains__domain-delete {
         margin-left: auto;
         text-decoration: none;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-critical-default);
         background: 0 none;
         cursor: pointer;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-detail/sw-sales-channel-modal-detail.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-detail/sw-sales-channel-modal-detail.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-sales-channel-modal-detail {
     margin: -20px -30px;
     padding: 20px 30px;
@@ -28,14 +26,14 @@
     }
 
     .sw-sales-channel-modal-detail__header-name {
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         color: var(--color-text-primary-default);
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         margin: 6px 0;
     }
 
     .sw-sales-channel-modal-detail__header-manufacturer {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         color: var(--color-text-secondary-default);
     }
 
@@ -45,7 +43,7 @@
 
     .sw-sales-channel-modal-detail__description-title {
         margin-bottom: 20px;
-        font-weight: $font-weight-semi-bold;
+        font-weight: var(--font-weight-semibold);
         color: var(--color-text-primary-default);
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/sw-sales-channel-modal-grid.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-sales-channel-modal-grid {
     .sw-grid-row {
         border-bottom: 0;
@@ -13,7 +11,7 @@
         display: inline-flex;
         align-items: center;
         gap: 6px;
-        font-size: $font-size-m;
+        font-size: var(--font-size-m);
         margin-bottom: 0;
         color: var(--color-text-primary-default);
         font-weight: normal;
@@ -26,7 +24,7 @@
 
     .sw-sales-channel-modal-grid__item-description {
         color: var(--color-text-primary-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-top: 5px;
         cursor: pointer;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-product-assignment-categories/sw-sales-channel-product-assignment-categories.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-product-assignment-categories/sw-sales-channel-product-assignment-categories.scss
@@ -17,7 +17,7 @@
         width: 100%;
         height: 550px;
         z-index: 20;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         box-shadow: 0 3px 6px 0 var(--color-elevation-shadow-default);
         background-color: var(--color-elevation-surface-raised);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-file/sw-sales-channel-detail-agentic-file.scss
@@ -26,7 +26,7 @@
         text-decoration: none;
 
         &:hover {
-            color: var(--color-shopware-brand-600);
+            color: var(--color-text-brand-default);
             text-decoration: underline;
         }
     }
@@ -127,7 +127,7 @@
         flex-direction: column;
         gap: var(--scale-size-16);
         padding-top: var(--scale-size-20);
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &__custom-notes-input {
@@ -140,7 +140,7 @@
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: var(--scale-size-20) var(--scale-size-32);
         padding-top: var(--scale-size-20);
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     &__metadata-item {
@@ -189,7 +189,7 @@
 
         &:hover,
         &:focus-visible {
-            color: var(--color-shopware-brand-600);
+            color: var(--color-text-brand-default);
             text-decoration: none;
         }
     }
@@ -203,7 +203,7 @@
         max-height: 420px;
         padding: var(--scale-size-16);
         overflow: auto;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: var(--border-radius-default);
         background: var(--color-elevation-surface-sunken);
         color: var(--color-text-primary-default);
@@ -261,7 +261,7 @@
 
         &:hover,
         &:focus-visible {
-            color: var(--color-shopware-brand-600);
+            color: var(--color-text-brand-default);
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-agentic-files/sw-sales-channel-detail-agentic-files.scss
@@ -68,7 +68,7 @@
             text-decoration: none;
 
             .sw-sales-channel-detail-agentic-files__file-name {
-                color: var(--color-shopware-brand-600);
+                color: var(--color-text-brand-default);
                 text-decoration: underline;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-analytics/sw-sales-channel-detail-analytics.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-analytics/sw-sales-channel-detail-analytics.scss
@@ -1,14 +1,12 @@
-@import "~scss/variables";
-
 .sw-sales-channel-detail {
     .sw-sales-channel-detail-analytics__headline-text {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-m;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-m);
         margin-bottom: 20px;
     }
 
     .sw-sales-channel-detail-analytics__description {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 30px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.scss
@@ -1,7 +1,3 @@
-@import "~scss/variables";
-
-$sw-sales-channel-detail-color-text-access-key: var(--color-text-primary-default);
-
 .sw-sales-channel-detail-base {
     .sw-sales-channel-detail-base__secret-help-text-alert {
         margin-top: 22px;
@@ -31,7 +27,7 @@ $sw-sales-channel-detail-color-text-access-key: var(--color-text-primary-default
     .sw-sales-channel-detail-base__delete {
         margin-top: 30px;
         padding-top: 30px;
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
     }
 
     .sw-sales-channel-detail-base__headline {
@@ -39,12 +35,12 @@ $sw-sales-channel-detail-color-text-access-key: var(--color-text-primary-default
     }
 
     .sw-sales-channel-detail-base__headline-text {
-        font-weight: $font-weight-semi-bold;
-        font-size: $font-size-s;
+        font-weight: var(--font-weight-semibold);
+        font-size: var(--font-size-s);
     }
 
     .sw-sales-channel-detail-base__description-text {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         margin-bottom: 20px;
     }
 
@@ -86,7 +82,7 @@ $sw-sales-channel-detail-color-text-access-key: var(--color-text-primary-default
 
 .sw-sales-channel-detail-base__delete-modal {
     .sw-modal__body {
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 
     p {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/sw-multi-snippet-drag-and-drop.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/sw-multi-snippet-drag-and-drop.scss
@@ -1,9 +1,4 @@
 /* stylelint-disable max-nesting-depth */
-@import "~scss/variables";
-
-$sw-tree-item-color-border: var(--color-border-primary-default);
-$sw-tree-item-color-background: var(--color-background-secondary-default);
-$sw-tree-item-color-text: var(--color-text-primary-default);
 
 .sw-multi-snippet-drag-and-drop {
     position: relative;
@@ -59,13 +54,13 @@ $sw-tree-item-color-text: var(--color-text-primary-default);
         user-select: none;
         pointer-events: none;
         background: transparent;
-        border: 1px dashed $sw-tree-item-color-border;
+        border: 1px dashed var(--color-border-secondary-default);
     }
 
     .is--drag-element {
         user-select: none;
         pointer-events: none;
         background: var(--color-elevation-surface-raised);
-        box-shadow: 0 0 5px 1px var(--color-border-brand-selected);
+        box-shadow: 0 0 5px 1px var(--color-border-brand-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/sw-settings-country-address-handling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/sw-settings-country-address-handling.scss
@@ -15,7 +15,7 @@
 
     &__text-field {
         border-radius: 4px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         padding: 16px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-currency-dependent-modal/sw-settings-country-currency-dependent-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-currency-dependent-modal/sw-settings-country-currency-dependent-modal.scss
@@ -32,7 +32,7 @@
 
         /* stylelint-disable-next-line max-line-length */
         &.sw-data-grid.sw-data-grid--plain-appearance .sw-data-grid__body .sw-data-grid__row:last-child .sw-data-grid__cell {
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
 
         .sw-data-grid__row .sw-data-grid__cell {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-general/sw-settings-country-general.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-general/sw-settings-country-general.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-country-general {
     &__option-items.sw-field--switch {
         margin: 12px 0;
@@ -7,7 +5,7 @@
 
     &__currency-dependent-modal {
         color: var(--color-text-brand-default);
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         cursor: pointer;
         text-decoration: underline;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/sw-settings-country-new-snippet-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/sw-settings-country-new-snippet-modal.scss
@@ -1,4 +1,3 @@
-@import "~scss/variables";
 @import "~scss/mixins";
 
 .sw-settings-country-new-snippet-modal {
@@ -63,7 +62,7 @@
         }
 
         .sw-field__label label {
-            font-weight: $font-weight-semi-bold;
+            font-weight: var(--font-weight-semibold);
         }
 
         .sw-block-field__block input {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.scss
@@ -1,16 +1,11 @@
-@import "~scss/variables";
-
-$sw-country-list-color-error: var(--color-icon-critical-default);
-$sw-country-list-color-success: var(--color-icon-positive-default);
-
 .sw-settings-country-list {
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
-            color: $sw-country-list-color-error;
+            color: var(--color-icon-critical-default);
         }
 
         .is--active {
-            color: $sw-country-list-color-success;
+            color: var(--color-icon-positive-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.scss
@@ -1,11 +1,9 @@
-@import "~scss/variables";
-
 .sw-settings-price-rounding {
     .sw-settings-price-rounding__headline {
-        font-size: $font-size-s;
+        font-size: var(--font-size-s);
         color: var(--color-text-secondary-default);
         margin: 0 0 10px;
-        font-weight: $font-weight-bold;
+        font-weight: var(--font-weight-bold);
     }
 
     .sw-settings-price-rounding__info-text {
@@ -16,6 +14,6 @@
         margin: 0 0 20px;
         border: none;
         height: 1px;
-        background-color: var(--color-border-primary-default);
+        background-color: var(--color-border-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.scss
@@ -1,11 +1,3 @@
-@import "~scss/variables";
-
-$sw-custom-field-list-color-label-link: $color-shopware-brand-500;
-$sw-custom-field-list-color-toolbar-background: $color-gray-100;
-$sw-custom-field-list-color-toolbar-bottom: $color-gray-300;
-$sw-custom-field-list-color-border: $color-crimson-500;
-$sw-custom-field-list-color-label-link: $color-shopware-brand-500;
-
 .sw-custom-field-list {
     .sw-empty-state {
         position: static;
@@ -21,14 +13,14 @@ $sw-custom-field-list-color-label-link: $color-shopware-brand-500;
 
     .sw-custom-field-list__toolbar {
         padding: 25px 35px;
-        background-color: $sw-custom-field-list-color-toolbar-background;
-        border-bottom: 1px solid $sw-custom-field-list-color-toolbar-bottom;
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-custom-field-list__delete-button.mt-button--square {
-            border-color: $sw-custom-field-list-color-border;
+            border-color: var(--color-border-critical-default);
 
             .mt-icon {
-                color: $sw-custom-field-list-color-border;
+                color: var(--color-icon-critical-default);
             }
 
             &.mt-button--disabled {
@@ -47,7 +39,7 @@ $sw-custom-field-list-color-label-link: $color-shopware-brand-500;
         cursor: pointer;
 
         &:hover {
-            color: $sw-custom-field-list-color-label-link;
+            color: var(--color-text-brand-default);
             text-decoration: underline;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/sw-custom-field-type-select.scss
@@ -1,12 +1,7 @@
-@import "~scss/variables";
-
-$sw-custom-field-type-select-button-add-color: $color-shopware-brand-500;
-$sw-custom-field-type-select-button-delete-color: $color-crimson-500;
-
 .sw-custom-field-type-base {
     .sw-custom-field-type-select__delete-option-button {
         background: none;
-        color: $sw-custom-field-type-select-button-delete-color;
+        color: var(--color-text-critical-default);
         margin-left: 20px;
     }
 
@@ -15,7 +10,7 @@ $sw-custom-field-type-select-button-delete-color: $color-crimson-500;
     }
 
     .sw-custom-field-type-select__button-add {
-        color: $sw-custom-field-type-select-button-add-color;
-        border-color: $sw-custom-field-type-select-button-add-color;
+        color: var(--color-text-brand-default);
+        border-color: var(--color-border-brand-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-list/sw-settings-language-list.scss
@@ -21,7 +21,7 @@
         grid-template-columns: 1fr auto;
         align-items: center;
         cursor: pointer;
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
         padding: var(--scale-size-16) var(--scale-size-24);
 
         .sw-media-collapse__button {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/component/sw-settings-listing-option-criteria-grid/sw-settings-listing-option-criteria-grid.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/component/sw-settings-listing-option-criteria-grid/sw-settings-listing-option-criteria-grid.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-listing-option-criteria-grid__criteria-card {
     div.sw-select {
         margin-bottom: 0;
@@ -11,7 +9,7 @@
     }
 
     div.sw-card__toolbar {
-        background-color: $color-white;
+        background-color: var(--color-elevation-surface-sunken);
     }
 
     div.sw-card__content {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/component/sw-settings-logging-mail-sent-info/sw-settings-logging-mail-sent-info.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/component/sw-settings-logging-mail-sent-info/sw-settings-logging-mail-sent-info.scss
@@ -1,7 +1,5 @@
-@import "~scss/variables";
-
 .sw-settings-logging-mail-sent-info__mail-content {
-    border: 1px solid $color-gray-500;
+    border: 1px solid var(--color-border-secondary-default);
     padding: 12px;
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-measurement/component/sw-settings-measurement-default-units/sw-settings-measurement-default-units.scss
@@ -3,13 +3,13 @@
         margin-bottom: var(--scale-size-32);
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-regular);
-        line-height: var(--line-height-sm);
+        line-height: var(--font-line-height-s);
     }
 
     &__description a.sw-internal-link {
         font-size: var(--font-size-xs);
         font-weight: var(--font-weight-regular);
-        line-height: var(--line-height-sm);
+        line-height: var(--font-line-height-s);
     }
 }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-message-stats/page/sw-settings-message-stats/sw-settings-message-stats.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-message-stats/page/sw-settings-message-stats/sw-settings-message-stats.scss
@@ -29,8 +29,8 @@
         box-sizing: border-box;
         overflow: hidden;
         padding: 16px 24px;
-        background: $color-white;
-        border: 1px solid var(--color-border-primary-default, #cdced4);
+        background: var(--color-background-primary-default);
+        border: 1px solid var(--color-border-secondary-default, #cdced4);
         border-radius: $border-radius-sm;
         cursor: pointer;
         transition: background 0.1s;
@@ -47,7 +47,7 @@
         width: 4px;
         height: 44px;
         border-radius: 0 $border-radius-pill $border-radius-pill 0;
-        background: var(--color-border-brand-selected, #0870ff);
+        background: var(--color-border-brand-default, #0870ff);
     }
 
     &__stat-content {
@@ -90,14 +90,14 @@
     }
 
     &__message-types .sw-data-grid {
-        border: 1px solid $color-gray-300;
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-lg;
     }
 
     &__divider {
         margin: 24px 0;
         border: none;
-        border-top: 1px solid var(--color-border-primary-default, #cdced4);
+        border-top: 1px solid var(--color-border-secondary-default, #cdced4);
     }
 
     &__description {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.scss
@@ -1,12 +1,6 @@
-@import "~scss/variables";
-
-$sw-settings-number-range-list-color-success: $color-emerald-500;
-$sw-settings-number-range-list-color-border-collapse: $color-gray-300;
-$sw-settings-number-range-list-font-size-default: $font-size-s;
-
 .sw-settings-number-range-list {
     .is--default {
-        color: $sw-settings-number-range-list-color-success;
+        color: var(--color-text-positive-default);
     }
 
     .sw-settings-number-range-list__columns-assignment-tag {
@@ -14,7 +8,7 @@ $sw-settings-number-range-list-font-size-default: $font-size-s;
     }
 
     .sw-settings-number-range-list__collapse-title {
-        font-size: $sw-settings-number-range-list-font-size-default;
+        font-size: var(--font-size-s);
         font-weight: normal;
         margin: 0 25px;
     }
@@ -24,8 +18,8 @@ $sw-settings-number-range-list-font-size-default: $font-size-s;
         grid-template-columns: 1fr auto;
         cursor: pointer;
         padding-bottom: 16px;
-        color: #607182;
-        border-bottom: 1px solid $sw-settings-number-range-list-color-border-collapse;
+        color: var(--color-text-secondary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-settings-number-range-list__collapse-indicator {
             margin-right: 25px;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.scss
@@ -1,12 +1,8 @@
-@import "~scss/variables";
-
-$sw-payment-card_content-gap: 20px;
-
 .sw-payment-card {
     .sw-payment-card_content {
         display: flex;
         align-items: center;
-        column-gap: $sw-payment-card_content-gap;
+        column-gap: 20px;
     }
 
     .sw-payment-card__preview {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-plugin-box/sw-plugin-box.scss
@@ -1,16 +1,9 @@
 @import "~scss/variables";
 
-$sw-plugin-box-color-container-border: var(--color-border-primary-default);
-$sw-plugin-box-color-container-border-radius: $border-radius-default;
-$sw-plugin-box-color-container-description-label-font-size: $font-size-xs;
-$sw-plugin-box-color-container-description-author-font-size: 12px;
-$sw-plugin-box-color-container-image-size: 48px;
-$sw-plugin-box-color-container-description-author-color: var(--color-text-secondary-default);
-
 .sw-plugin-box {
     .sw-plugin-box__container {
-        border: 1px solid $sw-plugin-box-color-container-border;
-        border-radius: $sw-plugin-box-color-container-border-radius;
+        border: 1px solid var(--color-border-secondary-default);
+        border-radius: $border-radius-default;
         padding: 8px 16px;
         margin-bottom: 22px;
 
@@ -25,24 +18,24 @@ $sw-plugin-box-color-container-description-author-color: var(--color-text-second
         }
 
         .sw-plugin-box__icon {
-            height: $sw-plugin-box-color-container-image-size;
-            width: $sw-plugin-box-color-container-image-size;
+            height: 48px;
+            width: 48px;
         }
 
         .sw-plugin-box__description {
             margin: auto 0;
 
             .sw-plugin-box__label {
-                font-size: $sw-plugin-box-color-container-description-label-font-size;
-                font-weight: $font-weight-semi-bold;
-                line-height: $sw-plugin-box-color-container-description-label-font-size;
+                font-size: var(--font-size-xs);
+                font-weight: var(--font-weight-semibold);
+                line-height: var(--font-size-xs);
                 margin-bottom: 2px;
             }
 
             .sw-plugin-box__author {
-                font-size: $sw-plugin-box-color-container-description-author-font-size;
-                color: $sw-plugin-box-color-container-description-author-color;
-                line-height: $sw-plugin-box-color-container-description-author-font-size;
+                font-size: 12px;
+                color: var(--color-text-secondary-default);
+                line-height: 12px;
             }
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-settings-payment-sorting-modal/sw-settings-payment-sorting-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-settings-payment-sorting-modal/sw-settings-payment-sorting-modal.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-modal {
     .sw-modal__body {
         &.sw-settings-payment-sorting-modal__subtitle {
@@ -7,7 +5,7 @@
             display: flex;
             flex: none;
             overflow-y: hidden;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
     }
 }
@@ -22,17 +20,17 @@
         align-items: center;
         gap: 8px;
         padding: 12px 24px 12px 12px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
 
         &.is--disabled {
             color: var(--color-text-secondary-disabled);
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
         }
 
         &__name {
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-xs;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-xs);
         }
 
         &__icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/sw-settings-product-feature-sets-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/sw-settings-product-feature-sets-modal.scss
@@ -1,5 +1,5 @@
 .sw-product-feature-set__toolbar {
     padding: var(--scale-size-24) var(--scale-size-32);
-    background-color: var(--color-background-secondary-default);
-    border-bottom: var(--scale-size-1) solid var(--color-border-primary-default);
+    background-color: var(--color-elevation-surface-sunken);
+    border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-values-card/sw-settings-product-feature-sets-values-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-values-card/sw-settings-product-feature-sets-values-card.scss
@@ -24,14 +24,14 @@
 
     .sw-product-feature-set__toolbar {
         padding: var(--scale-size-24) var(--scale-size-32);
-        background-color: var(--color-background-secondary-default);
-        border-bottom: var(--scale-size-1) solid var(--color-border-primary-default);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: var(--scale-size-1) solid var(--color-border-secondary-default);
 
         .sw-product-feature-set__delete-button {
-            border-color: var(--color-crimson-500);
+            border-color: var(--color-border-critical-default);
 
             .mt-icon {
-                color: var(--color-crimson-500);
+                color: var(--color-icon-critical-default);
             }
 
             &.mt-button--disabled {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-listing/sw-settings-rule-add-assignment-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-listing/sw-settings-rule-add-assignment-listing.scss
@@ -23,7 +23,7 @@
         }
 
         &__content {
-            border: 1px solid var(--color-border-primary-default);
+            border: 1px solid var(--color-border-secondary-default);
             padding: 0;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search-keyword/sw-settings-search-live-search-keyword.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search-keyword/sw-settings-search-live-search-keyword.scss
@@ -1,6 +1,6 @@
 .sw-settings-search-live-search-keyword {
     &__highlight {
-        color: var(--color-shopware-brand-500);
+        color: var(--color-text-brand-default);
         font-weight: var(--font-weight-bold);
         text-decoration: underline;
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.scss
@@ -8,7 +8,7 @@
     }
 
     .sw-seo-url-template-card__preview {
-        color: var(--color-darkgray-200);
+        color: var(--color-text-primary-default);
         font-size: var(--font-size-xs);
     }
 
@@ -39,15 +39,15 @@
 
         &.icon--regular {
             &-checkmark {
-                color: var(--color-emerald-500);
+                color: var(--color-icon-positive-default);
             }
 
             &-exclamation-triangle {
-                color: var(--color-pumpkin-spice-500);
+                color: var(--color-icon-attention-default);
             }
 
             &-times {
-                color: var(--color-crimson-500);
+                color: var(--color-icon-critical-default);
             }
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/sw-settings-services-hero.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-hero/sw-settings-services-hero.scss
@@ -64,7 +64,7 @@
             linear-gradient(
                 90deg,
                 var(--color-elevation-surface-default) 0%,
-                var(--color-border-brand-selected) 50%,
+                var(--color-border-brand-default) 50%,
                 var(--color-elevation-surface-default) 100%
             );
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.scss
@@ -1,7 +1,7 @@
 .sw-settings-services-service-card {
     border-radius: var(--border-radius-card);
     background: var(--color-elevation-surface-default);
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     padding: var(--scale-size-24);
 
     .sw-settings-services-service-card__content {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-shipping-price-matrix {
     &.sw-card .sw-card__content {
         padding: 0;
@@ -9,7 +7,7 @@
     .sw-settings-shipping-price-matrix__top-container {
         padding: 32px 24px;
         background-color: var(--color-background-tertiary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-select__single-selection {
             min-height: 30px;
@@ -47,7 +45,7 @@
 
     .sw-settings-shipping-price-matrix__empty-text {
         max-width: 500px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
         text-align: center;
         margin-bottom: 17px;
     }
@@ -78,7 +76,7 @@
     }
 
     .sw-settings-shipping-price-matrix__price-load-all {
-        border-top: 1px solid var(--color-border-primary-default);
+        border-top: 1px solid var(--color-border-secondary-default);
         padding: 20px;
 
         &-button {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-settings-shipping-list-color-error: var(--color-icon-critical-default);
-$sw-settings-shipping-list-color-success: var(--color-icon-positive-default);
-
 .sw-settings-shipping-list {
     &__content {
         width: 100%;
@@ -19,11 +14,11 @@ $sw-settings-shipping-list-color-success: var(--color-icon-positive-default);
 
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
-            color: $sw-settings-shipping-list-color-error;
+            color: var(--color-icon-critical-default);
         }
 
         .is--active {
-            color: $sw-settings-shipping-list-color-success;
+            color: var(--color-icon-positive-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/view/sw-settings-shopware-updates-info/sw-shopware-updates-info.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/view/sw-settings-shopware-updates-info/sw-shopware-updates-info.scss
@@ -6,7 +6,7 @@
     word-break: break-word;
     color: var(--color-text-primary-default);
     font-size: var(--font-size-xs);
-    line-height: var(--line-height-md);
+    line-height: var(--font-line-height-m);
 
     h2 {
         font-size: var(--font-size-m);
@@ -28,7 +28,7 @@
 
     p {
         margin: 0 0 var(--scale-size-12);
-        line-height: var(--line-height-md);
+        line-height: var(--font-line-height-m);
     }
 
     ul,
@@ -82,9 +82,9 @@
 .sw-changelog a[href^="https://github.com/shopware/shopware/compare"] {
     font-family: ui-monospace, SFMono-Regular, menlo, monaco, consolas, monospace;
     font-size: var(--font-size-2xs);
-    color: $color-darkgray-300;
+    color: var(--color-text-secondary-default);
 
     &:visited {
-        color: $color-darkgray-200;
+        color: var(--color-text-secondary-default);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/component/sidebar/sw-settings-snippet-filter-switch/sw-settings-snippet-filter-switch.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/component/sidebar/sw-settings-snippet-filter-switch/sw-settings-snippet-filter-switch.scss
@@ -1,15 +1,13 @@
-$sw-settings-snippets-sidebar-border: var(--color-border-primary-default);
-
 .sw-settings-snippet-filter-switch {
     .sw-settings-snippet-filter-switch__field {
         padding-left: 20px;
 
         &.border-top {
-            border-top: 1px solid $sw-settings-snippets-sidebar-border;
+            border-top: 1px solid var(--color-border-secondary-default);
         }
 
         &.border-bottom {
-            border-bottom: 1px solid $sw-settings-snippets-sidebar-border;
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
 
         &.sw-settings-snippet-filter-switch--small {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/component/sidebar/sw-settings-snippet-sidebar/sw-settings-snippet-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/component/sidebar/sw-settings-snippet-sidebar/sw-settings-snippet-sidebar.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-snippet-settings {
     &__sidebar .sw-sidebar-item .sw-sidebar-item__headline {
         display: flex;
@@ -7,12 +5,12 @@
         align-items: center;
         margin: 0;
         padding: 0 25px;
-        border-bottom: 1px solid var(--color-border-primary-default);
+        border-bottom: 1px solid var(--color-border-secondary-default);
     }
 
     &__sidebar-reset-all {
         margin-right: auto;
         padding-left: 10px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/component/sw-settings-tag-detail-assignments/sw-settings-tag-detail-assignments.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-tag-detail-assignments {
     display: grid;
 
@@ -10,12 +8,12 @@
         width: 100%;
 
         &.mt-card {
-            border: 1px solid $color-gray-300;
+            border: 1px solid var(--color-border-secondary-default);
             filter: none;
 
             .mt-card__toolbar {
                 border: 0;
-                background-color: $color-gray-100;
+                background-color: var(--color-elevation-surface-sunken);
             }
 
             .mt-card__content {
@@ -42,9 +40,9 @@
 
             .sw-settings-tag-detail-assignments__total-selected {
                 padding: 15px 20px;
-                font-size: $font-size-xs;
+                font-size: var(--font-size-xs);
                 text-align: right;
-                color: $color-gray-500;
+                color: var(--color-text-secondary-default);
             }
         }
 
@@ -58,7 +56,7 @@
                 .sw-data-grid__row.is--selected,
                 .sw-data-grid__row:hover {
                     .sw-data-grid__cell {
-                        background: $color-white;
+                        background: var(--color-background-primary-default);
                     }
                 }
                 /* stylelint-enable max-nesting-depth */
@@ -75,7 +73,7 @@
 
             .sw-highlight-text + .sw-highlight-text {
                 margin-left: 8px;
-                color: $color-gray-500;
+                color: var(--color-text-secondary-default);
             }
 
             &:not(.is--scroll-x) {
@@ -126,13 +124,13 @@
             background: transparent;
 
             &:hover:not([disabled]) {
-                color: $color-shopware-brand-500;
-                background: $color-gray-50;
+                color: var(--color-text-brand-default);
+                background: var(--color-background-secondary-default);
             }
 
             &.is--selected {
-                background: $color-gray-50;
-                color: $color-shopware-brand-500;
+                background: var(--color-background-secondary-default);
+                color: var(--color-text-brand-default);
                 cursor: auto;
             }
 
@@ -143,8 +141,8 @@
         }
 
         .associations-grid__count {
-            font-size: $font-size-xxs;
-            color: $color-gray-500;
+            font-size: var(--font-size-2xs);
+            color: var(--color-text-secondary-default);
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/page/sw-settings-tag-list/sw-settings-tag-list.scss
@@ -1,5 +1,3 @@
-@import "~scss/variables";
-
 .sw-settings-tag-list {
     &__grid {
         .sw-label {
@@ -30,7 +28,7 @@
         }
 
         &-footer {
-            background: $color-gray-100;
+            background: var(--color-background-secondary-default);
             margin: 32px -8px -8px;
             padding: 20px 24px;
             text-align: right;
@@ -38,7 +36,7 @@
             border-bottom-right-radius: 4px;
 
             a {
-                color: $color-crimson-900;
+                color: var(--color-text-critical-default);
             }
         }
     }
@@ -57,9 +55,9 @@
                 padding: 2px 8px;
                 transform: translate(30%, -30%);
                 border-radius: 18px;
-                color: $color-white;
-                background: $color-shopware-brand-500;
-                font-size: $font-size-xxs;
+                color: var(--color-static-white);
+                background: var(--color-interaction-primary-default);
+                font-size: var(--font-size-2xs);
                 font-style: normal;
                 pointer-events: none;
             }
@@ -96,7 +94,7 @@
     &__bulk-merge-progress {
         text-align: center;
         padding: 50px 0 30px;
-        color: $color-shopware-brand-500;
+        color: var(--color-text-brand-default);
     }
 
     &__bulk-merge-progress-icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/sw-settings-tax-provider-sorting-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/sw-settings-tax-provider-sorting-modal.scss
@@ -1,12 +1,10 @@
-@import "~scss/variables";
-
 .sw-modal {
     .sw-modal__body {
         &.sw-settings-tax-provider-sorting-modal__subtitle {
             display: flex;
             flex: none;
             overflow-y: hidden;
-            border-bottom: 1px solid var(--color-border-primary-default);
+            border-bottom: 1px solid var(--color-border-secondary-default);
         }
     }
 }
@@ -21,18 +19,18 @@
         padding: 12px 24px 12px 12px;
         grid-template-columns: 30px auto;
         grid-column-gap: 8px;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: 4px;
         align-items: center;
 
         &.is--disabled {
             color: var(--color-text-secondary-disabled);
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
         }
 
         &__name {
-            font-weight: $font-weight-semi-bold;
-            font-size: $font-size-xs;
+            font-weight: var(--font-weight-semibold);
+            font-size: var(--font-size-xs);
         }
 
         &__action {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.scss
@@ -1,11 +1,9 @@
 @import "~scss/variables";
 
-$sw-settings-tax-list-color-success: var(--color-icon-positive-default);
-
 .sw-settings-tax-list {
     .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--active {
-            color: $sw-settings-tax-list-color-success;
+            color: var(--color-icon-positive-default);
         }
     }
 }
@@ -26,12 +24,12 @@ $sw-settings-tax-list-color-success: var(--color-icon-positive-default);
         display: grid;
         grid-template-columns: auto 1fr auto auto;
         align-items: center;
-        border: 1px solid var(--color-border-primary-default);
+        border: 1px solid var(--color-border-secondary-default);
         border-radius: $border-radius-default;
         margin-bottom: 16px;
         column-gap: 16px;
         padding: 10px 16px;
-        font-size: $font-size-xs;
+        font-size: var(--font-size-xs);
 
         .sw-tax-provider__link {
             text-align: right;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/subcomponents/sw-settings-usage-data-consent-modal-sub-cards.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-consent-modal/subcomponents/sw-settings-usage-data-consent-modal-sub-cards.scss
@@ -3,7 +3,7 @@
     position: relative;
     padding: var(--scale-size-16) var(--scale-size-24);
     border-radius: var(--border-radius-m);
-    border: 1px solid var(--color-border-primary-default);
+    border: 1px solid var(--color-border-secondary-default);
     text-align: start;
     font-size: var(--font-size-xs);
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-settings-item/sw-settings-item.scss
@@ -1,8 +1,3 @@
-@import "~scss/variables";
-
-$sw-settings-item-text-color: $color-darkgray-200;
-$sw-settings-item-hover-text-color: $color-shopware-brand-500;
-
 .sw-settings__card--hero {
     .sw-settings-item {
         color: var(--color-text-primary-default, #2d2e32);
@@ -41,7 +36,7 @@ $sw-settings-item-hover-text-color: $color-shopware-brand-500;
         }
 
         .sw-settings-item__label {
-            font-size: $font-size-xs;
+            font-size: var(--font-size-xs);
             word-break: break-all;
             padding: 8px 0;
         }
@@ -53,7 +48,7 @@ $sw-settings-item-hover-text-color: $color-shopware-brand-500;
         }
 
         &:focus-visible {
-            outline: 2px solid var(--color-border-brand-selected, #0870ff);
+            outline: 2px solid var(--color-border-brand-default, #0870ff);
             outline-offset: 0;
         }
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-sso-error/page/index/sw-sso-error-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sso-error/page/index/sw-sso-error-index.scss
@@ -19,7 +19,7 @@
         width: 420px;
 
         .lock-icon {
-            background-color: var(--color-background-primary-disabled);
+            background-color: var(--color-background-tertiary-default);
             border-radius: var(--border-radius-xs);
             width: var(--scale-size-48);
             height: var(--scale-size-48);

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.scss
@@ -15,8 +15,8 @@
         display: flex;
         gap: var(--scale-size-20);
         padding: var(--scale-size-20) var(--scale-size-24);
-        background-color: var(--color-background-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-simple-search-field {
             width: 100%;

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.scss
@@ -15,8 +15,8 @@
         display: flex;
         gap: var(--scale-size-20);
         padding: var(--scale-size-20) var(--scale-size-24);
-        background-color: var(--color-background-secondary-default);
-        border-bottom: 1px solid var(--color-border-primary-default);
+        background-color: var(--color-elevation-surface-sunken);
+        border-bottom: 1px solid var(--color-border-secondary-default);
 
         .sw-simple-search-field {
             width: 100%;


### PR DESCRIPTION
### 1. Why is this change necessary?
Replace legacy color/typography SCSS variables and legacy CSS custom properties with official Meteor design tokens across the Administration.

### 2. What does this change do, exactly?
- map legacy $color-* / `--color-{gray,darkgray,shopware-brand,white,black}` and typography vars to semantic Meteor tokens
- replace deprecated Meteor tokens with their documented successors
- fix invalid token usages
- reclassify decorative borders to `--color-border-secondary-default`, keeping primary on interactive controls
- unify card/list toolbars to `--color-elevation-surface-sunken`
- inline single/double-use local SCSS vars and drop now-dead imports


### 3. Describe each step to reproduce the issue or behaviour.
Check Administration in light and dark mode.

### 4. Please link to the relevant issues (if any).
Closes #13450, #16235

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
