### PR TITLE
fix: hide breadcrumb config behind feature flag

### DIFF
--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -24,10 +24,11 @@
 
         <input-field type="bool">
             <name>buildBreadcrumbByReferrerCategory</name>
+            <flag>BREADCRUMB_REWORK</flag>
             <label>Build breadcrumb based on referrer category</label>
             <label lang="de-DE">Breadcrumb anhand der Referrer-Kategorie aufbauen</label>
-            <helpText>Build the product breadcrumb based on the linking category if available. Feature flag BREADCRUMB_REWORK has to be active.</helpText>
-            <helpText lang="de-DE">Produkt-Breadcrumb basierend auf der verlinkenden Kategorie aufbauen, falls verfügbar. Feature-Flag BREADCRUMB_REWORK muss dafür aktiv sein.</helpText>
+            <helpText>Build the product breadcrumb based on the linking category if available.</helpText>
+            <helpText lang="de-DE">Produkt-Breadcrumb basierend auf der verlinkenden Kategorie aufbauen, falls verfügbar.</helpText>
             <defaultValue>false</defaultValue>
         </input-field>
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The setting "Build breadcrumb based on referrer category" is only useful when `BREADCRUMB_REWORK` is active, but it was still shown in the listing settings when the feature was inactive.

### 2. What does this change do, exactly?

Adds the existing system-config `<flag>` metadata to the setting so it is hidden unless `BREADCRUMB_REWORK` is active. The help text no longer mentions the feature flag because users only see the field after the flag is active.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run Shopware with `BREADCRUMB_REWORK` inactive.
2. Open `admin#/sw/settings/listing/index`.
3. The breadcrumb referrer setting should not be visible.

### 4. Please link to the relevant issues (if any).

- closes #17566

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
