### PR TITLE
fix: set milestone label when ready for review

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -5,6 +5,7 @@ on:
     types:
       - opened
       - reopened
+      - ready_for_review
       - closed
 
 permissions:


### PR DESCRIPTION
Adds `ready_for_review` to the milestone workflow so draft PRs that were opened without a milestone label get one when they become ready. Existing milestone labels are handled by shopware/saas#672.