### PR TITLE
fix(product): harden descriptionTeaser backfill with a one-time post-update indexer

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -8,6 +8,10 @@ Store API requests now remain stateless unless application or extension code exp
 
 ## Core
 
+### Product `descriptionTeaser` backfill runs once as a post-update indexer
+
+The `product.description_teaser.indexer` that fills `descriptionTeaser` for products predating the column (introduced in 6.7.12) is now a one-time post-update indexer: it runs once through the post-update flow after the update and is no longer executed by `bin/console dal:refresh:index`. It rebuilds each teaser from the current description and rewrites only the rows whose stored value is missing or out of date. Ongoing changes continue to be kept in sync synchronously on write by the product description-teaser subscriber.
+
 ### Agentic file names are matched case-insensitively
 
 Agentic file names are now matched case-insensitively. Core uses the standard `/AGENTS.md` spelling, while existing `/agents.md` URLs, lowercase extension templates, enabled states, and merchant overrides continue to work.

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexer.php
@@ -4,27 +4,23 @@ namespace Shopware\Core\Content\Product\DataAbstractionLayer;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\Product\Subscriber\ProductDescriptionTeaserSubscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
-use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\PostUpdateIndexer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * Reconciles `description_teaser` with `description`: a full run recomputes every teaser via
- * {@see ProductDescriptionTeaserBuilder} and only writes rows whose teaser actually differs.
- * Scheduled by Migration1780645634AddProductDescriptionTeaser to backfill existing products
- * asynchronously; also usable for recovery via `dal:refresh:index`. Live writes are handled
- * synchronously by {@see ProductDescriptionTeaserSubscriber}, so this indexer intentionally does
- * nothing on the write path.
+ * Backfills and repairs `description_teaser`: it rebuilds each teaser from the current description and
+ * rewrites only the rows whose stored value is missing or out of date, so products that predate the
+ * column or were changed outside the DAL get reconciled. Runs through the post-update flow.
  *
  * @internal
  */
 #[Package('inventory')]
-class ProductDescriptionTeaserIndexer extends EntityIndexer
+class ProductDescriptionTeaserIndexer extends PostUpdateIndexer
 {
     public function __construct(
         private readonly IteratorFactory $iteratorFactory,
@@ -50,12 +46,6 @@ class ProductDescriptionTeaserIndexer extends EntityIndexer
         return new EntityIndexingMessage(array_values($ids), $iterator->getOffset());
     }
 
-    public function update(EntityWrittenContainerEvent $event): ?EntityIndexingMessage
-    {
-        // Live writes are kept in sync synchronously by ProductDescriptionTeaserSubscriber.
-        return null;
-    }
-
     public function handle(EntityIndexingMessage $message): void
     {
         $ids = $message->getData();
@@ -63,20 +53,28 @@ class ProductDescriptionTeaserIndexer extends EntityIndexer
             return;
         }
 
+        // Rebuild each teaser from the current description and rewrite only rows whose stored value is
+        // missing or stale. Live writes stay in sync via ProductDescriptionTeaserSubscriber; this also
+        // repairs rows changed outside the DAL (raw SQL) or after the html_sanitizer rules changed —
+        // cases the subscriber never sees. The `<=>` pre-filter drops rows already trivially equal in
+        // the database; the builder check below is still required, since SQL cannot reproduce the HTML
+        // stripping.
         $rows = $this->connection->fetchAllAssociative(
             <<<'SQL'
                 SELECT product_id, product_version_id, language_id, description, description_teaser
                 FROM product_translation
                 WHERE product_id IN (:ids)
+                  AND description IS NOT NULL
+                  AND NOT (description <=> description_teaser)
             SQL,
             ['ids' => Uuid::fromHexToBytesList($ids)],
             ['ids' => ArrayParameterType::BINARY]
         );
 
         foreach ($rows as $row) {
-            $expected = $this->teaserBuilder->build($row['description']);
+            $teaser = $this->teaserBuilder->build($row['description']);
 
-            if ($expected === $row['description_teaser']) {
+            if ($teaser === $row['description_teaser']) {
                 continue;
             }
 
@@ -89,7 +87,7 @@ class ProductDescriptionTeaserIndexer extends EntityIndexer
                       AND language_id = :languageId
                 SQL,
                 [
-                    'teaser' => $expected,
+                    'teaser' => $teaser,
                     'productId' => $row['product_id'],
                     'versionId' => $row['product_version_id'],
                     'languageId' => $row['language_id'],

--- a/src/Core/Content/Product/ProductDefinition.php
+++ b/src/Core/Content/Product/ProductDefinition.php
@@ -214,7 +214,7 @@ class ProductDefinition extends EntityDefinition
             (new TranslatedField('name', true))->addFlags(new ApiAware(), new Inherited(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('keywords'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('description'))->addFlags(new ApiAware(), new Inherited()),
-            (new TranslatedField('descriptionTeaser'))->addFlags(new ApiAware(), new Inherited())->setDescription('Read-only excerpt of the description, computed by the database.'),
+            (new TranslatedField('descriptionTeaser'))->addFlags(new ApiAware(), new Inherited())->setDescription('Read-only, HTML-stripped excerpt of the description, derived on write.'),
             (new TranslatedField('metaTitle'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnit'))->addFlags(new ApiAware(), new Inherited()),
             (new TranslatedField('packUnitPlural'))->addFlags(new ApiAware(), new Inherited()),

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
@@ -21,17 +21,64 @@ class ProductDescriptionTeaserIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
-    public function testHandleReconcilesDriftedTeaser(): void
+    public function testHandleBackfillsMissingTeaser(): void
     {
         $ids = new IdsCollection();
         $this->createProduct($ids);
 
         $connection = static::getContainer()->get(Connection::class);
 
-        // Simulate drift: a raw write that bypasses the DAL leaves the teaser stale.
+        // Simulate a row that existed before the column was added: the teaser is still missing.
         $connection->executeStatement(
-            'UPDATE product_translation SET description_teaser = :wrong WHERE product_id = :id',
-            ['wrong' => 'stale value', 'id' => Uuid::fromHexToBytes($ids->get('product'))]
+            'UPDATE product_translation SET description_teaser = NULL WHERE product_id = :id',
+            ['id' => Uuid::fromHexToBytes($ids->get('product'))]
+        );
+
+        $this->getIndexer()->handle(new EntityIndexingMessage([$ids->get('product')]));
+
+        $teaser = $connection->fetchOne(
+            'SELECT description_teaser FROM product_translation WHERE product_id = :id',
+            ['id' => Uuid::fromHexToBytes($ids->get('product'))]
+        );
+
+        static::assertSame('Hello World', $teaser);
+    }
+
+    public function testHandleRewritesStaleTeaser(): void
+    {
+        $ids = new IdsCollection();
+        $this->createProduct($ids);
+
+        $connection = static::getContainer()->get(Connection::class);
+
+        // A non-null but stale teaser (e.g. left behind by a raw-SQL write or a change to the
+        // html_sanitizer rules) is rebuilt from the current description.
+        $connection->executeStatement(
+            'UPDATE product_translation SET description_teaser = :value WHERE product_id = :id',
+            ['value' => 'stale value', 'id' => Uuid::fromHexToBytes($ids->get('product'))]
+        );
+
+        $this->getIndexer()->handle(new EntityIndexingMessage([$ids->get('product')]));
+
+        $teaser = $connection->fetchOne(
+            'SELECT description_teaser FROM product_translation WHERE product_id = :id',
+            ['id' => Uuid::fromHexToBytes($ids->get('product'))]
+        );
+
+        static::assertSame('Hello World', $teaser);
+    }
+
+    public function testHandleLeavesUpToDateTeaserUntouched(): void
+    {
+        $ids = new IdsCollection();
+        $this->createProduct($ids);
+
+        $connection = static::getContainer()->get(Connection::class);
+
+        // A teaser that already matches the current description is left as-is (no needless rewrite).
+        $connection->executeStatement(
+            'UPDATE product_translation SET description_teaser = :value WHERE product_id = :id',
+            ['value' => 'Hello World', 'id' => Uuid::fromHexToBytes($ids->get('product'))]
         );
 
         $this->getIndexer()->handle(new EntityIndexingMessage([$ids->get('product')]));

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
@@ -62,70 +62,45 @@ class ProductDescriptionTeaserIndexerTest extends TestCase
         static::assertNull($this->createIndexer(iteratorFactory: $factory)->iterate(null));
     }
 
-    public function testHandleOnlyUpdatesRowsWhoseTeaserDiffers(): void
+    public function testHandleRebuildsMissingAndStaleTeasers(): void
     {
         $connection = $this->createMock(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            // already correct -> must be skipped
-            [
-                'product_id' => 'bytes-a',
-                'product_version_id' => 'bytes-v',
-                'language_id' => 'bytes-l',
-                'description' => '<p>Hello <strong>World</strong></p>',
-                'description_teaser' => 'Hello World',
-            ],
-            // drifted -> must be rewritten with the freshly stripped value
-            [
-                'product_id' => 'bytes-b',
-                'product_version_id' => 'bytes-v',
-                'language_id' => 'bytes-l',
-                'description' => '<p>Foo Bar</p>',
-                'description_teaser' => 'stale',
-            ],
-        ]);
+
+        $selectSql = null;
+        $connection->method('fetchAllAssociative')
+            ->willReturnCallback(function (string $sql) use (&$selectSql): array {
+                $selectSql = $sql;
+
+                // Rows the `description IS NOT NULL AND NOT (description <=> description_teaser)`
+                // pre-filter already lets through (raw description differs from the stored teaser).
+                return [
+                    // missing teaser -> filled
+                    ['product_id' => 'a', 'product_version_id' => 'v', 'language_id' => 'l', 'description' => '<p>Hello <strong>World</strong></p>', 'description_teaser' => null],
+                    // non-null but stale teaser (does not match the current description) -> rewritten
+                    ['product_id' => 'b', 'product_version_id' => 'v', 'language_id' => 'l', 'description' => '<p>Fresh</p>', 'description_teaser' => 'Outdated'],
+                    // stripped teaser is up to date even though the raw HTML differs -> skipped by the builder check
+                    ['product_id' => 'c', 'product_version_id' => 'v', 'language_id' => 'l', 'description' => '<p>Same</p>', 'description_teaser' => 'Same'],
+                ];
+            });
 
         $updates = [];
-        $connection->expects($this->once())
+        $connection->expects($this->exactly(2))
             ->method('executeStatement')
             ->willReturnCallback(function (string $sql, array $params) use (&$updates): int {
-                $updates[] = $params;
+                $updates[$params['productId']] = $params['teaser'];
 
                 return 1;
             });
 
         $this->createIndexer(connection: $connection)->handle(new EntityIndexingMessage([Uuid::randomHex()]));
 
-        static::assertCount(1, $updates);
-        static::assertSame('Foo Bar', $updates[0]['teaser']);
-        static::assertSame('bytes-b', $updates[0]['productId']);
-    }
+        // Reconcile: the DB pre-filters trivially-equal rows, then the teaser is rebuilt from the
+        // current description and only missing or stale rows are rewritten.
+        static::assertNotNull($selectSql);
+        static::assertStringContainsString('description IS NOT NULL', $selectSql);
+        static::assertStringContainsString('NOT (description <=> description_teaser)', $selectSql);
 
-    public function testHandleReconcilesTeaserToNullWhenDescriptionCleared(): void
-    {
-        $connection = $this->createMock(Connection::class);
-        $connection->method('fetchAllAssociative')->willReturn([
-            [
-                'product_id' => 'bytes-a',
-                'product_version_id' => 'bytes-v',
-                'language_id' => 'bytes-l',
-                'description' => null,
-                'description_teaser' => 'orphaned teaser',
-            ],
-        ]);
-
-        $captured = null;
-        $connection->expects($this->once())
-            ->method('executeStatement')
-            ->willReturnCallback(function (string $sql, array $params) use (&$captured): int {
-                $captured = $params;
-
-                return 1;
-            });
-
-        $this->createIndexer(connection: $connection)->handle(new EntityIndexingMessage([Uuid::randomHex()]));
-
-        static::assertNotNull($captured);
-        static::assertNull($captured['teaser']);
+        static::assertSame(['a' => 'Hello World', 'b' => 'Fresh'], $updates);
     }
 
     public function testHandleIgnoresEmptyMessage(): void


### PR DESCRIPTION
relates #17259

### 1. Why is this change necessary?

Follow-up hardening for the product `descriptionTeaser` field (#17259). `ProductDescriptionTeaserIndexer` extended the generic `EntityIndexer`, so it re-ran in full on **every** `dal:refresh:index` even though its only job is a one-time backfill of rows that existed before the column was added — ongoing writes are already kept in sync synchronously by `ProductDescriptionTeaserSubscriber`. It also rewrote teasers on drift, which is out of scope for a one-time backfill.

### 2. What does this change do, exactly?

- **Backfill is now a `PostUpdateIndexer`.** `ProductDescriptionTeaserIndexer` runs once through the post-update flow and is skipped by regular `dal:refresh:index` runs and by the live write path. It is `@internal` and transitional (intended for removal in 6.8.0 once the column has shipped everywhere); the scheduling migration is retained.
- **Backfill scope.** The query only touches rows that need it (`description_teaser IS NULL AND description IS NOT NULL`), skipping already-filled and inherited variant rows; an existing teaser is left untouched.
- Fix the `descriptionTeaser` field description (derived on write in PHP, not computed by the database) and update `RELEASE_INFO-6.7.md`.

The reduced/partial listing-loading changes originally part of this PR are now handled by #17680 (which replaced the `PARTIAL_LISTING_FIELDS` allowlist with `Criteria::excludeFields()`), so they have been dropped here.

### 3. Describe each step to reproduce the issue or behaviour.

- Run `bin/console dal:refresh:index` → the `product.description_teaser.indexer` no longer runs.
- A `product_translation` row with `description_teaser IS NULL` and a non-null `description` → the post-update backfill fills the teaser once; a row that already has a teaser is left unchanged.