### PR TITLE
fix(dal): deterministic ordering for paginated OneToMany associations

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -1095,9 +1095,15 @@ class EntityReader implements EntityReaderInterface
         $sqlAccessor = EntityDefinitionQueryHelper::escape($association->getReferenceDefinition()->getEntityName()) . '.'
             . EntityDefinitionQueryHelper::escape($foreignKey);
 
+        $primaryKeyAccessor = EntityDefinitionQueryHelper::escape($association->getReferenceDefinition()->getEntityName()) . '.id';
+
         $orderByParts = $query->getOrderByParts();
 
-        $windowOrderBy = $orderByParts !== [] ? implode(', ', $orderByParts) : $sqlAccessor;
+        // Always end the window ordering with the reference primary key so ROW_NUMBER() produces a deterministic
+        // total order within each partition. The criteria sortings may be absent or non-unique (e.g. sorting by a
+        // shared `name`); without a unique tie-breaker the row numbering is undefined within a parent and paginated
+        // reads (limit/offset) of the association can return overlapping rows across separate queries.
+        $windowOrderBy = implode(', ', [...$orderByParts, $primaryKeyAccessor]);
 
         // ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...) guarantees that rows are numbered in the declared sort
         // order within each parent entity, regardless of how the database engine executes the surrounding query, which
@@ -1110,7 +1116,7 @@ class EntityReader implements EntityReaderInterface
             $sqlAccessor,
 
             // add primary key select to group concat them
-            EntityDefinitionQueryHelper::escape($association->getReferenceDefinition()->getEntityName()) . '.id',
+            $primaryKeyAccessor,
         );
 
         foreach ($orderByParts as $i => $sorting) {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -1501,6 +1501,49 @@ class EntityRepositoryTest extends TestCase
         }
     }
 
+    public function testPaginatedOneToManyAssociationCoversEveryChildExactlyOnce(): void
+    {
+        $id = Uuid::randomHex();
+
+        // All children share the same (non-unique) name, so the paginated read must rely on a deterministic
+        // tie-breaker (the primary key) to number rows; otherwise pages can overlap or skip children.
+        $children = array_fill(0, 20, ['name' => 'test', 'configurationId' => $id]);
+
+        $data = [
+            'id' => $id,
+            'name' => 'default folder',
+            'configuration' => [
+                'id' => $id,
+                'createThumbnails' => true,
+            ],
+            'children' => $children,
+        ];
+
+        $context = Context::createDefaultContext();
+        /** @var EntityRepository<MediaFolderCollection> $repository */
+        $repository = static::getContainer()->get('media_folder.repository');
+        $repository->create([$data], $context);
+
+        $pageSize = 3;
+        $seen = [];
+
+        for ($offset = 0; $offset < 20; $offset += $pageSize) {
+            $criteria = new Criteria([$id]);
+            $criteria->getAssociation('children')->setLimit($pageSize)->setOffset($offset);
+
+            $folder = $repository->search($criteria, $context)->getEntities()->get($id);
+            static::assertInstanceOf(MediaFolderEntity::class, $folder);
+            static::assertInstanceOf(MediaFolderCollection::class, $folder->getChildren());
+
+            foreach ($folder->getChildren()->getIds() as $childId) {
+                static::assertArrayNotHasKey($childId, $seen, 'Paginated one-to-many read returned an overlapping child');
+                $seen[$childId] = true;
+            }
+        }
+
+        static::assertCount(20, $seen, 'Paginated one-to-many read skipped or duplicated children');
+    }
+
     public function testFilterConsistencyOnCriteriaObject(): void
     {
         $id = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?
Follow up of 

https://github.com/shopware/shopware/actions/runs/28069366676/job/83100527652

```
php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "core-framework-batch2"

There was 1 failure:

1) Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\EntityRepositoryTest::testReadPaginatedOneToManyChildrenAssociation
Failed asserting that an array does not contain '019ef74e23d870c89dd3d85425475710'.

/home/runner/work/shopware/shopware/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php:1500

```

Not classic state-poisoning.

#### Why it didn't fail before #17644. 

The old code numbered rows with the MySQL user-variable counter `(@n:=IF(@c=fk, …))`, which counts rows in the physical read order the inner SELECT produced. For these queries that order was consistently the primary-key (clustered-index) order. 

And since Uuid::randomHex() is UUIDv7 (time-ordered), PK order = insertion order. So pagination was de-facto stable across the 2 reads even though no explicit tie-breaker existed. The PR replaced that with ROW_NUMBER() OVER (PARTITION BY fk ORDER BY fk): ordering the window by the partition key, a constant within each parent. 

By the SQL standard that makes the row numbering undefined, so the implicit PK-order stability was thrown away.

####  Why it's order-sensitive but not full poisoning. 

EntityRepositoryTest uses IntegrationTestBehaviour → every test runs in a transaction that's rolled back, so no committed rows from other tests leak into media_folder for this test to read. 
What rollback does not reset is InnoDB-internal state: the internal row-id / auto-increment counters,clustered-index page layout/fragmentation, optimizer statistics, buffer-pool contents. 

The volume and pattern of insert+rollback activity from whatever tests ran before this one (which the random seed  determines) changes the physical layout of this test's freshly-inserted children (and therefore the order MariaDB hands them back). 
That undefined ORDER BY fk window is entirely at the mercy of tha  physical order.


### 2. What does this change do, exactly?
- Append the reference entity's primary key as a final tie-breaker to the paginated OneToMany ROW_NUMBER() window's ORDER BY, so row numbering is deterministic within each parent and limit/offset pages no longer overlap when the association is unsorted or sorted by a non-unique field.

- Write extra defensive safe-guard test

### 3. Describe each step to reproduce the issue or behaviour.

Run the failing command

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
