### PR TITLE
fix: add conflict repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -240,6 +240,10 @@
             "options": {
                 "symlink": true
             }
+        },
+        {
+            "type": "composer",
+            "url": "https://shopware.github.io/conflicts/"
         }
     ],
     "scripts-descriptions": {


### PR DESCRIPTION
### 1. Why is this change necessary?

Twig 3.28.0 changed the `include()` function to return a `Twig\Markup` object, which breaks the Administration on Shopware 6.7 with a 500 error (#18028). Normally we would block the incompatible Twig version through a new `shopware/conflicts` release on Packagist. This is no longer possible: released Shopware versions pin `shopware/conflicts` to an exact version, and Packagist's version immutability prevents updating the content of already-published versions.

As a replacement, the conflict rules are now also published as a Composer repository via GitHub Pages (https://shopware.github.io/conflicts/), which can serve updated metadata for the already-pinned versions.

### 2. What does this change do, exactly?

Adds `https://shopware.github.io/conflicts/` as a `composer` repository to the root `composer.json`. Custom repositories take precedence over Packagist, so `shopware/conflicts` is resolved from the GitHub Pages repository and picks up new conflict rules (currently `twig/twig >=3.28`) without requiring a new Packagist release.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `composer update` on a Shopware 6.7 installation (or a fresh install) after 2026-07-03, so `twig/twig` resolves to 3.28.0
2. Open the Administration
3. It fails with a 500 error: `TwigFeaturesWithInheritanceExtension::include(): Return value must be of type string, Twig\Markup returned`
4. With this change, `shopware/conflicts` served from the GitHub Pages repository blocks `twig/twig >=3.28`, so Composer keeps Twig at 3.27.1 and the Administration keeps working

### 4. Please link to the relevant issues (if any).

- relates #18028

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
