### PR TITLE
fix: resolve service label through the translation fallback chain

### DIFF
--- a/src/Core/Service/DTO/Service.php
+++ b/src/Core/Service/DTO/Service.php
@@ -74,10 +74,9 @@ readonly class Service
 
     private static function label(AppEntity $app): string
     {
-        $label = $app->getLabel();
-        \assert($label !== null);
+        $label = $app->getTranslation('label');
 
-        return $label;
+        return \is_string($label) && $label !== '' ? $label : $app->getName();
     }
 
     private static function description(AppEntity $app): ?string

--- a/tests/unit/Core/Service/DTO/ServiceTest.php
+++ b/tests/unit/Core/Service/DTO/ServiceTest.php
@@ -20,8 +20,9 @@ class ServiceTest extends TestCase
         $createdAt = new \DateTimeImmutable('2026-01-01 12:00:00');
         $updatedAt = new \DateTimeImmutable('2026-01-02 12:00:00');
         $app = AppFixture::createAppEntity(name: 'MyService', id: 'service-id');
-        $app->setLabel('My service');
+        $app->setLabel('My plain label');
         $app->setTranslated([
+            'label' => 'My translated label',
             'description' => 'My translated description',
         ]);
         $app->setIcon('service-icon');
@@ -39,7 +40,7 @@ class ServiceTest extends TestCase
 
         static::assertSame('service-id', $service->id);
         static::assertSame('MyService', $service->name);
-        static::assertSame('My service', $service->label);
+        static::assertSame('My translated label', $service->label);
         static::assertTrue($service->active);
         static::assertSame('service-icon', $service->icon);
         static::assertSame('My translated description', $service->description);
@@ -66,5 +67,32 @@ class ServiceTest extends TestCase
         static::assertSame([], $service->domains);
         static::assertSame([], $service->requirements);
         static::assertSame(State::INACTIVE, $service->state);
+    }
+
+    public function testLabelUsesTranslationWhenRequestedLanguageHasNoLabel(): void
+    {
+        $app = AppFixture::createAppEntity(name: 'MyService');
+        $app->setLabel(null);
+        $app->setTranslated(['label' => 'My translated label']);
+
+        static::assertSame('My translated label', Service::fromApp($app)->label);
+    }
+
+    public function testLabelFallsBackToNameWhenNoTranslationResolves(): void
+    {
+        $app = AppFixture::createAppEntity(name: 'MyService');
+        $app->setLabel(null);
+        $app->setTranslated([]);
+
+        static::assertSame('MyService', Service::fromApp($app)->label);
+    }
+
+    public function testLabelFallsBackToNameWhenTranslationIsEmpty(): void
+    {
+        $app = AppFixture::createAppEntity(name: 'MyService');
+        $app->setLabel(null);
+        $app->setTranslated(['label' => '']);
+
+        static::assertSame('MyService', Service::fromApp($app)->label);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The Shopware Services admin page fails to load with `Service::label(): Return value must be of type string, null returned` whenever the admin's content language has no label translation for a service — e.g. a freshly created language, or a German admin viewing services that only ship English labels.

`label` is a translated field and the plain property does not use the translation fallback chain. The old listing handled this (`getTranslated()['label'] ?? getName()`); the DTO introduced in #16988 made it strict, so one missing translation breaks the whole page.

### 2. What does this change do, exactly?

`Service::label()` now resolves the label through the translation fallback chain and falls back to the technical app name when no translation resolves (empty string counts as missing) — the previous listing's semantics. Covered by unit tests for all three cases.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new language and switch the admin content language to it.
2. Open Settings > System > Shopware Services.

Before: error banner, page unusable. After: the page loads with labels resolved through the chain.

### 4. Please link to the relevant issues (if any).

- relates #16843 (QA follow-up)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers (not relevant: unreleased feature branch)
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
