### PR TITLE
perf: Do not load hreflang information for ESI subrequests

### DIFF
--- a/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
+++ b/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
@@ -42,13 +42,13 @@ class TemplateDataSubscriber implements EventSubscriberInterface
     public function addHreflang(StorefrontRenderEvent $event): void
     {
         $request = $event->getRequest();
-        $route = $request->attributes->get('_route');
 
-        if ($route === null) {
+        if ($request->attributes->getBoolean('_esi')) {
             return;
         }
 
-        if ($request->attributes->getBoolean('_esi')) {
+        $route = $request->attributes->get('_route');
+        if ($route === null) {
             return;
         }
 

--- a/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
+++ b/src/Storefront/Framework/Routing/TemplateDataSubscriber.php
@@ -48,6 +48,10 @@ class TemplateDataSubscriber implements EventSubscriberInterface
             return;
         }
 
+        if ($request->attributes->getBoolean('_esi')) {
+            return;
+        }
+
         $routeParams = $request->attributes->get('_route_params', []);
         $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
         $parameter = new HreflangLoaderParameter($route, $routeParams, $salesChannelContext, $route === 'frontend.home.page');

--- a/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/TemplateDataSubscriberTest.php
@@ -90,6 +90,24 @@ class TemplateDataSubscriberTest extends TestCase
         $this->subscriber->addHreflang($event);
     }
 
+    public function testAddHreflangSkippedForEsiRequest(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.header');
+        $request->attributes->set('_esi', true);
+
+        $event = new StorefrontRenderEvent(
+            'test',
+            [],
+            $request,
+            Generator::generateSalesChannelContext()
+        );
+
+        $this->hreflangLoader->expects($this->never())->method('load');
+
+        $this->subscriber->addHreflang($event);
+    }
+
     public function testAddHreflangWithValidRoute(): void
     {
         $request = new Request();


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the Hreflang information is also loaded for ESI subrequests. This is not needed, as it is only relevant in the `head` for the main request.

### 2. What does this change do, exactly?
Do not load the hreflang information for subrequests.

Note on BC, even if one would try to load hreflang information in a ESI request, it would require a custom implementation, as the current hreflang loader checks the current request, which is in the case of a ESI request the subrequest and not the main request.

I think therefore also no `RELEASE_INFO` is needed?

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
