### PR TITLE
ci: use correct object in linkClosingPR

### DIFF
--- a/.github/workflows/link-private-pr.yml
+++ b/.github/workflows/link-private-pr.yml
@@ -26,4 +26,4 @@ jobs:
           github-token: ${{ steps.sts.outputs.token }}
           script: |
             const { linkClosingPR } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
-            await linkClosingPR({github, core, context}, github.event.issue.number)
+            await linkClosingPR({github, core, context}, context.issue.number)


### PR DESCRIPTION
### 1. Why is this change necessary?
`github` is a different object in `github-script`. We need to use `context`

### 2. What does this change do, exactly?
Use `context` instead of `github.event`

### 3. Describe each step to reproduce the issue or behaviour.
Close an issue through an PR.

### 4. Please link to the relevant issues (if any).
- closes #18194