### PR TITLE
fix: Add tests for bundle boot methods

### DIFF
--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -167,7 +167,6 @@ class Framework extends Bundle
 
         \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `src/Core/Kernel.php:186`.');
 
-        /** @var FeatureFlagRegistry $featureFlagRegistry */
         $featureFlagRegistry = $this->container->get(FeatureFlagRegistry::class);
         $featureFlagRegistry->register();
 
@@ -180,7 +179,6 @@ class Framework extends Bundle
         CacheValueCompressor::$compressMethod = $this->container->getParameter('shopware.cache.compression_method');
         Feature::$emitDeprecations = $this->container->getParameter('kernel.debug');
 
-        /** @var StampedeProtectionConfigurator $stampedeProtectionConfigurator */
         $stampedeProtectionConfigurator = $this->container->get(StampedeProtectionConfigurator::class);
         $stampedeProtectionConfigurator->apply();
     }

--- a/src/Core/Profiling/Profiling.php
+++ b/src/Core/Profiling/Profiling.php
@@ -54,7 +54,7 @@ class Profiling extends Bundle
         \assert($this->container instanceof ContainerInterface, 'Container is not set yet, please call setContainer() before calling boot(), see `src/Core/Kernel.php:186`.');
 
         // The profiler registers all profiler integrations in the constructor
-        // Therefor we need to get the service once to initialize it
+        // Therefore we need to get the service once to initialize it
         $this->container->get(Profiler::class);
     }
 

--- a/src/Core/System/System.php
+++ b/src/Core/System/System.php
@@ -8,7 +8,6 @@ use Shopware\Core\System\CustomEntity\CustomEntityRegistrar;
 use Shopware\Core\System\DependencyInjection\CompilerPass\NumberRangeIncrementerCompilerPass;
 use Shopware\Core\System\DependencyInjection\CompilerPass\SalesChannelEntityCompilerPass;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
@@ -60,8 +59,8 @@ class System extends Bundle
             $phpLoader->load('services_test.php');
         }
 
-        $container->addCompilerPass(new SalesChannelEntityCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
-        $container->addCompilerPass(new NumberRangeIncrementerCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+        $container->addCompilerPass(new SalesChannelEntityCompilerPass());
+        $container->addCompilerPass(new NumberRangeIncrementerCompilerPass());
     }
 
     public function boot(): void

--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -42,6 +42,8 @@ class FrameworkTest extends TestCase
         $container->setParameter('shopware.cache.compression_method', 'gzip');
         $container->setParameter('kernel.debug', true);
         $container->setParameter('kernel.environment', 'test');
+        $container->compile();
+
         $framework = new Framework();
         $framework->setContainer($container);
 

--- a/tests/unit/Core/Profiling/ProfilingTest.php
+++ b/tests/unit/Core/Profiling/ProfilingTest.php
@@ -4,7 +4,10 @@ namespace Shopware\Tests\Unit\Core\Profiling;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\Profiling\Profiling;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
 
 /**
  * @internal
@@ -17,5 +20,18 @@ class ProfilingTest extends TestCase
         $profiling = new Profiling();
 
         static::assertSame(-2, $profiling->getTemplatePriority());
+    }
+
+    public function testBoot(): void
+    {
+        $container = new Container();
+        $container->set(Profiler::class, static::createStub(Profiler::class));
+        $container->compile();
+
+        $profiling = new Profiling();
+        $profiling->setContainer($container);
+        $profiling->boot();
+
+        static::assertInstanceOf(FrozenParameterBag::class, $container->getParameterBag());
     }
 }

--- a/tests/unit/Core/System/SystemTest.php
+++ b/tests/unit/Core/System/SystemTest.php
@@ -5,7 +5,9 @@ namespace Shopware\Tests\Unit\Core\System;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\CustomEntity\CustomEntityRegistrar;
 use Shopware\Core\System\System;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -41,6 +43,20 @@ class SystemTest extends TestCase
         static::assertFalse($container->has('shopware.translation.mock_handler'), 'services_test.php');
         static::assertTrue($container->has('shopware.translation.client'), 'snippet.xml');
         static::assertSame([], $container->getDefinition('shopware.translation.client')->getArguments());
+    }
+
+    public function testBoot(): void
+    {
+        $registrar = $this->createMock(CustomEntityRegistrar::class);
+        $registrar->expects($this->once())->method('register');
+
+        $container = new Container();
+        $container->set(CustomEntityRegistrar::class, $registrar);
+        $container->compile();
+
+        $profiling = new System();
+        $profiling->setContainer($container);
+        $profiling->boot();
     }
 
     private function buildContainer(string $environment): ContainerBuilder

--- a/tests/unit/Core/System/SystemTest.php
+++ b/tests/unit/Core/System/SystemTest.php
@@ -54,9 +54,9 @@ class SystemTest extends TestCase
         $container->set(CustomEntityRegistrar::class, $registrar);
         $container->compile();
 
-        $profiling = new System();
-        $profiling->setContainer($container);
-        $profiling->boot();
+        $system = new System();
+        $system->setContainer($container);
+        $system->boot();
     }
 
     private function buildContainer(string $environment): ContainerBuilder


### PR DESCRIPTION
### 1. Why is this change necessary?

To prevent issues like this https://github.com/shopware/shopware/issues/18059 the `boot` methods of the bundle classes should be tested (with correctly compiled container) 

### 2. What does this change do, exactly?

Add and fix tests for the `boot` methods

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
