### PR TITLE
fix(storefront): silence legacy theme label deprecations

### DIFF
--- a/src/Storefront/Theme/ThemeMergedConfigBuilder.php
+++ b/src/Storefront/Theme/ThemeMergedConfigBuilder.php
@@ -66,8 +66,10 @@ class ThemeMergedConfigBuilder
         $configFields = [];
 
         if ($isLegacy) {
-            $labels = array_replace_recursive($baseTheme->getLabels() ?? [], $theme->getLabels() ?? []);
-            $helpTexts = array_replace_recursive($baseTheme->getHelpTexts() ?? [], $theme->getHelpTexts() ?? []);
+            [$labels, $helpTexts] = Feature::silent('v6.8.0.0', static fn (): array => [
+                array_replace_recursive($baseTheme->getLabels() ?? [], $theme->getLabels() ?? []),
+                array_replace_recursive($baseTheme->getHelpTexts() ?? [], $theme->getHelpTexts() ?? []),
+            ]);
         }
 
         if ($theme->getParentThemeId()) {
@@ -76,8 +78,10 @@ class ThemeMergedConfigBuilder
                 $baseThemeConfig = array_replace_recursive($baseThemeConfig, $configuredParentTheme);
 
                 if ($isLegacy) {
-                    $labels = array_replace_recursive($labels, $parentTheme->getLabels() ?? []);
-                    $helpTexts = array_replace_recursive($helpTexts, $parentTheme->getHelpTexts() ?? []);
+                    [$labels, $helpTexts] = Feature::silent('v6.8.0.0', static fn (): array => [
+                        array_replace_recursive($labels, $parentTheme->getLabels() ?? []),
+                        array_replace_recursive($helpTexts, $parentTheme->getHelpTexts() ?? []),
+                    ]);
                 }
             }
         }
@@ -185,7 +189,7 @@ class ThemeMergedConfigBuilder
 
         $translations = [];
         if ($isLegacy && $translate) {
-            $translations = $this->getTranslations($themeId, $context);
+            $translations = Feature::silent('v6.8.0.0', fn (): array => $this->getTranslations($themeId, $context));
             $mergedFieldConfig = $this->translateLabels($mergedFieldConfig, $translations);
         }
 

--- a/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
+++ b/tests/unit/Storefront/Theme/ThemeMergedConfigBuilderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
@@ -30,6 +31,8 @@ use Shopware\Tests\Unit\Storefront\Theme\fixtures\ThemeFixtures_6_7;
 #[CoversClass(ThemeMergedConfigBuilder::class)]
 class ThemeMergedConfigBuilderTest extends TestCase
 {
+    use EnvTestBehaviour;
+
     private StorefrontPluginRegistry&Stub $storefrontPluginRegistryMock;
 
     /**
@@ -99,6 +102,57 @@ class ThemeMergedConfigBuilderTest extends TestCase
         ?array $expectedStructured = null,
     ): void {
         $this->testGetPlainThemeConfiguration($ids, $themeCollection, $expected, $expectedStructured);
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 Will be removed together with legacy theme labels
+     *
+     * @param array<string, mixed> $ids
+     * @param array<string, mixed>|null $expected
+     * @param array<string, mixed>|null $expectedStructured
+     */
+    #[DataProviderExternal(ThemeFixtures_6_7::class, 'getThemeCollectionForThemeConfiguration')]
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testGetPlainThemeConfigurationDoesNotTriggerLegacyLabelDeprecations(
+        array $ids,
+        ThemeCollection $themeCollection,
+        ?array $expected = null,
+        ?array $expectedStructured = null,
+    ): void {
+        // Feature deprecations are suppressed in tests by default, so disable that to catch self-deprecations.
+        $this->setEnvVars(['TESTS_RUNNING' => false]);
+
+        $this->mockThemeRepositorySearch($themeCollection);
+
+        $storefrontPlugin = new StorefrontPluginConfiguration('Test');
+        $storefrontPlugin->setThemeConfig(ThemeFixtures::getThemeJsonConfig());
+
+        $this->storefrontPluginRegistryMock->method('getConfigurations')->willReturn(
+            new StorefrontPluginConfigurationCollection([$storefrontPlugin])
+        );
+
+        $deprecations = [];
+        set_error_handler(static function (int $errorNumber, string $message) use (&$deprecations): bool {
+            if ($errorNumber !== \E_USER_DEPRECATED) {
+                return false;
+            }
+
+            $deprecations[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->mergedConfigBuilder->getPlainThemeConfiguration($ids['themeId'], $this->context, true);
+            $this->mergedConfigBuilder->getThemeConfigurationFieldStructure($ids['themeId'], $this->context, true);
+        } finally {
+            restore_error_handler();
+        }
+
+        static::assertSame([], array_filter(
+            $deprecations,
+            static fn (string $message): bool => str_contains($message, ThemeEntity::class)
+        ));
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Core still reads deprecated legacy theme label and help text properties while building legacy theme configuration. Those internal reads trigger `ThemeEntity` deprecations even though the deprecated behavior is required for the pre-6.8 compatibility path.

### 2. What does this change do, exactly?

It wraps the legacy label/help text reads in `Feature::silent('v6.8.0.0', ...)` at the legacy call sites. The regression test disables the test-suite deprecation suppression and verifies that legacy theme config building does not emit `ThemeEntity` self-deprecations.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use trunk / 6.8.x-dev with the `v6.8.0.0` feature flag inactive.
2. Trigger a translated theme configuration read, for example through storefront/theme config loading.
3. Observe deprecations from `ThemeEntity::getLabels()` or `ThemeEntity::getHelpTexts()` before this change.

### 4. Please link to the relevant issues (if any).

- closes #16735

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers: not relevant, internal deprecation-noise bugfix
- [x] I have written or adjusted the documentation according to my changes: not required
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
