### PR TITLE
fix: update newsletter submit button on option change

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1782,8 +1782,6 @@ Because of the side-effects with large combined selectors, we have added a new s
 The use of `@extend` is still allowed on SCSS placeholder selectors (`%my-selector`) that are not included in the compiled CSS.
 If you have good reasons to use `@extend` and can ensure that the combined selectors do not grow too large, the rule can still be ignored via inline comment.
 
-## App System
-
 ## Hosting & Configuration
 
 ### Add custom HTML element configuration for HTML Sanitizer

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -210,6 +210,19 @@ The default storefront `robots.txt` now emits `Allow: /*referringSalesChannel=` 
 
 `loadDomains()` is already available: its default implementation builds the collection from `load()` for backward compatibility, but will become abstract with 6.8. If you decorate `AbstractDomainLoader`, implement `loadDomains()` in your decorator. If you consume the result, look up entries via the collection (e.g. `$domains->get($url)`) and access the values as objects (e.g. `$domain->url`) instead of array keys (`$domains[$url]['url']`).
 
+### FormFieldToggle can toggle related submit button labels
+
+The storefront `FormFieldToggle` plugin now supports optionally updating a related button label when the toggle value changes.
+
+This is useful for dynamic forms (for example subscribe vs unsubscribe flows) where hidden/visible field groups and the submit action label should stay in sync without introducing a dedicated custom plugin.
+
+For extension and theme developers, two optional data attributes are available on the controlling field:
+
+- `data-form-field-toggle-button-target`: CSS selector for the related button.
+- `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
+
+If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
+
 ## API
 
 ### Store API OpenAPI: JSON schema files take precedence over generated entity schemas
@@ -1768,18 +1781,6 @@ In addition, we have refactored several places to use direct CSS or SCSS variabl
 Because of the side-effects with large combined selectors, we have added a new stylelint rule `scss/at-extend-no-missing-placeholder` that does not allow the use of `@extend` on generic selectors.
 The use of `@extend` is still allowed on SCSS placeholder selectors (`%my-selector`) that are not included in the compiled CSS.
 If you have good reasons to use `@extend` and can ensure that the combined selectors do not grow too large, the rule can still be ignored via inline comment.
-### FormFieldToggle can toggle related submit button labels
-
-The storefront `FormFieldToggle` plugin now supports optionally updating a related button label when the toggle value changes.
-
-This is useful for dynamic forms (for example subscribe vs unsubscribe flows) where hidden/visible field groups and the submit action label should stay in sync without introducing a dedicated custom plugin.
-
-For extension and theme developers, two optional data attributes are available on the controlling field:
-
-- `data-form-field-toggle-button-target`: CSS selector for the related button.
-- `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
-
-If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
 
 ## App System
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1768,6 +1768,20 @@ In addition, we have refactored several places to use direct CSS or SCSS variabl
 Because of the side-effects with large combined selectors, we have added a new stylelint rule `scss/at-extend-no-missing-placeholder` that does not allow the use of `@extend` on generic selectors.
 The use of `@extend` is still allowed on SCSS placeholder selectors (`%my-selector`) that are not included in the compiled CSS.
 If you have good reasons to use `@extend` and can ensure that the combined selectors do not grow too large, the rule can still be ignored via inline comment.
+### FormFieldToggle can toggle related submit button labels
+
+The storefront `FormFieldToggle` plugin now supports optionally updating a related button label when the toggle value changes.
+
+This is useful for dynamic forms (for example subscribe vs unsubscribe flows) where hidden/visible field groups and the submit action label should stay in sync without introducing a dedicated custom plugin.
+
+For extension and theme developers, two optional data attributes are available on the controlling field:
+
+- `data-form-field-toggle-button-target`: CSS selector for the related button.
+- `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
+
+If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
+
+## App System
 
 ## Hosting & Configuration
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
@@ -127,12 +127,6 @@ export default class FormFieldTogglePlugin extends Plugin {
     _getButtonTarget() {
         const buttonSelector = this.el.getAttribute(this.options.buttonTargetDataAttribute);
 
-        if (!buttonSelector) {
-            this._buttonTarget = null;
-
-            return;
-        }
-
         if (this.el.form) {
             this._buttonTarget = this.el.form.querySelector(buttonSelector);
         } else {
@@ -209,7 +203,7 @@ export default class FormFieldTogglePlugin extends Plugin {
         if ('checkbox' !== type && 'radio' !== type) {
             return this.el.value === this._value;
         }
-    
+
         if (!this._value) {
             return this.el.checked;
         }

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-field-toggle.plugin.js
@@ -30,6 +30,18 @@ export default class FormFieldTogglePlugin extends Plugin {
         valueDataAttribute: 'data-form-field-toggle-value',
 
         /**
+         * the data attribute for a selector that points to a button
+         * whose label should be toggled together with the field toggle state
+         */
+        buttonTargetDataAttribute: 'data-form-field-toggle-button-target',
+
+        /**
+         * the data attribute for the alternate button text
+         * used when the target is hidden
+         */
+        buttonTextDataAttribute: 'data-form-field-toggle-button-text',
+
+        /**
          * the class which gets applied
          * when the field previously had the required attribute
          */
@@ -67,6 +79,7 @@ export default class FormFieldTogglePlugin extends Plugin {
     init() {
         this._getTargets();
         this._getControlValue();
+        this._getButtonTarget();
         this._registerEvents();
 
         // Since the target could be hidden from the start,
@@ -107,6 +120,29 @@ export default class FormFieldTogglePlugin extends Plugin {
     }
 
     /**
+     * sets the submit button target and remembers its default text
+     *
+     * @private
+     */
+    _getButtonTarget() {
+        const buttonSelector = this.el.getAttribute(this.options.buttonTargetDataAttribute);
+
+        if (!buttonSelector) {
+            this._buttonTarget = null;
+
+            return;
+        }
+
+        if (this.el.form) {
+            this._buttonTarget = this.el.form.querySelector(buttonSelector);
+        } else {
+            this._buttonTarget = document.querySelector(buttonSelector);
+        }
+
+        this._buttonDefaultText = this._buttonTarget ? this._buttonTarget.textContent.trim() : '';
+    }
+
+    /**
      * registers all needed events
      *
      * @private
@@ -136,7 +172,29 @@ export default class FormFieldTogglePlugin extends Plugin {
             }
         });
 
+        this._toggleButtonText(shouldShow);
+
         this.$emitter.publish('onChange');
+    }
+
+    /**
+     * toggles a linked button text based on visibility state
+     *
+     * @param {boolean} shouldShow
+     * @private
+     */
+    _toggleButtonText(shouldShow) {
+        if (!this._buttonTarget) {
+            return;
+        }
+
+        const alternateText = this.el.getAttribute(this.options.buttonTextDataAttribute);
+
+        if (!alternateText) {
+            return;
+        }
+
+        this._buttonTarget.textContent = shouldShow ? this._buttonDefaultText : alternateText;
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-field-toggle.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-field-toggle.plugin.test.js
@@ -6,43 +6,126 @@ describe('FormFieldTogglePlugin', () => {
     beforeEach(() => {
         const template = `
             <form id="register-form" action="/register" method="post">
-                <input 
-                    data-form-field-toggle="true" 
-                    data-form-field-toggle-target=".js-form-field-toggle-target" 
+                <input
+                    data-form-field-toggle="true"
+                    data-form-field-toggle-target=".js-form-field-toggle-target"
                     data-form-field-toggle-value="true"
-                    type="checkbox" 
+                    type="checkbox"
                     name="company"
-                    id="is-company" 
+                    id="is-company"
                 >
 
-                <input 
-                    class="js-form-field-toggle-target d-none" 
-                    type="text" 
+                <input
+                    class="js-form-field-toggle-target d-none"
+                    type="text"
                     name="company-name"
                 >
+            </form>
+
+            <form id="newsletterForm" action="/newsletter" method="post">
+                <select id="newsletterAction"
+                        data-form-field-toggle="true"
+                        data-form-field-toggle-target=".js-field-toggle-newsletter-additional"
+                        data-form-field-toggle-value="subscribe"
+                        data-form-field-toggle-button-target="[data-newsletter-submit-button]"
+                        data-form-field-toggle-button-text="Unsubscribe">
+                    <option value="subscribe" selected="selected">Subscribe</option>
+                    <option value="unsubscribe">Unsubscribe</option>
+                </select>
+
+                <div class="js-field-toggle-newsletter-additional d-none">
+                    <input id="firstName" type="text" required="required">
+                </div>
+
+                <button type="submit" data-newsletter-submit-button="true">Subscribe</button>
             </form>
         `;
 
         document.body.innerHTML = template;
-        element = document.querySelector('[data-form-field-toggle]');
+        window.PluginManager.initializePlugins = jest.fn();
+
+        element = document.querySelector('#is-company');
     });
 
+    afterEach(() => {
+        document.body.innerHTML = '';
+        jest.clearAllMocks();
+    });
+
+    function createCheckboxPlugin() {
+        return new FormFieldTogglePlugin(element);
+    }
+
+    function createNewsletterPlugin() {
+        const newsletterElement = document.querySelector('#newsletterAction');
+
+        return new FormFieldTogglePlugin(newsletterElement);
+    }
+
     test('creates plugin instance', () => {
-        const plugin = new FormFieldTogglePlugin(element);
-        expect(typeof plugin).toBe('object');
+        const plugin = createCheckboxPlugin();
+
+        expect(plugin instanceof FormFieldTogglePlugin).toBe(true);
     });
 
     test('shows target when checkbox is checked', () => {
-        new FormFieldTogglePlugin(element);
+        createCheckboxPlugin();
 
-        // Tick the checkbox
         const checkbox = document.querySelector('#is-company');
         checkbox.checked = true;
         checkbox.dispatchEvent(new Event('change'));
 
-        // Check if the target is shown
         const target = document.querySelector('.js-form-field-toggle-target');
+
         expect(target.classList.contains('d-block')).toBe(true);
         expect(target.classList.contains('d-none')).toBe(false);
+    });
+
+    test('shows newsletter target and keeps subscribe button text by default', () => {
+        createNewsletterPlugin();
+
+        const toggleTarget = document.querySelector('.js-field-toggle-newsletter-additional');
+        const submitButton = document.querySelector('[data-newsletter-submit-button]');
+        const firstNameField = document.querySelector('#firstName');
+
+        expect(toggleTarget.classList.contains('d-none')).toBe(false);
+        expect(toggleTarget.classList.contains('d-block')).toBe(true);
+        expect(firstNameField.hasAttribute('required')).toBe(true);
+        expect(firstNameField.hasAttribute('disabled')).toBe(false);
+        expect(submitButton.textContent.trim()).toBe('Subscribe');
+    });
+
+    test('hides newsletter target and switches to alternate button text when value does not match', () => {
+        createNewsletterPlugin();
+
+        const select = document.querySelector('#newsletterAction');
+        select.value = 'unsubscribe';
+        select.dispatchEvent(new Event('change'));
+
+        const toggleTarget = document.querySelector('.js-field-toggle-newsletter-additional');
+        const submitButton = document.querySelector('[data-newsletter-submit-button]');
+        const firstNameField = document.querySelector('#firstName');
+
+        expect(toggleTarget.classList.contains('d-none')).toBe(true);
+        expect(toggleTarget.classList.contains('d-block')).toBe(false);
+        expect(firstNameField.hasAttribute('required')).toBe(false);
+        expect(firstNameField.hasAttribute('disabled')).toBe(true);
+        expect(submitButton.textContent.trim()).toBe('Unsubscribe');
+    });
+
+    test('switches newsletter button back to default text when value matches again', () => {
+        createNewsletterPlugin();
+
+        const select = document.querySelector('#newsletterAction');
+
+        select.value = 'unsubscribe';
+        select.dispatchEvent(new Event('change'));
+
+        select.value = 'subscribe';
+        select.dispatchEvent(new Event('change'));
+
+        const submitButton = document.querySelector('[data-newsletter-submit-button]');
+
+        expect(submitButton.textContent.trim()).toBe('Subscribe');
     });
 });

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -590,6 +590,7 @@
     "subscribeOption": "Newsletter abonnieren",
     "unsubscribeOption": "Newsletter abbestellen",
     "formSubmit": "Abonnieren",
+    "formSubmitUnsubscribe": "Abbestellen",
     "subscriptionPersistedSuccess": "Sie haben gerade unseren Newsletter abonniert.\n Um die Registrierung abzuschließen, suchen Sie in Ihrer E-Mail-Box nach unserer Bestätigungsmail und klicken Sie auf den darin enthaltenen Link.",
     "subscriptionPersistedInfo": "Sollten Sie in den nächsten Minuten keine Bestätigungs-E-Mail erhalten, sind Sie eventuell bereits für den Newsletter angemeldet. Durchsuchen Sie Ihren Posteingang und auch den Spamordner. Versuchen Sie danach, sich ein weiteres Mal anzumelden und wenden Sie sich an unseren Support, falls auch das nicht funktioniert.",
     "subscriptionRevokeSuccess": "Sie haben sich erfolgreich vom Newsletter abgemeldet.",

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -590,6 +590,7 @@
     "subscribeOption": "Subscribe to newsletter",
     "unsubscribeOption": "Unsubscribe from newsletter",
     "formSubmit": "Subscribe",
+    "formSubmitUnsubscribe": "Unsubscribe",
     "subscriptionPersistedSuccess": "You have just subscribed to our newsletter.\n To complete the sign-up process, search your inbox for our confirmation email and click on the link provided with it.",
     "subscriptionPersistedInfo": "If you do not receive a confirmation email in the next few minutes, you may already be subscribed to the newsletter. Check your inbox and spam folder. Then try to subscribe again and contact our support if this does not work either.",
     "subscriptionRevokeSuccess": "You have successfully unsubscribed from the newsletter.",

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig
@@ -1,5 +1,8 @@
 {% block cms_form_submit %}
-    <button type="submit" class="btn btn-primary float-end">
+    {% set attributes = attributes|default({}) %}
+
+    <button type="submit" class="btn btn-primary float-end"
+            {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key ~ '=' ~ value ~ ' ' }}{% endif %}{% endfor %}{% endif %}>
         {{ ( submitText ? submitText : 'general.formSubmit' )|trans }}
     </button>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig
@@ -1,8 +1,15 @@
 {% block cms_form_submit %}
     {% set attributes = attributes|default({}) %}
 
-    <button type="submit" class="btn btn-primary float-end"
-            {% if attributes is not empty %}{% for key, value in attributes %}{% if value is not empty %}{{ key ~ '=' ~ value ~ ' ' }}{% endif %}{% endfor %}{% endif %}>
+    <button
+        type="submit"
+        class="btn btn-primary float-end"
+        {% if attributes is not empty %}
+            {% for key, value in attributes %}
+                {% if value is not empty %}{{ key }}="{{ value }}"{% else %}{{ key }}{% endif %}
+            {% endfor %}
+        {% endif %}
+    >
         {{ ( submitText ? submitText : 'general.formSubmit' )|trans }}
     </button>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/newsletter-form.html.twig
@@ -32,6 +32,8 @@
                             'data-form-field-toggle': 'true',
                             'data-form-field-toggle-target': '.js-field-toggle-newsletter-additional',
                             'data-form-field-toggle-value': 'subscribe',
+                            'data-form-field-toggle-button-target': '[data-newsletter-submit-button]',
+                            'data-form-field-toggle-button-text': 'newsletter.formSubmitUnsubscribe'|trans|sw_sanitize,
                         },
                     } %}
                 {% endblock %}
@@ -104,7 +106,11 @@
             {% endblock %}
 
             {% block cms_form_newsletter_submit %}
-                {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig' %}
+                {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-submit.html.twig' with {
+                    attributes: {
+                        'data-newsletter-submit-button': 'true',
+                    },
+                } %}
             {% endblock %}
         </div>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

This is a continuation of an older pull request of mine: https://github.com/shopware/shopware/pull/15684
I’ve implemented the feedback from that PR in this branch.

### 1. Why is this change necessary?

The submit button is stuck on `Subscribe` regardless of the action. This creates a confusing user experience when trying to unsubscribe.

### 2. What does this change do, exactly?

This change makes the newsletter submit button text switch automatically based on the selected action.
When the user selects `subscribe` the button shows `Subscribe`; when they select `unsubscribe`, it shows `Unsubscribe`.

### 3. Describe each step to reproduce the issue or behaviour.

Add a newsletter form to a page and toggle between the `Subscribe` and `Unsubscribe` options to observe the button label.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #15594 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
