### PR TITLE
fix(core): parse class schemas with the newest supported PHP version

### DIFF
--- a/src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
+++ b/src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
@@ -13,7 +13,6 @@ use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
-use PhpParser\PhpVersion;
 use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
@@ -143,7 +142,7 @@ class DumpClassSchemaCommand extends Command
      */
     private function parseFile(string $filePath): ?array
     {
-        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromString('7.0'));
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
 
         $names = $parser->parse((string) file_get_contents($filePath));
 


### PR DESCRIPTION
### 1. Why is this change necessary?

nikic/php-parser 5.8.0 was released on 2026-07-04 and CI installs it fresh, so `DumpClassSchemaCommandTest` fails deterministically since then — it currently blocks the merge queue (e.g. [this run](https://github.com/shopware/shopware/actions/runs/28775352069/job/85317956982) bounced #18027). `DumpClassSchemaCommand` parses real Shopware source files with a parser pinned to PHP **7.0** syntax; php-parser 5.8.0 made downgraded-version emulation stricter, so `static fn` (PHP 7.4+, present in `RuleCollection.php`) is now correctly rejected with a `PhpParser\Error` instead of parsing leniently.

### 2. What does this change do, exactly?

Replaces `createForVersion(PhpVersion::fromString('7.0'))` with `createForNewestSupportedVersion()` in `DumpClassSchemaCommand::parseFile()`. The command parses the codebase's own source files, which are PHP 8.2+, so the parser must target at least the current language level — the 7.0 pin only ever worked through upstream leniency.

### 3. Describe each step to reproduce the issue or behaviour.

1. `composer update nikic/php-parser` (resolves 5.8.0)
2. `vendor/bin/phpunit tests/unit/Core/Framework/Api/Command/DumpClassSchemaCommandTest.php`

Without this change the test fails with `PhpParser\Error: Syntax error, unexpected T_STRING, expecting T_PAAMAYIM_NEKUDOTAYIM on line 52` (the `static fn` in `RuleCollection.php`). With it the test passes on both php-parser 5.7.0 and 5.8.0 (verified A/B on both versions).

### 4. Please link to the relevant issues (if any).

- blocks the merge queue, e.g. for #18027

### 5. Checklist

- [x] I have written tests and verified that they fail without my change (no new test: the existing `DumpClassSchemaCommandTest` is the coverage — verified failing without / passing with this change on php-parser 5.8.0)
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
