### PR TITLE
fix: translator fallback locales reset

### DIFF
--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -61,6 +61,13 @@ class Translator extends AbstractTranslator
      */
     private array $snippets = [];
 
+    private readonly string $defaultLocale;
+
+    /**
+     * @var non-empty-list<string>
+     */
+    private array $defaultFallbackLocales = ['en_GB', 'en'];
+
     /**
      * @internal
      */
@@ -75,6 +82,20 @@ class Translator extends AbstractTranslator
         private readonly SnippetService $snippetService,
         private readonly CacheTagCollector $cacheTagCollector,
     ) {
+        $this->defaultLocale = $translator->getLocale();
+
+        if (!$translator instanceof SymfonyTranslator) {
+            return;
+        }
+
+        $defaultFallbackLocales = array_filter(array_map(
+            static fn (string $fallbackLocale): ?string => locale_canonicalize($fallbackLocale),
+            $translator->getFallbackLocales()
+        ));
+
+        if ($defaultFallbackLocales !== []) {
+            $this->defaultFallbackLocales = array_values($defaultFallbackLocales);
+        }
     }
 
     public static function buildName(string $id): string
@@ -205,11 +226,11 @@ class Translator extends AbstractTranslator
         $this->salesChannelId = null;
         $this->localeBeforeInject = null;
         $this->locale = null;
+        $this->translator->setLocale($this->defaultLocale);
         if ($this->translator instanceof SymfonyTranslator) {
             // Reset FallbackLocale in memory cache of symfony implementation
             // set fallback values from Framework/Resources/config/translation.yaml
-            $this->translator->setFallbackLocales(['en_GB', 'en']);
-            $this->translator->setLocale('en-GB');
+            $this->translator->setFallbackLocales($this->defaultFallbackLocales);
         }
     }
 

--- a/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Translation/TranslatorTest.php
@@ -190,6 +190,35 @@ class TranslatorTest extends TestCase
         static::assertSame($domainSnippetSetId, $translator->getSnippetSetId('en-GB'));
     }
 
+    public function testResetRestoresConfiguredFallbackLocalesAndLocale(): void
+    {
+        $decorated = $this->createMock(SymfonyTranslator::class);
+        $decorated->method('getLocale')->willReturn('en_GB');
+        $decorated->method('getFallbackLocales')->willReturn(['de-DE', 'en-GB', 'en']);
+
+        $decorated->expects($this->once())
+            ->method('setFallbackLocales')
+            ->with(['de_DE', 'en_GB', 'en']);
+
+        $decorated->expects($this->once())
+            ->method('setLocale')
+            ->with('en_GB');
+
+        $translator = new Translator(
+            $decorated,
+            new RequestStack(),
+            $this->createMock(CacheInterface::class),
+            $this->createMock(MessageFormatterInterface::class),
+            'prod',
+            $this->createMock(Connection::class),
+            $this->createMock(LanguageLocaleCodeProvider::class),
+            $this->createMock(SnippetService::class),
+            $this->createMock(CacheTagCollector::class),
+        );
+
+        $translator->reset();
+    }
+
     /**
      * @return iterable<string, array<int, string|Request|null>>
      */


### PR DESCRIPTION
### 1. Why is this change necessary?

`Translator::reset()` hardcoded the fallback locales (`['en_GB', 'en']`) and the locale (`'en-GB'`), overriding whatever was configured via `framework.translator.fallbacks`. The inline comment even claimed the values came from `Framework/Resources/config/translation.yaml`, but they did not.

Because `reset()` is executed between requests/messages (`kernel.reset`), any customized fallback chain was discarded at runtime — so the `framework.translator.fallbacks` configuration was effectively obsolete. A store that configured e.g. `['de-DE', 'en-GB', 'en']` would still fall back to `en-GB` instead of `de-DE` for untranslated snippets.


### 2. What does this change do, exactly?

`reset()` now restores the translator to the state the framework actually configured, instead of hardcoded values:

  - In the constructor, the decorator captures the inner Symfony translator's already-configured state:
    - `defaultLocale` from `$translator->getLocale()` (the configured `framework.default_locale`).
    - `defaultFallbackLocales` from `$translator->getFallbackLocales()` (which the framework has populated from `framework.translator.fallbacks`).
  - The captured fallback locales are normalized via `locale_canonicalize()`, empty results are filtered out, and the list is re-indexed. If nothing usable is configured, it falls back to the previous default `['en_GB', 'en']`, so behavior is unchanged for default installations.
  - `reset()` now calls `setFallbackLocales($this->defaultFallbackLocales)` and `setLocale($this->defaultLocale)` instead of the hardcoded `setFallbackLocales(['en_GB', 'en'])` / `setLocale('en-GB')`.

  The capture happens at construction time, by which point the framework has already applied its `setFallbackLocales(...)` method call to `translator.default`, so the decorator reads the real configured values rather than re-deriving them — keeping a single source of truth (`framework.translator.fallbacks`).

### 3. Describe each step to reproduce the issue or behaviour.

  1. Override the fallbacks in `config/packages/translation.yaml`:
```yaml
framework:
    default_locale: '%locale%'
    translator:
        fallbacks:
            - 'de-DE'
            - 'de'
```
  2. Run bin/console cache:clear.
  3. Open a storefront sales channel and request a snippet that is missing for the current language (e.g. da-DK) but present in de-DE.

  - Before: the snippet falls back to en-GB (configured chain ignored after reset()).
  - After: the snippet falls back to de-DE as configured.

### 4. Please link to the relevant issues (if any).

  - closes #17520
 
### 5. Checklist

  - [x] I have written tests and verified that they fail without my change
  - [ ] I have updated developer-facing release notes if this change is relevant for external developers:
    - Add a short entry to RELEASE_INFO-6.<major>.md under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
    - Add an UPGRADE section in UPGRADE-6.<next-major>.md for breaking changes (what/why/impact/how to adapt).
    - See the Documenting a Release Process for details.
  - [ ] I have written or adjusted the documentation according to my changes
  - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  - [x] I have read the contribution requirements and fulfilled them