### PR TITLE
fix: re-register events for zoom modal after viewport change

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
@@ -72,12 +72,12 @@ export default class ZoomModalPlugin extends Plugin {
     };
 
     init() {
-        this._triggers = this.el.querySelectorAll(this.options.triggerSelector);
-        this._triggersCanvas = this.el.querySelectorAll(this.options.triggerSelectorCanvas);
         this._clickInterrupted = false;
         this._pixelsMoved = 0;
         this._mouseDown = false;
+
         this._registerEvents();
+        this._registerViewportChangeEvent();
     }
 
     /**
@@ -85,6 +85,11 @@ export default class ZoomModalPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
+        this._triggers = this.el.querySelectorAll(this.options.triggerSelector);
+        this._triggersCanvas = this.el.querySelectorAll(
+          this.options.triggerSelectorCanvas,
+        );
+
         const eventType = (DeviceDetection.isTouchDevice()) ? 'touchend' : 'click';
 
         if (!this._boundOnClick) {
@@ -130,6 +135,15 @@ export default class ZoomModalPlugin extends Plugin {
             element.removeEventListener('pointermove', this._boundOnPointerMove);
             element.addEventListener('pointermove', this._boundOnPointerMove);
         });
+    }
+
+    _registerViewportChangeEvent() {
+        if (!this._boundOnViewportHasChanged) {
+            this._boundOnViewportHasChanged = this._registerEvents.bind(this);
+        }
+
+        document.removeEventListener('Viewport/hasChanged', this._boundOnViewportHasChanged);
+        document.addEventListener('Viewport/hasChanged', this._boundOnViewportHasChanged);
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
@@ -87,7 +87,7 @@ export default class ZoomModalPlugin extends Plugin {
     _registerEvents() {
         this._triggers = this.el.querySelectorAll(this.options.triggerSelector);
         this._triggersCanvas = this.el.querySelectorAll(
-          this.options.triggerSelectorCanvas,
+            this.options.triggerSelectorCanvas,
         );
 
         const eventType = (DeviceDetection.isTouchDevice()) ? 'touchend' : 'click';

--- a/src/Storefront/Resources/app/storefront/test/plugin/zoom-modal/zoom-modal.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/zoom-modal/zoom-modal.plugin.test.js
@@ -206,6 +206,31 @@ describe('ZoomModalPlugin tests', () => {
         expect(onKeyDownSpy).toHaveBeenCalledTimes(1);
     });
 
+    test('zoom modal re-registers trigger listeners after viewport changes', () => {
+        const registerEventsSpy = jest.spyOn(ZoomModalPlugin.prototype, '_registerEvents');
+        const onClickSpy = jest.spyOn(ZoomModalPlugin.prototype, '_onClick').mockImplementation(() => {});
+
+        const element = document.querySelector('[data-zoom-modal]');
+
+        const plugin = new ZoomModalPlugin(element);
+
+        expect(registerEventsSpy).toHaveBeenCalledTimes(1);
+
+        document.getElementById('gallery-slider').innerHTML = `
+            <img src="#" alt="" class="gallery-slider-image magnifier-image js-magnifier-image" tabindex="0" id="updated-trigger">
+        `;
+
+        document.dispatchEvent(new Event('Viewport/hasChanged'));
+
+        expect(registerEventsSpy).toHaveBeenCalledTimes(2);
+
+        document.getElementById('updated-trigger').dispatchEvent(new Event('click'));
+
+        expect(onClickSpy).toHaveBeenCalledTimes(1);
+
+        expect(plugin).toBeInstanceOf(ZoomModalPlugin);
+    });
+
     test('zoom modal closes via ESC key', () => {
         const triggerImgElement = document.querySelector('img');
         const modal = document.querySelector('.js-zoom-modal');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

On the product detail page, the zoom modal can stop opening after a viewport change on mobile devices.

The underlying issue is that `base-slider.plugin.js` rebuilds the slider on every viewport change:

```js
document.addEventListener('Viewport/hasChanged', () => this.rebuild(ViewportDetection.getCurrentViewport()));
```

When that happens, the gallery DOM is rebuilt and the previously registered zoom trigger listeners are no longer attached to the current image elements.

### 2. What does this change do, exactly?

This change updates `ZoomModalPlugin` to re-register its trigger listeners whenever `Viewport/hasChanged` is fired.

To make that work safely, the plugin now:
- re-queries the current trigger elements inside `_registerEvents()`
- subscribes to `Viewport/hasChanged`
- rebinds the zoom modal listeners after the gallery slider rebuilds its markup

It also adds a regression test that replaces the gallery trigger image, dispatches `Viewport/hasChanged`, and verifies that the new image still opens the zoom modal.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or open a product with multiple media images on the product detail page.
2. Open the page on a mobile device or in a responsive mobile viewport.
3. Open the image in portrait mode to verify the zoom modal works.
4. Rotate the device or otherwise trigger a viewport change.
5. Try to open the image again.
6. Before this change, the zoom modal no longer opens because the slider rebuild replaces the trigger DOM.
7. After this change, the rebuilt gallery images are bound again and the zoom modal continues to open.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #17993

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
