### PR TITLE
feat(core): reconcile services on the scheduled service task

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,7 +4,7 @@
 
 ### Shopware Services are updated by the scheduled service task
 
-The daily `services.install` scheduled task now runs a reconcile pass: in addition to installing newly-registered Shopware Services, it converges every already-installed service to the latest revision advertised by the service registry. Previously an installed service was only updated when it pushed an update via `POST /api/services/trigger-update`, so a shop that missed a push stayed on a stale revision until the next push. The same reconcile pass replaces the previous install-only pass everywhere it ran: `bin/console services:install` and re-enabling services also converge installed services now. Updates are idempotent — a service already on the latest revision is a no-op — and no configuration change is required (services must be enabled as before).
+The daily `services.install` scheduled task now runs a reconcile pass: in addition to installing newly-registered Shopware Services, it converges every already-installed service to the latest revision advertised by the service registry. Previously an installed service was only updated when it pushed an update via `POST /api/services/trigger-update`, so a shop that missed a push stayed on a stale revision until the next push. Updates are idempotent — a service already on the latest revision is a no-op — and no configuration change is required (services must be enabled as before).
 
 ### Per-thumbnail post-processing event and progressive JPEG thumbnails
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,10 @@
 
 ## Core
 
+### Shopware Services are updated by the scheduled service task
+
+The daily `services.install` scheduled task now runs a reconcile pass: in addition to installing newly-registered Shopware Services, it converges every already-installed service to the latest revision advertised by the service registry. Previously an installed service was only updated when it pushed an update via `POST /api/services/trigger-update`, so a shop that missed a push stayed on a stale revision until the next push. Updates are idempotent — a service already on the latest revision is a no-op — and no configuration change is required (services must be enabled as before).
+
 ### Per-thumbnail post-processing event and progressive JPEG thumbnails
 
 Thumbnail generation gained a new extension point and two output improvements:

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -4,7 +4,7 @@
 
 ### Shopware Services are updated by the scheduled service task
 
-The daily `services.install` scheduled task now runs a reconcile pass: in addition to installing newly-registered Shopware Services, it converges every already-installed service to the latest revision advertised by the service registry. Previously an installed service was only updated when it pushed an update via `POST /api/services/trigger-update`, so a shop that missed a push stayed on a stale revision until the next push. Updates are idempotent — a service already on the latest revision is a no-op — and no configuration change is required (services must be enabled as before).
+The daily `services.install` scheduled task now runs a reconcile pass: in addition to installing newly-registered Shopware Services, it converges every already-installed service to the latest revision advertised by the service registry. Previously an installed service was only updated when it pushed an update via `POST /api/services/trigger-update`, so a shop that missed a push stayed on a stale revision until the next push. The same reconcile pass replaces the previous install-only pass everywhere it ran: `bin/console services:install` and re-enabling services also converge installed services now. Updates are idempotent — a service already on the latest revision is a no-op — and no configuration change is required (services must be enabled as before).
 
 ### Per-thumbnail post-processing event and progressive JPEG thumbnails
 

--- a/src/Core/Service/AllServiceInstaller.php
+++ b/src/Core/Service/AllServiceInstaller.php
@@ -31,24 +31,10 @@ class AllServiceInstaller
     }
 
     /**
-     * Discovers services in the registry that are not yet installed and hands each one to
-     * ServiceLifecycle, which resolves the strategy and performs the resulting operation.
+     * Converges the shop toward the registry: discovers services that are not yet installed and hands
+     * each one to ServiceLifecycle, and schedules an update for every already-installed service still
+     * listed in the registry so it reaches the registry's latest revision.
      * It should only be called from a higher-level, 'state'-aware class: Shopware\Core\Service\LifecycleManager.
-     *
-     * @return array<string> The newly installed services
-     */
-    public function install(Context $context): array
-    {
-        return $this->installNewServices(
-            $this->serviceStorage->findAll($context),
-            $this->serviceRegistryClient->getAll(),
-            $context
-        );
-    }
-
-    /**
-     * Like install(), but also schedules an update for every already-installed service still listed in
-     * the registry, so it converges to the registry's latest revision.
      *
      * @return array<string> The newly installed services
      */

--- a/src/Core/Service/AllServiceInstaller.php
+++ b/src/Core/Service/AllServiceInstaller.php
@@ -2,11 +2,13 @@
 
 namespace Shopware\Core\Service;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Service\DTO\Service;
 use Shopware\Core\Service\Event\NewServicesInstalledEvent;
 use Shopware\Core\Service\Message\InstallServicesMessage;
+use Shopware\Core\Service\Message\UpdateServiceMessage;
 use Shopware\Core\Service\ServiceRegistry\Client;
 use Shopware\Core\Service\ServiceRegistry\ServiceEntry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -24,6 +26,7 @@ class AllServiceInstaller
         private readonly ServiceLifecycle $serviceLifecycle,
         private readonly MessageBusInterface $messageBus,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -36,10 +39,46 @@ class AllServiceInstaller
      */
     public function install(Context $context): array
     {
-        $existingServices = $this->serviceStorage->findAll($context);
+        return $this->installNewServices(
+            $this->serviceStorage->findAll($context),
+            $this->serviceRegistryClient->getAll(),
+            $context
+        );
+    }
 
+    /**
+     * Like install(), but also schedules an update for every already-installed service still listed in
+     * the registry, so it converges to the registry's latest revision.
+     *
+     * @return array<string> The newly installed services
+     */
+    public function reconcile(Context $context): array
+    {
+        $existingServices = $this->serviceStorage->findAll($context);
+        $registryServices = $this->serviceRegistryClient->getAll();
+
+        $installedServices = $this->installNewServices($existingServices, $registryServices, $context);
+
+        $this->scheduleUpdates($existingServices, $registryServices);
+
+        return $installedServices;
+    }
+
+    public function scheduleInstall(): void
+    {
+        $this->messageBus->dispatch(new InstallServicesMessage());
+    }
+
+    /**
+     * @param list<Service> $existingServices
+     * @param array<ServiceEntry> $registryServices
+     *
+     * @return array<string>
+     */
+    private function installNewServices(array $existingServices, array $registryServices, Context $context): array
+    {
         $installedServices = [];
-        foreach ($this->getNewServices($existingServices) as $entry) {
+        foreach ($this->getNewServices($existingServices, $registryServices) as $entry) {
             if ($this->serviceLifecycle->install($entry, $context)) {
                 $installedServices[] = $entry->name;
             }
@@ -52,22 +91,48 @@ class AllServiceInstaller
         return $installedServices;
     }
 
-    public function scheduleInstall(): void
+    /**
+     * The update is idempotent (ServiceLifecycle::update no-ops when the installed revision already
+     * matches), so enqueuing for every in-registry service is safe.
+     *
+     * @param list<Service> $existingServices
+     * @param array<ServiceEntry> $registryServices
+     */
+    private function scheduleUpdates(array $existingServices, array $registryServices): void
     {
-        $this->messageBus->dispatch(new InstallServicesMessage());
+        $registryServiceNames = [];
+        foreach ($registryServices as $registryService) {
+            $registryServiceNames[$registryService->name] = true;
+        }
+
+        $scheduled = [];
+        foreach ($existingServices as $service) {
+            if (isset($registryServiceNames[$service->name])) {
+                $this->messageBus->dispatch(new UpdateServiceMessage($service->name));
+                $scheduled[] = $service->name;
+            }
+        }
+
+        if ($scheduled !== []) {
+            $this->logger->debug('Reconcile scheduled updates for installed services', [
+                'count' => \count($scheduled),
+                'services' => $scheduled,
+            ]);
+        }
     }
 
     /**
      * @param list<Service> $installedServices
+     * @param array<ServiceEntry> $registryServices
      *
      * @return array<ServiceEntry>
      */
-    private function getNewServices(array $installedServices): array
+    private function getNewServices(array $installedServices, array $registryServices): array
     {
         $names = array_map(static fn (Service $service) => $service->name, $installedServices);
 
         return array_filter(
-            $this->serviceRegistryClient->getAll(),
+            $registryServices,
             static fn (ServiceEntry $service) => !\in_array($service->name, $names, true)
         );
     }

--- a/src/Core/Service/Command/Install.php
+++ b/src/Core/Service/Command/Install.php
@@ -38,7 +38,7 @@ class Install extends Command
             return Command::FAILURE;
         }
 
-        $installed = $this->manager->install(Context::createCLIContext());
+        $installed = $this->manager->reconcile(Context::createCLIContext());
 
         if ($installed === []) {
             $io->info('No services were installed');

--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -77,6 +77,7 @@
             <argument type="service" id="Shopware\Core\Service\ServiceLifecycle"/>
             <argument type="service" id="messenger.bus.default"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="logger"/>
         </service>
 
         <service id="Shopware\Core\Service\ScheduledTask\InstallServicesTask">

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -45,37 +45,26 @@ class LifecycleManager
     ) {
     }
 
-    /**
-     * This method installs all services, only if ENABLE_SERVICES allows installation.
-     *
-     * @return array<string> The newly installed services
-     */
-    public function install(Context $context): array
-    {
-        if (!$this->enabled()) {
-            return [];
-        }
-
-        return $this->serviceInstaller->install($context);
-    }
-
     public function sync(Context $context): void
     {
         $this->removeOrphanedServices($this->serviceStorage->findAll($context), $context);
     }
 
     /**
-     * Periodic (level-triggered) counterpart to the update push (ServiceController::triggerUpdate): installs
-     * new services and converges installed ones to the registry's latest revision, both via the same
-     * idempotent update path. No orphan removal — that stays in sync().
+     * Level-triggered counterpart to the update push (ServiceController::triggerUpdate): installs new
+     * services and converges installed ones to the registry's latest revision, both via the same
+     * idempotent update path. Only runs if ENABLE_SERVICES allows it. No orphan removal — that stays
+     * in sync().
+     *
+     * @return array<string> The newly installed services
      */
-    public function reconcile(Context $context): void
+    public function reconcile(Context $context): array
     {
         if (!$this->enabled()) {
-            return;
+            return [];
         }
 
-        $this->serviceInstaller->reconcile($context);
+        return $this->serviceInstaller->reconcile($context);
     }
 
     public function syncState(string $serviceName, Context $context): void

--- a/src/Core/Service/LifecycleManager.php
+++ b/src/Core/Service/LifecycleManager.php
@@ -64,6 +64,20 @@ class LifecycleManager
         $this->removeOrphanedServices($this->serviceStorage->findAll($context), $context);
     }
 
+    /**
+     * Periodic (level-triggered) counterpart to the update push (ServiceController::triggerUpdate): installs
+     * new services and converges installed ones to the registry's latest revision, both via the same
+     * idempotent update path. No orphan removal — that stays in sync().
+     */
+    public function reconcile(Context $context): void
+    {
+        if (!$this->enabled()) {
+            return;
+        }
+
+        $this->serviceInstaller->reconcile($context);
+    }
+
     public function syncState(string $serviceName, Context $context): void
     {
         $service = $this->serviceStorage->findByName($serviceName, $context);

--- a/src/Core/Service/MessageHandler/InstallServicesHandler.php
+++ b/src/Core/Service/MessageHandler/InstallServicesHandler.php
@@ -21,6 +21,6 @@ final readonly class InstallServicesHandler
 
     public function __invoke(InstallServicesMessage $installServicesMessage): void
     {
-        $this->manager->install(Context::createDefaultContext());
+        $this->manager->reconcile(Context::createDefaultContext());
     }
 }

--- a/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
+++ b/src/Core/Service/ScheduledTask/InstallServicesTaskHandler.php
@@ -31,6 +31,6 @@ final class InstallServicesTaskHandler extends ScheduledTaskHandler
 
     public function run(): void
     {
-        $this->manager->install(Context::createCLIContext());
+        $this->manager->reconcile(Context::createCLIContext());
     }
 }

--- a/tests/unit/Core/Service/AllServiceInstallerTest.php
+++ b/tests/unit/Core/Service/AllServiceInstallerTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Unit\Core\Service;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Service\AllServiceInstaller;
 use Shopware\Core\Service\Message\InstallServicesMessage;
+use Shopware\Core\Service\Message\UpdateServiceMessage;
 use Shopware\Core\Service\ServiceLifecycle;
 use Shopware\Core\Service\ServiceRegistry\Client as ServiceRegistryClient;
 use Shopware\Core\Service\ServiceRegistry\ServiceEntry;
@@ -114,6 +116,64 @@ class AllServiceInstallerTest extends TestCase
         static::assertSame([], $installer->install(Context::createDefaultContext()));
     }
 
+    public function testReconcileDoesNotDispatchUpdateMessageForOrphanedService(): void
+    {
+        $installer = $this->installer($this->buildAppRepository([
+            AppFixture::createAppEntity(name: 'Service1'),
+            AppFixture::createAppEntity(name: 'OrphanedService'),
+        ]));
+
+        $this->registryClient->method('getAll')->willReturn([$this->entry('Service1')]);
+
+        $this->serviceLifecycle->expects($this->never())->method('install');
+
+        $this->messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with(static::callback(static fn ($message): bool => $message instanceof UpdateServiceMessage && $message->name === 'Service1'))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $installer->reconcile(Context::createDefaultContext());
+    }
+
+    public function testReconcileInstallsNewServicesWithoutEnqueuingUpdateForThem(): void
+    {
+        $installer = $this->installer($this->buildAppRepository([AppFixture::createAppEntity(name: 'Service1')]));
+
+        $this->registryClient->method('getAll')->willReturn([$this->entry('Service1'), $this->entry('Service2')]);
+
+        $this->serviceLifecycle->expects($this->once())
+            ->method('install')
+            ->willReturnCallback(function (ServiceEntry $entry): bool {
+                static::assertSame('Service2', $entry->name);
+
+                return true;
+            });
+
+        $this->eventDispatcher->expects($this->once())->method('dispatch');
+
+        $this->messageBus->expects($this->once())
+            ->method('dispatch')
+            ->with(static::callback(static fn ($message): bool => $message instanceof UpdateServiceMessage && $message->name === 'Service1'))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        static::assertSame(['Service2'], $installer->reconcile(Context::createDefaultContext()));
+    }
+
+    public function testReconcileDispatchesNoUpdatesWhenNoServicesInstalled(): void
+    {
+        $installer = $this->installer($this->buildAppRepository());
+
+        $this->registryClient->method('getAll')->willReturn([$this->entry('Service1'), $this->entry('Service2')]);
+
+        $this->serviceLifecycle->expects($this->exactly(2))->method('install')->willReturn(true);
+        $this->eventDispatcher->expects($this->once())->method('dispatch');
+
+        // A fresh shop only installs; reconcile must not enqueue update messages when nothing is installed yet.
+        $this->messageBus->expects($this->never())->method('dispatch');
+
+        static::assertSame(['Service1', 'Service2'], $installer->reconcile(Context::createDefaultContext()));
+    }
+
     public function testScheduleInstallDispatchesMessage(): void
     {
         $installer = $this->installer($this->buildAppRepository());
@@ -137,6 +197,7 @@ class AllServiceInstallerTest extends TestCase
             $this->serviceLifecycle,
             $this->messageBus,
             $this->eventDispatcher,
+            static::createStub(LoggerInterface::class),
         );
     }
 

--- a/tests/unit/Core/Service/AllServiceInstallerTest.php
+++ b/tests/unit/Core/Service/AllServiceInstallerTest.php
@@ -53,27 +53,13 @@ class AllServiceInstallerTest extends TestCase
         $this->serviceLifecycle->expects($this->exactly(2))->method('install')->willReturn(true);
         $this->eventDispatcher->expects($this->once())->method('dispatch');
 
-        static::assertSame(['Service1', 'Service2'], $installer->install(Context::createDefaultContext()));
+        // A fresh shop only installs; reconcile must not enqueue update messages when nothing is installed yet.
+        $this->messageBus->expects($this->never())->method('dispatch');
+
+        static::assertSame(['Service1', 'Service2'], $installer->reconcile(Context::createDefaultContext()));
     }
 
-    public function testOnlyServicesNotYetInstalledAreHandled(): void
-    {
-        $installer = $this->installer($this->buildAppRepository([AppFixture::createAppEntity(name: 'Service1')]));
-
-        $this->registryClient->method('getAll')->willReturn([$this->entry('Service1'), $this->entry('Service2')]);
-
-        $this->serviceLifecycle->expects($this->once())
-            ->method('install')
-            ->willReturnCallback(function (ServiceEntry $entry): bool {
-                static::assertSame('Service2', $entry->name);
-
-                return true;
-            });
-
-        static::assertSame(['Service2'], $installer->install(Context::createDefaultContext()));
-    }
-
-    public function testNothingIsHandledWhenAllServicesAreInstalled(): void
+    public function testOnlyUpdatesAreScheduledWhenAllServicesAreInstalled(): void
     {
         $installer = $this->installer($this->buildAppRepository([
             AppFixture::createAppEntity(name: 'Service1'),
@@ -85,7 +71,12 @@ class AllServiceInstallerTest extends TestCase
         $this->serviceLifecycle->expects($this->never())->method('install');
         $this->eventDispatcher->expects($this->never())->method('dispatch');
 
-        static::assertSame([], $installer->install(Context::createDefaultContext()));
+        $this->messageBus->expects($this->exactly(2))
+            ->method('dispatch')
+            ->with(static::isInstanceOf(UpdateServiceMessage::class))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        static::assertSame([], $installer->reconcile(Context::createDefaultContext()));
     }
 
     public function testReturnsOnlyTheServicesThatWereInstalled(): void
@@ -102,18 +93,19 @@ class AllServiceInstallerTest extends TestCase
             static fn (ServiceEntry $entry): bool => $entry->name !== 'Service2'
         );
 
-        static::assertSame(['Service1', 'Service3'], $installer->install(Context::createDefaultContext()));
+        static::assertSame(['Service1', 'Service3'], $installer->reconcile(Context::createDefaultContext()));
     }
 
-    public function testInstallReturnsEmptyArrayWhenRegistryHasNoServices(): void
+    public function testReconcileReturnsEmptyArrayWhenRegistryHasNoServices(): void
     {
         $installer = $this->installer($this->buildAppRepository());
 
         $this->registryClient->method('getAll')->willReturn([]);
 
         $this->serviceLifecycle->expects($this->never())->method('install');
+        $this->messageBus->expects($this->never())->method('dispatch');
 
-        static::assertSame([], $installer->install(Context::createDefaultContext()));
+        static::assertSame([], $installer->reconcile(Context::createDefaultContext()));
     }
 
     public function testReconcileDoesNotDispatchUpdateMessageForOrphanedService(): void
@@ -157,21 +149,6 @@ class AllServiceInstallerTest extends TestCase
             ->willReturn(new Envelope(new \stdClass()));
 
         static::assertSame(['Service2'], $installer->reconcile(Context::createDefaultContext()));
-    }
-
-    public function testReconcileDispatchesNoUpdatesWhenNoServicesInstalled(): void
-    {
-        $installer = $this->installer($this->buildAppRepository());
-
-        $this->registryClient->method('getAll')->willReturn([$this->entry('Service1'), $this->entry('Service2')]);
-
-        $this->serviceLifecycle->expects($this->exactly(2))->method('install')->willReturn(true);
-        $this->eventDispatcher->expects($this->once())->method('dispatch');
-
-        // A fresh shop only installs; reconcile must not enqueue update messages when nothing is installed yet.
-        $this->messageBus->expects($this->never())->method('dispatch');
-
-        static::assertSame(['Service1', 'Service2'], $installer->reconcile(Context::createDefaultContext()));
     }
 
     public function testScheduleInstallDispatchesMessage(): void

--- a/tests/unit/Core/Service/Command/InstallTest.php
+++ b/tests/unit/Core/Service/Command/InstallTest.php
@@ -19,7 +19,7 @@ class InstallTest extends TestCase
         $manager = $this->createMock(LifecycleManager::class);
         $manager->method('enabled')
             ->willReturn(true);
-        $manager->expects($this->once())->method('install')->willReturn([]);
+        $manager->expects($this->once())->method('reconcile')->willReturn([]);
 
         $command = new Install($manager);
         $tester = new CommandTester($command);
@@ -33,7 +33,7 @@ class InstallTest extends TestCase
         $manager = $this->createMock(LifecycleManager::class);
         $manager->method('enabled')
             ->willReturn(false);
-        $manager->expects($this->never())->method('install');
+        $manager->expects($this->never())->method('reconcile');
 
         $command = new Install($manager);
         $tester = new CommandTester($command);
@@ -48,7 +48,7 @@ class InstallTest extends TestCase
         $manager = $this->createMock(LifecycleManager::class);
         $manager->method('enabled')
             ->willReturn(true);
-        $manager->expects($this->once())->method('install')->willReturn([
+        $manager->expects($this->once())->method('reconcile')->willReturn([
             'MyCoolService1',
             'MyCoolService2',
         ]);

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -247,6 +247,32 @@ class LifecycleManagerTest extends TestCase
         $manager->sync($this->context);
     }
 
+    public function testReconcileDelegatesToInstallerAndDoesNotRemoveOrphansWhenEnabled(): void
+    {
+        $this->serviceInstaller->expects($this->once())
+            ->method('reconcile')
+            ->with($this->context);
+
+        $this->serviceLifecycle->expects($this->never())
+            ->method('uninstall');
+        $this->client->expects($this->never())
+            ->method('getAll');
+
+        $manager = $this->createManager($this->createAppRepository());
+
+        $manager->reconcile($this->context);
+    }
+
+    public function testReconcileDoesNothingWhenServicesDisabled(): void
+    {
+        $this->serviceInstaller->expects($this->never())
+            ->method('reconcile');
+
+        $manager = $this->createManager($this->createAppRepository(), enabled: 'false');
+
+        $manager->reconcile($this->context);
+    }
+
     /**
      * @param array<string, bool> $systemConfig
      */

--- a/tests/unit/Core/Service/LifecycleManagerTest.php
+++ b/tests/unit/Core/Service/LifecycleManagerTest.php
@@ -61,34 +61,6 @@ class LifecycleManagerTest extends TestCase
         $this->context = Context::createDefaultContext();
     }
 
-    public function testInstallWhenEnabled(): void
-    {
-        $expectedServices = ['service1', 'service2'];
-
-        $this->serviceInstaller->expects($this->once())
-            ->method('install')
-            ->with($this->context)
-            ->willReturn($expectedServices);
-
-        $manager = $this->createManager($this->createAppRepository());
-
-        $result = $manager->install($this->context);
-
-        static::assertSame($expectedServices, $result);
-    }
-
-    public function testInstallWhenDisabled(): void
-    {
-        $this->serviceInstaller->expects($this->never())
-            ->method('install');
-
-        $manager = $this->createManager($this->createAppRepository(), enabled: 'false');
-
-        $result = $manager->install($this->context);
-
-        static::assertSame([], $result);
-    }
-
     public function testEnable(): void
     {
         $this->systemConfigService->expects($this->once())
@@ -249,9 +221,12 @@ class LifecycleManagerTest extends TestCase
 
     public function testReconcileDelegatesToInstallerAndDoesNotRemoveOrphansWhenEnabled(): void
     {
+        $expectedServices = ['service1', 'service2'];
+
         $this->serviceInstaller->expects($this->once())
             ->method('reconcile')
-            ->with($this->context);
+            ->with($this->context)
+            ->willReturn($expectedServices);
 
         $this->serviceLifecycle->expects($this->never())
             ->method('uninstall');
@@ -260,7 +235,7 @@ class LifecycleManagerTest extends TestCase
 
         $manager = $this->createManager($this->createAppRepository());
 
-        $manager->reconcile($this->context);
+        static::assertSame($expectedServices, $manager->reconcile($this->context));
     }
 
     public function testReconcileDoesNothingWhenServicesDisabled(): void
@@ -270,7 +245,7 @@ class LifecycleManagerTest extends TestCase
 
         $manager = $this->createManager($this->createAppRepository(), enabled: 'false');
 
-        $manager->reconcile($this->context);
+        static::assertSame([], $manager->reconcile($this->context));
     }
 
     /**

--- a/tests/unit/Core/Service/MessageHandler/InstallServicesHandlerTest.php
+++ b/tests/unit/Core/Service/MessageHandler/InstallServicesHandlerTest.php
@@ -19,7 +19,7 @@ class InstallServicesHandlerTest extends TestCase
     {
         $lifecycleManager = $this->createMock(LifecycleManager::class);
         $lifecycleManager->expects($this->once())
-            ->method('install')
+            ->method('reconcile')
             ->with(static::isInstanceOf(Context::class));
 
         $handler = new InstallServicesHandler($lifecycleManager);

--- a/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
+++ b/tests/unit/Core/Service/ScheduledTask/InstallServicesTaskHandlerTest.php
@@ -19,7 +19,7 @@ class InstallServicesTaskHandlerTest extends TestCase
     {
         $manager = $this->createMock(LifecycleManager::class);
         $manager->expects($this->once())
-            ->method('install');
+            ->method('reconcile');
 
         $handler = new InstallServicesTaskHandler(
             static::createStub(EntityRepository::class),


### PR DESCRIPTION
### 1. Why is this change necessary?

The daily `services.install` scheduled task only *installs* newly-registered self-managed services. An already-installed service is updated **only** when the service pushes an update (`POST /api/services/trigger-update`). That push is best-effort: if the queue worker was down, the message was lost, or the service never pushed, the shop drifts from the registry's latest revision with no self-healing.

### 2. What does this change do, exactly?

Turns the scheduled pass into a **reconcile pass** — the level-triggered counterpart to the event-driven push, both converging on the same idempotent update path:

- `AllServiceInstaller::reconcile()` — from a single registry snapshot, installs newly-registered services (unchanged) **and** dispatches the existing `UpdateServiceMessage` for every already-installed service still in the registry.
- `LifecycleManager::reconcile()` — gates on `enabled()` and delegates to the installer. **Orphan removal is intentionally not part of this pass** (it stays at system-update time, via `sync()`), so the pass is additive-only and non-destructive.
- `InstallServicesTaskHandler` now calls `reconcile()` instead of `install()`.

Updates are idempotent (`ServiceLifecycle::update` no-ops when the installed revision already matches), so re-running is a cheap no-op for up-to-date services and a push + the daily pull can't conflict on outcome.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable services and install a self-managed service.
2. Publish a newer revision for it in the service registry **without** triggering a push.
3. Run the `services.install` scheduled task.
4. The installed service is updated to the new revision. Previously it stayed stale until a push arrived.

### 4. Please link to the relevant issues (if any).

_None._

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - A `changelog/_unreleased` entry is included. The touched classes are `@internal`; there is no external API or breaking change, so no `RELEASE_INFO` / `UPGRADE` entry is required.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
