### PR TITLE
feat(build): add GENERATE_SOURCEMAPS env var to enable production sourcemaps

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -253,6 +253,21 @@ When an app has a `Resources/config/custom-fields.xml` file, it takes priority o
 
 An app tax provider's `priority` is now only seeded from the manifest when the provider is first installed. App updates no longer touch the priority, so the merchant's manual ordering is retained.
 
+## Hosting & Configuration
+
+### New `GENERATE_SOURCEMAPS` environment variable for production builds
+
+A new `GENERATE_SOURCEMAPS` environment variable controls whether JavaScript sourcemaps are emitted during production builds. Set it to `true` to generate sourcemaps when `NODE_ENV=production`; omit it or set it to any other value to keep the default behaviour (no sourcemaps in production).
+
+This applies to the Storefront webpack build and all Vite builds (Administration core, Administration extension plugins, and Storefront components).
+
+In non-production environments sourcemaps are always generated regardless of this variable.
+
+```bash
+GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:admin
+GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:storefront
+```
+
 ## Administration
 
 ### Snippet inheritance from JSON language files

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -43,7 +43,7 @@ const extensionEntries = loadExtensions();
 const getBaseConfig = (extension: ExtensionDefinition, isProd = false) => {
     const extensionInfoDebug = debug(`vite:${extension.isPlugin ? 'plugin' : 'app'}:${extension.technicalName}`);
     const configInfoDebug = debug('vite:config');
-    const useSourceMap = !isProd && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1';
+    const useSourceMap = (!isProd && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1') || (isProd && process.env.GENERATE_SOURCEMAPS === 'true');
 
     const logger = createLogger();
 

--- a/src/Administration/Resources/app/administration/build/plugins.vite.ts
+++ b/src/Administration/Resources/app/administration/build/plugins.vite.ts
@@ -43,7 +43,9 @@ const extensionEntries = loadExtensions();
 const getBaseConfig = (extension: ExtensionDefinition, isProd = false) => {
     const extensionInfoDebug = debug(`vite:${extension.isPlugin ? 'plugin' : 'app'}:${extension.technicalName}`);
     const configInfoDebug = debug('vite:config');
-    const useSourceMap = (!isProd && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1') || (isProd && process.env.GENERATE_SOURCEMAPS === 'true');
+    const useSourceMap =
+        (!isProd && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1') ||
+        (isProd && process.env.GENERATE_SOURCEMAPS === 'true');
 
     const logger = createLogger();
 

--- a/src/Administration/Resources/app/administration/vite.config.mts
+++ b/src/Administration/Resources/app/administration/vite.config.mts
@@ -49,7 +49,7 @@ export default defineConfig(({ command }) => {
     const isProd = command === 'build';
     const isDev = !isProd;
     const base = isProd ? '/bundles/administration/administration' : undefined;
-    const useSourceMap = isDev && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1';
+    const useSourceMap = (isDev && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1') || (isProd && process.env.GENERATE_SOURCEMAPS === 'true');
     const openBrowserForWatch = process.env.DISABLE_DEVSERVER_OPEN !== '1' && !isInsideDockerContainer();
 
     if (isProd) {

--- a/src/Storefront/Resources/app/storefront/build/vite/component-config-factory.ts
+++ b/src/Storefront/Resources/app/storefront/build/vite/component-config-factory.ts
@@ -59,7 +59,7 @@ export async function createComponentBuildConfig(options: ComponentBuildConfigOp
         namespace,
         storefrontAppDir,
         coreStorefrontAppDir = path.resolve(import.meta.dirname, '../..'),
-        sourcemap = process.env.NODE_ENV !== 'production',
+        sourcemap = process.env.NODE_ENV !== 'production' || process.env.GENERATE_SOURCEMAPS === 'true',
         cssLoadPaths,
         additionalPlugins = [],
         prependPlugins = [],

--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -106,7 +106,7 @@ const coreConfig = {
         }
 
         if (isProdMode) {
-            return false;
+            return process.env.GENERATE_SOURCEMAPS === 'true' ? 'source-map' : false;
         }
 
         return 'inline-cheap-source-map';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Production builds currently never emit sourcemaps, making it difficult to debug minified JavaScript in staging or production environments. The Shopware SaaS team needs sourcemaps on staging to debug production builds without switching to a full development build. Operators deploying self-hosted instances benefit from the same option.

### 2. What does this change do, exactly?

Introduces a GENERATE_SOURCEMAPS environment variable. When set to true alongside NODE_ENV=production, sourcemaps are generated for all JS build outputs:

- Storefront (webpack): uses source-map devtool instead of false
- Administration core (Vite): passes sourcemap: true to the Vite build
- Administration extension plugins (Vite): same as above for per-plugin builds
- Storefront components (Vite): same for the component build pipeline

In non-production environments sourcemaps are always generated regardless of GENERATE_SOURCEMAPS.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run a production build with the flag set:
GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:admin
GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:storefront
2. Confirm .map files are present in the build output.
3. Run the same commands without the flag and confirm no .map files are emitted.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
