### PR TITLE
fix: prevent 500 on guest login when redirectParameters is missing

### DIFF
--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -37,6 +37,9 @@ use Shopware\Storefront\Page\Account\RecoverPassword\AccountRecoverPasswordPageL
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * @internal
@@ -126,6 +129,22 @@ class AuthController extends StorefrontController
             return $this->createActionResponse($request);
         }
 
+        $redirectParameters = $request->query->all()['redirectParameters'] ?? [];
+        if (!\is_array($redirectParameters)) {
+            $redirectParameters = [];
+        }
+
+        // The template builds the form action via `path(redirectTo, redirectParameters)`. If the redirect target
+        // cannot be generated (e.g. the page was called directly without the required `redirectParameters`),
+        // rendering would fail with a 500. Behave like a direct call and send the user to the login page instead.
+        try {
+            $this->generateUrl($redirect, $redirectParameters);
+        } catch (RouteNotFoundException|MissingMandatoryParametersException|InvalidParameterException) {
+            $this->addFlash(self::DANGER, $this->trans('account.orderGuestLoginWrongCredentials'));
+
+            return $this->redirectToRoute('frontend.account.login.page');
+        }
+
         // WaitTime can be either set as attribute when it's forwarded to this route
         // or as query parameter when it's redirected
         $waitTime = (int) ($request->attributes->get('waitTime') ?? $request->query->get('waitTime'));
@@ -145,7 +164,7 @@ class AuthController extends StorefrontController
 
         return $this->renderStorefront('@Storefront/storefront/page/account/guest-auth.html.twig', [
             'redirectTo' => $redirect,
-            'redirectParameters' => $request->query->all()['redirectParameters'] ?? json_encode([]),
+            'redirectParameters' => $redirectParameters,
             'page' => $page,
         ]);
     }

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -598,7 +598,10 @@ class AuthControllerTest extends TestCase
 
     public function testAccountGuestLoginPageLoadedHookScriptsAreExecuted(): void
     {
-        $this->request('GET', '/account/guest/login', ['redirectTo' => 'foo']);
+        $this->request('GET', '/account/guest/login', [
+            'redirectTo' => 'frontend.account.order.single.page',
+            'redirectParameters' => ['deepLinkCode' => 'foo'],
+        ]);
 
         $traces = static::getContainer()->get(ScriptTraces::class)->getTraces();
 
@@ -608,6 +611,17 @@ class AuthControllerTest extends TestCase
     public function testAccountGuestLoginPageWithoutRedirectRedirects(): void
     {
         $response = $this->request('GET', '/account/guest/login', []);
+
+        static::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
+        static::assertSame('/account/login', $response->headers->get('location'));
+    }
+
+    public function testAccountGuestLoginPageWithMissingRedirectParametersRedirects(): void
+    {
+        // `redirectTo` points to a route that requires parameters (`/account/order/{deepLinkCode}`),
+        // but `redirectParameters` is missing (e.g. the page was called directly). The form action URL
+        // cannot be generated, so the user should be redirected to the login page instead of getting a 500.
+        $response = $this->request('GET', '/account/guest/login', ['redirectTo' => 'frontend.account.order.single.page']);
 
         static::assertSame(Response::HTTP_FOUND, $response->getStatusCode());
         static::assertSame('/account/login', $response->headers->get('location'));

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
 use Shopware\Storefront\Controller\AuthController;
+use Shopware\Storefront\Page\Account\Login\AccountGuestLoginPageLoadedHook;
 use Shopware\Storefront\Page\Account\Login\AccountLoginPage;
 use Shopware\Storefront\Page\Account\Login\AccountLoginPageLoadedHook;
 use Shopware\Storefront\Page\Account\Login\AccountLoginPageLoader;
@@ -107,6 +108,59 @@ class AuthControllerTest extends TestCase
         static::assertArrayHasKey('danger', $this->controller->flashBag);
         static::assertArrayHasKey(0, $this->controller->flashBag['danger']);
         static::assertSame('account.orderGuestLoginWrongCredentials', $this->controller->flashBag['danger'][0]);
+    }
+
+    public function testGuestLoginPageWithoutRedirectParametersRendersEmptyArray(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $request = new Request();
+        $request->query->set('redirectTo', 'frontend.account.order.single.page');
+
+        $page = new AccountLoginPage();
+        $this->accountLoginPageLoader->expects($this->once())
+            ->method('load')
+            ->willReturn($page);
+
+        $this->controller->guestLoginPage($request, $context);
+
+        static::assertSame('@Storefront/storefront/page/account/guest-auth.html.twig', $this->controller->renderStorefrontView);
+        static::assertSame([], $this->controller->renderStorefrontParameters['redirectParameters'] ?? null);
+        static::assertSame('frontend.account.order.single.page', $this->controller->renderStorefrontParameters['redirectTo'] ?? null);
+        static::assertInstanceOf(AccountGuestLoginPageLoadedHook::class, $this->controller->calledHook);
+    }
+
+    public function testGuestLoginPageNormalizesNonArrayRedirectParameters(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $request = new Request();
+        $request->query->set('redirectTo', 'frontend.account.order.single.page');
+        $request->query->set('redirectParameters', 'not-an-array');
+
+        $this->accountLoginPageLoader->method('load')->willReturn(new AccountLoginPage());
+
+        $this->controller->guestLoginPage($request, $context);
+
+        static::assertSame([], $this->controller->renderStorefrontParameters['redirectParameters'] ?? null);
+    }
+
+    public function testGuestLoginPageKeepsArrayRedirectParameters(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $request = new Request();
+        $request->query->set('redirectTo', 'frontend.account.order.single.page');
+        $request->query->set('redirectParameters', ['deepLinkCode' => 'abc']);
+
+        $this->accountLoginPageLoader->method('load')->willReturn(new AccountLoginPage());
+
+        $this->controller->guestLoginPage($request, $context);
+
+        static::assertSame(['deepLinkCode' => 'abc'], $this->controller->renderStorefrontParameters['redirectParameters'] ?? null);
     }
 
     public function testGuestCustomerOnLoginPageShouldBeLoggedOut(): void


### PR DESCRIPTION

### 1. Why is this change necessary?

`/account/guest/login` throws HTTP 500 when opened without `redirectParameters` (helpdesk #46023929935). The fallback is a JSON string (`"[]"`), but the template passes it to Twig's `path()`, which requires an array.

### 2. What does this change do, exactly?

Passes `redirectParameters` as an array. Since valid targets need route params (e.g. `/account/order/{deepLinkCode}`), an empty array alone would still 500 via `MissingMandatoryParametersException` — so the controller also redirects to the login page when the `redirectTo` URL can't be generated.

### 3. Describe each step to reproduce the issue or behaviour.

`GET /account/guest/login?redirectTo=frontend.account.order.single.page`

Before: HTTP 500. After: HTTP 302 to `/account/login`.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- relates #17649

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
