### PR TITLE
fix: prevent service writes through the auto-generated app API

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEvent.php
@@ -41,6 +41,17 @@ class PreWriteValidationEvent extends Event implements ShopwareEvent
         return $this->commands;
     }
 
+    /**
+     * @return list<WriteCommand>
+     */
+    public function getCommandsForEntity(string $entity): array
+    {
+        return array_values(array_filter(
+            $this->commands,
+            static fn (WriteCommand $command): bool => $command->getEntityName() === $entity
+        ));
+    }
+
     public function getExceptions(): WriteException
     {
         return $this->writeContext->getExceptions();

--- a/src/Core/Service/Api/ServiceController.php
+++ b/src/Core/Service/Api/ServiceController.php
@@ -71,9 +71,7 @@ class ServiceController
     {
         $this->validateActivationAccess($context);
 
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
-            $this->serviceLifecycle->activate($serviceName, $context);
-        });
+        $this->serviceLifecycle->activate($serviceName, $context);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
@@ -90,9 +88,7 @@ class ServiceController
     {
         $this->validateActivationAccess($context);
 
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($serviceName): void {
-            $this->serviceLifecycle->deactivate($serviceName, $context);
-        });
+        $this->serviceLifecycle->deactivate($serviceName, $context);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
@@ -114,9 +110,7 @@ class ServiceController
             throw ServiceException::notFound('name', $serviceName);
         }
 
-        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
-            $this->serviceLifecycle->uninstall($service->name, $context);
-        });
+        $this->serviceLifecycle->uninstall($service->name, $context);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Service/DependencyInjection/services.xml
+++ b/src/Core/Service/DependencyInjection/services.xml
@@ -208,6 +208,12 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="Shopware\Core\Service\Subscriber\ServiceWriteProtectionSubscriber">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Service\Notification">
             <argument type="service" id="Shopware\Core\Framework\Notification\NotificationService"/>
         </service>

--- a/src/Core/Service/ServiceLifecycle.php
+++ b/src/Core/Service/ServiceLifecycle.php
@@ -26,6 +26,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * Installs, updates and uninstalls self-managed service apps.
  *
+ * A service is a self-managed app whose app row may only be mutated internally; the
+ * {@see \Shopware\Core\Service\Subscriber\ServiceWriteProtectionSubscriber} rejects any such write
+ * outside the system scope. The state-changing operations therefore elevate to the system scope
+ * themselves, so every caller (controllers, subscribers, handlers) is safe regardless of its context.
+ *
  * @internal
  */
 #[Package('framework')]
@@ -118,7 +123,9 @@ class ServiceLifecycle
             throw ServiceException::stateChangeNotPermitted($serviceName);
         }
 
-        $this->appManager->activate($service->app, $context);
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
+            $this->appManager->activate($service->app, $context);
+        });
     }
 
     public function deactivate(string $serviceName, Context $context): void
@@ -133,7 +140,9 @@ class ServiceLifecycle
             throw ServiceException::stateChangeNotPermitted($serviceName);
         }
 
-        $this->appManager->deactivate($service->app, $context);
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
+            $this->appManager->deactivate($service->app, $context);
+        });
     }
 
     public function uninstall(string $serviceName, Context $context): void
@@ -144,7 +153,9 @@ class ServiceLifecycle
             throw ServiceException::notFound('name', $serviceName);
         }
 
-        $this->appManager->uninstall($service->app, $context, true);
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($service): void {
+            $this->appManager->uninstall($service->app, $context, true);
+        });
     }
 
     /**

--- a/src/Core/Service/Subscriber/ServiceWriteProtectionSubscriber.php
+++ b/src/Core/Service/Subscriber/ServiceWriteProtectionSubscriber.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Service\Subscriber;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\App\AppDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Services are owned by the internal service lifecycle, which always runs in the system scope.
+ *
+ * This subscriber prohibits creating, modifying or deleting a service through the auto-generated
+ * entity API (Admin and Sync), which writes in the crud scope and would otherwise bypass the
+ * lifecycle and its requirement gate.
+ *
+ * @internal
+ */
+#[Package('framework')]
+readonly class ServiceWriteProtectionSubscriber implements EventSubscriberInterface
+{
+    final public const VIOLATION_NO_PERMISSION = 'service_write_not_allowed_violation';
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreWriteValidationEvent::class => 'checkWrite',
+        ];
+    }
+
+    public function checkWrite(PreWriteValidationEvent $event): void
+    {
+        // Every legitimate service mutation runs in the system scope (ServiceLifecycle elevates to it),
+        // so a non-system write can never be the internal lifecycle. This also skips most writes cheaply.
+        if ($event->getContext()->getScope() === Context::SYSTEM_SCOPE) {
+            return;
+        }
+
+        $appCommands = $event->getCommandsForEntity(AppDefinition::ENTITY_NAME);
+        if ($appCommands === []) {
+            // The write does not touch the app entity at all , bail
+            return;
+        }
+
+        $serviceIds = $this->fetchServiceIds($appCommands);
+
+        $violations = new ConstraintViolationList(array_map(
+            $this->buildViolation(...),
+            array_filter($appCommands, fn (WriteCommand $command): bool => $this->isProtected($command, $serviceIds))
+        ));
+
+        if ($violations->count() > 0) {
+            $event->getExceptions()->add(new WriteConstraintViolationException($violations));
+        }
+    }
+
+    /**
+     * @param array<string> $selfManagedIds
+     */
+    private function isProtected(WriteCommand $command, array $selfManagedIds): bool
+    {
+        // creating a service or changing an app to a service is a lifecycle-only operation.
+        if (($command instanceof InsertCommand || $command instanceof UpdateCommand)
+            && ($command->getPayload()['self_managed'] ?? false)) {
+            return true;
+        }
+
+        // modifying or deleting a row that is already a service.
+        if ($command instanceof UpdateCommand || $command instanceof DeleteCommand) {
+            return \in_array($command->getPrimaryKey()['id'], $selfManagedIds, true);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<WriteCommand> $commands
+     *
+     * @return array<string>
+     */
+    private function fetchServiceIds(array $commands): array
+    {
+        $ids = array_map(static fn (WriteCommand $command): string => $command->getPrimaryKey()['id'], $commands);
+
+        return $this->connection->fetchFirstColumn(
+            'SELECT `id` FROM `app` WHERE `id` IN (:ids) AND `self_managed` = 1',
+            ['ids' => $ids],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+
+    private function buildViolation(WriteCommand $command): ConstraintViolation
+    {
+        return new ConstraintViolation(
+            'A service cannot be created, modified or deleted through the API.',
+            'A service cannot be created, modified or deleted through the API.',
+            [],
+            null,
+            '/' . $command->getEntityName(),
+            null,
+            null,
+            self::VIOLATION_NO_PERMISSION
+        );
+    }
+}

--- a/src/Core/Service/Subscriber/ServiceWriteProtectionSubscriber.php
+++ b/src/Core/Service/Subscriber/ServiceWriteProtectionSubscriber.php
@@ -25,6 +25,10 @@ use Symfony\Component\Validator\ConstraintViolationList;
  * lifecycle and its requirement gate.
  *
  * @internal
+ *
+ * @codeCoverageIgnore
+ *
+ * @see \Shopware\Tests\Integration\Core\Service\Subscriber\ServiceWriteProtectionSubscriberTest
  */
 #[Package('framework')]
 readonly class ServiceWriteProtectionSubscriber implements EventSubscriberInterface

--- a/tests/integration/Core/Framework/App/AppFixture.php
+++ b/tests/integration/Core/Framework/App/AppFixture.php
@@ -34,20 +34,15 @@ final class AppFixture
 
     public function createApp(Manifest $manifest, ?string $appSecret = 's3cr3t'): AppEntity
     {
-        $id = Uuid::randomHex();
         $metadata = $manifest->getMetadata();
         $name = $metadata->getName();
         $labels = $metadata->getLabel();
-        $label = $labels['en-GB'] ?? reset($labels) ?: $name;
 
-        $app = [
-            'id' => $id,
+        $data = [
             'name' => $name,
-            'active' => true,
             'path' => $manifest->getPath(),
             'version' => $metadata->getVersion(),
-            'label' => $label,
-            'accessToken' => 'test',
+            'label' => $labels['en-GB'] ?? reset($labels) ?: $name,
             'integration' => [
                 'label' => $name,
                 'accessKey' => $name,
@@ -59,8 +54,38 @@ final class AppFixture
         ];
 
         if ($appSecret !== null) {
-            $app['appSecret'] = $appSecret;
+            $data['appSecret'] = $appSecret;
         }
+
+        return $this->createAppFromData($data);
+    }
+
+    /**
+     * Persist an app without a manifest. Pass any app fields to override the defaults.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function createAppFromData(array $data = []): AppEntity
+    {
+        $id = Uuid::randomHex();
+
+        $app = array_merge([
+            'id' => $id,
+            'name' => 'app-' . $id,
+            'active' => true,
+            'path' => '/apps/app-' . $id,
+            'version' => '1.0.0',
+            'label' => 'app-' . $id,
+            'accessToken' => 'test',
+            'integration' => [
+                'label' => 'app-' . $id,
+                'accessKey' => 'app-' . $id,
+                'secretAccessKey' => 'test',
+            ],
+            'aclRole' => [
+                'name' => 'app-' . $id,
+            ],
+        ], $data);
 
         $this->appRepository->create([$app], Context::createDefaultContext());
 

--- a/tests/integration/Core/Service/Subscriber/ServiceWriteProtectionSubscriberTest.php
+++ b/tests/integration/Core/Service/Subscriber/ServiceWriteProtectionSubscriberTest.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Service\Subscriber;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\AppCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Service\Requirement\ServicesEnabledRequirement;
+use Shopware\Core\Service\Subscriber\ServiceWriteProtectionSubscriber;
+use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+class ServiceWriteProtectionSubscriberTest extends TestCase
+{
+    use AdminFunctionalTestBehaviour;
+
+    /**
+     * @var EntityRepository<AppCollection>
+     */
+    private EntityRepository $appRepository;
+
+    private AppFixture $appFixture;
+
+    protected function setUp(): void
+    {
+        $this->appRepository = static::getContainer()->get('app.repository');
+
+        $appFixture = static::getContainer()->get(AppFixture::class);
+        static::assertInstanceOf(AppFixture::class, $appFixture);
+        $this->appFixture = $appFixture;
+    }
+
+    public function testServiceCannotBeDeactivatedThroughTheEntityApi(): void
+    {
+        $appId = $this->appFixture->createAppFromData(['selfManaged' => true])->getId();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('PATCH', '/api/app/' . $appId, ['active' => false], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertBlocked($browser);
+        static::assertTrue($this->appFixture->getApp($appId)->isActive());
+    }
+
+    public function testServiceCannotBeDeletedThroughTheEntityApi(): void
+    {
+        $appId = $this->appFixture->createAppFromData(['selfManaged' => true])->getId();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('DELETE', '/api/app/' . $appId, [], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertBlocked($browser);
+        static::assertTrue($this->appFixture->getApp($appId)->isActive());
+    }
+
+    public function testAppCannotBeFlaggedAsServiceThroughTheEntityApi(): void
+    {
+        $appId = $this->appFixture->createAppFromData(['selfManaged' => false])->getId();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('PATCH', '/api/app/' . $appId, ['selfManaged' => true], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertBlocked($browser);
+        static::assertFalse($this->appFixture->getApp($appId)->isSelfManaged());
+    }
+
+    public function testServiceCannotBeCreatedThroughTheEntityApi(): void
+    {
+        // The guard rejects the write during pre-write validation, before the app row (and its foreign
+        // keys) are ever persisted, so the referenced ids do not need to exist.
+        $name = 'CreatedViaApi' . Uuid::randomHex();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('POST', '/api/app', [
+            'name' => $name,
+            'path' => 'foo/bar',
+            'version' => '1.0.0',
+            'label' => $name,
+            'active' => true,
+            'selfManaged' => true,
+            'integrationId' => Uuid::randomHex(),
+            'aclRoleId' => Uuid::randomHex(),
+        ], ['HTTP_ACCEPT' => 'application/json']);
+
+        $this->assertBlocked($browser);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $name));
+        static::assertNull($this->appRepository->searchIds($criteria, Context::createDefaultContext())->firstId());
+    }
+
+    public function testRegularAppCanStillBeModifiedThroughTheEntityApi(): void
+    {
+        $appId = $this->appFixture->createAppFromData(['selfManaged' => false])->getId();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('PATCH', '/api/app/' . $appId, ['active' => false], ['HTTP_ACCEPT' => 'application/json']);
+
+        static::assertSame(
+            Response::HTTP_NO_CONTENT,
+            $browser->getResponse()->getStatusCode(),
+            (string) $browser->getResponse()->getContent()
+        );
+        static::assertFalse($this->appFixture->getApp($appId)->isActive());
+    }
+
+    public function testDisablingServicesUninstallsThemWithoutBeingBlocked(): void
+    {
+        $appId = $this->appFixture->createAppFromData(
+            ['selfManaged' => true, 'sourceConfig' => ['requirements' => [ServicesEnabledRequirement::NAME]],
+            ]
+        )->getId();
+
+        $browser = $this->getBrowser();
+        $browser->jsonRequest('POST', '/api/services/disable', [], ['HTTP_ACCEPT' => 'application/json']);
+
+        static::assertSame(
+            Response::HTTP_OK,
+            $browser->getResponse()->getStatusCode(),
+            (string) $browser->getResponse()->getContent()
+        );
+        static::assertNull($this->appRepository->searchIds(new Criteria([$appId]), Context::createDefaultContext())->firstId());
+    }
+
+    private function assertBlocked(TestBrowser $browser): void
+    {
+        $response = $browser->getResponse();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), (string) $response->getContent());
+
+        $errors = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['errors'] ?? [];
+        $codes = array_column($errors, 'code');
+
+        static::assertContains(
+            ServiceWriteProtectionSubscriber::VIOLATION_NO_PERMISSION,
+            $codes,
+            'Expected the write to be rejected by the service write protection: ' . $response->getContent()
+        );
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEventTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Write/Validation/PreWriteValidationEventTest.php
@@ -93,6 +93,23 @@ class PreWriteValidationEventTest extends TestCase
         }
     }
 
+    public function testGetCommandsForEntity(): void
+    {
+        $ids = new IdsCollection();
+
+        $commands = $this->getCommands([
+            ['entityName' => 'product', 'type' => 'insert', 'primaryKey' => ['id' => $ids->getBytes('p1')]],
+            ['entityName' => 'category', 'type' => 'insert', 'primaryKey' => ['id' => $ids->getBytes('c1')]],
+            ['entityName' => 'product', 'type' => 'delete', 'primaryKey' => ['id' => $ids->getBytes('p2')]],
+        ]);
+
+        $event = new PreWriteValidationEvent($this->context, $commands);
+
+        static::assertSame([$commands[0], $commands[2]], $event->getCommandsForEntity('product'));
+        static::assertSame([$commands[1]], $event->getCommandsForEntity('category'));
+        static::assertSame([], $event->getCommandsForEntity('not-found'));
+    }
+
     public static function getPrimaryKeysProvider(): \Generator
     {
         $ids = new IdsCollection();

--- a/tests/unit/Core/Service/ServiceLifecycleTest.php
+++ b/tests/unit/Core/Service/ServiceLifecycleTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\AppException;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\App\Manifest\ManifestFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Service\AppInfo;
 use Shopware\Core\Service\Event\ServiceInstalledEvent;
 use Shopware\Core\Service\Event\ServiceUpdatedEvent;
@@ -428,6 +430,21 @@ class ServiceLifecycleTest extends TestCase
         $this->createLifecycle($this->buildAppRepository([$app]))->activate('MyCoolService', $context);
     }
 
+    public function testActivateRunsAppWriteInSystemScope(): void
+    {
+        // A service is a self-managed app; the app write must be elevated to the system scope even
+        // when the caller's context is not, otherwise the service write protection rejects it.
+        $context = new Context(new AdminApiSource(Uuid::randomHex()));
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+        $this->stateChangePermitted(true);
+
+        $this->appManager->expects($this->once())
+            ->method('activate')
+            ->with($app, static::callback($this->isSystemScope()));
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->activate('MyCoolService', $context);
+    }
+
     public function testActivateThrowsExceptionWhenServiceDoesNotExist(): void
     {
         static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
@@ -456,6 +473,19 @@ class ServiceLifecycleTest extends TestCase
         $this->stateChangePermitted(true);
 
         $this->appManager->expects($this->once())->method('deactivate')->with($app, $context);
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->deactivate('MyCoolService', $context);
+    }
+
+    public function testDeactivateRunsAppWriteInSystemScope(): void
+    {
+        $context = new Context(new AdminApiSource(Uuid::randomHex()));
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+        $this->stateChangePermitted(true);
+
+        $this->appManager->expects($this->once())
+            ->method('deactivate')
+            ->with($app, static::callback($this->isSystemScope()));
 
         $this->createLifecycle($this->buildAppRepository([$app]))->deactivate('MyCoolService', $context);
     }
@@ -493,6 +523,18 @@ class ServiceLifecycleTest extends TestCase
         $this->createLifecycle($this->buildAppRepository([$app]))->uninstall('MyCoolService', $context);
     }
 
+    public function testUninstallRunsAppWriteInSystemScope(): void
+    {
+        $context = new Context(new AdminApiSource(Uuid::randomHex()));
+        $app = AppFixture::createAppEntity(name: 'MyCoolService');
+
+        $this->appManager->expects($this->once())
+            ->method('uninstall')
+            ->with($app, static::callback($this->isSystemScope()), true);
+
+        $this->createLifecycle($this->buildAppRepository([$app]))->uninstall('MyCoolService', $context);
+    }
+
     public function testUninstallThrowsExceptionWhenServiceDoesNotExist(): void
     {
         static::expectExceptionObject(ServiceException::notFound('name', 'MyCoolService'));
@@ -521,6 +563,11 @@ class ServiceLifecycleTest extends TestCase
     private function stateChangePermitted(bool $allowed): void
     {
         $this->requirementsValidator->method('permitsStateChange')->willReturn($allowed);
+    }
+
+    private function isSystemScope(): \Closure
+    {
+        return static fn (Context $context): bool => $context->getScope() === Context::SYSTEM_SCOPE;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Services are self-managed apps owned by the internal service lifecycle, which enforces each service's requirements. The auto-generated app entity API (`PATCH`/`DELETE /api/app/{id}` and the Sync API) bypassed that gate, so a service (e.g. GMV) could be deactivated or deleted directly.

### 2. What does this change do, exactly?

A `PreWriteValidationEvent` subscriber rejects creating, modifying or deleting a self-managed app outside the system scope. `ServiceLifecycle` now elevates its own app writes to the system scope, so the lifecycle and the `/api/service/*` endpoints keep working. Adds `PreWriteValidationEvent::getCommandsForEntity()`.

### 3. Describe each step to reproduce the issue or behaviour.

With a service installed, `PATCH /api/app/{id}` with `{"active": false}` previously returned `204` and deactivated it, and `DELETE /api/app/{id}` removed it — both bypassing the `/api/service/*` guard. Both now return `400` (`FRAMEWORK__WRITE_CONSTRAINT_VIOLATION`).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
