### PR TITLE
chore: update sw-impact CI workflow to 0.3.0 release

### DIFF
--- a/.github/workflows/sw-impact.yml
+++ b/.github/workflows/sw-impact.yml
@@ -43,7 +43,7 @@ jobs:
     continue-on-error: true
     timeout-minutes: 15
     env:
-      SW_IMPACT_ARCHIVE_URL: https://github.com/shopware/sw-impact/releases/download/v0.2.0/sw-impact-x86_64-unknown-linux-gnu.tar.gz
+      SW_IMPACT_ARCHIVE_URL: https://github.com/shopware/sw-impact/releases/download/v0.3.0/sw-impact-x86_64-unknown-linux-gnu.tar.gz
 
     steps:
       - name: Define sw-impact paths


### PR DESCRIPTION
Update to new version of https://github.com/shopware/sw-impact , now with Vue prop extraction and break reporting, means Vue components should now be ~~fully~~ mostly checked (except their twig templates and advanced computed declarations with getters and setters).