### PR TITLE
fix(elasticsearch): remove wrong deprecation from SystemUpdateListener

### DIFF
--- a/src/Elasticsearch/Framework/SystemUpdateListener.php
+++ b/src/Elasticsearch/Framework/SystemUpdateListener.php
@@ -12,8 +12,6 @@ use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
- * @deprecated tag:v6.8.0 - reason:remove-subscriber - Will be removed as it unused
- *
  * @internal
  */
 #[Package('framework')]


### PR DESCRIPTION
Removes the wrong `@deprecated` annotation from the class docblock. No behavioural change; the class stays `@internal`.
