### PR TITLE
test: clear cache before validating flow

### DIFF
--- a/tests/acceptance/tests/Settings/FlowValidation.spec.ts
+++ b/tests/acceptance/tests/Settings/FlowValidation.spec.ts
@@ -32,7 +32,7 @@ test(
             },
         };
         const customer = await TestDataService.createCustomer(customerOverrides);
-        
+
         const order = await TestDataService.createOrder([{ product, quantity: 1 }], customer);
         TestDataService.addCreatedRecord('order', order.id);
 
@@ -48,11 +48,12 @@ test(
         });
 
         await test.step('Validate order state and customer tag via UI', async () => {
+            await TestDataService.clearCaches();
             await ShopAdmin.goesTo(AdminOrderDetail.url(order.id));
             await ShopAdmin.expects(AdminOrderDetail.orderStatus).toContainText('In Progress');
             await ShopAdmin.expects(AdminOrderDetail.orderPaymentStatus).toContainText('Paid');
             await ShopAdmin.expects(AdminOrderDetail.orderDeliveryStatus).toContainText('Shipped (partially)');
-            
+
             await ShopAdmin.goesTo(AdminCustomerDetail.url(customer.id));
             await ShopAdmin.expects(AdminCustomerDetail.tagList).toContainText(tagTrue.name);
         });


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently this test is failing in the recent `6.7.12.x` saas deployment ATS.
After some debugging I saw that the test passes when we clear the cache before checking the order.

### 2. What does this change do, exactly?
Clear the cache after triggering the state machine and before validating the order.

### 3. Describe each step to reproduce the issue or behaviour.
Run the ATS against a recent `6.7.12.x` version.