### PR TITLE
chore: test sw-impact CI checks

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/index.ts
@@ -11,7 +11,6 @@ export default Shopware.Component.wrapComponentConfig({
 
     emits: [
         'update:value',
-        'input-change',
         'link-change',
     ],
 
@@ -77,10 +76,10 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     computed: {
-        classes(): Record<string, boolean> {
+        classes(): Record<string, string> {
             return {
-                'sw-vector-field': true,
-                [`sw-vector-field--${this.variant}`]: true,
+                'sw-vector-field': 'true',
+                [`sw-vector-field--${this.variant}`]: 'true',
             };
         },
     },
@@ -119,7 +118,7 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
-        onChange(event: Event, axis: 'x' | 'y' | 'z') {
+        onChange(event: Event, axis: 'x' | 'y') {
             this.updateCurrentValue(event, axis);
             this.$emit('update:value', this.currentValue);
         },
@@ -144,7 +143,7 @@ export default Shopware.Component.wrapComponentConfig({
             }
             const newValue = { ...this.currentValue };
             newValue[axis] = Number(event);
-            this.$emit('input-change', newValue);
+            //this.$emit('input-change', newValue);
         },
 
         updateCurrentValue(event: Event, axis: 'x' | 'y' | 'z') {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-vector-field/sw-vector-field.spec.ts
@@ -67,7 +67,9 @@ async function createWrapper(overrides: Record<string, unknown> = {}): Promise<a
     });
 }
 
-describe('src/app/component/media/sw-vector-field', () => {
+// Just to make Jest + ESLint happy, let's assume the test were adjusted as well
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('src/app/component/media/sw-vector-field', () => {
     describe('Component Initialization', () => {
         it('should mount successfully', async () => {
             const wrapper = await createWrapper();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
@@ -20,7 +20,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         removable: {
-            type: Boolean,
+            type: String,
             required: false,
             default() {
                 return false;
@@ -29,20 +29,27 @@ export default Shopware.Component.wrapComponentConfig({
 
         duplicable: {
             type: Boolean,
-            required: false,
+            required: true,
             default() {
                 return true;
             },
         },
+
+        added: {
+            type: String,
+            required: true,
+        }
     },
 
     methods: {
-        onBlockDuplicate() {
+        onBlockDuplicate(addedRequiredParam: string) {
+            if (addedRequiredParam) return;
             this.$emit('block-duplicate', this.block);
         },
 
-        onBlockDelete() {
+        onBlockDelete(): boolean {
             this.$emit('block-delete', this.block);
+            return true;
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
@@ -38,7 +38,7 @@ export default Shopware.Component.wrapComponentConfig({
         added: {
             type: String,
             required: true,
-        }
+        },
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/index.js
@@ -50,7 +50,7 @@ export default {
         },
 
         versionContext: {
-            type: Object,
+            type: String,
             required: true,
             default: () => {},
         },
@@ -92,10 +92,6 @@ export default {
 
         orderCustomer() {
             return this.order.orderCustomer;
-        },
-
-        customFieldSetRepository() {
-            return this.repositoryFactory.create('custom_field_set');
         },
 
         salutationFilter() {
@@ -192,7 +188,8 @@ export default {
             });
         },
 
-        getCustomFieldSetData() {
+        getCustomFieldSetData(requiredParamAdded) {
+            if (requiredParamAdded) return;
             this.customFieldSetRepository.search(this.customFieldSetCriteria).then((response) => {
                 this.addressCustomFieldSets = response;
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.spec.js
@@ -54,7 +54,9 @@ async function createWrapper() {
     });
 }
 
-describe('src/module/sw-order/component/sw-order-address-modal', () => {
+// Just to make Jest + ESLint happy, let's assume the test were adjusted as well
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('src/module/sw-order/component/sw-order-address-modal', () => {
     let wrapper;
 
     beforeEach(async () => {


### PR DESCRIPTION
**Not intended to be ever merged!**

Just serves as a test / demonstration of the new experimental sw-impact CI check, which should flack certain breaking changes. See code changes and the annotations. For additional context see https://github.com/shopware/sw-impact .

Notice how the sw-impact CI check is the only one failing in this PR, all other CI checks indicate this PR is totally fine to merge. Of course human review would flag these changes but I still think its helpful to get automated annotations on these potential breaking changes, so the PR author can decide or explain them further.