### PR TITLE
fix: dispatch DAL write events in system scope

### DIFF
--- a/adr/2026-06-23-dal-write-events-system-scope.md
+++ b/adr/2026-06-23-dal-write-events-system-scope.md
@@ -1,0 +1,82 @@
+---
+title: Dispatch DAL Write Events in System Scope
+date: 2026-06-23
+area: framework
+tags: [dal, acl, api, events, extensions]
+status: accepted
+---
+
+## Context
+
+Shopware extensions can add DAL entities with their own ACL privileges and can react to core entity events, for example `product.written`.
+Those listeners often write extension-owned technical data derived from the core write.
+
+Today these follow-up writes happen in the same CRUD API scope as the original API request.
+That makes API permissions depend on active extensions: an API client updating a product may also need `custom_extension_entity:create` or `custom_extension_entity:update`, even when the API payload only writes `product`.
+
+The intended extension best practice is that technical listener side effects use system scope themselves.
+That is not enough as a platform behavior because existing extensions do not always do this, and their listeners can break otherwise valid API clients.
+
+## Decision
+
+DAL post-write event dispatch runs in `Context::SYSTEM_SCOPE`, while preserving the same `Context` instance and source.
+The context source must not be replaced with `SystemSource`.
+
+Conceptually:
+
+```php
+$context->scope(Context::SYSTEM_SCOPE, fn () => $eventDispatcher->dispatch($event));
+```
+
+API ACL validation remains attached to the original write commands and payload.
+Listeners that use the event context for follow-up DAL writes execute those writes as technical side effects, so the API caller does not need extension-internal entity privileges.
+
+The original caller identity stays available through the preserved context source.
+Listeners that intentionally need a user permission decision can still check the source or call `Context::isAllowed()` explicitly.
+
+## Affected Events
+
+This applies to DAL post-write events only:
+
+- `EntityWrittenContainerEvent`
+- nested `EntityWrittenEvent`, dispatched as `<entity>.written`
+- nested `EntityDeletedEvent`, dispatched as `<entity>.deleted`
+
+The rule applies to every DAL entity, including extension and custom entities.
+There must be no entity-name allowlist, because extension entities are dynamic and the bug is caused by active extensions changing the side effects of otherwise valid API writes.
+
+The affected dispatch sites are repository write results, Sync API write results, and version create or merge write results.
+The container event is enough as the implementation boundary because nested DAL write events are dispatched from the container event; dispatching the container in system scope makes subscribers to both `EntityWrittenContainerEvent` and `<entity>.written` / `<entity>.deleted` observe the same scoped context.
+
+These events must stay in the original caller scope:
+
+- `EntityWriteEvent`
+- `EntityDeleteEvent`
+- `PreWriteValidationEvent`
+- `PostWriteValidationEvent`
+- `WriteCommandExceptionEvent`
+- `BeforeVersionMergeEvent`
+- DAL read/search/load/aggregation events
+- normal business, checkout, and Flow events
+
+The reason is that those events are validation, command mutation, failure reporting, read, or business-process hooks.
+Most importantly, API ACL validation is attached to the write commands before persistence.
+Moving pre-write validation events to system scope would skip the caller's actual API ACL check instead of only making post-write technical side effects predictable.
+
+## Consequences
+
+- API write permissions become predictable again: they are based on the API route, payload, and DAL commands, not on active listener side effects.
+- Existing extensions that write extension-owned data from write listeners are fixed without opting in.
+- Audit and source-sensitive behavior can still see the original user, integration, app, or sales-channel source.
+- Listener writes using the event context bypass DAL write ACL because the scope is system.
+- Nested writes triggered by listeners inherit system scope while dispatch is running.
+- Listeners that branch on `Context::getScope()` may observe `system` instead of `crud` during DAL write events.
+
+## Rejected Alternatives
+
+- **Use `SystemSource` for event dispatch:** also skips ACL, but loses the caller identity that listeners and audit fields may need.
+- **Only document the best practice:** keeps the model clean, but does not fix existing extensions that already break API clients.
+- **Require plugins to declare listener permissions:** makes permission impact visible, but keeps API permissions coupled to plugin internals.
+- **Expand roles when plugins are installed:** avoids some runtime failures, but grants extension entity access outside the specific side effect.
+- **Use a custom "skip listener ACL" flag:** is narrower in name, but duplicates the existing `SYSTEM_SCOPE` mechanism without a clear extra benefit.
+- **Move listener side effects to async jobs:** is useful for indexing and denormalized data, but not a general fix for synchronous invariants.

--- a/changelog/_unreleased/2026-06-24-dal-write-event-listeners-system-scope.md
+++ b/changelog/_unreleased/2026-06-24-dal-write-event-listeners-system-scope.md
@@ -1,0 +1,17 @@
+---
+title: DAL write event listeners no longer expand API ACL requirements
+issue: #17697
+---
+# API
+* Changed DAL post-write event dispatching after Admin API and Sync API writes to use system scope while preserving the original context source.
+
+___
+# Upgrade Information
+## DAL write event listeners run in system scope
+DAL post-write events such as `EntityWrittenContainerEvent` and entity-specific `.written` events are now dispatched in system scope after Admin API and Sync API writes, while preserving the original context source.
+
+This matters for plugins that subscribe to core write events and update their own entities as a side effect. Previously, a listener on an event such as `product.written` still ran in the CRUD context of the triggering API request. When that listener wrote an extension-owned entity, the API user also needed permissions for that extension entity, even though the submitted request only changed products.
+
+With this change, listener-side DAL writes are treated as trusted system-side follow-up work of the original write. API consumers only need the privileges required for the submitted write payload; plugin-internal denormalization, synchronization, indexing, or bookkeeping writes performed from DAL write listeners no longer expand the caller's ACL requirements.
+
+Extension authors can still inspect who triggered the write via `$event->getContext()->getSource()`. If a listener intentionally wants to make a side effect depend on the triggering user or integration, it should check the source explicitly instead of relying on `$event->getContext()->getScope()` being `Context::USER_SCOPE`.

--- a/coding-guidelines/core/unit-tests.md
+++ b/coding-guidelines/core/unit-tests.md
@@ -10,6 +10,7 @@ When writing unit tests, the following is important:
 - **Performance** - As we grow more and more it is advisable to pay attention to the speed of the tests.
 - **Mocking** - Don't be lazy but deal with mock objects to optimize for example database access. So you don't have to persist every storage case before but you can describe it as a Mock.
 - **Readable** - You are not the only one who maintains the code. Therefore, it is important that others can quickly and easily understand your unit tests and extend them with additional cases.
+- **Callback assertions** - When a callback, listener, or inline test double observes the behavior under test, assert the observed arguments directly in that callback. Only keep the smallest state outside the callback that the test still needs, for example a boolean to prove it was called, a counter when cardinality matters, or captured values when later assertions need comparison across calls.
 - **Extensibility** - It is important that when more cases are added or certain cases are not tested that it is easy to extend your unit tests with another case without extending dozens of lines of code.
 - **Modularity** - Your test should not fail just because another test left artifacts (files, storage records, ...).
 - **Cleanup** - It is also important that you clean up your artifacts. If you register an event listener dynamically, make sure that it is removed again on `teardown`. If you write data to the database or change the schema, make sure it is rolled back.

--- a/src/Core/Framework/Api/Sync/SyncService.php
+++ b/src/Core/Framework/Api/Sync/SyncService.php
@@ -64,7 +64,7 @@ class SyncService implements SyncServiceInterface
             $writes->addEvent(...$deletes->getEvents()->getElements());
         }
 
-        $this->eventDispatcher->dispatch($writes);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($writes));
 
         $ids = $this->getWrittenEntities($result->getWritten());
 

--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -95,7 +95,7 @@ class EntityRepository
 
         $affected = $this->versionManager->update($this->definition, $data, WriteContext::createFromContext($context));
         $event = EntityWrittenContainerEvent::createWithWrittenEvents($affected, $context, []);
-        $this->eventDispatcher->dispatch($event);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         return $event;
     }
@@ -109,7 +109,7 @@ class EntityRepository
 
         $affected = $this->versionManager->upsert($this->definition, $data, WriteContext::createFromContext($context));
         $event = EntityWrittenContainerEvent::createWithWrittenEvents($affected, $context, []);
-        $this->eventDispatcher->dispatch($event);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         return $event;
     }
@@ -123,7 +123,7 @@ class EntityRepository
 
         $affected = $this->versionManager->insert($this->definition, $data, WriteContext::createFromContext($context));
         $event = EntityWrittenContainerEvent::createWithWrittenEvents($affected, $context, []);
-        $this->eventDispatcher->dispatch($event);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         return $event;
     }
@@ -146,7 +146,7 @@ class EntityRepository
             }
         }
 
-        $this->eventDispatcher->dispatch($event);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         return $event;
     }
@@ -191,7 +191,7 @@ class EntityRepository
         );
 
         $event = EntityWrittenContainerEvent::createWithWrittenEvents($affected, $context, [], true);
-        $this->eventDispatcher->dispatch($event);
+        $context->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         return $event;
     }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -148,7 +148,7 @@ class VersionManager
         $versionContext = $context->createWithVersionId($versionId);
 
         $event = EntityWrittenContainerEvent::createWithWrittenEvents($affected, $versionContext->getContext(), []);
-        $this->eventDispatcher->dispatch($event);
+        $versionContext->getContext()->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($event));
 
         $this->writeAuditLog($affected, $context, $versionId, true);
 
@@ -206,7 +206,7 @@ class VersionManager
         if ($deletes->getEvents() !== null) {
             $writes->addEvent(...$deletes->getEvents()->getElements());
         }
-        $this->eventDispatcher->dispatch($writes);
+        $liveContext->getContext()->scope(Context::SYSTEM_SCOPE, fn () => $this->eventDispatcher->dispatch($writes));
 
         $versionContext->removeState(self::MERGE_SCOPE);
         $liveContext->addState(self::MERGE_SCOPE);

--- a/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncBehavior;
 use Shopware\Core\Framework\Api\Sync\SyncFkResolver;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
@@ -13,6 +14,8 @@ use Shopware\Core\Framework\Api\Sync\SyncService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\ApiCriteriaValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\CriteriaArrayConverter;
@@ -26,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterfa
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteResult;
+use Shopware\Core\Framework\Event\NestedEventDispatcher;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -140,6 +144,66 @@ class SyncServiceTest extends TestCase
         );
 
         $service->sync($operations, Context::createCLIContext(), new SyncBehavior());
+    }
+
+    public function testWrittenEventsAreDispatchedInSystemScopeWithOriginalSource(): void
+    {
+        $writer = $this->createMock(EntityWriterInterface::class);
+        $writer
+            ->expects($this->once())
+            ->method('sync')
+            ->willReturn(new WriteResult([], [], [
+                'product' => [new EntityWriteResult('created-id', [], 'product', EntityWriteResult::OPERATION_INSERT)],
+            ]));
+
+        $dispatcher = new EventDispatcher();
+        $eventDispatcher = new NestedEventDispatcher($dispatcher);
+
+        $source = new AdminApiSource('user-id');
+        $context = Context::createDefaultContext($source);
+
+        $containerListenerWasCalled = false;
+        $dispatcher->addListener(EntityWrittenContainerEvent::class, static function (EntityWrittenContainerEvent $event) use (&$containerListenerWasCalled, $source): void {
+            $containerListenerWasCalled = true;
+            $eventSource = $event->getContext()->getSource();
+
+            static::assertSame(Context::SYSTEM_SCOPE, $event->getContext()->getScope());
+            static::assertInstanceOf(AdminApiSource::class, $eventSource);
+            static::assertSame($source->getUserId(), $eventSource->getUserId());
+        });
+
+        $nestedListenerWasCalled = false;
+        $dispatcher->addListener('product.written', static function (EntityWrittenEvent $event) use (&$nestedListenerWasCalled, $source): void {
+            $nestedListenerWasCalled = true;
+            $eventSource = $event->getContext()->getSource();
+
+            static::assertSame(Context::SYSTEM_SCOPE, $event->getContext()->getScope());
+            static::assertInstanceOf(AdminApiSource::class, $eventSource);
+            static::assertSame($source->getUserId(), $eventSource->getUserId());
+        });
+
+        $service = new SyncService(
+            $writer,
+            $eventDispatcher,
+            new StaticDefinitionInstanceRegistry(
+                [ProductDefinition::class],
+                $this->createMock(ValidatorInterface::class),
+                $this->createMock(EntityWriteGatewayInterface::class),
+            ),
+            $this->createMock(EntitySearcherInterface::class),
+            $this->createMock(RequestCriteriaBuilder::class),
+            $this->createMock(SyncFkResolver::class)
+        );
+
+        $service->sync(
+            [new SyncOperation('delete-product', 'product', SyncOperation::ACTION_DELETE, [['id' => 'created-id']])],
+            $context,
+            new SyncBehavior()
+        );
+
+        static::assertTrue($containerListenerWasCalled);
+        static::assertTrue($nestedListenerWasCalled);
+        static::assertSame(Context::USER_SCOPE, $context->getScope());
     }
 
     public function testWildcardDeleteForMappingEntities(): void

--- a/tests/unit/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedContainerEven
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntitySearchedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\PartialEntityLoadedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidEntityUuidException;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
@@ -31,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteResult;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Event\NestedEventDispatcher;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -408,6 +411,53 @@ class EntityRepositoryTest extends TestCase
         static::assertInstanceOf(EntityWrittenContainerEvent::class, $event);
 
         static::assertSame(['test'], $event->getPrimaryKeys('product'));
+    }
+
+    public function testWrittenEventsAreDispatchedInSystemScopeWithOriginalSource(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $eventDispatcher = new NestedEventDispatcher($dispatcher);
+
+        $source = new AdminApiSource('user-id');
+        $context = Context::createDefaultContext($source);
+
+        $containerListenerWasCalled = false;
+        $dispatcher->addListener(EntityWrittenContainerEvent::class, static function (EntityWrittenContainerEvent $event) use (&$containerListenerWasCalled, $source): void {
+            $containerListenerWasCalled = true;
+
+            static::assertSame(Context::SYSTEM_SCOPE, $event->getContext()->getScope());
+            static::assertSame($source, $event->getContext()->getSource());
+        });
+
+        $nestedListenerWasCalled = false;
+        $dispatcher->addListener('product.written', static function (EntityWrittenEvent $event) use (&$nestedListenerWasCalled, $source): void {
+            $nestedListenerWasCalled = true;
+
+            static::assertSame(Context::SYSTEM_SCOPE, $event->getContext()->getScope());
+            static::assertSame($source, $event->getContext()->getSource());
+        });
+
+        $versionManager = $this->createMock(VersionManager::class);
+        $versionManager
+            ->expects($this->once())
+            ->method('update')
+            ->willReturn([[new EntityWriteResult('test', [], 'product', EntityWriteResult::OPERATION_UPDATE)]]);
+
+        $repo = new EntityRepository(
+            new ProductDefinition(),
+            $this->createMock(EntityReaderInterface::class),
+            $versionManager,
+            $this->createMock(EntitySearcherInterface::class),
+            $this->createMock(EntityAggregatorInterface::class),
+            $eventDispatcher,
+            $this->createMock(EntityLoadedEventFactory::class),
+        );
+
+        $repo->update([['name' => 'foo']], $context);
+
+        static::assertTrue($containerListenerWasCalled);
+        static::assertTrue($nestedListenerWasCalled);
+        static::assertSame(Context::USER_SCOPE, $context->getScope());
     }
 
     public function testUpsert(): void


### PR DESCRIPTION
Backport of #17697 to `6.6.x`.

## What changed

- Dispatch DAL post-write events (`EntityWrittenContainerEvent` and entity-specific `.written` events) in system scope while preserving the original context source.
- Cover repository and Sync API writes with unit tests that assert listener scope, source preservation, and unchanged caller context scope.
- Add the ADR, unit-test guideline note, and 6.6 changelog entry.

## Why

Plugins can subscribe to core write events and write their own entities as follow-up work. Before this change, those listener-side writes still ran in the triggering API user's CRUD scope, so activating a plugin could unexpectedly require Admin API or Sync API clients to also have ACL permissions for extension-owned entities. With this backport, API permissions stay predictable and are based on the submitted payload, while plugin listeners can still inspect the triggering source via `$event->getContext()->getSource()`.

## Validation

- `php -l` on changed PHP files
- `vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes ...`
- `vendor/bin/phpunit --no-configuration --bootstrap vendor/autoload.php tests/devops/Core/DevOps/ADRValidationTest.php`
- Parsed `changelog/_unreleased/2026-06-24-dal-write-event-listeners-system-scope.md` with `ChangelogParser`

Local notes: the focused unit tests and root PHPUnit config are blocked in this worktree because no local database connection is configured (`Doctrine\\DBAL\\Exception\\DriverRequired` during the test bootstrap / `ReplicaConnection::ensurePrimary()`). PHPStan is also blocked before analysis by a missing local rule class (`Symplify\\PHPStanRules\\Rules\\CheckClassNamespaceFollowPsr4Rule`).
