### PR TITLE
fix: index products for sales channel languages inheriting an unindexed parent (backport: 6.6.x)

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
@@ -223,11 +224,14 @@ class SearchKeywordUpdater implements ResetInterface
     {
         $definition = $this->productRepository->getDefinition();
 
-        // Filter for products that have translations in the given language
-        // if there are no translations, we copy the keywords of the parent language without fetching the product
+        // Filter for products that have translations anywhere in the language inheritance chain
+        // (current language, its parent and the system default). A sales channel language may
+        // inherit from a parent language that is not itself indexed (e.g. de-CH inheriting de-DE),
+        // in which case the carried-over keywords of the parent language are not available and the
+        // product must be fetched here so its inherited translation can be indexed.
         $filters = [
-            new EqualsFilter('translations.languageId', $context->getLanguageId()),
-            new EqualsFilter('parent.translations.languageId', $context->getLanguageId()),
+            new EqualsAnyFilter('translations.languageId', $context->getLanguageIdChain()),
+            new EqualsAnyFilter('parent.translations.languageId', $context->getLanguageIdChain()),
         ];
 
         foreach ($accessors as $accessor) {

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
 
 /**
  * @internal
@@ -162,6 +163,59 @@ class SearchKeywordUpdaterTest extends TestCase
             ]
         );
         $this->assertKeywords($ids->get('1000'), $ids->get('language'), []);
+    }
+
+    /**
+     * Regression test for #13330: a sales channel language (de-CH) that inherits from a parent
+     * language (de-DE) which is itself not assigned to any sales channel. Products that only have a
+     * translation in the parent language were missing from product_search_keyword for the inheriting
+     * language, so they could not be found in the storefront search.
+     */
+    public function testItGeneratesKeywordsForLanguageInheritingFromUnindexedParent(): void
+    {
+        $ids = new IdsCollection();
+        $context = Context::createDefaultContext();
+        $deDeId = $this->getDeDeLanguageId();
+
+        // Create de-CH inheriting from de-DE
+        $languageRepo = static::getContainer()->get('language.repository');
+        $languageRepo->create([
+            [
+                'id' => $ids->get('de-CH'),
+                'name' => 'German (Switzerland)',
+                'localeId' => $this->getLocaleIdByIsoCode('de-CH'),
+                'parentId' => $deDeId,
+            ],
+        ], $context);
+
+        // Make de-CH a sales channel language and remove de-DE from sales channels, so the parent
+        // language (de-DE) is never indexed on its own and cannot provide carried-over keywords.
+        $this->salesChannelLanguageRepository->create([
+            ['salesChannelId' => TestDefaults::SALES_CHANNEL, 'languageId' => $ids->get('de-CH')],
+        ], $context);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('languageId', $deDeId));
+        /** @var list<array<string, string>> $deDeSalesChannelLanguageIds */
+        $deDeSalesChannelLanguageIds = $this->salesChannelLanguageRepository->searchIds($criteria, $context)->getIds();
+        $this->salesChannelLanguageRepository->delete($deDeSalesChannelLanguageIds, $context);
+
+        // Product only has a de-DE translation besides the required system default name.
+        $this->productRepository->create([
+            (new ProductBuilder($ids, '1000'))
+                ->price(10)
+                ->name('Test product')
+                ->translation($deDeId, 'name', 'Test produkt')
+                ->build(),
+        ], $context);
+
+        // de-CH inherits the de-DE translation, so its keywords must be derived from "Test produkt".
+        $this->assertKeywords($ids->get('1000'), $ids->get('de-CH'), [
+            '1000', // productNumber
+            'produkt', // part of inherited de-DE name
+            'test', // part of inherited de-DE name
+            'test produkt', // inherited de-DE name
+        ]);
     }
 
     /**

--- a/tests/unit/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/unit/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\DataAbstractionLayer;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\SearchKeyword\ProductSearchKeywordAnalyzerInterface;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[CoversClass(SearchKeywordUpdater::class)]
+class SearchKeywordUpdaterTest extends TestCase
+{
+    public function testBuildCriteriaFiltersTranslationsByLanguageChain(): void
+    {
+        /** @var StaticEntityRepository<ProductCollection> $productRepository */
+        $productRepository = new StaticEntityRepository([], new ProductDefinition());
+        $updater = new SearchKeywordUpdater(
+            $this->createMock(Connection::class),
+            $this->createMock(EntityRepository::class),
+            $productRepository,
+            $this->createMock(ProductSearchKeywordAnalyzerInterface::class)
+        );
+
+        $chain = [Uuid::randomHex(), Uuid::randomHex(), Defaults::LANGUAGE_SYSTEM];
+        $context = new Context(new SystemSource(), [], Defaults::CURRENCY, $chain);
+
+        $criteria = new Criteria();
+        $method = new \ReflectionMethod($updater, 'buildCriteria');
+        // no searchable association accessors: this isolates the translation language filters,
+        // which are the product fields the fix changes, without resolving association definitions
+        $method->invoke($updater, [], $criteria, $context);
+
+        $translationFilters = [];
+        foreach ($this->flattenFilters($criteria->getFilters()) as $filter) {
+            if ($filter instanceof EqualsAnyFilter
+                && \in_array($filter->getField(), ['translations.languageId', 'parent.translations.languageId'], true)) {
+                $translationFilters[$filter->getField()] = $filter->getValue();
+            }
+        }
+
+        // both the product and the parent translations must be matched against the full
+        // language inheritance chain, not just the current sales channel language
+        static::assertArrayHasKey('translations.languageId', $translationFilters);
+        static::assertArrayHasKey('parent.translations.languageId', $translationFilters);
+        static::assertSame($chain, $translationFilters['translations.languageId']);
+        static::assertSame($chain, $translationFilters['parent.translations.languageId']);
+    }
+
+    /**
+     * @param Filter[] $filters
+     *
+     * @return Filter[]
+     */
+    private function flattenFilters(array $filters): array
+    {
+        $result = [];
+        foreach ($filters as $filter) {
+            $result[] = $filter;
+            if ($filter instanceof MultiFilter) {
+                $result = array_merge($result, $this->flattenFilters($filter->getQueries()));
+            }
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
Backport of #17708 to `6.6.x`. Relates to #13330.

## Problem
When a sales channel language inherits from a parent language that is **not itself assigned to any sales channel** (e.g. `de-CH` inheriting `de-DE`), products whose translations only exist in the parent language were never written to `product_search_keyword` for the child language, so they could not be found in the storefront search for that sales channel.

## Fix
`SearchKeywordUpdater::buildCriteria()` matched only the exact sales channel language:

```php
new EqualsFilter('translations.languageId', $context->getLanguageId()),
new EqualsFilter('parent.translations.languageId', $context->getLanguageId()),
```

`update()` only processes languages assigned to a sales channel, so when the parent language is not assigned to one it is never processed — the carry-forward set is empty *and* the exact-match filter matches nothing, dropping the product from indexing for the child language.

The fix matches the full language inheritance chain instead:

```php
new EqualsAnyFilter('translations.languageId', $context->getLanguageIdChain()),
new EqualsAnyFilter('parent.translations.languageId', $context->getLanguageIdChain()),
```

## Notes on the backport
- The source change is identical to the trunk PR.
- 6.6.x has no `searchKeywordIndexingEnabled` flag, so the integration test uses the auto-indexing pattern (matching the existing 6.6.x tests) rather than a manually constructed updater.
- The integration test sets up `de-CH` inheriting `de-DE` (with `de-DE` removed from the sales channel), creates a product translated only in `de-DE`, and asserts the `de-CH` keywords come from the inherited translation. A unit test asserts `buildCriteria()` filters on the full language chain.