### PR TITLE
fix: remove noisy deprecated DI service tags

### DIFF
--- a/.agents/skills/shopware-php-code/SKILL.md
+++ b/.agents/skills/shopware-php-code/SKILL.md
@@ -35,6 +35,7 @@ Prefer the existing Shopware extension point over a new abstraction.
 ## Deprecations
 
 - Core code should never trigger self-deprecation notices. If core must keep calling deprecated behavior for BC, wrap that call with `Feature::silent($majorFlag, static fn () => ...)` so the deprecation notice is suppressed, the code path is explicitly tied to the major feature flag, and the branch will disappear when the flag is removed.
+- Do not mark DI service definitions as deprecated while Shopware core still references that service id anywhere. Internal DI references still trigger container deprecations and spam logs during warmup/compile. Deprecate the PHP API or class if needed, but only add the DI `<deprecated>` service tag once core no longer uses that service internally.
 - When adding an `@deprecated` annotation to executable PHP code, add a matching `Feature::triggerDeprecationOrThrow()` in the deprecated code path unless the deprecation uses an explicit exception reason supported by the PHPStan deprecation rule.
 - Do not leave new Shopware core code paths calling deprecated functionality. Move internal callers to the replacement API/service and keep legacy behavior only in focused BC tests.
 - For private implementation cleanup reminders, do not add method-level deprecations. Use a short inline `// @deprecated tag:vX.Y.Z - ...` comment near the branch or code that should be removed later, with enough detail to simplify the future cleanup.

--- a/src/Core/Checkout/DependencyInjection/payment.xml
+++ b/src/Core/Checkout/DependencyInjection/payment.xml
@@ -71,8 +71,6 @@
             <argument type="service" id="shopware.jwt_config"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Psr\Clock\ClockInterface"/>
-
-            <deprecated package="shopware/core" version="6.8.0.0">tag:v6.8.0 - The %service_id% service will be removed in v6.8.0.0. Use Shopware\Core\Checkout\Payment\Cart\Token\PaymentTokenGenerator instead.</deprecated>
         </service>
 
         <service id="Shopware\Core\Checkout\Payment\Cart\Token\Constraint\PaymentTokenRegisteredValidator">

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -471,8 +471,6 @@
         <service id="Shopware\Core\Content\Product\DataAbstractionLayer\StatesUpdater">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="event_dispatcher"/>
-
-            <deprecated package="shopware/core" version="6.8.0">tag:v6.8.0 - The %service_id% service will be removed, as product states are deprecated.</deprecated>
         </service>
 
         <service id="Shopware\Core\Content\Product\DataAbstractionLayer\VariantListingUpdater">


### PR DESCRIPTION
### 1. Why is this change necessary?

Core still injects  and  through DI, so marking those service definitions as deprecated causes Symfony to emit container deprecation notices during warmup and compile. That pollutes logs even for empty projects.

### 2. What does this change do, exactly?

It removes the deprecated DI service tags from  and  while keeping the PHP-level deprecation handling intact.

It also updates the PHP skill guidance so DI services are only marked as deprecated once core no longer references that service id internally.

### 3. Describe each step to reproduce the issue or behaviour.

1. Start from a Shopware checkout where a deprecated DI service is still injected by core services.
2. Warm up the container or trigger the first request.
3. Check the logs and observe deprecated service notices emitted during container compilation.

### 4. Please link to the relevant issues (if any).

- closes #16737

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to  under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an  section in  for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them