### PR TITLE
fix: Storefront Dev-Server in Docker Image

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,11 +4,14 @@ services:
         ports:
             - 8000:8000
             - 5173:5173
+            - 5175:5175
             - 9998:9998
             - 9999:9999
         environment:
             COMPOSER_ROOT_VERSION: 6.7.9999999-dev
             HOST: '0.0.0.0'
+            STOREFRONT_VITE_HOST: '0.0.0.0'
+            STOREFRONT_VITE_ORIGIN: http://localhost:5175
             APP_URL: http://localhost:8000
             DATABASE_URL: mysql://root:root@database/shopware
             MAILER_DSN: smtp://mailer:1025

--- a/src/Storefront/Resources/app/storefront/build/README.md
+++ b/src/Storefront/Resources/app/storefront/build/README.md
@@ -46,6 +46,13 @@ The Vite dev server:
 - exposes `/theme-scss/all.css` for theme styles in dev
 - serves component style files via `/__sw-comp-css/...`
 
+Environment overrides:
+
+- `STOREFRONT_VITE_PORT` - changes the Vite port (default `5175`)
+- `STOREFRONT_VITE_HOST` - bind host for Vite (default `localhost`)
+- `STOREFRONT_VITE_ORIGIN` - absolute URL used in `storefront_components.dev.json`
+  (useful in Docker/WSL/remote setups, e.g. `http://host.docker.internal:5175`)
+
 When the dev server stops, Shopware falls back to production assets/import map.
 
 ## File map

--- a/src/Storefront/Resources/app/storefront/build/vite/dev-import-map-plugin.test.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/dev-import-map-plugin.test.ts
@@ -24,7 +24,7 @@ function resolveHook<T extends (...args: never[]) => unknown>(
     return hook?.handler;
 }
 
-function createMockServer(port: number): MockServer {
+function createMockServer(port: number, origin?: string): MockServer {
     const watcher = new EventEmitter() as EventEmitter & { add: ReturnType<typeof vi.fn> };
     watcher.add = vi.fn();
 
@@ -42,7 +42,7 @@ function createMockServer(port: number): MockServer {
 
     const server = {
         config: {
-            server: { port },
+            server: { port, origin },
             logger: {
                 info: vi.fn(),
                 warn: vi.fn(),
@@ -251,5 +251,45 @@ describe('devImportMapPlugin', () => {
         expect(next).toHaveBeenCalledOnce();
         expect(res.headers['Content-Type']).toBeUndefined();
         expect(res.body).toBe('');
+    });
+
+    it('prefers configured Vite origin for dev map URLs', async () => {
+        const pluginRoot = path.join(fixtureRoot, 'fourth-project');
+        const viteRoot = path.join(pluginRoot, 'src/Storefront/Resources/app/storefront');
+        const componentsRoot = path.join(pluginRoot, 'src/Storefront/Resources/views/components');
+        const varRoot = path.join(pluginRoot, 'var');
+        fs.mkdirSync(path.join(viteRoot, 'src'), { recursive: true });
+        fs.mkdirSync(path.join(componentsRoot, 'Sw/Header'), { recursive: true });
+        fs.mkdirSync(varRoot, { recursive: true });
+
+        fs.writeFileSync(path.join(viteRoot, 'src/shopware.ts'), 'export const test = true;');
+        fs.writeFileSync(path.join(componentsRoot, 'Sw/Header/Navbar.css'), '.navbar { color: red; }');
+        fs.writeFileSync(path.join(varRoot, 'plugins.json'), JSON.stringify({
+            Storefront: {
+                basePath: 'src/Storefront',
+                technicalName: 'storefront',
+            },
+        }));
+        fs.writeFileSync(path.join(varRoot, 'theme-files.json'), JSON.stringify({ themeId: 'test-theme-id' }));
+
+        const plugin = devImportMapPlugin(pluginRoot);
+        const server = createMockServer(5183, 'http://host.docker.internal:5183/');
+        (resolveHook(plugin.configResolved) as ((...args: unknown[]) => unknown) | undefined)?.call({}, { root: viteRoot } as never);
+        (resolveHook(plugin.configureServer) as ((...args: unknown[]) => unknown) | undefined)?.call({}, server);
+        server.httpServer.emit('listening');
+
+        const flagFile = path.join(pluginRoot, 'var/cache/storefront_components.dev.json');
+        await waitUntil(() => {
+            expect(fs.existsSync(flagFile)).toBe(true);
+        });
+
+        const devMap = JSON.parse(fs.readFileSync(flagFile, 'utf-8')) as {
+            imports: Record<string, string>;
+            styles: string[];
+        };
+
+        expect(devMap.imports['shopware']).toBe('http://host.docker.internal:5183/src/shopware.ts');
+        expect(devMap.styles).toContain('http://host.docker.internal:5183/theme-scss/all.css');
+        expect(devMap.styles).toContain('http://host.docker.internal:5183/__sw-comp-css/Sw/Header/Navbar.css');
     });
 });

--- a/src/Storefront/Resources/app/storefront/build/vite/dev-import-map-plugin.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/dev-import-map-plugin.ts
@@ -79,6 +79,15 @@ export function devImportMapPlugin(projectRoot: string, scssLoadPaths: string[] 
     const flagFile = path.join(projectRoot, 'var/cache/storefront_components.dev.json');
     let viteRoot = '';
     const resolveBundleBasePath = (basePath?: string): string => path.resolve(projectRoot, basePath ?? '');
+    const resolveDevOrigin = (server: ViteDevServer): string => {
+        const configuredOrigin = server.config.server.origin;
+        if (configuredOrigin) {
+            return configuredOrigin.replace(/\/$/, '');
+        }
+
+        const port = server.config.server.port ?? 5175;
+        return `http://localhost:${port}`;
+    };
 
     const cleanup = (): void => {
         try {
@@ -330,8 +339,7 @@ export function devImportMapPlugin(projectRoot: string, scssLoadPaths: string[] 
             });
 
             const write = (): void => {
-                const port = server.config.server.port ?? 5175;
-                const origin = `http://localhost:${port}`;
+                const origin = resolveDevOrigin(server);
                 const imports: Record<string, string> = {};
 
                 // shopware runtime module — lives inside the Vite root so it

--- a/src/Storefront/Resources/app/storefront/vite.components.config.mts
+++ b/src/Storefront/Resources/app/storefront/vite.components.config.mts
@@ -33,6 +33,9 @@ const scssLoadPaths = [
     path.resolve(import.meta.dirname, 'src/scss'),
 ];
 
+const storefrontViteOrigin = process.env.STOREFRONT_VITE_ORIGIN;
+const storefrontViteHost = process.env.STOREFRONT_VITE_HOST;
+
 export default defineConfig(async ({ command }): Promise<UserConfig> => {
     const jsEntries = await buildComponentEntries();
     const { scssEntries, plainCssEntries, plainCssShims } = await buildComponentStyleEntries();
@@ -121,6 +124,8 @@ export default defineConfig(async ({ command }): Promise<UserConfig> => {
         },
         server: {
             port: Number(process.env.STOREFRONT_VITE_PORT ?? 5175),
+            host: storefrontViteHost ?? 'localhost',
+            origin: storefrontViteOrigin,
             cors: true,
             fs: {
                 // Allow Vite to serve component sources from any bundle under


### PR DESCRIPTION
### 1. Why is this change necessary?

When using the Docker image without the dev-containers feature, the dev-server port is not available.

### 2. What does this change do, exactly?

* Expose port for the dev-server in the Docker file.
* Make the host and origin for the dev-server configurable via an env variable.
