### PR TITLE
fix(checkout): lock individual promotion code redemptions

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
@@ -245,7 +245,9 @@ class PromotionItemBuilder
         $payload['preventCombination'] = $promotion->isPreventCombination();
 
         // set whether the promotion has limited redemptions
-        $payload['limitedRedemptions'] = $promotion->getMaxRedemptionsGlobal() || $promotion->getMaxRedemptionsPerCustomer();
+        $payload['limitedRedemptions'] = $promotion->getMaxRedemptionsGlobal()
+            || $promotion->getMaxRedemptionsPerCustomer()
+            || $promotion->isUseIndividualCodes();
 
         // If all combinations are prevented the exclusions dont matter
         // otherwise sets a list of excluded promotion ids

--- a/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionRedemptionLocker.php
@@ -44,7 +44,12 @@ class PromotionRedemptionLocker implements EventSubscriberInterface
             }
 
             // use code for individual or global codes (reduces conflicts) and promotionId for automatic promotions
-            $key = $lineItem->getPayloadValue('code') ?: $lineItem->getPayloadValue('promotionId');
+            $code = $lineItem->getPayloadValue('code');
+            $key = \is_string($code) && $code !== '' ? \mb_strtolower($code) : $lineItem->getPayloadValue('promotionId');
+
+            if (!\is_string($key) || $key === '') {
+                continue;
+            }
 
             if (isset($locks[$key])) {
                 // probably multiple discounts of one promotion

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPayloadTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPayloadTest.php
@@ -161,7 +161,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
             'exclusions' => [],
             'preventCombination' => false,
             'promotionCodeType' => 'individual',
-            'limitedRedemptions' => false,
+            'limitedRedemptions' => true,
         ];
 
         static::assertEquals($expected, $item->getPayload());

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
@@ -101,6 +101,37 @@ class PromotionRedemptionLockerTest extends TestCase
         static::assertSame([$firstLineItem->getPayloadValue('code') => $lock], $lockExtension->locks);
     }
 
+    public function testAcquireLockNormalizesPromotionCode(): void
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $lock = $this->createMock(SharedLockInterface::class);
+        $lock->expects($this->once())
+            ->method('acquire')
+            ->with(true)
+            ->willReturn(true);
+
+        $lockFactory->expects($this->once())
+            ->method('createLock')
+            ->with('promotion-promotion-code', 5.0, true)
+            ->willReturn($lock);
+
+        $locker = new PromotionRedemptionLocker($lockFactory);
+
+        $cart = new Cart('test');
+        $lineItem = new LineItem('id', PromotionProcessor::LINE_ITEM_TYPE);
+        $lineItem->setPayloadValue('code', 'Promotion-Code');
+        $lineItem->setPayloadValue('limitedRedemptions', true);
+        $cart->add($lineItem);
+        $extension = new CheckoutPlaceOrderExtension($cart, Generator::generateSalesChannelContext(), new RequestDataBag());
+
+        $locker->acquireLocks($extension);
+
+        $lockExtension = $extension->getExtensionOfType(LockExtension::KEY, LockExtension::class);
+        static::assertNotNull($lockExtension);
+
+        static::assertSame(['promotion-code' => $lock], $lockExtension->locks);
+    }
+
     public function testAcquireLockWithValidPromotionItemFails(): void
     {
         $lockFactory = $this->createMock(LockFactory::class);


### PR DESCRIPTION
### 1. Why is this change necessary?

Individual-code promotions with the default redemption limits are currently not marked as `limitedRedemptions` in the promotion line item payload. The promotion redemption locker therefore skips them, even though individual codes are single-code resources and should participate in the locking feature introduced for limited promotion redemptions.

### 2. What does this change do, exactly?

This change marks individual-code promotions as limited redemptions when building promotion line items, so checkout acquires the existing promotion lock for those codes.

It also normalizes promotion-code lock keys to lowercase, matching the existing case-insensitive comparison used when individual codes are marked as redeemed.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a promotion that uses individual codes and keeps the default global/per-customer redemption limits.
2. Add one of the generated individual codes to a cart.
3. Place the order while another checkout flow for the same individual code is also being processed.
4. The promotion line item is not flagged as limited, so the promotion redemption locker does not acquire a lock for that individual code.

### 4. Please link to the relevant issues (if any).

- relates #11862

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them