### PR TITLE
ci: exclude Twig token parser BC false positive

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -97,6 +97,9 @@ return [
         // The implemented Twig extension contract already documents this as array<NodeVisitorInterface>
         preg_quote('CHANGED: The return type of Twig\Extension\AbstractExtension#getNodeVisitors() changed from no type to array', '/'),
 
+        // Twig added this method in 3.27 via https://github.com/twigphp/Twig/pull/4816
+        preg_quote('REMOVED: Method Twig\TokenParser\AbstractTokenParser#isAlwaysAllowedInSandbox() was removed', '/'),
+
         // MailDataSimulatorFieldEvent no longer exposes Faker in the runtime simulate feature
         preg_quote('REMOVED: Property Shopware\Core\Content\MailTemplate\Service\Event\MailDataSimulatorFieldEvent#$faker was removed', '/'),
         preg_quote('REMOVED: Parameter faker was removed from Method Shopware\Core\Content\MailTemplate\Service\Event\MailDataSimulatorFieldEvent::__construct()', '/'),


### PR DESCRIPTION
### 1. Why is this change necessary?

The BC check can report `Twig\TokenParser\AbstractTokenParser#isAlwaysAllowedInSandbox()` when dependency resolution changes around Twig 3.27. This is a third-party Twig API change, not a Shopware BC break.

The method was introduced upstream in Twig PR https://github.com/twigphp/Twig/pull/4816 via commit https://github.com/twigphp/Twig/commit/2d75c87d0547cee44924a08eb5a53731c8108ee1.

### 2. What does this change do, exactly?

Adds the Roave message for `Twig\TokenParser\AbstractTokenParser#isAlwaysAllowedInSandbox()` to `.bc-exclude.php`.

### 3. Describe each step to reproduce the issue or behaviour.

Run the BC check with a dependency set that compares against a Twig version containing `AbstractTokenParser::isAlwaysAllowedInSandbox()` and a target dependency set without it.

The check reports:

`REMOVED: Method Twig\TokenParser\AbstractTokenParser#isAlwaysAllowedInSandbox() was removed`

### 4. Please link to the relevant issues (if any).

Related CI failure: https://github.com/shopware/shopware/pull/18034

Upstream Twig change:
- https://github.com/twigphp/Twig/pull/4816
- https://github.com/twigphp/Twig/commit/2d75c87d0547cee44924a08eb5a53731c8108ee1

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
