### PR TITLE
fix(administration): guard MCP allowlist against nullish

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/helper/mcp-privilege.helper.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/helper/mcp-privilege.helper.spec.js
@@ -1,7 +1,7 @@
 /**
  * @sw-package fundamentals@framework
  */
-import { colonToDot, isPrivilegeGranted } from 'src/core/helper/mcp-privilege.helper';
+import { colonToDot, isPrivilegeGranted, computePrivilegeChips } from 'src/core/helper/mcp-privilege.helper';
 
 describe('colonToDot', () => {
     it('converts read → viewer', () => {
@@ -27,6 +27,11 @@ describe('colonToDot', () => {
     it('returns null for dynamic chip placeholder', () => {
         expect(colonToDot('<entity>:read')).toBeNull();
     });
+
+    it('returns null for nullish input instead of throwing', () => {
+        expect(colonToDot(undefined)).toBeNull();
+        expect(colonToDot(null)).toBeNull();
+    });
 });
 
 describe('isPrivilegeGranted', () => {
@@ -48,5 +53,50 @@ describe('isPrivilegeGranted', () => {
 
     it('returns false for dynamic chip placeholders that have no matching entry', () => {
         expect(isPrivilegeGranted('<entity>:read', [])).toBe(false);
+    });
+
+    it('returns false for nullish chips instead of throwing', () => {
+        expect(isPrivilegeGranted(undefined, ['product.viewer'])).toBe(false);
+        expect(isPrivilegeGranted(null, ['product.viewer'])).toBe(false);
+    });
+});
+
+describe('computePrivilegeChips', () => {
+    it('returns an empty list for nullish required privileges', () => {
+        expect(computePrivilegeChips(null)).toStrictEqual([]);
+        expect(computePrivilegeChips(undefined)).toStrictEqual([]);
+    });
+
+    it('drops nullish static privilege entries', () => {
+        expect(
+            computePrivilegeChips({
+                static: [
+                    'product:read',
+                    undefined,
+                    null,
+                    'order:update',
+                ],
+            }),
+        ).toStrictEqual([
+            'product:read',
+            'order:update',
+        ]);
+    });
+
+    it('expands entity/operation pairs into dynamic chips', () => {
+        expect(
+            computePrivilegeChips({
+                static: ['product:read'],
+                entityParam: 'entity',
+                operations: [
+                    'read',
+                    'update',
+                ],
+            }),
+        ).toStrictEqual([
+            'product:read',
+            '<entity>:read',
+            '<entity>:update',
+        ]);
     });
 });

--- a/src/Administration/Resources/app/administration/src/core/helper/mcp-privilege.helper.ts
+++ b/src/Administration/Resources/app/administration/src/core/helper/mcp-privilege.helper.ts
@@ -16,7 +16,7 @@ const operationToRole: Record<string, string> = {
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export function colonToDot(chip: string): string | null {
-    if (chip.startsWith('<')) return null;
+    if (typeof chip !== 'string' || chip.startsWith('<')) return null;
     const [
         entity,
         operation,
@@ -27,6 +27,7 @@ export function colonToDot(chip: string): string | null {
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export function isPrivilegeGranted(chip: string, grantedPrivileges: string[]): boolean {
+    if (typeof chip !== 'string') return false;
     if (grantedPrivileges.includes(chip)) return true;
     const [
         entity,
@@ -51,7 +52,7 @@ export function computePrivilegeChips(requiredPrivileges: RequiredPrivileges | n
         return [];
     }
 
-    const chips = [...(requiredPrivileges.static ?? [])];
+    const chips = (requiredPrivileges.static ?? []).filter((priv): priv is string => typeof priv === 'string');
 
     if (requiredPrivileges.entityParam) {
         (requiredPrivileges.operations ?? []).forEach((op) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/index.js
@@ -390,7 +390,7 @@ export default {
         },
 
         privilegeChipClass(chip) {
-            if (this.isAdmin || this.grantedPrivileges.length === 0 || chip.startsWith('<')) {
+            if (this.isAdmin || this.grantedPrivileges.length === 0 || typeof chip !== 'string' || chip.startsWith('<')) {
                 return 'neutral';
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/component/sw-integration-mcp-allowlist/index.spec.js
@@ -1,7 +1,7 @@
 /**
  * @sw-package fundamentals@framework
  */
-import { mount } from '@vue/test-utils';
+import { mount, flushPromises } from '@vue/test-utils';
 import 'src/module/sw-integration/component/sw-integration-mcp-allowlist';
 
 const defaultCapabilities = {
@@ -341,5 +341,72 @@ describe('sw-integration-mcp-allowlist', () => {
         const names = wrapper.vm.missingCapabilitySuggestions.map((s) => s.name);
         expect(names).toContain('shopware-context');
         expect(names).not.toContain('shopware-debug');
+    });
+
+    describe('no capabilities registered', () => {
+        it('renders the empty state when capabilities are empty and all-toggle is off', async () => {
+            mcpToolService.getCapabilities.mockResolvedValue({ tools: [], resources: [], prompts: [] });
+
+            const wrapper = await createWrapper({
+                allowlist: { tools: null, resources: null, prompts: null },
+            });
+            await flushPromises();
+
+            expect(wrapper.find('mt-empty-state-stub').exists()).toBe(true);
+        });
+
+        it('tolerates a capabilities payload with missing keys', async () => {
+            mcpToolService.getCapabilities.mockResolvedValue({});
+
+            const wrapper = await createWrapper({
+                allowlist: { tools: null, resources: null, prompts: null },
+            });
+            await flushPromises();
+
+            expect(wrapper.vm.availableTools).toStrictEqual([]);
+            expect(wrapper.vm.availableResources).toStrictEqual([]);
+            expect(wrapper.vm.availablePrompts).toStrictEqual([]);
+            expect(wrapper.find('mt-empty-state-stub').exists()).toBe(true);
+        });
+
+        it('does not throw when toggling all capabilities off with no capabilities', async () => {
+            mcpToolService.getCapabilities.mockResolvedValue({ tools: [], resources: [], prompts: [] });
+
+            const wrapper = await createWrapper({ allowlist: null });
+            await flushPromises();
+
+            expect(() => {
+                wrapper.vm.allCapabilitiesEnabled = false;
+            }).not.toThrow();
+        });
+    });
+
+    describe('malformed capability data', () => {
+        it('does not throw when a tool exposes an undefined privilege chip', async () => {
+            mcpToolService.getCapabilities.mockResolvedValue({
+                tools: [
+                    {
+                        name: 'broken-tool',
+                        description: 'Broken tool',
+                        dependencies: [],
+                        // static privilege list contains a nullish entry
+                        requiredPrivileges: { static: [undefined] },
+                    },
+                ],
+                resources: [],
+                prompts: [],
+            });
+
+            const wrapper = await createWrapper({
+                allowlist: { tools: null, resources: null, prompts: null },
+                // non-empty granted privileges + non-admin => the chip guard is actually evaluated
+                isAdmin: false,
+                grantedPrivileges: ['product.viewer'],
+            });
+            await flushPromises();
+
+            expect(() => wrapper.vm.privilegeChipClass(undefined)).not.toThrow();
+            expect(wrapper.vm.privilegeChipClass(undefined)).toBe('neutral');
+        });
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

When an MCP integration is restricted via the allowlist, the Admin integration allowlist crashes if a tool exposes a nullish or non-string privilege entry. Two failures were observed with the same root cause:

- "Cannot read properties of undefined (reading 'startsWith')" in privilegeChipClass (render path).
- "Cannot read properties of undefined (reading 'split')" inside the uncoveredTools computed, via isPrivilegeGranted (mcp-privilege.helper).

The second one is thrown inside a Vue computed, which surfaces as a captured module error and matches the trace reported from the field.

### 2. What does this change do, exactly?

Hardens the shared privilege handling so a malformed privilege entry can no longer crash the allowlist UI:

- mcp-privilege.helper.ts: colonToDot and isPrivilegeGranted return safely on non-string input; computePrivilegeChips drops nullish entries from the static list so undefined chips never reach the UI.
- sw-integration-mcp-allowlist/index.js: privilegeChipClass guards `typeof chip !== 'string'` before calling startsWith.

Adds Jest coverage: empty capabilities (empty state, missing keys, toggle with nothing registered) and malformed privilege data (does not throw, renders neutral chip).

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable MCP_SERVER and open Settings, Integrations, an integration with MCP enabled.
2. Open the MCP allowlist with a non-admin integration that has granted privileges, where a tool reports a privilege list containing a nullish entry.
3. Toggle the capability restrictions.

Before: the allowlist throws in a computed and the UI breaks.
After: no throw; the chip renders as neutral and the allowlist works.

### 4. Please link to the relevant issues (if any).

<!-- Add the issue for the MCP allowlist crash here. -->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is relevant for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
