### PR TITLE
chore: update danger configuration to add php service definitions

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -389,7 +389,7 @@ return (new Config())
             }
 
             // DependencyInjection service-wiring files (PHP closures using ContainerConfigurator) need no unit tests.
-            if (str_contains($file->name, '/DependencyInjection/') && str_contains($content, 'ContainerConfigurator')) {
+            if ((str_contains($file->name, '/DependencyInjection/') || preg_match('#/Resources/config/services(?:_[^/]*)?\.php$#', $file->name) === 1) && str_contains($content, 'ContainerConfigurator')) {
                 continue;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Danger already exempts PHP service definition files from the unit test requirement, but only under `/DependencyInjection/`. Elasticsearch keeps its service definitions at `Resources/config/services.php`, so the XML→PHP migration pilot PR (#XXXX) fails the Danger step. `.danger.php` changes don't apply within the same PR, hence this separate one.

### 2. What does this change do, exactly?
Extends the path check of the existing exemption with `Resources/config/services*.php` (same pattern as the PHPStan `ServiceDefinitionRule`). One line, nothing else changes.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a `ContainerConfigurator` services file outside `DependencyInjection/`, e.g. `src/Elasticsearch/Resources/config/services.php`.
2. Danger fails with "Please be kind and add unit tests …".
3. With this change the file is exempt, like the existing PHP definitions under `DependencyInjection/`.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
