### PR TITLE
fix: sw-filter-panel race condition

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
@@ -40,6 +40,7 @@ export default {
             activeFilters: {},
             filterChanged: false,
             storedFilters: null,
+            storedFiltersRequestId: 0,
         };
     },
 
@@ -106,14 +107,21 @@ export default {
 
     methods: {
         createdComponent() {
+            const requestId = this.storedFiltersRequestId + 1;
+            this.storedFiltersRequestId = requestId;
+
             Shopware.Service('filterService')
                 .getStoredFilters(this.storeKey)
                 .then((filters) => {
+                    if (requestId !== this.storedFiltersRequestId || this.filterChanged) {
+                        return;
+                    }
+
                     this.activeFilters = {};
-                    this.storedFilters = filters;
+                    this.storedFilters = filters ?? {};
 
                     this.listFilters.forEach((filter) => {
-                        const criteria = filters[filter.name] ? filters[filter.name].criteria : null;
+                        const criteria = this.storedFilters[filter.name] ? this.storedFilters[filter.name].criteria : null;
                         if (criteria) {
                             this.activeFilters[filter.name] = criteria;
                         }
@@ -123,18 +131,23 @@ export default {
 
         updateFilter(name, filter, value) {
             this.filterChanged = true;
+            this.storedFilters = this.storedFilters ?? {};
+
             this.activeFilters[name] = filter;
             this.storedFilters[name] = { value: value, criteria: filter };
         },
 
         resetFilter(name) {
             this.filterChanged = true;
+            this.storedFilters = this.storedFilters ?? {};
+
             delete this.activeFilters[name];
             this.storedFilters[name] = { value: null, criteria: null };
         },
 
         resetAll() {
             this.filterChanged = true;
+            this.storedFilters = this.storedFilters ?? {};
             this.activeFilters = {};
 
             Object.values(this.storedFilters).forEach((el) => {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
@@ -67,6 +67,8 @@ const filters = [
 ];
 
 let savedFilterData = {};
+let getStoredFiltersMock = () => Promise.resolve(savedFilterData);
+let saveFiltersMock = (storeKey, storedFilters) => Promise.resolve(storedFilters);
 
 async function createWrapper() {
     return mount(await wrapTestComponent('sw-filter-panel', { sync: true }), {
@@ -129,12 +131,18 @@ async function createWrapper() {
 
 Shopware.Service().register('filterService', () => {
     return {
-        getStoredFilters: () => Promise.resolve(savedFilterData),
-        saveFilters: (storeKey, storedFilters) => Promise.resolve(storedFilters),
+        getStoredFilters: (...args) => getStoredFiltersMock(...args),
+        saveFilters: (...args) => saveFiltersMock(...args),
     };
 });
 
 describe('components/sw-filter-panel', () => {
+    beforeEach(() => {
+        savedFilterData = {};
+        getStoredFiltersMock = () => Promise.resolve(savedFilterData);
+        saveFiltersMock = (storeKey, storedFilters) => Promise.resolve(storedFilters);
+    });
+
     it('should render filter components correctly', async () => {
         const wrapper = await createWrapper();
 
@@ -230,6 +238,41 @@ describe('components/sw-filter-panel', () => {
         await wrapper.vm.$nextTick();
 
         expect(Object.keys(wrapper.vm.activeFilters)).toHaveLength(1);
+    });
+
+    it('should keep filter changes while stored filters are still loading', async () => {
+        let resolveStoredFilters;
+        getStoredFiltersMock = () =>
+            new Promise((resolve) => {
+                resolveStoredFilters = resolve;
+            });
+
+        const wrapper = await createWrapper();
+        const filterCriteria = [
+            {
+                type: 'equalsAny',
+                field: 'stateMachineState.id',
+                value: ['state-open'],
+            },
+        ];
+        const filterValue = [
+            {
+                id: 'state-open',
+                name: 'Open',
+            },
+        ];
+
+        wrapper.vm.updateFilter('filter3', filterCriteria, filterValue);
+        await wrapper.vm.$nextTick();
+
+        resolveStoredFilters({});
+        await flushPromises();
+
+        expect(wrapper.vm.activeFilters.filter3).toEqual(filterCriteria);
+        expect(wrapper.vm.storedFilters.filter3).toEqual({
+            value: filterValue,
+            criteria: filterCriteria,
+        });
     });
 
     it('should return breadcrumb path when item has breadcrumb array', async () => {


### PR DESCRIPTION
### Actual behaviour

When filtering by payment status in the order overview, the filter is sometimes only applied on the second click. For example, if I click on "Open," it is not marked with a checkmark or applied to the field. This occurs very sporadically but was reproducible in my case.

<img width="1449" height="820" alt="Image" src="https://github.com/user-attachments/assets/8977ae00-ff5a-42a0-b38c-6b0b3803655f" />

The filter UI is already clickable whilst getStoredFilters() is still loading. When the first click occurs, storedFilters is still null, or the initial load response, which arrives later, can overwrite the new UI state again.

fixes: https://github.com/shopware/shopware/issues/17641
related to: https://github.com/shopware/shopware/pull/16708