### PR TITLE
ci: use pr read token for linkClosingPR

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@shopware-ag/gh-project-automation": "1.15.0"
+        "@shopware-ag/gh-project-automation": "1.15.2"
       },
       "devDependencies": {
         "@types/node": "24.10.0"
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.15.0.tgz",
-      "integrity": "sha512-s0W6hktYVZWokQ2iKBjT2K3a/Bp9sCGnLu4V/bfnfVIeKMLDNIn+LjGDso4Rd2dO5HiDrc6qBxm+2IbY9oBjdA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.15.2.tgz",
+      "integrity": "sha512-c6tGiOWZMRf/Luy3l7nDehNmKjvMecutoGmXe9+IwoFiNUMjh1Vn/Wg8RNvbvdzXwRFf+MIgS5qxc+3mRhjS6Q==",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "^7.17.0"

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "@shopware-ag/gh-project-automation": "1.15.0"
+    "@shopware-ag/gh-project-automation": "1.15.2"
   },
   "devDependencies": {
     "@types/node": "24.10.0"

--- a/.github/workflows/link-private-pr.yml
+++ b/.github/workflows/link-private-pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   id-token: write
 
 jobs:
@@ -22,8 +23,10 @@ jobs:
       - shell: bash
         run: npm ci --prefix .github/bin/js/
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+            PR_READ_TOKEN: ${{ steps.sts.outputs.token }}
         with:
-          github-token: ${{ steps.sts.outputs.token }}
+          github-token: ${{ github.token }}
           script: |
             const { linkClosingPR } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
-            await linkClosingPR({github, core, context}, context.issue.number)
+            await linkClosingPR({github, core, context}, context.issue.number, process.env.PR_READ_TOKEN)


### PR DESCRIPTION
### 1. Why is this change necessary?
The octo-sts token can't create issue comments. So I've added a pr read client to the js function.

### 2. What does this change do, exactly?
Use the octo-sts token only to read the PRs

### 3. Describe each step to reproduce the issue or behaviour.
Close an issue

### 4. Please link to the relevant issues (if any).
- closes #18194