### PR TITLE
fix: resolve webhook signing secret at delivery time (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-06-30-sign-webhooks-with-current-app-secret-after-rotation.md
+++ b/changelog/_unreleased/2026-06-30-sign-webhooks-with-current-app-secret-after-rotation.md
@@ -1,0 +1,9 @@
+---
+title: Sign webhooks with the current app secret after a secret rotation
+issue: #17679
+author: Ghaith Olabi
+author_email: m.olabi@shopware.com
+author_github: @Gaitholabi
+---
+# Core
+* Changed app webhook delivery to resolve the HMAC signing secret at delivery time (via the new `WebhookSigningSecretResolver`) instead of reusing the secret captured on the queued `WebhookEventMessage`. A webhook that is queued or retried across an app-secret rotation is now signed with the secret the app currently verifies against: the app's current secret, then the retained `deleted_apps` secret for an uninstalled app, then the secret carried on the message for messages already queued before this change. Apps no longer need to do anything — deliveries that span a rotation stop being rejected with a signature error.

--- a/src/Core/Framework/DependencyInjection/webhook.xml
+++ b/src/Core/Framework/DependencyInjection/webhook.xml
@@ -67,10 +67,16 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Webhook\Service\WebhookSigningSecretResolver">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Webhook\Handler\WebhookEventMessageHandler">
             <argument type="service" id="shopware.app_system.guzzle"/>
             <argument type="service" id="webhook_event_log.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\RelatedWebhooks"/>
+            <argument type="service" id="Shopware\Core\Framework\Webhook\Service\WebhookSigningSecretResolver"/>
 
             <tag name="messenger.message_handler"/>
         </service>

--- a/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
+++ b/src/Core/Framework/Webhook/Handler/WebhookEventMessageHandler.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Service\RelatedWebhooks;
+use Shopware\Core\Framework\Webhook\Service\WebhookSigningSecretResolver;
 use Shopware\Core\Framework\Webhook\WebhookException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -34,6 +35,7 @@ final class WebhookEventMessageHandler
         private readonly Client $client,
         private readonly EntityRepository $webhookEventLogRepository,
         private readonly RelatedWebhooks $relatedWebhooks,
+        private readonly WebhookSigningSecretResolver $signingSecretResolver,
     ) {
     }
 
@@ -69,9 +71,12 @@ final class WebhookEventMessageHandler
             'timeout' => self::TIMEOUT,
         ];
 
-        if ($message->getSecret()) {
+        // Resolve the signing secret at delivery time so a webhook queued or retried across an
+        // app-secret rotation is signed with the secret the app currently verifies against.
+        $secret = $this->signingSecretResolver->resolve($message);
+        if ($secret) {
             $requestContent[AuthMiddleware::APP_REQUEST_TYPE] = [
-                AuthMiddleware::APP_SECRET => $message->getSecret(),
+                AuthMiddleware::APP_SECRET => $secret,
             ];
         }
 

--- a/src/Core/Framework/Webhook/Message/WebhookEventMessage.php
+++ b/src/Core/Framework/Webhook/Message/WebhookEventMessage.php
@@ -28,6 +28,12 @@ class WebhookEventMessage implements AsyncMessageInterface
         private readonly string $languageId,
         private readonly string $userLocale,
         private readonly array $webhookHeaders = [],
+        /**
+         * The app's name. Lets delivery look up the signing secret from deleted_apps after an app is
+         * uninstalled (for example the app.deleted webhook). Null for non-app webhooks, and for
+         * messages that were already queued before this field was added.
+         */
+        private readonly ?string $appName = null,
     ) {
     }
 
@@ -42,6 +48,13 @@ class WebhookEventMessage implements AsyncMessageInterface
     public function getAppId(): ?string
     {
         return $this->appId;
+    }
+
+    public function getAppName(): ?string
+    {
+        // Coalesce to null for messages serialized before this field existed: the promoted property
+        // is then uninitialized and a bare read would throw.
+        return $this->appName ?? null;
     }
 
     public function getWebhookId(): string

--- a/src/Core/Framework/Webhook/Service/WebhookManager.php
+++ b/src/Core/Framework/Webhook/Service/WebhookManager.php
@@ -160,7 +160,8 @@ class WebhookManager implements ResetInterface
                 $webhook->appSecret,
                 $languageId,
                 $userLocale,
-                $webhookHeaders
+                $webhookHeaders,
+                $webhook->appName
             );
 
             $this->logWebhookWithEvent($webhook, $webhookEventMessage);

--- a/src/Core/Framework/Webhook/Service/WebhookSigningSecretResolver.php
+++ b/src/Core/Framework/Webhook/Service/WebhookSigningSecretResolver.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Webhook\Service;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+
+/**
+ * Picks the secret an outgoing webhook is signed with, at the moment it is sent.
+ *
+ * App secrets can change (they get rotated). A webhook can wait in the queue or be retried long
+ * after it was created, so the secret stored on the message may be out of date. Reading the current
+ * secret at send time keeps the signature valid for the receiving app.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class WebhookSigningSecretResolver
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly DeletedAppsGateway $deletedAppsGateway,
+    ) {
+    }
+
+    public function resolve(WebhookEventMessage $message): ?string
+    {
+        $appId = $message->getAppId();
+        if ($appId === null) {
+            return $message->getSecret();
+        }
+
+        return $this->currentSecret($appId)
+            ?? $this->deletedAppSecret($message->getAppName())
+            // Older queued messages still carry the secret; use it until the queue has drained.
+            ?? $message->getSecret();
+    }
+
+    private function currentSecret(string $appId): ?string
+    {
+        $secret = $this->connection->fetchOne(
+            'SELECT `app_secret` FROM `app` WHERE `id` = :id',
+            ['id' => Uuid::fromHexToBytes($appId)]
+        );
+
+        return \is_string($secret) ? $this->emptyToNull($secret) : null;
+    }
+
+    // The app was uninstalled but still has webhooks in flight; its secret is kept in deleted_apps.
+    private function deletedAppSecret(?string $appName): ?string
+    {
+        if ($appName === null) {
+            return null;
+        }
+
+        return $this->emptyToNull($this->deletedAppsGateway->getDeletedAppSecret($appName));
+    }
+
+    private function emptyToNull(?string $secret): ?string
+    {
+        return $secret === '' ? null : $secret;
+    }
+}

--- a/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Handler/WebhookEventMessageHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Webhook\Handler;
 
+use Doctrine\DBAL\Connection;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -199,6 +200,85 @@ class WebhookEventMessageHandlerTest extends TestCase
 
         static::assertInstanceOf(WebhookEventLogEntity::class, $webhookEventLog);
         static::assertEquals($webhookEventLog->getDeliveryStatus(), WebhookEventLogDefinition::STATUS_SUCCESS);
+    }
+
+    /**
+     * A webhook queued with the secret captured at queue time, then delivered after the app rotated
+     * its secret, must be signed with the app's CURRENT secret — otherwise the receiving app rejects
+     * the signature until the message is dropped.
+     */
+    public function testSignsWithTheCurrentSecretAfterASecretRotation(): void
+    {
+        $webhookId = Uuid::randomHex();
+        $appId = Uuid::randomHex();
+
+        $appRepository = static::getContainer()->get('app.repository');
+        $appRepository->create([[
+            'id' => $appId,
+            'name' => 'SwagApp',
+            'active' => true,
+            'path' => __DIR__ . '/Manifest/_fixtures/test',
+            'version' => '0.0.1',
+            'label' => 'test',
+            'appSecret' => 'old-secret',
+            'integration' => [
+                'label' => 'test',
+                'accessKey' => 'api access key',
+                'secretAccessKey' => 'test',
+            ],
+            'aclRole' => [
+                'name' => 'SwagApp',
+            ],
+            'webhooks' => [
+                [
+                    'id' => $webhookId,
+                    'name' => 'hook1',
+                    'eventName' => 'order',
+                    'url' => 'https://test.com',
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        $webhookEventLogRepository = static::getContainer()->get('webhook_event_log.repository');
+        $webhookEventId = Uuid::randomHex();
+        // The message carries the secret as it was when the webhook was queued.
+        $webhookEventMessage = new WebhookEventMessage($webhookEventId, ['body' => 'payload'], $appId, $webhookId, '6.4', 'http://test.com', 'old-secret', Defaults::LANGUAGE_SYSTEM, 'en-GB', [], 'SwagApp');
+
+        $webhookEventLogRepository->create([[
+            'id' => $webhookEventId,
+            'appName' => 'SwagApp',
+            'deliveryStatus' => WebhookEventLogDefinition::STATUS_QUEUED,
+            'webhookName' => 'hook1',
+            'eventName' => 'order',
+            'appVersion' => '0.0.1',
+            'url' => 'https://test.com',
+            'serializedWebhookMessage' => serialize($webhookEventMessage),
+        ]], Context::createDefaultContext());
+
+        // Rotate the app secret after the message was queued but before it is delivered.
+        static::getContainer()->get(Connection::class)->update(
+            'app',
+            ['app_secret' => 'new-secret'],
+            ['id' => Uuid::fromHexToBytes($appId)]
+        );
+
+        $this->appendNewResponse(new Response(200));
+
+        ($this->webhookEventMessageHandler)($webhookEventMessage);
+
+        $request = $this->getLastRequest();
+        static::assertInstanceOf(RequestInterface::class, $request);
+        $payload = $request->getBody()->getContents();
+
+        static::assertSame(
+            hash_hmac('sha256', $payload, 'new-secret'),
+            $request->getHeaderLine('shopware-shop-signature'),
+            'Webhook must be signed with the current app secret, not the one captured when it was queued'
+        );
+        static::assertNotSame(
+            hash_hmac('sha256', $payload, 'old-secret'),
+            $request->getHeaderLine('shopware-shop-signature')
+        );
     }
 
     public function testNonJsonErrorResponse(): void

--- a/tests/unit/Core/Framework/Webhook/Message/WebhookEventMessageTest.php
+++ b/tests/unit/Core/Framework/Webhook/Message/WebhookEventMessageTest.php
@@ -65,15 +65,15 @@ class WebhookEventMessageTest extends TestCase
      */
     private function stripAppName(string $serialized): string
     {
-        $key = sprintf("\0%s\0appName", WebhookEventMessage::class);
-        $entry = sprintf('s:%d:"%s";N;', \strlen($key), $key);
+        $key = \sprintf("\0%s\0appName", WebhookEventMessage::class);
+        $entry = \sprintf('s:%d:"%s";N;', \strlen($key), $key);
 
         $stripped = str_replace($entry, '', $serialized);
         static::assertNotSame($serialized, $stripped, 'Expected the serialized payload to carry the appName property');
 
         return str_replace(
-            sprintf('%s":11:{', WebhookEventMessage::class),
-            sprintf('%s":10:{', WebhookEventMessage::class),
+            \sprintf('%s":11:{', WebhookEventMessage::class),
+            \sprintf('%s":10:{', WebhookEventMessage::class),
             $stripped
         );
     }

--- a/tests/unit/Core/Framework/Webhook/Message/WebhookEventMessageTest.php
+++ b/tests/unit/Core/Framework/Webhook/Message/WebhookEventMessageTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Webhook\Message;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(WebhookEventMessage::class)]
+class WebhookEventMessageTest extends TestCase
+{
+    public function testSerializationRoundTripPreservesAppName(): void
+    {
+        $restored = unserialize(serialize($this->message(appName: 'SwagApp')));
+
+        static::assertInstanceOf(WebhookEventMessage::class, $restored);
+        static::assertSame('SwagApp', $restored->getAppName());
+        static::assertSame('s3cr3t', $restored->getSecret());
+    }
+
+    /**
+     * Messages queued before $appName existed are still on the queue (and stored serialized in
+     * webhook_event_log) during a rollout. Deserializing such a payload must not fail: the property
+     * is absent, so getAppName() has to read as null rather than throw on an uninitialized typed
+     * property — otherwise every in-flight delivery would error until the queue drains.
+     */
+    public function testLegacyMessageSerializedWithoutAppNameDeserializesToNull(): void
+    {
+        $legacyBlob = $this->stripAppName(serialize($this->message(appName: null)));
+
+        $restored = unserialize($legacyBlob);
+
+        static::assertInstanceOf(WebhookEventMessage::class, $restored);
+        static::assertNull($restored->getAppName());
+        static::assertSame('s3cr3t', $restored->getSecret());
+    }
+
+    private function message(?string $appName): WebhookEventMessage
+    {
+        return new WebhookEventMessage(
+            'event-id',
+            ['body' => 'payload'],
+            Uuid::randomHex(),
+            Uuid::randomHex(),
+            '6.6.0.0',
+            'https://example.com/webhook',
+            's3cr3t',
+            Defaults::LANGUAGE_SYSTEM,
+            'en-GB',
+            [],
+            $appName,
+        );
+    }
+
+    /**
+     * Rewrites a serialized message into the pre-$appName shape: drops the (null) appName property
+     * and decrements the object's property count, mirroring a payload written before the field existed.
+     */
+    private function stripAppName(string $serialized): string
+    {
+        $key = sprintf("\0%s\0appName", WebhookEventMessage::class);
+        $entry = sprintf('s:%d:"%s";N;', \strlen($key), $key);
+
+        $stripped = str_replace($entry, '', $serialized);
+        static::assertNotSame($serialized, $stripped, 'Expected the serialized payload to carry the appName property');
+
+        return str_replace(
+            sprintf('%s":11:{', WebhookEventMessage::class),
+            sprintf('%s":10:{', WebhookEventMessage::class),
+            $stripped
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Webhook/Service/WebhookSigningSecretResolverTest.php
+++ b/tests/unit/Core/Framework/Webhook/Service/WebhookSigningSecretResolverTest.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Webhook\Service;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
+use Shopware\Core\Framework\Webhook\Service\WebhookSigningSecretResolver;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(WebhookSigningSecretResolver::class)]
+class WebhookSigningSecretResolverTest extends TestCase
+{
+    public function testUsesTheCurrentSecretNotTheOneCapturedWhenQueued(): void
+    {
+        // Rotation regression: the message carries the OLD secret; the app has rotated to NEW.
+        $resolver = $this->resolver(appSecret: 'new-secret', deletedSecret: false);
+
+        static::assertSame(
+            'new-secret',
+            $resolver->resolve($this->message(Uuid::randomHex(), carried: 'old-secret', appName: 'TestApp'))
+        );
+    }
+
+    public function testFallsBackToTheDeletedAppsSecretWhenTheAppIsGone(): void
+    {
+        $resolver = $this->resolver(appSecret: false, deletedSecret: 'retained-secret');
+
+        static::assertSame(
+            'retained-secret',
+            $resolver->resolve($this->message(Uuid::randomHex(), carried: 'old-secret', appName: 'TestApp'))
+        );
+    }
+
+    public function testFallsBackToTheCarriedSecretWhenNoLiveOrDeletedSecretExists(): void
+    {
+        $resolver = $this->resolver(appSecret: false, deletedSecret: false);
+
+        static::assertSame(
+            'carried-secret',
+            $resolver->resolve($this->message(Uuid::randomHex(), carried: 'carried-secret', appName: 'TestApp'))
+        );
+    }
+
+    public function testNonAppWebhookKeepsItsCarriedSecretWithoutAnyLookup(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('fetchOne');
+        $resolver = new WebhookSigningSecretResolver($connection, new DeletedAppsGateway($connection));
+
+        static::assertSame(
+            'carried-secret',
+            $resolver->resolve($this->message(appId: null, carried: 'carried-secret', appName: null))
+        );
+    }
+
+    private function resolver(string|false $appSecret, string|false $deletedSecret): WebhookSigningSecretResolver
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchOne')->willReturnCallback(
+            static fn (string $sql): string|false => str_contains($sql, 'deleted_apps') ? $deletedSecret : $appSecret
+        );
+
+        return new WebhookSigningSecretResolver($connection, new DeletedAppsGateway($connection));
+    }
+
+    private function message(?string $appId, ?string $carried, ?string $appName): WebhookEventMessage
+    {
+        return new WebhookEventMessage(
+            'event-id',
+            ['source' => ['eventId' => 'event-id']],
+            $appId,
+            Uuid::randomHex(),
+            '6.6.0.0',
+            'https://example.com/webhook',
+            $carried,
+            Defaults::LANGUAGE_SYSTEM,
+            'en-GB',
+            [],
+            $appName,
+        );
+    }
+}


### PR DESCRIPTION
Manually created backport of: https://github.com/shopware/shopware/pull/17679 - since code to achieve the same thing have significantly diverged.