### PR TITLE
fix: validate admin extension assets before config exposure

### DIFF
--- a/public/.htaccess.dist
+++ b/public/.htaccess.dist
@@ -25,6 +25,11 @@ DirectoryIndex index.php
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule ^ - [L]
 
+    # Missing bundle assets should not be routed through the front controller.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule ^bundles/ - [R=404,L]
+
     # Rewrite all other queries to the front controller.
     RewriteRule ^ %{ENV:BASE}/index.php [L]
 </IfModule>

--- a/src/Administration/DependencyInjection/framework.xml
+++ b/src/Administration/DependencyInjection/framework.xml
@@ -53,6 +53,8 @@
             <argument type="service" id="Shopware\Administration\Framework\App\ActiveAdminAppLoader"/>
             <argument type="service" id="filesystem"/>
             <argument type="service" id="Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator"/>
+            <argument type="service" id="logger"/>
 
             <tag name="kernel.event_subscriber"/>
         </service>

--- a/src/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriber.php
+++ b/src/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriber.php
@@ -2,11 +2,14 @@
 
 namespace Shopware\Administration\Framework\Api\Subscriber;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Administration\Framework\App\ActiveAdminAppLoader;
 use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Framework\Api\Event\AdminInfoConfigEvent;
 use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetViolation;
 use Shopware\Core\Kernel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -25,6 +28,8 @@ readonly class AdminInfoConfigBundlesSubscriber implements EventSubscriberInterf
         private ActiveAdminAppLoader $activeAdminAppLoader,
         private Filesystem $filesystem,
         private ViteFileAccessorDecorator $viteFileAccessorDecorator,
+        private AdministrationExtensionAssetValidator $administrationExtensionAssetValidator,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -65,12 +70,36 @@ readonly class AdminInfoConfigBundlesSubscriber implements EventSubscriberInterf
                 continue;
             }
 
-            $viteEntryPoints = $this->viteFileAccessorDecorator->getBundleData($bundle);
+            try {
+                $viteEntryPoints = $this->viteFileAccessorDecorator->getBundleData($bundle);
+            } catch (\Throwable $exception) {
+                $this->logger->warning('Skipping Administration extension asset metadata because it could not be read.', [
+                    'bundleName' => $bundle->getName(),
+                    'technicalBundleName' => $this->administrationExtensionAssetValidator->getTechnicalBundleName($bundle),
+                    'entrypointsFilePath' => $this->administrationExtensionAssetValidator->getEntrypointsFilePath($bundle),
+                    'exception' => $exception,
+                ]);
 
-            $technicalBundleName = $this->getTechnicalBundleName($bundle);
-            $styles = $viteEntryPoints['entryPoints'][$technicalBundleName]['css'] ?? [];
-            $scripts = $viteEntryPoints['entryPoints'][$technicalBundleName]['js'] ?? [];
+                continue;
+            }
+
+            $technicalBundleName = $this->administrationExtensionAssetValidator->getTechnicalBundleName($bundle);
+            $styles = $this->filterAssetUrls($bundle, $viteEntryPoints['entryPoints'][$technicalBundleName]['css'] ?? [], 'css');
+            $scripts = $this->filterAssetUrls($bundle, $viteEntryPoints['entryPoints'][$technicalBundleName]['js'] ?? [], 'js');
+            $this->logValidationViolations(
+                $this->administrationExtensionAssetValidator->validateEntrypointsData($bundle, $viteEntryPoints),
+            );
             $baseUrl = $this->getBaseUrl($bundle);
+
+            if (($viteEntryPoints['entryPoints'][$technicalBundleName]['js'] ?? []) !== [] && $scripts === [] && $baseUrl === null) {
+                $this->logger->warning('Skipping Administration extension asset bundle because no JavaScript asset remains after validation.', [
+                    'bundleName' => $bundle->getName(),
+                    'technicalBundleName' => $technicalBundleName,
+                    'entrypointsFilePath' => $this->administrationExtensionAssetValidator->getEntrypointsFilePath($bundle),
+                ]);
+
+                continue;
+            }
 
             if ($styles === [] && $scripts === [] && $baseUrl === null) {
                 continue;
@@ -128,8 +157,25 @@ readonly class AdminInfoConfigBundlesSubscriber implements EventSubscriberInterf
         }
     }
 
-    private function getTechnicalBundleName(Bundle $bundle): string
+    /**
+     * @return list<string>
+     */
+    private function filterAssetUrls(Bundle $bundle, mixed $assetUrls, string $assetType): array
     {
-        return str_replace('_', '-', $bundle->getContainerPrefix());
+        return $this->administrationExtensionAssetValidator->filterAssetUrls($bundle, $assetUrls, $assetType)->assets;
+    }
+
+    /**
+     * @param list<AdministrationExtensionAssetViolation> $violations
+     */
+    private function logValidationViolations(array $violations): void
+    {
+        foreach ($violations as $violation) {
+            $message = $violation->isMissingAsset()
+                ? 'Skipping missing Administration extension asset.'
+                : 'Skipping invalid Administration extension asset.';
+
+            $this->logger->warning($message, $violation->toLogContext());
+        }
     }
 }

--- a/src/Administration/Resources/app/administration/src/core/application.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/application.spec.js
@@ -4,16 +4,28 @@
 
 describe('core/application.js', () => {
     const originalInjectJs = Shopware.Application.injectJs;
+    const originalInjectCss = Shopware.Application.injectCss;
+    const originalInjectPlugin = Shopware.Application.injectPlugin;
     const originalInjectIframe = Shopware.Application.injectIframe;
     const originalNodeEnv = process.env.NODE_ENV;
 
     beforeEach(() => {
         jest.clearAllMocks();
         Shopware.Application.injectJs = originalInjectJs;
+        Shopware.Application.injectCss = originalInjectCss;
+        Shopware.Application.injectPlugin = originalInjectPlugin;
         Shopware.Application.injectIframe = originalInjectIframe;
         process.env.NODE_ENV = originalNodeEnv;
         Shopware.Context.app.config.bundles = {};
         global.fetch = jest.fn(() => Promise.resolve());
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        jest.useRealTimers();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
     });
 
     it("should be error tolerant if loading a plugin's files fails", async () => {
@@ -97,6 +109,7 @@ describe('core/application.js', () => {
     it('should load plugins correctly in prod', async () => {
         // Mock injectIframe method
         Shopware.Application.injectIframe = jest.fn();
+        Shopware.Application.injectPlugin = jest.fn(() => Promise.resolve());
 
         // Mock plugins
         Shopware.Context.app.config.bundles = {
@@ -194,5 +207,87 @@ describe('core/application.js', () => {
             integrationId: undefined,
             active: undefined,
         });
+    });
+
+    it('should resolve CSS injection before timeout', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectCss('/bundles/acme/administration/assets/app.css');
+        const link = document.head.querySelector('link');
+
+        expect(link).not.toBeNull();
+        expect(link.getAttribute('href')).toBe('/bundles/acme/administration/assets/app.css');
+
+        link.dispatchEvent(new Event('load'));
+
+        await expect(result).resolves.toBeUndefined();
+    });
+
+    it('should reject CSS injection on load error before timeout', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectCss('/bundles/acme/administration/assets/app.css');
+        const link = document.head.querySelector('link');
+
+        expect(link).not.toBeNull();
+
+        link.dispatchEvent(new Event('error'));
+
+        await expect(result).rejects.toThrow(
+            'Failed to load Administration extension CSS asset: /bundles/acme/administration/assets/app.css',
+        );
+    });
+
+    it('should reject CSS injection after timeout when request stays pending', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectCss('/bundles/acme/administration/assets/pending.css');
+
+        jest.advanceTimersByTime(15000);
+
+        await expect(result).rejects.toThrow(
+            'Loading Administration extension CSS asset timed out after 15000ms: /bundles/acme/administration/assets/pending.css',
+        );
+    });
+
+    it('should resolve JS injection before timeout', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectJs('/bundles/acme/administration/assets/app.js');
+        const script = document.body.querySelector('script');
+
+        expect(script).not.toBeNull();
+        expect(script.getAttribute('src')).toBe('/bundles/acme/administration/assets/app.js');
+
+        script.dispatchEvent(new Event('load'));
+
+        await expect(result).resolves.toBeUndefined();
+    });
+
+    it('should reject JS injection on load error before timeout', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectJs('/bundles/acme/administration/assets/app.js');
+        const script = document.body.querySelector('script');
+
+        expect(script).not.toBeNull();
+
+        script.dispatchEvent(new Event('error'));
+
+        await expect(result).rejects.toThrow(
+            'Failed to load Administration extension JavaScript asset: /bundles/acme/administration/assets/app.js',
+        );
+    });
+
+    it('should reject JS injection after timeout when request stays pending', async () => {
+        jest.useFakeTimers();
+
+        const result = Shopware.Application.injectJs('/bundles/acme/administration/assets/pending.js');
+
+        jest.advanceTimersByTime(15000);
+
+        await expect(result).rejects.toThrow(
+            'Loading Administration extension JavaScript asset timed out after 15000ms: /bundles/acme/administration/assets/pending.js',
+        );
     });
 });

--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -42,6 +42,8 @@ class ApplicationBootstrapper {
 
     public view: null | VueAdapter;
 
+    private readonly extensionAssetLoadTimeout = 15000;
+
     /**
      * Provides the necessary class properties for the class to work probably
      */
@@ -757,15 +759,18 @@ class ApplicationBootstrapper {
             script.src = scriptSrc;
             script.async = true;
             script.type = 'module';
+            const timeout = this.createAssetLoadTimeout('JavaScript', scriptSrc, reject);
 
             // resolve when script was loaded successfully
             script.onload = (): void => {
+                window.clearTimeout(timeout);
                 resolve();
             };
 
             // when script get not loaded successfully
             script.onerror = (): void => {
-                reject();
+                window.clearTimeout(timeout);
+                reject(new Error(`Failed to load Administration extension JavaScript asset: ${scriptSrc}`));
             };
 
             // Append the script to the end of body
@@ -782,20 +787,37 @@ class ApplicationBootstrapper {
             const link = document.createElement('link');
             link.rel = 'stylesheet';
             link.href = styleSrc;
+            const timeout = this.createAssetLoadTimeout('CSS', styleSrc, reject);
 
             // resolve when script was loaded succcessfully
             link.onload = (): void => {
+                window.clearTimeout(timeout);
                 resolve();
             };
 
             // when style get not loaded successfully
             link.onerror = (): void => {
-                reject();
+                window.clearTimeout(timeout);
+                reject(new Error(`Failed to load Administration extension CSS asset: ${styleSrc}`));
             };
 
             // Append the style to the end of head
             document.head.appendChild(link);
         });
+    }
+
+    private createAssetLoadTimeout(
+        assetType: 'CSS' | 'JavaScript',
+        assetSrc: string,
+        reject: (reason?: unknown) => void,
+    ): number {
+        return window.setTimeout(() => {
+            reject(
+                new Error(
+                    `Loading Administration extension ${assetType} asset timed out after ${this.extensionAssetLoadTimeout}ms: ${assetSrc}`,
+                ),
+            );
+        }, this.extensionAssetLoadTimeout);
     }
 
     /**

--- a/src/Core/Framework/Adapter/Asset/AssetInstallCommand.php
+++ b/src/Core/Framework/Adapter/Asset/AssetInstallCommand.php
@@ -8,8 +8,11 @@ use League\Flysystem\UnableToCreateDirectory;
 use League\Flysystem\UnableToDeleteDirectory;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetViolation;
 use Shopware\Core\Installer\Installer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -32,6 +35,7 @@ class AssetInstallCommand extends Command
         private readonly KernelInterface $kernel,
         private readonly AssetService $assetService,
         private readonly ActiveAppsLoader $activeAppsLoader,
+        private readonly AdministrationExtensionAssetValidator $administrationExtensionAssetValidator,
     ) {
         parent::__construct();
     }
@@ -39,6 +43,7 @@ class AssetInstallCommand extends Command
     protected function configure(): void
     {
         $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the install of assets regardless of the manifest state');
+        $this->addOption('strict-extension-assets', null, InputOption::VALUE_NONE, 'Fail when Administration extension asset metadata references missing or invalid local files');
     }
 
     /**
@@ -53,9 +58,15 @@ class AssetInstallCommand extends Command
         $io = new ShopwareStyle($input, $output);
         $io->title('Copying assets');
 
+        $assetViolations = [];
+
         foreach ($this->kernel->getBundles() as $bundle) {
             $io->writeln(\sprintf('Copying files for bundle: %s', $bundle->getName()));
             $this->assetService->copyAssets($bundle, $input->getOption('force'));
+
+            if ($bundle instanceof Bundle) {
+                array_push($assetViolations, ...$this->validateAdministrationExtensionAssets($bundle, $io));
+            }
         }
 
         foreach ($this->activeAppsLoader->getActiveApps() as $app) {
@@ -72,8 +83,28 @@ class AssetInstallCommand extends Command
             copy($publicDir . '/.htaccess.dist', $publicDir . '/.htaccess');
         }
 
+        if ($assetViolations !== [] && $input->getOption('strict-extension-assets')) {
+            $io->error('Administration extension asset validation failed.');
+
+            return self::FAILURE;
+        }
+
         $io->success('Successfully copied all bundle files');
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @return list<AdministrationExtensionAssetViolation>
+     */
+    private function validateAdministrationExtensionAssets(Bundle $bundle, ShopwareStyle $io): array
+    {
+        $violations = $this->administrationExtensionAssetValidator->validateEntrypointsFile($bundle);
+
+        foreach ($violations as $violation) {
+            $io->warning($violation->toConsoleMessage());
+        }
+
+        return $violations;
     }
 }

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -58,7 +58,12 @@
             <argument type="service" id="kernel"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\Util\AssetService"/>
             <argument type="service" id="Shopware\Core\Framework\App\ActiveAppsLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator"/>
             <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator">
+            <argument type="service" id="filesystem"/>
         </service>
 
         <!-- Assets -->

--- a/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetFilterResult.php
+++ b/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetFilterResult.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Util\AssetValidation;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final readonly class AdministrationExtensionAssetFilterResult
+{
+    /**
+     * @param list<string> $assets
+     * @param list<AdministrationExtensionAssetViolation> $violations
+     */
+    public function __construct(
+        public array $assets,
+        public array $violations,
+    ) {
+    }
+}

--- a/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetValidator.php
+++ b/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetValidator.php
@@ -1,0 +1,234 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Util\AssetValidation;
+
+use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final readonly class AdministrationExtensionAssetValidator
+{
+    public const ADMINISTRATION_PUBLIC_PATH = 'Resources/public/administration';
+
+    public const ENTRYPOINTS_FILE_PATH = self::ADMINISTRATION_PUBLIC_PATH . '/.vite/entrypoints.json';
+
+    private const REASON_MISSING = 'The referenced Administration extension asset is missing.';
+
+    private const REASON_INVALID_PATH = 'The referenced Administration extension asset path is invalid.';
+
+    private const REASON_MALFORMED_ASSET_LIST = 'The Administration extension asset list is malformed.';
+
+    private const REASON_MALFORMED_ENTRYPOINTS = 'The Administration extension entrypoints file is malformed.';
+
+    /**
+     * @var list<string>
+     */
+    private const ASSET_TYPES = ['css', 'js', 'dynamic', 'preload'];
+
+    public function __construct(private Filesystem $filesystem)
+    {
+    }
+
+    public function getTechnicalBundleName(Bundle $bundle): string
+    {
+        return str_replace('_', '-', $bundle->getContainerPrefix());
+    }
+
+    public function getAssetBundleName(Bundle $bundle): string
+    {
+        return preg_replace('/bundle$/', '', mb_strtolower($bundle->getName())) ?? mb_strtolower($bundle->getName());
+    }
+
+    public function getEntrypointsFilePath(Bundle $bundle): string
+    {
+        return Path::join($bundle->getPath(), self::ENTRYPOINTS_FILE_PATH);
+    }
+
+    /**
+     * @return list<AdministrationExtensionAssetViolation>
+     */
+    public function validateEntrypointsFile(Bundle $bundle): array
+    {
+        $entrypointsFilePath = $this->getEntrypointsFilePath($bundle);
+
+        if (!$this->filesystem->exists($entrypointsFilePath) || !is_file($entrypointsFilePath)) {
+            return [];
+        }
+
+        try {
+            $entrypointsData = json_decode(
+                $this->filesystem->readFile($entrypointsFilePath),
+                true,
+                flags: \JSON_THROW_ON_ERROR
+            );
+        } catch (\Throwable $exception) {
+            return [
+                $this->createViolation(
+                    $bundle,
+                    'entrypoints',
+                    $entrypointsFilePath,
+                    null,
+                    self::REASON_MALFORMED_ENTRYPOINTS . ' ' . $exception->getMessage(),
+                ),
+            ];
+        }
+
+        if (!\is_array($entrypointsData)) {
+            return [
+                $this->createViolation(
+                    $bundle,
+                    'entrypoints',
+                    $entrypointsFilePath,
+                    null,
+                    self::REASON_MALFORMED_ENTRYPOINTS,
+                ),
+            ];
+        }
+
+        return $this->validateEntrypointsData($bundle, $entrypointsData);
+    }
+
+    /**
+     * @param array<string, mixed> $entrypointsData
+     *
+     * @return list<AdministrationExtensionAssetViolation>
+     */
+    public function validateEntrypointsData(Bundle $bundle, array $entrypointsData): array
+    {
+        $entryPoints = $entrypointsData['entryPoints'] ?? [];
+
+        if (!\is_array($entryPoints)) {
+            return [
+                $this->createViolation($bundle, 'entrypoints', '', null, self::REASON_MALFORMED_ENTRYPOINTS),
+            ];
+        }
+
+        $technicalBundleName = $this->getTechnicalBundleName($bundle);
+        $bundleEntryPoint = $entryPoints[$technicalBundleName] ?? [];
+
+        if ($bundleEntryPoint === []) {
+            return [];
+        }
+
+        if (!\is_array($bundleEntryPoint)) {
+            return [
+                $this->createViolation($bundle, 'entrypoints', '', null, self::REASON_MALFORMED_ENTRYPOINTS),
+            ];
+        }
+
+        $violations = [];
+
+        foreach (self::ASSET_TYPES as $assetType) {
+            $filterResult = $this->filterAssetUrls($bundle, $bundleEntryPoint[$assetType] ?? [], $assetType);
+            array_push($violations, ...$filterResult->violations);
+        }
+
+        return $violations;
+    }
+
+    public function filterAssetUrls(Bundle $bundle, mixed $assetUrls, string $assetType): AdministrationExtensionAssetFilterResult
+    {
+        if ($assetUrls === null || $assetUrls === []) {
+            return new AdministrationExtensionAssetFilterResult([], []);
+        }
+
+        if (!\is_array($assetUrls)) {
+            return new AdministrationExtensionAssetFilterResult([], [
+                $this->createViolation($bundle, $assetType, '', null, self::REASON_MALFORMED_ASSET_LIST),
+            ]);
+        }
+
+        $filteredAssetUrls = [];
+        $violations = [];
+
+        foreach ($assetUrls as $assetUrl) {
+            if (!\is_string($assetUrl) || $assetUrl === '') {
+                $violations[] = $this->createViolation($bundle, $assetType, '', null, self::REASON_MALFORMED_ASSET_LIST);
+
+                continue;
+            }
+
+            $violation = $this->validateAssetUrl($bundle, $assetType, $assetUrl);
+            if ($violation !== null) {
+                $violations[] = $violation;
+
+                continue;
+            }
+
+            $filteredAssetUrls[] = $assetUrl;
+        }
+
+        return new AdministrationExtensionAssetFilterResult($filteredAssetUrls, $violations);
+    }
+
+    private function validateAssetUrl(Bundle $bundle, string $assetType, string $assetUrl): ?AdministrationExtensionAssetViolation
+    {
+        $path = \parse_url($assetUrl, \PHP_URL_PATH);
+        if (!\is_string($path) || $path === '') {
+            return null;
+        }
+
+        $decodedPath = rawurldecode($path);
+        $expectedBasePath = \sprintf('/bundles/%s/administration/', $this->getAssetBundleName($bundle));
+        $expectedBasePathPosition = mb_strpos($decodedPath, $expectedBasePath);
+
+        if ($expectedBasePathPosition === false) {
+            return null;
+        }
+
+        if (str_contains($decodedPath, "\0")) {
+            return $this->createViolation($bundle, $assetType, $assetUrl, null, self::REASON_INVALID_PATH);
+        }
+
+        $relativeAssetPath = mb_substr($decodedPath, $expectedBasePathPosition + mb_strlen($expectedBasePath));
+        if ($relativeAssetPath === '' || str_contains($relativeAssetPath, '\\')) {
+            return $this->createViolation($bundle, $assetType, $assetUrl, null, self::REASON_INVALID_PATH);
+        }
+
+        $relativeAssetPath = Path::canonicalize($relativeAssetPath);
+        if (
+            $relativeAssetPath === ''
+            || $relativeAssetPath === '..'
+            || str_starts_with($relativeAssetPath, '../')
+            || Path::isAbsolute($relativeAssetPath)
+        ) {
+            return $this->createViolation($bundle, $assetType, $assetUrl, null, self::REASON_INVALID_PATH);
+        }
+
+        $administrationPublicPath = Path::join($bundle->getPath(), self::ADMINISTRATION_PUBLIC_PATH);
+        $expectedFilePath = Path::join($administrationPublicPath, $relativeAssetPath);
+
+        if (!Path::isBasePath($administrationPublicPath, $expectedFilePath) || $expectedFilePath === $administrationPublicPath) {
+            return $this->createViolation($bundle, $assetType, $assetUrl, $expectedFilePath, self::REASON_INVALID_PATH);
+        }
+
+        if (!is_file($expectedFilePath)) {
+            return $this->createViolation($bundle, $assetType, $assetUrl, $expectedFilePath, self::REASON_MISSING);
+        }
+
+        return null;
+    }
+
+    private function createViolation(
+        Bundle $bundle,
+        string $assetType,
+        string $assetUrl,
+        ?string $expectedFilePath,
+        string $reason,
+    ): AdministrationExtensionAssetViolation {
+        return new AdministrationExtensionAssetViolation(
+            $bundle->getName(),
+            $this->getTechnicalBundleName($bundle),
+            $assetType,
+            $assetUrl,
+            $expectedFilePath,
+            $this->getEntrypointsFilePath($bundle),
+            $reason,
+        );
+    }
+}

--- a/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetViolation.php
+++ b/src/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetViolation.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Util\AssetValidation;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+final readonly class AdministrationExtensionAssetViolation
+{
+    public function __construct(
+        public string $bundleName,
+        public string $technicalBundleName,
+        public string $assetType,
+        public string $assetUrl,
+        public ?string $expectedFilePath,
+        public string $entrypointsFilePath,
+        public string $reason,
+    ) {
+    }
+
+    public function isMissingAsset(): bool
+    {
+        return str_contains($this->reason, 'is missing');
+    }
+
+    /**
+     * @return array{
+     *     bundleName: string,
+     *     technicalBundleName: string,
+     *     assetType: string,
+     *     assetUrl: string,
+     *     expectedFilePath: ?string,
+     *     entrypointsFilePath: string,
+     *     reason: string
+     * }
+     */
+    public function toLogContext(): array
+    {
+        return [
+            'bundleName' => $this->bundleName,
+            'technicalBundleName' => $this->technicalBundleName,
+            'assetType' => $this->assetType,
+            'assetUrl' => $this->assetUrl,
+            'expectedFilePath' => $this->expectedFilePath,
+            'entrypointsFilePath' => $this->entrypointsFilePath,
+            'reason' => $this->reason,
+        ];
+    }
+
+    public function toConsoleMessage(): string
+    {
+        $subject = $this->assetUrl !== '' ? $this->assetUrl : $this->entrypointsFilePath;
+
+        if ($this->expectedFilePath === null) {
+            return \sprintf(
+                '%s Bundle: %s, type: %s, asset: %s, entrypoints: %s',
+                $this->reason,
+                $this->bundleName,
+                $this->assetType,
+                $subject,
+                $this->entrypointsFilePath
+            );
+        }
+
+        return \sprintf(
+            '%s Bundle: %s, type: %s, asset: %s, expected file: %s, entrypoints: %s',
+            $this->reason,
+            $this->bundleName,
+            $this->assetType,
+            $subject,
+            $this->expectedFilePath,
+            $this->entrypointsFilePath
+        );
+    }
+}

--- a/tests/unit/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriberTest.php
+++ b/tests/unit/Administration/Framework/Api/Subscriber/AdminInfoConfigBundlesSubscriberTest.php
@@ -6,13 +6,16 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Shopware\Administration\Framework\Api\Subscriber\AdminInfoConfigBundlesSubscriber;
 use Shopware\Administration\Framework\App\ActiveAdminAppLoader;
 use Shopware\Administration\Framework\Twig\ViteFileAccessorDecorator;
 use Shopware\Core\Framework\Api\Event\AdminInfoConfigEvent;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
 use Shopware\Core\Test\Stub\Symfony\StubKernel;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -22,6 +25,16 @@ use Symfony\Component\Routing\RouterInterface;
 #[CoversClass(AdminInfoConfigBundlesSubscriber::class)]
 class AdminInfoConfigBundlesSubscriberTest extends TestCase
 {
+    /**
+     * @var list<string>
+     */
+    private array $temporaryDirectories = [];
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->temporaryDirectories);
+    }
+
     #[TestDox('Subscribes to AdminInfoConfigEvent via the enrichBundles handler')]
     public function testSubscribesToAdminInfoConfigEvent(): void
     {
@@ -71,6 +84,90 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
         static::assertSame(['/bundles/acmebundle/main.css'], $bundles['AcmeBundle']['css']);
         static::assertSame(['/bundles/acmebundle/main.js'], $bundles['AcmeBundle']['js']);
         static::assertSame('plugin', $bundles['AcmeBundle']['type']);
+    }
+
+    public function testMissingCssIsFilteredAndLoggedWhileJsRemains(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles([
+            'assets/app.js' => '',
+        ]);
+
+        $viteAccessor = static::createStub(ViteFileAccessorDecorator::class);
+        $viteAccessor->method('getBundleData')->willReturn([
+            'entryPoints' => [
+                'acme-bundle' => [
+                    'css' => ['/bundles/acme/administration/assets/missing.css'],
+                    'js' => ['/bundles/acme/administration/assets/app.js'],
+                ],
+            ],
+        ]);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                'Skipping missing Administration extension asset.',
+                static::callback(static function (array $context): bool {
+                    static::assertSame('AcmeBundle', $context['bundleName']);
+                    static::assertSame('acme-bundle', $context['technicalBundleName']);
+                    static::assertSame('css', $context['assetType']);
+                    static::assertSame('/bundles/acme/administration/assets/missing.css', $context['assetUrl']);
+                    static::assertIsString($context['expectedFilePath']);
+                    static::assertStringEndsWith('/Resources/public/administration/assets/missing.css', $context['expectedFilePath']);
+
+                    return true;
+                })
+            );
+
+        $bundles = $this->collectBundles(new StubKernel([$bundle]), viteAccessor: $viteAccessor, logger: $logger);
+
+        static::assertSame([], $bundles['AcmeBundle']['css']);
+        static::assertSame(['/bundles/acme/administration/assets/app.js'], $bundles['AcmeBundle']['js']);
+    }
+
+    public function testBundleIsSkippedWhenMissingJsLeavesNoScriptOrBaseUrl(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles();
+
+        $viteAccessor = static::createStub(ViteFileAccessorDecorator::class);
+        $viteAccessor->method('getBundleData')->willReturn([
+            'entryPoints' => [
+                'acme-bundle' => [
+                    'css' => [],
+                    'js' => ['/bundles/acme/administration/assets/missing.js'],
+                ],
+            ],
+        ]);
+
+        $bundles = $this->collectBundles(new StubKernel([$bundle]), viteAccessor: $viteAccessor);
+
+        static::assertSame([], $bundles);
+    }
+
+    public function testUnreadableViteEntrypointsDoNotBreakConfigEndpoint(): void
+    {
+        $bundle = new BundleFixture('AcmeBundle', '/tmp/AcmeBundle');
+
+        $viteAccessor = static::createStub(ViteFileAccessorDecorator::class);
+        $viteAccessor->method('getBundleData')->willThrowException(new \JsonException('broken entrypoints'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with(
+                'Skipping Administration extension asset metadata because it could not be read.',
+                static::callback(static function (array $context): bool {
+                    static::assertSame('AcmeBundle', $context['bundleName']);
+                    static::assertSame('acme-bundle', $context['technicalBundleName']);
+                    static::assertInstanceOf(\JsonException::class, $context['exception']);
+
+                    return true;
+                })
+            );
+
+        $bundles = $this->collectBundles(new StubKernel([$bundle]), viteAccessor: $viteAccessor, logger: $logger);
+
+        static::assertSame([], $bundles);
     }
 
     #[TestDox('Bundle::getAdminBaseUrl() short-circuits getBaseUrl and is used verbatim')]
@@ -171,6 +268,7 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
         ?RouterInterface $router = null,
         ?Filesystem $filesystem = null,
         ?ViteFileAccessorDecorator $viteAccessor = null,
+        ?LoggerInterface $logger = null,
     ): array {
         $event = $this->dispatchEnrichBundles(
             $kernel,
@@ -178,6 +276,7 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
             $router,
             $filesystem,
             $viteAccessor,
+            $logger,
         );
 
         return $event->getConfig()['bundles'];
@@ -189,16 +288,20 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
         ?RouterInterface $router = null,
         ?Filesystem $filesystem = null,
         ?ViteFileAccessorDecorator $viteAccessor = null,
+        ?LoggerInterface $logger = null,
     ): AdminInfoConfigEvent {
         $loader ??= $this->emptyLoader();
         $viteAccessor ??= $this->emptyViteAccessor();
+        $filesystem ??= new Filesystem();
 
         $subscriber = new AdminInfoConfigBundlesSubscriber(
             $kernel,
             $router ?? static::createStub(RouterInterface::class),
             $loader,
-            $filesystem ?? new Filesystem(),
+            $filesystem,
             $viteAccessor,
+            new AdministrationExtensionAssetValidator($filesystem),
+            $logger ?? static::createStub(LoggerInterface::class),
         );
 
         $event = new AdminInfoConfigEvent([]);
@@ -221,5 +324,24 @@ class AdminInfoConfigBundlesSubscriberTest extends TestCase
         $vite->method('getBundleData')->willReturn(['entryPoints' => []]);
 
         return $vite;
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createBundleWithAdministrationFiles(array $files = []): BundleFixture
+    {
+        $bundlePath = Path::join(sys_get_temp_dir(), uniqid('sw-admin-info-config-bundles-', true));
+        $this->temporaryDirectories[] = $bundlePath;
+
+        $filesystem = new Filesystem();
+        foreach ($files as $relativePath => $contents) {
+            $filesystem->dumpFile(
+                Path::join($bundlePath, AdministrationExtensionAssetValidator::ADMINISTRATION_PUBLIC_PATH, $relativePath),
+                $contents
+            );
+        }
+
+        return new BundleFixture('AcmeBundle', $bundlePath);
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Asset/AssetInstallCommandTest.php
+++ b/tests/unit/Core/Framework/Adapter/Asset/AssetInstallCommandTest.php
@@ -11,9 +11,11 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator;
 use Shopware\Core\Framework\Util\Filesystem as UtilFilesystem;
 use Shopware\Core\Installer\Installer;
 use Shopware\Core\Test\Stub\App\StaticSourceResolver;
+use Shopware\Core\Test\Stub\Framework\BundleFixture;
 use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\ExampleBundle\ExampleBundle;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -42,7 +44,8 @@ class AssetInstallCommandTest extends TestCase
         $command = new AssetInstallCommand(
             $kernel,
             $this->createMock(AssetService::class),
-            $this->createMock(ActiveAppsLoader::class)
+            $this->createMock(ActiveAppsLoader::class),
+            new AdministrationExtensionAssetValidator($fs),
         );
 
         $runner = new CommandTester($command);
@@ -82,11 +85,98 @@ class AssetInstallCommandTest extends TestCase
         $command = new AssetInstallCommand(
             $kernel,
             $service,
-            $appLoader
+            $appLoader,
+            new AdministrationExtensionAssetValidator(new Filesystem()),
         );
 
         $runner = new CommandTester($command);
         $runner->execute(['--force' => true]);
+    }
+
+    public function testMissingAdministrationExtensionAssetsWarnWithoutFailingInDefaultMode(): void
+    {
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs->dumpFile(
+            Path::join($tmpDir, 'Resources/public/administration/.vite/entrypoints.json'),
+            json_encode([
+                'entryPoints' => [
+                    'acme-bundle' => [
+                        'css' => [
+                            '/bundles/acme/administration/assets/missing.css',
+                        ],
+                        'js' => [],
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR)
+        );
+
+        $bundle = new BundleFixture('AcmeBundle', $tmpDir);
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getBundles')->willReturn([$bundle]);
+        $kernel->method('getProjectDir')->willReturn($tmpDir);
+
+        $service = $this->createMock(AssetService::class);
+        $appLoader = $this->createMock(ActiveAppsLoader::class);
+        $appLoader->method('getActiveApps')->willReturn([]);
+
+        $command = new AssetInstallCommand(
+            $kernel,
+            $service,
+            $appLoader,
+            new AdministrationExtensionAssetValidator($fs),
+        );
+
+        $runner = new CommandTester($command);
+        $status = $runner->execute([]);
+
+        static::assertSame(Command::SUCCESS, $status);
+        static::assertStringContainsString('The referenced Administration extension asset is missing.', $runner->getDisplay());
+
+        $fs->remove($tmpDir);
+    }
+
+    public function testStrictExtensionAssetsFailsOnMissingAdministrationExtensionAssets(): void
+    {
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('shopware', true);
+        $fs->dumpFile(
+            Path::join($tmpDir, 'Resources/public/administration/.vite/entrypoints.json'),
+            json_encode([
+                'entryPoints' => [
+                    'acme-bundle' => [
+                        'css' => [],
+                        'js' => [
+                            '/bundles/acme/administration/assets/missing.js',
+                        ],
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR)
+        );
+
+        $bundle = new BundleFixture('AcmeBundle', $tmpDir);
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getBundles')->willReturn([$bundle]);
+        $kernel->method('getProjectDir')->willReturn($tmpDir);
+
+        $service = $this->createMock(AssetService::class);
+        $appLoader = $this->createMock(ActiveAppsLoader::class);
+        $appLoader->method('getActiveApps')->willReturn([]);
+
+        $command = new AssetInstallCommand(
+            $kernel,
+            $service,
+            $appLoader,
+            new AdministrationExtensionAssetValidator($fs),
+        );
+
+        $runner = new CommandTester($command);
+        $status = $runner->execute(['--strict-extension-assets' => true]);
+
+        static::assertSame(Command::FAILURE, $status);
+        static::assertStringContainsString('Administration extension asset validation failed.', $runner->getDisplay());
+
+        $fs->remove($tmpDir);
     }
 
     public function testItInstallsAppAssets(): void
@@ -121,7 +211,8 @@ class AssetInstallCommandTest extends TestCase
                 $this->createMock(ParameterBagInterface::class),
                 new EventDispatcher()
             ),
-            $activeAppsLoaderMock
+            $activeAppsLoaderMock,
+            new AdministrationExtensionAssetValidator(new Filesystem()),
         );
 
         $runner = new CommandTester($command);

--- a/tests/unit/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetValidatorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetValidation/AdministrationExtensionAssetValidatorTest.php
@@ -1,0 +1,179 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin\Util\AssetValidation;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetFilterResult;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetValidator;
+use Shopware\Core\Framework\Plugin\Util\AssetValidation\AdministrationExtensionAssetViolation;
+use Shopware\Core\Test\Stub\Framework\BundleFixture;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+/**
+ * @internal
+ */
+#[CoversClass(AdministrationExtensionAssetFilterResult::class)]
+#[CoversClass(AdministrationExtensionAssetValidator::class)]
+#[CoversClass(AdministrationExtensionAssetViolation::class)]
+class AdministrationExtensionAssetValidatorTest extends TestCase
+{
+    private Filesystem $filesystem;
+
+    /**
+     * @var list<string>
+     */
+    private array $temporaryDirectories = [];
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->temporaryDirectories);
+    }
+
+    public function testExistingCssAndJsRemainInConfig(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles([
+            'assets/app.css' => '',
+            'assets/app.js' => '',
+        ]);
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+
+        $cssUrl = '/bundles/acme/administration/assets/app.css?v=1#main';
+        $jsUrl = '/bundles/acme/administration/assets/app.js?v=1#main';
+
+        $cssResult = $validator->filterAssetUrls($bundle, [$cssUrl], 'css');
+        $jsResult = $validator->filterAssetUrls($bundle, [$jsUrl], 'js');
+
+        static::assertSame([$cssUrl], $cssResult->assets);
+        static::assertSame([], $cssResult->violations);
+        static::assertSame([$jsUrl], $jsResult->assets);
+        static::assertSame([], $jsResult->violations);
+    }
+
+    public function testMissingCssIsRemovedWhileExistingJsRemains(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles([
+            'assets/app.js' => '',
+        ]);
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+
+        $cssResult = $validator->filterAssetUrls($bundle, ['/bundles/acme/administration/assets/missing.css'], 'css');
+        $jsResult = $validator->filterAssetUrls($bundle, ['/bundles/acme/administration/assets/app.js'], 'js');
+
+        static::assertSame([], $cssResult->assets);
+        static::assertCount(1, $cssResult->violations);
+        static::assertSame('css', $cssResult->violations[0]->assetType);
+        static::assertTrue($cssResult->violations[0]->isMissingAsset());
+        static::assertSame(['/bundles/acme/administration/assets/app.js'], $jsResult->assets);
+        static::assertSame([], $jsResult->violations);
+    }
+
+    public function testExternalOrUnmappableAssetUrlIsPreserved(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles();
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+        $externalUrl = 'https://cdn.example.com/extensions/acme/app.css';
+
+        $result = $validator->filterAssetUrls($bundle, [$externalUrl], 'css');
+
+        static::assertSame([$externalUrl], $result->assets);
+        static::assertSame([], $result->violations);
+    }
+
+    public function testPathTraversalIsRejected(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles([
+            'assets/app.js' => '',
+        ]);
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+
+        $result = $validator->filterAssetUrls($bundle, ['/bundles/acme/administration/../secret.js'], 'js');
+
+        static::assertSame([], $result->assets);
+        static::assertCount(1, $result->violations);
+        static::assertSame('The referenced Administration extension asset path is invalid.', $result->violations[0]->reason);
+    }
+
+    public function testSubdirectoryAndAbsoluteAssetBaseUrlsAreParsedByUrlPath(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles([
+            'assets/app.js' => '',
+        ]);
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+        $assetUrl = 'https://shop.example.com/subdirectory/bundles/acme/administration/assets/app.js';
+
+        $result = $validator->filterAssetUrls($bundle, [$assetUrl], 'js');
+
+        static::assertSame([$assetUrl], $result->assets);
+        static::assertSame([], $result->violations);
+    }
+
+    public function testValidateEntrypointsFileReportsMalformedJson(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles();
+        $this->writeEntrypointsFile($bundle, '{invalid');
+
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+        $violations = $validator->validateEntrypointsFile($bundle);
+
+        static::assertCount(1, $violations);
+        static::assertSame('entrypoints', $violations[0]->assetType);
+        static::assertStringContainsString('malformed', $violations[0]->reason);
+    }
+
+    public function testValidateEntrypointsFileReportsMissingJs(): void
+    {
+        $bundle = $this->createBundleWithAdministrationFiles();
+        $this->writeEntrypointsFile($bundle, json_encode([
+            'entryPoints' => [
+                'acme-bundle' => [
+                    'css' => [],
+                    'dynamic' => [],
+                    'js' => [
+                        '/bundles/acme/administration/assets/missing.js',
+                    ],
+                    'preload' => [],
+                ],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+
+        $validator = new AdministrationExtensionAssetValidator($this->filesystem);
+        $violations = $validator->validateEntrypointsFile($bundle);
+
+        static::assertCount(1, $violations);
+        static::assertSame('js', $violations[0]->assetType);
+        static::assertTrue($violations[0]->isMissingAsset());
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createBundleWithAdministrationFiles(array $files = []): BundleFixture
+    {
+        $bundlePath = Path::join(sys_get_temp_dir(), uniqid('sw-admin-extension-assets-', true));
+        $this->temporaryDirectories[] = $bundlePath;
+
+        foreach ($files as $relativePath => $contents) {
+            $this->filesystem->dumpFile(
+                Path::join($bundlePath, AdministrationExtensionAssetValidator::ADMINISTRATION_PUBLIC_PATH, $relativePath),
+                $contents
+            );
+        }
+
+        return new BundleFixture('AcmeBundle', $bundlePath);
+    }
+
+    private function writeEntrypointsFile(BundleFixture $bundle, string $contents): void
+    {
+        $this->filesystem->dumpFile(
+            Path::join($bundle->getPath(), AdministrationExtensionAssetValidator::ENTRYPOINTS_FILE_PATH),
+            $contents
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

A malformed or stale Administration extension asset reference can currently be exposed through `/api/_info/config`. When the Administration frontend injects that missing JS/CSS file, some hosting setups route the missing `/bundles/...` request through PHP and can keep it pending long enough to block Administration boot or exhaust PHP-FPM workers.

### 2. What does this change do, exactly?

- Adds validation for classic Administration extension assets before they are exposed in `/api/_info/config`.
- Filters missing local `/bundles/<bundle>/administration/...` CSS/JS entries and logs warnings with bundle, asset type, URL, expected file path, and entrypoints metadata.
- Skips a classic plugin asset bundle when all JS entry assets are filtered and no `baseUrl` remains.
- Preserves external or unmappable asset URLs.
- Adds validation during `assets:install`, warning by default and failing with `--strict-extension-assets`.
- Adds a 15s frontend timeout for dynamically injected Administration extension CSS/JS assets.
- Adds Apache `.htaccess.dist` hardening so missing `/bundles/` files return a static 404 before reaching `index.php`.
- Adds changelog documentation including an equivalent Nginx `try_files` rule.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or install a plugin with Administration entrypoint metadata that references a non-existing compiled JS or CSS file under `Resources/public/administration`.
2. Activate that plugin.
3. Open the Administration or activate/deactivate another plugin so `/api/_info/config` is refreshed.
4. The missing asset URL is exposed to the browser.
5. On affected hosting setups, the missing `/bundles/...` request can be routed through PHP and stay pending or overload PHP-FPM.
6. The Administration may fail to boot or the server may return `Service unavailable`.

### 4. Please link to the relevant issues (if any).

- closes #14091

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them