### PR TITLE
ci: post slack message on release

### DIFF
--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -147,4 +147,4 @@ jobs:
       - name: Post slack message
         run: |
             SLACK_PAYLOAD=$(jq --null-input --arg version "${{ github.ref_name }}" '{"version": $version, "github_url": "https://github.com/shopware/shopware/releases/tag/\($version)"}');
-            echo curl --silent --request POST --url "${{ secrets.SLACK_RELEASE_WORKFLOW_URL }}" --header "Content-Type: application/json" --data "${SLACK_PAYLOAD}"
+            curl --silent --request POST --url "${{ secrets.SLACK_RELEASE_WORKFLOW_URL }}" --header "Content-Type: application/json" --data "${SLACK_PAYLOAD}"


### PR DESCRIPTION
### 1. Why is this change necessary?
The slack message is still in "dry run mode"

### 2. What does this change do, exactly?
Remove the echo to execute the curl.

### 3. Describe each step to reproduce the issue or behaviour.
Release a new 6.6.x