### PR TITLE
fix: pass a list to MetadataMinifier::expand() in the web installer

### DIFF
--- a/src/WebInstaller/Services/ProjectComposerJsonUpdater.php
+++ b/src/WebInstaller/Services/ProjectComposerJsonUpdater.php
@@ -103,12 +103,10 @@ class ProjectComposerJsonUpdater
 
     private function getConflictMinVersion(string $shopwareVersion): ?string
     {
-        /** @var array{packages: array{"shopware/conflicts": array{version: string, require: array{"shopware/core": string}}[]}} $data */
+        /** @var array{packages: array{"shopware/conflicts": list<array{version: string, require: array{"shopware/core": string}}>}} $data */
         $data = $this->httpClient->request('GET', 'https://repo.packagist.org/p2/shopware/conflicts.json')->toArray();
 
-        // expand() expects a list; the packagist p2 response is already a sequential array of
-        // versions, so array_values() only satisfies the type and does not change the data.
-        $data['packages']['shopware/conflicts'] = MetadataMinifier::expand(array_values($data['packages']['shopware/conflicts']));
+        $data['packages']['shopware/conflicts'] = MetadataMinifier::expand($data['packages']['shopware/conflicts']);
 
         $versions = $data['packages']['shopware/conflicts'];
 

--- a/src/WebInstaller/Services/ProjectComposerJsonUpdater.php
+++ b/src/WebInstaller/Services/ProjectComposerJsonUpdater.php
@@ -106,7 +106,9 @@ class ProjectComposerJsonUpdater
         /** @var array{packages: array{"shopware/conflicts": array{version: string, require: array{"shopware/core": string}}[]}} $data */
         $data = $this->httpClient->request('GET', 'https://repo.packagist.org/p2/shopware/conflicts.json')->toArray();
 
-        $data['packages']['shopware/conflicts'] = MetadataMinifier::expand($data['packages']['shopware/conflicts']);
+        // expand() expects a list; the packagist p2 response is already a sequential array of
+        // versions, so array_values() only satisfies the type and does not change the data.
+        $data['packages']['shopware/conflicts'] = MetadataMinifier::expand(array_values($data['packages']['shopware/conflicts']));
 
         $versions = $data['packages']['shopware/conflicts'];
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`composer/metadata-minifier` (a transitive dependency, not pinned in `composer.lock`) tightened `MetadataMinifier::expand()` to require `list<mixed>`. In `ProjectComposerJsonUpdater::getConflictMinVersion()` the `@var` annotation types `$data['packages']['shopware/conflicts']` as `array{...}[]` — i.e. `array<...>`, not a `list` — so `composer phpstan` now fails on `6.6.x`. This blocks CI on any PR built against the branch since the dependency drifted (e.g. #17863).

This is `6.6.x`-only: the web installer was removed from the platform on `6.7` (#9482), so there is no counterpart on `6.7.x`/trunk and nothing to forward-port.

### 2. What does this change do, exactly?

Corrects the `@var` annotation to declare `shopware/conflicts` as a `list<...>`, which is what it already is — the packagist p2 response is a sequential array of version entries. That satisfies `expand()`'s `list<mixed>` parameter. It is a type-annotation-only fix: no runtime code changes.

### 3. Describe each step to reproduce the issue or behaviour.

Run `composer phpstan` on `6.6.x` with the current `composer/metadata-minifier`:

- Before: `Parameter #1 $versions of static method Composer\MetadataMinifier\MetadataMinifier::expand() expects list<mixed>, array<...> given` in `src/WebInstaller/Services/ProjectComposerJsonUpdater.php`.
- After: PHPStan reports no errors.

### 4. Please link to the relevant issues (if any).

Unblocks PHPStan for open `6.6.x` pull requests.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
