### PR TITLE
fix: Do not use deprecated cs fixer command

### DIFF
--- a/.agents-templates/AGENTS.local.template.ddev.md
+++ b/.agents-templates/AGENTS.local.template.ddev.md
@@ -12,7 +12,7 @@ ddev npm <command>               # NPM commands
 ```
 
 ### Examples:
-- `ddev composer ecs-fix`
+- `ddev composer cs-fix`
 - `ddev exec bin/console cache:clear`
 
 **All commands from AGENTS.md must be adapted to use the appropriate DDEV pattern.**

--- a/.agents-templates/AGENTS.local.template.docker.md
+++ b/.agents-templates/AGENTS.local.template.docker.md
@@ -10,7 +10,7 @@ docker exec -it shopware_node <command>   # Node/NPM commands
 ```
 
 ### Examples:
-- `docker exec -it shopware_app composer ecs-fix`
+- `docker exec -it shopware_app composer cs-fix`
 - `docker exec -it shopware_app bin/console cache:clear`
 
 **All commands from AGENTS.md must be prefixed with the appropriate docker exec pattern.**

--- a/.agents-templates/AGENTS.local.template.native.md
+++ b/.agents-templates/AGENTS.local.template.native.md
@@ -6,7 +6,7 @@
 Execute all commands directly as shown in AGENTS.md without any prefix.
 
 ### Examples:
-- `composer ecs-fix`
+- `composer cs-fix`
 - `bin/console cache:clear`
 
 **All commands from AGENTS.md can be executed directly without modification.**

--- a/.agents-templates/AGENTS.local.template.vagrant.md
+++ b/.agents-templates/AGENTS.local.template.vagrant.md
@@ -9,7 +9,7 @@ vagrant ssh -c "cd /vagrant && <command>"
 ```
 
 ### Examples:
-- `vagrant ssh -c "cd /vagrant && composer ecs-fix"`
+- `vagrant ssh -c "cd /vagrant && composer cs-fix"`
 - `vagrant ssh -c "cd /vagrant && bin/console cache:clear"`
 
 **All commands from AGENTS.md must be wrapped with the Vagrant SSH pattern.**

--- a/.run/PHP Lint.run.xml
+++ b/.run/PHP Lint.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="PHP Lint" type="CompoundRunConfigurationType">
     <toRun name="Run BC-Checker" type="ComposerRunConfigurationType" />
-    <toRun name="Run ECS Fixer" type="ComposerRunConfigurationType" />
+    <toRun name="Run CS Fixer" type="ComposerRunConfigurationType" />
     <toRun name="Run Lint Changelog" type="ComposerRunConfigurationType" />
     <toRun name="Run Lint Snippets" type="ComposerRunConfigurationType" />
     <toRun name="Run PHPStan" type="ComposerRunConfigurationType" />

--- a/.run/Run ECS Fixer.run.xml
+++ b/.run/Run ECS Fixer.run.xml
@@ -1,8 +1,8 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run ECS Fixer" type="ComposerRunConfigurationType" factoryName="Composer Script">
+  <configuration default="false" name="Run CS Fixer" type="ComposerRunConfigurationType" factoryName="Composer Script">
     <option name="commandLineParameters" value="" />
     <option name="pathToComposerJson" value="$PROJECT_DIR$/composer.json" />
-    <option name="script" value="ecs-fix" />
+    <option name="script" value="cs-fix" />
     <method v="2" />
   </configuration>
 </component>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ To add a new skill (interactive or unattended), follow the checklist in [`coding
 
 | File Type              | Check Command                 | Fix Command                                  |
 |------------------------|-------------------------------|----------------------------------------------|
-| **PHP** (.php)         | `composer ecs`                | `composer ecs-fix`                           |
+| **PHP** (.php)         | `composer cs`                 | `composer cs-fix`                            |
 | **PHP** (types)        | `composer phpstan`            | N/A - must fix manually                      |
 | **JS/TS/Vue** (Admin)  | `composer eslint:admin`       | `composer eslint:admin:fix`                  |
 | **JS/TS** (Storefront) | `composer eslint:storefront`  | `composer eslint:storefront:fix`             |

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -60,7 +60,7 @@ then
 
     echo "Fix code style"
 
-    composer run ecs-fix -- --config=.php-cs-fixer.dist.php ${PHP_FILES_FOR_CHECKS}
+    composer run cs-fix -- --config=.php-cs-fixer.dist.php ${PHP_FILES_FOR_CHECKS}
 
     composer run static-analyze -- --no-progress
 fi

--- a/composer.json
+++ b/composer.json
@@ -436,7 +436,7 @@
         "lint": [
             "@stylelint",
             "@eslint",
-            "@ecs",
+            "@cs",
             "@php bin/shopware translation:validate"
         ],
         "lint:snippets": "@php bin/shopware translation:validate",


### PR DESCRIPTION
### 1. Why is this change necessary?

We no longer use ECS as PHP code style fixer tool and therefore the command names are misleading. 
I deprecated them a while ago in https://github.com/shopware/shopware/commit/4a57faaae808c5b37194042ccb65715f6e4ea68a but missed some places. 

### 2. What does this change do, exactly?

Use `cs-fix` instead of `ecs-fix`

### 3. Describe each step to reproduce the issue or behaviour.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
