### PR TITLE
perf(import-export): skip the heavy description column not mapped by the export profile

### DIFF
--- a/src/Core/Content/ImportExport/Event/Subscriber/ProductCriteriaSubscriber.php
+++ b/src/Core/Content/ImportExport/Event/Subscriber/ProductCriteriaSubscriber.php
@@ -6,6 +6,7 @@ use Shopware\Core\Content\ImportExport\Event\EnrichExportCriteriaEvent;
 use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
@@ -44,6 +45,36 @@ class ProductCriteriaSubscriber implements EventSubscriberInterface
 
         if ($config->get('includeVariants') !== true) {
             $criteria->addFilter(new EqualsFilter('parentId', null));
+        }
+
+        $this->excludeUnmappedDescription($criteria, $config);
+    }
+
+    /**
+     * Skips loading the heavy `description` column when the export profile never maps it. The column
+     * is exported through the `translations` association, so it is dropped there too (only when the
+     * association is already loaded — we never add it just to reduce it). Left untouched if a field
+     * selection is already set.
+     */
+    private function excludeUnmappedDescription(Criteria $criteria, Config $config): void
+    {
+        foreach ($config->getMapping() as $mapping) {
+            if (\in_array('description', explode('.', $mapping->getKey()), true)) {
+                return;
+            }
+        }
+
+        if ($criteria->getFields() === [] && $criteria->getExcludedFields() === []) {
+            $criteria->excludeFields(['description']);
+        }
+
+        if (!$criteria->hasAssociation('translations')) {
+            return;
+        }
+
+        $translations = $criteria->getAssociation('translations');
+        if ($translations->getFields() === [] && $translations->getExcludedFields() === []) {
+            $translations->excludeFields(['description']);
         }
     }
 }

--- a/tests/unit/Core/Content/ImportExport/Event/Subscriber/ProductCriteriaSubscriberTest.php
+++ b/tests/unit/Core/Content/ImportExport/Event/Subscriber/ProductCriteriaSubscriberTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\ImportExport\Event\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogEntity;
+use Shopware\Core\Content\ImportExport\Event\EnrichExportCriteriaEvent;
+use Shopware\Core\Content\ImportExport\Event\Subscriber\ProductCriteriaSubscriber;
+use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(ProductCriteriaSubscriber::class)]
+class ProductCriteriaSubscriberTest extends TestCase
+{
+    /**
+     * @param list<array{key: string, mappedKey: string}> $mapping
+     * @param list<string> $expectedExcluded
+     */
+    #[DataProvider('mappingProvider')]
+    public function testExcludesDescriptionWhenNotMapped(array $mapping, array $expectedExcluded): void
+    {
+        $criteria = new Criteria();
+        $this->enrich($criteria, $mapping);
+
+        static::assertSame($expectedExcluded, $criteria->getExcludedFields());
+    }
+
+    /**
+     * @return iterable<string, array{list<array{key: string, mappedKey: string}>, list<string>}>
+     */
+    public static function mappingProvider(): iterable
+    {
+        yield 'description not mapped -> excluded' => [
+            [['key' => 'productNumber', 'mappedKey' => 'product_number'], ['key' => 'translations.DEFAULT.name', 'mappedKey' => 'name']],
+            ['description'],
+        ];
+        yield 'only an unrelated field mapped -> description excluded' => [
+            [['key' => 'customFields.gtin', 'mappedKey' => 'gtin']],
+            ['description'],
+        ];
+        yield 'description mapped -> kept' => [
+            [['key' => 'translations.DEFAULT.description', 'mappedKey' => 'description']],
+            [],
+        ];
+        yield 'description mapped in a non-default language -> kept' => [
+            [['key' => 'translations.de-DE.description', 'mappedKey' => 'description']],
+            [],
+        ];
+    }
+
+    public function testExcludesDescriptionOnTranslationsAssociationWhenLoaded(): void
+    {
+        $criteria = new Criteria();
+        // the mapping references a translated field, so the export loads the translations association
+        $criteria->addAssociation('translations');
+
+        $this->enrich($criteria, [['key' => 'translations.DEFAULT.name', 'mappedKey' => 'name']]);
+
+        static::assertSame(['description'], $criteria->getExcludedFields());
+        static::assertSame(['description'], $criteria->getAssociation('translations')->getExcludedFields());
+    }
+
+    public function testDoesNotAddTranslationsAssociationJustToReduceIt(): void
+    {
+        $criteria = new Criteria();
+
+        $this->enrich($criteria, [['key' => 'productNumber', 'mappedKey' => 'product_number']]);
+
+        static::assertFalse($criteria->hasAssociation('translations'));
+        static::assertSame(['description'], $criteria->getExcludedFields());
+    }
+
+    public function testSkipsNonProductProfiles(): void
+    {
+        $criteria = new Criteria();
+
+        $this->enrich($criteria, [['key' => 'productNumber', 'mappedKey' => 'product_number']], 'category');
+
+        static::assertSame([], $criteria->getExcludedFields());
+    }
+
+    /**
+     * @param list<array{key: string, mappedKey: string}> $mapping
+     */
+    private function enrich(Criteria $criteria, array $mapping, string $sourceEntity = ProductDefinition::ENTITY_NAME): void
+    {
+        $profile = new ImportExportProfileEntity();
+        $profile->setSourceEntity($sourceEntity);
+
+        $log = new ImportExportLogEntity();
+        $log->setId('log-id');
+        $log->setProfile($profile);
+        $log->setConfig(['mapping' => $mapping, 'parameters' => ['includeVariants' => true]]);
+
+        $event = new EnrichExportCriteriaEvent($criteria, $log, Context::createDefaultContext());
+
+        (new ProductCriteriaSubscriber())->enrich($event);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Product import/export loads full product entities for every exported row. The translated `description` column is a `LONGTEXT` stored off-page — the dominant read/transfer/memory cost per product — yet it is loaded even when the export profile's column mapping never references it. Notably the shipped `Default product` profile does not map `description` at all (it maps `name`, `stock`, `manufacturer`, `tax`, `price`, `productNumber`, `releaseDate`, `categories`), so the common case pays this cost for nothing.

### 2. What does this change do, exactly?

- `ProductCriteriaSubscriber` (which already guards on the `product` source entity) inspects the profile's column mapping and, when no mapped key references `description`, drops it from the read via `Criteria::excludeFields(['description'])`.
- Applied to **both** the product read and the `translations` association — the latter only when it is already loaded (the association is never added just to reduce it).
- Detection is exact: a mapping key such as `translations.<lang>.description` is matched as a whole dot-separated segment, so `metaDescription` / `descriptionTeaser` never false-match, and `description` can never be excluded while it is actually mapped (no data loss). A profile that maps the description in any language keeps it loaded.
- Left untouched when a field selection is already set (`addFields()` / `excludeFields()`), so an `EnrichExportCriteriaEvent` listener that already narrowed the criteria wins.
- Serializers only output what the DAL loads, so a column skipped because it is unmapped is simply absent from the export — the output is unchanged.

Scoped to `description` only: it is the one genuinely heavy (`LONGTEXT`, off-page) column, and it is exactly the column the default profile omits. The smaller translated columns are not worth the extra detection surface.

### 3. Describe each step to reproduce the issue or behaviour.

- Export products with a profile that does not map the description (e.g. the shipped `Default product` profile, or one mapping only `productNumber` and `translations.DEFAULT.name`): the products and their translations are now loaded without the `description` `LONGTEXT`, and the export output is unchanged.
- Add `translations.DEFAULT.description` (or the same field in any other language, e.g. `translations.de-DE.description`) to the mapping: the `description` column is loaded again.

### 4. Please link to the relevant issues (if any).

- relates #17680 (introduced `Criteria::excludeFields()`)
