### PR TITLE
feat: add document rework feature flag

### DIFF
--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -36,6 +36,11 @@ shopware:
         major: true
         toggleable: true
         description: "Execute flows after the main unit of work has concluded. Will become the default for next major 6.8"
+      - name: DOCUMENT_GENERATION_REWORK
+        default: false
+        major: true
+        toggleable: true
+        description: "Experimental! Enable the new document generation implementation and its accompanying UI changes."
       - name: PERFORMANCE_TWEAKS
         default: false
         major: true


### PR DESCRIPTION
- add `DOCUMENT_GENERATION_REWORK` feature flag so we have a switch ready for the upcoming document generation rework in the Administration.
- there is no API endpoint or public service right now that exposes DocumentV2 logic so I dont see the need to put the php code behind the feature flag. Once we add new API endpoints we should put those behind the feature flag too. Let me know if you disagree

fixes https://github.com/shopware/shopware/issues/17816