### PR TITLE
fix(administration): resolve sw-sortable-list freeze with multiple lists

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
@@ -121,14 +121,16 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         mergedDragConfig(): DragConfig {
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            this.defaultConfig.onDragStart = this.onDragStart;
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            this.defaultConfig.onDragEnter = this.onDragEnter;
-            // eslint-disable-next-line @typescript-eslint/unbound-method
-            this.defaultConfig.onDrop = this.onDrop;
-
-            return { ...this.defaultConfig, ...this.dragConf } as DragConfig;
+            return {
+                ...this.defaultConfig,
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                onDragStart: this.onDragStart,
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                onDragEnter: this.onDragEnter,
+                // eslint-disable-next-line @typescript-eslint/unbound-method
+                onDrop: this.onDrop,
+                ...this.dragConf,
+            } as DragConfig;
         },
 
         mergedScrollOnDragConfig(): ScrollOnDragConf {

--- a/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
@@ -12,10 +12,10 @@ interface DragConfig {
     preventEvent: boolean;
     validateDrop: boolean;
     validateDrag: boolean;
-    onDragStart: (...args: never[]) => void;
-    onDragEnter: (...args: never[]) => void;
-    onDragLeave: (...args: never[]) => void;
-    onDrop: (...args: never[]) => void;
+    onDragStart?: (...args: never[]) => void;
+    onDragEnter?: (...args: never[]) => void;
+    onDragLeave?: (...args: never[]) => void;
+    onDrop?: (...args: never[]) => void;
     data: Record<string, unknown>;
     disabled: boolean;
 }

--- a/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/sw-sortable-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/sw-sortable-list.spec.js
@@ -301,4 +301,60 @@ describe('src/component/list/sw-sortable-list', () => {
 
         expect(scrollByOptions).toHaveLength(0);
     });
+
+    it('should build mergedDragConfig without mutating the shared default config', async () => {
+        wrapper = await createWrapper();
+
+        const merged = wrapper.vm.mergedDragConfig;
+
+        expect(merged.onDragStart).toBe(wrapper.vm.onDragStart);
+        expect(merged.onDragEnter).toBe(wrapper.vm.onDragEnter);
+        expect(merged.onDrop).toBe(wrapper.vm.onDrop);
+
+        expect(wrapper.vm.defaultConfig.onDragStart).toBeUndefined();
+        expect(wrapper.vm.defaultConfig.onDragEnter).toBeUndefined();
+        expect(wrapper.vm.defaultConfig.onDrop).toBeUndefined();
+    });
+
+    it('should let caller-supplied dragConf override the built-in handlers', async () => {
+        const customOnDrop = jest.fn();
+
+        wrapper = await createWrapper({
+            props: {
+                dragConf: {
+                    dragGroup: 'custom-group',
+                    onDrop: customOnDrop,
+                },
+            },
+        });
+
+        const merged = wrapper.vm.mergedDragConfig;
+
+        // caller overrides win (spread last)...
+        expect(merged.dragGroup).toBe('custom-group');
+        expect(merged.onDrop).toBe(customOnDrop);
+        // ...while handlers the caller did not override fall back to the instance methods
+        expect(merged.onDragStart).toBe(wrapper.vm.onDragStart);
+        expect(merged.onDragEnter).toBe(wrapper.vm.onDragEnter);
+    });
+
+    it('should not trigger an infinite update loop when multiple lists are mounted', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const wrapperA = await createWrapper();
+        const wrapperB = await createWrapper();
+
+        await flushPromises();
+
+        const recursiveWarnings = warnSpy.mock.calls.filter((call) =>
+            call.some((arg) => typeof arg === 'string' && arg.includes('Maximum recursive updates exceeded')),
+        );
+
+        expect(recursiveWarnings).toHaveLength(0);
+        expect(wrapperA.findAll('.sw-sortable-list__item')).toHaveLength(3);
+        expect(wrapperB.findAll('.sw-sortable-list__item')).toHaveLength(3);
+
+        warnSpy.mockRestore();
+        wrapperA.unmount();
+        wrapperB.unmount();
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  `sw-sortable-list` freezes the Administration with "Maximum recursive updates exceeded" when two or more non-empty sortable lists are rendered at the same time.                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  ### 2. What does this change do, exactly?                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  The `mergedDragConfig` computed mutated the shared module-level `defaultConfig` singleton and then read it back. Since that object is shared by every instance, each instance overwrote the others' handlers, invalidating their computeds endlessly. `mergedDragConfig` is now a pure computed that builds a     
  fresh object (caller `dragConf` still wins), so nothing mutates the shared object.                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  ### 3. Describe each step to reproduce the issue or behaviour.                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  1. Render two or more `sw-sortable-list` instances on the same view, each with a non-empty `items` array.                                                                                                                                                                                                         
  2. The Administration freezes and Vue logs "Maximum recursive updates exceeded".                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  ### 4. Please link to the relevant issues (if any).                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                    
  ### 5. Checklist                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                    
  - [x] I have written tests and verified that they fail without my change                                                                                                                                                                                                                                          
  - [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:                                                                                                                                                                                                       
    - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.                                                                                                                                 
    - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).                                                                                                                                                                                                  
    - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.                                                                                                                                                               
  - [ ] I have written or adjusted the documentation according to my changes                                                                                                                                                                                                                                        
  - [x] This change has comments for package types, values, functions, and non-obvious lines of code                                                                                                                                                                                                                
  - [x] I have read the contribution requirements and fulfilled them