### PR TITLE
fix: hydrate file hash during media hydration

### DIFF
--- a/src/Core/Content/Media/MediaHydrator.php
+++ b/src/Core/Content/Media/MediaHydrator.php
@@ -62,6 +62,9 @@ class MediaHydrator extends EntityHydrator
         if (isset($row[$root . '.updatedAt'])) {
             $entity->updatedAt = new \DateTimeImmutable($row[$root . '.updatedAt']);
         }
+        if (isset($row[$root . '.fileHash'])) {
+            $entity->fileHash = $row[$root . '.fileHash'];
+        }
         $entity->user = $this->manyToOne($row, $root, $definition->getField('user'), $context);
         $entity->mediaFolder = $this->manyToOne($row, $root, $definition->getField('mediaFolder'), $context);
 

--- a/tests/unit/Core/Content/Media/MediaHydratorTest.php
+++ b/tests/unit/Core/Content/Media/MediaHydratorTest.php
@@ -72,6 +72,7 @@ class MediaHydratorTest extends TestCase
                 'test.path' => 'media/foo.jpg',
                 'test.private' => false,
                 'test.metaDataRaw' => json_encode(['foo' => 'bar']),
+                'test.fileHash' => 'hash',
             ],
         ];
 
@@ -97,6 +98,7 @@ class MediaHydratorTest extends TestCase
         static::assertSame($date->format(Defaults::STORAGE_DATE_TIME_FORMAT), $first->getUpdatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT));
         static::assertSame('media/foo.jpg', $first->getPath());
         static::assertFalse($first->isPrivate());
+        static::assertSame('hash', $first->getFileHash());
     }
 
     public function testHydrationForTranslation(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The `media` table has a `file_hash` column, which is automatically populated by the database from `meta_data->$.hash`.
The `MediaDefinition` has that field as part of the defined fields.

While the `MediaEntity` has the `fileHash` property, it is never populated by the `MediaHydrator` even though it is fetched due to it's presence in the defined fields.


### 2. What does this change do, exactly?

The `MediaHydrator` will check for the existence of the file hash and populate the property in `MediaEntity`, if present.


### 3. Describe each step to reproduce the issue or behaviour.

1. Create a media entry with a file hash present.
2. Use `media.repository` to fetch a `MediaCollection` with full `MediaEntity`s
3. `fileHash` will be `null`


### 4. Please link to the relevant issues (if any).

I've not found nor created an issue for this.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
