### PR TITLE
fix: prevent flicker on second image in image slider

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -103,8 +103,12 @@
                                             {% set attributes = attributes|merge({ fetchpriority: 'high' }) %}
                                         {% endif %}
 
+                                        {% if loop.index0 == 1 %}
+                                            {% set attributes = attributes|merge({ decoding: 'sync' }) %}
+                                        {% endif %}
+
                                         {% sw_thumbnails 'cms-image-slider-thumbnails' with {
-                                            media: image.media
+                                            media: image.media,
                                         } %}
                                     </div>
                                 {% endset %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

In Firefox, the storefront image slider shows a brief flicker on the second slide transition after page load. The issue is visible in both full-width and boxed content, so it is not tied to a specific CMS layout. The current image loading strategy already uses responsive sources, so the flicker appears to be caused by Firefox repainting or decoding the next slide too late.

### 2. What does this change do, exactly?

This change adds `decoding="sync"` to the second slide image in the CMS image slider.

That encourages Firefox to decode the next image before the first transition, which removes the visible flash during the second-slide change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a CMS image slider element with at least three images.
2. Open the storefront in Firefox.
3. Trigger the first slide transition.
4. Observe the brief flicker when switching to the second slide.
5. The issue also occurs in both full-width and boxed content.
6. The third slide renders normally without the flicker.

Before/after video evidence:

https://github.com/user-attachments/assets/49a4303d-5708-499c-93b8-241a2c24e4f2

https://github.com/user-attachments/assets/9b748d65-2102-45b9-af1a-15c80d01450c

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6000

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
