### PR TITLE
chore: bump gh-project-automation from 1.14.1 to 1.15.0

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@shopware-ag/gh-project-automation": "1.14.1"
+        "@shopware-ag/gh-project-automation": "1.15.0"
       },
       "devDependencies": {
         "@types/node": "24.10.0"
@@ -216,12 +216,12 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.14.1.tgz",
-      "integrity": "sha512-0kj+jYljKeOZwVrAJSHmbnGJ1r3tI//z5HvCg1sG0EoNgnNHn1m+JqxrDv1O1mRlH9nrJO3Kr+ca3n40uxSlIw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.15.0.tgz",
+      "integrity": "sha512-s0W6hktYVZWokQ2iKBjT2K3a/Bp9sCGnLu4V/bfnfVIeKMLDNIn+LjGDso4Rd2dO5HiDrc6qBxm+2IbY9oBjdA==",
       "license": "MIT",
       "dependencies": {
-        "@slack/web-api": "^7.9.2"
+        "@slack/web-api": "^7.17.0"
       },
       "optionalDependencies": {
         "@actions/core": "^2.0.2",
@@ -234,12 +234,12 @@
       }
     },
     "node_modules/@slack/logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
-      "integrity": "sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+      "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=18.0.0"
+        "@types/node": ">=18"
       },
       "engines": {
         "node": ">= 18",
@@ -247,9 +247,9 @@
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.0.tgz",
-      "integrity": "sha512-PVF6P6nxzDMrzPC8fSCsnwaI+kF8YfEpxf3MqXmdyjyWTYsZQURpkK7WWUWvP5QpH55pB7zyYL9Qem/xSgc5VA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.22.0.tgz",
+      "integrity": "sha512-sZ9lIgJhPX2qft/tKWiklFlc0o1FWeI7QtciZJfW1+ErH1eGGHvOZ8e73sleTCFEFJp1q/R0WeS8Oa7AsiDprg==",
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0",
@@ -257,16 +257,16 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.14.1.tgz",
-      "integrity": "sha512-RoygyteJeFswxDPJjUMESn9dldWVMD2xUcHHd9DenVavSfVC6FeVnSdDerOO7m8LLvw4Q132nQM4hX8JiF7dng==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.19.0.tgz",
+      "integrity": "sha512-ItjyjEZml+LDH8CjcCLRLJHh7VZtevPKExrRN3l5KWyBliyDnGAeoO4Y+K+fFBmRpKLYVPgqWMX4THldv2HVtA==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.0",
-        "@slack/types": "^2.20.0",
-        "@types/node": ">=18.0.0",
+        "@slack/logger": "^4.0.1",
+        "@slack/types": "^2.21.0",
+        "@types/node": ">=18",
         "@types/retry": "0.12.0",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "eventemitter3": "^5.0.1",
         "form-data": "^4.0.4",
         "is-electron": "2.2.2",

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@shopware-ag/gh-project-automation": "1.14.1"
+    "@shopware-ag/gh-project-automation": "1.15.0"
   },
   "devDependencies": {
     "@types/node": "24.10.0"


### PR DESCRIPTION
I noticed that github-actions replaced `milestone/6.7.12.0` with the `6.7.13.0` label on #18050. 

This appears to be fixed in https://github.com/shopware/gh-project-automation/releases/tag/v1.15.0 (?)

I’m not familiar enough with these workflows to know whether just bumping the package here is enough.