### PR TITLE
ci: fix link private pr workflow permissions

### DIFF
--- a/.github/workflows/link-private-pr.yml
+++ b/.github/workflows/link-private-pr.yml
@@ -4,6 +4,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   link_pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The new link private pr workflow from #18094 failed on my issue (#17720):

> Error: Missing required environment variables; have you set 'id-token: write' in your workflow permissions?

– https://github.com/shopware/shopware/actions/runs/28934824925/job/85842474880