### PR TITLE
fix(core): honor phpunit coverage-exclude directories in Danger

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -402,7 +402,7 @@ return (new Config())
             $fileName = basename($file->name);
 
             foreach ($excludedDirs as $excludedDir) {
-                if (str_starts_with($dir, $excludedDir['path']) && str_ends_with($fileName, $excludedDir['suffix'])) {
+                if (str_starts_with($dir . '/', $excludedDir['path']) && str_ends_with($fileName, $excludedDir['suffix'])) {
                     continue 2;
                 }
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

The Danger missing-unit-test check reads the `<source><exclude>` directory list from `phpunit.xml.dist`, but the comparison never matches: the exclude paths are normalized with a trailing slash (`src/Foo/Bar/`) while the compared `dirname()` of an added file has none (`src/Foo/Bar`). As a result, **every directory entry in the phpunit coverage-exclude list is silently ineffective in Danger**, and PRs adding files inside excluded directories are incorrectly failed with "Please be kind and add unit tests".

Observed on https://github.com/shopware/shopware/pull/17979 / https://github.com/shopware/shopware/pull/17992, where `src/Core/Framework/Deprecation/BCChange` is excluded from coverage in `phpunit.xml.dist` but Danger still demands unit tests for the data-only attribute classes.

### 2. What does this change do, exactly?

Appends a trailing slash to the compared directory before the `str_starts_with()` check, so `src/Foo/Bar` matches the normalized exclude path `src/Foo/Bar/` — and `src/Foo/Barista` still does not.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a directory to `<source><exclude>` in `phpunit.xml.dist`.
2. Open a PR adding a PHP class inside that directory without a unit test.
3. The Danger `pr` check fails despite the exclusion.

### 4. Please link to the relevant issues (if any).

- relates https://github.com/shopware/shopware/discussions/17798 (surfaced while stacking the BC-change attribute PRs)

### 5. Checklist

- [x] I have read the contribution requirements and fulfilled them
- Tests: `.danger.php` is not unit-testable in this repo (Danger notes itself that changes only take effect outside the PR); verified by evaluating the exclude-matching logic with the paths above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)