### PR TITLE
perf(product-export): skip heavy product columns unused by the export template

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -399,6 +399,10 @@ Admin API requests authenticated with a standard integration access key now supp
 
 Editing or deleting a product cross-selling entry, including assigned products and translations, now correctly invalidates the product detail route cache and prevents stale storefront results.
 
+### Product export skips the heavy description column when the template does not render it
+
+Product export now analyses the body template and, via `Criteria::excludeFields()`, stops loading the heavy translated `description` column when the template does not render it — reducing database load, transfer size and memory for large catalogs. Products are still loaded as full entities; only the unused column is skipped. If the template dereferences the whole `product` (or its `translated` array), nothing is excluded. A `ProductExportProductCriteriaEvent` listener that already narrows the field selection (via `addFields()` or `excludeFields()`) is left untouched.
+
 ### Enforce "Allow payment change after checkout" when re-paying an order
 
 `Shopware\Core\Checkout\Order\SalesChannel\SetPaymentOrderRoute` now rejects payment methods whose `afterOrderEnabled` ("Allow payment change after checkout") flag is disabled, matching the methods offered on the edit-order page. Previously the flag was only applied as a UI filter, so a payment method that renders its own JavaScript payment button (e.g. PayPal smart buttons) could still be used to pay an existing order. The store-api route `POST /store-api/order/payment` now returns `CHECKOUT__ORDER_PAYMENT_METHOD_NOT_CHANGEABLE` (HTTP 403) for such methods. (shopware/shopware#17495)

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -41,6 +41,8 @@ use Twig\Environment;
 #[Package('inventory')]
 class ProductExportGenerator implements ProductExportGeneratorInterface
 {
+    private const PRODUCT_ROOT = 'product';
+
     private readonly TwigVariableParser $twigVariableParser;
 
     /**
@@ -112,7 +114,7 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             $criteria->addFilter(...$productStreamBuilder->buildFilters($productExport->getProductStreamId(), $context->getContext()));
         }
 
-        $associations = $this->getAssociations($productExport, $context);
+        $templateVariables = $this->parseTemplateVariables($productExport, $context);
 
         $criteria
             ->setTitle('product-export::products')
@@ -129,7 +131,7 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             $criteria->addFilter(new EqualsFilter('parentId', null));
         }
 
-        foreach ($associations as $association) {
+        foreach ($templateVariables['associations'] as $association) {
             $criteria->addAssociation($association);
         }
 
@@ -141,6 +143,8 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         $this->eventDispatcher->dispatch(
             new ProductExportProductCriteriaEvent($criteria, $productExport, $exportBehavior, $context)
         );
+
+        $this->excludeDescriptionIfUnused($criteria, $templateVariables['others']);
 
         // Pagination is delegated to SalesChannelRepositoryIterator: when the criteria has no sorting
         // it seeks by an autoIncrement keyset (constant cost, no COUNT); when a subscriber added its
@@ -301,9 +305,12 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
     }
 
     /**
-     * @return array<string>
+     * Parses the body template and splits the referenced variables into association paths (to
+     * eager-load) and everything else (scalar field accessors, whole-entity dereferences).
+     *
+     * @return array{associations: list<string>, others: list<string>}
      */
-    private function getAssociations(ProductExportEntity $productExport, SalesChannelContext $context): array
+    private function parseTemplateVariables(ProductExportEntity $productExport, SalesChannelContext $context): array
     {
         try {
             $variables = $this->twigVariableParser->parse((string) $productExport->getBodyTemplate());
@@ -318,10 +325,65 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         }
 
         $associations = [];
+        $others = [];
         foreach ($variables as $variable) {
-            $associations[] = EntityDefinitionQueryHelper::getAssociationPath($variable, $this->productDefinition);
+            if (!\is_string($variable)) {
+                continue;
+            }
+
+            $association = EntityDefinitionQueryHelper::getAssociationPath($variable, $this->productDefinition);
+            if ($association !== null && $association !== '') {
+                $associations[] = $association;
+
+                continue;
+            }
+
+            $others[] = $variable;
         }
 
-        return array_filter(array_unique($associations));
+        return [
+            'associations' => array_values(array_unique($associations)),
+            'others' => $others,
+        ];
+    }
+
+    /**
+     * Skips loading the heavy `description` column when the export template never reads it.
+     * Conservative: a dereference of the whole `product` or its `translated` array counts as reading
+     * it, so nothing is excluded then. Left untouched when a {@see ProductExportProductCriteriaEvent}
+     * listener already narrowed the field selection.
+     *
+     * @param list<string> $others
+     */
+    private function excludeDescriptionIfUnused(Criteria $criteria, array $others): void
+    {
+        if ($criteria->getFields() !== [] || $criteria->getExcludedFields() !== []) {
+            return;
+        }
+
+        if ($this->templateReadsDescription($others)) {
+            return;
+        }
+
+        $criteria->excludeFields(['description']);
+    }
+
+    /**
+     * @param list<string> $others
+     */
+    private function templateReadsDescription(array $others): bool
+    {
+        foreach ($others as $variable) {
+            if (\in_array($variable, [
+                self::PRODUCT_ROOT,
+                self::PRODUCT_ROOT . '.translated',
+                self::PRODUCT_ROOT . '.description',
+                self::PRODUCT_ROOT . '.translated.description',
+            ], true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\ProductExport\Service;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
@@ -673,6 +674,78 @@ class ProductExportGeneratorTest extends TestCase
         static::assertNotNull($result);
         static::assertFalse($result->hasNextBatch());
         static::assertSame(41, $result->getOffset());
+    }
+
+    /**
+     * @param list<string> $templateVariables
+     * @param list<string> $expectedExcluded
+     */
+    #[DataProvider('descriptionExclusionProvider')]
+    public function testExcludesDescriptionWhenNotReferencedInTemplate(array $templateVariables, array $expectedExcluded): void
+    {
+        $productExport = $this->getProductExportEntity();
+        $productExport->setEncoding(ProductExportEntity::ENCODING_UTF8);
+        $productExport->setFileFormat(ProductExportEntity::FILE_FORMAT_CSV);
+        $productExport->setBodyTemplate('{{ product.id }}');
+        $productExport->setIncludeVariants(false);
+
+        $context = $this->createSalesChannelContext();
+        $product = $this->createProduct('product-id');
+
+        $this->contextPersister->method('save');
+        $this->salesChannelContextService->method('get')->willReturn($context);
+        $this->languageLocaleProvider->method('getLocaleForLanguageId')->willReturn('en-GB');
+        $this->translator->method('injectSettings');
+        $this->translator->method('resetInjection');
+        $this->productStreamBuilder->method('enrichCriteria');
+
+        $twigVariableParser = static::createStub(TwigVariableParser::class);
+        $twigVariableParser->method('parse')->willReturn($templateVariables);
+        $this->parserFactory->method('getParser')->willReturn($twigVariableParser);
+
+        // Batch mode performs a single search, so excludeDescriptionIfUnused() has already run on the
+        // criteria handed to the repository.
+        $captured = null;
+        $this->productRepository->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(function (Criteria $criteria) use (&$captured, $product, $context): EntitySearchResult {
+                $captured = $criteria;
+
+                return $this->createProductSearchResult($product, $context);
+            });
+
+        $this->productExportRender->method('renderBody')->willReturn('product');
+        $this->seoUrlPlaceholderHandler->method('replace')->willReturnArgument(0);
+        $this->productExportValidator->method('validate')->willReturn([]);
+        $this->connection->method('delete');
+
+        $this->createGenerator()->generate($productExport, new ExportBehavior(false, false, true, false, false));
+
+        static::assertInstanceOf(Criteria::class, $captured);
+        static::assertSame($expectedExcluded, $captured->getExcludedFields());
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, list<string>}>
+     */
+    public static function descriptionExclusionProvider(): iterable
+    {
+        yield 'description not referenced -> excluded' => [
+            ['product.id', 'product.translated.name', 'product.calculatedPrice'],
+            ['description'],
+        ];
+        yield 'description referenced -> kept' => [
+            ['product.translated.description', 'product.id'],
+            [],
+        ];
+        yield 'whole translated array dereferenced -> kept' => [
+            ['product.translated'],
+            [],
+        ];
+        yield 'whole product dereferenced -> kept' => [
+            ['product'],
+            [],
+        ];
     }
 
     private function createGenerator(): ProductExportGenerator


### PR DESCRIPTION
### 1. Why is this change necessary?

`ProductExportGenerator` loads full product entities for every exported product. The heavy translated column `description` (a `LONGTEXT`, stored off-page) is loaded even when the export's body template never renders it, wasting database load, transfer size and memory on large catalogs. Association loading is already tailored to the template (via `TwigVariableParser`), but scalar columns were always fully loaded.

### 2. What does this change do, exactly?

- Parses the body template once (`parseTemplateVariables()`), reused for both association resolution and the new field reduction.
- After the `ProductExportProductCriteriaEvent` dispatch, drops the heavy translated columns `description`, `keywords` and `customSearchKeywords` from the read via `Criteria::excludeFields()` when the template does not reference them. Products are still loaded as full entities; only the unused columns are skipped.
- Conservative and safe:
  - A column is excluded only when no template variable reads it (`product.<field>` or `product.translated.<field>`).
  - If the template dereferences the whole `product` or its `translated` array, nothing is excluded.
  - Left untouched when a `ProductExportProductCriteriaEvent` listener already narrowed the field selection via `addFields()` / `excludeFields()`.

### 3. Describe each step to reproduce the issue or behaviour.

- Configure a product export whose body template renders only e.g. `product.productNumber` and `product.translated.name`: products are now loaded without the `description` / `keywords` / `customSearchKeywords` columns (the rendered output is unchanged).
- Add `{{ product.translated.description }}` to the template: the `description` column is loaded again.
- Dereference the whole `product` (or `product.translated`) in the template: nothing is excluded.