### PR TITLE
refactor: cache watch signalable

### DIFF
--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -139,9 +139,10 @@ class CacheWatchDelayedCommand extends Command implements SignalableCommandInter
      */
     private function resolveInterval(int $microseconds): int
     {
-        return max(
+        return clamp(
+            $microseconds,
             self::MIN_POLL_INTERVAL_MICROSECONDS,
-            min(self::DEFAULT_POLL_INTERVAL_MICROSECONDS, $microseconds),
+            self::DEFAULT_POLL_INTERVAL_MICROSECONDS,
         );
     }
 

--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\Framework\Adapter\Command;
 
+use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Tests\Integration\Core\Framework\Adapter\Command\CacheWatchDelayedCommandTest;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
@@ -10,11 +12,12 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @phpstan-import-type RedisTypeHint from \Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory
+ * @phpstan-import-type RedisTypeHint from RedisConnectionFactory
  */
 #[Package('framework')]
 #[AsCommand(name: 'cache:watch:delayed', description: 'Watches the delayed cache keys/tags')]
@@ -96,15 +99,30 @@ class CacheWatchDelayedCommand extends Command implements SignalableCommandInter
         $this->output = $output;
 
         $interval = $this->resolveInterval((int) $input->getOption('interval'));
-
-        $before = $adapter->sMembers('invalidation');
-
         $section = $output->section();
         $table = new Table($section);
+
+        $this->watch(static fn (): array => $adapter->sMembers('invalidation'), $section, $table, $interval);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The watch loop only returns once a signal flips $shouldStop, so it cannot be reached in-process.
+     *
+     * @codeCoverageIgnore
+     *
+     * @see CacheWatchDelayedCommandTest
+     *
+     * @param callable(): array<string> $poll
+     */
+    private function watch(callable $poll, ConsoleSectionOutput $section, Table $table, int $interval): void
+    {
+        $before = $poll();
         $this->render($table, $before);
 
         while (!$this->shouldStop) {
-            $current = $adapter->sMembers('invalidation');
+            $current = $poll();
 
             if ($before !== $current) {
                 $section->clear();
@@ -114,8 +132,6 @@ class CacheWatchDelayedCommand extends Command implements SignalableCommandInter
 
             usleep($interval);
         }
-
-        return self::SUCCESS;
     }
 
     /**

--- a/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
+++ b/src/Core/Framework/Adapter/Command/CacheWatchDelayedCommand.php
@@ -5,30 +5,69 @@ namespace Shopware\Core\Framework\Adapter\Command;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\ConsoleEvents;
-use Symfony\Component\Console\Event\ConsoleSignalEvent;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @phpstan-import-type RedisTypeHint from \Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory
  */
 #[Package('framework')]
 #[AsCommand(name: 'cache:watch:delayed', description: 'Watches the delayed cache keys/tags')]
-class CacheWatchDelayedCommand extends Command
+class CacheWatchDelayedCommand extends Command implements SignalableCommandInterface
 {
+    private const DEFAULT_POLL_INTERVAL_MICROSECONDS = 1000;
+    private const MIN_POLL_INTERVAL_MICROSECONDS = 1;
+
+    private bool $shouldStop = false;
+
+    private ?OutputInterface $output = null;
+
     /**
      * @internal
      */
-    public function __construct(
-        private readonly EventDispatcherInterface $dispatcher,
-        private readonly ContainerInterface $container
-    ) {
+    public function __construct(private readonly ContainerInterface $container)
+    {
         parent::__construct();
+    }
+
+    /**
+     * @return array<int>
+     */
+    public function getSubscribedSignals(): array
+    {
+        return [\SIGINT, \SIGTERM];
+    }
+
+    public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+    {
+        $this->shouldStop = true;
+
+        if ($signal === \SIGINT && $this->output !== null) {
+            $this->output->writeln('Cache is now on its own.. bye!');
+        }
+
+        // Let execute() leave its loop and return SUCCESS rather than forcing an exit here.
+        return false;
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'interval',
+            null,
+            InputOption::VALUE_REQUIRED,
+            \sprintf(
+                'Poll interval in microseconds (%d-%d).',
+                self::MIN_POLL_INTERVAL_MICROSECONDS,
+                self::DEFAULT_POLL_INTERVAL_MICROSECONDS,
+            ),
+            self::DEFAULT_POLL_INTERVAL_MICROSECONDS,
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,15 +84,6 @@ class CacheWatchDelayedCommand extends Command
             return self::FAILURE;
         }
 
-        $this->dispatcher->addListener(ConsoleEvents::SIGNAL, static function (ConsoleSignalEvent $event): void {
-            $signal = $event->getHandlingSignal();
-            $event->setExitCode(0);
-
-            if ($signal === \SIGINT) {
-                $event->getOutput()->writeln('Cache is now on its own.. bye!');
-            }
-        });
-
         /** @var RedisTypeHint $adapter */
         $adapter = $this->container->get('shopware.cache.invalidator.storage.redis_adapter');
 
@@ -63,18 +93,18 @@ class CacheWatchDelayedCommand extends Command
             return self::FAILURE;
         }
 
-        $before = $adapter
-            ->sMembers('invalidation');
+        $this->output = $output;
+
+        $interval = $this->resolveInterval((int) $input->getOption('interval'));
+
+        $before = $adapter->sMembers('invalidation');
 
         $section = $output->section();
-
         $table = new Table($section);
         $this->render($table, $before);
 
-        // @phpstan-ignore-next-line
-        while (true) {
-            $current = $adapter
-                ->sMembers('invalidation');
+        while (!$this->shouldStop) {
+            $current = $adapter->sMembers('invalidation');
 
             if ($before !== $current) {
                 $section->clear();
@@ -82,8 +112,21 @@ class CacheWatchDelayedCommand extends Command
                 $before = $current;
             }
 
-            usleep(1000);
+            usleep($interval);
         }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Clamps the requested poll interval into the supported range.
+     */
+    private function resolveInterval(int $microseconds): int
+    {
+        return max(
+            self::MIN_POLL_INTERVAL_MICROSECONDS,
+            min(self::DEFAULT_POLL_INTERVAL_MICROSECONDS, $microseconds),
+        );
     }
 
     /**

--- a/src/Core/Profiling/DependencyInjection/services.xml
+++ b/src/Core/Profiling/DependencyInjection/services.xml
@@ -16,7 +16,6 @@
 
         <service id="Shopware\Core\Framework\Adapter\Command\CacheWatchDelayedCommand">
             <tag name="console.command"/>
-            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="service_container"/>
         </service>
 

--- a/tests/integration/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
+++ b/tests/integration/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Adapter\Command;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Symfony\Component\Process\Process;
+
+/**
+ * Drives the real watch loop end to end: the command keeps polling until a signal arrives.
+ * The loop cannot be reached in-process (it only returns on a delivered signal), so it is
+ * exercised here by running the command in a subprocess and sending it SIGTERM.
+ *
+ * @internal
+ */
+class CacheWatchDelayedCommandTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    #[TestDox('watch mode keeps rendering until it receives a signal and then exits cleanly')]
+    public function testWatchModeRendersAndExitsOnSignal(): void
+    {
+        $projectDir = (string) static::getContainer()->getParameter('kernel.project_dir');
+
+        // --interval=1 keeps the poll loop tight so the test stays fast.
+        // SHELL_VERBOSITY is forced to normal: phpunit runs with -1 (quiet), which the
+        // subprocess would otherwise inherit and suppress all command output.
+        $process = new Process(
+            ['php', 'bin/console', 'cache:watch:delayed', '--interval=1'],
+            $projectDir,
+            ['SHELL_VERBOSITY' => '0'],
+        );
+        $process->start();
+
+        $deadline = microtime(true) + 15.0;
+        while ($process->isRunning() && !str_contains($process->getOutput(), 'Tags at:') && microtime(true) < $deadline) {
+            usleep(50_000);
+        }
+
+        // Environments without delayed redis invalidation cannot enter the watch loop.
+        if (!str_contains($process->getOutput(), 'Tags at:')) {
+            if ($process->isRunning()) {
+                $process->stop();
+            }
+            static::markTestSkipped(
+                'Delayed redis cache invalidation is not available in this environment: '
+                . trim($process->getOutput() . ' ' . $process->getErrorOutput()),
+            );
+        }
+
+        static::assertTrue($process->isRunning(), 'The watch command must keep running until it is signalled.');
+
+        $process->signal(\SIGTERM);
+        $process->wait();
+
+        static::assertSame(0, $process->getExitCode());
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
+++ b/tests/unit/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Command\CacheWatchDelayedCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(CacheWatchDelayedCommand::class)]
+class CacheWatchDelayedCommandTest extends TestCase
+{
+    #[TestDox('fails outside of a console context')]
+    public function testFailsOutsideConsoleContext(): void
+    {
+        $command = new CacheWatchDelayedCommand(static::createStub(ContainerInterface::class));
+
+        $output = new BufferedOutput();
+        $status = $command->run(new ArrayInput([]), $output);
+
+        static::assertSame(Command::FAILURE, $status);
+        static::assertStringContainsString('only available in console context', $output->fetch());
+    }
+
+    #[TestDox('fails when redis cache invalidation is not configured')]
+    public function testFailsWhenRedisNotConfigured(): void
+    {
+        $container = static::createStub(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+
+        $command = new CacheWatchDelayedCommand($container);
+        $status = $this->runWithConsoleOutput($command);
+
+        static::assertSame(Command::FAILURE, $status);
+    }
+
+    #[TestDox('fails when the redis adapter does not support sMembers')]
+    public function testFailsWhenAdapterHasNoSMembers(): void
+    {
+        $container = static::createStub(ContainerInterface::class);
+        $container->method('has')->willReturn(true);
+        $container->method('get')->willReturn(new \stdClass());
+
+        $command = new CacheWatchDelayedCommand($container);
+        $status = $this->runWithConsoleOutput($command);
+
+        static::assertSame(Command::FAILURE, $status);
+    }
+
+    #[TestDox('subscribes to SIGINT and SIGTERM')]
+    public function testGetSubscribedSignals(): void
+    {
+        $command = new CacheWatchDelayedCommand(static::createStub(ContainerInterface::class));
+
+        static::assertSame([\SIGINT, \SIGTERM], $command->getSubscribedSignals());
+    }
+
+    #[TestDox('handling a signal requests a graceful stop without forcing an exit')]
+    public function testHandleSignalRequestsGracefulStop(): void
+    {
+        $command = new CacheWatchDelayedCommand(static::createStub(ContainerInterface::class));
+
+        static::assertFalse($command->handleSignal(\SIGTERM));
+        static::assertFalse($command->handleSignal(\SIGINT));
+    }
+
+    #[TestDox('the interval option defaults to 1000 microseconds')]
+    public function testIntervalOptionDefault(): void
+    {
+        $command = new CacheWatchDelayedCommand(static::createStub(ContainerInterface::class));
+
+        $option = $command->getDefinition()->getOption('interval');
+        static::assertTrue($option->isValueRequired());
+        static::assertSame(1000, $option->getDefault());
+    }
+
+    #[TestDox('the poll interval is clamped to the supported range')]
+    #[DataProvider('intervalProvider')]
+    public function testResolveIntervalClampsToSupportedRange(int $microseconds, int $expected): void
+    {
+        $command = new CacheWatchDelayedCommand(static::createStub(ContainerInterface::class));
+
+        $resolved = (new \ReflectionMethod($command, 'resolveInterval'))->invoke($command, $microseconds);
+
+        static::assertSame($expected, $resolved);
+    }
+
+    /**
+     * @return \Generator<string, array{0: int, 1: int}>
+     */
+    public static function intervalProvider(): \Generator
+    {
+        yield 'within range is kept' => [500, 500];
+        yield 'lower bound is kept' => [1, 1];
+        yield 'upper bound is kept' => [1000, 1000];
+        yield 'below minimum is raised to 1' => [0, 1];
+        yield 'negative is raised to 1' => [-50, 1];
+        yield 'above maximum is capped at 1000' => [5000, 1000];
+    }
+
+    private function runWithConsoleOutput(CacheWatchDelayedCommand $command): int
+    {
+        // The watch command requires a ConsoleOutputInterface; execute() returns before the
+        // watch loop in the failure paths, so a stubbed console output is sufficient.
+        $status = (new \ReflectionMethod($command, 'execute'))
+            ->invoke($command, new ArrayInput([]), static::createStub(ConsoleOutputInterface::class));
+
+        \assert(\is_int($status));
+
+        return $status;
+    }
+}


### PR DESCRIPTION
 ### 1. Why is this change necessary?

  `cache:watch:delayed` used `while (true)` with a `@phpstan-ignore` and an ad-hoc signal listener, and had no test coverage.

  ### 2. What does this change do, exactly?

  - Implements `SignalableCommandInterface`: the loop runs on `while (!$this->shouldStop)` and SIGINT/SIGTERM exit gracefully — no more `while(true)`/`@phpstan-ignore`, and the now-dead`event_dispatcher` dependency is dropped.
  - Adds a `--interval` option (microseconds, clamped 1–1000, default 1000) so polling is tunable.
  - Adds unit tests (guards, signals, interval clamping) and a signal-driven integration test that drives the real loop in a subprocess; the loop itself is `@codeCoverageIgnore` with an attribute `@see` to that integration test.

  ### 3. Describe each step to reproduce the issue or behaviour.
  
  Run `bin/console cache:watch:delayed --interval=1`, then Ctrl+C — it exits cleanly. `vendor/bin/phpstan` passes without the `while(true)` ignore.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
