### PR TITLE
ci: prevent execution of nightly on tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,17 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  guard:
-    if: github.ref_type != 'tag'
-    runs-on: ubuntu-24.04
-    steps:
-      - run: 'echo "not a tag – running nightly"'
-
   redis:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     name: Redis
     runs-on: ubuntu-24.04
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -46,62 +39,52 @@ jobs:
           ./vendor/bin/phpunit --group=redis --testsuite migration,unit,integration,devops
 
   admin:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/admin.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   integration:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/integration.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   integration-major:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/integration-major.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   acceptance:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/acceptance.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   visual-tests:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/visual-tests.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       currents: ${{ github.event_name == 'schedule' }}
   php:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/php.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   storefront:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/storefront.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   downstream:
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/downstream.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   prepare-release: # This will only execute dry-runs and push current trunk to the many-repos
-    needs: guard
+    if: (github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch') && github.ref_type != 'tag'
     uses: ./.github/workflows/05-prepare-release.yml
     secrets: inherit
-    if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
 
   # we need this for our LTS, because gh only runs scheduled for the default branch
   nightly-other-branches:
-    needs: guard
     runs-on: ubuntu-24.04
     if: github.repository == 'shopware/shopware' && github.ref == 'refs/heads/trunk'
     permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  guard:
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-24.04
+    steps:
+      - run: 'echo "not a tag – running nightly"'
+
   redis:
+    needs: guard
     name: Redis
     runs-on: ubuntu-24.04
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
@@ -39,52 +46,62 @@ jobs:
           ./vendor/bin/phpunit --group=redis --testsuite migration,unit,integration,devops
 
   admin:
+    needs: guard
     uses: ./.github/workflows/admin.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   integration:
+    needs: guard
     uses: ./.github/workflows/integration.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   integration-major:
+    needs: guard
     uses: ./.github/workflows/integration-major.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   acceptance:
+    needs: guard
     uses: ./.github/workflows/acceptance.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   visual-tests:
+    needs: guard
     uses: ./.github/workflows/visual-tests.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       currents: ${{ github.event_name == 'schedule' }}
   php:
+    needs: guard
     uses: ./.github/workflows/php.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   storefront:
+    needs: guard
     uses: ./.github/workflows/storefront.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
   downstream:
+    needs: guard
     uses: ./.github/workflows/downstream.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
     with:
       nightly: true
   prepare-release: # This will only execute dry-runs and push current trunk to the many-repos
+    needs: guard
     uses: ./.github/workflows/05-prepare-release.yml
     secrets: inherit
     if: github.repository == 'shopware/shopware' || github.event_name == 'workflow_dispatch'
 
   # we need this for our LTS, because gh only runs scheduled for the default branch
   nightly-other-branches:
+    needs: guard
     runs-on: ubuntu-24.04
     if: github.repository == 'shopware/shopware' && github.ref == 'refs/heads/trunk'
     permissions:


### PR DESCRIPTION
Running the nightly on a **tag** (via manual `workflow_dispatch`) accidentally triggered a real release: `nightly` calls `prepare-release` → `05-prepare-release.yml`, which switches to real-release mode when `github.ref_type == 'tag'` (dry-run only for branches). That re-split and **re-tagged** the many-repos onto a freshly built commit — bad for Packagist.
