### PR TITLE
[codex] Wait for rule assignment cards before screenshot

### DIFF
--- a/tests/acceptance/tests/Visual/Administration/RuleBuilderDetail.spec.ts
+++ b/tests/acceptance/tests/Visual/Administration/RuleBuilderDetail.spec.ts
@@ -20,6 +20,14 @@ test('Visual: Rule Builder Detail page', { tag: '@Visual' }, async ({
     });
     await test.step('Creates a screenshot of the Rule Builder assignments tab.', async () => {
         await ShopAdmin.goesTo(AdminRuleDetail.url(rule.id, 'assignments'));
+        await ShopAdmin.expects(async () => {
+            const assignmentCards = AdminRuleDetail.page.locator('mt-card, mt-empty-state');
+            const assignmentCardCount = await assignmentCards.count();
+
+            await ShopAdmin.expects(assignmentCardCount).toBeGreaterThanOrEqual(11);
+        }).toPass({
+            intervals: [1_000, 2_500],
+        });
         await setViewport(AdminRuleDetail.page, {
             requestURL: 'api/search/shipping-method',
         });


### PR DESCRIPTION
## What changed

- Added a DOM readiness wait in the Rule Builder assignments visual test.
- The screenshot step now counts the `mt-card` / `mt-empty-state` Playwright locator matches and asserts that at least 11 elements are rendered before continuing.

## Why

The shipping-method request can finish before Vue has rendered the full assignments page, so the visual screenshot can happen too early.

## Validation

- Targeted lint attempted with `npm run lint -- tests/Visual/Administration/RuleBuilderDetail.spec.ts`, but this environment cannot execute `/usr/local/bin/npm` due to permission denied.
