### PR TITLE
fix(administration): visual regressions after SCSS token migration

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/sw-context-button.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/sw-context-button.scss
@@ -37,7 +37,7 @@ $sw-context-button-color-disabled: var(--color-icon-primary-disabled);
         border-radius: $sw-context-button-border-radius;
         cursor: pointer;
         height: var(--scale-size-24);
-        line-height: var(--font-line-height-s);
+        line-height: var(--font-line-height-xs);
         padding: 0 var(--scale-size-8);
         outline: none;
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -61,6 +61,9 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-context-button__button {
+            height: 16px;
+            padding: 0 2px;
+            line-height: 13px;
             background: $sw-media-base-item-color-context-button;
             border: 1px solid $sw-media-base-item-color-border;
             border-radius: $sw-media-base-item-border-radius;

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-base-item/sw-media-base-item.scss
@@ -61,9 +61,6 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-context-button__button {
-            height: 16px;
-            padding: 0 2px;
-            line-height: 13px;
             background: $sw-media-base-item-color-context-button;
             border: 1px solid $sw-media-base-item-color-border;
             border-radius: $sw-media-base-item-border-radius;
@@ -162,7 +159,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         grid-column-gap: 10px;
         grid-auto-flow: column;
         align-items: center;
-        padding: 8px;
+        padding: var(--scale-size-8) var(--scale-size-12) var(--scale-size-8) var(--scale-size-8);
         margin: 0 0 8px;
         border: 1px solid $sw-media-base-item-color-border;
         border-radius: $sw-media-base-item-border-radius;
@@ -170,8 +167,9 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         .sw-media-base-item__preview-container {
             width: 40px;
             height: 40px;
+            grid-row: 1 / span 2;
             overflow: hidden;
-            border: none !important;
+            border-radius: var(--border-radius-xs);
 
             &::after {
                 content: none;
@@ -197,7 +195,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
         }
 
         .sw-media-base-item__name {
-            line-height: var(--font-line-height-xs);
+            line-height: var(--font-line-height-2xs);
         }
 
         .sw-media-base-item__metadata-container {
@@ -205,7 +203,7 @@ $sw-media-base-item-preview-background: var(--color-elevation-surface-raised);
             margin: -5px 0 0;
             text-align: left;
             color: $sw-media-base-item-color-metadata;
-            font-size: var(--font-size-xs);
+            font-size: var(--font-size-2xs);
         }
 
         &:hover {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-item/sw-media-folder-item.scss
@@ -21,8 +21,15 @@
 
     &.is--list {
         .sw-media-folder-item__folder-thumbnails.is--inner {
-            max-width: 15px;
+            width: 16px;
+            height: 16px;
+            max-width: 16px;
             transform: translate(-50%, -40%);
+
+            svg {
+                width: 16px !important;
+                height: 16px !important;
+            }
         }
 
         .sw-media-base-item__preview-container {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-media-item/sw-media-media-item.scss
@@ -11,7 +11,6 @@
     .sw-media-base-item.is--list .sw-media-preview-v2 {
         width: 40px;
         height: 40px;
-        grid-row: 1 / span 2;
         overflow: hidden;
 
         .sw-media-preview-v2__item {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
@@ -3,6 +3,7 @@ import './sw-sidebar-media-item.scss';
 
 const { Context } = Shopware;
 const { Criteria } = Shopware.Data;
+const { debounce } = Shopware.Utils;
 
 /**
  * @status ready
@@ -97,11 +98,14 @@ export default {
             this.initializeContent();
         },
 
-        onSearchTermChange(searchTerm) {
-            this.term = searchTerm;
+        onSearchTermChange() {
             this.page = 1;
-            this.getList();
+            this.debouncedSearch();
         },
+
+        debouncedSearch: debounce(function debouncedSearch() {
+            this.getList();
+        }, 400),
 
         initializeContent() {
             if (this.disabled) {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.html.twig
@@ -10,9 +10,10 @@
     {% block sw_sidebar_media_item_content %}
     <div class="sw-sidebar-media-item__content">
         {% block sw_sidebar_media_item_search_field %}
-        <sw-simple-search-field
-            v-model:value="term"
-            @search-term-change="onSearchTermChange"
+        <mt-search
+            v-model="term"
+            size="small"
+            @update:model-value="onSearchTermChange"
         />
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.scss
@@ -7,7 +7,12 @@
         margin-bottom: 10px;
     }
 
-    .sw-simple-search-field.is--searching {
-        margin-bottom: 12px;
+    .mt-search {
+        margin-top: 4px;
+        margin-bottom: 16px;
+    }
+
+    .sw-media-breadcrumbs {
+        margin-bottom: 24px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/sw-sidebar-media-item.scss
@@ -15,4 +15,10 @@
     .sw-media-breadcrumbs {
         margin-bottom: 24px;
     }
+
+    .sw-media-base-item .sw-context-button .sw-context-button__button {
+        height: var(--scale-size-24);
+        padding: 0 var(--scale-size-8);
+        line-height: var(--font-line-height-xs);
+    }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
@@ -214,7 +214,7 @@ $sw-admin-menu-active-text: $color-white;
         padding: 12px 30px;
         text-decoration: none;
         font-size: var(--font-size-xs);
-        line-height: var(--font-line-height-m);
+        line-height: var(--font-line-height-s);
         cursor: pointer;
         position: relative;
         font-weight: var(--font-weight-medium);
@@ -276,7 +276,7 @@ $sw-admin-menu-active-text: $color-white;
         padding: 20px 32px;
         text-decoration: none;
         font-size: var(--font-size-xs);
-        line-height: var(--font-line-height-m);
+        line-height: var(--font-line-height-s);
         width: 100%;
         cursor: pointer;
         white-space: nowrap;
@@ -293,7 +293,7 @@ $sw-admin-menu-active-text: $color-white;
             margin: 0 16px 0 0;
             vertical-align: middle;
             position: relative;
-            top: -2px;
+            top: -1px;
         }
 
         &:hover {
@@ -365,15 +365,14 @@ $sw-admin-menu-active-text: $color-white;
     .sw-admin-menu__user-name {
         margin-top: 2px;
         font-size: var(--font-size-xs);
-        font-weight: var(--font-weight-bold);
+        font-weight: var(--font-weight-semibold);
         color: $sw-admin-menu-active-text;
     }
 
     .sw-admin-menu__user-type {
-        color: var(--color-text-attention-default);
-        font-size: var(--font-size-xs);
+        color: #ffd700;
+        font-size: var(--font-size-2xs);
         font-weight: var(--font-weight-medium);
-        margin-top: 2px;
     }
 
     .sw-admin-menu__user-actions {

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -259,7 +259,7 @@
             text-overflow: ellipsis;
             color: inherit;
             text-decoration: inherit;
-            padding: var(--scale-size-12) 0;
+            padding: var(--scale-size-10) 0;
             display: block;
 
             &:focus {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/sw-flow-sequence-action.scss
@@ -54,7 +54,7 @@
         display: flex;
         align-items: baseline;
         justify-content: space-between;
-        padding: var(--scale-size-16) var(--scale-size-12) var(--scale-size-12) var(--scale-size-20);
+        padding: var(--scale-size-16) var(--scale-size-12) var(--scale-size-16) var(--scale-size-20);
         border-bottom: 1px solid var(--color-border-secondary-default);
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
@@ -88,7 +88,7 @@
             left: 0;
             top: 64px;
             width: var(--scale-size-32);
-            height: 54px;
+            height: 58px;
             border-bottom: 2px dashed var(--color-border-secondary-default);
             border-left: 2px dashed var(--color-border-secondary-default);
             border-bottom-left-radius: 40px;


### PR DESCRIPTION
PR #17603 migrated legacy SCSS vars to Meteor tokens by **name** rather than
by **value**, so several `--font-line-height-*` tokens came out 4px taller than
the pixel values they replaced. This broke a few layouts and one text colour.

### Regression fixes
- **Admin menu** — corrected `user-type` colour/contrast and nav line-heights
  (`m` → `s`), plus minor icon/weight alignment.
- **Context button, tree item, flow sequence/detail** — line-height/padding
  tweaks to undo the inflated spacing.

### Additional: media sidebar improvements
Not regressions from #17603 — opportunistic polish while in the area:
- **List layout** — preview thumbnail now spans both grid rows so the
  filename/date stack correctly in column 2 (was: icon + date side-by-side,
  filename in the date slot).
- **Thumbnails** — image previews get a secondary border + `xs` radius; folder
  thumbnails stay borderless; inner folder icons forced back to 16×16.
- **Search field** — swapped to `mt-search` (`size="small"`), re-adding the
  400ms debounce so we don't query on every keystroke.
  
### Visual tests
Visual tests manually checked on this branch ✅ Need to be updated when merged.
