### PR TITLE
fix: resolve image slider preview from media entity

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/config.spec.js
@@ -352,4 +352,52 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
         expect(wrapper.vm.element.config.sliderItems.value).toHaveLength(1);
         expect(wrapper.vm.element.config.sliderItems.value[0].mediaUrl).toBe('http://shopware.com/image1-updated.jpg');
     });
+
+    it('should prefer the resolved media item url in the settings link preview', async () => {
+        const wrapper = await createWrapper('settings', [
+            {
+                mediaId: '1',
+                mediaUrl: 'http://shopware.com/image1-stale.jpg',
+                ariaLabel: null,
+                newTab: false,
+                url: null,
+            },
+        ]);
+        await flushPromises();
+
+        await wrapper.setData({
+            mediaItems: [
+                {
+                    id: '1',
+                    url: 'http://shopware.com/image1-current.jpg',
+                },
+            ],
+        });
+        await wrapper.vm.$nextTick();
+
+        const previewImage = wrapper.find('.sw-cms-el-config-image-slider__settings-link-prefix');
+
+        expect(previewImage.exists()).toBe(true);
+        expect(previewImage.attributes('src')).toBe('http://shopware.com/image1-current.jpg');
+    });
+
+    it('should not render a settings link preview when the media item cannot be resolved', async () => {
+        const wrapper = await createWrapper('settings', [
+            {
+                mediaId: 'missing-media',
+                mediaUrl: 'http://shopware.com/image1-stale.jpg',
+                ariaLabel: null,
+                newTab: false,
+                url: null,
+            },
+        ]);
+        await flushPromises();
+
+        await wrapper.setData({ mediaItems: [] });
+        await wrapper.vm.$nextTick();
+
+        const previewImage = wrapper.find('.sw-cms-el-config-image-slider__settings-link-prefix');
+
+        expect(previewImage.exists()).toBe(false);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -341,6 +341,6 @@ export default {
             return this.mediaItems.find((item) => {
                 return item.id === mediaId;
             });
-        }
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -336,5 +336,11 @@ export default {
 
             this.$emit('element-update', this.element);
         },
+
+        getMediaItemById(mediaId) {
+            return this.mediaItems.find((item) => {
+                return item.id === mediaId;
+            });
+        }
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -327,9 +327,9 @@
                                 class="sw-cms-el-config-image-slider__settings-link-container"
                             >
                                 <img
-                                    v-if="sliderItem.mediaUrl"
+                                    v-if="getMediaItemById(sliderItem.mediaId)"
                                     class="sw-cms-el-config-image-slider__settings-link-prefix"
-                                    :src="sliderItem.mediaUrl"
+                                    :src="getMediaItemById(sliderItem.mediaId).url"
                                     alt=""
                                 >
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The image slider configuration in Administration still used the persisted `mediaUrl` for the link preview image. After a domain change or database copy, that stored URL can become stale and show the wrong preview or no preview at all.

### 2. What does this change do, exactly?

The link preview in the image slider configuration now resolves the image from the currently loaded media entity via `mediaId` instead of reusing the persisted `mediaUrl`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create or edit a Shopping Experience with an image slider element.
2. Assign an image and save the layout.
3. Change the `mediaUrl` of the corresponding `sliderItem` in `cms_slot_translation.config` in the database to simulate an outdated URL.
4. Open the image slider configuration and go to the link settings.
5. Observe that the preview image is based on the persisted `mediaUrl` instead of the currently resolved media entity URL.

<img width="1300" height="1424" alt="Bildschirmfoto 2026-07-08 um 12 53 33" src="https://github.com/user-attachments/assets/35654f77-ec68-4627-87eb-d856d7959c4a" />

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6739

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
