### PR TITLE
fix: resolve CMS form slot config inheritance

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -176,6 +176,10 @@ Previously, these routes could return unrelated records or fail because the unde
 
 <details>
 
+## Landing page slot config must not be null
+
+`LandingPageEntity::setSlotConfig()` and `LandingPageTranslationEntity::setSlotConfig()` no longer accept `null` for their `$slotConfig` argument. Pass the slot configuration array when writing a landing page or its translation.
+
 ## `EntitySearchResult`, `ProductListingResult` and `ProductReviewResult` no longer extend `EntityCollection`
 
 `EntitySearchResult` no longer extends `EntityCollection`, and `ProductListingResult` / `ProductReviewResult` no longer extend `EntitySearchResult`. All three are standalone result wrappers now. They remain `Struct`, so extensions, states, and JSON serialization keep working.

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -11,12 +11,6 @@ $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
     'identifier' => 'empty.notAllowed',
     'count' => 3,
-    'path' => __DIR__ . '/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 3,
     'path' => __DIR__ . '/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php',
 ];
 $ignoreErrors[] = [
@@ -204,12 +198,6 @@ $ignoreErrors[] = [
     'identifier' => 'shopware.domainException',
     'count' => 2,
     'path' => __DIR__ . '/src/Core/Content/ProductStream/Service/ProductStreamBuilder.php',
-];
-$ignoreErrors[] = [
-    'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',
-    'identifier' => 'empty.notAllowed',
-    'count' => 3,
-    'path' => __DIR__ . '/src/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRoute.php',
 ];
 $ignoreErrors[] = [
     'rawMessage' => 'Construct empty() is not allowed. Use more strict comparison.',

--- a/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
+++ b/src/Core/Content/Category/Aggregate/CategoryTranslation/CategoryTranslationEntity.php
@@ -29,7 +29,7 @@ class CategoryTranslationEntity extends TranslationEntity
     protected ?LanguageEntity $language = null;
 
     /**
-     * @var array<string, mixed>|null
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -80,7 +80,7 @@ class CategoryTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -88,7 +88,7 @@ class CategoryTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @param array<string, mixed> $slotConfig
+     * @param array<string, array<string, array<string, mixed>>|null> $slotConfig
      */
     public function setSlotConfig(array $slotConfig): void
     {

--- a/src/Core/Content/Category/CategoryEntity.php
+++ b/src/Core/Content/Category/CategoryEntity.php
@@ -78,7 +78,7 @@ class CategoryEntity extends Entity
     protected ?ProductStreamEntity $productStream = null;
 
     /**
-     * @var array<mixed>|null
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -363,7 +363,7 @@ class CategoryEntity extends Entity
     }
 
     /**
-     * @return array<mixed>|null
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -371,7 +371,7 @@ class CategoryEntity extends Entity
     }
 
     /**
-     * @param array<mixed> $slotConfig
+     * @param array<string, array<string, array<string, mixed>>|null> $slotConfig
      */
     public function setSlotConfig(array $slotConfig): void
     {

--- a/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
+++ b/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Service;
+
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+#[Package('discovery')]
+readonly class CmsFormSlotConfigResolver
+{
+    /**
+     * @internal
+     *
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<LandingPageCollection> $landingPageRepository
+     * @param EntityRepository<ProductCollection> $productRepository
+     * @param EntityRepository<CmsSlotCollection> $cmsSlotRepository
+     */
+    public function __construct(
+        private EntityRepository $categoryRepository,
+        private EntityRepository $landingPageRepository,
+        private EntityRepository $productRepository,
+        private EntityRepository $cmsSlotRepository,
+        private SystemConfigService $systemConfigService,
+    ) {
+    }
+
+    /**
+     * @return array{receivers: array<string, string>, message: string}
+     */
+    public function resolve(SalesChannelContext $context, ?string $slotId, ?string $navigationId, ?string $entityName): array
+    {
+        $slotConfig = $this->getSlotConfig($context, $slotId, $navigationId, $entityName);
+
+        if (!\is_array($slotConfig['receivers']) || $slotConfig['receivers'] === []) {
+            $slotConfig['receivers'] = [
+                $this->systemConfigService->getString('core.basicInformation.email', $context->getSalesChannelId()) => $this->systemConfigService->getString('core.basicInformation.shopName', $context->getSalesChannelId()),
+            ];
+        } else {
+            $slotConfig['receivers'] = \array_combine($slotConfig['receivers'], $slotConfig['receivers']);
+        }
+
+        if (!\is_string($slotConfig['message'])) {
+            $slotConfig['message'] = '';
+        }
+
+        return $slotConfig;
+    }
+
+    /**
+     * @return array{receivers: array<int, string>|null, message: string|null}
+     */
+    private function getSlotConfig(SalesChannelContext $context, ?string $slotId, ?string $navigationId, ?string $entityName): array
+    {
+        $slotConfig = ['receivers' => null, 'message' => null];
+
+        if (!$slotId) {
+            return $slotConfig;
+        }
+
+        if ($navigationId) {
+            $slotConfig = $this->getSlotConfigFromEntity($context, $slotId, $navigationId, $entityName);
+
+            if (\is_array($slotConfig['receivers']) && \is_string($slotConfig['message'])) {
+                return $slotConfig;
+            }
+        }
+
+        $criteria = new Criteria([$slotId]);
+        $slot = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
+
+        if (!$slot) {
+            return $slotConfig;
+        }
+
+        if (!\is_array($slotConfig['receivers'])) {
+            $slotConfig['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
+        }
+
+        if (!\is_string($slotConfig['message'])) {
+            $slotConfig['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
+        }
+
+        return $slotConfig;
+    }
+
+    /**
+     * @return array{receivers: array<int, string>|null, message: string|null}
+     */
+    private function getSlotConfigFromEntity(SalesChannelContext $context, string $slotId, string $navigationId, ?string $entityName = null): array
+    {
+        $slotConfig = ['receivers' => null, 'message' => null];
+
+        $criteria = new Criteria([$navigationId]);
+
+        $entity = match ($entityName) {
+            ProductDefinition::ENTITY_NAME => $this->productRepository->search($criteria, $context->getContext())->getEntities()->first(),
+            LandingPageDefinition::ENTITY_NAME => $this->landingPageRepository->search($criteria, $context->getContext())->getEntities()->first(),
+            default => $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first(),
+        };
+
+        if (!$entity || !$entity->getSlotConfig() || !\array_key_exists($slotId, $entity->getSlotConfig())) {
+            return $slotConfig;
+        }
+
+        $config = $entity->getSlotConfig()[$slotId];
+
+        if (\array_key_exists('mailReceiver', $config) && \array_key_exists('value', $config['mailReceiver'])) {
+            $slotConfig['receivers'] = $config['mailReceiver']['value'];
+        }
+
+        if (\array_key_exists('confirmationText', $config) && \array_key_exists('value', $config['confirmationText'])) {
+            $slotConfig['message'] = $config['confirmationText']['value'];
+        }
+
+        return $slotConfig;
+    }
+}

--- a/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
+++ b/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
@@ -82,12 +82,22 @@ readonly class CmsFormSlotConfigResolver
             return $slotConfig;
         }
 
-        if (!\is_array($slotConfig['receivers'])) {
-            $slotConfig['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
-        }
+        $config = $slot->getTranslated()['config'] ?? null;
 
-        if (!\is_string($slotConfig['message'])) {
-            $slotConfig['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
+        if (\is_array($config)) {
+            if (!\is_array($slotConfig['receivers'])
+                && \is_array($config['mailReceiver'] ?? null)
+                && \is_array($config['mailReceiver']['value'] ?? null)
+            ) {
+                $slotConfig['receivers'] = $config['mailReceiver']['value'];
+            }
+
+            if (!\is_string($slotConfig['message'])
+                && \is_array($config['confirmationText'] ?? null)
+                && \is_string($config['confirmationText']['value'] ?? null)
+            ) {
+                $slotConfig['message'] = $config['confirmationText']['value'];
+            }
         }
 
         return $slotConfig;
@@ -114,15 +124,15 @@ readonly class CmsFormSlotConfigResolver
 
         $config = $entity->getSlotConfig()[$slotId];
 
-        if (!$config) {
+        if (!\is_array($config)) {
             return $slotConfig;
         }
 
-        if (\array_key_exists('mailReceiver', $config) && \array_key_exists('value', $config['mailReceiver'])) {
+        if (\is_array($config['mailReceiver'] ?? null) && \is_array($config['mailReceiver']['value'] ?? null)) {
             $slotConfig['receivers'] = $config['mailReceiver']['value'];
         }
 
-        if (\array_key_exists('confirmationText', $config) && \array_key_exists('value', $config['confirmationText'])) {
+        if (\is_array($config['confirmationText'] ?? null) && \is_string($config['confirmationText']['value'] ?? null)) {
             $slotConfig['message'] = $config['confirmationText']['value'];
         }
 

--- a/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
+++ b/src/Core/Content/Cms/Service/CmsFormSlotConfigResolver.php
@@ -114,6 +114,10 @@ readonly class CmsFormSlotConfigResolver
 
         $config = $entity->getSlotConfig()[$slotId];
 
+        if (!$config) {
+            return $slotConfig;
+        }
+
         if (\array_key_exists('mailReceiver', $config) && \array_key_exists('value', $config['mailReceiver'])) {
             $slotConfig['receivers'] = $config['mailReceiver']['value'];
         }

--- a/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
+++ b/src/Core/Content/Cms/Service/EntityCmsSlotConfigInheritanceBuilder.php
@@ -42,7 +42,9 @@ readonly class EntityCmsSlotConfigInheritanceBuilder
         $merged = [];
         foreach ($languageInheritanceChain as $currentLanguageId) {
             foreach ($slotConfigs[$currentLanguageId] ?? [] as $slotId => $fields) {
-                $merged[$slotId] = \array_replace($merged[$slotId] ?? [], $fields);
+                if ($fields) {
+                    $merged[$slotId] = \array_replace($merged[$slotId] ?? [], $fields);
+                }
             }
         }
 
@@ -54,7 +56,7 @@ readonly class EntityCmsSlotConfigInheritanceBuilder
      *
      * @param EntityCollection<TTranslation>|null $translations
      *
-     * @return array<string, array<string, array<string, mixed>>>
+     * @return array<string, array<string, array<string, array<string, mixed>>|null>>
      */
     private function collectSlotConfigs(?EntityCollection $translations): array
     {

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -83,20 +83,16 @@ class ContactFormRoute extends AbstractContactFormRoute
             $data->set('salutation', $salutationSearchResult->getEntities()->first());
         }
 
-        if ($this->isEmptyReceivers($mailConfigs['receivers'])) {
-            $mailConfigs['receivers'][] = $this->systemConfigService->get('core.basicInformation.email', $context->getSalesChannelId());
+        if (!\is_array($mailConfigs['receivers']) || $mailConfigs['receivers'] === []) {
+            $mailConfigs['receivers'] = [$this->systemConfigService->getString('core.basicInformation.email', $context->getSalesChannelId()) => 'Admin'];
+        } else {
+            $mailConfigs['receivers'] = \array_combine($mailConfigs['receivers'], $mailConfigs['receivers']);
         }
 
-        $recipientStructs = [];
-        foreach ($mailConfigs['receivers'] as $mail) {
-            $recipientStructs[$mail] = $mail;
-        }
-
-        /** @var array<string, mixed> $recipientStructs */
         $event = new ContactFormEvent(
             $context->getContext(),
             $context->getSalesChannelId(),
-            new MailRecipientStruct($recipientStructs),
+            new MailRecipientStruct($mailConfigs['receivers']),
             $data
         );
 
@@ -124,13 +120,11 @@ class ContactFormRoute extends AbstractContactFormRoute
     }
 
     /**
-     * @return array<string, string|array<int, string>>
+     * @return array{receivers: array<int, string>|null, message: string|null}
      */
     private function getSlotConfig(string $slotId, string $navigationId, SalesChannelContext $context, ?string $entityName = null): array
     {
-        $mailConfigs = [];
-        $mailConfigs['receivers'] = [];
-        $mailConfigs['message'] = '';
+        $mailConfigs = ['receivers' => null, 'message' => null];
 
         $criteria = new Criteria([$navigationId]);
 
@@ -158,13 +152,11 @@ class ContactFormRoute extends AbstractContactFormRoute
     }
 
     /**
-     * @return array<string, array<string, array<int, mixed>|bool|float|int|string|null>|string|mixed>
+     * @return array{receivers: array<int, string>|null, message: string|null}
      */
     private function getMailConfigs(SalesChannelContext $context, ?string $slotId = null, ?string $navigationId = null, ?string $entityName = null): array
     {
-        $mailConfigs = [];
-        $mailConfigs['receivers'] = [];
-        $mailConfigs['message'] = '';
+        $mailConfigs = ['receivers' => null, 'message' => null];
 
         if (!$slotId) {
             return $mailConfigs;
@@ -172,37 +164,27 @@ class ContactFormRoute extends AbstractContactFormRoute
 
         if ($navigationId) {
             $mailConfigs = $this->getSlotConfig($slotId, $navigationId, $context, $entityName);
-            if (!$this->isEmptyReceivers($mailConfigs['receivers']) && !$this->isEmptyMessage($mailConfigs['message'])) {
+
+            if (\is_array($mailConfigs['receivers']) && \is_string($mailConfigs['message'])) {
                 return $mailConfigs;
             }
         }
 
         $criteria = new Criteria([$slotId]);
-
         $slot = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         if (!$slot) {
             return $mailConfigs;
         }
 
-        if ($this->isEmptyReceivers($mailConfigs['receivers'])) {
+        if (!\is_array($mailConfigs['receivers'])) {
             $mailConfigs['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
         }
 
-        if ($this->isEmptyMessage($mailConfigs['message'])) {
+        if (!\is_string($mailConfigs['message'])) {
             $mailConfigs['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
         }
 
         return $mailConfigs;
-    }
-
-    private function isEmptyReceivers(mixed $receivers): bool
-    {
-        return !\is_array($receivers) || $receivers === [];
-    }
-
-    private function isEmptyMessage(mixed $message): bool
-    {
-        return !\is_string($message) || $message === '';
     }
 }

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -3,13 +3,8 @@
 namespace Shopware\Core\Content\ContactForm\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
-use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver;
 use Shopware\Core\Content\ContactForm\Event\ContactFormEvent;
-use Shopware\Core\Content\LandingPage\LandingPageCollection;
-use Shopware\Core\Content\LandingPage\LandingPageDefinition;
-use Shopware\Core\Content\Product\ProductCollection;
-use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
@@ -25,7 +20,6 @@ use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalutationCollection;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -37,24 +31,16 @@ class ContactFormRoute extends AbstractContactFormRoute
     /**
      * @internal
      *
-     * @param EntityRepository<CmsSlotCollection> $cmsSlotRepository
      * @param EntityRepository<SalutationCollection> $salutationRepository
-     * @param EntityRepository<CategoryCollection> $categoryRepository
-     * @param EntityRepository<LandingPageCollection> $landingPageRepository
-     * @param EntityRepository<ProductCollection> $productRepository
      */
     public function __construct(
         private readonly DataValidationFactoryInterface $contactFormValidationFactory,
         private readonly DataValidator $validator,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly SystemConfigService $systemConfigService,
-        private readonly EntityRepository $cmsSlotRepository,
         private readonly EntityRepository $salutationRepository,
-        private readonly EntityRepository $categoryRepository,
-        private readonly EntityRepository $landingPageRepository,
-        private readonly EntityRepository $productRepository,
         private readonly RequestStack $requestStack,
-        private readonly RateLimiter $rateLimiter
+        private readonly RateLimiter $rateLimiter,
+        private readonly CmsFormSlotConfigResolver $cmsFormSlotConfigResolver,
     ) {
     }
 
@@ -74,19 +60,13 @@ class ContactFormRoute extends AbstractContactFormRoute
             $this->rateLimiter->ensureAccepted(RateLimiter::CONTACT_FORM, $request->getClientIp());
         }
 
-        $mailConfigs = $this->getMailConfigs($context, $data->get('slotId'), $data->get('navigationId'), $data->get('entityName'));
+        $mailConfigs = $this->cmsFormSlotConfigResolver->resolve($context, $data->get('slotId'), $data->get('navigationId'), $data->get('entityName'));
 
         $salutationCriteria = new Criteria([$data->get('salutationId')]);
         $salutationSearchResult = $this->salutationRepository->search($salutationCriteria, $context->getContext());
 
         if ($salutationSearchResult->getEntities()->count() !== 0) {
             $data->set('salutation', $salutationSearchResult->getEntities()->first());
-        }
-
-        if (!\is_array($mailConfigs['receivers']) || $mailConfigs['receivers'] === []) {
-            $mailConfigs['receivers'] = [$this->systemConfigService->getString('core.basicInformation.email', $context->getSalesChannelId()) => 'Admin'];
-        } else {
-            $mailConfigs['receivers'] = \array_combine($mailConfigs['receivers'], $mailConfigs['receivers']);
         }
 
         $event = new ContactFormEvent(
@@ -117,74 +97,5 @@ class ContactFormRoute extends AbstractContactFormRoute
         if ($violations->count() > 0) {
             throw new ConstraintViolationException($violations, $data->all());
         }
-    }
-
-    /**
-     * @return array{receivers: array<int, string>|null, message: string|null}
-     */
-    private function getSlotConfig(string $slotId, string $navigationId, SalesChannelContext $context, ?string $entityName = null): array
-    {
-        $mailConfigs = ['receivers' => null, 'message' => null];
-
-        $criteria = new Criteria([$navigationId]);
-
-        $entity = match ($entityName) {
-            ProductDefinition::ENTITY_NAME => $this->productRepository->search($criteria, $context->getContext())->getEntities()->first(),
-            LandingPageDefinition::ENTITY_NAME => $this->landingPageRepository->search($criteria, $context->getContext())->getEntities()->first(),
-            default => $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first(),
-        };
-
-        if (!$entity || !$entity->getSlotConfig() || !\array_key_exists($slotId, $entity->getSlotConfig())) {
-            return $mailConfigs;
-        }
-
-        $slotConfig = $entity->getSlotConfig()[$slotId];
-
-        if (\array_key_exists('mailReceiver', $slotConfig) && \array_key_exists('value', $slotConfig['mailReceiver'])) {
-            $mailConfigs['receivers'] = $slotConfig['mailReceiver']['value'];
-        }
-
-        if (\array_key_exists('confirmationText', $slotConfig) && \array_key_exists('value', $slotConfig['confirmationText'])) {
-            $mailConfigs['message'] = $slotConfig['confirmationText']['value'];
-        }
-
-        return $mailConfigs;
-    }
-
-    /**
-     * @return array{receivers: array<int, string>|null, message: string|null}
-     */
-    private function getMailConfigs(SalesChannelContext $context, ?string $slotId = null, ?string $navigationId = null, ?string $entityName = null): array
-    {
-        $mailConfigs = ['receivers' => null, 'message' => null];
-
-        if (!$slotId) {
-            return $mailConfigs;
-        }
-
-        if ($navigationId) {
-            $mailConfigs = $this->getSlotConfig($slotId, $navigationId, $context, $entityName);
-
-            if (\is_array($mailConfigs['receivers']) && \is_string($mailConfigs['message'])) {
-                return $mailConfigs;
-            }
-        }
-
-        $criteria = new Criteria([$slotId]);
-        $slot = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
-
-        if (!$slot) {
-            return $mailConfigs;
-        }
-
-        if (!\is_array($mailConfigs['receivers'])) {
-            $mailConfigs['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
-        }
-
-        if (!\is_string($mailConfigs['message'])) {
-            $mailConfigs['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
-        }
-
-        return $mailConfigs;
     }
 }

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -140,22 +140,18 @@ class ContactFormRoute extends AbstractContactFormRoute
             default => $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first(),
         };
 
-        if (!$entity) {
-            return $mailConfigs;
-        }
-
-        if (empty($entity->getSlotConfig()[$slotId])) {
+        if (!$entity || !$entity->getSlotConfig() || !\array_key_exists($slotId, $entity->getSlotConfig())) {
             return $mailConfigs;
         }
 
         $slotConfig = $entity->getSlotConfig()[$slotId];
 
         if (\array_key_exists('mailReceiver', $slotConfig) && \array_key_exists('value', $slotConfig['mailReceiver'])) {
-            $mailConfigs['receivers'] = $entity->getSlotConfig()[$slotId]['mailReceiver']['value'];
+            $mailConfigs['receivers'] = $slotConfig['mailReceiver']['value'];
         }
 
         if (\array_key_exists('confirmationText', $slotConfig) && \array_key_exists('value', $slotConfig['confirmationText'])) {
-            $mailConfigs['message'] = $entity->getSlotConfig()[$slotId]['confirmationText']['value'];
+            $mailConfigs['message'] = $slotConfig['confirmationText']['value'];
         }
 
         return $mailConfigs;

--- a/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
+++ b/src/Core/Content/ContactForm/SalesChannel/ContactFormRoute.php
@@ -83,7 +83,7 @@ class ContactFormRoute extends AbstractContactFormRoute
             $data->set('salutation', $salutationSearchResult->getEntities()->first());
         }
 
-        if (empty($mailConfigs['receivers'])) {
+        if ($this->isEmptyReceivers($mailConfigs['receivers'])) {
             $mailConfigs['receivers'][] = $this->systemConfigService->get('core.basicInformation.email', $context->getSalesChannelId());
         }
 
@@ -148,8 +148,15 @@ class ContactFormRoute extends AbstractContactFormRoute
             return $mailConfigs;
         }
 
-        $mailConfigs['receivers'] = $entity->getSlotConfig()[$slotId]['mailReceiver']['value'];
-        $mailConfigs['message'] = $entity->getSlotConfig()[$slotId]['confirmationText']['value'];
+        $slotConfig = $entity->getSlotConfig()[$slotId];
+
+        if (\array_key_exists('mailReceiver', $slotConfig) && \array_key_exists('value', $slotConfig['mailReceiver'])) {
+            $mailConfigs['receivers'] = $entity->getSlotConfig()[$slotId]['mailReceiver']['value'];
+        }
+
+        if (\array_key_exists('confirmationText', $slotConfig) && \array_key_exists('value', $slotConfig['confirmationText'])) {
+            $mailConfigs['message'] = $entity->getSlotConfig()[$slotId]['confirmationText']['value'];
+        }
 
         return $mailConfigs;
     }
@@ -169,7 +176,7 @@ class ContactFormRoute extends AbstractContactFormRoute
 
         if ($navigationId) {
             $mailConfigs = $this->getSlotConfig($slotId, $navigationId, $context, $entityName);
-            if (!empty($mailConfigs['receivers'])) {
+            if (!$this->isEmptyReceivers($mailConfigs['receivers']) && !$this->isEmptyMessage($mailConfigs['message'])) {
                 return $mailConfigs;
             }
         }
@@ -182,9 +189,24 @@ class ContactFormRoute extends AbstractContactFormRoute
             return $mailConfigs;
         }
 
-        $mailConfigs['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
-        $mailConfigs['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
+        if ($this->isEmptyReceivers($mailConfigs['receivers'])) {
+            $mailConfigs['receivers'] = $slot->getTranslated()['config']['mailReceiver']['value'];
+        }
+
+        if ($this->isEmptyMessage($mailConfigs['message'])) {
+            $mailConfigs['message'] = $slot->getTranslated()['config']['confirmationText']['value'];
+        }
 
         return $mailConfigs;
+    }
+
+    private function isEmptyReceivers(mixed $receivers): bool
+    {
+        return !\is_array($receivers) || $receivers === [];
+    }
+
+    private function isEmptyMessage(mixed $message): bool
+    {
+        return !\is_string($message) || $message === '';
     }
 }

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -65,6 +65,14 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollector"/>
         </service>
 
+        <service id="Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver">
+            <argument type="service" id="category.repository"/>
+            <argument type="service" id="landing_page.repository"/>
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="cms_slot.repository"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
+
         <service id="Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>

--- a/src/Core/Content/DependencyInjection/contact_form.xml
+++ b/src/Core/Content/DependencyInjection/contact_form.xml
@@ -13,14 +13,10 @@
             <argument type="service" id="Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory"/>
             <argument type="service" id="Shopware\Core\Framework\Validation\DataValidator"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="cms_slot.repository" />
             <argument type="service" id="salutation.repository" />
-            <argument type="service" id="category.repository" />
-            <argument type="service" id="landing_page.repository" />
-            <argument type="service" id="product.repository" />
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
             <argument type="service" id="shopware.rate_limiter" />
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver" />
         </service>
     </services>
 </container>

--- a/src/Core/Content/DependencyInjection/revocation_request_form.xml
+++ b/src/Core/Content/DependencyInjection/revocation_request_form.xml
@@ -16,12 +16,8 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="shopware.rate_limiter" />
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="cms_slot.repository" />
-            <argument type="service" id="category.repository" />
             <argument type="service" id="Psr\Clock\ClockInterface"/>
-            <argument type="service" id="landing_page.repository" />
-            <argument type="service" id="product.repository" />
+            <argument type="service" id="Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver" />
         </service>
     </services>
 </container>

--- a/src/Core/Content/DependencyInjection/revocation_request_form.xml
+++ b/src/Core/Content/DependencyInjection/revocation_request_form.xml
@@ -20,6 +20,8 @@
             <argument type="service" id="cms_slot.repository" />
             <argument type="service" id="category.repository" />
             <argument type="service" id="Psr\Clock\ClockInterface"/>
+            <argument type="service" id="landing_page.repository" />
+            <argument type="service" id="product.repository" />
         </service>
     </services>
 </container>

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
@@ -117,7 +117,7 @@ class LandingPageTranslationEntity extends TranslationEntity
      */
     public function setSlotConfig(?array $slotConfig): void
     {
-        if (!$slotConfig) {
+        if ($slotConfig === null) {
             Feature::triggerDeprecationOrThrow(
                 'v6.8.0.0',
                 '$slotConfig will be mandatory in future implementation'

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
@@ -117,10 +117,12 @@ class LandingPageTranslationEntity extends TranslationEntity
      */
     public function setSlotConfig(?array $slotConfig): void
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
-        );
+        if (!$slotConfig) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                '$slotConfig will be mandatory in future implementation'
+            );
+        }
 
         $this->slotConfig = $slotConfig;
     }

--- a/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
+++ b/src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\LandingPage\Aggregate\LandingPageTranslation;
 use Shopware\Core\Content\LandingPage\LandingPageEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\TranslationEntity;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('discovery')]
@@ -27,7 +28,7 @@ class LandingPageTranslationEntity extends TranslationEntity
     protected ?string $keywords = null;
 
     /**
-     * @var ?array<string, mixed>
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -102,7 +103,7 @@ class LandingPageTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @return ?array<string, mixed>
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -110,10 +111,17 @@ class LandingPageTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @param ?array<string, mixed> $slotConfig
+     * @deprecated tag:v6.8.0 - $slotConfig will be mandatory in future implementation
+     *
+     * @param array<string, array<string, array<string, mixed>>|null>|null $slotConfig
      */
     public function setSlotConfig(?array $slotConfig): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
+        );
+
         $this->slotConfig = $slotConfig;
     }
 }

--- a/src/Core/Content/LandingPage/LandingPageEntity.php
+++ b/src/Core/Content/LandingPage/LandingPageEntity.php
@@ -175,7 +175,7 @@ class LandingPageEntity extends Entity
      */
     public function setSlotConfig(?array $slotConfig): void
     {
-        if (!$slotConfig) {
+        if ($slotConfig === null) {
             Feature::triggerDeprecationOrThrow(
                 'v6.8.0.0',
                 '$slotConfig will be mandatory in future implementation'

--- a/src/Core/Content/LandingPage/LandingPageEntity.php
+++ b/src/Core/Content/LandingPage/LandingPageEntity.php
@@ -175,10 +175,12 @@ class LandingPageEntity extends Entity
      */
     public function setSlotConfig(?array $slotConfig): void
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.8.0.0',
-            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
-        );
+        if (!$slotConfig) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                '$slotConfig will be mandatory in future implementation'
+            );
+        }
 
         $this->slotConfig = $slotConfig;
     }

--- a/src/Core/Content/LandingPage/LandingPageEntity.php
+++ b/src/Core/Content/LandingPage/LandingPageEntity.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\Tag\TagCollection;
@@ -43,7 +44,7 @@ class LandingPageEntity extends Entity
     protected ?string $url = null;
 
     /**
-     * @var ?array<string, mixed>
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -160,7 +161,7 @@ class LandingPageEntity extends Entity
     }
 
     /**
-     * @return ?array<string, mixed>
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -168,10 +169,17 @@ class LandingPageEntity extends Entity
     }
 
     /**
-     * @param ?array<string, mixed> $slotConfig
+     * @deprecated tag:v6.8.0 - $slotConfig will be mandatory in future implementation
+     *
+     * @param array<string, array<string, array<string, mixed>>|null>|null $slotConfig
      */
     public function setSlotConfig(?array $slotConfig): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'v6.8.0.0')
+        );
+
         $this->slotConfig = $slotConfig;
     }
 

--- a/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
@@ -35,7 +35,7 @@ class ProductTranslationEntity extends TranslationEntity
     protected ?ProductEntity $product = null;
 
     /**
-     * @var array<string, mixed>|null
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -139,7 +139,7 @@ class ProductTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -147,7 +147,7 @@ class ProductTranslationEntity extends TranslationEntity
     }
 
     /**
-     * @param array<string, mixed> $slotConfig
+     * @param array<string, array<string, array<string, mixed>>|null> $slotConfig
      */
     public function setSlotConfig(array $slotConfig): void
     {

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -187,7 +187,7 @@ class ProductEntity extends Entity implements \Stringable
     protected ?CmsPageEntity $cmsPage = null;
 
     /**
-     * @var array<string, array<string, array<string, string>>>|null
+     * @var array<string, array<string, array<string, mixed>>|null>|null
      */
     protected ?array $slotConfig = null;
 
@@ -793,7 +793,7 @@ class ProductEntity extends Entity implements \Stringable
     }
 
     /**
-     * @return array<string, mixed>|null
+     * @return array<string, array<string, array<string, mixed>>|null>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -801,7 +801,7 @@ class ProductEntity extends Entity implements \Stringable
     }
 
     /**
-     * @param array<string, mixed> $slotConfig
+     * @param array<string, array<string, array<string, mixed>>|null> $slotConfig
      */
     public function setSlotConfig(array $slotConfig): void
     {

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -793,7 +793,7 @@ class ProductEntity extends Entity implements \Stringable
     }
 
     /**
-     * @return array<string, array<string, array<string, string>>>|null
+     * @return array<string, mixed>|null
      */
     public function getSlotConfig(): ?array
     {
@@ -801,7 +801,7 @@ class ProductEntity extends Entity implements \Stringable
     }
 
     /**
-     * @param array<string, array<string, array<string, string>>> $slotConfig
+     * @param array<string, mixed> $slotConfig
      */
     public function setSlotConfig(array $slotConfig): void
     {

--- a/src/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRoute.php
+++ b/src/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRoute.php
@@ -5,8 +5,11 @@ namespace Shopware\Core\Content\RevocationRequest\SalesChannel;
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
 use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\RevocationRequest\Event\RevocationRequestEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -35,6 +38,8 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
     /**
      * @param EntityRepository<CmsSlotCollection> $cmsSlotRepository
      * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param EntityRepository<LandingPageCollection> $landingPageRepository
+     * @param EntityRepository<ProductCollection> $productRepository
      *
      * @internal
      */
@@ -48,6 +53,8 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
         private readonly EntityRepository $cmsSlotRepository,
         private readonly EntityRepository $categoryRepository,
         private readonly ClockInterface $clock,
+        private readonly EntityRepository $landingPageRepository,
+        private readonly EntityRepository $productRepository,
     ) {
     }
 
@@ -70,6 +77,12 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
 
         $mailConfig = $this->getMailConfig($context, $dataBag);
 
+        if (!\is_array($mailConfig['receivers']) || $mailConfig['receivers'] === []) {
+            $mailConfig['receivers'] = [$this->systemConfigService->getString('core.basicInformation.email', $context->getSalesChannelId()) => 'Admin'];
+        } else {
+            $mailConfig['receivers'] = \array_combine($mailConfig['receivers'], $mailConfig['receivers']);
+        }
+
         $merchantMailRecipientStruct = new MailRecipientStruct($mailConfig['receivers']);
         $merchantEvent = new RevocationRequestEvent($context->getContext(), $context->getSalesChannelId(), $merchantMailRecipientStruct, $dataBag);
         $this->eventDispatcher->dispatch($merchantEvent, RevocationRequestEvent::EVENT_NAME);
@@ -88,88 +101,75 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
     }
 
     /**
-     * @return array{receivers: array<string, string>, message?: string|null}
+     * @return array{receivers: array<int, string>|null, message: string|null}
      */
     private function getMailConfig(SalesChannelContext $context, RequestDataBag $dataBag): array
     {
         $slotId = $dataBag->get('slotId');
         $navigationId = $dataBag->get('navigationId');
-        $mailConfig = ['receivers' => []];
+        $entityName = $dataBag->get('entityName');
+
+        $mailConfig = ['receivers' => null, 'message' => null];
 
         if (!$slotId) {
-            return $this->createDefaultConfig($context, $mailConfig);
+            return $mailConfig;
         }
 
         if ($navigationId) {
-            $criteria = new Criteria([$navigationId]);
-            $categoryEntity = $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first();
+            $mailConfig = $this->getSlotConfig($slotId, $navigationId, $context, $entityName);
 
-            if ($categoryEntity instanceof CategoryEntity && !empty($categoryEntity->getSlotConfig()[$slotId])) {
-                $categoryEntityConfig = $categoryEntity->getSlotConfig()[$slotId];
-                $this->addReceivers($mailConfig, $categoryEntityConfig);
-                $mailConfig['message'] = $this->getStringMessage($categoryEntityConfig['confirmationText']['value']);
+            if (\is_array($mailConfig['receivers']) && \is_string($mailConfig['message'])) {
+                return $mailConfig;
             }
-        }
-
-        if (!empty($mailConfig['receivers'])) {
-            return $mailConfig;
         }
 
         $criteria = new Criteria([$slotId]);
         $slotEntity = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         if (!$slotEntity) {
-            return $this->createDefaultConfig($context, $mailConfig);
+            return $mailConfig;
         }
 
-        $slotConfig = $slotEntity->getTranslated()['config'];
-        $this->addReceivers($mailConfig, $slotConfig);
-        $mailConfig['message'] = $this->getStringMessage($slotConfig['confirmationText']['value']);
+        if (!\is_array($mailConfig['receivers'])) {
+            $mailConfig['receivers'] = $slotEntity->getTranslated()['config']['mailReceiver']['value'];
+        }
 
-        if (empty($mailConfig['receivers'])) {
-            return $this->createDefaultConfig($context, $mailConfig);
+        if (!\is_string($mailConfig['message'])) {
+            $mailConfig['message'] = $slotEntity->getTranslated()['config']['confirmationText']['value'];
         }
 
         return $mailConfig;
     }
 
     /**
-     * @param array<string, mixed> $config
-     *
-     * @return array{receivers: array<string>, message?: string|null}
+     * @return array{receivers: array<int, string>|null, message: string|null}
      */
-    private function createDefaultConfig(SalesChannelContext $context, array $config): array
+    private function getSlotConfig(string $slotId, string $navigationId, SalesChannelContext $context, ?string $entityName = null): array
     {
-        $config['receivers'][$this->systemConfigService->get('core.basicInformation.email', $context->getSalesChannelId())] = 'Admin';
+        $mailConfig = ['receivers' => null, 'message' => null];
 
-        return $config;
-    }
+        $criteria = new Criteria([$navigationId]);
 
-    /**
-     * @param array<string, mixed> $mailConfig
-     * @param array<string, mixed> $slotConfig
-     */
-    private function addReceivers(array &$mailConfig, array $slotConfig): void
-    {
-        $receivers = $slotConfig['mailReceiver']['value'] ?? null;
+        $entity = match ($entityName) {
+            ProductDefinition::ENTITY_NAME => $this->productRepository->search($criteria, $context->getContext())->getEntities()->first(),
+            LandingPageDefinition::ENTITY_NAME => $this->landingPageRepository->search($criteria, $context->getContext())->getEntities()->first(),
+            default => $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first(),
+        };
 
-        if (\is_array($receivers)) {
-            foreach ($receivers as $receiver) {
-                $mailConfig['receivers'][$receiver] = $receiver;
-            }
-        }
-    }
-
-    private function getStringMessage(mixed $value): string
-    {
-        if ($value === null) {
-            return '';
+        if (!$entity || !$entity->getSlotConfig() || !\array_key_exists($slotId, $entity->getSlotConfig())) {
+            return $mailConfig;
         }
 
-        if (\is_string($value)) {
-            return $value;
+        $slotConfig = $entity->getSlotConfig()[$slotId];
+
+        if (\array_key_exists('mailReceiver', $slotConfig) && \array_key_exists('value', $slotConfig['mailReceiver'])) {
+            $mailConfig['receivers'] = $slotConfig['mailReceiver']['value'];
         }
 
-        return (string) $value;
+        if (\array_key_exists('confirmationText', $slotConfig) && \array_key_exists('value', $slotConfig['confirmationText'])) {
+            $mailConfig['message'] = $slotConfig['confirmationText']['value'];
+        }
+
+        return $mailConfig;
     }
 }

--- a/src/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRoute.php
+++ b/src/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRoute.php
@@ -4,15 +4,8 @@ namespace Shopware\Core\Content\RevocationRequest\SalesChannel;
 
 use Psr\Clock\ClockInterface;
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
-use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
-use Shopware\Core\Content\LandingPage\LandingPageCollection;
-use Shopware\Core\Content\LandingPage\LandingPageDefinition;
-use Shopware\Core\Content\Product\ProductCollection;
-use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver;
 use Shopware\Core\Content\RevocationRequest\Event\RevocationRequestEvent;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -25,7 +18,6 @@ use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Attribute\Route;
@@ -36,11 +28,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class RevocationRequestRoute extends AbstractRevocationRequestRoute
 {
     /**
-     * @param EntityRepository<CmsSlotCollection> $cmsSlotRepository
-     * @param EntityRepository<CategoryCollection> $categoryRepository
-     * @param EntityRepository<LandingPageCollection> $landingPageRepository
-     * @param EntityRepository<ProductCollection> $productRepository
-     *
      * @internal
      */
     public function __construct(
@@ -49,12 +36,8 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
         private readonly RequestStack $requestStack,
         private readonly RateLimiter $rateLimiter,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly SystemConfigService $systemConfigService,
-        private readonly EntityRepository $cmsSlotRepository,
-        private readonly EntityRepository $categoryRepository,
         private readonly ClockInterface $clock,
-        private readonly EntityRepository $landingPageRepository,
-        private readonly EntityRepository $productRepository,
+        private readonly CmsFormSlotConfigResolver $cmsFormSlotConfigResolver,
     ) {
     }
 
@@ -75,13 +58,7 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
 
         $this->validateRevocationRequestForm($dataBag, $context);
 
-        $mailConfig = $this->getMailConfig($context, $dataBag);
-
-        if (!\is_array($mailConfig['receivers']) || $mailConfig['receivers'] === []) {
-            $mailConfig['receivers'] = [$this->systemConfigService->getString('core.basicInformation.email', $context->getSalesChannelId()) => 'Admin'];
-        } else {
-            $mailConfig['receivers'] = \array_combine($mailConfig['receivers'], $mailConfig['receivers']);
-        }
+        $mailConfig = $this->cmsFormSlotConfigResolver->resolve($context, $dataBag->get('slotId'), $dataBag->get('navigationId'), $dataBag->get('entityName'));
 
         $merchantMailRecipientStruct = new MailRecipientStruct($mailConfig['receivers']);
         $merchantEvent = new RevocationRequestEvent($context->getContext(), $context->getSalesChannelId(), $merchantMailRecipientStruct, $dataBag);
@@ -98,78 +75,5 @@ class RevocationRequestRoute extends AbstractRevocationRequestRoute
         if ($violations->count() > 0) {
             throw new ConstraintViolationException($violations, $dataBag->all());
         }
-    }
-
-    /**
-     * @return array{receivers: array<int, string>|null, message: string|null}
-     */
-    private function getMailConfig(SalesChannelContext $context, RequestDataBag $dataBag): array
-    {
-        $slotId = $dataBag->get('slotId');
-        $navigationId = $dataBag->get('navigationId');
-        $entityName = $dataBag->get('entityName');
-
-        $mailConfig = ['receivers' => null, 'message' => null];
-
-        if (!$slotId) {
-            return $mailConfig;
-        }
-
-        if ($navigationId) {
-            $mailConfig = $this->getSlotConfig($slotId, $navigationId, $context, $entityName);
-
-            if (\is_array($mailConfig['receivers']) && \is_string($mailConfig['message'])) {
-                return $mailConfig;
-            }
-        }
-
-        $criteria = new Criteria([$slotId]);
-        $slotEntity = $this->cmsSlotRepository->search($criteria, $context->getContext())->getEntities()->first();
-
-        if (!$slotEntity) {
-            return $mailConfig;
-        }
-
-        if (!\is_array($mailConfig['receivers'])) {
-            $mailConfig['receivers'] = $slotEntity->getTranslated()['config']['mailReceiver']['value'];
-        }
-
-        if (!\is_string($mailConfig['message'])) {
-            $mailConfig['message'] = $slotEntity->getTranslated()['config']['confirmationText']['value'];
-        }
-
-        return $mailConfig;
-    }
-
-    /**
-     * @return array{receivers: array<int, string>|null, message: string|null}
-     */
-    private function getSlotConfig(string $slotId, string $navigationId, SalesChannelContext $context, ?string $entityName = null): array
-    {
-        $mailConfig = ['receivers' => null, 'message' => null];
-
-        $criteria = new Criteria([$navigationId]);
-
-        $entity = match ($entityName) {
-            ProductDefinition::ENTITY_NAME => $this->productRepository->search($criteria, $context->getContext())->getEntities()->first(),
-            LandingPageDefinition::ENTITY_NAME => $this->landingPageRepository->search($criteria, $context->getContext())->getEntities()->first(),
-            default => $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first(),
-        };
-
-        if (!$entity || !$entity->getSlotConfig() || !\array_key_exists($slotId, $entity->getSlotConfig())) {
-            return $mailConfig;
-        }
-
-        $slotConfig = $entity->getSlotConfig()[$slotId];
-
-        if (\array_key_exists('mailReceiver', $slotConfig) && \array_key_exists('value', $slotConfig['mailReceiver'])) {
-            $mailConfig['receivers'] = $slotConfig['mailReceiver']['value'];
-        }
-
-        if (\array_key_exists('confirmationText', $slotConfig) && \array_key_exists('value', $slotConfig['confirmationText'])) {
-            $mailConfig['message'] = $slotConfig['confirmationText']['value'];
-        }
-
-        return $mailConfig;
     }
 }

--- a/src/Storefront/Page/LandingPage/LandingPage.php
+++ b/src/Storefront/Page/LandingPage/LandingPage.php
@@ -12,6 +12,8 @@ class LandingPage extends Page
 {
     protected ?LandingPageEntity $landingPage = null;
 
+    protected ?string $navigationId = null;
+
     public function getEntityName(): string
     {
         return LandingPageDefinition::ENTITY_NAME;
@@ -25,5 +27,15 @@ class LandingPage extends Page
     public function setLandingPage(?LandingPageEntity $landingPage): void
     {
         $this->landingPage = $landingPage;
+    }
+
+    public function getNavigationId(): ?string
+    {
+        return $this->navigationId;
+    }
+
+    public function setNavigationId(?string $navigationId): void
+    {
+        $this->navigationId = $navigationId;
     }
 }

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -52,6 +52,7 @@ class LandingPageLoader
         $page = LandingPage::createFrom($page);
 
         $page->setLandingPage($landingPage);
+        $page->setNavigationId($landingPage->getId());
 
         $metaTitle = $landingPage->getTranslation('metaTitle') ?? $landingPage->getTranslation('name');
         $metaDescription = $landingPage->getTranslation('metaDescription');

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/online-revocation-request-form.html.twig
@@ -107,7 +107,13 @@
 
         {% block cms_form_revocation_hidden_fields %}
             <div class="form-hidden-fields">
-                <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ shopware.navigation.id }}">
+                {% if page.navigationId and page.entityName %}
+                    <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ page.navigationId }}">
+                    <input type="hidden" id="{{ formPrefix }}-entityName" name="entityName" value="{{ page.entityName }}">
+                {% else %}
+                    <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ shopware.navigation.id }}">
+                {% endif %}
+
                 <input type="hidden" id="{{ formPrefix }}-slotId" name="slotId" value="{{ element.id }}">
                 <input type="submit" class="submit--hidden d-none">
             </div>

--- a/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
@@ -262,6 +262,17 @@ class ContactFormRouteTest extends TestCase
             'inherited@example.com',
             'Child success message',
         ];
+
+        yield 'empty custom confirmation text is not inherited' => [
+            [
+                'confirmationText' => [
+                    'source' => 'static',
+                    'value' => '',
+                ],
+            ],
+            'inherited@example.com',
+            '',
+        ];
     }
 
     #[DataProvider('contactFormWithDomainProvider')]

--- a/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
@@ -5,11 +5,8 @@ namespace Shopware\Tests\Integration\Core\Content\ContactForm;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
-use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -59,20 +56,19 @@ class ContactFormRouteTest extends TestCase
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
 
-        $this->browser
-            ->request(
-                'POST',
-                '/store-api/contact-form',
-                [
-                    'salutationId' => $this->getValidSalutationId(),
-                    'firstName' => 'Firstname',
-                    'lastName' => 'Lastname',
-                    'email' => 'test@shäpware.com',
-                    'phone' => '12345/6789',
-                    'subject' => 'Subject',
-                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-                ]
-            );
+        $this->browser->request(
+            'POST',
+            '/store-api/contact-form',
+            [
+                'salutationId' => $this->getValidSalutationId(),
+                'firstName' => 'Firstname',
+                'lastName' => 'Lastname',
+                'email' => 'test@shäpware.com',
+                'phone' => '12345/6789',
+                'subject' => 'Subject',
+                'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+            ]
+        );
 
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -84,14 +80,9 @@ class ContactFormRouteTest extends TestCase
         static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
     }
 
-    #[DataProvider('navigationProvider')]
-    public function testContactFormSendMailWithNavigationIdAndSlotId(string $entityName): void
+    public function testContactFormSendMailWithLandingPageContext(): void
     {
-        [$navigationId, $slotId] = match ($entityName) {
-            LandingPageDefinition::ENTITY_NAME => $this->createLandingPageData(),
-            ProductDefinition::ENTITY_NAME => $this->createProductData(),
-            default => $this->createCategoryData(true),
-        };
+        [$navigationId, $slotId] = $this->createLandingPageData();
 
         /** @var EventDispatcher $dispatcher */
         $dispatcher = static::getContainer()->get('event_dispatcher');
@@ -102,30 +93,29 @@ class ContactFormRouteTest extends TestCase
             $eventDidRun = true;
             $recipients = $event->getRecipients();
             static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            static::assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
         };
 
         $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
 
-        $this->browser
-            ->request(
-                'POST',
-                '/store-api/contact-form',
-                [
-                    'salutationId' => $this->getValidSalutationId(),
-                    'navigationId' => $navigationId,
-                    'slotId' => $slotId,
-                    'entityName' => $entityName,
-                    'firstName' => 'Firstname',
-                    'lastName' => 'Lastname',
-                    'email' => 'test@shopware.com',
-                    'phone' => '12345/6789',
-                    'subject' => 'Subject',
-                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-                ]
-            );
+        $this->browser->request(
+            'POST',
+            '/store-api/contact-form',
+            [
+                'salutationId' => $this->getValidSalutationId(),
+                'navigationId' => $navigationId,
+                'slotId' => $slotId,
+                'entityName' => LandingPageDefinition::ENTITY_NAME,
+                'firstName' => 'Firstname',
+                'lastName' => 'Lastname',
+                'email' => 'test@shopware.com',
+                'phone' => '12345/6789',
+                'subject' => 'Subject',
+                'comment' => 'Lorem ipsum dolor sit amet',
+            ]
+        );
 
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
         static::assertArrayHasKey('individualSuccessMessage', $response);
         static::assertEmpty($response['individualSuccessMessage']);
 
@@ -135,163 +125,22 @@ class ContactFormRouteTest extends TestCase
         static::assertArrayHasKey('h.mac@example.com', $recipients);
     }
 
-    public static function navigationProvider(): \Generator
-    {
-        yield 'Category with Slot Config' => [CategoryDefinition::ENTITY_NAME];
-        yield 'Landing Page with Slot Config' => [LandingPageDefinition::ENTITY_NAME];
-        yield 'Product Page with Slot Config' => [ProductDefinition::ENTITY_NAME];
-    }
-
-    public function testContactFormSendMailWithSlotId(): void
-    {
-        [$categoryId] = $this->createCategoryData();
-
-        $formSlotId = $this->ids->create('form-slot');
-        $this->createCmsFormData($formSlotId);
-
-        /** @var EventDispatcher $dispatcher */
-        $dispatcher = static::getContainer()->get('event_dispatcher');
-
-        $eventDidRun = false;
-        $listenerClosure = static function (MailSentEvent $event) use (&$eventDidRun): void {
-            $eventDidRun = true;
-            static::assertStringContainsString('Contact email address: test@shopware.com', $event->getContents()['text/html']);
-            static::assertStringContainsString('essage: Lorem ipsum dolor sit amet', $event->getContents()['text/html']);
-        };
-
-        $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
-
-        $this->browser
-            ->request(
-                'POST',
-                '/store-api/contact-form',
-                [
-                    'salutationId' => $this->getValidSalutationId(),
-                    'navigationId' => $categoryId,
-                    'slotId' => $formSlotId,
-                    'firstName' => 'Firstname',
-                    'lastName' => 'Lastname',
-                    'email' => 'test@shopware.com',
-                    'phone' => '12345/6789',
-                    'subject' => 'Subject',
-                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-                ]
-            );
-
-        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-        static::assertArrayHasKey('individualSuccessMessage', $response);
-        static::assertEmpty($response['individualSuccessMessage']);
-
-        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
-
-        static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
-    }
-
-    /**
-     * @param array<string, array{source: string, value: array<int, string>|string}> $slotConfig
-     */
-    #[DataProvider('partialSlotConfigProvider')]
-    public function testContactFormSendMailUsesInheritedSlotConfigFieldsIndependently(array $slotConfig, string $expectedRecipient, string $expectedSuccessMessage): void
-    {
-        $formSlotId = $this->ids->create('form-slot');
-        $this->createCmsFormData($formSlotId, ['inherited@example.com'], 'Inherited success message');
-        [$landingPageId] = $this->createLandingPageData($formSlotId, $slotConfig);
-
-        /** @var EventDispatcher $dispatcher */
-        $dispatcher = static::getContainer()->get('event_dispatcher');
-
-        $eventDidRun = false;
-        $recipients = [];
-        $listenerClosure = static function (MailSentEvent $event) use (&$eventDidRun, &$recipients): void {
-            $eventDidRun = true;
-            $recipients = $event->getRecipients();
-        };
-
-        $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
-
-        $this->browser
-            ->request(
-                'POST',
-                '/store-api/contact-form',
-                [
-                    'salutationId' => $this->getValidSalutationId(),
-                    'navigationId' => $landingPageId,
-                    'slotId' => $formSlotId,
-                    'entityName' => LandingPageDefinition::ENTITY_NAME,
-                    'firstName' => 'Firstname',
-                    'lastName' => 'Lastname',
-                    'email' => 'test@shopware.com',
-                    'phone' => '12345/6789',
-                    'subject' => 'Subject',
-                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-                ]
-            );
-
-        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-        static::assertArrayHasKey('individualSuccessMessage', $response);
-        static::assertSame($expectedSuccessMessage, $response['individualSuccessMessage']);
-
-        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
-
-        static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
-        static::assertArrayHasKey($expectedRecipient, $recipients);
-    }
-
-    public static function partialSlotConfigProvider(): \Generator
-    {
-        yield 'custom receiver inherits confirmation text' => [
-            [
-                'mailReceiver' => [
-                    'source' => 'static',
-                    'value' => ['child@example.com'],
-                ],
-            ],
-            'child@example.com',
-            'Inherited success message',
-        ];
-
-        yield 'custom confirmation text inherits receiver' => [
-            [
-                'confirmationText' => [
-                    'source' => 'static',
-                    'value' => 'Child success message',
-                ],
-            ],
-            'inherited@example.com',
-            'Child success message',
-        ];
-
-        yield 'empty custom confirmation text is not inherited' => [
-            [
-                'confirmationText' => [
-                    'source' => 'static',
-                    'value' => '',
-                ],
-            ],
-            'inherited@example.com',
-            '',
-        ];
-    }
-
     #[DataProvider('contactFormWithDomainProvider')]
     public function testContactFormWithInvalid(string $firstName, string $lastName, \Closure $expectClosure): void
     {
-        $this->browser
-            ->request(
-                'POST',
-                '/store-api/contact-form',
-                [
-                    'salutationId' => $this->getValidSalutationId(),
-                    'firstName' => $firstName,
-                    'lastName' => $lastName,
-                    'email' => 'test@shopware.com',
-                    'phone' => '12345/6789',
-                    'subject' => 'Subject',
-                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-                ]
-            );
+        $this->browser->request(
+            'POST',
+            '/store-api/contact-form',
+            [
+                'salutationId' => $this->getValidSalutationId(),
+                'firstName' => $firstName,
+                'lastName' => $lastName,
+                'email' => 'test@shopware.com',
+                'phone' => '12345/6789',
+                'subject' => 'Subject',
+                'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+            ]
+        );
 
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
@@ -341,111 +190,14 @@ class ContactFormRouteTest extends TestCase
     }
 
     /**
-     * @return array<int, string>
+     * @return array{0: string, 1: string}
      */
-    private function createCategoryData(bool $withSlotConfig = false): array
-    {
-        $contactCategoryId = $this->ids->get('contact-category-test');
-
-        $slotId = $this->ids->create('form-slot');
-        $slotConfig = $withSlotConfig ? [
-            $slotId => [
-                'mailReceiver' => [
-                    'source' => 'static',
-                    'value' => ['h.mac@example.com'],
-                ],
-                'confirmationText' => [
-                    'source' => 'static',
-                    'value' => '',
-                ],
-            ],
-        ] : [];
-
-        $data = [
-            [
-                'id' => $contactCategoryId,
-                'translations' => [
-                    [
-                        'name' => 'EN-Entry',
-                        'languageId' => Defaults::LANGUAGE_SYSTEM,
-                        'slotConfig' => $slotConfig,
-                    ],
-                ],
-            ],
-        ];
-        static::getContainer()->get('category.repository')->create($data, Context::createDefaultContext());
-
-        return [$contactCategoryId, $slotId];
-    }
-
-    /**
-     * @param array<int, string> $receivers
-     */
-    private function createCmsFormData(string $slotId, array $receivers = ['h.mac@example.com'], string $confirmationText = ''): void
-    {
-        $cmsData = [
-            [
-                'id' => $this->ids->create('cms-page'),
-                'name' => 'test page',
-                'type' => 'landingpage',
-                'sections' => [
-                    [
-                        'id' => $this->ids->create('section'),
-                        'type' => 'default',
-                        'position' => 0,
-                        'blocks' => [
-                            [
-                                'type' => 'form',
-                                'position' => 0,
-                                'slots' => [
-                                    [
-                                        'id' => $slotId,
-                                        'type' => 'form',
-                                        'slot' => 'content',
-                                        'config' => [
-                                            'mailReceiver' => [
-                                                'source' => 'static',
-                                                'value' => $receivers,
-                                            ],
-                                            'confirmationText' => [
-                                                'source' => 'static',
-                                                'value' => $confirmationText,
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        static::getContainer()->get('cms_page.repository')->create($cmsData, Context::createDefaultContext());
-    }
-
-    /**
-     * @param array<string, array{source: string, value: array<int, string>|string}>|null $slotConfig
-     *
-     * @return array<int, string>
-     */
-    private function createLandingPageData(?string $slotId = null, ?array $slotConfig = null): array
+    private function createLandingPageData(): array
     {
         $landingPageId = $this->ids->get('contact-landingpage-test');
+        $slotId = $this->ids->create('form-slot');
 
-        $slotId ??= $this->ids->create('form-slot');
-        $slotConfig ??= [
-            'mailReceiver' => [
-                'source' => 'static',
-                'value' => ['h.mac@example.com'],
-            ],
-            'confirmationText' => [
-                'source' => 'static',
-                'value' => '',
-            ],
-        ];
-
-        $data = [
+        static::getContainer()->get('landing_page.repository')->create([
             [
                 'id' => $landingPageId,
                 'name' => Uuid::randomHex(),
@@ -454,51 +206,20 @@ class ContactFormRouteTest extends TestCase
                     ['id' => TestDefaults::SALES_CHANNEL],
                 ],
                 'slotConfig' => [
-                    $slotId => $slotConfig,
+                    $slotId => [
+                        'mailReceiver' => [
+                            'source' => 'static',
+                            'value' => ['h.mac@example.com'],
+                        ],
+                        'confirmationText' => [
+                            'source' => 'static',
+                            'value' => '',
+                        ],
+                    ],
                 ],
             ],
-        ];
-        static::getContainer()->get('landing_page.repository')->create($data, Context::createDefaultContext());
+        ], Context::createDefaultContext());
 
         return [$landingPageId, $slotId];
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function createProductData(): array
-    {
-        $productId = $this->ids->get('contact-product-test');
-
-        $slotId = $this->ids->create('form-slot');
-        $slotConfig = [
-            $slotId => [
-                'mailReceiver' => [
-                    'source' => 'static',
-                    'value' => ['h.mac@example.com'],
-                ],
-                'confirmationText' => [
-                    'source' => 'static',
-                    'value' => '',
-                ],
-            ],
-        ];
-
-        $data = [
-            [
-                'id' => $productId,
-                'productNumber' => Uuid::randomHex(),
-                'stock' => 1,
-                'name' => 'Test Product',
-                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10.99, 'net' => 11.99, 'linked' => false]],
-                'manufacturer' => ['name' => 'create'],
-                'taxId' => $this->getValidTaxId(),
-                'active' => true,
-                'slotConfig' => $slotConfig,
-            ],
-        ];
-        static::getContainer()->get('product.repository')->create($data, Context::createDefaultContext());
-
-        return [$productId, $slotId];
     }
 }

--- a/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormRouteTest.php
@@ -188,6 +188,82 @@ class ContactFormRouteTest extends TestCase
         static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
     }
 
+    /**
+     * @param array<string, array{source: string, value: array<int, string>|string}> $slotConfig
+     */
+    #[DataProvider('partialSlotConfigProvider')]
+    public function testContactFormSendMailUsesInheritedSlotConfigFieldsIndependently(array $slotConfig, string $expectedRecipient, string $expectedSuccessMessage): void
+    {
+        $formSlotId = $this->ids->create('form-slot');
+        $this->createCmsFormData($formSlotId, ['inherited@example.com'], 'Inherited success message');
+        [$landingPageId] = $this->createLandingPageData($formSlotId, $slotConfig);
+
+        /** @var EventDispatcher $dispatcher */
+        $dispatcher = static::getContainer()->get('event_dispatcher');
+
+        $eventDidRun = false;
+        $recipients = [];
+        $listenerClosure = static function (MailSentEvent $event) use (&$eventDidRun, &$recipients): void {
+            $eventDidRun = true;
+            $recipients = $event->getRecipients();
+        };
+
+        $this->addEventListener($dispatcher, MailSentEvent::class, $listenerClosure);
+
+        $this->browser
+            ->request(
+                'POST',
+                '/store-api/contact-form',
+                [
+                    'salutationId' => $this->getValidSalutationId(),
+                    'navigationId' => $landingPageId,
+                    'slotId' => $formSlotId,
+                    'entityName' => LandingPageDefinition::ENTITY_NAME,
+                    'firstName' => 'Firstname',
+                    'lastName' => 'Lastname',
+                    'email' => 'test@shopware.com',
+                    'phone' => '12345/6789',
+                    'subject' => 'Subject',
+                    'comment' => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+                ]
+            );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertArrayHasKey('individualSuccessMessage', $response);
+        static::assertSame($expectedSuccessMessage, $response['individualSuccessMessage']);
+
+        $dispatcher->removeListener(MailSentEvent::class, $listenerClosure);
+
+        static::assertTrue($eventDidRun, 'The mail.sent Event did not run');
+        static::assertArrayHasKey($expectedRecipient, $recipients);
+    }
+
+    public static function partialSlotConfigProvider(): \Generator
+    {
+        yield 'custom receiver inherits confirmation text' => [
+            [
+                'mailReceiver' => [
+                    'source' => 'static',
+                    'value' => ['child@example.com'],
+                ],
+            ],
+            'child@example.com',
+            'Inherited success message',
+        ];
+
+        yield 'custom confirmation text inherits receiver' => [
+            [
+                'confirmationText' => [
+                    'source' => 'static',
+                    'value' => 'Child success message',
+                ],
+            ],
+            'inherited@example.com',
+            'Child success message',
+        ];
+    }
+
     #[DataProvider('contactFormWithDomainProvider')]
     public function testContactFormWithInvalid(string $firstName, string $lastName, \Closure $expectClosure): void
     {
@@ -291,7 +367,10 @@ class ContactFormRouteTest extends TestCase
         return [$contactCategoryId, $slotId];
     }
 
-    private function createCmsFormData(string $slotId): void
+    /**
+     * @param array<int, string> $receivers
+     */
+    private function createCmsFormData(string $slotId, array $receivers = ['h.mac@example.com'], string $confirmationText = ''): void
     {
         $cmsData = [
             [
@@ -315,11 +394,11 @@ class ContactFormRouteTest extends TestCase
                                         'config' => [
                                             'mailReceiver' => [
                                                 'source' => 'static',
-                                                'value' => ['h.mac@example.com'],
+                                                'value' => $receivers,
                                             ],
                                             'confirmationText' => [
                                                 'source' => 'static',
-                                                'value' => '',
+                                                'value' => $confirmationText,
                                             ],
                                         ],
                                     ],
@@ -335,23 +414,23 @@ class ContactFormRouteTest extends TestCase
     }
 
     /**
+     * @param array<string, array{source: string, value: array<int, string>|string}>|null $slotConfig
+     *
      * @return array<int, string>
      */
-    private function createLandingPageData(): array
+    private function createLandingPageData(?string $slotId = null, ?array $slotConfig = null): array
     {
         $landingPageId = $this->ids->get('contact-landingpage-test');
 
-        $slotId = $this->ids->create('form-slot');
-        $slotConfig = [
-            $slotId => [
-                'mailReceiver' => [
-                    'source' => 'static',
-                    'value' => ['h.mac@example.com'],
-                ],
-                'confirmationText' => [
-                    'source' => 'static',
-                    'value' => '',
-                ],
+        $slotId ??= $this->ids->create('form-slot');
+        $slotConfig ??= [
+            'mailReceiver' => [
+                'source' => 'static',
+                'value' => ['h.mac@example.com'],
+            ],
+            'confirmationText' => [
+                'source' => 'static',
+                'value' => '',
             ],
         ];
 
@@ -363,7 +442,9 @@ class ContactFormRouteTest extends TestCase
                 'salesChannels' => [
                     ['id' => TestDefaults::SALES_CHANNEL],
                 ],
-                'slotConfig' => $slotConfig,
+                'slotConfig' => [
+                    $slotId => $slotConfig,
+                ],
             ],
         ];
         static::getContainer()->get('landing_page.repository')->create($data, Context::createDefaultContext());

--- a/tests/integration/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
+++ b/tests/integration/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
@@ -5,6 +5,8 @@ namespace Shopware\Tests\Integration\Core\Content\RevocationRequest\SalesChannel
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\MailTemplateTestBehaviour;
@@ -70,6 +72,67 @@ class RevocationRequestRouteTest extends TestCase
         static::assertArrayHasKey('individualSuccessMessage', $response);
         static::assertEmpty($response['individualSuccessMessage']);
         static::assertTrue($listenerIsCalled);
+
+        $this->eventDispatcher->removeListener(MailSentEvent::class, $revocationRequestCallback);
+    }
+
+    public function testRequestUsesEntitySpecificSlotConfig(): void
+    {
+        $categoryId = $this->ids->create('revocation-category');
+        $slotId = $this->ids->create('revocation-form-slot');
+        $recipient = 'revocation@example.com';
+        $successMessage = 'Revocation request configured message';
+
+        static::getContainer()->get('category.repository')->create([
+            [
+                'id' => $categoryId,
+                'translations' => [
+                    [
+                        'name' => 'Revocation category',
+                        'languageId' => Defaults::LANGUAGE_SYSTEM,
+                        'slotConfig' => [
+                            $slotId => [
+                                'mailReceiver' => [
+                                    'source' => 'static',
+                                    'value' => [$recipient],
+                                ],
+                                'confirmationText' => [
+                                    'source' => 'static',
+                                    'value' => $successMessage,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $recipients = [];
+        $revocationRequestCallback = static function (MailSentEvent $event) use (&$recipients): void {
+            $recipients = $event->getRecipients();
+        };
+
+        $this->addEventListener($this->eventDispatcher, MailSentEvent::class, $revocationRequestCallback);
+
+        $this->browser->request(
+            Request::METHOD_POST,
+            '/store-api/revocation-request-form',
+            [
+                'firstName' => 'Max',
+                'lastName' => 'Mustermann',
+                'email' => 'test@example.com',
+                'contractNumber' => 'SW123456789',
+                'comment' => 'Lorem ipsum dolor sit amet',
+                'slotId' => $slotId,
+                'navigationId' => $categoryId,
+                'entityName' => 'category',
+            ]
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame($successMessage, $response['individualSuccessMessage']);
+        static::assertArrayHasKey($recipient, $recipients);
 
         $this->eventDispatcher->removeListener(MailSentEvent::class, $revocationRequestCallback);
     }

--- a/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -131,7 +131,9 @@ class CategoryRouteTest extends TestCase
                 $salesChannelContext,
                 [
                     'content' => [
-                        'value' => $expected,
+                        'field' => [
+                            'value' => $expected,
+                        ],
                     ],
                 ],
                 new EntityResolverContext($salesChannelContext, $request, new CategoryDefinition(), $category),
@@ -249,7 +251,9 @@ class CategoryRouteTest extends TestCase
         $category->setType(CategoryDefinition::TYPE_PAGE);
         $category->addTranslated('slotConfig', [
             'content' => [
-                'value' => 'en config',
+                'field' => [
+                    'value' => 'en config',
+                ],
             ],
         ]);
 
@@ -259,7 +263,9 @@ class CategoryRouteTest extends TestCase
             $translation->setLanguageId(self::LANGUAGE_IDS[$languageCode]);
             $translation->setSlotConfig([
                 'content' => [
-                    'value' => $languageCode . ' config',
+                    'field' => [
+                        'value' => $languageCode . ' config',
+                    ],
                 ],
             ]);
 

--- a/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
+++ b/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
@@ -51,6 +51,24 @@ class CmsFormSlotConfigResolverTest extends TestCase
         );
     }
 
+    public function testResolveIgnoresMalformedCmsSlotConfig(): void
+    {
+        $slotId = Uuid::randomHex();
+        $slot = new CmsSlotEntity();
+        $slot->setId($slotId);
+        $slot->setTranslated(['config' => [
+            'mailReceiver' => null,
+            'confirmationText' => null,
+        ]]);
+
+        $resolver = $this->createResolver(slotEntities: [$slot]);
+
+        static::assertSame(
+            ['receivers' => ['' => ''], 'message' => ''],
+            $resolver->resolve($this->createSalesChannelContext(), $slotId, null, null)
+        );
+    }
+
     /**
      * @param class-string<CategoryEntity|LandingPageEntity|ProductEntity> $entityClass
      */
@@ -112,6 +130,71 @@ class CmsFormSlotConfigResolverTest extends TestCase
 
         static::assertSame(
             $expected,
+            $resolver->resolve(
+                $this->createSalesChannelContext(),
+                $slotId,
+                $navigationId,
+                LandingPageDefinition::ENTITY_NAME
+            )
+        );
+    }
+
+    public function testResolveIgnoresMalformedEntityConfigValues(): void
+    {
+        $slotId = Uuid::randomHex();
+        $navigationId = Uuid::randomHex();
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId($navigationId);
+        $landingPage->setSlotConfig([$slotId => [
+            'mailReceiver' => null,
+            'confirmationText' => null,
+        ]]);
+
+        $resolver = $this->createResolver(landingPageEntities: [$landingPage]);
+
+        static::assertSame(
+            ['receivers' => ['' => ''], 'message' => ''],
+            $resolver->resolve(
+                $this->createSalesChannelContext(),
+                $slotId,
+                $navigationId,
+                LandingPageDefinition::ENTITY_NAME
+            )
+        );
+    }
+
+    public function testResolveUsesDefaultsWhenEntityHasNoSlotConfig(): void
+    {
+        $slotId = Uuid::randomHex();
+        $navigationId = Uuid::randomHex();
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId($navigationId);
+
+        $resolver = $this->createResolver(landingPageEntities: [$landingPage]);
+
+        static::assertSame(
+            ['receivers' => ['' => ''], 'message' => ''],
+            $resolver->resolve(
+                $this->createSalesChannelContext(),
+                $slotId,
+                $navigationId,
+                LandingPageDefinition::ENTITY_NAME
+            )
+        );
+    }
+
+    public function testResolveUsesDefaultsWhenEntitySlotConfigIsNotAnArray(): void
+    {
+        $slotId = Uuid::randomHex();
+        $navigationId = Uuid::randomHex();
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId($navigationId);
+        $landingPage->setSlotConfig([$slotId => null]);
+
+        $resolver = $this->createResolver(landingPageEntities: [$landingPage]);
+
+        static::assertSame(
+            ['receivers' => ['' => ''], 'message' => ''],
             $resolver->resolve(
                 $this->createSalesChannelContext(),
                 $slotId,

--- a/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
+++ b/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Service;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotDefinition;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CmsFormSlotConfigResolver::class)]
+class CmsFormSlotConfigResolverTest extends TestCase
+{
+    public function testResolveUsesCmsSlotConfigWhenNoEntityContextIsGiven(): void
+    {
+        $slotId = Uuid::randomHex();
+        $slot = new CmsSlotEntity();
+        $slot->setId($slotId);
+        $slot->setTranslated(['config' => $this->createSlotConfig('slot@example.com', 'Slot message')]);
+
+        $resolver = $this->createResolver(slotEntities: [$slot]);
+
+        static::assertSame(
+            [
+                'receivers' => ['slot@example.com' => 'slot@example.com'],
+                'message' => 'Slot message',
+            ],
+            $resolver->resolve($this->createSalesChannelContext(), $slotId, null, null)
+        );
+    }
+
+    /**
+     * @param class-string<CategoryEntity|LandingPageEntity|ProductEntity> $entityClass
+     */
+    #[DataProvider('entityProvider')]
+    public function testResolveUsesEntitySpecificConfig(string $entityClass, string $entityName): void
+    {
+        $slotId = Uuid::randomHex();
+        $navigationId = Uuid::randomHex();
+        $entity = new $entityClass();
+        $entity->setId($navigationId);
+        $entity->setSlotConfig([
+            $slotId => $this->createSlotConfig('entity@example.com', 'Entity message'),
+        ]);
+
+        $resolver = $this->createResolver(
+            categoryEntities: $entity instanceof CategoryEntity ? [$entity] : [],
+            landingPageEntities: $entity instanceof LandingPageEntity ? [$entity] : [],
+            productEntities: $entity instanceof ProductEntity ? [$entity] : [],
+        );
+
+        static::assertSame(
+            [
+                'receivers' => ['entity@example.com' => 'entity@example.com'],
+                'message' => 'Entity message',
+            ],
+            $resolver->resolve($this->createSalesChannelContext(), $slotId, $navigationId, $entityName)
+        );
+    }
+
+    public static function entityProvider(): \Generator
+    {
+        yield 'category' => [CategoryEntity::class, CategoryDefinition::ENTITY_NAME];
+        yield 'landing page' => [LandingPageEntity::class, LandingPageDefinition::ENTITY_NAME];
+        yield 'product' => [ProductEntity::class, ProductDefinition::ENTITY_NAME];
+    }
+
+    /**
+     * @param array<string, array{value: list<string>|string}> $entityConfig
+     * @param array{receivers: array<string, string>, message: string} $expected
+     */
+    #[DataProvider('partialConfigProvider')]
+    public function testResolveInheritsEachFieldIndependently(array $entityConfig, array $expected): void
+    {
+        $slotId = Uuid::randomHex();
+        $navigationId = Uuid::randomHex();
+
+        $slot = new CmsSlotEntity();
+        $slot->setId($slotId);
+        $slot->setTranslated(['config' => $this->createSlotConfig('slot@example.com', 'Slot message')]);
+
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId($navigationId);
+        $landingPage->setSlotConfig([$slotId => $entityConfig]);
+
+        $resolver = $this->createResolver(
+            slotEntities: [$slot],
+            landingPageEntities: [$landingPage],
+        );
+
+        static::assertSame(
+            $expected,
+            $resolver->resolve(
+                $this->createSalesChannelContext(),
+                $slotId,
+                $navigationId,
+                LandingPageDefinition::ENTITY_NAME
+            )
+        );
+    }
+
+    public static function partialConfigProvider(): \Generator
+    {
+        yield 'entity receiver inherits message' => [
+            ['mailReceiver' => ['value' => ['entity@example.com']]],
+            ['receivers' => ['entity@example.com' => 'entity@example.com'], 'message' => 'Slot message'],
+        ];
+
+        yield 'entity message inherits receiver' => [
+            ['confirmationText' => ['value' => 'Entity message']],
+            ['receivers' => ['slot@example.com' => 'slot@example.com'], 'message' => 'Entity message'],
+        ];
+
+        yield 'explicit empty entity message is preserved' => [
+            ['confirmationText' => ['value' => '']],
+            ['receivers' => ['slot@example.com' => 'slot@example.com'], 'message' => ''],
+        ];
+    }
+
+    public function testResolveUsesSystemDefaultsWhenNoConfigCanBeResolved(): void
+    {
+        $systemConfigService = static::createStub(SystemConfigService::class);
+        $systemConfigService->method('getString')->willReturnCallback(
+            static fn (string $key): string => match ($key) {
+                'core.basicInformation.email' => 'default@example.com',
+                'core.basicInformation.shopName' => 'Shopware',
+                default => '',
+            }
+        );
+
+        $resolver = $this->createResolver(systemConfigService: $systemConfigService);
+
+        static::assertSame(
+            [
+                'receivers' => ['default@example.com' => 'Shopware'],
+                'message' => '',
+            ],
+            $resolver->resolve($this->createSalesChannelContext(), null, null, null)
+        );
+    }
+
+    /**
+     * @param array<int, CmsSlotEntity> $slotEntities
+     * @param array<int, CategoryEntity> $categoryEntities
+     * @param array<int, LandingPageEntity> $landingPageEntities
+     * @param array<int, ProductEntity> $productEntities
+     */
+    private function createResolver(
+        array $slotEntities = [],
+        array $categoryEntities = [],
+        array $landingPageEntities = [],
+        array $productEntities = [],
+        ?SystemConfigService $systemConfigService = null,
+    ): CmsFormSlotConfigResolver {
+        /** @var StaticEntityRepository<CmsSlotCollection> $cmsSlotRepository */
+        $cmsSlotRepository = new StaticEntityRepository([$slotEntities], new CmsSlotDefinition());
+        /** @var StaticEntityRepository<CategoryCollection> $categoryRepository */
+        $categoryRepository = new StaticEntityRepository([$categoryEntities], new CategoryDefinition());
+        /** @var StaticEntityRepository<LandingPageCollection> $landingPageRepository */
+        $landingPageRepository = new StaticEntityRepository([$landingPageEntities], new LandingPageDefinition());
+        /** @var StaticEntityRepository<ProductCollection> $productRepository */
+        $productRepository = new StaticEntityRepository([$productEntities], new ProductDefinition());
+
+        return new CmsFormSlotConfigResolver(
+            $categoryRepository,
+            $landingPageRepository,
+            $productRepository,
+            $cmsSlotRepository,
+            $systemConfigService ?? static::createStub(SystemConfigService::class),
+        );
+    }
+
+    /**
+     * @return array{
+     *     mailReceiver: array{value: array<int, string>},
+     *     confirmationText: array{value: string}
+     * }
+     */
+    private function createSlotConfig(string $receiver, string $message): array
+    {
+        return [
+            'mailReceiver' => ['value' => [$receiver]],
+            'confirmationText' => ['value' => $message],
+        ];
+    }
+
+    private function createSalesChannelContext(): SalesChannelContext
+    {
+        return Generator::generateSalesChannelContext(Context::createDefaultContext());
+    }
+}

--- a/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
+++ b/tests/unit/Core/Content/Cms/Service/CmsFormSlotConfigResolverTest.php
@@ -145,6 +145,7 @@ class CmsFormSlotConfigResolverTest extends TestCase
         $navigationId = Uuid::randomHex();
         $landingPage = new LandingPageEntity();
         $landingPage->setId($navigationId);
+        // @phpstan-ignore argument.type (intentionally malformed fixture)
         $landingPage->setSlotConfig([$slotId => [
             'mailReceiver' => null,
             'confirmationText' => null,

--- a/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
+++ b/tests/unit/Core/Content/ContactForm/SalesChannel/ContactFormRouteTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\ContactForm\SalesChannel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver;
 use Shopware\Core\Content\ContactForm\SalesChannel\ContactFormRoute;
 use Shopware\Core\Content\ContactForm\Validation\ContactFormValidationFactory;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
@@ -21,7 +22,6 @@ use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
@@ -76,18 +76,20 @@ class ContactFormRouteTest extends TestCase
             }
         });
 
+        $slotConfigResolverMock = static::createStub(CmsFormSlotConfigResolver::class);
+        $slotConfigResolverMock->method('resolve')->willReturn([
+            'receivers' => ['foo' => 'bar'],
+            'message' => 'baz',
+        ]);
+
         $contactFormRoute = new ContactFormRoute(
             static::createStub(DataValidationFactoryInterface::class),
             $mock,
             static::createStub(EventDispatcherInterface::class),
-            static::createStub(SystemConfigService::class),
-            $entityRepository,
-            $entityRepository,
-            $entityRepository,
-            $entityRepository,
             $entityRepository,
             static::createStub(RequestStack::class),
-            static::createStub(RateLimiter::class)
+            static::createStub(RateLimiter::class),
+            $slotConfigResolverMock,
         );
 
         $contactFormRoute->load($requestData, $this->salesChannelContext);

--- a/tests/unit/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
+++ b/tests/unit/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Content\RevocationRequest\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryCollection;
@@ -11,6 +12,13 @@ use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotDefinition;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\RevocationRequest\Event\RevocationRequestEvent;
 use Shopware\Core\Content\RevocationRequest\SalesChannel\RevocationRequestRoute;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
@@ -72,6 +80,125 @@ class RevocationRequestRouteTest extends TestCase
         $result = $this->createRevocationRequestRoute([$cmsSlot])->request($dataBag, $this->createSalesChannelContext());
 
         static::assertSame($successMessage, $result->getIndividualSuccessMessage());
+    }
+
+    public function testRequestShouldReturnLandingPageSuccessMessage(): void
+    {
+        $successMessage = 'landing page success message';
+        $slotId = Uuid::randomHex();
+
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId(Uuid::randomHex());
+        $landingPage->setSlotConfig($this->createSlotConfig($slotId, $successMessage, ['landing-page@example.com']));
+
+        $dispatchedEvent = null;
+        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
+
+        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $landingPage->getId(), LandingPageDefinition::ENTITY_NAME));
+
+        $revocationRequestRoute = $this->createRevocationRequestRoute(
+            landingPageEntities: [$landingPage],
+            eventDispatcher: $eventDispatcher,
+        );
+
+        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
+
+        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
+        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
+        static::assertSame(['landing-page@example.com' => 'landing-page@example.com'], $dispatchedEvent->getMailStruct()->getRecipients());
+    }
+
+    public function testRequestShouldReturnProductSuccessMessage(): void
+    {
+        $successMessage = 'product success message';
+        $slotId = Uuid::randomHex();
+
+        $product = new ProductEntity();
+        $product->setId(Uuid::randomHex());
+        $product->setSlotConfig($this->createSlotConfig($slotId, $successMessage, ['product@example.com']));
+
+        $dispatchedEvent = null;
+        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
+
+        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $product->getId(), ProductDefinition::ENTITY_NAME));
+
+        $revocationRequestRoute = $this->createRevocationRequestRoute(
+            productEntities: [$product],
+            eventDispatcher: $eventDispatcher,
+        );
+
+        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
+
+        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
+        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
+        static::assertSame(['product@example.com' => 'product@example.com'], $dispatchedEvent->getMailStruct()->getRecipients());
+    }
+
+    /**
+     * @param array<string, array{value: array<int, string>|string}> $slotConfig
+     */
+    #[DataProvider('partialSlotConfigProvider')]
+    public function testRequestShouldUseInheritedSlotConfigFieldsIndependently(array $slotConfig, string $expectedRecipient, string $expectedSuccessMessage): void
+    {
+        $slotId = Uuid::randomHex();
+
+        $cmsSlot = new CmsSlotEntity();
+        $cmsSlot->setId($slotId);
+        $cmsSlot->setTranslated(['config' => $this->createSlotConfig($slotId, 'Inherited success message', ['inherited@example.com'])[$slotId]]);
+
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId(Uuid::randomHex());
+        $landingPage->setSlotConfig([$slotId => $slotConfig]);
+
+        $dispatchedEvent = null;
+        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
+
+        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $landingPage->getId(), LandingPageDefinition::ENTITY_NAME));
+
+        $revocationRequestRoute = $this->createRevocationRequestRoute(
+            slotEntities: [$cmsSlot],
+            landingPageEntities: [$landingPage],
+            eventDispatcher: $eventDispatcher,
+        );
+
+        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
+
+        static::assertSame($expectedSuccessMessage, $result->getIndividualSuccessMessage());
+        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
+        static::assertArrayHasKey($expectedRecipient, $dispatchedEvent->getMailStruct()->getRecipients());
+    }
+
+    public static function partialSlotConfigProvider(): \Generator
+    {
+        yield 'custom receiver inherits confirmation text' => [
+            [
+                'mailReceiver' => [
+                    'value' => ['child@example.com'],
+                ],
+            ],
+            'child@example.com',
+            'Inherited success message',
+        ];
+
+        yield 'custom confirmation text inherits receiver' => [
+            [
+                'confirmationText' => [
+                    'value' => 'Child success message',
+                ],
+            ],
+            'inherited@example.com',
+            'Child success message',
+        ];
+
+        yield 'empty custom confirmation text is not inherited' => [
+            [
+                'confirmationText' => [
+                    'value' => '',
+                ],
+            ],
+            'inherited@example.com',
+            '',
+        ];
     }
 
     public function testRequestWithoutSlotIdShouldReturnDefaultsMessage(): void
@@ -142,9 +269,16 @@ class RevocationRequestRouteTest extends TestCase
     /**
      * @param array<int, CmsSlotEntity>|null $slotEntities
      * @param array<int, CategoryEntity>|null $categoryEntities
+     * @param array<int, LandingPageEntity>|null $landingPageEntities
+     * @param array<int, ProductEntity>|null $productEntities
      */
-    private function createRevocationRequestRoute(?array $slotEntities = [], ?array $categoryEntities = []): RevocationRequestRoute
-    {
+    private function createRevocationRequestRoute(
+        ?array $slotEntities = [],
+        ?array $categoryEntities = [],
+        ?array $landingPageEntities = [],
+        ?array $productEntities = [],
+        ?EventDispatcherInterface $eventDispatcher = null,
+    ): RevocationRequestRoute {
         $validatorFactoryMock = static::createStub(DataValidationFactoryInterface::class);
 
         $validatorMock = $this->createValidatorMock();
@@ -152,13 +286,17 @@ class RevocationRequestRouteTest extends TestCase
         $requestStackMock = $this->createRequestStackMock();
 
         $rateLimiterMock = static::createStub(RateLimiter::class);
-        $eventDispatcherMock = static::createStub(EventDispatcherInterface::class);
+        $eventDispatcherMock = $eventDispatcher ?? static::createStub(EventDispatcherInterface::class);
         $systemConfigServiceMock = static::createStub(SystemConfigService::class);
 
         /** @var StaticEntityRepository<CmsSlotCollection> $cmsSlotRepository */
         $cmsSlotRepository = new StaticEntityRepository([$slotEntities], new CmsSlotDefinition());
         /** @var StaticEntityRepository<CategoryCollection> $categoryRepository */
         $categoryRepository = new StaticEntityRepository([$categoryEntities], new CategoryDefinition());
+        /** @var StaticEntityRepository<LandingPageCollection> $landingPageRepository */
+        $landingPageRepository = new StaticEntityRepository([$landingPageEntities], new LandingPageDefinition());
+        /** @var StaticEntityRepository<ProductCollection> $productRepository */
+        $productRepository = new StaticEntityRepository([$productEntities], new ProductDefinition());
 
         return new RevocationRequestRoute(
             $validatorFactoryMock,
@@ -169,7 +307,9 @@ class RevocationRequestRouteTest extends TestCase
             $systemConfigServiceMock,
             $cmsSlotRepository,
             $categoryRepository,
-            new NativeClock()
+            new NativeClock(),
+            $landingPageRepository,
+            $productRepository,
         );
     }
 
@@ -185,14 +325,30 @@ class RevocationRequestRouteTest extends TestCase
     }
 
     /**
+     * @param array<int, string> $receivers
+     *
      * @return array<string, array{
-     *     mailReceiver: array{value: string},
+     *     mailReceiver: array{value: array<int, string>},
      *     confirmationText: array{value: string}
      * }>
      */
-    private function createSlotConfig(string $slotId, string $successMessage): array
+    private function createSlotConfig(string $slotId, string $successMessage, array $receivers = ['admin']): array
     {
-        return [$slotId => ['mailReceiver' => ['value' => 'admin'], 'confirmationText' => ['value' => $successMessage]]];
+        return [$slotId => ['mailReceiver' => ['value' => $receivers], 'confirmationText' => ['value' => $successMessage]]];
+    }
+
+    private function createEventDispatcherCapturingRevocationRequestEvent(?RevocationRequestEvent &$dispatchedEvent): EventDispatcherInterface
+    {
+        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')->willReturnCallback(static function (object $event, ?string $eventName = null) use (&$dispatchedEvent): object {
+            if ($event instanceof RevocationRequestEvent) {
+                $dispatchedEvent = $event;
+            }
+
+            return $event;
+        });
+
+        return $eventDispatcher;
     }
 
     /**
@@ -204,9 +360,10 @@ class RevocationRequestRouteTest extends TestCase
      *     comment: string,
      *     slotId?: string,
      *     navigationId?: string,
+     *     entityName?: string,
      * }
      */
-    private function createValidFormData(?string $cmsSlotId = null, ?string $navigationId = null): array
+    private function createValidFormData(?string $cmsSlotId = null, ?string $navigationId = null, ?string $entityName = null): array
     {
         $forData = [
             'firstName' => 'Max',
@@ -222,6 +379,10 @@ class RevocationRequestRouteTest extends TestCase
 
         if ($navigationId !== null) {
             $forData['navigationId'] = $navigationId;
+        }
+
+        if ($entityName !== null) {
+            $forData['entityName'] = $entityName;
         }
 
         return $forData;

--- a/tests/unit/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
+++ b/tests/unit/Core/Content/RevocationRequest/SalesChannel/RevocationRequestRouteTest.php
@@ -4,21 +4,8 @@ namespace Shopware\Tests\Unit\Core\Content\RevocationRequest\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Content\Category\CategoryCollection;
-use Shopware\Core\Content\Category\CategoryDefinition;
-use Shopware\Core\Content\Category\CategoryEntity;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotDefinition;
-use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
-use Shopware\Core\Content\LandingPage\LandingPageCollection;
-use Shopware\Core\Content\LandingPage\LandingPageDefinition;
-use Shopware\Core\Content\LandingPage\LandingPageEntity;
-use Shopware\Core\Content\Product\ProductCollection;
-use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\Product\ProductEntity;
-use Shopware\Core\Content\RevocationRequest\Event\RevocationRequestEvent;
+use Shopware\Core\Content\Cms\Service\CmsFormSlotConfigResolver;
 use Shopware\Core\Content\RevocationRequest\SalesChannel\RevocationRequestRoute;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
@@ -26,13 +13,12 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidationFactoryInterface;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\Clock\NativeClock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -46,219 +32,61 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[CoversClass(RevocationRequestRoute::class)]
 class RevocationRequestRouteTest extends TestCase
 {
-    public function testRequestShouldReturnCategorySuccessMessage(): void
-    {
-        $successMessage = 'category success message';
-        $slotId = Uuid::randomHex();
-        $category = new CategoryEntity();
-        $category->setId(Uuid::randomHex());
-        $category->setSlotConfig($this->createSlotConfig($slotId, $successMessage));
-
-        $dataBag = new RequestDataBag($this->createValidFormData($slotId, Uuid::randomHex()));
-
-        $revocationRequestRoute = $this->createRevocationRequestRoute(categoryEntities: [$category]);
-
-        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-    }
-
-    public function testRequestShouldReturnCmsSlotSuccessMessage(): void
-    {
-        $successMessage = 'cms slot success message';
-
-        $slotId = Uuid::randomHex();
-        $config = $this->createSlotConfig($slotId, $successMessage);
-
-        $cmsSlot = new CmsSlotEntity();
-        $cmsSlot->setId($slotId);
-        $cmsSlot->setTranslated(['config' => $config[$slotId]]);
-
-        $formData = $this->createValidFormData($slotId);
-        $dataBag = new RequestDataBag($formData);
-
-        $result = $this->createRevocationRequestRoute([$cmsSlot])->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-    }
-
-    public function testRequestShouldReturnLandingPageSuccessMessage(): void
-    {
-        $successMessage = 'landing page success message';
-        $slotId = Uuid::randomHex();
-
-        $landingPage = new LandingPageEntity();
-        $landingPage->setId(Uuid::randomHex());
-        $landingPage->setSlotConfig($this->createSlotConfig($slotId, $successMessage, ['landing-page@example.com']));
-
-        $dispatchedEvent = null;
-        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
-
-        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $landingPage->getId(), LandingPageDefinition::ENTITY_NAME));
-
-        $revocationRequestRoute = $this->createRevocationRequestRoute(
-            landingPageEntities: [$landingPage],
-            eventDispatcher: $eventDispatcher,
-        );
-
-        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
-        static::assertSame(['landing-page@example.com' => 'landing-page@example.com'], $dispatchedEvent->getMailStruct()->getRecipients());
-    }
-
-    public function testRequestShouldReturnProductSuccessMessage(): void
-    {
-        $successMessage = 'product success message';
-        $slotId = Uuid::randomHex();
-
-        $product = new ProductEntity();
-        $product->setId(Uuid::randomHex());
-        $product->setSlotConfig($this->createSlotConfig($slotId, $successMessage, ['product@example.com']));
-
-        $dispatchedEvent = null;
-        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
-
-        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $product->getId(), ProductDefinition::ENTITY_NAME));
-
-        $revocationRequestRoute = $this->createRevocationRequestRoute(
-            productEntities: [$product],
-            eventDispatcher: $eventDispatcher,
-        );
-
-        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
-        static::assertSame(['product@example.com' => 'product@example.com'], $dispatchedEvent->getMailStruct()->getRecipients());
-    }
-
     /**
-     * @param array<string, array{value: array<int, string>|string}> $slotConfig
+     * @param array<string, string> $data
      */
-    #[DataProvider('partialSlotConfigProvider')]
-    public function testRequestShouldUseInheritedSlotConfigFieldsIndependently(array $slotConfig, string $expectedRecipient, string $expectedSuccessMessage): void
+    #[DataProvider('validationDataProvider')]
+    public function testRequestValidatesFormData(array $data): void
     {
-        $slotId = Uuid::randomHex();
+        $requestData = new RequestDataBag($data);
+        $definition = new DataValidationDefinition('revocation_request_form.create');
 
-        $cmsSlot = new CmsSlotEntity();
-        $cmsSlot->setId($slotId);
-        $cmsSlot->setTranslated(['config' => $this->createSlotConfig($slotId, 'Inherited success message', ['inherited@example.com'])[$slotId]]);
+        $validationFactory = static::createStub(DataValidationFactoryInterface::class);
+        $validationFactory->method('create')->willReturn($definition);
 
-        $landingPage = new LandingPageEntity();
-        $landingPage->setId(Uuid::randomHex());
-        $landingPage->setSlotConfig([$slotId => $slotConfig]);
+        $validator = $this->createMock(DataValidator::class);
+        $validator->expects($this->once())
+            ->method('getViolations')
+            ->willReturnCallback(static function (array $validatedData, DataValidationDefinition $validatedDefinition) use ($data, $definition): ConstraintViolationList {
+                foreach ($data as $property => $value) {
+                    static::assertSame($value, $validatedData[$property] ?? null);
+                }
+                static::assertSame($definition, $validatedDefinition);
 
-        $dispatchedEvent = null;
-        $eventDispatcher = $this->createEventDispatcherCapturingRevocationRequestEvent($dispatchedEvent);
+                return new ConstraintViolationList();
+            });
 
-        $dataBag = new RequestDataBag($this->createValidFormData($slotId, $landingPage->getId(), LandingPageDefinition::ENTITY_NAME));
-
-        $revocationRequestRoute = $this->createRevocationRequestRoute(
-            slotEntities: [$cmsSlot],
-            landingPageEntities: [$landingPage],
-            eventDispatcher: $eventDispatcher,
+        $route = $this->createRevocationRequestRoute(
+            validatorFactory: $validationFactory,
+            validator: $validator,
         );
 
-        $result = $revocationRequestRoute->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($expectedSuccessMessage, $result->getIndividualSuccessMessage());
-        static::assertInstanceOf(RevocationRequestEvent::class, $dispatchedEvent);
-        static::assertArrayHasKey($expectedRecipient, $dispatchedEvent->getMailStruct()->getRecipients());
+        $route->request($requestData, $this->createSalesChannelContext());
     }
 
-    public static function partialSlotConfigProvider(): \Generator
+    public static function validationDataProvider(): \Generator
     {
-        yield 'custom receiver inherits confirmation text' => [
-            [
-                'mailReceiver' => [
-                    'value' => ['child@example.com'],
-                ],
-            ],
-            'child@example.com',
-            'Inherited success message',
-        ];
+        yield 'valid form data' => [[
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'email' => 'max@muster.com',
+            'contractNumber' => 'SW123456789',
+            'comment' => 'This is a simple comment',
+        ]];
 
-        yield 'custom confirmation text inherits receiver' => [
-            [
-                'confirmationText' => [
-                    'value' => 'Child success message',
-                ],
-            ],
-            'inherited@example.com',
-            'Child success message',
-        ];
-
-        yield 'empty custom confirmation text is not inherited' => [
-            [
-                'confirmationText' => [
-                    'value' => '',
-                ],
-            ],
-            'inherited@example.com',
-            '',
-        ];
+        yield 'form data with optional context fields' => [[
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'email' => 'max@muster.com',
+            'contractNumber' => 'SW123456789',
+            'comment' => 'This is a simple comment',
+            'slotId' => Uuid::randomHex(),
+            'navigationId' => Uuid::randomHex(),
+            'entityName' => 'landing_page',
+        ]];
     }
 
-    public function testRequestWithoutSlotIdShouldReturnDefaultsMessage(): void
-    {
-        $successMessage = '';
-
-        $formData = $this->createValidFormData();
-        $dataBag = new RequestDataBag($formData);
-
-        $result = $this->createRevocationRequestRoute()->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-    }
-
-    public function testRequestWithoutSlotEntityShouldReturnDefaultsMessage(): void
-    {
-        $successMessage = '';
-
-        $slotId = Uuid::randomHex();
-
-        $formData = $this->createValidFormData($slotId);
-        $dataBag = new RequestDataBag($formData);
-
-        $result = $this->createRevocationRequestRoute()->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-    }
-
-    public function testRequestWithSlotEntityWithoutTranslationShouldReturnDefaultsMessage(): void
-    {
-        $successMessage = '';
-
-        $slotId = Uuid::randomHex();
-
-        $config = $this->createSlotConfig($slotId, $successMessage);
-
-        $formData = $this->createValidFormData($slotId);
-        $dataBag = new RequestDataBag($formData);
-
-        $cmsSlot = new CmsSlotEntity();
-        $cmsSlot->setId($slotId);
-        $cmsSlot->setTranslated(['config' => $config[$slotId]]);
-
-        $result = $this->createRevocationRequestRoute([$cmsSlot])->request($dataBag, $this->createSalesChannelContext());
-
-        static::assertSame($successMessage, $result->getIndividualSuccessMessage());
-    }
-
-    public function createValidatorMock(): DataValidator&Stub
-    {
-        $validatorMock = static::createStub(DataValidator::class);
-
-        $validatorMock->method('getViolations')->willReturnCallback(static function (): ConstraintViolationList {
-            return new ConstraintViolationList();
-        });
-
-        return $validatorMock;
-    }
-
-    public function createRequestStackMock(): RequestStack&Stub
+    private function createRequestStackMock(): RequestStack
     {
         $requestStackMock = static::createStub(RequestStack::class);
         $requestStackMock->method('getMainRequest')->willReturn(new Request());
@@ -266,50 +94,28 @@ class RevocationRequestRouteTest extends TestCase
         return $requestStackMock;
     }
 
-    /**
-     * @param array<int, CmsSlotEntity>|null $slotEntities
-     * @param array<int, CategoryEntity>|null $categoryEntities
-     * @param array<int, LandingPageEntity>|null $landingPageEntities
-     * @param array<int, ProductEntity>|null $productEntities
-     */
     private function createRevocationRequestRoute(
-        ?array $slotEntities = [],
-        ?array $categoryEntities = [],
-        ?array $landingPageEntities = [],
-        ?array $productEntities = [],
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?DataValidationFactoryInterface $validatorFactory = null,
+        ?DataValidator $validator = null,
     ): RevocationRequestRoute {
-        $validatorFactoryMock = static::createStub(DataValidationFactoryInterface::class);
+        $validatorFactory ??= static::createStub(DataValidationFactoryInterface::class);
+        $validator ??= static::createStub(DataValidator::class);
 
-        $validatorMock = $this->createValidatorMock();
-
-        $requestStackMock = $this->createRequestStackMock();
-
-        $rateLimiterMock = static::createStub(RateLimiter::class);
-        $eventDispatcherMock = $eventDispatcher ?? static::createStub(EventDispatcherInterface::class);
-        $systemConfigServiceMock = static::createStub(SystemConfigService::class);
-
-        /** @var StaticEntityRepository<CmsSlotCollection> $cmsSlotRepository */
-        $cmsSlotRepository = new StaticEntityRepository([$slotEntities], new CmsSlotDefinition());
-        /** @var StaticEntityRepository<CategoryCollection> $categoryRepository */
-        $categoryRepository = new StaticEntityRepository([$categoryEntities], new CategoryDefinition());
-        /** @var StaticEntityRepository<LandingPageCollection> $landingPageRepository */
-        $landingPageRepository = new StaticEntityRepository([$landingPageEntities], new LandingPageDefinition());
-        /** @var StaticEntityRepository<ProductCollection> $productRepository */
-        $productRepository = new StaticEntityRepository([$productEntities], new ProductDefinition());
+        $slotConfigResolver = static::createStub(CmsFormSlotConfigResolver::class);
+        $slotConfigResolver->method('resolve')->willReturn([
+            'receivers' => ['foo' => 'bar'],
+            'message' => 'baz',
+        ]);
 
         return new RevocationRequestRoute(
-            $validatorFactoryMock,
-            $validatorMock,
-            $requestStackMock,
-            $rateLimiterMock,
-            $eventDispatcherMock,
-            $systemConfigServiceMock,
-            $cmsSlotRepository,
-            $categoryRepository,
+            $validatorFactory,
+            $validator,
+            $this->createRequestStackMock(),
+            static::createStub(RateLimiter::class),
+            $eventDispatcher ?? static::createStub(EventDispatcherInterface::class),
             new NativeClock(),
-            $landingPageRepository,
-            $productRepository,
+            $slotConfigResolver,
         );
     }
 
@@ -322,69 +128,5 @@ class RevocationRequestRouteTest extends TestCase
             baseContext: new Context(new SalesChannelApiSource(Uuid::randomHex())),
             salesChannel: $salesChannel
         );
-    }
-
-    /**
-     * @param array<int, string> $receivers
-     *
-     * @return array<string, array{
-     *     mailReceiver: array{value: array<int, string>},
-     *     confirmationText: array{value: string}
-     * }>
-     */
-    private function createSlotConfig(string $slotId, string $successMessage, array $receivers = ['admin']): array
-    {
-        return [$slotId => ['mailReceiver' => ['value' => $receivers], 'confirmationText' => ['value' => $successMessage]]];
-    }
-
-    private function createEventDispatcherCapturingRevocationRequestEvent(?RevocationRequestEvent &$dispatchedEvent): EventDispatcherInterface
-    {
-        $eventDispatcher = static::createStub(EventDispatcherInterface::class);
-        $eventDispatcher->method('dispatch')->willReturnCallback(static function (object $event, ?string $eventName = null) use (&$dispatchedEvent): object {
-            if ($event instanceof RevocationRequestEvent) {
-                $dispatchedEvent = $event;
-            }
-
-            return $event;
-        });
-
-        return $eventDispatcher;
-    }
-
-    /**
-     * @return array{
-     *     firstName: string,
-     *     lastName: string,
-     *     email: string,
-     *     contractNumber: string,
-     *     comment: string,
-     *     slotId?: string,
-     *     navigationId?: string,
-     *     entityName?: string,
-     * }
-     */
-    private function createValidFormData(?string $cmsSlotId = null, ?string $navigationId = null, ?string $entityName = null): array
-    {
-        $forData = [
-            'firstName' => 'Max',
-            'lastName' => 'Mustermann',
-            'email' => 'max@muster.com',
-            'contractNumber' => 'SW123456789',
-            'comment' => 'This is a simple comment',
-        ];
-
-        if ($cmsSlotId !== null) {
-            $forData['slotId'] = $cmsSlotId;
-        }
-
-        if ($navigationId !== null) {
-            $forData['navigationId'] = $navigationId;
-        }
-
-        if ($entityName !== null) {
-            $forData['entityName'] = $entityName;
-        }
-
-        return $forData;
     }
 }

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageLoaderTest.php
@@ -98,6 +98,7 @@ class LandingPageLoaderTest extends TestCase
         $cmsPageLoaded = $page->getLandingPage();
         static::assertNotNull($cmsPageLoaded);
         static::assertSame($cmsPage, $cmsPageLoaded->getCmsPage());
+        static::assertSame($landingPageId, $page->getNavigationId());
     }
 
     public function testItLoadsProperPageMetaInformation(): void

--- a/tests/unit/Storefront/Page/LandingPage/LandingPageTest.php
+++ b/tests/unit/Storefront/Page/LandingPage/LandingPageTest.php
@@ -20,10 +20,13 @@ class LandingPageTest extends TestCase
     {
         $page = new LandingPage();
         $entity = new LandingPageEntity();
+        $navigationId = 'navigation-id';
 
         $page->setLandingPage($entity);
+        $page->setNavigationId($navigationId);
 
         static::assertSame(LandingPageDefinition::ENTITY_NAME, $page->getEntityName());
         static::assertSame($entity, $page->getLandingPage());
+        static::assertSame($navigationId, $page->getNavigationId());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The CMS form configuration inheritance for contact and revocation request forms did not resolve entity-specific slot configuration correctly in all cases.

Originally, issue #6481 showed that landing page contact forms did not submit the correct entityName, so their landing page slot configuration was not resolved. While fixing that, it turned out that the revocation request route only loaded entity-specific slot configuration for categories. On product pages and landing pages, it fell back to the original CMS layout configuration instead of the entity override.

Additionally, receiver and confirmation message inheritance were handled too coarsely: if one field was overridden, the route could ignore inheritance for the other field.

### 2. What does this change do, exactly?

This change centralizes CMS form slot configuration resolution in CmsFormSlotConfigResolver and uses it for both contact and revocation request forms.

It:
- adds the landing page navigation ID to the storefront landing page object
- passes entityName for revocation request forms in the same way as contact forms
- resolves entity-specific slot configuration for categories, products, and landing pages
- inherits mailReceiver and confirmationText independently
- preserves explicitly configured empty confirmation text values
- keeps route tests focused on validation and request handling
- adds unit coverage for the resolver and integration coverage for the route wiring

Additionally, when no receiver configuration is available, both contact and revocation request forms now use the configured shop name as the receiver label. Previously, the contact form displayed the email address and the revocation request form displayed “Admin”.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a CMS layout with a contact or revocation request form.
2. Assign the layout to a category, product, or landing page.
3. Override only the form recipients on the entity-specific slot config.
4. Keep the confirmation message inherited.
5. Submit the form in the storefront.
6. The form should use the overridden recipients and the inherited confirmation message.

Also verify the opposite case:

1. Override only the confirmation message on the entity-specific slot config.
2. Keep the recipients inherited.
3. Submit the form in the storefront.
4. The form should use the inherited recipients and the overridden confirmation message.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #6481

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
