### PR TITLE
fix: make tree item ellipsis use dynamic width

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -60,14 +60,24 @@
 
     &.is--no-checkbox {
         .sw-tree-item__element {
-            grid-template-columns: var(--scale-size-30) 0 var(--scale-size-20) auto var(--scale-size-64);
+            grid-template-columns:
+                var(--scale-size-30)
+                0
+                var(--scale-size-20)
+                minmax(0, 1fr)
+                var(--scale-size-64);
         }
     }
 
     .sw-tree-item__element {
         height: var(--scale-size-42);
         display: grid;
-        grid-template-columns: var(--scale-size-30) var(--scale-size-24) var(--scale-size-20) auto var(--scale-size-64);
+        grid-template-columns:
+            var(--scale-size-30)
+            var(--scale-size-24)
+            var(--scale-size-20)
+            minmax(0, 1fr)
+            var(--scale-size-64);
         grid-column-gap: var(--scale-size-2);
         align-items: center;
         align-content: center;
@@ -243,7 +253,12 @@
 .sw-tree-item__element {
     height: var(--scale-size-42);
     display: grid;
-    grid-template-columns: var(--scale-size-30) var(--scale-size-24) var(--scale-size-20) auto var(--scale-size-64);
+    grid-template-columns:
+        var(--scale-size-30)
+        var(--scale-size-24)
+        var(--scale-size-20)
+        minmax(0, 1fr)
+        var(--scale-size-64);
     grid-column-gap: var(--scale-size-2);
     align-items: center;
     align-content: center;

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -37,13 +37,11 @@
 
         .tree-items {
             padding: var(--scale-size-8);
-            width: max-content;
-            min-width: 100%;
+            width: 100%;
         }
 
         .sw-tree-item {
-            width: max-content;
-            min-width: 100%;
+            width: 100%;
         }
 
         .sw-tree-item__children {
@@ -72,7 +70,8 @@
             overflow: hidden;
             text-overflow: ellipsis;
             padding-right: var(--scale-size-8);
-            max-width: 21.25rem;
+            min-width: 0;
+            max-width: 100%;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Tree items in the category tree use a fixed content width. On deeper category levels, the nesting indentation reduces the available space, but the row can still grow horizontally, which causes a horizontal scrollbar instead of truncating the category name with an ellipsis.

### 2. What does this change do, exactly?

This change updates the shared `sw-tree` layout so category tree rows use the available container width and the content column can shrink dynamically.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the category module in the Administration.
2. Create or open a category structure with multiple nested levels and long category names.
3. Expand the tree so categories on deeper levels are visible.
4. Observe that deeper nested category rows can overflow horizontally and trigger a horizontal scrollbar instead of truncating the category name correctly.

After the change:

<img width="457" height="608" alt="Bildschirmfoto 2026-07-08 um 10 20 45" src="https://github.com/user-attachments/assets/bb2b1da8-6418-41cd-8c47-c5721279883f" />

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6644

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
