### PR TITLE
fix: listing components layout

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Button/index.scss
+++ b/src/Storefront/Resources/views/components/Sw/Button/index.scss
@@ -11,7 +11,6 @@
     --bs-btn-hover-bg: var(--buy-btn-bg);
     --bs-btn-hover-border-color: var(--buy-btn-bg);
     --bs-btn-hover-color: var(--buy-btn-color);
-    --bs-btn-focus-box-shadow: var(--focus-ring-box-shadow);
 
     &.disabled,
     &:disabled {

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -95,6 +95,8 @@
 .sw-filter-item__count {
     --bs-badge-padding-x: 0.5rem;
     --bs-badge-padding-y: 0.2rem;
+    line-height: 1;
+    height: auto;
 
     &.is--hidden {
         display: none;

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.html.twig
@@ -126,11 +126,13 @@
             <twig:Slot name="additional-filters-end"></twig:Slot>
 
             {# Expand or collapse hidden filters #}
-            <button class="sw-filter-panel__filter-btn sw-filter-panel__expand btn-light btn d-none d-md-block">
-                <span class="sw-filter-panel__expand-text">{{ 'listing.filterButtonMore'|trans|sw_sanitize }}</span>
-                <span class="sw-filter-panel__collapse-text">{{ 'listing.filterButtonLess'|trans|sw_sanitize }}</span>
-                <twig:Sw:Icon name="sliders-horizontal" size="xs" />
-            </button>
+            {% if filterAggregations|length > visibleFilterCount %}
+                <button class="sw-filter-panel__filter-btn sw-filter-panel__expand btn-light btn d-none d-md-block">
+                    <span class="sw-filter-panel__expand-text">{{ 'listing.filterButtonMore'|trans|sw_sanitize }}</span>
+                    <span class="sw-filter-panel__collapse-text">{{ 'listing.filterButtonLess'|trans|sw_sanitize }}</span>
+                    <twig:Sw:Icon name="sliders-horizontal" size="xs" />
+                </button>
+            {% endif %}
         </div>
     </twig:Sw:Content:Offcanvas>
 

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.js
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.js
@@ -11,6 +11,11 @@ export default class FilterPanel extends ShopwareComponent {
 
     init() {
         this.expandButton = this.el.querySelector('.sw-filter-panel__expand');
+
+        if (!this.expandButton) {
+            return;
+        }
+
         this.expandText = this.expandButton.querySelector('.sw-filter-panel__expand-text');
         this.collapseText = this.expandButton.querySelector('.sw-filter-panel__collapse-text');
         this.filterItems = this.el.querySelectorAll('.sw-filter-item');
@@ -22,7 +27,8 @@ export default class FilterPanel extends ShopwareComponent {
     }
 
     registerEvents() {
-        this.expandButton.addEventListener('click', this.onToggleHiddenFilters.bind(this))
+        this.onToggleHiddenFiltersBound = this.onToggleHiddenFilters.bind(this);
+        this.expandButton.addEventListener('click', this.onToggleHiddenFiltersBound);
     }
 
     onToggleHiddenFilters(event) {
@@ -58,6 +64,10 @@ export default class FilterPanel extends ShopwareComponent {
     }
 
     destroy() {
-        this.expandButton.removeEventListener('click', this.onToggleHiddenFilters.bind(this));
+        if (!this.expandButton || !this.onToggleHiddenFiltersBound) {
+            return;
+        }
+
+        this.expandButton.removeEventListener('click', this.onToggleHiddenFiltersBound);
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
+++ b/src/Storefront/Resources/views/components/Sw/Product/CardLoader.scss
@@ -8,7 +8,7 @@
     --bs-btn-disabled-bg: var(--bs-secondary-bg-subtle);
 }
 
-.has-element-loader {
+.is--loading {
     .sw-product-card__content {
         visibility: hidden;
         pointer-events: none;

--- a/src/Storefront/Resources/views/components/Sw/Product/Listing.js
+++ b/src/Storefront/Resources/views/components/Sw/Product/Listing.js
@@ -8,7 +8,7 @@ export default class ProductListing extends ShopwareComponent {
         sortingParamName: 'order',
         layoutGridClasses: {
             horizontal: ['columns-1'],
-            default: ['columns-sm-2', 'columns-lg-2', 'columns-xl-3', 'columns-4'],
+            default: ['columns-xs-1', 'columns-sm-2', 'columns-md-3', 'columns-lg-4', 'columns-xl-4'],
         },
     };
 
@@ -23,7 +23,7 @@ export default class ProductListing extends ShopwareComponent {
         this.debouncedLoad = this.debounce(async () => {
             const productGrid = this.el.querySelector('.sw-product-listing__grid');
             const pagination = this.el.querySelector('.sw-product-listing__pagination');
-            productGrid.classList.add('has-element-loader');
+            productGrid.classList.add('is--loading');
 
             const location = new URL(window.location);
             const params = { ...this.activeParams };
@@ -38,7 +38,7 @@ export default class ProductListing extends ShopwareComponent {
 
             productGrid.replaceWith(grid);
             pagination.replaceWith(pagi);
-            productGrid.classList.remove('has-element-loader');
+            productGrid.classList.remove('is--loading');
         }, 200);
 
         this.getStateFromUrl();


### PR DESCRIPTION
## ⚠️ Only relevant for `feat/experience-studio`

* Fix horizontal grid layout
* Fix missing focus outline for buy-btn
* Don't display the "expand filters" button when there aren't enough filters displayed
* Fix the filter item count badges looking weird (too much height)
* Replace the `has-element-loader` class. This was from the old listing and caused side-effects.