### PR TITLE
ci: generalize phpunit-run composite and use it for php.yml unit/migration

### DIFF
--- a/.github/actions/phpunit-run/action.yaml
+++ b/.github/actions/phpunit-run/action.yaml
@@ -1,11 +1,17 @@
-name: "PHPUnit integration run"
-description: "Set up Shopware and run a single integration shard (path or testsuite), then upload results to Codecov"
+name: "PHPUnit run"
+description: "Set up Shopware and run a PHPUnit suite (integration shard or unit/migration), optionally with coverage, then upload to Codecov"
 author: "shopware AG"
 
 inputs:
   php-version:
-    required: true
+    default: "8.2"
     description: PHP version to set up
+  mysql-version:
+    default: "skip"
+    description: "setup-shopware mysql-version. 'skip' when the caller provides a database service; set a version to let setup-shopware provision MySQL."
+  keep-composer-tools:
+    default: "false"
+    description: Pass through to setup-shopware's keep-composer-tools
   test-path:
     default: ""
     description: "tests/integration path to run (mutually exclusive with test-testsuite)"
@@ -15,13 +21,22 @@ inputs:
   needs-opensearch:
     default: "false"
     description: "Wait for OpenSearch/Elasticsearch to be healthy before running (set for the Elasticsearch shard)"
-  codecov-token:
-    required: false
+  coverage:
+    default: "false"
+    description: "Run with cobertura coverage and upload it to Codecov"
+  coverage-flags:
     default: ""
-    description: "Codecov token for uploading test results (empty on fork PRs, where secrets are unavailable)"
+    description: "Codecov coverage flags (e.g. phpunit-unit)"
+  migration-coverage:
+    default: "false"
+    description: "Rewrite phpunit.xml.dist to scope coverage to the */Migration directories (migration suite)"
+  codecov-token:
+    default: ""
+    description: "Codecov token. Empty on fork PRs (secrets unavailable) or for callers that opt out of Codecov uploads."
 
 # Note: the caller controls feature flags via job-level env (e.g. FEATURE_ALL: major); the run steps below
-# inherit it, so this action stays flag-agnostic.
+# inherit it, so this action stays flag-agnostic. The caller must run actions/checkout before using this
+# local action, and provide a database (service container, or via mysql-version).
 runs:
   using: composite
   steps:
@@ -29,7 +44,8 @@ runs:
       uses: shopware/setup-shopware@main
       with:
         php-version: ${{ inputs.php-version }}
-        mysql-version: "skip"
+        mysql-version: ${{ inputs.mysql-version }}
+        keep-composer-tools: ${{ inputs.keep-composer-tools }}
         shopware-version: ${{ github.ref }}
         shopware-repository: ${{ github.repository }}
 
@@ -55,6 +71,12 @@ runs:
       shell: bash
       run: symfony server:start -d
 
+    - name: Scope coverage to migration directories
+      if: ${{ inputs.migration-coverage == 'true' }}
+      shell: bash
+      run: |
+          sed -i -e 's|<directory suffix=".php">src</directory>|<directory suffix=".php">src/Administration/Migration</directory><directory suffix=".php">src/Core/Migration</directory><directory suffix=".php">src/ElasticSearch/Migration</directory><directory suffix=".php">src/Storefront/Migration</directory>|' phpunit.xml.dist
+
     - name: Install Shopware
       shell: bash
       run: php src/Core/TestBootstrap.php
@@ -62,12 +84,21 @@ runs:
     - name: Run PHPUnit testsuite
       if: ${{ inputs.test-testsuite != '' }}
       shell: bash
-      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml --testsuite "${{ inputs.test-testsuite }}"
+      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} --testsuite "${{ inputs.test-testsuite }}"
 
     - name: Run PHPUnit path
       if: ${{ inputs.test-path != '' }}
       shell: bash
-      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml -- tests/integration/${{ inputs.test-path }}
+      run: php -d memory_limit=-1 vendor/bin/phpunit --log-junit junit.xml ${{ inputs.coverage == 'true' && '--coverage-cobertura coverage.xml' || '' }} -- tests/integration/${{ inputs.test-path }}
+
+    - name: Upload coverage to Codecov
+      if: ${{ inputs.coverage == 'true' && inputs.codecov-token != '' }}
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      env:
+        CODECOV_TOKEN: ${{ inputs.codecov-token }}
+      with:
+        files: coverage.xml
+        flags: ${{ inputs.coverage-flags }}
 
     - name: Upload test results to Codecov
       # skip when no token: fork PRs (secrets unavailable) and callers that opt out of Test Analytics

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -221,6 +221,7 @@ jobs:
       ADMIN_OPENSEARCH_URL: 127.0.0.1:9200
       BLUE_GREEN_DEPLOYMENT: 1
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      FEATURE_ALL: ${{ matrix.suite == 'migration' && 'major' || '' }}
 
     services:
       elasticsearch:
@@ -231,49 +232,30 @@ jobs:
           OPENSEARCH_INITIAL_ADMIN_PASSWORD: "yourStrongPassword123!"
         ports:
           - "9200:9200"
+      database:
+        # Run the migration suite against MySQL 8.4, where restrict_fk_on_non_standard_key
+        # defaults to ON. This makes the install/migrate step reject any foreign key that
+        # references a non-unique key (the MySQL 8.4 disaster-recovery import failure),
+        # before tests even run. Other suites stay on MySQL 8.0.
+        image: ${{ matrix.suite == 'migration' && 'mysql:8.4' || 'mysql:8.0' }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: shopware
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping || mariadb-admin ping"
 
     steps:
-      - name: Setup Shopware
-        uses: shopware/setup-shopware@main
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ./.github/actions/phpunit-run
         with:
-          php-version: 8.2
-          shopware-version: ${{ github.ref }}
-          shopware-repository: ${{ github.repository }}
-          keep-composer-tools: true
-          # Run the migration suite against MySQL 8.4, where restrict_fk_on_non_standard_key
-          # defaults to ON. This makes the install/migrate step reject any foreign key that
-          # references a non-unique key (the MySQL 8.4 disaster-recovery import failure),
-          # before tests even run. Other suites keep the runner's builtin MySQL.
-          mysql-version: ${{ matrix.suite == 'migration' && 'mysql:8.4' || 'builtin' }}
-
-      - name: Start Webserver
-        run: symfony server:start -d
-
-      - name: Migration test suite setup
-        if: ${{ matrix.suite == 'migration' }}
-        run: |
-          sed -i -e 's|<directory suffix=".php">src</directory>|<directory suffix=".php">src/Administration/Migration</directory><directory suffix=".php">src/Core/Migration</directory><directory suffix=".php">src/ElasticSearch/Migration</directory><directory suffix=".php">src/Storefront/Migration</directory>|' phpunit.xml.dist
-          echo "FEATURE_ALL=major" >> $GITHUB_ENV
-
-      - name: Install Shopware
-        run: php src/Core/TestBootstrap.php
-
-      - name: Run PHPUnit with coverage
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "${{ matrix.suite }}" --coverage-cobertura coverage.xml --log-junit junit.xml
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: coverage.xml
-          flags: phpunit-${{ matrix.suite }}
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # 1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          test-testsuite: ${{ matrix.suite }}
+          keep-composer-tools: "true"
+          coverage: "true"
+          coverage-flags: phpunit-${{ matrix.suite }}
+          migration-coverage: ${{ matrix.suite == 'migration' }}
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   license-check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
⚠️ Based against  #17766 and to be rebased to trunk once parent branch approved (this one is not vital, just best practice)

### 1. Why is this change necessary?
Follow-up to #17766. 

That PR introduced the `phpunit-run` composite for the integration jobs, let's use it for unit/migration suites

### 2. What does this change do, exactly?
  - Generalized `phpunit-run` with `coverage` / `coverage-flags`, `keep-composer-tools`, `migration-coverage` (the phpunit.xml.dist coverage-path rewrite) and `mysql-version` inputs. Integration callers are unchanged (new inputs default off).
  - php.yml `unit`/`migration` jobs now use the composite. `FEATURE_ALL=major` for migration moved to conditional job env.
  - **DB model change**: php.yml now uses a `mysql:8.0` service container with `mysql-version: skip` (same as integration), instead of setup-shopware-provisioned MySQL. Same `DATABASE_URL`, so transparent 

### 3. Describe each step to reproduce the issue or behaviour.

Run CI


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
