### PR TITLE
fix: Frozen container parameter bag with deprecated cache config (6.7.12.x backport)

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DependencyInjection;
 
 use Shopware\Core\Content\Media\File\DownloadResponseGenerator;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Telemetry\Metrics\Config\LabelPolicy;
 use Shopware\Core\Framework\Telemetry\Metrics\Metric\Type;
@@ -608,6 +609,32 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode = (new TreeBuilder('cache'))->getRootNode();
         $rootNode
+            // @deprecated tag:v6.8.0 - remove this whole "beforeNormalization" block
+            ->beforeNormalization()
+                ->always()->then(static function ($config) {
+                    if (!\is_array($config)) {
+                        return $config;
+                    }
+
+                    if (\array_key_exists('cache_compression', $config) && !\array_key_exists('compress', $config)) {
+                        Feature::triggerDeprecationOrThrow(
+                            'v6.8.0.0',
+                            'Parameter "shopware.cache.cache_compression" is deprecated and will be removed. Please use "shopware.cache.compress" instead.'
+                        );
+                        $config['compress'] = $config['cache_compression'];
+                    }
+
+                    if (\array_key_exists('cache_compression_method', $config) && !\array_key_exists('compression_method', $config)) {
+                        Feature::triggerDeprecationOrThrow(
+                            'v6.8.0.0',
+                            'Parameter "shopware.cache.cache_compression_method" is deprecated and will be removed. Please use "shopware.cache.compression_method" instead.'
+                        );
+                        $config['compression_method'] = $config['cache_compression_method'];
+                    }
+
+                    return $config;
+                })
+            ->end()
             ->children()
                 ->scalarNode('redis_prefix')->end()
                 ->booleanNode('cache_compression')

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -174,26 +174,6 @@ class Framework extends Bundle
             MeterProvider::bindMeter($this->container);
         }
 
-        // @deprecated tag:v6.8.0 - remove this if block
-        if ($this->container->hasParameter('shopware.cache.cache_compression') && $this->container->getParameter('shopware.cache.cache_compression') !== null) {
-            Feature::triggerDeprecationOrThrow(
-                'v6.8.0.0',
-                'Parameter "shopware.cache.cache_compression" is deprecated and will be removed. Please use "shopware.cache.compress" instead.'
-            );
-
-            $this->container->setParameter('shopware.cache.compress', $this->container->getParameter('shopware.cache.cache_compression'));
-        }
-
-        // @deprecated tag:v6.8.0 - remove this if block
-        if ($this->container->hasParameter('shopware.cache.cache_compression_method') && $this->container->getParameter('shopware.cache.cache_compression_method') !== null) {
-            Feature::triggerDeprecationOrThrow(
-                'v6.8.0.0',
-                'Parameter "shopware.cache.cache_compression_method" is deprecated and will be removed. Please use "shopware.cache.compression_method" instead.'
-            );
-
-            $this->container->setParameter('shopware.cache.compression_method', $this->container->getParameter('shopware.cache.cache_compression_method'));
-        }
-
         CacheValueCompressor::$compress = $this->container->getParameter('shopware.cache.compress');
         CacheValueCompressor::$compressMethod = $this->container->getParameter('shopware.cache.compression_method');
         Feature::$emitDeprecations = $this->container->getParameter('kernel.debug');

--- a/tests/unit/Core/Framework/DependencyInjection/FrameworkExtensionTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/FrameworkExtensionTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DependencyInjection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DependencyInjection\Configuration;
+use Shopware\Core\Framework\DependencyInjection\FrameworkExtension;
+use Shopware\Core\Framework\Feature\FeatureException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+#[CoversClass(FrameworkExtension::class)]
+#[CoversClass(Configuration::class)]
+class FrameworkExtensionTest extends TestCase
+{
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testDeprecatedCacheCompressionConfigSetsReplacementParameters(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new FrameworkExtension())->load([
+            [
+                'cache' => [
+                    'cache_compression' => false,
+                    'cache_compression_method' => 'deflate',
+                ],
+            ],
+        ], $container);
+
+        static::assertFalse($container->getParameter('shopware.cache.compress'));
+        static::assertSame('deflate', $container->getParameter('shopware.cache.compression_method'));
+        static::assertFalse($container->getParameter('shopware.cache.cache_compression'));
+        static::assertSame('deflate', $container->getParameter('shopware.cache.cache_compression_method'));
+    }
+
+    public function testDeprecatedCacheCompressionConfigThrowsException(): void
+    {
+        $this->expectExceptionObject(FeatureException::error('Tried to access deprecated functionality: Parameter "shopware.cache.cache_compression" is deprecated and will be removed. Please use "shopware.cache.compress" instead.'));
+        (new FrameworkExtension())->load([
+            [
+                'cache' => [
+                    'cache_compression' => false,
+                    'cache_compression_method' => 'deflate',
+                ],
+            ],
+        ], new ContainerBuilder());
+    }
+
+    public function testReplacementCacheCompressionConfigHasPrecedenceOverDeprecatedConfig(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new FrameworkExtension())->load([
+            [
+                'cache' => [
+                    'cache_compression' => false,
+                    'compress' => true,
+                    'cache_compression_method' => 'deflate',
+                    'compression_method' => 'gzip',
+                ],
+            ],
+        ], $container);
+
+        static::assertTrue($container->getParameter('shopware.cache.compress'));
+        static::assertSame('gzip', $container->getParameter('shopware.cache.compression_method'));
+        static::assertFalse($container->getParameter('shopware.cache.cache_compression'));
+        static::assertSame('deflate', $container->getParameter('shopware.cache.cache_compression_method'));
+    }
+}

--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\StampedeProtectionConfigurator;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Feature\FeatureFlagRegistry;
 use Shopware\Core\Framework\Framework;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry;
@@ -39,13 +38,8 @@ class FrameworkTest extends TestCase
         $container->set(DefinitionInstanceRegistry::class, $this->createMock(DefinitionInstanceRegistry::class));
         $container->set(SalesChannelDefinitionInstanceRegistry::class, $this->createMock(SalesChannelDefinitionInstanceRegistry::class));
         $container->setParameter('kernel.cache_dir', '/tmp');
-        if (Feature::isActive('v6.8.0.0')) {
-            $container->setParameter('shopware.cache.compress', true);
-            $container->setParameter('shopware.cache.compression_method', 'gzip');
-        } else {
-            $container->setParameter('shopware.cache.cache_compression', true);
-            $container->setParameter('shopware.cache.cache_compression_method', 'gzip');
-        }
+        $container->setParameter('shopware.cache.compress', true);
+        $container->setParameter('shopware.cache.compression_method', 'gzip');
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.environment', 'test');
         $framework = new Framework();


### PR DESCRIPTION
Backport of https://github.com/shopware/shopware/pull/18061

fixes https://github.com/shopware/shopware/issues/18059