### PR TITLE
perf: Improve category breadcrumb updater

### DIFF
--- a/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
+++ b/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
@@ -4,33 +4,22 @@ namespace Shopware\Core\Content\Category\DataAbstractionLayer;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Category\CategoryException;
-use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\Language\LanguageCollection;
 
 #[Package('discovery')]
 class CategoryBreadcrumbUpdater
 {
+    private const WRITE_CHUNK_SIZE = 250;
+
     /**
      * @internal
-     *
-     * @param EntityRepository<CategoryCollection> $categoryRepository
-     * @param EntityRepository<LanguageCollection> $languageRepository
      */
     public function __construct(
-        private readonly Connection $connection,
-        private readonly EntityRepository $categoryRepository,
-        private readonly EntityRepository $languageRepository
+        private readonly Connection $connection
     ) {
     }
 
@@ -43,99 +32,199 @@ class CategoryBreadcrumbUpdater
             return;
         }
 
-        $versionId = Uuid::fromHexToBytes($context->getVersionId());
+        $all = $this->collectCategoryIds($ids, $context);
 
+        foreach ($this->fetchActiveLanguages() as $language) {
+            $languageChain = array_values(array_unique(array_filter([
+                $language['id'],
+                $language['parentId'],
+                Defaults::LANGUAGE_SYSTEM,
+            ])));
+
+            $names = $this->fetchNames($all, $languageChain);
+
+            $this->updateLanguage($ids, $language['id'], $names);
+        }
+    }
+
+    /**
+     * @return list<array{id: string, parentId: string|null}>
+     */
+    private function fetchActiveLanguages(): array
+    {
+        /** @var list<array{id: string, parentId: string|null}> $languages */
+        $languages = $this->connection->fetchAllAssociative(
+            'SELECT LOWER(HEX(`id`)) AS id, LOWER(HEX(`parent_id`)) AS parentId FROM `language` WHERE `active` = 1'
+        );
+
+        return $languages;
+    }
+
+    /**
+     * @param string[] $ids
+     *
+     * @return string[]
+     */
+    private function collectCategoryIds(array $ids, Context $context): array
+    {
         $query = $this->connection->createQueryBuilder();
         $query->select('category.path');
         $query->from('category');
         $query->where('category.id IN (:ids)');
         $query->andWhere('category.version_id = :version');
-        $query->setParameter('version', $versionId);
+        $query->setParameter('version', Uuid::fromHexToBytes($context->getVersionId()));
         $query->setParameter('ids', Uuid::fromHexToBytesList($ids), ArrayParameterType::BINARY);
 
         $paths = $query->executeQuery()->fetchFirstColumn();
 
         $all = $ids;
         foreach ($paths as $path) {
-            $path = explode('|', (string) $path);
-            foreach ($path as $id) {
+            foreach (explode('|', (string) $path) as $id) {
                 $all[] = $id;
             }
         }
 
-        $all = array_filter(array_keys(array_flip($all)));
-        $languageCriteria = new Criteria();
-        $languageCriteria->addFilter(new EqualsFilter('active', true));
-
-        $languages = $this->languageRepository->search($languageCriteria, $context)->getEntities();
-
-        foreach ($languages as $language) {
-            $context = new Context(
-                new SystemSource(),
-                [],
-                Defaults::CURRENCY,
-                array_values(array_filter([$language->getId(), $language->getParentId(), Defaults::LANGUAGE_SYSTEM])),
-                Defaults::LIVE_VERSION
-            );
-
-            $this->updateLanguage($ids, $context, $all);
-        }
+        return array_filter(array_keys(array_flip($all)));
     }
 
     /**
      * @param string[] $ids
-     * @param string[] $all
+     * @param string[] $languageChain
+     *
+     * @return array<string, array{parentId: string|null, name: string|null}>
      */
-    private function updateLanguage(array $ids, Context $context, array $all): void
+    private function fetchNames(array $ids, array $languageChain): array
     {
-        $versionId = Uuid::fromHexToBytes($context->getVersionId());
-        $languageId = Uuid::fromHexToBytes($context->getLanguageId());
+        $query = $this->connection->createQueryBuilder();
+        $query->from('category');
+        $query->where('category.id IN (:ids)');
+        $query->andWhere('category.version_id = :version');
+        $query->setParameter('version', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
+        $query->setParameter('ids', Uuid::fromHexToBytesList($ids), ArrayParameterType::BINARY);
 
-        $categories = $this->categoryRepository
-            ->search(new Criteria($all), $context)
-            ->getEntities();
+        $coalesce = [];
+        foreach ($languageChain as $index => $languageId) {
+            $alias = 'translation' . $index;
+            $query->leftJoin(
+                'category',
+                'category_translation',
+                $alias,
+                \sprintf(
+                    '%1$s.category_id = category.id'
+                    . ' AND %1$s.category_version_id = category.version_id'
+                    . ' AND %1$s.language_id = :language%2$d',
+                    $alias,
+                    $index
+                )
+            );
+            $query->setParameter('language' . $index, Uuid::fromHexToBytes($languageId));
+            $coalesce[] = $alias . '.name';
+        }
 
-        $update = $this->connection->prepare('
-            INSERT INTO `category_translation` (`category_id`, `category_version_id`, `language_id`, `breadcrumb`, `created_at`)
-            VALUES (:categoryId, :versionId, :languageId, :breadcrumb, DATE(NOW()))
-            ON DUPLICATE KEY UPDATE `breadcrumb` = :breadcrumb
-        ');
-        $update = new RetryableQuery($this->connection, $update);
+        $query->select(
+            'LOWER(HEX(category.id)) AS id',
+            'LOWER(HEX(category.parent_id)) AS parentId',
+            'COALESCE(' . implode(', ', $coalesce) . ') AS name'
+        );
 
+        $names = [];
+        foreach ($query->executeQuery()->fetchAllAssociative() as $row) {
+            $names[(string) $row['id']] = [
+                'parentId' => $row['parentId'] !== null ? (string) $row['parentId'] : null,
+                'name' => $row['name'] !== null ? (string) $row['name'] : null,
+            ];
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param string[] $ids
+     * @param array<string, array{parentId: string|null, name: string|null}> $names
+     */
+    private function updateLanguage(array $ids, string $languageId, array $names): void
+    {
+        $versionId = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
+        $languageIdBytes = Uuid::fromHexToBytes($languageId);
+
+        $cache = [];
+        $rows = [];
         foreach ($ids as $id) {
-            try {
-                $path = $this->buildBreadcrumb($id, $categories);
-            } catch (CategoryNotFoundException) {
+            $breadcrumb = $this->buildBreadcrumb($id, $names, $cache);
+            if ($breadcrumb === null) {
                 continue;
             }
 
-            $update->execute([
-                'categoryId' => Uuid::fromHexToBytes($id),
-                'versionId' => $versionId,
-                'languageId' => $languageId,
-                'breadcrumb' => json_encode($path, \JSON_THROW_ON_ERROR),
-            ]);
+            $rows[] = [
+                Uuid::fromHexToBytes($id),
+                $versionId,
+                $languageIdBytes,
+                json_encode($breadcrumb, \JSON_THROW_ON_ERROR),
+            ];
+        }
+
+        foreach (array_chunk($rows, self::WRITE_CHUNK_SIZE) as $chunk) {
+            $this->write($chunk);
         }
     }
 
     /**
-     * @return array<string, string>
+     * @param array<string, array{parentId: string|null, name: string|null}> $names
+     * @param array<string, array<string, string|null>|null> $cache
+     *
+     * @return array<string, string|null>|null
      */
-    private function buildBreadcrumb(string $id, CategoryCollection $categories): array
+    private function buildBreadcrumb(string $id, array $names, array &$cache): ?array
     {
-        $category = $categories->get($id);
+        if (\array_key_exists($id, $cache)) {
+            return $cache[$id];
+        }
 
-        if (!$category) {
-            throw CategoryException::categoryNotFound($id);
+        $category = $names[$id] ?? null;
+        if ($category === null) {
+            return $cache[$id] = null;
         }
 
         $breadcrumb = [];
-        if ($category->getParentId()) {
-            $breadcrumb = $this->buildBreadcrumb($category->getParentId(), $categories);
+        if ($category['parentId'] !== null) {
+            $parent = $this->buildBreadcrumb($category['parentId'], $names, $cache);
+            if ($parent === null) {
+                // A missing ancestor invalidates the whole chain, as in core.
+                return $cache[$id] = null;
+            }
+            $breadcrumb = $parent;
         }
 
-        $breadcrumb[$category->getId()] = $category->getTranslation('name');
+        $breadcrumb[$id] = $category['name'];
 
-        return $breadcrumb;
+        return $cache[$id] = $breadcrumb;
+    }
+
+    /**
+     * @param array<int, array{0: string, 1: string, 2: string, 3: string}> $rows
+     */
+    private function write(array $rows): void
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        $placeholders = implode(', ', array_fill(0, \count($rows), '(?, ?, ?, ?, DATE(NOW()))'));
+
+        $parameters = [];
+        foreach ($rows as $row) {
+            foreach ($row as $value) {
+                $parameters[] = $value;
+            }
+        }
+
+        RetryableQuery::retryable($this->connection, function () use ($placeholders, $parameters): void {
+            $this->connection->executeStatement(
+                'INSERT INTO `category_translation` (`category_id`, `category_version_id`, `language_id`, `breadcrumb`, `created_at`)
+                 VALUES ' . $placeholders . '
+                 ON DUPLICATE KEY UPDATE `breadcrumb` = VALUES(`breadcrumb`)',
+                $parameters
+            );
+        });
     }
 }

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -79,8 +79,6 @@
 
         <service id="Shopware\Core\Content\Category\DataAbstractionLayer\CategoryBreadcrumbUpdater">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="category.repository"/>
-            <argument type="service" id="language.repository"/>
         </service>
 
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Indexing\TreeUpdater">

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdaterTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdaterTest.php
@@ -276,6 +276,60 @@ class CategoryBreadcrumbUpdaterTest extends TestCase
         static::assertSame(['EN-A', 'DE-B', 'EN-C'], $c3->getBreadcrumb());
     }
 
+    public function testSiblingsSharingAParentAreAllResolved(): void
+    {
+        $parentId = Uuid::randomHex();
+        $siblingIds = [Uuid::randomHex(), Uuid::randomHex(), Uuid::randomHex()];
+
+        $context = new Context(
+            new SystemSource(),
+            [],
+            Defaults::CURRENCY,
+            [Defaults::LANGUAGE_SYSTEM]
+        );
+
+        $this->repository->create([
+            [
+                'id' => $parentId,
+                'translations' => [
+                    ['name' => 'EN-Root', 'languageId' => Defaults::LANGUAGE_SYSTEM],
+                    ['name' => 'DE-Root', 'languageId' => $this->deLanguageId],
+                ],
+                'children' => array_map(
+                    fn (string $id, int $i): array => [
+                        'id' => $id,
+                        'translations' => [
+                            ['name' => 'EN-Child-' . $i, 'languageId' => Defaults::LANGUAGE_SYSTEM],
+                            ['name' => 'DE-Child-' . $i, 'languageId' => $this->deLanguageId],
+                        ],
+                    ],
+                    $siblingIds,
+                    array_keys($siblingIds)
+                ),
+            ],
+        ], $context);
+
+        $allIds = [$parentId, ...$siblingIds];
+
+        $englishContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [Defaults::LANGUAGE_SYSTEM]);
+        $englishCategories = $this->repository->search(new Criteria($allIds), $englishContext)->getEntities();
+
+        foreach ($siblingIds as $i => $siblingId) {
+            $sibling = $englishCategories->get($siblingId);
+            static::assertInstanceOf(CategoryEntity::class, $sibling);
+            static::assertSame(['EN-Root', 'EN-Child-' . $i], $sibling->getBreadcrumb());
+        }
+
+        $germanContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [$this->deLanguageId]);
+        $germanCategories = $this->repository->search(new Criteria($allIds), $germanContext)->getEntities();
+
+        foreach ($siblingIds as $i => $siblingId) {
+            $sibling = $germanCategories->get($siblingId);
+            static::assertInstanceOf(CategoryEntity::class, $sibling);
+            static::assertSame(['DE-Root', 'DE-Child-' . $i], $sibling->getBreadcrumb());
+        }
+    }
+
     private function getSetUpData(): SetUpData
     {
         $level1 = Uuid::randomHex();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
CategoryBreadcrumbUpdater hydrates a full DAL Category entity (target ids + all children) once per active language and writes one prepared statement per category per language. On large catalogs with many languages this is quite slow during category indexing.

### 2. What does this change do, exactly?
Behaviour stays identical. The expensive DAL requests are swapped with leaner SQL queries.

### 3. Describe each step to reproduce the issue or behaviour.
Create a category tree with translations in multiple active languages, edit a category name, run the category indexer, and check category_translation.breadcrumb.
Breadcrumbs match the previous implementation for every language, but runs faster.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
