### PR TITLE
feat(administration): refine admin sidebar and content area UX

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -43,6 +43,7 @@ import MtSearch from '@shopware-ag/meteor-component-library/dist/esm/MtSearch';
 import MtLink from '@shopware-ag/meteor-component-library/dist/esm/MtLink';
 import MtUnitField from '@shopware-ag/meteor-component-library/dist/esm/MtUnitField';
 import MtSnackbar from '@shopware-ag/meteor-component-library/dist/esm/MtSnackbar';
+import MtTooltip from '@shopware-ag/meteor-component-library/dist/esm/MtTooltip';
 
 import getBlockDataScope from '../../component/structure/sw-block-override/sw-block/get-block-data-scope';
 import useSystem from '../../composables/use-system';
@@ -384,6 +385,7 @@ export default class VueAdapter extends ViewAdapter {
             MtLink,
             MtUnitField,
             MtSnackbar,
+            MtTooltip,
         } as const;
 
         const lazyMeteorComponents = {

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/index.ts
@@ -19,5 +19,17 @@ export default {
         setActiveSidebar(locationId: string) {
             Shopware.Store.get('sidebar').setActiveSidebar(locationId);
         },
+
+        toggleSidebar(locationId: string) {
+            const store = Shopware.Store.get('sidebar');
+            const sidebar = store.sidebars.find((item) => item.locationId === locationId);
+
+            if (sidebar?.active && store.closingSidebar !== locationId) {
+                store.requestCloseSidebar(locationId);
+                return;
+            }
+
+            store.setActiveSidebar(locationId);
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.html.twig
@@ -1,16 +1,27 @@
 <template v-if="sidebars && sidebars.length === 1">
-    <button
-        v-tooltip="{ message: sidebars[0].title, placement: 'right' }"
-        class="sw-app-topbar-sidebar__icon"
-        :class="{ 'sw-app-topbar-sidebar__icon-active': sidebars[0].active }"
-        :aria-label="$tc('sidebar.ariaLabelButtonOpen')"
-        @click="setActiveSidebar(sidebars[0].locationId)"
+    <mt-tooltip
+        :content="$tc(sidebars[0].title)"
+        placement="bottom"
+        :delay-duration-in-ms="500"
     >
-        <mt-icon
-            :name="sidebars[0].icon"
-            :size="20"
-        />
-    </button>
+        <template #default="{ ...tooltipProps }">
+            <mt-button
+                v-bind="tooltipProps"
+                class="sw-app-topbar-sidebar__icon"
+                :class="{ 'sw-app-topbar-sidebar__icon-active': sidebars[0].active }"
+                :aria-label="$tc('sidebar.ariaLabelButtonOpen')"
+                variant="tertiary"
+                size="default"
+                square
+                @click="toggleSidebar(sidebars[0].locationId)"
+            >
+                <mt-icon
+                    :name="sidebars[0].icon"
+                    :size="20"
+                />
+            </mt-button>
+        </template>
+    </mt-tooltip>
 </template>
 
 <template v-if="sidebars.length && sidebars.length > 1">

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-sidebar/sw-app-topbar-sidebar.scss
@@ -1,14 +1,3 @@
-.sw-app-topbar-sidebar__icon {
-    width: 40px;
-    height: 40px;
-    border-radius: var(--border-radius-button);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    transition: background-color 0.2s ease-in-out;
-
-    &-active,
-    &:hover {
-        background: var(--color-interaction-secondary-hover);
-    }
+.sw-app-topbar-sidebar__icon.sw-app-topbar-sidebar__icon-active {
+    background: var(--color-interaction-secondary-hover);
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
@@ -1,8 +1,7 @@
 @import "~scss/mixins";
 
 .sw-admin-menu {
-    border-right: 1px solid var(--color-border-secondary-default);
-    background: var(--color-elevation-surface-default);
+    background: var(--color-elevation-surface-sunken);
     width: 52px;
     height: 100%;
     display: flex;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-desktop/sw-desktop.scss
@@ -15,11 +15,22 @@
         grid-template-rows: 50px auto;
     }
 
+    .sw-desktop__content {
+        margin: var(--scale-size-8) var(--scale-size-8) var(--scale-size-8) var(--scale-size-0);
+        border: 1px solid var(--color-border-secondary-default);
+        border-radius: var(--border-radius-l);
+        background: var(--color-elevation-surface-default);
+        overflow: hidden;
+    }
+
     @media screen and (max-width: 500px) {
         display: block;
 
         .sw-desktop__content {
             height: 100%;
+            margin: 0;
+            border: 0;
+            border-radius: 0;
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/index.ts
@@ -14,11 +14,15 @@ export default Shopware.Component.wrapComponentConfig({
 
     setup() {
         const MAIN_CONTENT_MIN_SIZE = 1300;
-        const MIN_SIDEBAR_WIDTH = 545;
+        const DEFAULT_SIDEBAR_WIDTH = 512;
+        const MIN_SIDEBAR_WIDTH = 400;
+        const SIDEBAR_MARGIN = 8;
 
-        const sidebarSetWidth = ref(545);
+        const sidebarSetWidth = ref(DEFAULT_SIDEBAR_WIDTH);
         const isResizing = ref(false);
         const windowWidth = ref(window.innerWidth);
+
+        const closingSidebar = computed(() => Shopware.Store.get('sidebar').closingSidebar);
 
         const activeSidebar = computed(() => {
             return Shopware.Store.get('sidebar').getActiveSidebar;
@@ -31,31 +35,34 @@ export default Shopware.Component.wrapComponentConfig({
         const sidebarDisplayOptions = computed(() => {
             const availableWidth = activeSidebar.value?.resizable
                 ? windowWidth.value - MAIN_CONTENT_MIN_SIZE
-                : MIN_SIDEBAR_WIDTH;
+                : DEFAULT_SIDEBAR_WIDTH;
 
             const currentWidth = Math.max(MIN_SIDEBAR_WIDTH, sidebarSetWidth.value);
+            const isOverlayMode = availableWidth < currentWidth;
+
             return {
                 availableWidth: `${Math.max(availableWidth, 0)}px`,
                 currentWidth: `${currentWidth}px`,
-                isOverlayMode: availableWidth < currentWidth,
-                isCollapsable: availableWidth > MIN_SIDEBAR_WIDTH,
+                panelWidth: isOverlayMode ? `${currentWidth}px` : `${currentWidth - SIDEBAR_MARGIN}px`,
+                isOverlayMode,
+                isCollapsable: availableWidth > DEFAULT_SIDEBAR_WIDTH,
                 isResizing: isResizing.value,
             };
         });
 
         const closeSidebar = (locationId: string) => {
-            Shopware.Store.get('sidebar').closeSidebar(locationId);
+            Shopware.Store.get('sidebar').requestCloseSidebar(locationId);
         };
 
         const collapseSidebar = () => {
-            sidebarSetWidth.value = MIN_SIDEBAR_WIDTH;
-            localStorage.setItem('sw-sidebar-width', MIN_SIDEBAR_WIDTH.toString());
+            sidebarSetWidth.value = DEFAULT_SIDEBAR_WIDTH;
+            localStorage.setItem('sw-sidebar-width', DEFAULT_SIDEBAR_WIDTH.toString());
         };
 
         const handleSidebarResize = (event: MouseEvent) => {
             if (!isResizing.value) return;
 
-            sidebarSetWidth.value = windowWidth.value - event.clientX;
+            sidebarSetWidth.value = Math.max(MIN_SIDEBAR_WIDTH, windowWidth.value - event.clientX);
         };
 
         const stopSidebarResize = () => {
@@ -85,8 +92,8 @@ export default Shopware.Component.wrapComponentConfig({
         };
 
         onUpdated(() => {
-            if (activeSidebar.value && !activeSidebar.value?.resizable && sidebarSetWidth.value !== MIN_SIDEBAR_WIDTH) {
-                sidebarSetWidth.value = MIN_SIDEBAR_WIDTH;
+            if (activeSidebar.value && !activeSidebar.value?.resizable && sidebarSetWidth.value !== DEFAULT_SIDEBAR_WIDTH) {
+                sidebarSetWidth.value = DEFAULT_SIDEBAR_WIDTH;
             }
         });
 
@@ -107,6 +114,7 @@ export default Shopware.Component.wrapComponentConfig({
             activeSidebar,
             sidebars,
             sidebarDisplayOptions,
+            closingSidebar,
             closeSidebar,
             startSidebarResize,
             collapseSidebar,

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.html.twig
@@ -2,18 +2,21 @@
     v-for="sidebar in sidebars"
     :key="sidebar.locationId"
 >
-    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions, vuejs-accessibility/click-events-have-key-events -->
-    <div
-        v-if="activeSidebar && activeSidebar.resizable && activeSidebar.locationId === sidebar.locationId && sidebarDisplayOptions.isOverlayMode"
-        class="sw-sidebar-renderer-backdrop"
-        :class="{ 'is-resizing': sidebarDisplayOptions.isResizing }"
-        @click="closeSidebar(sidebar.locationId)"
-    ></div>
+    <transition name="sw-sidebar-renderer-backdrop">
+        <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions, vuejs-accessibility/click-events-have-key-events -->
+        <div
+            v-if="activeSidebar && activeSidebar.resizable && activeSidebar.locationId === sidebar.locationId && sidebarDisplayOptions.isOverlayMode && closingSidebar !== sidebar.locationId"
+            class="sw-sidebar-renderer-backdrop"
+            :class="{ 'is-resizing': sidebarDisplayOptions.isResizing }"
+            @click="closeSidebar(sidebar.locationId)"
+        ></div>
+    </transition>
 
     <aside
         class="sw-sidebar-renderer"
         :class="{
             'is-active': activeSidebar && activeSidebar.locationId === sidebar.locationId,
+            'is-closing': closingSidebar === sidebar.locationId,
             'is-resizing': sidebarDisplayOptions.isResizing,
             'is-overlay': activeSidebar && activeSidebar.resizable && sidebarDisplayOptions.isOverlayMode,
         }"
@@ -28,7 +31,7 @@
                 'sw-sidebar-renderer__overlay-resizable': activeSidebar && activeSidebar.resizable,
             }"
             :style="{
-                width: sidebarDisplayOptions.currentWidth
+                width: sidebarDisplayOptions.panelWidth
             }"
         >
             <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
@@ -42,37 +45,38 @@
                     <h3 class="sw-sidebar-renderer__title">
                         {{ $tc(sidebar.title) }}
                     </h3>
-                    <mt-button
-                        v-if="sidebarDisplayOptions.isOverlayMode && sidebarDisplayOptions.isCollapsable"
-                        show-front-icon="true"
-                        class="sw-sidebar-renderer__button-collapse"
-                        :aria-label="$tc('sidebar.ariaLabelButtonCollapse')"
-                        variant="secondary"
-                        @click="collapseSidebar"
-                    >
-
-                        <template #iconFront>
-                            <mt-icon
-                                name="regular-long-arrow-right"
-                                size="12px"
-                            />
-                        </template>
-
-                        {{ $tc('sidebar.buttonCollapse') }}
-
-                    </mt-button>
                 </div>
 
-                <button
-                    class="sw-sidebar-renderer__button-close"
-                    :aria-label="$tc('sidebar.ariaLabelButtonClose')"
-                    @click="closeSidebar(sidebar.locationId)"
-                >
-                    <mt-icon
-                        name="regular-times-xs"
-                        size="12px"
-                    />
-                </button>
+                <div class="sw-sidebar-renderer__header-actions">
+                    <mt-button
+                        v-if="sidebarDisplayOptions.isOverlayMode && sidebarDisplayOptions.isCollapsable"
+                        class="sw-sidebar-renderer__button-collapse"
+                        :aria-label="$tc('sidebar.ariaLabelButtonCollapse')"
+                        variant="tertiary"
+                        size="default"
+                        square
+                        @click="collapseSidebar"
+                    >
+                        <mt-icon
+                            name="solid-sidebar"
+                            size="16px"
+                        />
+                    </mt-button>
+
+                    <mt-button
+                        class="sw-sidebar-renderer__button-close"
+                        :aria-label="$tc('sidebar.ariaLabelButtonClose')"
+                        variant="tertiary"
+                        size="default"
+                        square
+                        @click="closeSidebar(sidebar.locationId)"
+                    >
+                        <mt-icon
+                            name="regular-times-s"
+                            size="12px"
+                        />
+                    </mt-button>
+                </div>
             </header>
 
             <section class="sw-sidebar-renderer__content">

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.scss
@@ -1,28 +1,27 @@
 .sw-sidebar-renderer-backdrop {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 30%);
+    background: var(--color-elevation-backdrop-default);
     z-index: 999;
     cursor: pointer;
-    animation: fadeIn 0.3s ease-in-out;
 
     &.is-resizing {
         cursor: col-resize;
     }
+}
 
-    @keyframes fadeIn {
-        from {
-            opacity: 0;
-        }
+// Fade the backdrop on open, close and the resize threshold.
+.sw-sidebar-renderer-backdrop-enter-active,
+.sw-sidebar-renderer-backdrop-leave-active {
+    transition: opacity 0.3s ease-in-out;
+}
 
-        to {
-            opacity: 1;
-        }
-    }
+.sw-sidebar-renderer-backdrop-enter-from,
+.sw-sidebar-renderer-backdrop-leave-to {
+    opacity: 0;
 }
 
 .sw-sidebar-renderer {
-    background: var(--color-elevation-surface-raised);
     transition: all 0.3s ease-in-out;
     will-change: width;
     display: none;
@@ -50,6 +49,50 @@
 
     &.is-active {
         display: block;
+
+        // Animate the column width so the content resizes in sync with the slide-in.
+        animation: expandSidebar 0.4s cubic-bezier(0.32, 0.72, 0, 1);
+
+        .sw-sidebar-renderer__overlay {
+            animation: slideInFromRight 0.4s cubic-bezier(0.32, 0.72, 0, 1);
+        }
+    }
+
+    // Reverse animations played while closing; the element stays mounted until they finish.
+    &.is-active.is-closing {
+        animation: shrinkSidebar 0.4s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+
+        .sw-sidebar-renderer__overlay {
+            animation: slideOutToRight 0.4s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+        }
+    }
+
+    @keyframes slideInFromRight {
+        from {
+            transform: translateX(100%);
+        }
+
+        to {
+            transform: translateX(0);
+        }
+    }
+
+    @keyframes slideOutToRight {
+        to {
+            transform: translateX(100%);
+        }
+    }
+
+    @keyframes expandSidebar {
+        from {
+            width: 0;
+        }
+    }
+
+    @keyframes shrinkSidebar {
+        to {
+            width: 0;
+        }
     }
 
     &__overlay {
@@ -59,10 +102,13 @@
         top: 0;
         right: 0;
         bottom: 0;
-        border-left: 1px solid var(--color-border-primary-default);
-        height: 100%;
-        max-width: 90vw;
-        transition: all 0.3s ease-in-out;
+        margin: var(--scale-size-8) var(--scale-size-8) var(--scale-size-8) 0;
+        border: 1px solid var(--color-border-secondary-default);
+        border-radius: var(--border-radius-l);
+        background: var(--color-elevation-surface-default);
+        height: calc(100% - 2 * var(--scale-size-8));
+        max-width: 90dvw;
+        transition: all 0.4s cubic-bezier(0.32, 0.72, 0, 1);
         overflow: hidden;
 
         &-resizable {
@@ -71,38 +117,32 @@
     }
 
     &.is-overlay .sw-sidebar-renderer__overlay {
-        box-shadow: -4px 0 16px rgba(0, 0, 0, 15%);
-        border-left: 1px solid var(--color-border-primary-default);
-        border-radius: 8px 0 0 8px;
+        box-shadow: 0 0 80px var(--color-elevation-shadow-default);
     }
 
     &__resize-handle {
         position: absolute;
         left: 0;
-        top: 0;
-        bottom: 0;
-        width: 6px;
+        top: 12px;
+        bottom: 12px;
+        width: 2px;
         cursor: col-resize;
         background: transparent;
         z-index: 10;
+        border-radius: var(--border-radius-round);
+        transition: background 0.2s ease;
 
         &:hover {
-            background: var(--color-interaction-primary-default);
-            opacity: 0.3;
-        }
-
-        &:active {
-            background: var(--color-interaction-primary-default);
-            opacity: 0.5;
+            background: var(--color-border-primary-default);
         }
 
         &::before {
             content: "";
             position: absolute;
-            left: -3px;
-            right: -3px;
-            top: 0;
-            bottom: 0;
+            left: -8px;
+            right: -8px;
+            top: -12px;
+            bottom: -12px;
         }
     }
 
@@ -124,6 +164,12 @@
             align-items: center;
             gap: 16px;
         }
+
+        &-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
     }
 
     .sw-iframe-renderer {
@@ -134,26 +180,10 @@
         height: 100%;
     }
 
-    &__button-close {
-        width: 40px;
-        height: 40px;
-        border-radius: var(--border-radius-button);
-        transition: background-color 0.2s ease-in-out;
-
-        &:hover {
-            background: var(--color-interaction-secondary-hover);
-        }
-
-        &-active {
-            background: var(--color-interaction-secondary-hover);
-        }
-    }
-
-    &__close-icon {
-        cursor: pointer;
-    }
-
     &__title {
         margin: 0;
+        font-size: var(--font-size-m);
+        line-height: var(--font-line-height-m);
+        font-weight: var(--font-weight-semibold);
     }
 }

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sidebar-renderer/sw-sidebar-renderer.spec.js
@@ -97,9 +97,20 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
 
         expect(wrapper.find('.sw-sidebar-renderer').exists()).toBe(true);
 
+        jest.useFakeTimers();
+
         await wrapper.find('.sw-sidebar-renderer__button-close').trigger('click');
 
+        // Closing is animated: it enters the closing state first, deactivating only after.
+        expect(Shopware.Store.get('sidebar').closingSidebar).toBe('test-sidebar');
+        expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(true);
+
+        jest.advanceTimersByTime(400);
+
         expect(Shopware.Store.get('sidebar').sidebars[0].active).toBe(false);
+        expect(Shopware.Store.get('sidebar').closingSidebar).toBeNull();
+
+        jest.useRealTimers();
     });
 
     describe('resize functionality', () => {
@@ -140,7 +151,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$forceUpdate();
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('545px');
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('512px');
             expect(mockLocalStorage.getItem).toHaveBeenCalledWith('sw-sidebar-width');
         });
 
@@ -162,8 +173,8 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
             await wrapper.vm.$nextTick();
 
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('545px');
-            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '545');
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe('512px');
+            expect(mockLocalStorage.setItem).toHaveBeenCalledWith('sw-sidebar-width', '512');
         });
 
         it('should not render handle when resizing is not allowed', async () => {
@@ -283,7 +294,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${PAGE_WIDTH - MAIN_CONTENT_MIN_SIZE}px`);
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`512px`);
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(false);
             expect(window.addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
             expect(eventListener).toBeDefined();
@@ -293,7 +304,7 @@ describe('src/app/component/structure/sw-sidebar-renderer', () => {
             await wrapper.vm.$nextTick();
 
             expect(wrapper.vm.sidebarDisplayOptions.availableWidth).toBe(`${1400 - MAIN_CONTENT_MIN_SIZE}px`);
-            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`545px`);
+            expect(wrapper.vm.sidebarDisplayOptions.currentWidth).toBe(`512px`);
             expect(wrapper.vm.sidebarDisplayOptions.isOverlayMode).toBe(true);
 
             // Restore original method

--- a/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/sidebar.store.ts
@@ -11,11 +11,15 @@ export type SidebarItemEntry = Omit<uiSidebarAdd, 'responseType'> & {
     active: boolean;
 };
 
+// Keep in sync with the close animation duration in sw-sidebar-renderer.scss.
+const CLOSE_ANIMATION_DURATION = 400;
+
 const sidebarsStore = Shopware.Store.register({
     id: 'sidebar',
 
     state: () => ({
         sidebars: [] as SidebarItemEntry[],
+        closingSidebar: null as string | null,
     }),
 
     getters: {
@@ -54,6 +58,24 @@ const sidebarsStore = Shopware.Store.register({
             sidebar.active = false;
         },
 
+        // Play the closing animation, then deactivate once it finishes.
+        requestCloseSidebar(locationId: string): void {
+            if (this.closingSidebar === locationId) {
+                return;
+            }
+
+            this.closingSidebar = locationId;
+            window.setTimeout(() => {
+                // Skip if it was reopened in the meantime.
+                if (this.closingSidebar !== locationId) {
+                    return;
+                }
+
+                this.closeSidebar(locationId);
+                this.closingSidebar = null;
+            }, CLOSE_ANIMATION_DURATION);
+        },
+
         removeSidebar(locationId: string): void {
             this.sidebars = this.sidebars.filter((sidebar) => {
                 return sidebar.locationId !== locationId;
@@ -62,6 +84,9 @@ const sidebarsStore = Shopware.Store.register({
 
         // Store API
         setActiveSidebar(locationId: string): void {
+            // cancel any pending close animation
+            this.closingSidebar = null;
+
             // reset all sidebars
             this.sidebars.forEach((sidebar) => {
                 sidebar.active = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/index.js
@@ -40,7 +40,6 @@ export default {
 
     methods: {
         createdComponent() {
-            Shopware.Store.get('adminMenu').collapseSidebar();
             this.resetRelatedStores();
 
             const isSystemDefaultLanguage = Shopware.Store.get('context').isSystemDefaultLanguage;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
@@ -168,8 +168,6 @@ export default {
 
     methods: {
         createdComponent() {
-            Shopware.Store.get('adminMenu').collapseSidebar();
-
             if (this.acl.can('user_config:read')) {
                 this.loadGridUserSettings();
             }


### PR DESCRIPTION
- inset the content area and sidebar panel with an 8px margin, secondary border and large radius; sunken background for the app/navigation, surface-default for content and sidebar
- animate sidebar open/close (slide + synced content resize) and fade the backdrop on every appear/hide path (open, close, resize threshold)
- allow resizing the sidebar down to 400px while keeping the 512px default
- toggle the sidebar from the topbar trigger; convert it to an mt-button with mt-tooltip (bottom placement, delayed)
- use square tertiary mt-buttons in the sidebar header
- drop adminMenu.collapseSidebar() calls from the CMS create/list pages
