### PR TITLE
fix(storefront): mark VAT ID as required in account profile

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
@@ -21,6 +21,7 @@
             autocomplete: 'off',
             value: vatIdValue,
             violationPath: violationPath,
+            validationRules: vatIdRequired ? 'required' : '',
             additionalClass: 'col-md-6',
         } %}
     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -232,8 +232,10 @@
                             {# @deprecated tag:v6.8.0 - Unused variable `editMode` and will be removed #}
                             {% set editMode = true %}
 
+                            {# There is no country select on the profile form, so derive the "required" state from the customer's default billing country (same source the backend validates against). #}
                             {% sw_include '@Storefront/storefront/component/address/address-personal-vat-id.html.twig' with {
                                 'vatIds': data.get('vatIds'),
+                                'vatIdRequired': data.defaultBillingAddress.country.vatIdRequired ?? false,
                             } %}
                         {% endblock %}
                     </div>

--- a/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
+++ b/tests/integration/Storefront/Controller/AccountProfileControllerTest.php
@@ -174,6 +174,46 @@ class AccountProfileControllerTest extends TestCase
         static::assertSame(CustomerEntity::ACCOUNT_TYPE_PRIVATE, $updatedCustomer->getAccountType());
     }
 
+    public function testVatIdFieldIsRequiredOnProfileWhenBillingCountryRequiresVatId(): void
+    {
+        $context = Context::createDefaultContext();
+        $customer = $this->createBusinessCustomer($context, true);
+
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.loginRegistration.showAccountTypeSelection', true);
+
+        $browser = $this->login($customer->getEmail());
+
+        $crawler = $browser->request('GET', '/account/profile');
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+
+        $vatIdField = $crawler->filter('#vatIds');
+        static::assertCount(1, $vatIdField);
+        static::assertStringContainsString('required', (string) $vatIdField->attr('data-validation'));
+        static::assertCount(1, $crawler->filter('label[for="vatIds"] .form-required-label'));
+    }
+
+    public function testVatIdFieldIsOptionalOnProfileWhenBillingCountryDoesNotRequireVatId(): void
+    {
+        $context = Context::createDefaultContext();
+        $customer = $this->createBusinessCustomer($context, false);
+
+        static::getContainer()->get(SystemConfigService::class)
+            ->set('core.loginRegistration.showAccountTypeSelection', true);
+
+        $browser = $this->login($customer->getEmail());
+
+        $crawler = $browser->request('GET', '/account/profile');
+
+        static::assertSame(Response::HTTP_OK, $browser->getResponse()->getStatusCode());
+
+        $vatIdField = $crawler->filter('#vatIds');
+        static::assertCount(1, $vatIdField);
+        static::assertNull($vatIdField->attr('data-validation'));
+        static::assertCount(0, $crawler->filter('label[for="vatIds"] .form-required-label'));
+    }
+
     private function login(string $email): KernelBrowser
     {
         $browser = KernelLifecycleManager::createBrowser($this->getKernel());
@@ -222,6 +262,48 @@ class AccountProfileControllerTest extends TestCase
         /** @var EntityRepository<CustomerCollection> $repo */
         $repo = static::getContainer()->get('customer.repository');
 
+        $repo->create([$customer], $context);
+
+        $customer = $repo->search(new Criteria([$customerId]), $context)->getEntities()->first();
+
+        static::assertNotNull($customer);
+
+        return $customer;
+    }
+
+    private function createBusinessCustomer(Context $context, bool $vatIdRequired): CustomerEntity
+    {
+        $customerId = Uuid::randomHex();
+        $addressId = Uuid::randomHex();
+
+        $customer = [
+            'id' => $customerId,
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'accountType' => CustomerEntity::ACCOUNT_TYPE_BUSINESS,
+            'company' => 'shopware AG',
+            'defaultShippingAddress' => [
+                'id' => $addressId,
+                'firstName' => 'Max',
+                'lastName' => 'Mustermann',
+                'street' => 'Musterstraße 1',
+                'city' => 'Schöppingen',
+                'zipcode' => '12345',
+                'company' => 'shopware AG',
+                'salutationId' => $this->getValidSalutationId(),
+                'country' => ['name' => 'VAT Test Country', 'vatIdRequired' => $vatIdRequired],
+            ],
+            'defaultBillingAddressId' => $addressId,
+            'groupId' => TestDefaults::FALLBACK_CUSTOMER_GROUP,
+            'email' => 'business.customer@test.com',
+            'password' => TestDefaults::HASHED_PASSWORD,
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'salutationId' => $this->getValidSalutationId(),
+            'customerNumber' => '12345',
+        ];
+
+        /** @var EntityRepository<CustomerCollection> $repo */
+        $repo = static::getContainer()->get('customer.repository');
         $repo->create([$customer], $context);
 
         $customer = $repo->search(new Criteria([$customerId]), $context)->getEntities()->first();


### PR DESCRIPTION
### 1. Why is this change necessary?

When a country has "VAT Reg.No. required" enabled, the registration form marks the VAT ID field as required (asterisk + frontend validation), but the account profile form does not. The backend already enforces it, so customers only find out after submitting — with no `*` marker or client-side feedback beforehand.

### 2. What does this change do, exactly?

The profile form has no country select to drive the existing `CountryStateSelectPlugin`, so the required state is now derived in Twig from the customer's default billing country (`defaultBillingAddress.country.vatIdRequired`) — the same source the backend validates against in `ChangeCustomerProfileRoute`. The change is scoped to the profile-only `component_address_personal_company_vat_id` block; registration and the address book keep their country-select-driven behavior.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable "Show selection between company and customer account".
2. Enable "VAT Reg.No. required" on a country.
3. Register / log in as a business customer whose billing address is in that country.
4. Open the account profile. Before: VAT ID has no required marker and frontend validation ignores it. After: it shows the `*` and is validated client-side, matching registration.

### 4. Please link to the relevant issues (if any).

closes #17529

### 5. Checklist

- [x] I have written tests and verified that they fail without my change (2 integration tests; both pass with the change, the required case fails without it)
- [ ] Release notes — not applicable (frontend validation/UX consistency; no external-developer action)
- [ ] Documentation — not applicable
- [x] This change has comments for non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
