### PR TITLE
fix(core): compatibility with Twig 3.28

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Extension/TwigFeaturesWithInheritanceExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/TwigFeaturesWithInheritanceExtension.php
@@ -14,6 +14,7 @@ use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\CoreExtension;
+use Twig\Markup;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\BlockReferenceExpression;
 use Twig\Node\Node;
@@ -102,7 +103,7 @@ class TwigFeaturesWithInheritanceExtension extends AbstractExtension
         bool $withContext = true,
         bool $ignoreMissing = false,
         bool $sandboxed = false
-    ): string {
+    ): string|Markup {
         // sw-fix-start
         if (\is_array($template)) {
             foreach ($template as &$value) {

--- a/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
@@ -73,7 +73,8 @@ TWIG;
         $renderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
 
         $this->expectException(AdapterException::class);
-        $this->expectExceptionMessageMatches('/Failed rendering Twig string template due syntax error: "Unexpected "}" in "[^"]+" at line 1."/');
+        // Twig 3.28 appends the column to syntax error messages, older versions stop at the line
+        $this->expectExceptionMessageMatches('/Failed rendering Twig string template due syntax error: "Unexpected "}" in "[^"]+" at line 1( column \d+)?."/');
         $renderer->render($template, [], $context);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Twig 3.28.0 was released on 2026-07-03 and CI installs it fresh, so every PR pipeline is red since then.
`CoreExtension::include()` now returns `Twig\Markup` instead of `string`, and syntax error messages gained a column suffix.

⚠️ Notes: 
The other Twig 3.28 changes were audited: `getAttribute()` only changed internals, the new `TokenParserInterface::isAlwaysAllowedInSandbox()` is inherited from `AbstractTokenParser` by all custom token parsers, and `EmptyNode` returned by `sw_extends`/`sw_use` still passes the new root node validation

The [ATS update 6.7.11](https://github.com/shopware/shopware/actions/runs/28688073396/job/85084302078?pr=18027) initially could not pass, as all 3 conditions met: old released code with the typed wrapper, no conflicts protection yet, and sw_include sitting directly on the admin login render path.

✅ **Update:** the [ATS update 6.7.11 job passes now](https://github.com/shopware/shopware/actions/runs/28688073396/job/85267252016). The conflicts protection is live: [shopware/conflicts#36](https://github.com/shopware/conflicts/pull/36) (`twig/twig >=3.28`) is merged and served through the new GitHub Pages composer repository (Packagist versions are immutable, so the pinned `0.6.1` could not be updated there), with the repository entry rolled out via [shopware/production#189](https://github.com/shopware/production/pull/189), [web-installer#24](https://github.com/shopware/web-installer/pull/24) and [shopware-cli#1160](https://github.com/shopware/shopware-cli/pull/1160). The old 6.7.11.1 instance therefore resolves twig 3.27.1 again and its admin login renders. #18029 adds the same repository entry to this repo's root composer.json.

### 2. What does this change do, exactly?

- Widens the `sw_include` return type to `string|Markup`. This is a production fix: rendering any non-empty template through `sw_include` throws a `TypeError` under Twig 3.28.
- Relaxes the syntax error regex in `StringTemplateRendererTest` to accept the optional ` column N` suffix.

Both changes stay compatible with the full `^3.26.0` constraint range.

### 3. Describe each step to reproduce the issue or behaviour.

Update `twig/twig` to 3.28.0 and run the unit suite.

Without this change the two tests above fail (TypeError and regex mismatch).
With it the full unit suite (16,444 tests) and the Twig adapter integration tests (64 tests) pass under 3.28.


### 4. Please link to the relevant issues (if any).

- relates #18029 (adds the conflicts composer repository to this repo's root composer.json, so CI resolves twig through the updated conflict rules)
- Fixes https://github.com/shopware/shopware/issues/18028

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

