### PR TITLE
fix: accept present-null honeypot captcha parameter

### DIFF
--- a/src/Storefront/Framework/Captcha/HoneypotCaptcha.php
+++ b/src/Storefront/Framework/Captcha/HoneypotCaptcha.php
@@ -50,7 +50,7 @@ class HoneypotCaptcha extends AbstractCaptcha
             return \count($this->validator->validate($this)) < 1;
         }
 
-        return $request->request->get(self::CAPTCHA_REQUEST_PARAMETER, '') === '';
+        return ($request->request->get(self::CAPTCHA_REQUEST_PARAMETER) ?? '') === '';
     }
 
     /**

--- a/tests/unit/Storefront/Framework/Captcha/HoneypotCaptchaTest.php
+++ b/tests/unit/Storefront/Framework/Captcha/HoneypotCaptchaTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Captcha;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
+use Shopware\Storefront\Framework\Captcha\HoneypotCaptcha;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(HoneypotCaptcha::class)]
+class HoneypotCaptchaTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $requestParameters
+     */
+    #[DataProvider('honeypotProvider')]
+    #[TestDox('The honeypot captcha is valid only when the honeypot field is empty')]
+    public function testIsValid(array $requestParameters, bool $expectedValid): void
+    {
+        Feature::fake(['v6.8.0.0'], function () use ($requestParameters, $expectedValid): void {
+            $captcha = new HoneypotCaptcha(static::createStub(ValidatorInterface::class));
+
+            static::assertSame(
+                $expectedValid,
+                $captcha->isValid(new Request(request: $requestParameters), [])
+            );
+        });
+    }
+
+    /**
+     * @return \Generator<string, array{0: array<string, mixed>, 1: bool}>
+     */
+    public static function honeypotProvider(): \Generator
+    {
+        yield 'absent honeypot field is valid' => [[], true];
+        yield 'empty honeypot field is valid' => [[HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER => ''], true];
+        // InputBag::get() returns a present-but-null value as null (not the default), so without the
+        // null-coalescing fix `null === ''` would wrongly reject this empty submission.
+        yield 'present-but-null honeypot field is valid' => [[HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER => null], true];
+        yield 'filled honeypot field is invalid' => [[HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER => 'i-am-a-bot'], false];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Carved out of #18056 (integration-major adaptation). In v6.8 major mode, `HoneypotCaptcha` rejects a legitimately-empty submission when the honeypot field is present with a `null` value — a real bug, reproducible today.

### 2. What does this change do, exactly?

`HoneypotCaptcha::isValid()` (v6.8 path) decided emptiness via `$request->request->get(self::CAPTCHA_REQUEST_PARAMETER, '') === ''`. `Symfony\Component\HttpFoundation\InputBag::get()` returns a **present-but-null** value as `null` (it does not fall back to the `''` default), so `null === ''` is `false` and the honeypot is treated as "filled" — rejecting a valid empty submission, where the legacy `Blank` constraint accepted it. The check now reads `($request->request->get(self::CAPTCHA_REQUEST_PARAMETER) ?? '') === ''`.

### 3. Describe each step to reproduce the issue or behaviour.

Added unit test `tests/unit/Storefront/Framework/Captcha/HoneypotCaptchaTest.php` (runs under `Feature::fake(['v6.8.0.0'])`): a `Request` with the honeypot parameter present and `null` must be valid. This case fails without the change (`false is not true`) and passes with it; absent / empty / filled cases are covered too.

### 4. Please link to the relevant issues (if any).

- fixes #18136

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
