### PR TITLE
test: adapt Storefront integration tests to v6.8 major mode

### DIFF
--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -265,6 +265,7 @@ class ControllerRateLimiterTest extends TestCase
 
         $newsletterRequestRoute = $this->createMock(AbstractNewsletterSubscribeRoute::class);
         $newsletterRequestRoute->method('subscribe')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
+        $newsletterRequestRoute->method('subscribeWithResponse')->willThrowException(new RateLimitExceededException($now->getTimestamp() + 5));
 
         $controller = new FormController(
             static::getContainer()->get(ContactFormRoute::class),

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Adapter\Cache\Http\CacheStore;
 use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -211,6 +212,14 @@ class HttpCacheIntegrationTest extends TestCase
 
         $this->addEventListener(static::getContainer()->get('event_dispatcher'), KernelEvents::RESPONSE, static function (ResponseEvent $event) use ($route): void {
             if ($event->getRequest()->getPathInfo() !== $route) {
+                return;
+            }
+            if (Feature::isActive('v6.8.0.0')) {
+                // with v6.8.0.0 cache policies drive the headers: the script's shared max age
+                // overrides the policy's s-maxage, invalidation states are removed
+                static::assertSame(5, $event->getResponse()->getMaxAge());
+                static::assertNull($event->getResponse()->headers->get(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
+
                 return;
             }
             static::assertSame(5, $event->getResponse()->getMaxAge());

--- a/tests/integration/Storefront/Framework/Cache/_fixtures/http-cache-cases/Resources/scripts/storefront-custom-cache-config/script.twig
+++ b/tests/integration/Storefront/Framework/Cache/_fixtures/http-cache-cases/Resources/scripts/storefront-custom-cache-config/script.twig
@@ -1,5 +1,5 @@
 {% set response = services.response.render('@Storefront/storefront/base.html.twig', { 'page': hook.page }) %}
 {% do response.cache.invalidationState('logged-in') %}
-{% do response.cache.maxAge(5) %}
+{% do response.cache.sharedMaxAge(5) %}
 
 {% do hook.setResponse(response) %}

--- a/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBu
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
@@ -160,6 +161,8 @@ class ThumbnailExtensionTest extends TestCase
             'layout' => $layout,
             'media' => $this->createExampleMediaWithThumbnails([280, 400, 800, 1920]),
             'context' => Generator::generateSalesChannelContext(),
+            // with v6.8.0.0 breakpoint defaults are only resolved for theme-bound renders
+            'themeId' => Uuid::randomHex(),
         ]);
 
         $sizes = self::getSizesAttribute($result);

--- a/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\CloneBehavior;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
@@ -336,8 +337,8 @@ class ThemeLifecycleServiceTest extends TestCase
         $firstTranslation = $theme->getTranslations()->first();
         static::assertNotNull($firstTranslation);
         static::assertSame('en-GB', $firstTranslation->getLanguage()?->getLocale()?->getCode());
-        static::assertSame(['fields.sw-image' => 'test label'], $firstTranslation->getLabels());
-        static::assertSame(['fields.sw-image' => 'test help'], $firstTranslation->getHelpTexts());
+        static::assertSame(['fields.sw-image' => 'test label'], Feature::silent('v6.8.0.0', fn () => $firstTranslation->getLabels()));
+        static::assertSame(['fields.sw-image' => 'test help'], Feature::silent('v6.8.0.0', fn () => $firstTranslation->getHelpTexts()));
     }
 
     public function testItUsesEnglishTranslationsAsFallbackIfDefaultLanguageIsNotProvided(): void
@@ -354,18 +355,18 @@ class ThemeLifecycleServiceTest extends TestCase
         $translation = $this->getTranslationByLocale('de-DE-1', $theme->getTranslations());
         static::assertSame([
             'fields.sw-image' => 'test label',
-        ], $translation->getLabels());
+        ], Feature::silent('v6.8.0.0', fn () => $translation->getLabels()));
         static::assertSame([
             'fields.sw-image' => 'test help',
-        ], $translation->getHelpTexts());
+        ], Feature::silent('v6.8.0.0', fn () => $translation->getHelpTexts()));
 
         $germanTranslation = $this->getTranslationByLocale('de-DE', $theme->getTranslations());
         static::assertSame([
             'fields.sw-image' => 'Test label',
-        ], $germanTranslation->getLabels());
+        ], Feature::silent('v6.8.0.0', fn () => $germanTranslation->getLabels()));
         static::assertSame([
             'fields.sw-image' => 'Test Hilfe',
-        ], $germanTranslation->getHelpTexts());
+        ], Feature::silent('v6.8.0.0', fn () => $germanTranslation->getHelpTexts()));
     }
 
     public function testItRemovesAThemeCorrectly(): void

--- a/tests/integration/Storefront/Theme/ThemeTest.php
+++ b/tests/integration/Storefront/Theme/ThemeTest.php
@@ -326,7 +326,7 @@ class ThemeTest extends TestCase
             }
         }
 
-        static::assertEquals($themeInheritedConfig, $theme);
+        static::assertEquals(ThemeFixtures::stripLabelsAndHelpTexts($themeInheritedConfig), $theme);
     }
 
     /**
@@ -374,7 +374,7 @@ class ThemeTest extends TestCase
             }
         }
 
-        static::assertEquals($themeInheritedConfig, $theme);
+        static::assertEquals(ThemeFixtures::stripLabelsAndHelpTexts($themeInheritedConfig), $theme);
     }
 
     public function testInheritedSecondLevelThemeConfig(): void
@@ -437,7 +437,7 @@ class ThemeTest extends TestCase
         $themeInheritedConfig['themeTechnicalName'] = $theme['themeTechnicalName'];
         $themeInheritedConfig['currentFields']['sw-color-brand-secondary']['value'] = '#474a57';
 
-        static::assertEquals($themeInheritedConfig, $theme);
+        static::assertEquals(ThemeFixtures::stripLabelsAndHelpTexts($themeInheritedConfig), $theme);
     }
 
     public function testThemeConfigWithMultiSelect(): void

--- a/tests/integration/Storefront/Theme/fixtures/ThemeFixtures.php
+++ b/tests/integration/Storefront/Theme/fixtures/ThemeFixtures.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Tests\Integration\Storefront\Theme\fixtures;
 
+use Shopware\Core\Framework\Feature;
+
 /**
  * @internal
  */
@@ -255,7 +257,7 @@ class ThemeFixtures
      */
     public static function getThemeStructuredFields(): array
     {
-        return [
+        return self::stripStructuredLabelsAndHelpTexts([
             'tabs' => [
                 'default' => [
                     'label' => '',
@@ -560,7 +562,7 @@ class ThemeFixtures
             ],
             'themeTechnicalName' => 'Storefront',
             'configInheritance' => [],
-        ];
+        ]);
     }
 
     /**
@@ -568,7 +570,7 @@ class ThemeFixtures
      */
     public static function getThemeInheritedConfig(string $faviconId, string $demostoreLogoId): array
     {
-        return [
+        return self::stripLabelsAndHelpTexts([
             'fields' => [
                 'sw-color-brand-primary' => [
                     'name' => 'sw-color-brand-primary',
@@ -1278,7 +1280,7 @@ class ThemeFixtures
                 ],
             ],
             'configInheritance' => self::getConfigInheritance(),
-        ];
+        ]);
     }
 
     /**
@@ -1286,7 +1288,7 @@ class ThemeFixtures
      */
     public static function getThemeInheritedBlankConfig(string $faviconId, string $demostoreLogoId): array
     {
-        return [
+        return self::stripLabelsAndHelpTexts([
             'fields' => [
                 'sw-color-brand-primary' => [
                     'name' => 'sw-color-brand-primary',
@@ -1996,7 +1998,7 @@ class ThemeFixtures
                 ],
             ],
             'configInheritance' => self::getConfigInheritance(),
-        ];
+        ]);
     }
 
     /**
@@ -2004,7 +2006,7 @@ class ThemeFixtures
      */
     public static function getThemeConfig(string $faviconId, string $demostoreLogoId): array
     {
-        return [
+        return self::stripLabelsAndHelpTexts([
             'fields' => [
                 'sw-color-brand-primary' => [
                     'name' => 'sw-color-brand-primary',
@@ -2714,7 +2716,32 @@ class ThemeFixtures
                 ],
             ],
             'configInheritance' => [],
-        ];
+        ]);
+    }
+
+    /**
+     * With v6.8.0.0 the merged theme config no longer exposes field labels and help texts
+     * ({@see \Shopware\Storefront\Theme\ThemeMergedConfigBuilder}), only the snippet keys remain.
+     *
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public static function stripLabelsAndHelpTexts(array $config): array
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return $config;
+        }
+
+        foreach (array_keys($config['fields'] ?? []) as $key) {
+            unset($config['fields'][$key]['label'], $config['fields'][$key]['helpText']);
+        }
+
+        foreach (array_keys($config['blocks'] ?? []) as $key) {
+            unset($config['blocks'][$key]['label']);
+        }
+
+        return $config;
     }
 
     /**
@@ -2725,5 +2752,35 @@ class ThemeFixtures
         return [
             0 => '@Storefront',
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $structure
+     *
+     * @return array<string, mixed>
+     */
+    private static function stripStructuredLabelsAndHelpTexts(array $structure): array
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return $structure;
+        }
+
+        foreach ($structure['tabs'] ?? [] as $tabKey => $tab) {
+            unset($structure['tabs'][$tabKey]['label']);
+            foreach ($tab['blocks'] ?? [] as $blockKey => $block) {
+                unset($structure['tabs'][$tabKey]['blocks'][$blockKey]['label']);
+                foreach ($block['sections'] ?? [] as $sectionKey => $section) {
+                    unset($structure['tabs'][$tabKey]['blocks'][$blockKey]['sections'][$sectionKey]['label']);
+                    foreach (array_keys($section['fields'] ?? []) as $fieldKey) {
+                        unset(
+                            $structure['tabs'][$tabKey]['blocks'][$blockKey]['sections'][$sectionKey]['fields'][$fieldKey]['label'],
+                            $structure['tabs'][$tabKey]['blocks'][$blockKey]['sections'][$sectionKey]['fields'][$fieldKey]['helpText'],
+                        );
+                    }
+                }
+            }
+        }
+
+        return $structure;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Carved out of #18056. These Storefront integration tests assert pre-major behavior against intentional v6.8 changes, so they fail under the `integration-major` nightly (#17975). Test-only, no production code.

### 2. What does this change do, exactly?

- `ThemeTest` / `ThemeFixtures`: strip `label`/`helpText` under major, mirroring `ThemeMergedConfigBuilder`.
- `ThemeLifecycleServiceTest`: `Feature::silent` around persisted-but-deprecated translation getters.
- `ThumbnailExtensionTest`: render with a `themeId` — breakpoint defaults are only resolved for theme-bound renders in major.
- `HttpCacheIntegrationTest` (+ the `storefront-custom-cache-config` script fixture): in v6.8 cache policies drive the headers and invalidation states are removed; the fixture is migrated from the deprecated `maxAge()` to `sharedMaxAge()`.
- `ControllerRateLimiterTest`: mock `subscribeWithResponse()` (the method the controller calls in major).

### 3. Describe each step to reproduce the issue or behaviour.

```bash
APP_ENV=test FEATURE_ALL=major BLUE_GREEN_DEPLOYMENT=1 FORCE_INSTALL=true composer init:testdb
APP_ENV=test FEATURE_ALL=major BLUE_GREEN_DEPLOYMENT=1 vendor/bin/phpunit --testsuite integration --filter '<test>'
```

Verified via the `major-tests` CI matrix; these integration tests require a major-migrated test DB.

### 4. Please link to the relevant issues (if any).

- fixes #18140

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
