### PR TITLE
fix: service storage ACL role association

### DIFF
--- a/src/Core/Service/ServiceStorage.php
+++ b/src/Core/Service/ServiceStorage.php
@@ -28,7 +28,7 @@ class ServiceStorage
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('selfManaged', true));
-        $criteria->addAssociation('app.acl_role');
+        $criteria->addAssociation('aclRole');
         $criteria->addFilter(new EqualsFilter('name', $name));
         $criteria->setLimit(1);
 
@@ -39,7 +39,7 @@ class ServiceStorage
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('selfManaged', true));
-        $criteria->addAssociation('app.acl_role');
+        $criteria->addAssociation('aclRole');
         $criteria->addFilter(new EqualsFilter('name', $name));
         $criteria->addFilter(new EqualsFilter('integrationId', $integrationId));
         $criteria->setLimit(1);
@@ -51,7 +51,7 @@ class ServiceStorage
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('selfManaged', true));
-        $criteria->addAssociation('app.acl_role');
+        $criteria->addAssociation('aclRole');
         $criteria->addFilter(new EqualsFilter('integrationId', $integrationId));
         $criteria->setLimit(1);
 
@@ -65,7 +65,7 @@ class ServiceStorage
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('selfManaged', true));
-        $criteria->addAssociation('app.acl_role');
+        $criteria->addAssociation('aclRole');
 
         return array_values($this->repository->search($criteria, $context)->getEntities()->map(
             static fn (AppEntity $app): Service => Service::fromApp($app)

--- a/tests/unit/Core/Service/ServiceStorageTest.php
+++ b/tests/unit/Core/Service/ServiceStorageTest.php
@@ -56,6 +56,25 @@ class ServiceStorageTest extends TestCase
         static::assertSame($app->getId(), $service->id);
     }
 
+    public function testFindByNameAndIntegrationId(): void
+    {
+        $app = AppFixture::createAppEntity(name: 'MyService');
+        /** @var StaticEntityRepository<AppCollection> $repository */
+        $repository = new StaticEntityRepository([
+            static function (Criteria $criteria) use ($app): array {
+                self::assertServiceFilter($criteria);
+
+                return [$app];
+            },
+        ]);
+
+        $service = (new ServiceStorage($repository))->findByNameAndIntegrationId('MyService', 'integration-id', Context::createDefaultContext());
+
+        static::assertInstanceOf(Service::class, $service);
+        static::assertSame($app->getId(), $service->id);
+        static::assertSame('MyService', $service->name);
+    }
+
     public function testFindAll(): void
     {
         $app = AppFixture::createAppEntity();
@@ -77,5 +96,7 @@ class ServiceStorageTest extends TestCase
     private static function assertServiceFilter(Criteria $criteria): void
     {
         static::assertContainsEquals(new EqualsFilter('selfManaged', true), $criteria->getFilters());
+        static::assertTrue($criteria->hasAssociation('aclRole'));
+        static::assertFalse($criteria->hasAssociation('app'));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

`ServiceStorage` queries the `app.repository`, but requested the stale association path `app.acl_role`. Because the criteria root is already `AppEntity`, the association has to be loaded as `aclRole`.

With the old path, loading service DTOs can trigger unresolved criteria association warnings and can miss currently granted ACL role privileges in service permission responses.

### 2. What does this change do, exactly?

- Replaces the stale `app.acl_role` association with `aclRole` in all `ServiceStorage` lookup paths.
- Adds unit coverage for the service storage criteria so service lookups load `aclRole` directly and do not request an `app` association.
- Adds missing coverage for `findByNameAndIntegrationId`, which is used by the self-uninstall path.

### 3. Describe each step to reproduce the issue or behaviour.

1. Check out `feat/gmv-service-protection`.
2. Install or update self-managed services so a service has an ACL role.
3. Open the Administration Services page or request `/api/service/list`.
4. Observe that the service storage criteria requests `app.acl_role` even though the repository root is already `app`, leading to unresolved association handling and missing loaded ACL role data.

### 4. Please link to the relevant issues (if any).

- relates #16843

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them