### PR TITLE
fix: remove leftover console logs from page loading screen in admin

### DIFF
--- a/src/Administration/Resources/shared/page-loading-screen/page-loading-screen.js
+++ b/src/Administration/Resources/shared/page-loading-screen/page-loading-screen.js
@@ -2,8 +2,6 @@
  * @sw-package framework
  */
 
-console.log('page loading screen script loaded');
-
 (() => {
     const pageLoadTime = Date.now();
 
@@ -27,7 +25,6 @@ console.log('page loading screen script loaded');
     };
 
     const onError = (event) => {
-        console.log('onError', event);
         addErrorMessage(event.message);
     };
 
@@ -55,8 +52,6 @@ console.log('page loading screen script loaded');
 
     window.addEventListener('error', onError);
     window.addEventListener('unhandledrejection', onUnhandledRejection);
-
-    console.log('page loading screen initialized');
 
     window.removePageLoadingIndicator = () => {
         // `DELAY` matches animation-delay that is used in `administration/index.html`


### PR DESCRIPTION
### 1. Why is this change necessary?
console.log messages from debugging sneaked into production (I'm sorry, I'm guilty)

### 2. What does this change do, exactly?
- removes the three `console.logs` which were not caught by eslint.
- I didn't add ESLint to the `shared/*` directory since we'll rarely edit files in that directory and there's no global ESLint config.

### 3. Describe each step to reproduce the issue or behaviour.
1. open the admin
2. open dev tools
3. first two messages are debugging console.logs

### 4. Please link to the relevant issues (if any).
Came from https://github.com/shopware/shopware/pull/14895.