### PR TITLE
fix(administration): center extension permissions modal image

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-permissions-modal/sw-extension-permissions-modal.scss
@@ -10,7 +10,7 @@
         padding: 0 var(--scale-size-24);
 
         img {
-            margin-bottom: var(--scale-size-24);
+            margin: 0 auto var(--scale-size-24) auto;
         }
     }
 


### PR DESCRIPTION
| Before |After|
| -------- | ------- |
|<img width="597" height="579" alt="before" src="https://github.com/user-attachments/assets/3ebbb5b3-d0b4-49c1-92e3-0439108d22f9" />|<img width="611" height="564" alt="after" src="https://github.com/user-attachments/assets/5c01100e-cb36-4e93-abb1-1861876ebee7" />|