### PR TITLE
fix: product image microdata for standalone image gallery CMS elements

### DIFF
--- a/src/Storefront/Resources/views/storefront/block/cms-block-gallery-buybox.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-gallery-buybox.html.twig
@@ -7,7 +7,6 @@
             {% block block_gallery_buybox_column_left_inner %}
                 {% sw_include '@Storefront/storefront/element/cms-element-' ~ element.type ~ '.html.twig' ignore missing
                     with {
-                    isProduct: config.sliderItems.value == 'product.media' and config.sliderItems.source == 'mapped',
                     startIndexThumbnails: 1,
                     startIndexSlider: 1
                 } %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -61,6 +61,9 @@
                 launchingArView: 'spatial.ar.launchingArView'|trans|striptags,
             }
         } %}
+
+        {# @deprecated tag:v6.8.0 - Product video microdata replaced by JSON-LD in json-ld-product.html.twig. Will be removed. #}
+        {% set isProduct = element.fieldConfig.elements.sliderItems.value == 'product.media' and element.fieldConfig.elements.sliderItems.source == 'mapped' %}
     {% endif %}
 
     {% if fallbackImageTitle is not defined %}

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -348,6 +348,74 @@ class ProductControllerTest extends TestCase
         static::assertStringNotContainsString('itemprop="length"', $content);
     }
 
+    public function testSeparateProductGalleryCmsElementRendersImageMicrodata(): void
+    {
+        Feature::skipTestIfActive('JSON_LD_DATA', $this);
+
+        $cmsPageId = Uuid::randomHex();
+
+        static::getContainer()->get('cms_page.repository')->create([
+            [
+                'id' => $cmsPageId,
+                'type' => 'product_detail',
+                'sections' => [
+                    [
+                        'id' => Uuid::randomHex(),
+                        'type' => 'default',
+                        'position' => 0,
+                        'blocks' => [
+                            [
+                                'id' => Uuid::randomHex(),
+                                'type' => 'image-gallery',
+                                'position' => 0,
+                                'sectionPosition' => 'main',
+                                'slots' => [
+                                    [
+                                        'id' => Uuid::randomHex(),
+                                        'type' => 'image-gallery',
+                                        'slot' => 'imageGallery',
+                                        'config' => [
+                                            'sliderItems' => ['source' => 'mapped', 'value' => 'product.media'],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $productId = $this->createProduct([
+            'cmsPageId' => $cmsPageId,
+            'media' => [
+                [
+                    'id' => Uuid::randomHex(),
+                    'position' => 0,
+                    'media' => [
+                        'fileName' => 'gallery-image',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->request(
+            'GET',
+            '/my-product/' . $productId,
+            []
+        );
+
+        $this->checkStatusCode($response);
+
+        $content = $response->getContent();
+        static::assertIsString($content);
+
+        $crawler = new Crawler();
+        $crawler->addHtmlContent($content);
+
+        static::assertCount(1, $crawler->filter('img.gallery-slider-image[itemprop="image"]'));
+    }
+
     public function testReferencePriceIsRenderedWithSingleCalculatedPrice(): void
     {
         $unitId = Uuid::randomHex();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When a product detail page uses separate CMS elements for the image gallery and the buy box, the legacy product microdata no longer marks gallery images as product images. This causes crawlers such as Google Search Console to report that the product `image` field is missing.

### 2. What does this change do, exactly?

The change moves the `isProduct` detection into `cms-element-image-gallery.html.twig` so the image gallery can determine on its own whether it renders mapped `product.media`, regardless of whether it is used inside the combined `gallery-buybox` block or as a standalone CMS element.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or assign a product detail CMS layout that uses a standalone `image-gallery` element instead of the combined `gallery-buybox` block.
2. Configure the image gallery to use mapped `product.media`.
3. Open a product detail page using that layout with legacy microdata enabled.
4. Inspect the rendered HTML or crawl the page with Google Search Console.
5. Observe that the gallery image is missing product image microdata.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6191

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
