### PR TITLE
fix: Ensure backward compatibility of new cache compression config keys

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -707,6 +707,14 @@ class Configuration implements ConfigurationInterface
                         $config['compression_method'] = $config['cache_compression_method'];
                     }
 
+                    // backward compatibility
+                    if (!isset($config['cache_compression']) && isset($config['compress'])) {
+                        $config['cache_compression'] = $config['compress'];
+                    }
+                    if (!isset($config['cache_compression_method']) && isset($config['compression_method'])) {
+                        $config['cache_compression_method'] = $config['compression_method'];
+                    }
+
                     return $config;
                 })
             ->end()

--- a/tests/unit/Core/Framework/DependencyInjection/FrameworkExtensionTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/FrameworkExtensionTest.php
@@ -70,4 +70,21 @@ class FrameworkExtensionTest extends TestCase
         static::assertFalse($container->getParameter('shopware.cache.cache_compression'));
         static::assertSame('deflate', $container->getParameter('shopware.cache.cache_compression_method'));
     }
+
+    public function testDeprecatedCacheCompressionConfigIsSetForBC(): void
+    {
+        $container = new ContainerBuilder();
+
+        (new FrameworkExtension())->load([
+            [
+                'cache' => [
+                    'compress' => true,
+                    'compression_method' => 'gzip',
+                ],
+            ],
+        ], $container);
+
+        static::assertTrue($container->getParameter('shopware.cache.cache_compression'));
+        static::assertSame('gzip', $container->getParameter('shopware.cache.cache_compression_method'));
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

If only the new cache compression keys are configured, implementations that are relying on the old keys do not work anymore. 
Follow up of https://github.com/shopware/shopware/pull/18061

### 2. What does this change do, exactly?

Set the values of the old keys, if not present and new keys are present

### 3. Describe each step to reproduce the issue or behaviour.

See https://github.com/FriendsOfShopware/FroshTools/issues/434

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
