### PR TITLE
perf(ProductExport): filter via product_stream_mapping when indexed

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -17,6 +17,12 @@ The product export now paginates products by a keyset cursor on `product.autoInc
 - `Shopware\Core\Content\ProductExport\Struct\ProductExportResult::getTotal()` is deprecated and will be removed in 6.8. It no longer returns the grand total of matching products but the number of products in the last batch. Use the new `hasNextBatch()` to drive pagination and `getLastId()` for the cursor.
 - `Shopware\Core\Content\ProductExport\Struct\ExportBehavior::offset()` is deprecated in favor of the new `lastId()`. The value is now the keyset cursor (highest `product.autoIncrement` already exported), not a row offset.
 
+### Product export resolves dynamic product groups via the indexed mapping
+
+When `shopware.product_stream.indexing` is enabled (default) and the product stream has been indexed, product exports resolve the products of a dynamic product group through the precomputed `product_stream_mapping` (an indexed `streamIds` join) instead of re-evaluating the stream filters per export. It falls back to the dynamic filters when indexing is disabled or the stream has not been indexed yet, so freshly created streams still export immediately.
+
+Membership in `product_stream_mapping` is the union across all sales-channel languages, so for streams that filter on translated fields an export may now include products that match the stream in another language. This matches how the storefront already evaluates dynamic product groups. Disable `shopware.product_stream.indexing` to keep the previous per-export, single-language evaluation.
+
 ### Deprecated `maintenanceIpWhitelist` wording of the sales channel
 
 The non-inclusive `maintenanceIpWhitelist` wording on the sales channel is deprecated in favor of `maintenanceIpAllowlist`.

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="Shopware\Core\System\Locale\LanguageLocaleCodeProvider"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
+            <argument>%shopware.product_stream.indexing%</argument>
         </service>
 
         <service id="Shopware\Core\Content\ProductExport\Command\ProductExportGenerateCommand">

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -63,7 +63,8 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         Environment $twig,
         private readonly ProductDefinition $productDefinition,
         private readonly LanguageLocaleCodeProvider $languageLocaleProvider,
-        TwigVariableParserFactory $parserFactory
+        TwigVariableParserFactory $parserFactory,
+        private readonly bool $productStreamIndexingEnabled = false
     ) {
         $this->twigVariableParser = $parserFactory->getParser($twig);
     }
@@ -103,19 +104,15 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             $context->getContext()
         );
 
-        $filters = $this->productStreamBuilder->buildFilters(
-            $productExport->getProductStreamId(),
-            $context->getContext()
-        );
-
         $associations = $this->getAssociations($productExport, $context);
 
         $criteria = new Criteria();
         $criteria
             ->setTitle('product-export::products')
-            ->addFilter(...$filters)
             ->addSorting(new FieldSorting('autoIncrement', FieldSorting::ASCENDING))
             ->setLimit($this->readBufferSize);
+
+        $this->addProductStreamFilter($criteria, $productExport->getProductStreamId(), $context);
 
         if ($productExport->isIncludeVariants()) {
             // Only fetch variants and standalone products; parent products that have variants are skipped
@@ -254,6 +251,33 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             $fetched,
             $cursor,
             $exportBehavior->batchMode() && $fetched === $this->readBufferSize
+        );
+    }
+
+    /**
+     * Constrain the export to the products of the given dynamic product group.
+     *
+     * When product-stream indexing is enabled and the stream has already been indexed,
+     * the precomputed `product_stream_mapping` is used (an indexed join via `streamIds`)
+     * instead of re-evaluating the dynamic filter tree on every batch. Falls back to the
+     * dynamic filters when indexing is disabled or the stream has not been indexed yet.
+     */
+    private function addProductStreamFilter(Criteria $criteria, string $productStreamId, SalesChannelContext $context): void
+    {
+        if ($this->productStreamIndexingEnabled && $this->streamMappingExists($productStreamId)) {
+            $criteria->addFilter(new EqualsFilter('streamIds', $productStreamId));
+
+            return;
+        }
+
+        $criteria->addFilter(...$this->productStreamBuilder->buildFilters($productStreamId, $context->getContext()));
+    }
+
+    private function streamMappingExists(string $productStreamId): bool
+    {
+        return (bool) $this->connection->fetchOne(
+            'SELECT 1 FROM product_stream_mapping WHERE product_stream_id = :id LIMIT 1',
+            ['id' => Uuid::fromHexToBytes($productStreamId)]
         );
     }
 

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
@@ -619,7 +620,115 @@ class ProductExportGeneratorTest extends TestCase
         static::assertSame(41, $result->getLastId());
     }
 
-    private function createGenerator(): ProductExportGenerator
+    public function testGenerateUsesStreamMappingWhenIndexingEnabledAndStreamIsMapped(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $productExport = $this->getProductExportEntity();
+        $productExport->setFileFormat(ProductExportEntity::FILE_FORMAT_CSV);
+        $productExport->setEncoding(ProductExportEntity::ENCODING_UTF8);
+        $productExport->setBodyTemplate('{{ product.id }}');
+        $productExport->setIncludeVariants(false);
+        $productExport->setProductStreamId($streamId);
+
+        $context = $this->createSalesChannelContext();
+        $product = $this->createProduct('product-id', null, 0, 7);
+
+        $this->contextPersister->expects($this->once())->method('save');
+        $this->salesChannelContextService->expects($this->once())->method('get')->willReturn($context);
+        $this->languageLocaleProvider->expects($this->once())->method('getLocaleForLanguageId')->with('languageId')->willReturn('en-GB');
+        $this->translator->expects($this->once())->method('injectSettings');
+        $this->translator->expects($this->once())->method('resetInjection');
+
+        $twigVariableParser = $this->createMock(TwigVariableParser::class);
+        $twigVariableParser->expects($this->once())->method('parse')->with('{{ product.id }}')->willReturn([]);
+        $this->parserFactory->expects($this->once())->method('getParser')->willReturn($twigVariableParser);
+
+        // Indexing is on and the stream mapping has rows -> the dynamic filter builder must
+        // not be used; the export filters by the precomputed streamIds mapping instead.
+        $this->connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn('1');
+        $this->productStreamBuilder->expects($this->never())->method('buildFilters');
+
+        $results = [
+            $this->createProductSearchResult($product, $context),
+            $this->createEmptyProductSearchResult($context),
+        ];
+        $this->productRepository->expects($this->exactly(2))
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria) use (&$results, $streamId): EntitySearchResult {
+                $streamFilters = array_filter(
+                    $criteria->getFilters(),
+                    static fn ($f) => $f instanceof EqualsFilter && $f->getField() === 'streamIds' && $f->getValue() === $streamId
+                );
+                static::assertNotEmpty($streamFilters, 'Criteria must filter by streamIds when the product stream mapping is used');
+
+                return array_shift($results);
+            });
+
+        $this->productExportRender->method('renderBody')->willReturn('product');
+        $this->seoUrlPlaceholderHandler->method('replace')->willReturnArgument(0);
+        $this->productExportValidator->method('validate')->willReturn([]);
+        $this->connection->expects($this->once())->method('delete');
+
+        $result = $this->createGenerator(true)->generate($productExport, new ExportBehavior(false, false, false, false, false));
+
+        static::assertNotNull($result);
+    }
+
+    public function testGenerateFallsBackToDynamicFiltersWhenStreamNotYetMapped(): void
+    {
+        $streamId = Uuid::randomHex();
+
+        $productExport = $this->getProductExportEntity();
+        $productExport->setFileFormat(ProductExportEntity::FILE_FORMAT_CSV);
+        $productExport->setEncoding(ProductExportEntity::ENCODING_UTF8);
+        $productExport->setBodyTemplate('{{ product.id }}');
+        $productExport->setIncludeVariants(false);
+        $productExport->setProductStreamId($streamId);
+
+        $context = $this->createSalesChannelContext();
+        $product = $this->createProduct('product-id', null, 0, 7);
+
+        $this->contextPersister->expects($this->once())->method('save');
+        $this->salesChannelContextService->expects($this->once())->method('get')->willReturn($context);
+        $this->languageLocaleProvider->expects($this->once())->method('getLocaleForLanguageId')->with('languageId')->willReturn('en-GB');
+        $this->translator->expects($this->once())->method('injectSettings');
+        $this->translator->expects($this->once())->method('resetInjection');
+
+        $twigVariableParser = $this->createMock(TwigVariableParser::class);
+        $twigVariableParser->expects($this->once())->method('parse')->with('{{ product.id }}')->willReturn([]);
+        $this->parserFactory->expects($this->once())->method('getParser')->willReturn($twigVariableParser);
+
+        // Indexing is on but the mapping has no rows for this stream yet -> fall back to the
+        // dynamic filter builder so a freshly created stream still exports immediately.
+        $this->connection->expects($this->once())
+            ->method('fetchOne')
+            ->willReturn(false);
+        $this->productStreamBuilder->expects($this->once())
+            ->method('buildFilters')
+            ->with($streamId, $context->getContext())
+            ->willReturn([]);
+
+        $this->productRepository->expects($this->exactly(2))
+            ->method('search')
+            ->willReturnOnConsecutiveCalls(
+                $this->createProductSearchResult($product, $context),
+                $this->createEmptyProductSearchResult($context)
+            );
+
+        $this->productExportRender->method('renderBody')->willReturn('product');
+        $this->seoUrlPlaceholderHandler->method('replace')->willReturnArgument(0);
+        $this->productExportValidator->method('validate')->willReturn([]);
+        $this->connection->expects($this->once())->method('delete');
+
+        $result = $this->createGenerator(true)->generate($productExport, new ExportBehavior(false, false, false, false, false));
+
+        static::assertNotNull($result);
+    }
+
+    private function createGenerator(bool $productStreamIndexingEnabled = false): ProductExportGenerator
     {
         return new ProductExportGenerator(
             $this->productStreamBuilder,
@@ -636,7 +745,8 @@ class ProductExportGeneratorTest extends TestCase
             $this->twig,
             $this->productDefinition,
             $this->languageLocaleProvider,
-            $this->parserFactory
+            $this->parserFactory,
+            $productStreamIndexingEnabled
         );
     }
 


### PR DESCRIPTION
Relates to #17826. **Stacked on #17887** (base branch is `export-keyset-pagination-pr1`); review/merge that first. The diff here is only the stream-mapping change.

## Change
When `shopware.product_stream.indexing` is enabled **and** the product stream has already been indexed, resolve the export's products through the precomputed `product_stream_mapping` (an indexed `streamIds` join) instead of re-evaluating the dynamic `MultiFilter` tree on every batch. Falls back to the dynamic builder when indexing is disabled or the stream is not yet mapped, so freshly created streams still export immediately.

## Behavioral note
`product_stream_mapping` membership is the **union across all sales-channel languages**, so for streams filtering on translated fields an export may now include products that match in another language. This matches how the storefront already evaluates dynamic product groups; documented in the upgrade information. Disable `shopware.product_stream.indexing` to keep the previous per-export, single-language evaluation.

## Tests
- ProductExport unit suite green (incl. mapping-used and fallback cases).
- Integration suite to be run against a migrated test DB before merge.
