### PR TITLE
fix: acceptance Slack status job aggregation

### DIFF
--- a/.github/bin/acceptance-slack-status.bash
+++ b/.github/bin/acceptance-slack-status.bash
@@ -20,7 +20,7 @@ jobs="[]"
 page=1
 while true; do
   response=$(gh api "/repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100&page=${page}")
-  jobs=$(jq --argjson new "$(jq '.jobs' <<<"$response")" '. + $new' <<<"$jobs")
+  jobs=$(jq -s '.[0] + .[1].jobs' <(printf '%s\n' "$jobs") <(printf '%s\n' "$response"))
 
   if [ "$(jq '.jobs | length' <<<"$response")" -lt 100 ]; then
     break


### PR DESCRIPTION
## What changed

Updated `.github/bin/acceptance-slack-status.bash` so paginated GitHub Actions job data is merged by streaming JSON into `jq` via stdin/file descriptors instead of passing the next page's `.jobs` array through `--argjson` as a command-line argument.

## Root cause

The nightly `acceptance / acceptance-status-check` job failed in run `28211936282` while executing `.github/bin/acceptance-slack-status.bash`:

```text
.github/bin/acceptance-slack-status.bash: line 23: /usr/bin/jq: Argument list too long
```

The script accumulated workflow jobs page by page with:

```bash
jq --argjson new "$(jq '.jobs' <<<"$response")" ...
```

For large nightly runs, the serialized jobs page can exceed the OS command-line argument size limit before `jq` starts. This causes the Slack status reporting job to fail even though the job data itself is valid JSON.

## Impact

The acceptance Slack status report can now handle larger workflow runs without depending on command-line argument limits. The reporting behavior and output ordering remain unchanged.

## Validation

- `bash -n .github/bin/acceptance-slack-status.bash`
- Local oversized-data harness with large paginated mocked `gh api` responses and stubbed `curl`
- Dry-run against the real failed run `28211936282` with `curl` stubbed; it produced the expected acceptance status message without posting to Slack