### PR TITLE
test: enforce createStub rule for Core `Service`, `Installer`, `Maintenance`, `SsoUser`, `Saas`, `Test`

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoCreateMockWithoutExpectationsRule.php
@@ -52,6 +52,12 @@ class NoCreateMockWithoutExpectationsRule implements Rule
         'Shopware\\Tests\\Unit\\Core\\Profiling\\',
         'Shopware\\Tests\\Unit\\Administration\\',
         'Shopware\\Tests\\Unit\\Storefront\\',
+        'Shopware\\Tests\\Unit\\Core\\Service\\',
+        'Shopware\\Tests\\Unit\\Core\\Installer\\',
+        'Shopware\\Tests\\Unit\\Core\\Maintenance\\',
+        'Shopware\\Tests\\Unit\\Core\\SsoUser\\',
+        'Shopware\\Tests\\Unit\\Core\\Saas\\',
+        'Shopware\\Tests\\Unit\\Core\\Test\\',
     ];
 
     public function getNodeType(): string

--- a/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseConfigurationControllerTest.php
@@ -68,6 +68,11 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoute(): void
     {
+        $this->translator->expects($this->never())->method('trans');
+        $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
+        $this->setupDatabaseAdapter->expects($this->never())->method('getTableCount');
+        $this->router->expects($this->never())->method('generate');
+
         $this->setEnvVars([
             'DATABASE_URL' => 'mysql://shopware:secret@db.example:3307/shopware_prefill',
         ]);
@@ -104,6 +109,11 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRouteFallsBackOnInvalidDatabaseUrl(): void
     {
+        $this->translator->expects($this->never())->method('trans');
+        $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
+        $this->setupDatabaseAdapter->expects($this->never())->method('getTableCount');
+        $this->router->expects($this->never())->method('generate');
+
         $this->setEnvVars([
             'DATABASE_URL' => 'not-a-valid-url',
         ]);
@@ -132,7 +142,9 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoutePostWithEmptyExistingDB(): void
     {
-        $connection = $this->createMock(Connection::class);
+        $this->translator->expects($this->never())->method('trans');
+
+        $connection = static::createStub(Connection::class);
 
         $this->connectionFactory->expects($this->once())
             ->method('getConnection')
@@ -166,6 +178,8 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoutePostWithNonEmptyExistingDB(): void
     {
+        $this->router->expects($this->never())->method('generate');
+
         $this->twig->expects($this->once())->method('render')
             ->with(
                 '@Installer/installer/database-configuration.html.twig',
@@ -181,7 +195,7 @@ class DatabaseConfigurationControllerTest extends TestCase
             ->with('shopware.installer.database-configuration_non_empty_database')
             ->willReturn('translated error');
 
-        $connection = $this->createMock(Connection::class);
+        $connection = static::createStub(Connection::class);
 
         $this->connectionFactory->expects($this->once())
             ->method('getConnection')
@@ -208,8 +222,10 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoutePostWithNonExistingDB(): void
     {
-        $connectionWithoutDb = $this->createMock(Connection::class);
-        $connection = $this->createMock(Connection::class);
+        $this->translator->expects($this->never())->method('trans');
+
+        $connectionWithoutDb = static::createStub(Connection::class);
+        $connection = static::createStub(Connection::class);
 
         $this->connectionFactory->expects($this->exactly(3))
             ->method('getConnection')
@@ -251,6 +267,9 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoutePostWithUnexpectedException(): void
     {
+        $this->translator->expects($this->never())->method('trans');
+        $this->router->expects($this->never())->method('generate');
+
         $this->twig->expects($this->once())->method('render')
             ->with(
                 '@Installer/installer/database-configuration.html.twig',
@@ -283,6 +302,8 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseGetConfigurationRoutePostWithDatabaseSetupException(): void
     {
+        $this->router->expects($this->never())->method('generate');
+
         $this->twig->expects($this->once())->method('render')
             ->with(
                 '@Installer/installer/database-configuration.html.twig',
@@ -320,6 +341,10 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseInformationRouteWithIncompleteConnectionInformation(): void
     {
+        $this->translator->expects($this->never())->method('trans');
+        $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
+        $this->router->expects($this->never())->method('generate');
+
         $request = Request::create('/installer/database-information', 'POST');
 
         $this->connectionFactory->expects($this->once())
@@ -336,6 +361,9 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseInformationRouteWithWrongMysqlVersion(): void
     {
+        $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
+        $this->router->expects($this->never())->method('generate');
+
         $request = Request::create('/installer/database-information', 'POST');
 
         $this->connectionFactory->expects($this->once())
@@ -357,9 +385,13 @@ class DatabaseConfigurationControllerTest extends TestCase
 
     public function testDatabaseInformationRoute(): void
     {
+        $this->translator->expects($this->never())->method('trans');
+        $this->blueGreenDeploymentService->expects($this->never())->method('setEnvironmentVariable');
+        $this->router->expects($this->never())->method('generate');
+
         $request = Request::create('/installer/database-information', 'POST');
 
-        $connection = $this->createMock(Connection::class);
+        $connection = static::createStub(Connection::class);
 
         $this->connectionFactory->expects($this->once())
             ->method('getConnection')

--- a/tests/unit/Core/Installer/Controller/DatabaseImportControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/DatabaseImportControllerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Migration\MigrationStep;
 use Shopware\Core\Installer\Controller\DatabaseImportController;
@@ -30,7 +31,7 @@ class DatabaseImportControllerTest extends TestCase
 {
     use InstallerControllerTestTrait;
 
-    private MockObject&DatabaseConnectionFactory $connectionFactory;
+    private DatabaseConnectionFactory&Stub $connectionFactory;
 
     private MockObject&DatabaseMigrator $databaseMigrator;
 
@@ -42,7 +43,7 @@ class DatabaseImportControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $this->connectionFactory = static::createStub(DatabaseConnectionFactory::class);
         $this->databaseMigrator = $this->createMock(DatabaseMigrator::class);
         $this->twig = $this->createMock(Environment::class);
         $this->router = $this->createMock(RouterInterface::class);
@@ -67,6 +68,8 @@ class DatabaseImportControllerTest extends TestCase
 
     public function testImportDatabaseRedirectsToConfigPageWhenDatabaseConnectionWasNotConfigured(): void
     {
+        $this->databaseMigrator->expects($this->never())->method('migrate');
+
         $this->twig->expects($this->never())
             ->method('render');
 
@@ -85,6 +88,9 @@ class DatabaseImportControllerTest extends TestCase
 
     public function testImportDatabaseRoute(): void
     {
+        $this->databaseMigrator->expects($this->never())->method('migrate');
+        $this->router->expects($this->never())->method('generate');
+
         $this->twig->expects($this->once())->method('render')
             ->with(
                 '@Installer/installer/database-import.html.twig',
@@ -106,6 +112,7 @@ class DatabaseImportControllerTest extends TestCase
     public function testDatabaseMigrateReturnsErrorIfSessionExpired(): void
     {
         $this->databaseMigrator->expects($this->never())->method('migrate');
+        $this->router->expects($this->never())->method('generate');
 
         $session = new Session(new MockArraySessionStorage());
         $request = Request::create('/installer/database-import');
@@ -121,9 +128,10 @@ class DatabaseImportControllerTest extends TestCase
 
     public function testDatabaseMigrateWithoutOffset(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $this->connectionFactory->expects($this->once())
-            ->method('getConnection')
+        $this->router->expects($this->never())->method('generate');
+
+        $connection = static::createStub(Connection::class);
+        $this->connectionFactory->method('getConnection')
             ->willReturn($connection);
 
         $result = [
@@ -150,9 +158,10 @@ class DatabaseImportControllerTest extends TestCase
 
     public function testDatabaseMigrateWillReportException(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $this->connectionFactory->expects($this->once())
-            ->method('getConnection')
+        $this->router->expects($this->never())->method('generate');
+
+        $connection = static::createStub(Connection::class);
+        $this->connectionFactory->method('getConnection')
             ->willReturn($connection);
 
         $this->databaseMigrator->expects($this->once())

--- a/tests/unit/Core/Installer/Controller/ShopConfigurationControllerTest.php
+++ b/tests/unit/Core/Installer/Controller/ShopConfigurationControllerTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Installer\Configuration\AdminConfigurationService;
@@ -42,7 +43,7 @@ class ShopConfigurationControllerTest extends TestCase
 
     private MockObject&RouterInterface $router;
 
-    private Connection&MockObject $connection;
+    private Connection&Stub $connection;
 
     private MockObject&EnvConfigWriter $envConfigWriter;
 
@@ -55,7 +56,7 @@ class ShopConfigurationControllerTest extends TestCase
     private ShopConfigurationController $controller;
 
     /**
-     * @var TranslatorInterface&MockObject
+     * @var TranslatorInterface&Stub
      */
     private TranslatorInterface $translator;
 
@@ -64,14 +65,14 @@ class ShopConfigurationControllerTest extends TestCase
         $this->twig = $this->createMock(Environment::class);
         $this->router = $this->createMock(RouterInterface::class);
 
-        $this->connection = $this->createMock(Connection::class);
-        $connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $this->connection = static::createStub(Connection::class);
+        $connectionFactory = static::createStub(DatabaseConnectionFactory::class);
         $connectionFactory->method('getConnection')->willReturn($this->connection);
 
         $this->envConfigWriter = $this->createMock(EnvConfigWriter::class);
         $this->shopConfigService = $this->createMock(ShopConfigurationService::class);
         $this->adminConfigService = $this->createMock(AdminConfigurationService::class);
-        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->translator = static::createStub(TranslatorInterface::class);
 
         $this->translationConfig = new TranslationConfig(
             new Uri('http://localhost:8000'),
@@ -118,8 +119,12 @@ class ShopConfigurationControllerTest extends TestCase
         $request->setSession($session);
         $request->attributes->set('_locale', $requestLocale);
 
-        $this->connection->expects($this->once())
-            ->method('fetchAllAssociative')
+        $this->router->expects($this->never())->method('generate');
+        $this->envConfigWriter->expects($this->never())->method('writeConfig');
+        $this->shopConfigService->expects($this->never())->method('updateShop');
+        $this->adminConfigService->expects($this->never())->method('createAdmin');
+
+        $this->connection->method('fetchAllAssociative')
             ->willReturn([
                 ['iso3' => 'DEU', 'iso' => 'DE'],
                 ['iso3' => 'GBR', 'iso' => 'GB'],
@@ -174,6 +179,10 @@ class ShopConfigurationControllerTest extends TestCase
         $session = new Session(new MockArraySessionStorage());
         $request->setMethod('GET');
         $request->setSession($session);
+
+        $this->envConfigWriter->expects($this->never())->method('writeConfig');
+        $this->shopConfigService->expects($this->never())->method('updateShop');
+        $this->adminConfigService->expects($this->never())->method('createAdmin');
 
         $this->router->expects($this->once())->method('generate')
             ->with('installer.database-configuration', [], UrlGeneratorInterface::ABSOLUTE_PATH)
@@ -274,13 +283,16 @@ class ShopConfigurationControllerTest extends TestCase
             'SCRIPT_NAME' => '/shop/index.php',
         ]);
 
-        $this->connection->expects($this->once())
-            ->method('fetchAllAssociative')
+        $this->connection->method('fetchAllAssociative')
             ->willReturn([
                 ['iso3' => 'DEU', 'iso' => 'DE'],
                 ['iso3' => 'GBR', 'iso' => 'GB'],
                 ['iso3' => 'USA', 'iso' => 'US'],
             ]);
+
+        $this->router->expects($this->never())->method('generate');
+        $this->shopConfigService->expects($this->never())->method('updateShop');
+        $this->adminConfigService->expects($this->never())->method('createAdmin');
 
         $this->envConfigWriter->expects($this->once())->method('writeConfig')->willThrowException(new \Exception('Test Exception'));
 
@@ -350,9 +362,12 @@ class ShopConfigurationControllerTest extends TestCase
             ['iso3' => 'DEU', 'iso' => 'DE'],
         ];
 
-        $this->connection->expects($this->once())
-            ->method('fetchAllAssociative')
+        $this->connection->method('fetchAllAssociative')
             ->willReturn($countries);
+
+        $this->router->expects($this->never())->method('generate');
+        $this->shopConfigService->expects($this->never())->method('updateShop');
+        $this->adminConfigService->expects($this->never())->method('createAdmin');
 
         $this->envConfigWriter->expects($this->once())->method('writeConfig')->willThrowException(new \Exception('Test Exception'));
 

--- a/tests/unit/Core/Installer/Database/BlueGreenDeploymentServiceTest.php
+++ b/tests/unit/Core/Installer/Database/BlueGreenDeploymentServiceTest.php
@@ -47,7 +47,7 @@ class BlueGreenDeploymentServiceTest extends TestCase
         $connection->expects($this->exactly(2))
             ->method('executeQuery')
             ->willReturnOnConsecutiveCalls(
-                $this->createMock(Result::class),
+                static::createStub(Result::class),
                 static::throwException(TestExceptionFactory::createException('test')),
             );
 

--- a/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
+++ b/tests/unit/Core/Installer/Database/DatabaseMigratorTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
@@ -24,7 +25,7 @@ class DatabaseMigratorTest extends TestCase
 {
     private MockObject&SetupDatabaseAdapter $setupAdapter;
 
-    private Connection&MockObject $connection;
+    private Connection&Stub $connection;
 
     private MockObject&MigrationCollection $migrationCollection;
 
@@ -38,23 +39,26 @@ class DatabaseMigratorTest extends TestCase
     {
         $this->setupAdapter = $this->createMock(SetupDatabaseAdapter::class);
 
-        $this->connection = $this->createMock(Connection::class);
+        $this->connection = static::createStub(Connection::class);
 
         $this->migrationCollection = $this->createMock(MigrationCollection::class);
 
         $migrationLoader = $this->createMock(MigrationCollectionLoader::class);
-        $migrationLoader->method('collectAllForVersion')
+        $migrationLoader->expects($this->once())
+            ->method('collectAllForVersion')
             ->with(Kernel::SHOPWARE_FALLBACK_VERSION)
             ->willReturn($this->migrationCollection);
 
         $migrationCollectorFactory = $this->createMock(MigrationCollectionFactory::class);
         $migrationCollectorFactory
+            ->expects($this->once())
             ->method('getMigrationCollectionLoader')
             ->with($this->connection)
             ->willReturn($migrationLoader);
 
         $this->iniConfigReader = $this->createMock(IniConfigReader::class);
         $this->iniConfigReader
+            ->expects($this->once())
             ->method('get')
             ->with('max_execution_time')
             ->willReturnCallback(fn (): string => $this->maxExecutionTime);

--- a/tests/unit/Core/Installer/Database/MigrationCollectionFactoryTest.php
+++ b/tests/unit/Core/Installer/Database/MigrationCollectionFactoryTest.php
@@ -18,7 +18,7 @@ class MigrationCollectionFactoryTest extends TestCase
     {
         $factory = new MigrationCollectionFactory((new TestBootstrapper())->getProjectDir());
         $loader = $factory->getMigrationCollectionLoader(
-            $this->createMock(Connection::class)
+            static::createStub(Connection::class)
         );
 
         static::assertArrayHasKey('core', $loader->collectAll());

--- a/tests/unit/Core/Installer/Requirements/ConfigurationRequirementsValidatorTest.php
+++ b/tests/unit/Core/Installer/Requirements/ConfigurationRequirementsValidatorTest.php
@@ -4,7 +4,7 @@ namespace Shopware\Tests\Unit\Core\Installer\Requirements;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Installer\Requirements\ConfigurationRequirementsValidator;
 use Shopware\Core\Installer\Requirements\IniConfigReader;
@@ -18,13 +18,13 @@ use Shopware\Core\Installer\Requirements\Struct\SystemCheck;
 #[CoversClass(ConfigurationRequirementsValidator::class)]
 class ConfigurationRequirementsValidatorTest extends TestCase
 {
-    private MockObject&IniConfigReader $configReader;
+    private Stub&IniConfigReader $configReader;
 
     private ConfigurationRequirementsValidator $validator;
 
     protected function setUp(): void
     {
-        $this->configReader = $this->createMock(IniConfigReader::class);
+        $this->configReader = static::createStub(IniConfigReader::class);
         $this->validator = new ConfigurationRequirementsValidator($this->configReader);
     }
 

--- a/tests/unit/Core/Installer/Requirements/EnvironmentRequirementsValidatorTest.php
+++ b/tests/unit/Core/Installer/Requirements/EnvironmentRequirementsValidatorTest.php
@@ -36,7 +36,7 @@ class EnvironmentRequirementsValidatorTest extends TestCase
         $corePackage = new RootPackage($coreComposerName ?? 'shopware/platform', '1.0.0', '1.0.0');
         $corePackage->setRequires($requires);
 
-        $repoManagerMock = $this->createMock(RepositoryManager::class);
+        $repoManagerMock = static::createStub(RepositoryManager::class);
 
         if ($coreComposerName) {
             $repoManagerMock->method('getLocalRepository')->willReturn(

--- a/tests/unit/Core/Installer/Subscriber/InstallerLocaleListenerTest.php
+++ b/tests/unit/Core/Installer/Subscriber/InstallerLocaleListenerTest.php
@@ -34,7 +34,7 @@ class InstallerLocaleListenerTest extends TestCase
 
         $listener->setInstallerLocale(
             new RequestEvent(
-                $this->createMock(HttpKernelInterface::class),
+                static::createStub(HttpKernelInterface::class),
                 $request,
                 HttpKernelInterface::MAIN_REQUEST
             )
@@ -173,7 +173,7 @@ class InstallerLocaleListenerTest extends TestCase
 
         $listener->setInstallerLocale(
             new RequestEvent(
-                $this->createMock(HttpKernelInterface::class),
+                static::createStub(HttpKernelInterface::class),
                 $request,
                 HttpKernelInterface::MAIN_REQUEST
             )

--- a/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelCreateCommandTest.php
+++ b/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelCreateCommandTest.php
@@ -31,7 +31,7 @@ class SalesChannelCreateCommandTest extends TestCase
     {
         $accessKey = AccessKeyHelper::generateAccessKey('sales-channel');
 
-        $salesChannelCreatorMock = $this->createMock(SalesChannelCreator::class);
+        $salesChannelCreatorMock = static::createStub(SalesChannelCreator::class);
         $salesChannelCreatorMock->method('createSalesChannel')
             ->willReturn($accessKey);
 
@@ -39,11 +39,11 @@ class SalesChannelCreateCommandTest extends TestCase
 
         $refMethod = new \ReflectionMethod(SalesChannelCreateCommand::class, 'execute');
 
-        $inputMock = $this->createMock(InputInterface::class);
+        $inputMock = static::createStub(InputInterface::class);
         $inputMock->method('getOption')
             ->willReturnOnConsecutiveCalls(...array_values($inputMockValues));
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = static::createStub(OutputInterface::class);
 
         $result = $refMethod->invoke($salesChannelCreateCmd, $inputMock, $outputMock);
 
@@ -56,7 +56,7 @@ class SalesChannelCreateCommandTest extends TestCase
     #[DataProvider('dataProviderTestExecuteFailure')]
     public function testExecuteFailure(array $inputMockValues): void
     {
-        $constraintViolationMock = $this->createMock(ConstraintViolationInterface::class);
+        $constraintViolationMock = static::createStub(ConstraintViolationInterface::class);
         $constraintViolationMock->method('getPropertyPath')
             ->willReturn('Dummy');
 
@@ -65,15 +65,15 @@ class SalesChannelCreateCommandTest extends TestCase
 
         $constraintViolationListMock = new ConstraintViolationList([$constraintViolationMock]);
 
-        $writeConstraintViolationExceptionMock = $this->createMock(WriteConstraintViolationException::class);
+        $writeConstraintViolationExceptionMock = static::createStub(WriteConstraintViolationException::class);
         $writeConstraintViolationExceptionMock->method('getViolations')
             ->willReturn($constraintViolationListMock);
 
-        $writeExceptionMock = $this->createMock(WriteException::class);
+        $writeExceptionMock = static::createStub(WriteException::class);
         $writeExceptionMock->method('getExceptions')
             ->willReturn([$writeConstraintViolationExceptionMock]);
 
-        $salesChannelCreatorMock = $this->createMock(SalesChannelCreator::class);
+        $salesChannelCreatorMock = static::createStub(SalesChannelCreator::class);
         $salesChannelCreatorMock->method('createSalesChannel')
             ->willThrowException($writeExceptionMock);
 
@@ -81,11 +81,11 @@ class SalesChannelCreateCommandTest extends TestCase
 
         $refMethod = new \ReflectionMethod(SalesChannelCreateCommand::class, 'execute');
 
-        $inputMock = $this->createMock(InputInterface::class);
+        $inputMock = static::createStub(InputInterface::class);
         $inputMock->method('getOption')
             ->willReturnOnConsecutiveCalls(...array_values($inputMockValues));
 
-        $outputMock = $this->createMock(OutputInterface::class);
+        $outputMock = static::createStub(OutputInterface::class);
 
         $result = $refMethod->invoke($salesChannelCreateCmd, $inputMock, $outputMock);
 

--- a/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelReplaceUrlCommandTest.php
+++ b/tests/unit/Core/Maintenance/SalesChannel/Command/SalesChannelReplaceUrlCommandTest.php
@@ -34,7 +34,7 @@ class SalesChannelReplaceUrlCommandTest extends TestCase
         $domainEntity->setId($domainId);
         $domainEntity->setUrl($previousUrl);
 
-        $searchResultMock = $this->createMock(EntitySearchResult::class);
+        $searchResultMock = static::createStub(EntitySearchResult::class);
         $searchResultMock->method('first')
             ->willReturn($domainEntity);
 
@@ -82,7 +82,7 @@ class SalesChannelReplaceUrlCommandTest extends TestCase
         $previousUrl = 'https://non-existent-domain.com';
         $newUrl = 'https://new-domain.com';
 
-        $searchResultMock = $this->createMock(EntitySearchResult::class);
+        $searchResultMock = static::createStub(EntitySearchResult::class);
         $searchResultMock->method('first')
             ->willReturn(null);
 
@@ -135,7 +135,7 @@ class SalesChannelReplaceUrlCommandTest extends TestCase
         $domainEntity->setId($domainId);
         $domainEntity->setUrl($previousUrl);
 
-        $searchResultMock = $this->createMock(EntitySearchResult::class);
+        $searchResultMock = static::createStub(EntitySearchResult::class);
         $searchResultMock->method('first')
             ->willReturn($domainEntity);
 

--- a/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
@@ -22,8 +22,8 @@ class SystemSetupStagingCommandTest extends TestCase
     public function testCancelPrompt(): void
     {
         $command = new SystemSetupStagingCommand(
-            $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(SystemConfigService::class),
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(SystemConfigService::class),
             true,
             [],
             [],
@@ -108,8 +108,8 @@ class SystemSetupStagingCommandTest extends TestCase
     public function testRunNoInteractionWithoutForce(): void
     {
         $command = new SystemSetupStagingCommand(
-            $this->createMock(EventDispatcherInterface::class),
-            $this->createMock(SystemConfigService::class),
+            static::createStub(EventDispatcherInterface::class),
+            static::createStub(SystemConfigService::class),
             true,
             [],
             [],

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingAppHandlerTest.php
@@ -19,7 +19,7 @@ class StagingAppHandlerTest extends TestCase
 {
     public function testDeletion(): void
     {
-        $connection = $this->createMock(Connection::class);
+        $connection = static::createStub(Connection::class);
         $connection
             ->method('fetchAllAssociative')
             ->willReturn([
@@ -45,7 +45,7 @@ class StagingAppHandlerTest extends TestCase
         $handler = new StagingAppHandler($connection, $shopIdProvider);
         $handler->__invoke(new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             []
         ));

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingExtensionHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingExtensionHandlerTest.php
@@ -31,14 +31,14 @@ class StagingExtensionHandlerTest extends TestCase
         $lifecycle->expects($this->never())->method('deactivate');
 
         $handler = new StagingExtensionHandler(
-            $this->createMock(Kernel::class),
+            static::createStub(Kernel::class),
             $dataProvider,
             $lifecycle,
         );
 
         $handler(new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             [],
             [],
@@ -81,10 +81,10 @@ class StagingExtensionHandlerTest extends TestCase
                 static::isInstanceOf(Context::class)
             );
 
-        $io = $this->createMock(SymfonyStyle::class);
+        $io = static::createStub(SymfonyStyle::class);
 
         $handler = new StagingExtensionHandler(
-            $this->createMock(Kernel::class),
+            static::createStub(Kernel::class),
             $dataProvider,
             $lifecycle,
         );
@@ -119,7 +119,7 @@ class StagingExtensionHandlerTest extends TestCase
             }));
 
         $handler = new StagingExtensionHandler(
-            $this->createMock(Kernel::class),
+            static::createStub(Kernel::class),
             $dataProvider,
             $lifecycle,
         );
@@ -161,7 +161,7 @@ class StagingExtensionHandlerTest extends TestCase
             }));
 
         $handler = new StagingExtensionHandler(
-            $this->createMock(Kernel::class),
+            static::createStub(Kernel::class),
             $dataProvider,
             $lifecycle,
         );

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingMailHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingMailHandlerTest.php
@@ -24,7 +24,7 @@ class StagingMailHandlerTest extends TestCase
 
         $handler(new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             []
         ));
@@ -39,7 +39,7 @@ class StagingMailHandlerTest extends TestCase
 
         $handler(new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             true,
             []
         ));

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingSalesChannelHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingSalesChannelHandlerTest.php
@@ -41,7 +41,7 @@ class StagingSalesChannelHandlerTest extends TestCase
 
         $event = new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             $domainMapping
         );
@@ -70,7 +70,7 @@ class StagingSalesChannelHandlerTest extends TestCase
 
         $event = new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             $domainMapping
         );
@@ -103,7 +103,7 @@ class StagingSalesChannelHandlerTest extends TestCase
 
         $event = new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             $domainMapping
         );
@@ -136,7 +136,7 @@ class StagingSalesChannelHandlerTest extends TestCase
 
         $event = new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             false,
             $domainMapping
         );

--- a/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Handler/StagingSystemConfigHandlerTest.php
@@ -23,7 +23,7 @@ class StagingSystemConfigHandlerTest extends TestCase
 
         $handler(new SetupStagingEvent(
             Context::createDefaultContext(),
-            $this->createMock(SymfonyStyle::class),
+            static::createStub(SymfonyStyle::class),
             true,
             [],
             [],

--- a/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
+++ b/tests/unit/Core/Maintenance/System/Command/SystemInstallCommandTest.php
@@ -57,7 +57,7 @@ class SystemInstallCommandTest extends TestCase
 
         $refMethod = new \ReflectionMethod(SystemInstallCommand::class, 'execute');
 
-        $result = $refMethod->invoke($systemInstallCmd, $this->getMockInput($mockInputValues), $this->createMock(OutputInterface::class));
+        $result = $refMethod->invoke($systemInstallCmd, $this->getMockInput($mockInputValues), static::createStub(OutputInterface::class));
 
         static::assertSame(Command::FAILURE, $result);
     }
@@ -187,17 +187,17 @@ class SystemInstallCommandTest extends TestCase
 
     public function testInstallLockNotCreatedOnFailure(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $connection = static::createStub(Connection::class);
+        $connectionFactory = static::createStub(DatabaseConnectionFactory::class);
         $connectionFactory->method('getConnection')->willReturn($connection);
-        $setupDatabaseAdapterMock = $this->createMock(SetupDatabaseAdapter::class);
+        $setupDatabaseAdapterMock = static::createStub(SetupDatabaseAdapter::class);
 
         $systemInstallCmd = new SystemInstallCommand(
             __DIR__,
             $setupDatabaseAdapterMock,
             $connectionFactory,
-            $this->createMock(CacheClearer::class),
-            $this->createMock(SystemLocker::class),
+            static::createStub(CacheClearer::class),
+            static::createStub(SystemLocker::class),
             new NativeClock()
         );
 
@@ -295,17 +295,17 @@ class SystemInstallCommandTest extends TestCase
     {
         $this->createHtaccessDist('Test .htaccess content');
 
-        $connection = $this->createMock(Connection::class);
-        $connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $connection = static::createStub(Connection::class);
+        $connectionFactory = static::createStub(DatabaseConnectionFactory::class);
         $connectionFactory->method('getConnection')->willReturn($connection);
-        $setupDatabaseAdapterMock = $this->createMock(SetupDatabaseAdapter::class);
+        $setupDatabaseAdapterMock = static::createStub(SetupDatabaseAdapter::class);
 
         $systemInstallCmd = new SystemInstallCommand(
             __DIR__,
             $setupDatabaseAdapterMock,
             $connectionFactory,
-            $this->createMock(CacheClearer::class),
-            $this->createMock(SystemLocker::class),
+            static::createStub(CacheClearer::class),
+            static::createStub(SystemLocker::class),
             new NativeClock()
         );
 
@@ -336,10 +336,10 @@ class SystemInstallCommandTest extends TestCase
      */
     public function testEventsForSubCommandsAreFired(): void
     {
-        $connection = $this->createMock(Connection::class);
-        $connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $connection = static::createStub(Connection::class);
+        $connectionFactory = static::createStub(DatabaseConnectionFactory::class);
         $connectionFactory->method('getConnection')->willReturn($connection);
-        $setupDatabaseAdapterMock = $this->createMock(SetupDatabaseAdapter::class);
+        $setupDatabaseAdapterMock = static::createStub(SetupDatabaseAdapter::class);
 
         $dispatcher = new EventDispatcher();
 
@@ -361,8 +361,8 @@ class SystemInstallCommandTest extends TestCase
                 __DIR__,
                 $setupDatabaseAdapterMock,
                 $connectionFactory,
-                $this->createMock(CacheClearer::class),
-                $this->createMock(SystemLocker::class),
+                static::createStub(CacheClearer::class),
+                static::createStub(SystemLocker::class),
                 new NativeClock()
             )
         );
@@ -380,19 +380,19 @@ class SystemInstallCommandTest extends TestCase
      */
     private function prepareCommandInstance(array $expectedCommands = [], string $projectDir = __DIR__): SystemInstallCommand
     {
-        $connection = $this->createMock(Connection::class);
-        $connectionFactory = $this->createMock(DatabaseConnectionFactory::class);
+        $connection = static::createStub(Connection::class);
+        $connectionFactory = static::createStub(DatabaseConnectionFactory::class);
 
         $connectionFactory->method('getConnection')->willReturn($connection);
 
-        $setupDatabaseAdapterMock = $this->createMock(SetupDatabaseAdapter::class);
+        $setupDatabaseAdapterMock = static::createStub(SetupDatabaseAdapter::class);
         $systemLocker = new SystemLocker($projectDir);
 
         $systemInstallCmd = new SystemInstallCommand(
             $projectDir,
             $setupDatabaseAdapterMock,
             $connectionFactory,
-            $this->createMock(CacheClearer::class),
+            static::createStub(CacheClearer::class),
             $systemLocker,
             new NativeClock()
         );
@@ -435,7 +435,7 @@ class SystemInstallCommandTest extends TestCase
      */
     private function getMockInput(array $mockInputValues): InputInterface
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = static::createStub(InputInterface::class);
         $input->method('getOption')
             ->willReturnOnConsecutiveCalls(...array_values($mockInputValues));
 

--- a/tests/unit/Core/Maintenance/System/Command/SystemUpdateFinishCommandTest.php
+++ b/tests/unit/Core/Maintenance/System/Command/SystemUpdateFinishCommandTest.php
@@ -40,7 +40,7 @@ class SystemUpdateFinishCommandTest extends TestCase
         $application
             ->expects($this->exactly(3))
             ->method('find')
-            ->willReturn($this->createMock(Command::class));
+            ->willReturn(static::createStub(Command::class));
 
         $application->method('doRun')->willReturn(Command::SUCCESS);
 
@@ -73,7 +73,7 @@ class SystemUpdateFinishCommandTest extends TestCase
         $command = new SystemUpdateFinishCommand($this->eventDispatcher, $this->systemConfigService, '6.5.0.0');
 
         $application = $this->createMock(Application::class);
-        $migrationCommand = $this->createMock(Command::class);
+        $migrationCommand = static::createStub(Command::class);
         $migrationCommand->method('run')->willReturn(Command::SUCCESS);
 
         $application

--- a/tests/unit/Core/Maintenance/System/Service/AppUrlVerifierTest.php
+++ b/tests/unit/Core/Maintenance/System/Service/AppUrlVerifierTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
@@ -23,13 +23,13 @@ class AppUrlVerifierTest extends TestCase
 
     private Client $client;
 
-    private Connection&MockObject $connection;
+    private Connection&Stub $connection;
 
     protected function setUp(): void
     {
         $this->mockHandler = new MockHandler();
         $this->client = new Client(['handler' => $this->mockHandler]);
-        $this->connection = $this->createMock(Connection::class);
+        $this->connection = static::createStub(Connection::class);
     }
 
     public function testAppUrlReachableReturnsTrueIfAppEnvIsNotProd(): void
@@ -136,22 +136,24 @@ class AppUrlVerifierTest extends TestCase
 
     public function testAppsThatNeedAppUrlReturnFalseWithoutAppsThatRequireRegistration(): void
     {
-        $this->connection->expects($this->once())
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
             ->method('fetchOne')
             ->willReturn('0');
 
-        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $connection, 'prod', false);
 
         static::assertFalse($verifier->hasAppsThatNeedAppUrl());
     }
 
     public function testAppsThatNeedAppUrlReturnTrueWithAppsThatRequireRegistration(): void
     {
-        $this->connection->expects($this->once())
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())
             ->method('fetchOne')
             ->willReturn('1');
 
-        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $connection, 'prod', false);
 
         static::assertTrue($verifier->hasAppsThatNeedAppUrl());
     }

--- a/tests/unit/Core/Maintenance/User/Command/UserChangePasswordCommandTest.php
+++ b/tests/unit/Core/Maintenance/User/Command/UserChangePasswordCommandTest.php
@@ -69,7 +69,7 @@ class UserChangePasswordCommandTest extends TestCase
 
     public function testEmptyPasswordOption(): void
     {
-        $userRepo = $this->createMock(EntityRepository::class);
+        $userRepo = static::createStub(EntityRepository::class);
         $command = new UserChangePasswordCommand($userRepo);
 
         $commandTester = new CommandTester($command);

--- a/tests/unit/Core/Maintenance/User/Command/UserCreateCommandTest.php
+++ b/tests/unit/Core/Maintenance/User/Command/UserCreateCommandTest.php
@@ -53,8 +53,8 @@ class UserCreateCommandTest extends TestCase
 
     private function createConnection(): Connection
     {
-        $connection = $this->createMock(Connection::class);
-        $builder = $this->createMock(QueryBuilder::class);
+        $connection = static::createStub(Connection::class);
+        $builder = static::createStub(QueryBuilder::class);
         $builder->method('select')->willReturnSelf();
         $builder->method('from')->willReturnSelf();
         $builder->method('where')->willReturnSelf();

--- a/tests/unit/Core/Saas/SsoServiceTest.php
+++ b/tests/unit/Core/Saas/SsoServiceTest.php
@@ -32,10 +32,10 @@ class SsoServiceTest extends TestCase
                 'scope' => 'scope',
                 'register_url' => 'https://register.url',
             ],
-            $this->createMock(RouterInterface::class)
+            static::createStub(RouterInterface::class)
         );
 
-        $ssoService = new SsoService($loginConfigService, $this->createMock(RefreshTokenRepository::class));
+        $ssoService = new SsoService($loginConfigService, static::createStub(RefreshTokenRepository::class));
 
         static::assertTrue($ssoService->isSso());
     }
@@ -43,9 +43,9 @@ class SsoServiceTest extends TestCase
     public function testIsSsoShouldReturnFalse(): void
     {
         // @phpstan-ignore argument.type (LoginConfigService expected an array with specific key-value pairs)
-        $loginConfigService = new LoginConfigService([], $this->createMock(RouterInterface::class));
+        $loginConfigService = new LoginConfigService([], static::createStub(RouterInterface::class));
 
-        $ssoService = new SsoService($loginConfigService, $this->createMock(RefreshTokenRepository::class));
+        $ssoService = new SsoService($loginConfigService, static::createStub(RefreshTokenRepository::class));
 
         static::assertFalse($ssoService->isSso());
     }
@@ -53,7 +53,7 @@ class SsoServiceTest extends TestCase
     public function testRevokeUserTokensDelegatesToRepository(): void
     {
         // @phpstan-ignore argument.type (LoginConfigService expected an array with specific key-value pairs)
-        $loginConfigService = new LoginConfigService([], $this->createMock(RouterInterface::class));
+        $loginConfigService = new LoginConfigService([], static::createStub(RouterInterface::class));
 
         $refreshTokenRepository = $this->createMock(RefreshTokenRepository::class);
         $refreshTokenRepository->expects($this->once())

--- a/tests/unit/Core/Service/AllServiceInstallerTest.php
+++ b/tests/unit/Core/Service/AllServiceInstallerTest.php
@@ -28,7 +28,7 @@ class AllServiceInstallerTest extends TestCase
     {
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
@@ -72,7 +72,7 @@ class AllServiceInstallerTest extends TestCase
 
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
@@ -114,7 +114,7 @@ class AllServiceInstallerTest extends TestCase
 
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
@@ -142,10 +142,10 @@ class AllServiceInstallerTest extends TestCase
 
     public function testScheduleInstallDispatchesMessage(): void
     {
-        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
-        $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
+        $serviceRegistryClient = static::createStub(ServiceRegistryClient::class);
+        $serviceLifeCycle = static::createStub(ServiceLifecycle::class);
         $messageBus = $this->createMock(MessageBusInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
             $serviceRegistryClient,
@@ -170,8 +170,8 @@ class AllServiceInstallerTest extends TestCase
     {
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
+        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
             $serviceRegistryClient,
@@ -197,8 +197,8 @@ class AllServiceInstallerTest extends TestCase
     {
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
+        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
             $serviceRegistryClient,
@@ -235,8 +235,8 @@ class AllServiceInstallerTest extends TestCase
     {
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
         $serviceLifeCycle = $this->createMock(ServiceLifecycle::class);
-        $messageBus = $this->createMock(MessageBusInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $messageBus = static::createStub(MessageBusInterface::class);
+        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
 
         $serviceInstaller = new AllServiceInstaller(
             $serviceRegistryClient,

--- a/tests/unit/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/unit/Core/Service/Api/ServiceControllerTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Service\Api;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleEntity;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -38,13 +38,13 @@ class ServiceControllerTest extends TestCase
      */
     private StaticEntityRepository $appRepo;
 
-    private MessageBusInterface&MockObject $bus;
+    private MessageBusInterface&Stub $bus;
 
-    private AppStateService&MockObject $appStateService;
+    private AppStateService&Stub $appStateService;
 
-    private AppLifecycle&MockObject $appLifecycle;
+    private AppLifecycle&Stub $appLifecycle;
 
-    private LifecycleManager&MockObject $manager;
+    private LifecycleManager&Stub $manager;
 
     protected function setUp(): void
     {
@@ -64,11 +64,11 @@ class ServiceControllerTest extends TestCase
 
         $this->appRepo = new StaticEntityRepository([[$this->app]]);
 
-        $this->bus = $this->createMock(MessageBusInterface::class);
+        $this->bus = static::createStub(MessageBusInterface::class);
 
-        $this->appStateService = $this->createMock(AppStateService::class);
-        $this->appLifecycle = $this->createMock(AppLifecycle::class);
-        $this->manager = $this->createMock(LifecycleManager::class);
+        $this->appStateService = static::createStub(AppStateService::class);
+        $this->appLifecycle = static::createStub(AppLifecycle::class);
+        $this->manager = static::createStub(LifecycleManager::class);
     }
 
     public function testExceptionIsThrownIfServiceDoesNotExist(): void
@@ -78,9 +78,10 @@ class ServiceControllerTest extends TestCase
         /** @var StaticEntityRepository<AppCollection> $appRepo */
         $appRepo = new StaticEntityRepository([[]]);
 
-        $this->bus->expects($this->never())->method('dispatch');
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController($appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController($appRepo, $bus, $this->appStateService, $this->appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
@@ -93,9 +94,10 @@ class ServiceControllerTest extends TestCase
         $source = new ShopApiSource('AABB');
         static::expectExceptionObject(ServiceException::updateRequiresAdminApiSource($source));
 
-        $this->bus->expects($this->never())->method('dispatch');
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController($this->appRepo, $bus, $this->appStateService, $this->appLifecycle, $this->manager);
 
         $context = Context::createDefaultContext($source);
 
@@ -106,9 +108,10 @@ class ServiceControllerTest extends TestCase
     {
         static::expectExceptionObject(ServiceException::updateRequiresIntegration());
 
-        $this->bus->expects($this->never())->method('dispatch');
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
 
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController($this->appRepo, $bus, $this->appStateService, $this->appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB');
         $context = Context::createDefaultContext($source);
@@ -118,13 +121,14 @@ class ServiceControllerTest extends TestCase
 
     public function testUpdateIsTriggered(): void
     {
-        $this->bus->expects($this->once())->method('dispatch')->willReturnCallback(static function (UpdateServiceMessage $msg) {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnCallback(static function (UpdateServiceMessage $msg) {
             static::assertSame('MyCoolService', $msg->name);
 
             return new Envelope($msg, []);
         });
 
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $controller = new ServiceController($this->appRepo, $bus, $this->appStateService, $this->appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
@@ -173,12 +177,13 @@ class ServiceControllerTest extends TestCase
     public function testActivate(): void
     {
         $this->app->setActive(false);
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $appStateService = $this->createMock(AppStateService::class);
+        $controller = new ServiceController($this->appRepo, $this->bus, $appStateService, $this->appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->appStateService->expects($this->once())->method('activateApp')->with($this->appId, $context);
+        $appStateService->expects($this->once())->method('activateApp')->with($this->appId, $context);
         $controller->activate('MyCoolService', $context);
     }
 
@@ -223,23 +228,25 @@ class ServiceControllerTest extends TestCase
     public function testDeactivate(): void
     {
         $this->app->setActive(true);
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $appStateService = $this->createMock(AppStateService::class);
+        $controller = new ServiceController($this->appRepo, $this->bus, $appStateService, $this->appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->appStateService->expects($this->once())->method('deactivateApp')->with($this->appId, $context);
+        $appStateService->expects($this->once())->method('deactivateApp')->with($this->appId, $context);
         $controller->deactivate('MyCoolService', $context);
     }
 
     public function testUninstall(): void
     {
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $appLifecycle = $this->createMock(AppLifecycle::class);
+        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $appLifecycle, $this->manager);
 
         $source = new AdminApiSource('AABB', 'CCDD');
         $context = Context::createDefaultContext($source);
 
-        $this->appLifecycle->expects($this->once())->method('uninstall')->with($this->appId, ['id' => $this->appId], $context);
+        $appLifecycle->expects($this->once())->method('uninstall')->with($this->appId, ['id' => $this->appId], $context);
         $controller->uninstall('MyCoolService', $context);
     }
 
@@ -269,20 +276,22 @@ class ServiceControllerTest extends TestCase
 
     public function testDisableServices(): void
     {
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $manager = $this->createMock(LifecycleManager::class);
+        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $manager);
 
         $source = new AdminApiSource('AABB', 'EEFF');
         $context = Context::createDefaultContext($source);
 
-        $this->manager->expects($this->once())->method('disable');
+        $manager->expects($this->once())->method('disable');
         $controller->disableServices($context);
     }
 
     public function testEnableServices(): void
     {
-        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $this->manager);
+        $manager = $this->createMock(LifecycleManager::class);
+        $controller = new ServiceController($this->appRepo, $this->bus, $this->appStateService, $this->appLifecycle, $manager);
 
-        $this->manager->expects($this->once())->method('enable');
+        $manager->expects($this->once())->method('enable');
         $controller->enableServices();
     }
 

--- a/tests/unit/Core/Service/Command/InstallTest.php
+++ b/tests/unit/Core/Service/Command/InstallTest.php
@@ -30,7 +30,7 @@ class InstallTest extends TestCase
 
     public function testCommandWhenServicesAreDisabled(): void
     {
-        $manager = $this->createMock(LifecycleManager::class);
+        $manager = static::createStub(LifecycleManager::class);
         $manager->method('enabled')
             ->willReturn(false);
 

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -296,14 +296,14 @@ class LifecycleManagerTest extends TestCase
         $manager = new LifecycleManager(
             $envEnabled,
             $appEnv,
-            $this->createMock(Privileges::class),
+            static::createStub(Privileges::class),
             new StaticSystemConfigService($systemConfig),
             $this->createAppRepository(),
-            $this->createMock(AppLifecycle::class),
-            $this->createMock(AllServiceInstaller::class),
-            $this->createMock(PermissionsService::class),
-            $this->createMock(Client::class),
-            $this->createMock(RequirementsValidator::class),
+            static::createStub(AppLifecycle::class),
+            static::createStub(AllServiceInstaller::class),
+            static::createStub(PermissionsService::class),
+            static::createStub(Client::class),
+            static::createStub(RequirementsValidator::class),
         );
 
         static::assertSame($expectedEnabled, $manager->enabled());

--- a/tests/unit/Core/Service/Permission/PermissionsServiceTest.php
+++ b/tests/unit/Core/Service/Permission/PermissionsServiceTest.php
@@ -96,6 +96,10 @@ class PermissionsServiceTest extends TestCase
             ->expects($this->never())
             ->method('dispatch');
 
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
+
         $this->expectExceptionObject(ServiceException::invalidPermissionsRevisionFormat($invalidRevision));
 
         $this->permissionsService->grant($invalidRevision, $this->context);
@@ -112,6 +116,10 @@ class PermissionsServiceTest extends TestCase
         $this->eventDispatcher
             ->expects($this->never())
             ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
 
         $this->expectExceptionObject(ServiceException::invalidPermissionsRevisionFormat($invalidRevision));
 
@@ -165,6 +173,10 @@ class PermissionsServiceTest extends TestCase
             ->expects($this->never())
             ->method('dispatch');
 
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
+
         $this->expectExceptionObject(ServiceException::invalidPermissionsContext());
 
         $this->permissionsService->grant('2025-06-13', $context);
@@ -182,6 +194,10 @@ class PermissionsServiceTest extends TestCase
         $this->eventDispatcher
             ->expects($this->never())
             ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
 
         $this->expectExceptionObject(ServiceException::invalidPermissionsContext());
 
@@ -201,6 +217,10 @@ class PermissionsServiceTest extends TestCase
             ->expects($this->never())
             ->method('dispatch');
 
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
+
         $this->expectExceptionObject(ServiceException::invalidPermissionsContext());
         $this->permissionsService->grant('2025-06-13', $context);
     }
@@ -216,6 +236,11 @@ class PermissionsServiceTest extends TestCase
         $this->eventDispatcher
             ->expects($this->never())
             ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
+
         $this->expectExceptionObject(ServiceException::invalidPermissionsRevisionFormat($revision));
         $this->permissionsService->grant($revision, $this->context);
     }
@@ -296,6 +321,14 @@ class PermissionsServiceTest extends TestCase
             ->with('core.services.permissionsConsent')
             ->willReturn($validConsentJson);
 
+        $this->eventDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
+
         $result = $this->permissionsService->areGranted();
 
         static::assertTrue($result);
@@ -308,6 +341,14 @@ class PermissionsServiceTest extends TestCase
             ->method('getString')
             ->with('core.services.permissionsConsent')
             ->willReturn('');
+
+        $this->eventDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
 
         $result = $this->permissionsService->areGranted();
 
@@ -323,6 +364,14 @@ class PermissionsServiceTest extends TestCase
             ->method('getString')
             ->with('core.services.permissionsConsent')
             ->willReturn($invalidConsentJson);
+
+        $this->eventDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
 
         $result = $this->permissionsService->areGranted();
 
@@ -341,6 +390,14 @@ class PermissionsServiceTest extends TestCase
             ->method('getString')
             ->with('core.services.permissionsConsent')
             ->willReturn($malformedConsentJson);
+
+        $this->eventDispatcher
+            ->expects($this->never())
+            ->method('dispatch');
+
+        $this->remoteConsentLogger
+            ->expects($this->never())
+            ->method('log');
 
         $result = $this->permissionsService->areGranted();
 

--- a/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
+++ b/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
@@ -22,8 +22,8 @@ class InstallServicesTaskHandlerTest extends TestCase
             ->method('install');
 
         $handler = new InstallServicesTaskHandler(
-            $this->createMock(EntityRepository::class),
-            $this->createMock(LoggerInterface::class),
+            static::createStub(EntityRepository::class),
+            static::createStub(LoggerInterface::class),
             $manager,
         );
 

--- a/tests/unit/Core/Service/ServiceClientFactoryTest.php
+++ b/tests/unit/Core/Service/ServiceClientFactoryTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Unit\Core\Service;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
@@ -27,60 +27,59 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 #[CoversClass(ServiceClientFactory::class)]
 class ServiceClientFactoryTest extends TestCase
 {
-    private HttpClientInterface&MockObject $httpClient;
+    private AuthMiddleware&Stub $authMiddleware;
 
-    private HttpClientInterface&MockObject $scopedClient;
-
-    private AuthMiddleware&MockObject $authMiddleware;
-
-    private AppPayloadServiceHelper&MockObject $appPayloadServiceHelper;
+    private AppPayloadServiceHelper&Stub $appPayloadServiceHelper;
 
     protected function setUp(): void
     {
-        $this->scopedClient = $this->createMock(HttpClientInterface::class);
-        $this->httpClient = $this->createMock(HttpClientInterface::class);
-
-        $this->authMiddleware = $this->createMock(AuthMiddleware::class);
-        $this->appPayloadServiceHelper = $this->createMock(AppPayloadServiceHelper::class);
+        $this->authMiddleware = static::createStub(AuthMiddleware::class);
+        $this->appPayloadServiceHelper = static::createStub(AppPayloadServiceHelper::class);
     }
 
     public function testNewForServiceRegistryEntry(): void
     {
-        $this->httpClient
+        $scopedClient = $this->createMock(HttpClientInterface::class);
+        $scopedClient->expects($this->never())->method('request');
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient
             ->expects($this->once())
             ->method('withOptions')
             ->with([
                 'base_uri' => 'https://mycoolservice.com',
             ])
-            ->willReturn($this->scopedClient);
+            ->willReturn($scopedClient);
 
-        $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);
+        $serviceClientRegistry = static::createStub(ServiceRegistryClient::class);
 
-        $clientFactory = new ServiceClientFactory($this->httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
+        $clientFactory = new ServiceClientFactory($httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
         $client = $clientFactory->newFor(new ServiceEntry('MyCoolService', 'My Cool Service', 'https://mycoolservice.com', '/app-endpoint'));
 
-        static::assertSame($this->scopedClient, $client->client);
+        static::assertSame($scopedClient, $client->client);
     }
 
     public function testFromNameProxiesToServiceRegistryClient(): void
     {
-        $this->httpClient
+        $scopedClient = $this->createMock(HttpClientInterface::class);
+        $scopedClient->expects($this->never())->method('request');
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient
             ->expects($this->once())
             ->method('withOptions')
             ->with([
                 'base_uri' => 'https://mycoolservice.com',
             ])
-            ->willReturn($this->scopedClient);
+            ->willReturn($scopedClient);
         $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);
         $serviceClientRegistry->expects($this->once())
             ->method('get')
             ->with('MyCoolService')
             ->willReturn(new ServiceEntry('MyCoolService', 'My Cool Service', 'https://mycoolservice.com', '/app-endpoint'));
 
-        $clientFactory = new ServiceClientFactory($this->httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
+        $clientFactory = new ServiceClientFactory($httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
         $client = $clientFactory->fromName('MyCoolService');
 
-        static::assertSame($this->scopedClient, $client->client);
+        static::assertSame($scopedClient, $client->client);
     }
 
     public function testCreateAuthenticatedClient(): void
@@ -94,8 +93,8 @@ class ServiceClientFactoryTest extends TestCase
         $app->setName('TestApp');
         $context = Context::createDefaultContext();
 
-        $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);
-        $clientFactory = new ServiceClientFactory($this->httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
+        $serviceClientRegistry = static::createStub(ServiceRegistryClient::class);
+        $clientFactory = new ServiceClientFactory(static::createStub(HttpClientInterface::class), $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
         $serviceAuthedClient = $clientFactory->newAuthenticatedFor($entry, $app, $context);
         $config = $this->getConfigFromClient($serviceAuthedClient->client);
 
@@ -124,8 +123,8 @@ class ServiceClientFactoryTest extends TestCase
         $context = Context::createDefaultContext();
 
         $this->expectException(ServiceException::class);
-        $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);
-        $clientFactory = new ServiceClientFactory($this->httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
+        $serviceClientRegistry = static::createStub(ServiceRegistryClient::class);
+        $clientFactory = new ServiceClientFactory(static::createStub(HttpClientInterface::class), $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
         $clientFactory->newAuthenticatedFor($entry, $app, $context);
     }
 
@@ -145,8 +144,8 @@ class ServiceClientFactoryTest extends TestCase
             ->willThrowException(new ShopIdChangeSuggestedException(ShopId::v2('shopid'), new FingerprintComparisonResult([], [], 75)));
 
         $this->expectException(ShopIdChangeSuggestedException::class);
-        $serviceClientRegistry = static::createMock(ServiceRegistryClient::class);
-        $clientFactory = new ServiceClientFactory($this->httpClient, $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
+        $serviceClientRegistry = static::createStub(ServiceRegistryClient::class);
+        $clientFactory = new ServiceClientFactory(static::createStub(HttpClientInterface::class), $serviceClientRegistry, '6.6.0.0', $this->authMiddleware, $this->appPayloadServiceHelper);
         $clientFactory->newAuthenticatedFor($entry, $app, $context);
     }
 

--- a/tests/unit/Core/Service/ServiceClientTest.php
+++ b/tests/unit/Core/Service/ServiceClientTest.php
@@ -83,7 +83,7 @@ class ServiceClientTest extends TestCase
 
     public function testLatestInfoThrowsExceptionWhenRequestFails(): void
     {
-        $response = static::createMock(ResponseInterface::class);
+        $response = static::createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(Response::HTTP_BAD_REQUEST);
 
         static::expectExceptionObject(ServiceException::requestFailed($response));

--- a/tests/unit/Core/Service/ServiceExceptionTest.php
+++ b/tests/unit/Core/Service/ServiceExceptionTest.php
@@ -46,7 +46,7 @@ class ServiceExceptionTest extends TestCase
 
     public function testRequestFailed(): void
     {
-        $response = static::createMock(ResponseInterface::class);
+        $response = static::createStub(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(Response::HTTP_NOT_FOUND);
 
         $e = ServiceException::requestFailed($response);

--- a/tests/unit/Core/Service/ServiceLifecycleTest.php
+++ b/tests/unit/Core/Service/ServiceLifecycleTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Service;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\AppCollection;
@@ -41,23 +41,15 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(ServiceLifecycle::class)]
 class ServiceLifecycleTest extends TestCase
 {
-    private AbstractAppLifecycle&MockObject $appLifecycle;
-
     private ServiceEntry $entry;
 
-    private LoggerInterface&MockObject $logger;
+    private LoggerInterface&Stub $logger;
 
-    private ManifestFactory&MockObject $manifestFactory;
+    private ServiceRegistryClient&Stub $serviceRegistryClient;
 
-    private ServiceClient&MockObject $serviceClient;
+    private ServiceSourceResolver&Stub $sourceResolver;
 
-    private ServiceClientFactory&MockObject $serviceClientFactory;
-
-    private ServiceRegistryClient&MockObject $serviceRegistryClient;
-
-    private ServiceSourceResolver&MockObject $sourceResolver;
-
-    private AppStateService&MockObject $appState;
+    private AppStateService&Stub $appState;
 
     private AppInfo $appInfo;
 
@@ -66,56 +58,55 @@ class ServiceLifecycleTest extends TestCase
      * */
     private EntityRepository $appRepo;
 
-    private EventDispatcherInterface&MockObject $eventDispatcher;
-
-    private RequirementsValidator&MockObject $requirementsValidator;
+    private RequirementsValidator&Stub $requirementsValidator;
 
     protected function setUp(): void
     {
-        $this->appLifecycle = $this->createMock(AbstractAppLifecycle::class);
         $this->entry = new ServiceEntry('MyCoolService', 'MyCoolService', 'https://example.com', '/service/lifecycle/choose-app');
         $this->appInfo = new AppInfo('MyCoolService', '6.6.0.0', 'a1bcd', '6.6.0.0-a1bcd', 'https://example.com/service/lifecycle/app-zip/6.6.0.0', ['service_consent'], 'sha256', '6.6.0.0');
-        $this->logger = $this->createMock(LoggerInterface::class);
-        $this->manifestFactory = $this->createMock(ManifestFactory::class);
-        $this->serviceClient = $this->createMock(ServiceClient::class);
-        $this->serviceClientFactory = $this->createMock(ServiceClientFactory::class);
-        $this->serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
-        $this->sourceResolver = $this->createMock(ServiceSourceResolver::class);
-        $this->appState = $this->createMock(AppStateService::class);
+        $this->logger = static::createStub(LoggerInterface::class);
+        $this->serviceRegistryClient = static::createStub(ServiceRegistryClient::class);
+        $this->sourceResolver = static::createStub(ServiceSourceResolver::class);
+        $this->appState = static::createStub(AppStateService::class);
         $this->appRepo = new StaticEntityRepository([
             [], // empty search for app -> service migration
         ]);
-        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $this->requirementsValidator = $this->createMock(RequirementsValidator::class);
+        $this->requirementsValidator = static::createStub(RequirementsValidator::class);
         $this->requirementsValidator->method('isValidSet')->willReturn(true);
     }
 
     public function testInstallDoesNotLogErrorIfAppCannotBeDownloaded(): void
     {
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willThrowException(ServiceException::missingAppVersionInformation('app-version'));
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willThrowException(ServiceException::missingAppVersionInformation('app-version'));
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory->expects($this->never())->method('createFromXmlFile');
 
-        $this->appLifecycle->expects($this->never())->method('install');
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('install');
 
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->never())
             ->method('error')
             ->with('Cannot install service "MyCoolService" because of error: "Error downloading app. The version information was missing."');
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository(),
-            $this->logger,
-            $this->manifestFactory,
+            $logger,
+            $manifestFactory,
             $this->sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -124,13 +115,16 @@ class ServiceLifecycleTest extends TestCase
 
     public function testInstallLogsErrorIfAppCannotBeInstalled(): void
     {
-        $tempDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
+        $tempDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
         $tempDirectoryFactory->method('path')->willReturn('/tmp/path');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
@@ -143,27 +137,30 @@ class ServiceLifecycleTest extends TestCase
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('install')
             ->willThrowException(AppException::notCompatible('MyCoolService'));
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('warning')
             ->with('Cannot install service "MyCoolService" because of error: "App MyCoolService is not compatible with this Shopware version"');
 
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository(),
-            $this->logger,
+            $logger,
             $manifestFactory,
-            $this->sourceResolver,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -172,26 +169,31 @@ class ServiceLifecycleTest extends TestCase
 
     public function testInstall(): void
     {
-        $tempDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
+        $tempDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
 
         $tempDirectoryFactory->method('path')->willReturn('/tmp/path');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
 
         $manifest = $this->createManifest();
-        $this->manifestFactory
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory
             ->expects($this->once())
             ->method('createFromXmlFile')
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('install')
             ->willReturnCallback(static function (Manifest $manifest): void {
                 static::assertSame('https://example.com', $manifest->getPath());
@@ -208,7 +210,8 @@ class ServiceLifecycleTest extends TestCase
                 static::assertSame('6.6.0.0-a1bcd', $manifest->getMetadata()->getVersion());
             });
 
-        $this->eventDispatcher
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with(
@@ -219,14 +222,14 @@ class ServiceLifecycleTest extends TestCase
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->appRepo,
             $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -265,30 +268,37 @@ class ServiceLifecycleTest extends TestCase
             },
         ]);
 
-        $tempDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
+        $tempDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
         $tempDirectoryFactory->method('path')->willReturn('/tmp/path');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
 
         $manifest = $this->createManifest();
-        $this->manifestFactory
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory
             ->expects($this->once())
             ->method('createFromXmlFile')
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appState->expects($this->once())
+        $appState = $this->createMock(AppStateService::class);
+        $appState->expects($this->once())
             ->method('activateApp')
             ->with($app->getId(), $context);
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('update')
             ->willReturnCallback(static function (Manifest $manifest): void {
                 static::assertSame('https://example.com', $manifest->getPath());
@@ -305,7 +315,8 @@ class ServiceLifecycleTest extends TestCase
                 static::assertSame('6.6.0.0-a1bcd', $manifest->getMetadata()->getVersion());
             });
 
-        $this->eventDispatcher
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with(
@@ -315,15 +326,15 @@ class ServiceLifecycleTest extends TestCase
             );
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $appRepo,
             $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
-            $this->appState,
-            $this->eventDispatcher,
+            $manifestFactory,
+            $sourceResolver,
+            $appState,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -345,25 +356,30 @@ class ServiceLifecycleTest extends TestCase
     {
         $entry = new ServiceEntry('MyCoolService', 'MyCoolService', 'https://example.com', '/service/lifecycle/choose-app', activateOnInstall: false);
 
-        $tempDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
+        $tempDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
         $tempDirectoryFactory->method('path')->willReturn('/tmp/path');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($entry)->willReturn($serviceClient);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
 
         $manifest = $this->createManifest();
-        $this->manifestFactory
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory
             ->expects($this->once())
             ->method('createFromXmlFile')
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('install')
             ->willReturnCallback(static function (Manifest $manifest, AppInstallParameters $options): void {
                 static::assertFalse($options->activate);
@@ -381,7 +397,8 @@ class ServiceLifecycleTest extends TestCase
                 static::assertSame('6.6.0.0-a1bcd', $manifest->getMetadata()->getVersion());
             });
 
-        $this->eventDispatcher
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with(
@@ -392,14 +409,14 @@ class ServiceLifecycleTest extends TestCase
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository(),
             $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -411,13 +428,14 @@ class ServiceLifecycleTest extends TestCase
         static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
 
         $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
-        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
-        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
-        $logger = $this->createMock(LoggerInterface::class);
-        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $serviceClientFactory = static::createStub(ServiceClientFactory::class);
+        $appLifecycle = static::createStub(AbstractAppLifecycle::class);
+        $logger = static::createStub(LoggerInterface::class);
+        $manifestFactory = static::createStub(ManifestFactory::class);
 
         $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
             $serviceRegistryClient,
@@ -428,7 +446,7 @@ class ServiceLifecycleTest extends TestCase
             $manifestFactory,
             $this->sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -442,31 +460,38 @@ class ServiceLifecycleTest extends TestCase
         $app->setUniqueIdentifier(Uuid::randomHex());
         $app->assign(['name' => 'MyCoolService']);
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willThrowException(ServiceException::missingAppVersionInformation('app-version'));
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willThrowException(ServiceException::missingAppVersionInformation('app-version'));
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory->expects($this->never())->method('createFromXmlFile');
 
-        $this->appLifecycle->expects($this->never())->method('update');
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('update');
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Cannot update service "MyCoolService" because of error: "Error downloading app. The version information was missing: app-version"');
 
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository([$app]),
-            $this->logger,
-            $this->manifestFactory,
+            $logger,
+            $manifestFactory,
             $this->sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -480,23 +505,29 @@ class ServiceLifecycleTest extends TestCase
         $app->setUniqueIdentifier(Uuid::randomHex());
         $app->assign(['name' => 'MyCoolService', 'version' => '6.6.0.0-a1bcd', 'aclRoleId' => Uuid::randomHex()]);
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
-        $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('update');
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory->expects($this->never())->method('createFromXmlFile');
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('update');
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository([$app]),
             $this->logger,
-            $this->manifestFactory,
+            $manifestFactory,
             $this->sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -510,43 +541,51 @@ class ServiceLifecycleTest extends TestCase
         $app->setUniqueIdentifier(Uuid::randomHex());
         $app->assign(['name' => 'MyCoolService', 'version' => '8.0.0', 'aclRoleId' => Uuid::randomHex()]);
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
 
         $manifest = $this->createManifest();
-        $this->manifestFactory
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory
             ->expects($this->once())
             ->method('createFromXmlFile')
             ->with('/app-root/manifest.xml')
             ->willReturn($manifest);
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('update')
             ->willThrowException(AppException::notCompatible('MyCoolService'));
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Cannot update service "MyCoolService" because of error: "App MyCoolService is not compatible with this Shopware version"');
 
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository([$app]),
-            $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $logger,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -560,22 +599,27 @@ class ServiceLifecycleTest extends TestCase
         $app->setUniqueIdentifier(Uuid::randomHex());
         $app->assign(['name' => 'MyCoolService', 'version' => '6.0.0', 'aclRoleId' => Uuid::randomHex()]);
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($this->appInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
-        $this->sourceResolver->expects($this->once())
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->once())
             ->method('filesystemForVersion')
             ->with($this->appInfo)
             ->willReturn(new StaticFilesystem());
 
         $manifest = $this->createManifest();
-        $this->manifestFactory
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory
             ->expects($this->once())
             ->method('createFromXmlFile')
             ->with('/app-root/manifest.xml')
             ->willReturn($this->createManifest());
 
-        $this->appLifecycle->expects($this->once())
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->once())
             ->method('update')
             ->willReturnCallback(static function (Manifest $manifest): void {
                 static::assertSame('https://example.com', $manifest->getPath());
@@ -592,9 +636,11 @@ class ServiceLifecycleTest extends TestCase
                 static::assertSame('6.6.0.0-a1bcd', $manifest->getMetadata()->getVersion());
             });
 
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
 
-        $this->eventDispatcher
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with(
@@ -604,15 +650,15 @@ class ServiceLifecycleTest extends TestCase
             );
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository([$app]),
             $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $this->requirementsValidator
         );
 
@@ -623,8 +669,10 @@ class ServiceLifecycleTest extends TestCase
     {
         $invalidAppInfo = new AppInfo('MyCoolService', '6.6.0.0', 'a1bcd', '6.6.0.0-a1bcd', 'https://example.com/service/lifecycle/app-zip/6.6.0.0', ['invalid_requirement'], 'sha256', '6.6.0.0');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($invalidAppInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($invalidAppInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
 
         $requirementsValidator = $this->createMock(RequirementsValidator::class);
         $requirementsValidator
@@ -633,26 +681,31 @@ class ServiceLifecycleTest extends TestCase
             ->with(['invalid_requirement'])
             ->willReturn(false);
 
-        $this->sourceResolver->expects($this->never())->method('filesystemForVersion');
-        $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('install');
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->never())->method('filesystemForVersion');
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory->expects($this->never())->method('createFromXmlFile');
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('install');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Cannot install service "MyCoolService" because of invalid requirements: "invalid_requirement"');
 
         $lifecycle = new ServiceLifecycle(
             $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository(),
-            $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $logger,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $requirementsValidator
         );
 
@@ -668,9 +721,12 @@ class ServiceLifecycleTest extends TestCase
 
         $invalidAppInfo = new AppInfo('MyCoolService', '6.6.0.0', 'a1bcd', '6.6.0.0-a1bcd', 'https://example.com/service/lifecycle/app-zip/6.6.0.0', ['invalid_requirement'], 'sha256', '6.6.0.0');
 
-        $this->serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($invalidAppInfo);
-        $this->serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($this->serviceClient);
-        $this->serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
+        $serviceClient = $this->createMock(ServiceClient::class);
+        $serviceClient->expects($this->once())->method('latestAppInfo')->willReturn($invalidAppInfo);
+        $serviceClientFactory = $this->createMock(ServiceClientFactory::class);
+        $serviceClientFactory->expects($this->once())->method('newFor')->with($this->entry)->willReturn($serviceClient);
+        $serviceRegistryClient = $this->createMock(ServiceRegistryClient::class);
+        $serviceRegistryClient->expects($this->once())->method('get')->with('MyCoolService')->willReturn($this->entry);
 
         $requirementsValidator = $this->createMock(RequirementsValidator::class);
         $requirementsValidator
@@ -679,26 +735,31 @@ class ServiceLifecycleTest extends TestCase
             ->with(['invalid_requirement'])
             ->willReturn(false);
 
-        $this->sourceResolver->expects($this->never())->method('filesystemForVersion');
-        $this->manifestFactory->expects($this->never())->method('createFromXmlFile');
-        $this->appLifecycle->expects($this->never())->method('update');
-        $this->eventDispatcher->expects($this->never())->method('dispatch');
+        $sourceResolver = $this->createMock(ServiceSourceResolver::class);
+        $sourceResolver->expects($this->never())->method('filesystemForVersion');
+        $manifestFactory = $this->createMock(ManifestFactory::class);
+        $manifestFactory->expects($this->never())->method('createFromXmlFile');
+        $appLifecycle = $this->createMock(AbstractAppLifecycle::class);
+        $appLifecycle->expects($this->never())->method('update');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->never())->method('dispatch');
 
-        $this->logger
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
             ->expects($this->once())
             ->method('debug')
             ->with('Cannot update service "MyCoolService" because of invalid requirements: "invalid_requirement"');
 
         $lifecycle = new ServiceLifecycle(
-            $this->serviceRegistryClient,
-            $this->serviceClientFactory,
-            $this->appLifecycle,
+            $serviceRegistryClient,
+            $serviceClientFactory,
+            $appLifecycle,
             $this->buildAppRepository([$app]),
-            $this->logger,
-            $this->manifestFactory,
-            $this->sourceResolver,
+            $logger,
+            $manifestFactory,
+            $sourceResolver,
             $this->appState,
-            $this->eventDispatcher,
+            $eventDispatcher,
             $requirementsValidator
         );
 

--- a/tests/unit/Core/Service/ServiceRegistry/PermissionLoggerTest.php
+++ b/tests/unit/Core/Service/ServiceRegistry/PermissionLoggerTest.php
@@ -65,6 +65,10 @@ class PermissionLoggerTest extends TestCase
             }))
             ->willReturn(new Envelope(new \stdClass()));
 
+        $this->client->expects($this->never())->method('saveConsent');
+        $this->shopIdProvider->expects($this->never())->method('getShopId');
+        $this->systemConfigService->expects($this->never())->method('getString');
+
         $this->permissionLogger->log($consent, ConsentState::GRANTED);
     }
 
@@ -103,6 +107,8 @@ class PermissionLoggerTest extends TestCase
                     && $request->licenseHost === $licenseHost;
             }));
 
+        $this->messageBus->expects($this->never())->method('dispatch');
+
         $this->permissionLogger->logSync($consent, ConsentState::GRANTED);
     }
 
@@ -127,6 +133,8 @@ class PermissionLoggerTest extends TestCase
             ->expects($this->once())
             ->method('revokeConsent')
             ->with($consent->identifier);
+
+        $this->messageBus->expects($this->never())->method('dispatch');
 
         $this->permissionLogger->logSync($consent, ConsentState::REVOKED);
     }
@@ -165,6 +173,8 @@ class PermissionLoggerTest extends TestCase
                     && $request->licenseHost === '';
             }));
 
+        $this->messageBus->expects($this->never())->method('dispatch');
+
         $this->permissionLogger->logSync($consent, ConsentState::GRANTED);
     }
 
@@ -184,6 +194,10 @@ class PermissionLoggerTest extends TestCase
                 return $message->permissionsConsent === $consent && $message->consentState === ConsentState::REVOKED;
             }))
             ->willReturn(new Envelope(new \stdClass()));
+
+        $this->client->expects($this->never())->method('saveConsent');
+        $this->shopIdProvider->expects($this->never())->method('getShopId');
+        $this->systemConfigService->expects($this->never())->method('getString');
 
         $this->permissionLogger->log($consent, ConsentState::REVOKED);
     }

--- a/tests/unit/Core/Service/ServiceSourceResolverTest.php
+++ b/tests/unit/Core/Service/ServiceSourceResolverTest.php
@@ -29,10 +29,10 @@ class ServiceSourceResolverTest extends TestCase
     public function testName(): void
     {
         $source = new ServiceSourceResolver(
-            $this->createMock(Client::class),
+            static::createStub(Client::class),
             new TemporaryDirectoryFactory(),
-            $this->createMock(AppExtractor::class),
-            $this->createMock(Filesystem::class)
+            static::createStub(AppExtractor::class),
+            static::createStub(Filesystem::class)
         );
         static::assertSame('service', $source->name());
     }
@@ -44,10 +44,10 @@ class ServiceSourceResolverTest extends TestCase
         $app->setSourceType('service');
 
         $source = new ServiceSourceResolver(
-            $this->createMock(Client::class),
+            static::createStub(Client::class),
             new TemporaryDirectoryFactory(),
-            $this->createMock(AppExtractor::class),
-            $this->createMock(Filesystem::class)
+            static::createStub(AppExtractor::class),
+            static::createStub(Filesystem::class)
         );
 
         static::assertTrue($source->supports($app));
@@ -59,7 +59,7 @@ class ServiceSourceResolverTest extends TestCase
 
     public function testSupportSelfManagedManifestsWithHttpUrls(): void
     {
-        $manifest = static::createMock(Manifest::class);
+        $manifest = static::createStub(Manifest::class);
         $manifest->method('getPath')->willReturn('https://example.com');
 
         $metadata = Metadata::fromArray([
@@ -76,10 +76,10 @@ class ServiceSourceResolverTest extends TestCase
         $manifest->method('getMetadata')->willReturn($metadata);
 
         $source = new ServiceSourceResolver(
-            $this->createMock(Client::class),
+            static::createStub(Client::class),
             new TemporaryDirectoryFactory(),
-            $this->createMock(AppExtractor::class),
-            $this->createMock(Filesystem::class)
+            static::createStub(AppExtractor::class),
+            static::createStub(Filesystem::class)
         );
 
         static::assertTrue($source->supports($manifest));
@@ -253,8 +253,8 @@ class ServiceSourceResolverTest extends TestCase
     public function testDownloadVersionThrowsExceptionOnServiceError(): void
     {
         $client = $this->createMock(Client::class);
-        $temporaryDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
-        $appExtractor = $this->createMock(AppExtractor::class);
+        $temporaryDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
+        $appExtractor = static::createStub(AppExtractor::class);
         $filesystem = $this->createMock(Filesystem::class);
 
         $temporaryDirectoryFactory->method('path')
@@ -300,7 +300,7 @@ class ServiceSourceResolverTest extends TestCase
     public function testDownloadVersionThrowsExceptionOnExtractorError(): void
     {
         $client = $this->createMock(Client::class);
-        $temporaryDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
+        $temporaryDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
         $appExtractor = $this->createMock(AppExtractor::class);
         $filesystem = $this->createMock(Filesystem::class);
 
@@ -355,8 +355,8 @@ class ServiceSourceResolverTest extends TestCase
     public function testDownloadVersionThrowsExceptionOnFileWriteError(): void
     {
         $client = $this->createMock(Client::class);
-        $temporaryDirectoryFactory = $this->createMock(TemporaryDirectoryFactory::class);
-        $appExtractor = $this->createMock(AppExtractor::class);
+        $temporaryDirectoryFactory = static::createStub(TemporaryDirectoryFactory::class);
+        $appExtractor = static::createStub(AppExtractor::class);
         $filesystem = $this->createMock(Filesystem::class);
 
         $temporaryDirectoryFactory->method('path')

--- a/tests/unit/Core/Service/Subscriber/LicenseSyncSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/LicenseSyncSubscriberTest.php
@@ -83,6 +83,9 @@ class LicenseSyncSubscriberTest extends TestCase
             BeforeSystemConfigChangedEvent::class => 'syncLicense',
         ];
 
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+        $this->serviceRegistryClient->expects($this->never())->method('get');
+
         static::assertSame($expectedEvents, LicenseSyncSubscriber::getSubscribedEvents());
     }
 
@@ -139,7 +142,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
         $this->clientFactory->method('newAuthenticatedFor')->willReturn($serviceAuthedClient);
 
         $this->clientFactory->expects($this->exactly(2))->method('newAuthenticatedFor');
@@ -202,7 +205,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
         $this->clientFactory->method('newAuthenticatedFor')->willReturn($serviceAuthedClient);
 
         $this->clientFactory->expects($this->exactly(2))->method('newAuthenticatedFor');
@@ -326,7 +329,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
         $this->clientFactory->method('newAuthenticatedFor')->willReturn($serviceAuthedClient);
 
         $this->clientFactory->expects($this->exactly(2))->method('newAuthenticatedFor');
@@ -372,7 +375,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->never())->method('get');
 
         $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
         $serviceAuthedClient->expects($this->never())->method('syncLicense');
@@ -418,7 +421,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->never())->method('get');
 
         $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
         $serviceAuthedClient->expects($this->never())->method('syncLicense');
@@ -427,6 +430,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedWhenIntegrationIdDoesNotMatch(): void
     {
+        $this->serviceRegistryClient->expects($this->never())->method('get');
+
         $app = new AppEntity();
         $app->setId(Uuid::randomHex());
         $app->setUniqueIdentifier('app_id');
@@ -437,7 +442,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $event = new AppInstalledEvent(
             $app,
-            $this->createMock(Manifest::class),
+            static::createStub(Manifest::class),
             Context::createCLIContext(new AdminApiSource(
                 'user_id',
                 'integration_id',
@@ -460,7 +465,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $event = new AppInstalledEvent(
             $app,
-            $this->createMock(Manifest::class),
+            static::createStub(Manifest::class),
             Context::createCLIContext(new AdminApiSource(
                 'user_id',
                 'integration_id',
@@ -517,7 +522,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
 
         $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
         $serviceAuthedClient->expects($this->never())->method('syncLicense');
@@ -563,7 +568,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->never())->method('get');
 
         $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
         $serviceAuthedClient->expects($this->never())->method('syncLicense');
@@ -572,6 +577,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedWithValueIsNotString(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         $event = new BeforeSystemConfigChangedEvent(
             LicenseSyncSubscriber::CONFIG_STORE_LICENSE_KEY,
             1,
@@ -584,6 +591,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedWithInvalidConfigChanges(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         $event = new BeforeSystemConfigChangedEvent(
             'invalid_key',
             'valid_license_key',
@@ -596,6 +605,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedWithInvalidConfigValue(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         $event = new BeforeSystemConfigChangedEvent(
             LicenseSyncSubscriber::CONFIG_STORE_LICENSE_KEY,
             null,
@@ -614,7 +625,7 @@ class LicenseSyncSubscriberTest extends TestCase
         $app->setSelfManaged(true);
         $context = Context::createDefaultContext();
 
-        $event = new AppInstalledEvent($app, $this->createMock(Manifest::class), $context);
+        $event = new AppInstalledEvent($app, static::createStub(Manifest::class), $context);
         $providedEvents = [];
         $this->eventDispatcher->addListener(CommercialLicenseProvidedEvent::class, static function (CommercialLicenseProvidedEvent $event) use (&$providedEvents): void {
             $providedEvents[] = $event;
@@ -638,7 +649,7 @@ class LicenseSyncSubscriberTest extends TestCase
 
         $serviceEntry = new ServiceEntry('serviceA', 'description', 'host', 'appEndpoint', true, 'licenseSyncEndPoint');
 
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
 
         $this->clientFactory->expects($this->once())->method('newAuthenticatedFor');
         $this->subscriber->serviceInstalled($event);
@@ -667,6 +678,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsProvidedOnAppActivation(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         $app = new AppEntity();
         $app->setId(Uuid::randomHex());
         $app->setName('app_name');
@@ -709,12 +722,14 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedOnAppInstallWithInvalidSecret(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         $context = Context::createDefaultContext();
         $app = new AppEntity();
         $app->setName('app_name');
         $app->setSelfManaged(true);
 
-        $event = new AppInstalledEvent($app, $this->createMock(Manifest::class), $context);
+        $event = new AppInstalledEvent($app, static::createStub(Manifest::class), $context);
 
         $this->systemConfigService = new StaticSystemConfigService([]);
 
@@ -760,9 +775,9 @@ class LicenseSyncSubscriberTest extends TestCase
         );
 
         $serviceAuthedClient = $this->createMock(AuthenticatedServiceClient::class);
-        $this->serviceRegistryClient->method('get')->willReturn($serviceEntry);
+        $this->serviceRegistryClient->expects($this->atLeastOnce())->method('get')->willReturn($serviceEntry);
 
-        $this->clientFactory->method('newAuthenticatedFor')->willThrowException(new ServiceException(301, 'error', 'error'));
+        $this->clientFactory->expects($this->once())->method('newAuthenticatedFor')->willThrowException(new ServiceException(301, 'error', 'error'));
 
         $serviceAuthedClient->expects($this->never())->method('syncLicense');
         $this->subscriber->syncLicense($event);
@@ -770,6 +785,8 @@ class LicenseSyncSubscriberTest extends TestCase
 
     public function testLicenseIsNotSyncedWhenValueHasNotChanged(): void
     {
+        $this->clientFactory->expects($this->never())->method('newAuthenticatedFor');
+
         // Set up system config with existing value
         $this->systemConfigService = new StaticSystemConfigService([
             LicenseSyncSubscriber::CONFIG_STORE_LICENSE_KEY => 'existing_license_key',

--- a/tests/unit/Core/Service/Subscriber/PermissionsSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/PermissionsSubscriberTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Service\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Service\Event\PermissionsGrantedEvent;
@@ -19,16 +18,10 @@ use Shopware\Core\Service\Subscriber\PermissionsSubscriber;
 #[CoversClass(PermissionsSubscriber::class)]
 class PermissionsSubscriberTest extends TestCase
 {
-    private LifecycleManager&MockObject $manager;
-
-    private PermissionsSubscriber $subscriber;
-
     private Context $context;
 
     protected function setUp(): void
     {
-        $this->manager = $this->createMock(LifecycleManager::class);
-        $this->subscriber = new PermissionsSubscriber($this->manager);
         $this->context = Context::createDefaultContext();
     }
 
@@ -42,12 +35,13 @@ class PermissionsSubscriberTest extends TestCase
         );
         $event = new PermissionsGrantedEvent($consent, $this->context);
 
-        $this->manager
+        $manager = $this->createMock(LifecycleManager::class);
+        $manager
             ->expects($this->once())
             ->method('syncRequirement')
             ->with(ServiceConsentRequirement::NAME, $this->context);
 
-        $this->subscriber->syncConsentRequirement($event);
+        (new PermissionsSubscriber($manager))->syncConsentRequirement($event);
     }
 
     public function testSyncConsentRequirementOnRevoke(): void
@@ -60,12 +54,13 @@ class PermissionsSubscriberTest extends TestCase
         );
         $event = new PermissionsRevokedEvent($consent, $this->context);
 
-        $this->manager
+        $manager = $this->createMock(LifecycleManager::class);
+        $manager
             ->expects($this->once())
             ->method('syncRequirement')
             ->with(ServiceConsentRequirement::NAME, $this->context);
 
-        $this->subscriber->syncConsentRequirement($event);
+        (new PermissionsSubscriber($manager))->syncConsentRequirement($event);
     }
 
     public function testSubscribedEvents(): void

--- a/tests/unit/Core/Service/Subscriber/ServiceLifecycleSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/ServiceLifecycleSubscriberTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Service\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Notification\NotificationService;
@@ -20,19 +19,10 @@ use Shopware\Core\Service\Subscriber\ServiceLifecycleSubscriber;
 #[CoversClass(ServiceLifecycleSubscriber::class)]
 class ServiceLifecycleSubscriberTest extends TestCase
 {
-    private LifecycleManager&MockObject $lifecycleManager;
-
-    private NotificationService&MockObject $notificationService;
-
-    private ServiceLifecycleSubscriber $subscriber;
-
     private Context $context;
 
     protected function setUp(): void
     {
-        $this->lifecycleManager = $this->createMock(LifecycleManager::class);
-        $this->notificationService = $this->createMock(NotificationService::class);
-        $this->subscriber = new ServiceLifecycleSubscriber($this->lifecycleManager, new Notification($this->notificationService));
         $this->context = Context::createDefaultContext();
     }
 
@@ -50,11 +40,13 @@ class ServiceLifecycleSubscriberTest extends TestCase
         $serviceName = 'TestService';
         $event = new ServiceInstalledEvent($serviceName, $this->context);
 
-        $this->lifecycleManager->expects($this->once())
+        $lifecycleManager = $this->createMock(LifecycleManager::class);
+        $lifecycleManager->expects($this->once())
             ->method('syncState')
             ->with($serviceName, $this->context);
 
-        $this->subscriber->syncState($event);
+        $subscriber = new ServiceLifecycleSubscriber($lifecycleManager, new Notification(static::createStub(NotificationService::class)));
+        $subscriber->syncState($event);
     }
 
     public function testSyncStateWithServiceUpdatedEvent(): void
@@ -62,17 +54,21 @@ class ServiceLifecycleSubscriberTest extends TestCase
         $serviceName = 'TestService';
         $event = new ServiceUpdatedEvent($serviceName, $this->context);
 
-        $this->lifecycleManager->expects($this->once())
+        $lifecycleManager = $this->createMock(LifecycleManager::class);
+        $lifecycleManager->expects($this->once())
             ->method('syncState')
             ->with($serviceName, $this->context);
 
-        $this->subscriber->syncState($event);
+        $subscriber = new ServiceLifecycleSubscriber($lifecycleManager, new Notification(static::createStub(NotificationService::class)));
+        $subscriber->syncState($event);
     }
 
-    public function delegatesAllServicesInstalledEvents(): void
+    public function testDelegatesAllServicesInstalledEvents(): void
     {
-        $this->notificationService->expects($this->once())->method('createNotification');
+        $notificationService = $this->createMock(NotificationService::class);
+        $notificationService->expects($this->once())->method('createNotification');
 
-        $this->subscriber->sendInstalledNotification(new NewServicesInstalledEvent());
+        $subscriber = new ServiceLifecycleSubscriber(static::createStub(LifecycleManager::class), new Notification($notificationService));
+        $subscriber->sendInstalledNotification(new NewServicesInstalledEvent());
     }
 }

--- a/tests/unit/Core/Service/Subscriber/ShopwareAccountSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/ShopwareAccountSubscriberTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Service\Subscriber;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Store\Event\ShopwareAccountLoginEvent;
@@ -18,16 +17,10 @@ use Shopware\Core\Service\Subscriber\ShopwareAccountSubscriber;
 #[CoversClass(ShopwareAccountSubscriber::class)]
 class ShopwareAccountSubscriberTest extends TestCase
 {
-    private LifecycleManager&MockObject $manager;
-
-    private ShopwareAccountSubscriber $subscriber;
-
     private Context $context;
 
     protected function setUp(): void
     {
-        $this->manager = $this->createMock(LifecycleManager::class);
-        $this->subscriber = new ShopwareAccountSubscriber($this->manager);
         $this->context = Context::createDefaultContext();
     }
 
@@ -35,24 +28,26 @@ class ShopwareAccountSubscriberTest extends TestCase
     {
         $event = new ShopwareAccountLoginEvent($this->context);
 
-        $this->manager
+        $manager = $this->createMock(LifecycleManager::class);
+        $manager
             ->expects($this->once())
             ->method('syncRequirement')
             ->with(ShopwareAccountRequirement::NAME, $this->context);
 
-        $this->subscriber->syncAccountRequirement($event);
+        (new ShopwareAccountSubscriber($manager))->syncAccountRequirement($event);
     }
 
     public function testSyncAccountRequirementOnLogout(): void
     {
         $event = new ShopwareAccountLogoutEvent($this->context);
 
-        $this->manager
+        $manager = $this->createMock(LifecycleManager::class);
+        $manager
             ->expects($this->once())
             ->method('syncRequirement')
             ->with(ShopwareAccountRequirement::NAME, $this->context);
 
-        $this->subscriber->syncAccountRequirement($event);
+        (new ShopwareAccountSubscriber($manager))->syncAccountRequirement($event);
     }
 
     public function testSubscribedEvents(): void

--- a/tests/unit/Core/Service/Subscriber/SystemUpdateSubscriberTest.php
+++ b/tests/unit/Core/Service/Subscriber/SystemUpdateSubscriberTest.php
@@ -25,7 +25,7 @@ class SystemUpdateSubscriberTest extends TestCase
             ->method('sync')
             ->with($context);
 
-        $subscriber = new SystemUpdateSubscriber($lifecycleManager, $this->createMock(LoggerInterface::class));
+        $subscriber = new SystemUpdateSubscriber($lifecycleManager, static::createStub(LoggerInterface::class));
         $subscriber->sync(new UpdatePostFinishEvent($context, '6.7.0.0', '6.7.1.0'));
     }
 }

--- a/tests/unit/Core/Test/Stub/App/StaticSourceResolverTest.php
+++ b/tests/unit/Core/Test/Stub/App/StaticSourceResolverTest.php
@@ -20,7 +20,7 @@ class StaticSourceResolverTest extends TestCase
 {
     public function testCanResolveManifestToType(): void
     {
-        $app = $this->createMock(Manifest::class);
+        $app = static::createStub(Manifest::class);
 
         $resolver = new StaticSourceResolver();
 
@@ -36,7 +36,7 @@ class StaticSourceResolverTest extends TestCase
         ]);
 
         $metadata = Metadata::fromArray(['name' => 'myApp', 'label' => [], 'author' => 'myApp', 'copyright' => 'none', 'license' => 'none', 'version' => '99']);
-        $manifest = $this->createMock(Manifest::class);
+        $manifest = static::createStub(Manifest::class);
         $manifest->method('getMetadata')->willReturn($metadata);
         $app = (new AppEntity())->assign(['name' => 'myApp']);
 
@@ -54,7 +54,7 @@ class StaticSourceResolverTest extends TestCase
         ]);
 
         $metadata = Metadata::fromArray(['name' => 'myApp', 'label' => [], 'author' => 'myApp', 'copyright' => 'none', 'license' => 'none', 'version' => '99']);
-        $manifest = $this->createMock(Manifest::class);
+        $manifest = static::createStub(Manifest::class);
         $manifest->method('getMetadata')->willReturn($metadata);
         $app = (new AppEntity())->assign(['name' => 'myApp']);
 

--- a/tests/unit/Core/Test/Stub/Doctrine/FakeResultFactoryTest.php
+++ b/tests/unit/Core/Test/Stub/Doctrine/FakeResultFactoryTest.php
@@ -22,7 +22,7 @@ class FakeResultFactoryTest extends TestCase
             ['id' => 2, 'name' => 'bar', 'description' => 'foo description'],
         ];
 
-        $connection = $this->createMock(Connection::class);
+        $connection = static::createStub(Connection::class);
 
         $result = FakeResultFactory::createResult($data, $connection);
 

--- a/tests/unit/Core/Test/Stub/Doctrine/QueryBuilderDataExtractorTest.php
+++ b/tests/unit/Core/Test/Stub/Doctrine/QueryBuilderDataExtractorTest.php
@@ -21,7 +21,7 @@ class QueryBuilderDataExtractorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->queryBuilder = new QueryBuilder($this->createMock(Connection::class));
+        $this->queryBuilder = new QueryBuilder(static::createStub(Connection::class));
     }
 
     public function testGetSelect(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
  Compatibility PHPUnit 12, 13.

  Extends `NoCreateMockWithoutExpectationsRule` coverage to the remaining small Core domains and clears every violation, removing the PHPUnit 12 "no expectations were configured" notices (and the PHPUnit 14 `with()`-without-`expects()` removals). After this, only `Core\Framework` is left.

  ## 2. What does this change do?

  - Adds `Service`, `Installer`, `Maintenance`, `SsoUser`, `Saas`, `Test` to the rule's enabled-namespaces allowlist.
  - Sweeps 43 test files: pure value-provider doubles `createMock` → `createStub`; genuinely-mixed shared doubles keep being mocks and get `->expects($this->never())` in tests that don't exercise them, or become stubs with a local `createMock` only in the asserting test; value-provider collaborators (`connection`, `connectionFactory`) become stubs rather than mock+`never()`.

  ## 3. How to reproduce?

  ```bash
  php -d memory_limit=4G vendor/bin/phpstan analyse tests/unit/Core/Service tests/unit/Core/Installer tests/unit/Core/Maintenance tests/unit/Core/SsoUser tests/unit/Core/Saas tests/unit/Core/Test
  docker compose exec -T web vendor/bin/phpunit tests/unit/Core/Service tests/unit/Core/Installer tests/unit/Core/Maintenance tests/unit/Core/SsoUser tests/unit/Core/Saas tests/unit/Core/Test
```

 ### 4. Please link to the relevant issues (if any).
  - relates https://github.com/shopware/shopware/issues/17937

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
