### PR TITLE
fix: show services when service installation is disabled

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.html.twig
@@ -66,7 +66,7 @@
                 </mt-banner>
 
                 <div
-                    v-else-if="services.length === 0"
+                    v-if="!config.disabled && services.length === 0"
                     class="sw-settings-services-index__installing-card"
                 >
                     <div class="sw-settings-services-index__installing-card-loader">
@@ -81,7 +81,7 @@
                 </div>
 
                 <ul
-                    v-else
+                    v-else-if="services.length > 0"
                     class="sw-settings-services__available-services"
                 >
                     <sw-settings-services-service-card

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/page/sw-settings-services-index/sw-settings-services-index.spec.js
@@ -230,6 +230,34 @@ describe('/src/module/sw-setting-services/page/sw-settings-services-index', () =
         expect(page.findAll('sw-settings-services-service-card-stub')).toHaveLength(0);
     });
 
+    it('shows installed services that remain available when services are deactivated', async () => {
+        Shopware.Service('shopwareServicesService').getInstalledServices.mockImplementationOnce(async () => [
+            {
+                id: 'gmv-service-id',
+                active: true,
+                name: 'gmv',
+                label: 'GMV',
+                requirements: ['shopware_account'],
+            },
+        ]);
+
+        Shopware.Service('shopwareServicesService').getServicesContext.mockImplementationOnce(async () => ({
+            disabled: true,
+            permissionsConsent: null,
+        }));
+
+        const page = await mountPage();
+        await flushPromises();
+
+        const activateBanner = page.getComponent(MtBanner);
+
+        expect(activateBanner.props('variant')).toBe('attention');
+        expect(page.findComponent(SwSettingsServicesGrantPermissionsCard).exists()).toBe(false);
+        expect(page.findComponent(SwSettingsServicesRevokePermissionsModal).exists()).toBe(false);
+        expect(page.findComponent(SwSettingsServicesDeactivateModal).exists()).toBe(false);
+        expect(page.findAll('sw-settings-services-service-card-stub')).toHaveLength(1);
+    });
+
     it('can activate services', async () => {
         Shopware.Service('shopwareServicesService').getInstalledServices.mockImplementationOnce(async () => []);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When services are globally deactivated, the Services page currently renders the disabled-state banner as part of the same `v-if` / `v-else-if` / `v-else` chain that controls the service list. That means services which remain available after deactivation, such as GMV, are hidden even though they are still installed and active.

### 2. What does this change do, exactly?

It decouples the disabled-services banner from the list rendering state.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have GMV installed and active.
2. Deactivate services globally.
3. Open the Administration Services page.
4. The disabled-services banner is shown, but the GMV service card is missing.

After this change, the banner is still shown and GMV remains visible in the services list.

### 4. Please link to the relevant issues (if any).

- relates #16843

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
