### PR TITLE
feat: improve caching by reducing number of cache calls

### DIFF
--- a/src/Core/Framework/DependencyInjection/script.php
+++ b/src/Core/Framework/DependencyInjection/script.php
@@ -35,7 +35,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             param('twig.cache'),
             param('kernel.debug'),
         ])
-        ->tag('kernel.event_subscriber');
+        ->tag('kernel.event_subscriber')
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set(ScriptExecutor::class)
         ->public()

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ResetInterface;
 use Twig\Cache\FilesystemCache;
 
 /**
@@ -18,11 +19,16 @@ use Twig\Cache\FilesystemCache;
  * @phpstan-type ScriptInfo = array{app_id: ?string, scriptName: string, script: string, hook: string, appName: ?string, appVersion: ?string, integrationId: ?string, lastModified: string, active: string}
  */
 #[Package('framework')]
-class ScriptLoader implements EventSubscriberInterface
+class ScriptLoader implements EventSubscriberInterface, ResetInterface
 {
     final public const CACHE_KEY = 'shopware-executable-app-scripts';
 
     private readonly string $cacheDir;
+
+    /**
+     * @var array<string, list<Script>>|null
+     */
+    private ?array $scripts = null;
 
     public function __construct(
         private readonly Connection $connection,
@@ -47,20 +53,7 @@ class ScriptLoader implements EventSubscriberInterface
      */
     public function get(string $hook): array
     {
-        $hookScripts = [];
-
-        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
-        if ($cacheItem->isHit() && $cacheItem->get()) {
-            /** @var list<Script> */
-            $hookScripts = CacheCompressor::uncompress($cacheItem)[$hook] ?? [];
-        } else {
-            $scripts = $this->load();
-
-            $cacheItem = CacheCompressor::compress($cacheItem, $scripts);
-            $this->cache->save($cacheItem);
-
-            $hookScripts = $scripts[$hook] ?? [];
-        }
+        $hookScripts = $this->getScripts()[$hook] ?? [];
 
         foreach ($hookScripts as $script) {
             $info = $script->getScriptAppInformation();
@@ -81,7 +74,39 @@ class ScriptLoader implements EventSubscriberInterface
 
     public function invalidateCache(): void
     {
+        $this->reset();
+
         $this->cache->deleteItem(self::CACHE_KEY);
+    }
+
+    public function reset(): void
+    {
+        $this->scripts = null;
+    }
+
+    /**
+     * @return array<string, list<Script>>
+     */
+    private function getScripts(): array
+    {
+        if ($this->scripts !== null) {
+            return $this->scripts;
+        }
+
+        $cacheItem = $this->cache->getItem(self::CACHE_KEY);
+        if ($cacheItem->isHit() && $cacheItem->get()) {
+            /** @var array<string, list<Script>> $scripts */
+            $scripts = CacheCompressor::uncompress($cacheItem);
+
+            return $this->scripts = $scripts;
+        }
+
+        $scripts = $this->load();
+
+        $cacheItem = CacheCompressor::compress($cacheItem, $scripts);
+        $this->cache->save($cacheItem);
+
+        return $this->scripts = $scripts;
     }
 
     /**

--- a/src/Storefront/DependencyInjection/services.php
+++ b/src/Storefront/DependencyInjection/services.php
@@ -259,7 +259,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(CachedDomainLoader::class . '.inner'),
             service('cache.object'),
             service('logger'),
-        ]);
+        ])
+        ->tag('kernel.reset', ['method' => 'reset']);
 
     $services->set(CachedDomainLoaderInvalidator::class)
         ->args([

--- a/src/Storefront/Framework/Routing/CachedDomainLoader.php
+++ b/src/Storefront/Framework/Routing/CachedDomainLoader.php
@@ -8,12 +8,13 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Framework\Routing\Struct\DomainCollection;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @phpstan-import-type Domain from AbstractDomainLoader
  */
 #[Package('discovery')]
-class CachedDomainLoader extends AbstractDomainLoader
+class CachedDomainLoader extends AbstractDomainLoader implements ResetInterface
 {
     /**
      * @deprecated tag:v6.8.0 - reason:becomes-unused - Will be removed together with the deprecated load(), use DOMAIN_COLLECTION_CACHE_KEY instead
@@ -21,6 +22,13 @@ class CachedDomainLoader extends AbstractDomainLoader
     final public const CACHE_KEY = 'routing-domains';
 
     final public const DOMAIN_COLLECTION_CACHE_KEY = 'routing-domain-collection';
+
+    /**
+     * @var array<string, Domain>|null
+     */
+    private ?array $domains = null;
+
+    private ?DomainCollection $domainCollection = null;
 
     /**
      * @internal
@@ -48,6 +56,10 @@ class CachedDomainLoader extends AbstractDomainLoader
             Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0', 'loadDomains()')
         );
 
+        if ($this->domains !== null) {
+            return $this->domains;
+        }
+
         $value = $this->cache->get(self::CACHE_KEY, fn (ItemInterface $item) => CacheValueCompressor::compress(
             $this->getDecorated()->load()
         ));
@@ -55,11 +67,15 @@ class CachedDomainLoader extends AbstractDomainLoader
         /** @var array<string, Domain> $value */
         $value = CacheValueCompressor::uncompress($value);
 
-        return $value;
+        return $this->domains = $value;
     }
 
     public function loadDomains(): DomainCollection
     {
+        if ($this->domainCollection !== null) {
+            return $this->domainCollection;
+        }
+
         $value = $this->cache->get(self::DOMAIN_COLLECTION_CACHE_KEY, fn (ItemInterface $item) => CacheValueCompressor::compress(
             $this->getDecorated()->loadDomains()
         ));
@@ -67,6 +83,12 @@ class CachedDomainLoader extends AbstractDomainLoader
         /** @var DomainCollection $value */
         $value = CacheValueCompressor::uncompress($value);
 
-        return $value;
+        return $this->domainCollection = $value;
+    }
+
+    public function reset(): void
+    {
+        $this->domains = null;
+        $this->domainCollection = null;
     }
 }

--- a/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Script\Execution;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Lifecycle\Handler\ScriptLifecycleHandler;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\ScriptLoader;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\CacheItem;
+
+/**
+ * @internal
+ */
+#[CoversClass(ScriptLoader::class)]
+#[Package('framework')]
+class ScriptLoaderTest extends TestCase
+{
+    public function testCachesLoadedScriptsInMemory(): void
+    {
+        $cache = new CountingTagAwareAdapter();
+        $loader = new ScriptLoader(
+            $this->createConnection(),
+            $this->createMock(ScriptLifecycleHandler::class),
+            $cache,
+            sys_get_temp_dir(),
+            false,
+        );
+
+        static::assertCount(1, $loader->get('first-hook'));
+        static::assertCount(1, $loader->get('second-hook'));
+
+        static::assertSame(1, $cache->getItemCalls);
+    }
+
+    private function createConnection(): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->once())
+            ->method('fetchAllAssociative')
+            ->willReturn([
+                $this->createScriptInfo('first-hook'),
+                $this->createScriptInfo('second-hook'),
+            ]);
+
+        return $connection;
+    }
+
+    /**
+     * @return array{app_id: string, scriptName: string, script: string, hook: string, appName: string, appVersion: string, integrationId: string, lastModified: string, active: string}
+     */
+    private function createScriptInfo(string $hook): array
+    {
+        return [
+            'app_id' => '018f89c8a0cf70b5ac102d19a804db18',
+            'scriptName' => $hook,
+            'script' => '',
+            'hook' => $hook,
+            'appName' => 'TestApp',
+            'appVersion' => '1.0.0',
+            'integrationId' => '018f89c8a0cf70b5ac102d19a804db19',
+            'lastModified' => '2024-01-01 00:00:00.000',
+            'active' => '1',
+        ];
+    }
+}
+
+/**
+ * @internal
+ */
+class CountingTagAwareAdapter extends TagAwareAdapter
+{
+    public int $getItemCalls = 0;
+
+    public function __construct()
+    {
+        parent::__construct(new ArrayAdapter());
+    }
+
+    public function getItem(mixed $key): CacheItem
+    {
+        ++$this->getItemCalls;
+
+        return parent::getItem($key);
+    }
+}

--- a/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -15,8 +15,8 @@ use Symfony\Component\Cache\CacheItem;
 /**
  * @internal
  */
-#[CoversClass(ScriptLoader::class)]
 #[Package('framework')]
+#[CoversClass(ScriptLoader::class)]
 class ScriptLoaderTest extends TestCase
 {
     public function testCachesLoadedScriptsInMemory(): void

--- a/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -36,6 +36,54 @@ class ScriptLoaderTest extends TestCase
         static::assertSame(1, $cache->getItemCalls);
     }
 
+    public function testLoadsFromPersistentCacheAfterReset(): void
+    {
+        $cache = $this->createCache();
+        $loader = new ScriptLoader(
+            $this->createConnection(),
+            $this->createMock(ScriptLifecycleHandler::class),
+            $cache,
+            sys_get_temp_dir(),
+            false,
+        );
+
+        static::assertCount(1, $loader->get('first-hook'));
+
+        $loader->reset();
+
+        // Second get() must hit persistent cache, not DB — connection mock enforces once()
+        static::assertCount(1, $loader->get('first-hook'));
+
+        static::assertSame(2, $cache->getItemCalls);
+    }
+
+    public function testInvalidateCacheClearsMemoryAndPersistentCache(): void
+    {
+        $cache = $this->createCache();
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects($this->exactly(2))
+            ->method('fetchAllAssociative')
+            ->willReturn([$this->createScriptInfo('first-hook')]);
+
+        $loader = new ScriptLoader(
+            $connection,
+            $this->createMock(ScriptLifecycleHandler::class),
+            $cache,
+            sys_get_temp_dir(),
+            false,
+        );
+
+        static::assertCount(1, $loader->get('first-hook'));
+
+        $loader->invalidateCache();
+
+        // After invalidation both memory and persistent cache are cleared — DB must be hit again
+        static::assertCount(1, $loader->get('first-hook'));
+
+        static::assertSame(2, $cache->getItemCalls);
+    }
+
     /**
      * @return TagAwareAdapter&object{getItemCalls: int}
      */

--- a/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -21,7 +21,7 @@ class ScriptLoaderTest extends TestCase
 {
     public function testCachesLoadedScriptsInMemory(): void
     {
-        $cache = new CountingTagAwareAdapter();
+        $cache = $this->createCache();
         $loader = new ScriptLoader(
             $this->createConnection(),
             $this->createMock(ScriptLifecycleHandler::class),
@@ -34,6 +34,28 @@ class ScriptLoaderTest extends TestCase
         static::assertCount(1, $loader->get('second-hook'));
 
         static::assertSame(1, $cache->getItemCalls);
+    }
+
+    /**
+     * @return TagAwareAdapter&object{getItemCalls: int}
+     */
+    private function createCache(): TagAwareAdapter
+    {
+        return new class extends TagAwareAdapter {
+            public int $getItemCalls = 0;
+
+            public function __construct()
+            {
+                parent::__construct(new ArrayAdapter());
+            }
+
+            public function getItem(mixed $key): CacheItem
+            {
+                ++$this->getItemCalls;
+
+                return parent::getItem($key);
+            }
+        };
     }
 
     private function createConnection(): Connection
@@ -66,25 +88,5 @@ class ScriptLoaderTest extends TestCase
             'lastModified' => '2024-01-01 00:00:00.000',
             'active' => '1',
         ];
-    }
-}
-
-/**
- * @internal
- */
-class CountingTagAwareAdapter extends TagAwareAdapter
-{
-    public int $getItemCalls = 0;
-
-    public function __construct()
-    {
-        parent::__construct(new ArrayAdapter());
-    }
-
-    public function getItem(mixed $key): CacheItem
-    {
-        ++$this->getItemCalls;
-
-        return parent::getItem($key);
     }
 }

--- a/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/unit/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -24,7 +24,7 @@ class ScriptLoaderTest extends TestCase
         $cache = $this->createCache();
         $loader = new ScriptLoader(
             $this->createConnection(),
-            $this->createMock(ScriptLifecycleHandler::class),
+            static::createStub(ScriptLifecycleHandler::class),
             $cache,
             sys_get_temp_dir(),
             false,
@@ -41,7 +41,7 @@ class ScriptLoaderTest extends TestCase
         $cache = $this->createCache();
         $loader = new ScriptLoader(
             $this->createConnection(),
-            $this->createMock(ScriptLifecycleHandler::class),
+            static::createStub(ScriptLifecycleHandler::class),
             $cache,
             sys_get_temp_dir(),
             false,
@@ -68,7 +68,7 @@ class ScriptLoaderTest extends TestCase
 
         $loader = new ScriptLoader(
             $connection,
-            $this->createMock(ScriptLifecycleHandler::class),
+            static::createStub(ScriptLifecycleHandler::class),
             $cache,
             sys_get_temp_dir(),
             false,

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -14,8 +14,8 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 /**
  * @internal
  */
-#[CoversClass(CachedDomainLoader::class)]
 #[Package('framework')]
+#[CoversClass(CachedDomainLoader::class)]
 class CachedDomainLoaderTest extends TestCase
 {
     public function testCachesDomainCollectionInMemory(): void

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Routing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Framework\Routing\AbstractDomainLoader;
+use Shopware\Storefront\Framework\Routing\CachedDomainLoader;
+use Shopware\Storefront\Framework\Routing\Struct\DomainCollection;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @internal
+ */
+#[CoversClass(CachedDomainLoader::class)]
+#[Package('framework')]
+class CachedDomainLoaderTest extends TestCase
+{
+    public function testCachesDomainCollectionInMemory(): void
+    {
+        $decorated = new CountingDomainLoader();
+        $cache = new CountingArrayAdapter();
+        $loader = new CachedDomainLoader($decorated, $cache);
+
+        static::assertCount(1, $loader->loadDomains());
+        static::assertCount(1, $loader->loadDomains());
+
+        static::assertSame(1, $cache->getCalls);
+        static::assertSame(1, $decorated->loadDomainsCalls);
+    }
+}
+
+/**
+ * @internal
+ */
+class CountingArrayAdapter extends ArrayAdapter
+{
+    public int $getCalls = 0;
+
+    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+    {
+        ++$this->getCalls;
+
+        return parent::get($key, $callback, $beta, $metadata);
+    }
+}
+
+/**
+ * @internal
+ */
+class CountingDomainLoader extends AbstractDomainLoader
+{
+    public int $loadDomainsCalls = 0;
+
+    public function getDecorated(): AbstractDomainLoader
+    {
+        throw new \BadMethodCallException('This test loader does not decorate another loader.');
+    }
+
+    public function load(): array
+    {
+        throw new \BadMethodCallException('This test uses loadDomains().');
+    }
+
+    public function loadDomains(): DomainCollection
+    {
+        ++$this->loadDomainsCalls;
+
+        return DomainCollection::fromArray([
+            'https://example.com/' => [
+                'url' => 'https://example.com',
+                'id' => 'domain-id',
+                'salesChannelId' => 'sales-channel-id',
+                'typeId' => 'type-id',
+                'snippetSetId' => 'snippet-set-id',
+                'currencyId' => 'currency-id',
+                'languageId' => 'language-id',
+                'themeId' => 'theme-id',
+                'maintenance' => '0',
+                'maintenanceIpAllowlist' => null,
+                'locale' => 'en-GB',
+                'themeName' => 'Storefront',
+                'parentThemeName' => null,
+            ],
+        ]);
+    }
+}

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Storefront\Framework\Routing;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Storefront\Framework\Routing\AbstractDomainLoader;
 use Shopware\Storefront\Framework\Routing\CachedDomainLoader;
 use Shopware\Storefront\Framework\Routing\Struct\DomainCollection;
@@ -28,6 +29,41 @@ class CachedDomainLoaderTest extends TestCase
 
         static::assertSame(1, $cache->getCalls);
         static::assertSame(1, $decorated->loadDomainsCalls);
+    }
+
+    public function testResetClearsDomainCollectionCache(): void
+    {
+        $decorated = $this->createDomainLoader();
+        $cache = $this->createCache();
+        $loader = new CachedDomainLoader($decorated, $cache);
+
+        static::assertCount(1, $loader->loadDomains());
+
+        $loader->reset();
+
+        // After reset() memory is cleared — persistent cache is hit but inner loader is not called again
+        static::assertCount(1, $loader->loadDomains());
+
+        static::assertSame(2, $cache->getCalls);
+        static::assertSame(1, $decorated->loadDomainsCalls);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - Tests deprecated load(), remove when load() is removed
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testCachesDomainsInMemory(): void
+    {
+        $decorated = $this->createDomainLoaderWithLoadCounter();
+        $cache = $this->createCache();
+        $loader = new CachedDomainLoader($decorated, $cache);
+
+        static::assertSame([], $loader->load());
+        // Second call must return from memory without hitting the cache or inner loader
+        static::assertSame([], $loader->load());
+
+        static::assertSame(1, $cache->getCalls);
+        static::assertSame(1, $decorated->loadCalls);
     }
 
     /**
@@ -86,6 +122,33 @@ class CachedDomainLoaderTest extends TestCase
                         'parentThemeName' => null,
                     ],
                 ]);
+            }
+        };
+    }
+
+    /**
+     * @return AbstractDomainLoader&object{loadCalls: int}
+     */
+    private function createDomainLoaderWithLoadCounter(): AbstractDomainLoader
+    {
+        return new class extends AbstractDomainLoader {
+            public int $loadCalls = 0;
+
+            public function getDecorated(): AbstractDomainLoader
+            {
+                return $this;
+            }
+
+            public function load(): array
+            {
+                ++$this->loadCalls;
+
+                return [];
+            }
+
+            public function loadDomains(): DomainCollection
+            {
+                return DomainCollection::fromArray([]);
             }
         };
     }

--- a/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
+++ b/tests/unit/Storefront/Framework/Routing/CachedDomainLoaderTest.php
@@ -19,8 +19,8 @@ class CachedDomainLoaderTest extends TestCase
 {
     public function testCachesDomainCollectionInMemory(): void
     {
-        $decorated = new CountingDomainLoader();
-        $cache = new CountingArrayAdapter();
+        $decorated = $this->createDomainLoader();
+        $cache = $this->createCache();
         $loader = new CachedDomainLoader($decorated, $cache);
 
         static::assertCount(1, $loader->loadDomains());
@@ -29,60 +29,64 @@ class CachedDomainLoaderTest extends TestCase
         static::assertSame(1, $cache->getCalls);
         static::assertSame(1, $decorated->loadDomainsCalls);
     }
-}
 
-/**
- * @internal
- */
-class CountingArrayAdapter extends ArrayAdapter
-{
-    public int $getCalls = 0;
-
-    public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+    /**
+     * @return ArrayAdapter&object{getCalls: int}
+     */
+    private function createCache(): ArrayAdapter
     {
-        ++$this->getCalls;
+        return new class extends ArrayAdapter {
+            public int $getCalls = 0;
 
-        return parent::get($key, $callback, $beta, $metadata);
-    }
-}
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                ++$this->getCalls;
 
-/**
- * @internal
- */
-class CountingDomainLoader extends AbstractDomainLoader
-{
-    public int $loadDomainsCalls = 0;
-
-    public function getDecorated(): AbstractDomainLoader
-    {
-        throw new \BadMethodCallException('This test loader does not decorate another loader.');
+                return parent::get($key, $callback, $beta, $metadata);
+            }
+        };
     }
 
-    public function load(): array
+    /**
+     * @return AbstractDomainLoader&object{loadDomainsCalls: int}
+     */
+    private function createDomainLoader(): AbstractDomainLoader
     {
-        throw new \BadMethodCallException('This test uses loadDomains().');
-    }
+        return new class extends AbstractDomainLoader {
+            public int $loadDomainsCalls = 0;
 
-    public function loadDomains(): DomainCollection
-    {
-        ++$this->loadDomainsCalls;
+            public function getDecorated(): AbstractDomainLoader
+            {
+                return $this;
+            }
 
-        return DomainCollection::fromArray([
-            'https://example.com/' => [
-                'url' => 'https://example.com',
-                'id' => 'domain-id',
-                'salesChannelId' => 'sales-channel-id',
-                'typeId' => 'type-id',
-                'snippetSetId' => 'snippet-set-id',
-                'currencyId' => 'currency-id',
-                'languageId' => 'language-id',
-                'themeId' => 'theme-id',
-                'maintenance' => '0',
-                'maintenanceIpAllowlist' => null,
-                'locale' => 'en-GB',
-                'themeName' => 'Storefront',
-                'parentThemeName' => null,
-            ],
-        ]);
+            public function load(): array
+            {
+                return [];
+            }
+
+            public function loadDomains(): DomainCollection
+            {
+                ++$this->loadDomainsCalls;
+
+                return DomainCollection::fromArray([
+                    'https://example.com/' => [
+                        'url' => 'https://example.com',
+                        'id' => 'domain-id',
+                        'salesChannelId' => 'sales-channel-id',
+                        'typeId' => 'type-id',
+                        'snippetSetId' => 'snippet-set-id',
+                        'currencyId' => 'currency-id',
+                        'languageId' => 'language-id',
+                        'themeId' => 'theme-id',
+                        'maintenance' => '0',
+                        'maintenanceIpAllowlist' => null,
+                        'locale' => 'en-GB',
+                        'themeName' => 'Storefront',
+                        'parentThemeName' => null,
+                    ],
+                ]);
+            }
+        };
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

`ScriptLoader` and `CachedDomainLoader` can be called multiple times during the same request. Each call reads the same cached value from `cache.object` again and decompresses it again, even though the result cannot change within the same request unless the service is reset.

When `cache.object` is backed by Redis, this creates avoidable repeated Redis calls for script and storefront domain loading.


### 2. What does this change do, exactly?

This change adds request-local in-memory caching to both loaders:

- `ScriptLoader` stores the loaded scripts in memory after the first cacheread.
- `CachedDomainLoader` stores the loaded `DomainCollection` in memory after the first cache read.
- The deprecated `CachedDomainLoader::load()` path also gets its own in-memory cache.
- Both loaders implement `ResetInterface`.
- Both services are tagged with `kernel.reset` so long-running processes clear the in-memory values between requests.
- `ScriptLoader::invalidateCache()` now also clears its in-memory cache before deleting the shared cache item.
- Unit tests verify that repeated calls only hit the shared cache once.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure `cache.object` with Redis.
2. Trigger a request that resolves multiple app script hooks or calls `ScriptLoader::get()` multiple times.
3. Observe that the same `shopware-executable-app-scripts` cache item is fetched repeatedly during the same request.
4. Trigger a storefront request that resolves domains through `CachedDomainLoader::loadDomains()` multiple times.
5. Observe that the same `routing-domain-collection` cache item is fetched repeatedly during the same request.
6. With this change, the first call per request still reads from the shared cache, while subsequent calls reuse the in-memory value.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
