### PR TITLE
fix: admin service activate and deactivate

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/index.ts
@@ -107,12 +107,12 @@ export default Shopware.Component.wrapComponentConfig({
             this.isLoading = true;
 
             try {
-                const extensionService = Shopware.Service('shopwareExtensionService');
+                const servicesService = Shopware.Service('shopwareServicesService');
 
                 if (active) {
-                    await extensionService.activateExtension(this.service.name, 'app');
+                    await servicesService.activateService(this.service.name);
                 } else {
-                    await extensionService.deactivateExtension(this.service.name, 'app');
+                    await servicesService.deactivateService(this.service.name);
                 }
 
                 this._reloadPage();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.spec.js
@@ -30,12 +30,9 @@ const createService = (overrides = {}) => ({
 
 describe('src/module/sw-settings-services/component/sw-settings-services-service-card.ts', () => {
     beforeAll(() => {
-        Shopware.Service().register('shopwareExtensionService', () => ({
-            activateExtension: jest.fn(),
-            deactivateExtension: jest.fn(),
-        }));
-
         Shopware.Service().register('shopwareServicesService', () => ({
+            activateService: jest.fn(),
+            deactivateService: jest.fn(),
             getCategorizedPermissions: jest.fn(),
         }));
     });
@@ -138,7 +135,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
     });
 
     it('opens the deactivation modal and deactivates a service', async () => {
-        Shopware.Service('shopwareExtensionService').deactivateExtension.mockImplementationOnce(() => {
+        Shopware.Service('shopwareServicesService').deactivateService.mockImplementationOnce(() => {
             return Promise.resolve();
         });
 
@@ -200,7 +197,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
 
         await deactivateButton.trigger('click');
 
-        expect(Shopware.Service('shopwareExtensionService').deactivateExtension).toHaveBeenCalledWith('service-name', 'app');
+        expect(Shopware.Service('shopwareServicesService').deactivateService).toHaveBeenCalledWith('service-name');
         expect(card.vm._reloadPage).toHaveBeenCalled();
     });
 
@@ -250,7 +247,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
     });
 
     it('activates a service', async () => {
-        Shopware.Service('shopwareExtensionService').activateExtension.mockImplementationOnce(() => {
+        Shopware.Service('shopwareServicesService').activateService.mockImplementationOnce(() => {
             return Promise.resolve();
         });
 
@@ -307,7 +304,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
             setTimeout(resolve, 32);
         });
 
-        expect(Shopware.Service('shopwareExtensionService').activateExtension).toHaveBeenCalledWith('service-name', 'app');
+        expect(Shopware.Service('shopwareServicesService').activateService).toHaveBeenCalledWith('service-name');
         expect(card.vm._reloadPage).toHaveBeenCalled();
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.spec.js
@@ -183,6 +183,30 @@ describe('src/module/sw-settings-services/service/shopware-services-service.ts',
         expect(clientMock.history.post[0].url).toBe(`services/${action}`);
     });
 
+    it.each([
+        [
+            'activate',
+            'activateService',
+        ],
+        [
+            'deactivate',
+            'deactivateService',
+        ],
+    ])('%s a service', async (action, methodName) => {
+        const client = createHTTPClient();
+        const clientMock = new MockAdapter(client);
+        const loginService = createLoginService(client, Shopware.Context.api);
+        const systemConfigService = new SystemConfigApiService(client, loginService);
+        const shopwareServicesService = new ShopwareServicesService(client, loginService, systemConfigService);
+
+        clientMock.onPost(`service/${action}/MyCoolService`).reply(204);
+
+        await shopwareServicesService[methodName]('MyCoolService');
+
+        expect(clientMock.history.post).toHaveLength(1);
+        expect(clientMock.history.post[0].url).toBe(`service/${action}/MyCoolService`);
+    });
+
     it('returns categorized permissions', async () => {
         const client = createHTTPClient();
         const clientMock = new MockAdapter(client);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/service/shopware-services.service.ts
@@ -127,6 +127,26 @@ export default class ShopwareServicesService extends ApiService {
         );
     }
 
+    activateService(serviceName: string): Promise<void> {
+        return this.httpClient.post(
+            `service/activate/${serviceName}`,
+            {},
+            {
+                headers: this.getBasicHeaders(),
+            },
+        );
+    }
+
+    deactivateService(serviceName: string): Promise<void> {
+        return this.httpClient.post(
+            `service/deactivate/${serviceName}`,
+            {},
+            {
+                headers: this.getBasicHeaders(),
+            },
+        );
+    }
+
     getCategorizedPermissions(serviceName: string): Promise<{ permissions: CategorizedPermissions }> {
         return this.httpClient
             .get(`services/categorized-permissions/${serviceName}`, {

--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Service\Api;
 
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\Privileges\Utils;
 use Shopware\Core\Framework\Context;
@@ -61,13 +62,12 @@ class ServiceController
         name: 'api.service.activate',
         defaults: [
             'auth_required' => true,
-            PlatformRequest::ATTRIBUTE_ACL => ['api_service_toggle'],
         ],
         methods: [Request::METHOD_POST]
     )]
     public function activate(string $serviceName, Context $context): JsonResponse
     {
-        $this->extractIntegrationIdOrFail($context);
+        $this->validateActivationAccess($context);
 
         $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
             $this->serviceLifecycle->activate($serviceName, $context);
@@ -81,13 +81,12 @@ class ServiceController
         name: 'api.service.deactivate',
         defaults: [
             'auth_required' => true,
-            PlatformRequest::ATTRIBUTE_ACL => ['api_service_toggle'],
         ],
         methods: [Request::METHOD_POST]
     )]
     public function deactivate(string $serviceName, Context $context): JsonResponse
     {
-        $this->extractIntegrationIdOrFail($context);
+        $this->validateActivationAccess($context);
 
         $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
             $this->serviceLifecycle->deactivate($serviceName, $context);
@@ -216,6 +215,28 @@ class ServiceController
         \assert($source instanceof AdminApiSource);
 
         return $this->serviceStorage->findByIntegrationId((string) $source->getIntegrationId(), $context);
+    }
+
+    private function validateActivationAccess(Context $context): void
+    {
+        $source = $context->getSource();
+        if (!$source instanceof AdminApiSource) {
+            throw ServiceException::updateRequiresAdminApiSource($source);
+        }
+
+        if ($source->getIntegrationId() !== null) {
+            if ($context->isAllowed('api_service_toggle')) {
+                return;
+            }
+
+            throw ApiException::missingPrivileges(['api_service_toggle']); // @phpstan-ignore shopware.domainException (Same exception as route ACL listener)
+        }
+
+        if ($context->isAllowed('system.plugin_maintain')) {
+            return;
+        }
+
+        throw ApiException::missingPrivileges(['system.plugin_maintain']); // @phpstan-ignore shopware.domainException (Same exception as route ACL listener)
     }
 
     private function extractIntegrationIdOrFail(Context $context): string

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleEntity;
+use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\ShopApiSource;
 use Shopware\Core\Framework\App\AppCollection;
@@ -122,6 +123,24 @@ class ServiceControllerTest extends TestCase
         $controller->triggerUpdate($context);
     }
 
+    public function testActivateThrownExceptionIfInvalidName(): void
+    {
+        static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
+
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
+
+        $source = new AdminApiSource('AABB', 'CCDD');
+        $source->setPermissions(['api_service_toggle']);
+        $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())
+            ->method('activate')
+            ->with('invalidService', $context)
+            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
+
+        $controller->activate('invalidService', $context);
+    }
+
     public function testActivateThrownExceptionIfNotApiSource(): void
     {
         $source = new ShopApiSource('AABB');
@@ -134,9 +153,9 @@ class ServiceControllerTest extends TestCase
         $controller->activate('MyCoolService', $context);
     }
 
-    public function testActivateThrownExceptionIfNoIntegrationId(): void
+    public function testActivateThrownExceptionIfAdminUserCannotMaintainPlugins(): void
     {
-        static::expectExceptionObject(ServiceException::updateRequiresIntegration());
+        static::expectExceptionObject(ApiException::missingPrivileges(['system.plugin_maintain']));
 
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
@@ -146,21 +165,16 @@ class ServiceControllerTest extends TestCase
         $controller->activate('MyCoolService', $context);
     }
 
-    public function testActivateThrownExceptionIfInvalidName(): void
+    public function testActivateThrownExceptionIfIntegrationCannotToggleServices(): void
     {
-        static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
+        static::expectExceptionObject(ApiException::missingPrivileges(['api_service_toggle']));
 
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
-        $source = new AdminApiSource('AABB', 'CCDD');
+        $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->serviceLifecycle->expects($this->once())
-            ->method('activate')
-            ->with('invalidService', $context)
-            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
-
-        $controller->activate('invalidService', $context);
+        $controller->activate('MyCoolService', $context);
     }
 
     public function testActivate(): void
@@ -169,10 +183,42 @@ class ServiceControllerTest extends TestCase
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
+        $source->setPermissions(['api_service_toggle']);
         $context = Context::createDefaultContext($source);
 
         $this->serviceLifecycle->expects($this->once())->method('activate')->with('MyCoolService', $context);
         $controller->activate('MyCoolService', $context);
+    }
+
+    public function testAdminActivateUsesSameAction(): void
+    {
+        $this->app->setActive(false);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
+
+        $source = new AdminApiSource('AABB');
+        $source->setPermissions(['system.plugin_maintain']);
+        $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())->method('activate')->with('MyCoolService', $context);
+        $controller->activate('MyCoolService', $context);
+    }
+
+    public function testDeactivateThrownExceptionIfInvalidName(): void
+    {
+        static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
+
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
+
+        $source = new AdminApiSource('AABB', 'CCDD');
+        $source->setPermissions(['api_service_toggle']);
+        $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())
+            ->method('deactivate')
+            ->with('invalidService', $context)
+            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
+
+        $controller->deactivate('invalidService', $context);
     }
 
     public function testDeactivateThrownExceptionIfNotApiSource(): void
@@ -184,12 +230,12 @@ class ServiceControllerTest extends TestCase
 
         $context = Context::createDefaultContext($source);
 
-        $controller->activate('MyCoolService', $context);
+        $controller->deactivate('MyCoolService', $context);
     }
 
-    public function testDeactivateThrownExceptionIfNoIntegrationId(): void
+    public function testDeactivateThrownExceptionIfAdminUserCannotMaintainPlugins(): void
     {
-        static::expectExceptionObject(ServiceException::updateRequiresIntegration());
+        static::expectExceptionObject(ApiException::missingPrivileges(['system.plugin_maintain']));
 
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
@@ -199,21 +245,16 @@ class ServiceControllerTest extends TestCase
         $controller->deactivate('MyCoolService', $context);
     }
 
-    public function testDeactivateThrownExceptionIfInvalidName(): void
+    public function testDeactivateThrownExceptionIfIntegrationCannotToggleServices(): void
     {
-        static::expectExceptionObject(ServiceException::notFound('name', 'invalidService'));
+        static::expectExceptionObject(ApiException::missingPrivileges(['api_service_toggle']));
 
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
-        $source = new AdminApiSource('AABB', 'CCDD');
+        $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->serviceLifecycle->expects($this->once())
-            ->method('deactivate')
-            ->with('invalidService', $context)
-            ->willThrowException(ServiceException::notFound('name', 'invalidService'));
-
-        $controller->deactivate('invalidService', $context);
+        $controller->deactivate('MyCoolService', $context);
     }
 
     public function testDeactivate(): void
@@ -222,6 +263,20 @@ class ServiceControllerTest extends TestCase
         $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
+        $source->setPermissions(['api_service_toggle']);
+        $context = Context::createDefaultContext($source);
+
+        $this->serviceLifecycle->expects($this->once())->method('deactivate')->with('MyCoolService', $context);
+        $controller->deactivate('MyCoolService', $context);
+    }
+
+    public function testAdminDeactivateUsesSameAction(): void
+    {
+        $this->app->setActive(true);
+        $controller = new ServiceController(new ServiceStorage($this->appRepo), $this->bus, $this->serviceLifecycle, $this->manager);
+
+        $source = new AdminApiSource('AABB');
+        $source->setPermissions(['system.plugin_maintain']);
         $context = Context::createDefaultContext($source);
 
         $this->serviceLifecycle->expects($this->once())->method('deactivate')->with('MyCoolService', $context);


### PR DESCRIPTION
### 1. Why is this change necessary?

Service-backed apps shown in Settings > Services were toggled through the generic extension activation endpoints. Those endpoints look up extensions by app/plugin source and fail for service-backed apps due to recent refactors

### 2. What does this change do, exactly?

The Services Administration card now uses the Shopware services API client for activating and deactivating services.

The service API keeps the existing endpoints:

- `POST /api/service/activate/{serviceName}`
- `POST /api/service/deactivate/{serviceName}`

Those actions now perform the required access check directly:

- Admin users need `system.plugin_maintain`.
- Integrations need `api_service_toggle`.


### 3. Describe each step to reproduce the issue or behaviour.

1. Install a service-backed app such as `NormalService`.
2. Open Settings > Services in the Administration.
3. Try to deactivate the service card.
4. The Admin previously called the generic extension deactivate endpoint and failed with `Could not find extension with technical name "NormalService"`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
