### PR TITLE
fix(administration): keep sw-plugin-dev.json out of build output dir

### DIFF
--- a/src/Administration/Resources/.gitignore
+++ b/src/Administration/Resources/.gitignore
@@ -8,3 +8,4 @@ test/unit/coverage
 test/e2e/reports
 selenium-debug.log
 .tmp
+sw-plugin-dev.json

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -190,10 +190,10 @@ const main = async () => {
             }
         });
 
-        fs.writeFileSync(
-            path.resolve(__dirname, '../../../public/administration/sw-plugin-dev.json'),
-            JSON.stringify(swPluginDevJsonData),
-        );
+        // Write outside of public/administration on purpose: a parallel production
+        // build empties that directory (emptyOutDir), which would delete this file
+        // out from under the running watcher.
+        fs.writeFileSync(path.resolve(__dirname, '../../../sw-plugin-dev.json'), JSON.stringify(swPluginDevJsonData));
 
         // Start dev servers
         for (let i = 0; i < extensionEntries.length; i++) {

--- a/src/Administration/Resources/app/administration/build/vite-plugins/asset-plugin/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/asset-plugin/index.ts
@@ -61,11 +61,10 @@ export default function viteAssetPlugin(isProd: boolean, adminDir: string, exten
                 }
 
                 // Add a custom route for sw-plugin-dev.json
+                // Read from Resources/ (not public/administration/), since a parallel
+                // production build empties public/administration and would delete the file.
                 if (originalUrl.endsWith('sw-plugin-dev.json')) {
-                    const pluginDevContent = fs.readFileSync(
-                        path.resolve(adminDir, '../../public/administration/sw-plugin-dev.json'),
-                        'utf8',
-                    );
+                    const pluginDevContent = fs.readFileSync(path.resolve(adminDir, '../../sw-plugin-dev.json'), 'utf8');
 
                     res.writeHead(200, {
                         'Content-Type': 'application/json',


### PR DESCRIPTION
### 1. Why is this change necessary?

When the admin watcher (`composer watch:admin`) runs at the same time as a production admin build (`composer build:js:admin`), the watcher breaks: extensions stop loading because `sw-plugin-dev.json` disappears.

Root cause: the watcher writes `sw-plugin-dev.json` into `Resources/public/administration/`, but that directory is the production build's `outDir` with `emptyOutDir: true` (both the main admin build in `vite.config.mts` and the per-plugin builds in `plugins.vite.ts`). A parallel build empties the directory and deletes the file out from under the running dev server. The watcher only writes the file once at startup, so it never comes back, and `asset-plugin` then 500s trying to read the missing file.

### 2. What does this change do, exactly?

Moves `sw-plugin-dev.json` one level up, to `Resources/sw-plugin-dev.json` — outside any build output directory — so `emptyOutDir` can no longer wipe it.

- `plugins.vite.ts`: the watcher writes the file to the new path.
- `asset-plugin/index.ts`: the dev middleware reads from the new path. The browser-facing URL (`./sw-plugin-dev.json`) is unchanged, since the middleware still intercepts it.
- `Resources/.gitignore`: adds an explicit `sw-plugin-dev.json` rule (the old location was covered by the blanket `public/` ignore; the new one is not).

### 3. Describe each step to reproduce the issue or behaviour.

1. Start the admin watcher: `composer watch:admin`.
2. While it is running, in parallel run a production admin build: `composer build:js:admin`.
3. The build empties `Resources/public/administration/`, deleting `sw-plugin-dev.json`.
4. Reload the administration — extensions fail to load and the dev server errors reading the missing file.

With this change, the file lives outside the build output dir, so the parallel build no longer deletes it.

### 4. Please link to the relevant issues (if any).

<!-- none -->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them