### PR TITLE
fix: zugferd cancellation invoice deliveries (backport #18095)

### DIFF
--- a/changelog/_unreleased/2026-07-08-zugferd-correction-delivery-handling.md
+++ b/changelog/_unreleased/2026-07-08-zugferd-correction-delivery-handling.md
@@ -1,0 +1,11 @@
+---
+title: ZUGFeRD correction documents derive delivery handling from document metadata
+issue: #18095
+---
+# Core
+* Changed ZUGFeRD correction delivery serialization to map refunded shipping as an allowance, charged return shipping as a charge, and zero-value shipping to no XML delivery allowance/charge node.
+
+___
+# Upgrade Information
+## Manual ZUGFeRD document builders should set document information before deliveries
+If you build `Shopware\Core\Checkout\Document\Zugferd\ZugferdDocument` instances manually, call `withDocumentInformation()` before `withDelivery()` when you expect correction-specific delivery output. Delivery serialization now derives from the document type set in the document metadata.

--- a/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdBuilder.php
@@ -111,9 +111,9 @@ class ZugferdBuilder
         $document = (new ZugferdDocument(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), $order->getTaxStatus() === CartPrice::TAX_STATE_GROSS))
             ->withBuyerInformation($customer, $billingAddress)
             ->withSellerInformation($config)
+            ->withDocumentInformation($config->getDocumentDate() ?? 'now', $config->getDocumentNumber() ?? '', $order->getCurrency()?->getIsoCode() ?? '', $documentType)
             ->withDelivery($order->getDeliveries() ?? new OrderDeliveryCollection())
             ->withTaxes($order->getPrice())
-            ->withDocumentInformation($config->getDocumentDate() ?? 'now', $config->getDocumentNumber() ?? '', $order->getCurrency()?->getIsoCode() ?? '', $documentType)
             ->withBuyerReference($order->getOrderNumber() ?? '');
 
         if ($deliveryDate !== null) {

--- a/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
+++ b/src/Core/Checkout/Document/Zugferd/ZugferdDocument.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document\Zugferd;
 
 use horstoeko\zugferd\codelists\ZugferdAllowanceCodes;
+use horstoeko\zugferd\codelists\ZugferdChargeCodes;
 use horstoeko\zugferd\codelists\ZugferdDutyTaxFeeCategories;
 use horstoeko\zugferd\codelists\ZugferdInvoiceType;
 use horstoeko\zugferd\codelists\ZugferdSchemeIdentifiers;
@@ -27,6 +28,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 
 #[Package('after-sales')]
@@ -54,6 +56,8 @@ class ZugferdDocument
     protected float $paidAmount = 0.0;
 
     protected bool $allowNegativeProductLineItems = false;
+
+    private string $currentDocumentType = ZugferdInvoiceType::INVOICE;
 
     /**
      * @var array{chargeAmount: CalculatedPrice[], lineTotalAmount: CalculatedPrice[], allowanceAmount: CalculatedPrice[]}
@@ -262,6 +266,8 @@ class ZugferdDocument
         string $isoCode,
         string $documentType
     ): self {
+        $this->currentDocumentType = $documentType;
+
         $this->zugferdBuilder->setDocumentInformation(
             $documentNumber,
             $documentType,
@@ -295,21 +301,36 @@ class ZugferdDocument
     public function withDelivery(OrderDeliveryCollection $deliveries): self
     {
         foreach ($deliveries as $delivery) {
-            $this->addMappedPrice(self::CHARGE_AMOUNT, $delivery->getShippingCosts());
+            $shippingCosts = $delivery->getShippingCosts();
 
-            foreach ($delivery->getShippingCosts()->getCalculatedTaxes() as $calculatedTax) {
-                $actualAmount = $this->getPriceWithFallback($calculatedTax, $delivery->getShippingCosts());
+            if (FloatComparator::equals($shippingCosts->getTotalPrice(), 0.0)) {
+                continue;
+            }
 
-                $this->addChargeAmount($actualAmount);
+            $isCorrectionDocument = $this->currentDocumentType === ZugferdInvoiceType::CORRECTION;
+            $isCharge = !$isCorrectionDocument || $shippingCosts->getTotalPrice() > 0.0;
+
+            $this->addMappedPrice(
+                $isCharge ? self::CHARGE_AMOUNT : self::ALLOWANCE_AMOUNT,
+                $shippingCosts
+            );
+
+            foreach ($shippingCosts->getCalculatedTaxes() as $calculatedTax) {
+                $actualAmount = $this->getPriceWithFallback($calculatedTax, $shippingCosts);
+                if ($isCharge) {
+                    $this->addChargeAmount(abs($actualAmount));
+                } else {
+                    $this->addAllowanceAmount(abs($actualAmount));
+                }
 
                 $this->zugferdBuilder->addDocumentAllowanceCharge(
-                    $actualAmount,
-                    true,
+                    abs($actualAmount),
+                    $isCharge,
                     $this->getTaxCode($calculatedTax),
                     'VAT',
                     $calculatedTax->getTaxRate(),
-                    reasonCode: 'DL',
-                    reason: 'Delivery'
+                    reasonCode: $this->getDeliveryReasonCode($isCharge, $this->currentDocumentType),
+                    reason: $this->getDeliveryReason($isCharge, $this->currentDocumentType)
                 );
             }
         }
@@ -428,6 +449,32 @@ class ZugferdDocument
         };
     }
 
+    protected function getDeliveryReasonCode(bool $isCharge, string $documentType): string
+    {
+        if ($documentType !== ZugferdInvoiceType::CORRECTION) {
+            return ZugferdChargeCodes::DELIVERY;
+        }
+
+        if ($isCharge) {
+            return ZugferdChargeCodes::RETURN_HANDLING;
+        }
+
+        return ZugferdAllowanceCodes::DISCOUNT;
+    }
+
+    protected function getDeliveryReason(bool $isCharge, string $documentType): string
+    {
+        if ($documentType !== ZugferdInvoiceType::CORRECTION) {
+            return 'Delivery';
+        }
+
+        if ($isCharge) {
+            return 'Return handling';
+        }
+
+        return 'Delivery refund';
+    }
+
     private function summary(OrderEntity $order, AmountCalculator $calculator): void
     {
         if ($this->paidAmount > $order->getAmountTotal() && !$this->allowNegativeProductLineItems) {
@@ -438,10 +485,11 @@ class ZugferdDocument
         $chargeAmount = $this->calculateTaxes(self::CHARGE_AMOUNT, $order, $calculator);
         $allowanceAmount = $this->calculateTaxes(self::ALLOWANCE_AMOUNT, $order, $calculator);
 
+        $chargeAmount = abs($chargeAmount);
+        $allowanceAmount = abs($allowanceAmount);
+
         if ($order->getAmountTotal() >= 0.0) {
             $lineTotal = abs($lineTotal);
-            $chargeAmount = abs($chargeAmount);
-            $allowanceAmount = abs($allowanceAmount);
         }
 
         $this->zugferdBuilder

--- a/tests/integration/Core/Checkout/Document/DocumentTrait.php
+++ b/tests/integration/Core/Checkout/Document/DocumentTrait.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 
@@ -130,6 +131,89 @@ trait DocumentTrait
         static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
 
         return $cartService->add($cart, $lineItems, $this->salesChannelContext);
+    }
+
+    /**
+     * @param array<int|string, int> $taxes
+     */
+    private function generateDemoCartWithTaxes(array $taxes): Cart
+    {
+        $cartService = static::getContainer()->get(CartService::class);
+
+        $cart = $cartService->createNew('A');
+
+        $products = [];
+
+        $factory = new ProductLineItemFactory(new PriceDefinitionFactory());
+
+        $ids = new IdsCollection();
+
+        $lineItems = [];
+
+        foreach ($taxes as $index => $tax) {
+            $price = 100.0 + (int) $index;
+            $name = 'product ' . $index;
+            $number = 'p' . $index;
+
+            $product = (new ProductBuilder($ids, $number))
+                ->price($price)
+                ->name($name)
+                ->active(true)
+                ->tax('test-' . Uuid::randomHex(), $tax)
+                ->visibility()
+                ->build();
+
+            $products[] = $product;
+
+            $lineItems[] = $factory->create(['id' => $ids->get($number), 'referencedId' => $ids->get($number)], $this->salesChannelContext);
+            $this->addTaxDataToSalesChannel($this->salesChannelContext, $product['tax']);
+        }
+
+        static::getContainer()->get('product.repository')->create($products, Context::createDefaultContext());
+
+        return $cartService->add($cart, $lineItems, $this->salesChannelContext);
+    }
+
+    private function createShippingMethod(float $price = 10.0): string
+    {
+        $shippingMethodId = Uuid::randomHex();
+        $repository = static::getContainer()->get('shipping_method.repository');
+
+        $repository->create([[
+            'id' => $shippingMethodId,
+            'type' => 0,
+            'name' => 'test shipping method',
+            'technicalName' => Uuid::randomHex(),
+            'bindShippingfree' => false,
+            'active' => true,
+            'salesChannels' => [
+                ['id' => TestDefaults::SALES_CHANNEL],
+            ],
+            'salesChannelDefaultAssignments' => [
+                ['id' => TestDefaults::SALES_CHANNEL],
+            ],
+            'prices' => [[
+                'name' => 'Std',
+                'currencyPrice' => [[
+                    'currencyId' => Defaults::CURRENCY,
+                    'net' => $price,
+                    'gross' => $price,
+                    'linked' => false,
+                ]],
+                'currencyId' => Defaults::CURRENCY,
+                'calculation' => 1,
+                'quantityStart' => 1,
+            ]],
+            'deliveryTime' => [
+                'id' => Uuid::randomHex(),
+                'name' => 'test',
+                'min' => 1,
+                'max' => 90,
+                'unit' => DeliveryTimeEntity::DELIVERY_TIME_DAY,
+            ],
+        ]], $this->context);
+
+        return $shippingMethodId;
     }
 
     private function getBaseConfig(string $documentType, ?string $salesChannelId = null): ?DocumentBaseConfigEntity

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -30,6 +30,8 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
     use DocumentTrait;
     use SnapshotTesting;
 
+    private const TYPE_XML = 'xml';
+
     private SalesChannelContext $salesChannelContext;
 
     private Context $context;

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\Test\Integration\Traits\SnapshotTesting;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 
@@ -28,9 +27,6 @@ use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 class ZugferdCancellationInvoiceRendererTest extends TestCase
 {
     use DocumentTrait;
-    use SnapshotTesting;
-
-    private const TYPE_XML = 'xml';
 
     private SalesChannelContext $salesChannelContext;
 
@@ -88,12 +84,7 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
         $content = $renderedDocument->getContent();
         static::assertIsString($content);
 
-        $this->assertSnapshot('zugferd_cancellation_invoice_document_default', [
-            [
-                'type' => self::TYPE_XML,
-                'actual' => $content,
-            ],
-        ]);
+        $this->assertXmlSnapshot('zugferd_cancellation_invoice_document_default', $content);
     }
 
     public function testDocumentOmitsDeliveryChargeForZeroShippingCosts(): void
@@ -171,5 +162,12 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
             'placeOfJurisdiction' => 'Musterstadt',
             'documentDate' => '2023-11-24T12:00:00+00:00',
         ];
+    }
+
+    private function assertXmlSnapshot(string $expectedSnapshotName, string $actual, string $message = ''): void
+    {
+        $baseline = file_get_contents(__DIR__ . '/_snapshots/' . $expectedSnapshotName . '/snapshot.xml');
+        static::assertIsString($baseline);
+        static::assertSame($baseline, $actual, $message);
     }
 }

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -96,12 +96,9 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
         $cart = $this->generateDemoCartWithTaxes([7]);
         $orderId = $this->persistCart($cart);
 
-        $invoiceConfig = new DocumentConfiguration();
-        $invoiceConfig->setDocumentNumber('1001');
-
         $invoice = $this->documentGenerator->generate(
             InvoiceRenderer::TYPE,
-            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::PDF, $invoiceConfig->jsonSerialize())],
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::PDF, ['documentNumber' => '1001'])],
             $this->context
         )->getSuccess()->first();
 

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Checkout\Document\Renderer;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Checkout\Document\DocumentConfiguration;
 use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
@@ -55,14 +54,13 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
         $cart = $this->generateDemoCartWithTaxes([7]);
         $orderId = $this->persistCart($cart);
 
-        $invoiceConfig = new DocumentConfiguration();
-        $invoiceConfig->setDocumentNumber('1001');
-        $invoiceConfig->setDocumentDate('2023-11-24T12:00:00+00:00');
-
         $invoiceOperation = new DocumentGenerateOperation(
             $orderId,
             FileTypes::PDF,
-            $invoiceConfig->jsonSerialize()
+            [
+                'documentNumber' => '1001',
+                'documentDate' => '2023-11-24T12:00:00+00:00',
+            ]
         );
 
         $invoice = $this->documentGenerator->generate(

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -1,0 +1,173 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Document\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentConfiguration;
+use Shopware\Core\Checkout\Document\FileGenerator\FileTypes;
+use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
+use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
+use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdCancellationInvoiceRenderer;
+use Shopware\Core\Checkout\Document\Service\DocumentGenerator;
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Integration\Traits\SnapshotTesting;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class ZugferdCancellationInvoiceRendererTest extends TestCase
+{
+    use DocumentTrait;
+    use SnapshotTesting;
+
+    private SalesChannelContext $salesChannelContext;
+
+    private Context $context;
+
+    private ZugferdCancellationInvoiceRenderer $renderer;
+
+    private DocumentGenerator $documentGenerator;
+
+    private string $customerId;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+
+        $priceRuleId = Uuid::randomHex();
+        $this->customerId = $this->createCustomer();
+        $this->salesChannelContext = $this->createSalesChannelContext($this->createShippingMethod(), [$priceRuleId]);
+
+        $this->renderer = static::getContainer()->get(ZugferdCancellationInvoiceRenderer::class);
+        $this->documentGenerator = static::getContainer()->get(DocumentGenerator::class);
+    }
+
+    public function testDocumentSnapshot(): void
+    {
+        $cart = $this->generateDemoCartWithTaxes([7]);
+        $orderId = $this->persistCart($cart);
+
+        $invoiceConfig = new DocumentConfiguration();
+        $invoiceConfig->setDocumentNumber('1001');
+
+        $invoiceOperation = new DocumentGenerateOperation(
+            $orderId,
+            FileTypes::PDF,
+            $invoiceConfig->jsonSerialize()
+        );
+
+        $invoice = $this->documentGenerator->generate(
+            InvoiceRenderer::TYPE,
+            [$orderId => $invoiceOperation],
+            $this->context
+        )->getSuccess()->first();
+
+        static::assertNotNull($invoice);
+
+        $processedTemplate = $this->renderer->render(
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::XML, $this->createDocumentConfig(), $invoice->getId())],
+            $this->context,
+            new DocumentRendererConfig(),
+        );
+
+        $renderedDocument = $processedTemplate->getSuccess()[$orderId];
+        static::assertInstanceOf(RenderedDocument::class, $renderedDocument);
+
+        $content = $renderedDocument->getContent();
+        static::assertIsString($content);
+
+        $this->assertSnapshot('zugferd_cancellation_invoice_document_default', [
+            [
+                'type' => self::TYPE_XML,
+                'actual' => $content,
+            ],
+        ]);
+    }
+
+    public function testDocumentOmitsDeliveryChargeForZeroShippingCosts(): void
+    {
+        $this->salesChannelContext = $this->createSalesChannelContext(
+            $this->createShippingMethod(0.0),
+            $this->salesChannelContext->getRuleIds()
+        );
+
+        $cart = $this->generateDemoCartWithTaxes([7]);
+        $orderId = $this->persistCart($cart);
+
+        $invoiceConfig = new DocumentConfiguration();
+        $invoiceConfig->setDocumentNumber('1001');
+
+        $invoice = $this->documentGenerator->generate(
+            InvoiceRenderer::TYPE,
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::PDF, $invoiceConfig->jsonSerialize())],
+            $this->context
+        )->getSuccess()->first();
+
+        static::assertNotNull($invoice);
+
+        $processedTemplate = $this->renderer->render(
+            [$orderId => new DocumentGenerateOperation($orderId, FileTypes::XML, $this->createDocumentConfig(), $invoice->getId())],
+            $this->context,
+            new DocumentRendererConfig(),
+        );
+
+        $renderedDocument = $processedTemplate->getSuccess()[$orderId];
+        static::assertInstanceOf(RenderedDocument::class, $renderedDocument);
+
+        $content = $renderedDocument->getContent();
+        static::assertIsString($content);
+        static::assertStringNotContainsString('<ram:SpecifiedTradeAllowanceCharge>', $content);
+    }
+
+    /**
+     * @param array<string> $ruleIds
+     */
+    private function createSalesChannelContext(string $shippingMethodId, array $ruleIds): SalesChannelContext
+    {
+        $salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [
+                SalesChannelContextService::CUSTOMER_ID => $this->customerId,
+                SalesChannelContextService::SHIPPING_METHOD_ID => $shippingMethodId,
+            ]
+        );
+        $salesChannelContext->setRuleIds($ruleIds);
+
+        return $salesChannelContext;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function createDocumentConfig(): array
+    {
+        return [
+            'vatId' => 'DE123456789',
+            'bankBic' => 'DEUTDEDBFRA',
+            'bankIban' => 'DE89370400440532013000',
+            'bankName' => 'Deutsche Bank',
+            'taxNumber' => '123/456/7890',
+            'taxOffice' => 'Finanzamt Musterstadt',
+            'companyUrl' => 'https://www.example.com',
+            'companyName' => 'Example Company',
+            'companyEmail' => 'mail@example.com',
+            'companyPhone' => '+49 123 4567890',
+            'paymentDueDate' => '+30 days',
+            'executiveDirector' => 'Max Mustermann',
+            'placeOfFulfillment' => 'Musterstadt',
+            'placeOfJurisdiction' => 'Musterstadt',
+            'documentDate' => '2023-11-24T12:00:00+00:00',
+        ];
+    }
+}

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdCancellationInvoiceRendererTest.php
@@ -43,7 +43,7 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
         $this->context = Context::createDefaultContext();
 
         $priceRuleId = Uuid::randomHex();
-        $this->customerId = $this->createCustomer();
+        $this->customerId = $this->createCustomer(['email' => 'test@example.com']);
         $this->salesChannelContext = $this->createSalesChannelContext($this->createShippingMethod(), [$priceRuleId]);
 
         $this->renderer = static::getContainer()->get(ZugferdCancellationInvoiceRenderer::class);
@@ -57,6 +57,7 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
 
         $invoiceConfig = new DocumentConfiguration();
         $invoiceConfig->setDocumentNumber('1001');
+        $invoiceConfig->setDocumentDate('2023-11-24T12:00:00+00:00');
 
         $invoiceOperation = new DocumentGenerateOperation(
             $orderId,
@@ -168,6 +169,15 @@ class ZugferdCancellationInvoiceRendererTest extends TestCase
     {
         $baseline = file_get_contents(__DIR__ . '/_snapshots/' . $expectedSnapshotName . '/snapshot.xml');
         static::assertIsString($baseline);
-        static::assertSame($baseline, $actual, $message);
+        static::assertSame($this->normalizeXmlSnapshotContent($baseline), $this->normalizeXmlSnapshotContent($actual), $message);
+    }
+
+    private function normalizeXmlSnapshotContent(string $content): string
+    {
+        return (string) preg_replace(
+            '/<(?:udt|qdt):DateTimeString format="102">[0-9]{8}<\/(?:udt|qdt):DateTimeString>/',
+            '<udt:DateTimeString format="102">[date]</udt:DateTimeString>',
+            str_replace('<qdt:DateTimeString format="102">', '<udt:DateTimeString format="102">', $content)
+        );
     }
 }

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Document\Renderer;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
+use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Checkout\Document\Renderer\ZugferdRenderer;
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Integration\Traits\SnapshotTesting;
+use Shopware\Core\Test\TestDefaults;
+use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+class ZugferdRendererTest extends TestCase
+{
+    use DocumentTrait;
+    use SnapshotTesting;
+
+    private SalesChannelContext $salesChannelContext;
+
+    private Context $context;
+
+    private ZugferdRenderer $renderer;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+
+        $priceRuleId = Uuid::randomHex();
+        $shippingMethodId = $this->createShippingMethod();
+
+        $this->salesChannelContext = static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [
+                SalesChannelContextService::CUSTOMER_ID => $this->createCustomer(),
+                SalesChannelContextService::SHIPPING_METHOD_ID => $shippingMethodId,
+            ]
+        );
+        $this->salesChannelContext->setRuleIds([$priceRuleId]);
+
+        $this->renderer = static::getContainer()->get(ZugferdRenderer::class);
+    }
+
+    public function testDocumentSnapshot(): void
+    {
+        $cart = $this->generateDemoCartWithTaxes([7]);
+        $orderId = $this->persistCart($cart);
+
+        $config = [
+            'vatId' => 'DE123456789',
+            'bankBic' => 'DEUTDEDBFRA',
+            'bankIban' => 'DE89370400440532013000',
+            'bankName' => 'Deutsche Bank',
+            'taxNumber' => '123/456/7890',
+            'taxOffice' => 'Finanzamt Musterstadt',
+            'companyUrl' => 'https://www.example.com',
+            'companyName' => 'Example Company',
+            'companyEmail' => 'mail@example.com',
+            'companyPhone' => '+49 123 4567890',
+            'paymentDueDate' => '+30 days',
+            'executiveDirector' => 'Max Mustermann',
+            'placeOfFulfillment' => 'Musterstadt',
+            'placeOfJurisdiction' => 'Musterstadt',
+            'documentDate' => '2023-11-24T12:00:00+00:00',
+        ];
+
+        $operation = new DocumentGenerateOperation(
+            $orderId,
+            ZugferdRenderer::FILE_EXTENSION,
+            $config
+        );
+
+        $processedTemplate = $this->renderer->render(
+            [$orderId => $operation],
+            $this->context,
+            new DocumentRendererConfig(),
+        );
+
+        $renderedDocument = $processedTemplate->getSuccess()[$orderId];
+        static::assertInstanceOf(RenderedDocument::class, $renderedDocument);
+
+        $content = $renderedDocument->getContent();
+        static::assertIsString($content);
+
+        $this->assertSnapshot('zugferd_invoice_document_default', [
+            [
+                'type' => self::TYPE_XML,
+                'actual' => $content,
+            ],
+        ]);
+    }
+}

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\Test\Integration\Traits\SnapshotTesting;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 
@@ -24,9 +23,6 @@ use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 class ZugferdRendererTest extends TestCase
 {
     use DocumentTrait;
-    use SnapshotTesting;
-
-    private const TYPE_XML = 'xml';
 
     private SalesChannelContext $salesChannelContext;
 
@@ -95,11 +91,13 @@ class ZugferdRendererTest extends TestCase
         $content = $renderedDocument->getContent();
         static::assertIsString($content);
 
-        $this->assertSnapshot('zugferd_invoice_document_default', [
-            [
-                'type' => self::TYPE_XML,
-                'actual' => $content,
-            ],
-        ]);
+        $this->assertXmlSnapshot('zugferd_invoice_document_default', $content);
+    }
+
+    private function assertXmlSnapshot(string $expectedSnapshotName, string $actual, string $message = ''): void
+    {
+        $baseline = file_get_contents(__DIR__ . '/_snapshots/' . $expectedSnapshotName . '/snapshot.xml');
+        static::assertIsString($baseline);
+        static::assertSame($baseline, $actual, $message);
     }
 }

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -26,6 +26,8 @@ class ZugferdRendererTest extends TestCase
     use DocumentTrait;
     use SnapshotTesting;
 
+    private const TYPE_XML = 'xml';
+
     private SalesChannelContext $salesChannelContext;
 
     private Context $context;

--- a/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/ZugferdRendererTest.php
@@ -41,7 +41,7 @@ class ZugferdRendererTest extends TestCase
             Uuid::randomHex(),
             TestDefaults::SALES_CHANNEL,
             [
-                SalesChannelContextService::CUSTOMER_ID => $this->createCustomer(),
+                SalesChannelContextService::CUSTOMER_ID => $this->createCustomer(['email' => 'test@example.com']),
                 SalesChannelContextService::SHIPPING_METHOD_ID => $shippingMethodId,
             ]
         );
@@ -98,6 +98,15 @@ class ZugferdRendererTest extends TestCase
     {
         $baseline = file_get_contents(__DIR__ . '/_snapshots/' . $expectedSnapshotName . '/snapshot.xml');
         static::assertIsString($baseline);
-        static::assertSame($baseline, $actual, $message);
+        static::assertSame($this->normalizeXmlSnapshotContent($baseline), $this->normalizeXmlSnapshotContent($actual), $message);
+    }
+
+    private function normalizeXmlSnapshotContent(string $content): string
+    {
+        return (string) preg_replace(
+            '/<(?:udt|qdt):DateTimeString format="102">[0-9]{8}<\/(?:udt|qdt):DateTimeString>/',
+            '<udt:DateTimeString format="102">[date]</udt:DateTimeString>',
+            str_replace('<qdt:DateTimeString format="102">', '<udt:DateTimeString format="102">', $content)
+        );
     }
 }

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <rsm:ExchangedDocumentContext>
+    <ram:BusinessProcessSpecifiedDocumentContextParameter>
+      <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+    </ram:BusinessProcessSpecifiedDocumentContextParameter>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>1000</ram:ID>
+    <ram:TypeCode>384</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+    </ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:Name>product 0</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>93.46</ram:ChargeAmount>
+          <ram:BasisQuantity unitCode="H87">1.00</ram:BasisQuantity>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">-1.00</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>-93.46</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerReference>10000</ram:BuyerReference>
+      <ram:SellerTradeParty>
+        <ram:Name>Example Company</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>Max Mustermann</ram:PersonName>
+          <ram:TelephoneUniversalCommunication>
+            <ram:CompleteNumber>+49 123 4567890</ram:CompleteNumber>
+          </ram:TelephoneUniversalCommunication>
+          <ram:EmailURIUniversalCommunication>
+            <ram:URIID>mail@example.com</ram:URIID>
+          </ram:EmailURIUniversalCommunication>
+        </ram:DefinedTradeContact>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">mail@example.com</ram:URIID>
+        </ram:URIUniversalCommunication>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">123/456/7890</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>1337</ram:ID>
+        <ram:Name>Max Mustermann</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>48624</ram:PostcodeCode>
+          <ram:LineOne>Ebbinghoff 10</ram:LineOne>
+          <ram:CityName>Schöppingen</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">test@example.com</ram:URIID>
+        </ram:URIUniversalCommunication>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+        <ram:TypeCode>10</ram:TypeCode>
+        <ram:Information>Cash on delivery</ram:Information>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>-7.19</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>-102.81</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>false</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:ActualAmount>9.35</ram:ActualAmount>
+        <ram:ReasonCode>95</ram:ReasonCode>
+        <ram:Reason>Delivery refund</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:DueDateDateTime>
+          <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+        </ram:DueDateDateTime>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>-93.46</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>9.35</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>-102.81</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">-7.19</ram:TaxTotalAmount>
+        <ram:RoundingAmount>0.00</ram:RoundingAmount>
+        <ram:GrandTotalAmount>-110.00</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>-110.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+      <ram:InvoiceReferencedDocument>
+        <ram:IssuerAssignedID>1001</ram:IssuerAssignedID>
+        <ram:FormattedIssueDateTime>
+          <qdt:DateTimeString format="102">[date]</qdt:DateTimeString>
+        </ram:FormattedIssueDateTime>
+      </ram:InvoiceReferencedDocument>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
@@ -138,7 +138,7 @@
       <ram:InvoiceReferencedDocument>
         <ram:IssuerAssignedID>1001</ram:IssuerAssignedID>
         <ram:FormattedIssueDateTime>
-          <qdt:DateTimeString format="102">[date]</qdt:DateTimeString>
+          <udt:DateTimeString format="102">[date]</udt:DateTimeString>
         </ram:FormattedIssueDateTime>
       </ram:InvoiceReferencedDocument>
     </ram:ApplicableHeaderTradeSettlement>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_cancellation_invoice_document_default/snapshot.xml
@@ -90,8 +90,14 @@
     <ram:ApplicableHeaderTradeSettlement>
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
       <ram:SpecifiedTradeSettlementPaymentMeans>
-        <ram:TypeCode>10</ram:TypeCode>
-        <ram:Information>Cash on delivery</ram:Information>
+        <ram:TypeCode>30</ram:TypeCode>
+        <ram:Information>Invoice</ram:Information>
+        <ram:PayeePartyCreditorFinancialAccount>
+          <ram:IBANID>DE89370400440532013000</ram:IBANID>
+        </ram:PayeePartyCreditorFinancialAccount>
+        <ram:PayeeSpecifiedCreditorFinancialInstitution>
+          <ram:BICID>DEUTDEDBFRA</ram:BICID>
+        </ram:PayeeSpecifiedCreditorFinancialInstitution>
       </ram:SpecifiedTradeSettlementPaymentMeans>
       <ram:ApplicableTradeTax>
         <ram:CalculatedAmount>-7.19</ram:CalculatedAmount>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_invoice_document_default/snapshot.xml
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_invoice_document_default/snapshot.xml
@@ -91,8 +91,14 @@
     <ram:ApplicableHeaderTradeSettlement>
       <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
       <ram:SpecifiedTradeSettlementPaymentMeans>
-        <ram:TypeCode>10</ram:TypeCode>
-        <ram:Information>Cash on delivery</ram:Information>
+        <ram:TypeCode>30</ram:TypeCode>
+        <ram:Information>Invoice</ram:Information>
+        <ram:PayeePartyCreditorFinancialAccount>
+          <ram:IBANID>DE89370400440532013000</ram:IBANID>
+        </ram:PayeePartyCreditorFinancialAccount>
+        <ram:PayeeSpecifiedCreditorFinancialInstitution>
+          <ram:BICID>DEUTDEDBFRA</ram:BICID>
+        </ram:PayeeSpecifiedCreditorFinancialInstitution>
       </ram:SpecifiedTradeSettlementPaymentMeans>
       <ram:ApplicableTradeTax>
         <ram:CalculatedAmount>7.19</ram:CalculatedAmount>

--- a/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_invoice_document_default/snapshot.xml
+++ b/tests/integration/Core/Checkout/Document/Renderer/_snapshots/zugferd_invoice_document_default/snapshot.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <rsm:ExchangedDocumentContext>
+    <ram:BusinessProcessSpecifiedDocumentContextParameter>
+      <ram:ID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</ram:ID>
+    </ram:BusinessProcessSpecifiedDocumentContextParameter>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>1000</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime>
+      <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+    </ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:IncludedSupplyChainTradeLineItem>
+      <ram:AssociatedDocumentLineDocument>
+        <ram:LineID>1</ram:LineID>
+      </ram:AssociatedDocumentLineDocument>
+      <ram:SpecifiedTradeProduct>
+        <ram:SellerAssignedID>p0</ram:SellerAssignedID>
+        <ram:Name>product 0</ram:Name>
+      </ram:SpecifiedTradeProduct>
+      <ram:SpecifiedLineTradeAgreement>
+        <ram:NetPriceProductTradePrice>
+          <ram:ChargeAmount>93.46</ram:ChargeAmount>
+          <ram:BasisQuantity unitCode="H87">1.00</ram:BasisQuantity>
+        </ram:NetPriceProductTradePrice>
+      </ram:SpecifiedLineTradeAgreement>
+      <ram:SpecifiedLineTradeDelivery>
+        <ram:BilledQuantity unitCode="H87">1.00</ram:BilledQuantity>
+      </ram:SpecifiedLineTradeDelivery>
+      <ram:SpecifiedLineTradeSettlement>
+        <ram:ApplicableTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:ApplicableTradeTax>
+        <ram:SpecifiedTradeSettlementLineMonetarySummation>
+          <ram:LineTotalAmount>93.46</ram:LineTotalAmount>
+        </ram:SpecifiedTradeSettlementLineMonetarySummation>
+      </ram:SpecifiedLineTradeSettlement>
+    </ram:IncludedSupplyChainTradeLineItem>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerReference>10000</ram:BuyerReference>
+      <ram:SellerTradeParty>
+        <ram:Name>Example Company</ram:Name>
+        <ram:DefinedTradeContact>
+          <ram:PersonName>Max Mustermann</ram:PersonName>
+          <ram:TelephoneUniversalCommunication>
+            <ram:CompleteNumber>+49 123 4567890</ram:CompleteNumber>
+          </ram:TelephoneUniversalCommunication>
+          <ram:EmailURIUniversalCommunication>
+            <ram:URIID>mail@example.com</ram:URIID>
+          </ram:EmailURIUniversalCommunication>
+        </ram:DefinedTradeContact>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">mail@example.com</ram:URIID>
+        </ram:URIUniversalCommunication>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="FC">123/456/7890</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+        <ram:SpecifiedTaxRegistration>
+          <ram:ID schemeID="VA">DE123456789</ram:ID>
+        </ram:SpecifiedTaxRegistration>
+      </ram:SellerTradeParty>
+      <ram:BuyerTradeParty>
+        <ram:ID>1337</ram:ID>
+        <ram:Name>Max Mustermann</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>48624</ram:PostcodeCode>
+          <ram:LineOne>Ebbinghoff 10</ram:LineOne>
+          <ram:CityName>Schöppingen</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+        </ram:PostalTradeAddress>
+        <ram:URIUniversalCommunication>
+          <ram:URIID schemeID="EM">test@example.com</ram:URIID>
+        </ram:URIUniversalCommunication>
+      </ram:BuyerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery>
+      <ram:ActualDeliverySupplyChainEvent>
+        <ram:OccurrenceDateTime>
+          <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+        </ram:OccurrenceDateTime>
+      </ram:ActualDeliverySupplyChainEvent>
+    </ram:ApplicableHeaderTradeDelivery>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementPaymentMeans>
+        <ram:TypeCode>10</ram:TypeCode>
+        <ram:Information>Cash on delivery</ram:Information>
+      </ram:SpecifiedTradeSettlementPaymentMeans>
+      <ram:ApplicableTradeTax>
+        <ram:CalculatedAmount>7.19</ram:CalculatedAmount>
+        <ram:TypeCode>VAT</ram:TypeCode>
+        <ram:BasisAmount>102.81</ram:BasisAmount>
+        <ram:CategoryCode>S</ram:CategoryCode>
+        <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+      </ram:ApplicableTradeTax>
+      <ram:SpecifiedTradeAllowanceCharge>
+        <ram:ChargeIndicator>
+          <udt:Indicator>true</udt:Indicator>
+        </ram:ChargeIndicator>
+        <ram:ActualAmount>9.35</ram:ActualAmount>
+        <ram:ReasonCode>DL</ram:ReasonCode>
+        <ram:Reason>Delivery</ram:Reason>
+        <ram:CategoryTradeTax>
+          <ram:TypeCode>VAT</ram:TypeCode>
+          <ram:CategoryCode>S</ram:CategoryCode>
+          <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+        </ram:CategoryTradeTax>
+      </ram:SpecifiedTradeAllowanceCharge>
+      <ram:SpecifiedTradePaymentTerms>
+        <ram:DueDateDateTime>
+          <udt:DateTimeString format="102">[date]</udt:DateTimeString>
+        </ram:DueDateDateTime>
+      </ram:SpecifiedTradePaymentTerms>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>93.46</ram:LineTotalAmount>
+        <ram:ChargeTotalAmount>9.35</ram:ChargeTotalAmount>
+        <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+        <ram:TaxBasisTotalAmount>102.81</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount currencyID="EUR">7.19</ram:TaxTotalAmount>
+        <ram:RoundingAmount>0.00</ram:RoundingAmount>
+        <ram:GrandTotalAmount>110.00</ram:GrandTotalAmount>
+        <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+        <ram:DuePayableAmount>110.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>

--- a/tests/unit/Core/Checkout/Document/Zugferd/ZugferdDocumentTest.php
+++ b/tests/unit/Core/Checkout/Document/Zugferd/ZugferdDocumentTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
@@ -251,6 +252,55 @@ class ZugferdDocumentTest extends TestCase
         static::assertSame('20240102', \trim($occurrenceDateTime->getElementsByTagName('DateTimeString')->item(0)->nodeValue ?? ''));
     }
 
+    public function testWithDeliverySkipsZeroAmountAllowanceCharge(): void
+    {
+        $dom = $this->createDeliveryDocumentDom(0.0, ZugferdInvoiceType::INVOICE);
+
+        static::assertSame(0, $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->length);
+    }
+
+    public function testWithDeliveryAddsChargeNodeForPositiveInvoiceShippingCosts(): void
+    {
+        $dom = $this->createDeliveryDocumentDom(10.0, ZugferdInvoiceType::INVOICE);
+
+        static::assertSame(1, $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->length);
+
+        $allowanceCharge = $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->item(0);
+        static::assertNotNull($allowanceCharge);
+        static::assertSame('true', $allowanceCharge->getElementsByTagName('Indicator')->item(0)?->nodeValue);
+        static::assertSame('10.00', $allowanceCharge->getElementsByTagName('ActualAmount')->item(0)?->nodeValue);
+        static::assertSame('DL', $allowanceCharge->getElementsByTagName('ReasonCode')->item(0)?->nodeValue);
+        static::assertSame('Delivery', $allowanceCharge->getElementsByTagName('Reason')->item(0)?->nodeValue);
+    }
+
+    public function testWithDeliveryAddsChargeNodeForPositiveCorrectionShippingCosts(): void
+    {
+        $dom = $this->createDeliveryDocumentDom(10.0, ZugferdInvoiceType::CORRECTION);
+
+        static::assertSame(1, $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->length);
+
+        $allowanceCharge = $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->item(0);
+        static::assertNotNull($allowanceCharge);
+        static::assertSame('true', $allowanceCharge->getElementsByTagName('Indicator')->item(0)?->nodeValue);
+        static::assertSame('10.00', $allowanceCharge->getElementsByTagName('ActualAmount')->item(0)?->nodeValue);
+        static::assertSame('DAM', $allowanceCharge->getElementsByTagName('ReasonCode')->item(0)?->nodeValue);
+        static::assertSame('Return handling', $allowanceCharge->getElementsByTagName('Reason')->item(0)?->nodeValue);
+    }
+
+    public function testWithDeliveryAddsAllowanceNodeForNegativeCorrectionShippingCosts(): void
+    {
+        $dom = $this->createDeliveryDocumentDom(-10.0, ZugferdInvoiceType::CORRECTION);
+
+        static::assertSame(1, $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->length);
+
+        $allowanceCharge = $dom->getElementsByTagName('SpecifiedTradeAllowanceCharge')->item(0);
+        static::assertNotNull($allowanceCharge);
+        static::assertSame('false', $allowanceCharge->getElementsByTagName('Indicator')->item(0)?->nodeValue);
+        static::assertSame('10.00', $allowanceCharge->getElementsByTagName('ActualAmount')->item(0)?->nodeValue);
+        static::assertSame('95', $allowanceCharge->getElementsByTagName('ReasonCode')->item(0)?->nodeValue);
+        static::assertSame('Delivery refund', $allowanceCharge->getElementsByTagName('Reason')->item(0)?->nodeValue);
+    }
+
     public function testEmptyCalculatedTaxes(): void
     {
         $order = new OrderEntity();
@@ -292,6 +342,104 @@ class ZugferdDocumentTest extends TestCase
         );
 
         $this->validateDocument($document->getDomContent($order, $calculator), ['100.00', '0.00', '0.00', '100.00', '0.00', '100.00', '100.00', '0.00']);
+    }
+
+    #[DataProvider('basisQuantityProvider')]
+    public function testBasisQuantity(?int $purchaseUnit, string $expectedBasisQuantity): void
+    {
+        $order = new OrderEntity();
+        $order->setTaxStatus(CartPrice::TAX_STATE_GROSS);
+        $order->setAmountTotal(100.0);
+        $order->setAmountNet(100);
+        $order->setItemRounding(new CashRoundingConfig(2, .01, false));
+        $order->setTotalRounding(new CashRoundingConfig(2, .01, false));
+
+        $product = new ProductEntity();
+        $product->setProductNumber('123');
+        if ($purchaseUnit !== null) {
+            $product->setPurchaseUnit($purchaseUnit);
+        }
+
+        $lineItem = new OrderLineItemEntity();
+        $lineItem->setId(Uuid::randomHex());
+        $lineItem->setProduct($product);
+        $lineItem->setLabel('Product ' . $lineItem->getId());
+        $lineItem->setQuantity(1);
+        $lineItem->setPosition(1);
+        $lineItem->setPrice(new CalculatedPrice(
+            100.0,
+            100.0,
+            new CalculatedTaxCollection([]),
+            new TaxRuleCollection(),
+        ));
+
+        $document = new ZugferdDocumentMock(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), true);
+        $document->withProductLineItem($lineItem, '');
+        $document->withPaidAmount(100.0);
+
+        $calculator = new AmountCalculator(
+            new CashRounding(),
+            new PercentageTaxRuleBuilder(),
+            new TaxCalculator()
+        );
+
+        $document = $document->getDomContent($order, $calculator);
+
+        $basisQuantity = $document
+            ->getElementsByTagName('SupplyChainTradeTransaction')->item(0)
+            ?->getElementsByTagName('IncludedSupplyChainTradeLineItem')->item(0)
+            ?->getElementsByTagName('SpecifiedLineTradeAgreement')->item(0)
+            ?->getElementsByTagName('NetPriceProductTradePrice')->item(0)
+            ?->getElementsByTagName('BasisQuantity')->item(0);
+
+        static::assertSame($expectedBasisQuantity, $basisQuantity?->nodeValue);
+    }
+
+    /**
+     * @return \Generator<string, array{purchaseUnit: ?int, expectedBasisQuantity: string}>
+     */
+    public static function basisQuantityProvider(): \Generator
+    {
+        yield 'with purchase unit' => [
+            'purchaseUnit' => 5,
+            'expectedBasisQuantity' => '5.00',
+        ];
+        yield 'without purchase unit' => [
+            'purchaseUnit' => null,
+            'expectedBasisQuantity' => '1.00',
+        ];
+    }
+
+    private function createDeliveryDocumentDom(float $shippingTotal, string $documentType): \DOMDocument
+    {
+        $order = new OrderEntity();
+        $order->setTaxStatus(CartPrice::TAX_STATE_GROSS);
+        $order->setAmountTotal(abs($shippingTotal));
+        $order->setAmountNet(abs($shippingTotal));
+        $order->setItemRounding(new CashRoundingConfig(2, .01, false));
+        $order->setTotalRounding(new CashRoundingConfig(2, .01, false));
+
+        $delivery = new OrderDeliveryEntity();
+        $delivery->setId(Uuid::randomHex());
+        $delivery->setUniqueIdentifier($delivery->getId());
+        $delivery->setShippingCosts(new CalculatedPrice(
+            $shippingTotal,
+            $shippingTotal,
+            new CalculatedTaxCollection([new CalculatedTax(0.0, 19.0, $shippingTotal)]),
+            new TaxRuleCollection(),
+        ));
+
+        $document = new ZugferdDocumentMock(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), true);
+        $document->withDocumentInformation('2024-01-03', '1002', 'EUR', $documentType);
+        $document->withDelivery(new OrderDeliveryCollection([$delivery]));
+
+        $calculator = new AmountCalculator(
+            new CashRounding(),
+            new PercentageTaxRuleBuilder(),
+            new TaxCalculator()
+        );
+
+        return $document->getDomContent($order, $calculator);
     }
 
     /**

--- a/tests/unit/Core/Checkout/Document/Zugferd/ZugferdDocumentTest.php
+++ b/tests/unit/Core/Checkout/Document/Zugferd/ZugferdDocumentTest.php
@@ -24,7 +24,6 @@ use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
-use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
@@ -342,72 +341,6 @@ class ZugferdDocumentTest extends TestCase
         );
 
         $this->validateDocument($document->getDomContent($order, $calculator), ['100.00', '0.00', '0.00', '100.00', '0.00', '100.00', '100.00', '0.00']);
-    }
-
-    #[DataProvider('basisQuantityProvider')]
-    public function testBasisQuantity(?int $purchaseUnit, string $expectedBasisQuantity): void
-    {
-        $order = new OrderEntity();
-        $order->setTaxStatus(CartPrice::TAX_STATE_GROSS);
-        $order->setAmountTotal(100.0);
-        $order->setAmountNet(100);
-        $order->setItemRounding(new CashRoundingConfig(2, .01, false));
-        $order->setTotalRounding(new CashRoundingConfig(2, .01, false));
-
-        $product = new ProductEntity();
-        $product->setProductNumber('123');
-        if ($purchaseUnit !== null) {
-            $product->setPurchaseUnit($purchaseUnit);
-        }
-
-        $lineItem = new OrderLineItemEntity();
-        $lineItem->setId(Uuid::randomHex());
-        $lineItem->setProduct($product);
-        $lineItem->setLabel('Product ' . $lineItem->getId());
-        $lineItem->setQuantity(1);
-        $lineItem->setPosition(1);
-        $lineItem->setPrice(new CalculatedPrice(
-            100.0,
-            100.0,
-            new CalculatedTaxCollection([]),
-            new TaxRuleCollection(),
-        ));
-
-        $document = new ZugferdDocumentMock(ZugferdDocumentBuilder::createNew(ZugferdProfiles::PROFILE_XRECHNUNG_3), true);
-        $document->withProductLineItem($lineItem, '');
-        $document->withPaidAmount(100.0);
-
-        $calculator = new AmountCalculator(
-            new CashRounding(),
-            new PercentageTaxRuleBuilder(),
-            new TaxCalculator()
-        );
-
-        $document = $document->getDomContent($order, $calculator);
-
-        $basisQuantity = $document
-            ->getElementsByTagName('SupplyChainTradeTransaction')->item(0)
-            ?->getElementsByTagName('IncludedSupplyChainTradeLineItem')->item(0)
-            ?->getElementsByTagName('SpecifiedLineTradeAgreement')->item(0)
-            ?->getElementsByTagName('NetPriceProductTradePrice')->item(0)
-            ?->getElementsByTagName('BasisQuantity')->item(0);
-
-        static::assertSame($expectedBasisQuantity, $basisQuantity?->nodeValue);
-    }
-
-    /**
-     * @return \Generator<string, array{purchaseUnit: ?int, expectedBasisQuantity: string}>
-     */
-    public static function basisQuantityProvider(): \Generator
-    {
-        yield 'with purchase unit' => [
-            'purchaseUnit' => 5,
-            'expectedBasisQuantity' => '5.00',
-        ];
-        yield 'without purchase unit' => [
-            'purchaseUnit' => null,
-            'expectedBasisQuantity' => '1.00',
-        ];
     }
 
     private function createDeliveryDocumentDom(float $shippingTotal, string $documentType): \DOMDocument


### PR DESCRIPTION
Backport of https://github.com/shopware/shopware/pull/18095

Checked and invoice, cancellation invoice and partial cancellation still pass on https://erechnungs-validator.de/e-rechnung-validieren/