### PR TITLE
feat(core): add --no-scaffold flag to plugin:create command  

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -122,6 +122,14 @@ Sales Channels now have an optional business timezone setting. When configured, 
 
 Without a value, document rendering keeps its previous behaviour, which depends on the entry point: documents generated during a Storefront request can pick up the customer's browser timezone, while documents generated from the Administration or the message queue use Twig's configured default timezone. Starting with Shopware 6.8, this entry-point dependency is removed: without a business timezone, documents always render in Twig's configured default timezone (UTC unless changed via the `twig.date.timezone` configuration), regardless of how the document is generated.
 
+### Added `--no-scaffold` flag to `plugin:create` command
+
+The `bin/console plugin:create` command now accepts a `--no-scaffold` flag that skips all optional scaffold generators, producing only the minimal required plugin skeleton.
+
+```bash
+bin/console plugin:create MyPlugin MyNamespace --no-scaffold
+```
+
 ## API
 
 ### DAL write event listeners no longer expand API ACL requirements

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -44,7 +44,8 @@ class PluginCreateCommand extends Command
         $this
             ->addArgument('plugin-name', InputArgument::OPTIONAL, 'Plugin name (PascalCase)')
             ->addArgument('plugin-namespace', InputArgument::OPTIONAL, 'Plugin namespace (PascalCase)')
-            ->addOption('static', null, null, 'Plugin will be created in the static-plugins folder');
+            ->addOption('static', null, null, 'Plugin will be created in the static-plugins folder')
+            ->addOption('no-scaffold', null, null, 'Create only the required plugin files, skip all optional scaffold files');
 
         foreach ($this->generators as $generator) {
             if (!$generator->hasCommandOption()) {
@@ -103,7 +104,17 @@ class PluginCreateCommand extends Command
                 $directory
             );
 
+            $noScaffold = (bool) $input->getOption('no-scaffold');
+
+            if (!$noScaffold && $input->isInteractive()) {
+                $noScaffold = !$io->confirm('Would you like to scaffold optional plugin files?', true);
+            }
+
             foreach ($this->generators as $generator) {
+                if ($noScaffold && $generator->hasCommandOption()) {
+                    continue;
+                }
+
                 $generator->addScaffoldConfig($configuration, $input, $io);
             }
 

--- a/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
@@ -103,6 +103,21 @@ class PluginCreateCommandTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'with --no-scaffold skips optional generators' => [
+            'arguments' => [
+                'plugin-name' => 'TestPlugin',
+                'plugin-namespace' => 'Test',
+                '--no-scaffold' => true,
+            ],
+            'inputs' => [],
+            'generators' => [
+                [
+                    'hasCommandOption' => true,
+                    'getCommandOptionName' => 'test-option',
+                ],
+            ],
+        ];
     }
 
     /**
@@ -140,6 +155,68 @@ class PluginCreateCommandTest extends TestCase
             'expectedErrorMessage' => 'This command requires interactive mode or the argument must be provided.',
             'interactive' => false,
         ];
+    }
+
+    public function testNoScaffoldSkipsOptionalGenerators(): void
+    {
+        /** @var MockObject&ScaffoldingGenerator $optionalGenerator */
+        $optionalGenerator = $this->createMock(ScaffoldingGenerator::class);
+        $optionalGenerator->method('hasCommandOption')->willReturn(true);
+        $optionalGenerator->method('getCommandOptionName')->willReturn('test-option');
+        $optionalGenerator->expects($this->never())->method('addScaffoldConfig');
+
+        /** @var MockObject&ScaffoldingGenerator $requiredGenerator */
+        $requiredGenerator = $this->createMock(ScaffoldingGenerator::class);
+        $requiredGenerator->method('hasCommandOption')->willReturn(false);
+        $requiredGenerator->expects($this->once())->method('addScaffoldConfig');
+
+        $commandTester = $this->getCommandTester([$optionalGenerator, $requiredGenerator]);
+
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+            '--no-scaffold' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testInteractiveScaffoldQuestionNo(): void
+    {
+        /** @var MockObject&ScaffoldingGenerator $optionalGenerator */
+        $optionalGenerator = $this->createMock(ScaffoldingGenerator::class);
+        $optionalGenerator->method('hasCommandOption')->willReturn(true);
+        $optionalGenerator->method('getCommandOptionName')->willReturn('test-option');
+        $optionalGenerator->expects($this->never())->method('addScaffoldConfig');
+
+        $commandTester = $this->getCommandTester([$optionalGenerator]);
+        $commandTester->setInputs(['no']);
+
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testInteractiveScaffoldQuestionYes(): void
+    {
+        /** @var MockObject&ScaffoldingGenerator $optionalGenerator */
+        $optionalGenerator = $this->createMock(ScaffoldingGenerator::class);
+        $optionalGenerator->method('hasCommandOption')->willReturn(true);
+        $optionalGenerator->method('getCommandOptionName')->willReturn('test-option');
+        $optionalGenerator->expects($this->once())->method('addScaffoldConfig');
+
+        $commandTester = $this->getCommandTester([$optionalGenerator]);
+        $commandTester->setInputs(['yes']);
+
+        $commandTester->execute([
+            'plugin-name' => 'TestPlugin',
+            'plugin-namespace' => 'Test',
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
     }
 
     public function testDirectoryExists(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Users want to run `bin/console plugin:create` in CI or scripted environments and get a minimal plugin skeleton without optional scaffold files.

### 2. What does this change do, exactly?
Add `--no-scaffold` flag to `plugin:create` that skips all optional generators, producing only the minimal required plugin skeleton.
Additionally, when running the command interactively without the flag, the user is asked _"Would you like to scaffold optional plugin files?"_ - answering "no" has the same effect as passing `--no-scaffold`.

I used the existing `hasCommandOption()` method on `ScaffoldingGenerator` - generators returning true are optional, those returning `false` are always required. 

When `--no-scaffold` is passed, we simply skip calling `addScaffoldConfig()` on all optional generators, so they never add their options to the configuration and their `generateStubs()` methods.

Running command with `--no-scaffold` flag:
```bash
/var/www/html $ bin/console plugin:create TestPlugin Test --no-scaffold
                                                                                                    
 [INFO] Creating plugin files...                                                                                        
                                                     
 [OK] Plugin created successfully                                                                                                                                                                                  
```

Outcome:
```bash
/var/www/html $ find /var/www/html/custom/plugins/TestPlugin -type f | sort
/var/www/html/custom/plugins/TestPlugin/.gitignore
/var/www/html/custom/plugins/TestPlugin/composer.json
/var/www/html/custom/plugins/TestPlugin/phpunit.xml
/var/www/html/custom/plugins/TestPlugin/src/Resources/config/config.xml
/var/www/html/custom/plugins/TestPlugin/src/Resources/config/services.xml
/var/www/html/custom/plugins/TestPlugin/src/TestPlugin.php
/var/www/html/custom/plugins/TestPlugin/tests/TestBootstrap.php
```

### 3. Describe each step to reproduce the issue or behaviour.
Currently there is no flag that allows user to skip generating scaffold files.

### 4. Please link to the relevant issues (if any).
- Closes #17663

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers.
- [x] I have written or adjusted the documentation according to my changes https://github.com/shopware/docs/pull/2356
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them


