### PR TITLE
fix: inherit storefront sales channel toggle values

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.html.twig
@@ -66,6 +66,7 @@
                     <template #content="{ currentValue, updateCurrentValue, isInherited, isInheritField, restoreInheritance, removeInheritance }">
                         <mt-switch
                             :model-value="currentValue"
+                            :inherited-value="storefrontSettings['core.storefrontSettings.iconCache']"
                             :disabled="isInherited"
                             :is-inheritance-field="isInheritField"
                             :is-inherited="isInherited"
@@ -89,6 +90,7 @@
                     <template #content="{ currentValue, updateCurrentValue, isInherited, isInheritField, restoreInheritance, removeInheritance }">
                         <mt-switch
                             :model-value="currentValue"
+                            :inherited-value="storefrontSettings['core.storefrontSettings.speculationRules']"
                             :disabled="isInherited"
                             :is-inheritance-field="isInheritField"
                             :is-inherited="isInherited"

--- a/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.spec.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-settings-storefront/page/sw-settings-storefront-index/sw-settings-storefront-index.spec.js
@@ -18,6 +18,7 @@ describe('sw-settings-storefront-index', () => {
                         template: `
                             <div>
                                 <slot name="smart-bar-actions"></slot>
+                                <slot name="content"></slot>
                             </div>
                         `,
                     },
@@ -28,11 +29,66 @@ describe('sw-settings-storefront-index', () => {
                             <button class="sw-button-process" @click="$emit('click')"><slot></slot></button>
                         `,
                     },
-                    'sw-card-view': true,
+                    'sw-card-view': {
+                        template: '<div><slot></slot></div>',
+                    },
                     'sw-skeleton': true,
-                    'mt-card': true,
-                    'mt-switch': true,
-                    'sw-inherit-wrapper': true,
+                    'mt-card': {
+                        template: '<div><slot></slot><slot name="toolbar"></slot></div>',
+                    },
+                    'mt-switch': {
+                        name: 'mt-switch',
+                        props: [
+                            'modelValue',
+                            'inheritedValue',
+                            'disabled',
+                            'isInheritanceField',
+                            'isInherited',
+                        ],
+                        template: '<div class="mt-switch"></div>',
+                    },
+                    'sw-inherit-wrapper': {
+                        props: [
+                            'value',
+                            'inheritedValue',
+                            'hasParent',
+                        ],
+                        emits: ['update:value'],
+                        computed: {
+                            isInherited() {
+                                return this.hasParent && (this.value === null || this.value === undefined);
+                            },
+                            currentValue() {
+                                return this.isInherited ? this.inheritedValue : this.value;
+                            },
+                        },
+                        methods: {
+                            updateCurrentValue(value) {
+                                this.$emit('update:value', value);
+                            },
+                            restoreInheritance() {
+                                this.$emit('update:value', null);
+                            },
+                            removeInheritance() {
+                                this.$emit('update:value', this.currentValue);
+                            },
+                        },
+                        template: `
+                            <div class="sw-inherit-wrapper">
+                                <slot
+                                    name="content"
+                                    v-bind="{
+                                        currentValue,
+                                        updateCurrentValue,
+                                        isInherited,
+                                        isInheritField: hasParent,
+                                        restoreInheritance,
+                                        removeInheritance
+                                    }"
+                                ></slot>
+                            </div>
+                        `,
+                    },
                     'sw-sales-channel-switch': true,
                     'mt-icon': true,
                 },
@@ -115,6 +171,38 @@ describe('sw-settings-storefront-index', () => {
             'core.storefrontSettings.iconCache': false,
             'core.storefrontSettings.speculationRules': null,
         });
+    });
+
+    it('passes inherited global toggle values to sales channel switches', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setData({
+            selectedSalesChannelId: 'sales-channel-id',
+            storefrontSettings: {
+                'core.storefrontSettings.iconCache': true,
+                'core.storefrontSettings.asyncThemeCompilation': false,
+                'core.storefrontSettings.speculationRules': true,
+            },
+            salesChannelStorefrontSettings: {
+                'core.storefrontSettings.iconCache': null,
+                'core.storefrontSettings.speculationRules': null,
+            },
+        });
+
+        const switches = wrapper.findAllComponents({ name: 'mt-switch' });
+
+        expect(switches.at(0).props()).toEqual(expect.objectContaining({
+            disabled: true,
+            inheritedValue: true,
+            isInherited: true,
+            modelValue: true,
+        }));
+        expect(switches.at(1).props()).toEqual(expect.objectContaining({
+            disabled: true,
+            inheritedValue: true,
+            isInherited: true,
+            modelValue: true,
+        }));
     });
 
     it('normalizes empty values before saving default scoped and global settings', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

The storefront settings page keeps sales-channel-specific toggle values as `null` when they inherit from the global config. The switches were rendered as disabled but visually inactive, so inherited `true` values looked wrong.

### 2. What does this change do, exactly?

It passes the global toggle value to the Meteor switch as `inherited-value` for the sales-channel-specific storefront settings and adds a focused spec that covers inherited enabled toggle states.

#### Before

https://github.com/user-attachments/assets/cb7bbfac-5fe5-4c78-82d0-279499ad6860

#### After
https://www.loom.com/share/48ada50f61764f17ae99e4f944c7f165

### 3. Describe each step to reproduce the issue or behaviour.

1. Open `Settings > Storefront` in the administration.
2. Enable a storefront toggle such as icon cache or speculation rules in the global configuration.
3. Switch to a sales channel that does not override that setting.
4. Observe that the disabled toggle appears inactive instead of reflecting the inherited enabled state.

### 4. Please link to the relevant issues (if any).

N/A.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
