### PR TITLE
feat: move shopware account service hint to popover

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.html.twig
@@ -47,6 +47,12 @@
                     />
 
                     <mt-popover-item
+                        v-if="service.active && serviceHasShopwareAccountRequirement"
+                        :label="$t('sw-settings-services.service-card.cannot-remove-or-deactivate')"
+                        :disabled="true"
+                    />
+
+                    <mt-popover-item
                         :label="$t('sw-settings-services.service-card.permissions')"
                         :on-label-click="() => openPermissionsModal(toggleFloatingUi)"
                     />
@@ -54,17 +60,9 @@
             </mt-popover>
         </div>
 
-        <div class="sw-settings-services-service-card__description">
-            <p>{{ service.description }}</p>
-            <div
-                v-if="serviceHasShopwareAccountRequirement"
-                class="sw-settings-services-service-card__account-requirement"
-            >
-                <p>
-                    {{ $t('sw-settings-services.service-card.cannot-remove-or-deactivate') }}
-                </p>
-            </div>
-        </div>
+        <p class="sw-settings-services-service-card__description">
+            {{ service.description }}
+        </p>
 
         <div class="sw-settings-services-service-card__footer">
             {{  $t('sw-settings-services.service-card.updated-at-label', { updatedAt: updatedAt }) }}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.scss
@@ -34,16 +34,6 @@
     .sw-settings-services-service-card__description {
         flex-grow: 1;
         font-size: var(--font-size-xs);
-
-        & > *:not(:last-child) {
-            margin-block-end: var(--scale-size-10);
-        }
-    }
-
-    .sw-settings-services-service-card__account-requirement {
-        p {
-            margin: 0;
-        }
     }
 
     .sw-settings-services-service-card__footer {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-services/component/sw-settings-services-service-card/sw-settings-services-service-card.spec.js
@@ -201,7 +201,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
         expect(card.vm._reloadPage).toHaveBeenCalled();
     });
 
-    it('hides the deactivate action for services that require Shopware Account', async () => {
+    it('shows a disabled deactivate hint for services that require Shopware Account', async () => {
         const card = mount(SwSettingsServicesServiceCard, {
             props: {
                 service: createService({
@@ -232,7 +232,7 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
         });
 
         expect(card.vm.serviceHasShopwareAccountRequirement).toBe(true);
-        expect(card.text()).toContain('sw-settings-services.service-card.cannot-remove-or-deactivate');
+        expect(card.text()).not.toContain('sw-settings-services.service-card.cannot-remove-or-deactivate');
 
         await card.findComponent(MtPopover).findComponent(MtButton).trigger('click');
         // Wait 32ms for debounce
@@ -240,10 +240,16 @@ describe('src/module/sw-settings-services/component/sw-settings-services-service
             setTimeout(resolve, 32);
         });
 
-        const popoverItems = card.findAllComponents(MtPopoverItem).map((popoverItem) => popoverItem.text());
+        const popoverItems = card.findAllComponents(MtPopoverItem);
+        const popoverItemLabels = popoverItems.map((popoverItem) => popoverItem.text());
+        const disabledDeactivateHint = popoverItems.find((popoverItem) => {
+            return popoverItem.text() === 'sw-settings-services.service-card.cannot-remove-or-deactivate';
+        });
 
-        expect(popoverItems).not.toContain('sw-settings-services.general.deactivate');
-        expect(popoverItems).toContain('sw-settings-services.service-card.permissions');
+        expect(popoverItemLabels).not.toContain('sw-settings-services.general.deactivate');
+        expect(popoverItemLabels).toContain('sw-settings-services.service-card.cannot-remove-or-deactivate');
+        expect(popoverItemLabels).toContain('sw-settings-services.service-card.permissions');
+        expect(disabledDeactivateHint.props('disabled')).toBe(true);
     });
 
     it('activates a service', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Follow-up to parent PR [shopware/shopware#16843](https://github.com/shopware/shopware/pull/16843): services requiring a Shopware Account should explain why deactivation is unavailable without showing the warning permanently on the card.

### 2. What does this change do, exactly?

Moves the deactivation warning into the service card action popover as a disabled item and updates the component test.

### 3. Describe each step to reproduce the issue or behaviour.

Open Shopware Services and view an active service that requires a Shopware Account. Open the card action menu.

### 4. Please link to the relevant issues (if any).

Relates to [shopware/shopware#16843](https://github.com/shopware/shopware/pull/16843)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

<img width="1014" height="317" alt="Screenshot 2026-07-01 at 14 20 03" src="https://github.com/user-attachments/assets/a6374851-ab3a-4af9-a2b9-f85c6b07290c" />
