### PR TITLE
test: stub ReflectionProvider in ExemptionResolverTest

### DIFF
--- a/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/ExemptionResolverTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/PHPStan/Rules/CodeCoverageIgnore/ExemptionResolverTest.php
@@ -6,18 +6,21 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeFinder;
 use PhpParser\ParserFactory;
-use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\CodeCoverageIgnore\ExemptionResolver;
 
 /**
  * @internal
  */
 #[CoversClass(ExemptionResolver::class)]
-class ExemptionResolverTest extends PHPStanTestCase
+class ExemptionResolverTest extends TestCase
 {
+    private const EXISTING_TEST = 'Shopware\Tests\Integration\Core\Framework\Webhook\Service\RelatedWebhooksTest';
+
     /**
      * @param array<string, string> $useMap
      */
@@ -25,7 +28,13 @@ class ExemptionResolverTest extends PHPStanTestCase
     #[DataProvider('caseProvider')]
     public function testIsExempted(string $docComment, array $useMap, bool $expected): void
     {
-        $resolver = new ExemptionResolver(self::createReflectionProvider());
+        // a real ReflectionProvider would boot the whole PHPStan container; the resolver
+        // only asks hasClass(), and the end-to-end path runs in the devops rule test
+        $reflectionProvider = static::createStub(ReflectionProvider::class);
+        $reflectionProvider->method('hasClass')
+            ->willReturnCallback(static fn (string $class): bool => $class === self::EXISTING_TEST);
+
+        $resolver = new ExemptionResolver($reflectionProvider);
 
         $node = $this->makeClassWithDoc($docComment);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

TLDR; give speed back to unit test⚡ 

`ExemptionResolverTest` extended `PHPStanTestCase` and built the full PHPStan DI container via `createReflectionProvider()` — up to several seconds billed to a random data set (flagged by the slow-test detector), for a resolver that only ever calls `hasClass()`.

### 2. What does this change do, exactly?

Replaces the real provider with a `createStub(ReflectionProvider::class)` and extends plain `TestCase`. The end-to-end path with a real provider stays covered by the devops `CodeCoverageIgnoreEvaluationRuleTest`.

### 3. Describe each step to reproduce the issue or behaviour.

`vendor/bin/phpunit --testsuite unit --filter ExemptionResolverTest`

 before: one data set exceeds the 0.5s slow-test threshold (which one varies with the random seed, 0.7–3.6s depending on PHPStan cache state) 

after: no test exceeds it, same 9 tests and assertions.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
