### PR TITLE
fix: url handling for revocation category

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/footer/revocation-button.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/footer/revocation-button.html.twig
@@ -1,19 +1,28 @@
-
-
-
 {% set revocationRequestUrl = path(cmsPath, { id: revocationRequestCmsPageId }) %}
 
 {% for serviceMenuItem in footer.serviceMenu %}
-    {% if serviceMenuItem.cmsPageId == revocationRequestCmsPageId and serviceMenuItem.seoUrl %}
-        {% set revocationRequestUrl = serviceMenuItem.seoUrl %}
+    {% if serviceMenuItem.cmsPageId == revocationRequestCmsPageId %}
+        {% set revocationRequestUrl = category_url(serviceMenuItem) %}
     {% endif %}
+
+    {% for childItem in serviceMenuItem.children %}
+        {% if childItem.cmsPageId == revocationRequestCmsPageId %}
+            {% set revocationRequestUrl = category_url(childItem) %}
+        {% endif %}
+    {% endfor %}
 {% endfor %}
 
 {% if footer.navigation and footer.navigation.tree %}
     {% for footerItem in footer.navigation.tree %}
-        {% if footerItem.category.cmsPageId == revocationRequestCmsPageId and footerItem.category.seoUrl %}
-            {% set revocationRequestUrl = footerItem.category.seoUrl %}
+        {% if footerItem.category.cmsPageId == revocationRequestCmsPageId %}
+            {% set revocationRequestUrl = category_url(footerItem.category) %}
         {% endif %}
+
+        {% for childItem in footerItem.children %}
+            {% if childItem.category.cmsPageId == revocationRequestCmsPageId %}
+                {% set revocationRequestUrl = category_url(childItem.category) %}
+            {% endif %}
+        {% endfor %}
     {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In SW 6.6 the `seoUrl` property is not available

### 2. What does this change do, exactly?
* removes the `seoUrl` check
* add url generation for the matching category
* also check subcategories

### 3. Describe each step to reproduce the issue or behaviour.
Use version 6.6.X and check the url for the button

### 4. Please link to the relevant issues (if any).
🤷 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
