### PR TITLE
fix(storefront): replace deprecated Request::get in country state controller

### DIFF
--- a/src/Storefront/Controller/CountryStateController.php
+++ b/src/Storefront/Controller/CountryStateController.php
@@ -43,7 +43,7 @@ class CountryStateController extends StorefrontController
     )]
     public function getCountryData(Request $request, SalesChannelContext $context): Response
     {
-        $countryId = (string) $request->get('countryId');
+        $countryId = $request->query->getString('countryId', $request->request->getString('countryId'));
 
         if (!$countryId) {
             throw RoutingException::missingRequestParameter('countryId');

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -60,6 +60,13 @@ class CountryStateControllerTest extends TestCase
         static::assertCount(16, \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['states']);
     }
 
+    public function testGetCountryDataFromQueryParameter(): void
+    {
+        $response = $this->countryStateController->getCountryData(new Request(['countryId' => $this->countryIdDE]), $this->salesChannelContext);
+
+        static::assertCount(16, \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['states']);
+    }
+
     public function testEmptyCountryId(): void
     {
         $this->expectExceptionObject(RoutingException::missingRequestParameter('countryId'));

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -83,7 +83,7 @@ class CountryStateControllerTest extends TestCase
     public function testEmptyCountryId(): void
     {
         $this->expectExceptionObject(RoutingException::missingRequestParameter('countryId'));
-        $this->countryStateController->getCountryData(new Request([], ['countryId' => null]), $this->salesChannelContext);
+        $this->countryStateController->getCountryData(new Request(), $this->salesChannelContext);
     }
 
     public function testCountryStateControllerEvents(): void

--- a/tests/integration/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/integration/Storefront/Controller/CountryStateControllerTest.php
@@ -35,6 +35,8 @@ class CountryStateControllerTest extends TestCase
 
     private string $countryIdDE;
 
+    private string $countryIdAT;
+
     private CountryStateController $countryStateController;
 
     private SalesChannelContext $salesChannelContext;
@@ -43,9 +45,8 @@ class CountryStateControllerTest extends TestCase
     {
         $this->connection = static::getContainer()->get(Connection::class);
 
-        $this->countryIdDE = Uuid::fromBytesToHex(
-            $this->connection->fetchAllAssociative('SELECT id FROM country WHERE iso = \'DE\'')[0]['id']
-        );
+        $this->countryIdDE = $this->getCountryIdByIso();
+        $this->countryIdAT = $this->getCountryIdByIso('AT');
 
         $this->countryStateController = static::getContainer()->get(CountryStateController::class);
 
@@ -62,9 +63,21 @@ class CountryStateControllerTest extends TestCase
 
     public function testGetCountryDataFromQueryParameter(): void
     {
-        $response = $this->countryStateController->getCountryData(new Request(['countryId' => $this->countryIdDE]), $this->salesChannelContext);
+        $response = $this->countryStateController->getCountryData(new Request(['countryId' => $this->countryIdAT]), $this->salesChannelContext);
 
-        static::assertCount(16, \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['states']);
+        static::assertCount(0, \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['states']);
+    }
+
+    public function testGetCountryDataPrefersQueryParameterOverPostData(): void
+    {
+        $response = $this->countryStateController->getCountryData(
+            new Request(['countryId' => $this->countryIdDE], ['countryId' => $this->countryIdAT]),
+            $this->salesChannelContext
+        );
+
+        $states = \json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR)['states'];
+
+        static::assertCount(16, $states);
     }
 
     public function testEmptyCountryId(): void
@@ -141,6 +154,14 @@ class CountryStateControllerTest extends TestCase
         static::assertArrayHasKey(CountryStateDataPageletLoadedHook::HOOK_NAME, $traces);
 
         static::assertSame([16], $traces['country-state-data-pagelet-loaded'][0]['output']);
+    }
+
+    private function getCountryIdByIso(string $iso = 'DE'): string
+    {
+        $countryId = $this->connection->fetchOne('SELECT LOWER(HEX(id)) FROM country WHERE iso = :iso', ['iso' => $iso]);
+        static::assertIsString($countryId);
+
+        return $countryId;
     }
 }
 

--- a/tests/unit/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/unit/Storefront/Controller/CountryStateControllerTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\Test\Generator;
+use Shopware\Storefront\Controller\CountryStateController;
+use Shopware\Storefront\Pagelet\Country\CountryStateDataPagelet;
+use Shopware\Storefront\Pagelet\Country\CountryStateDataPageletLoader;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(CountryStateController::class)]
+class CountryStateControllerTest extends TestCase
+{
+    private CountryStateDataPageletLoader&MockObject $pageletLoader;
+
+    private CountryStateControllerTestClass $controller;
+
+    protected function setUp(): void
+    {
+        $this->pageletLoader = static::createMock(CountryStateDataPageletLoader::class);
+        $this->controller = new CountryStateControllerTestClass($this->pageletLoader);
+    }
+
+    public function testGetCountryDataUsesCountryIdFromQuery(): void
+    {
+        $request = new Request(['countryId' => 'query-country-id']);
+        $context = Generator::generateSalesChannelContext();
+
+        $this->pageletLoader->expects($this->once())
+            ->method('load')
+            ->with('query-country-id', $request, $context)
+            ->willReturn(new CountryStateDataPagelet());
+
+        $this->controller->getCountryData($request, $context);
+    }
+
+    public function testGetCountryDataFallsBackToCountryIdFromPost(): void
+    {
+        $request = new Request([], ['countryId' => 'post-country-id']);
+        $context = Generator::generateSalesChannelContext();
+
+        $this->pageletLoader->expects($this->once())
+            ->method('load')
+            ->with('post-country-id', $request, $context)
+            ->willReturn(new CountryStateDataPagelet());
+
+        $this->controller->getCountryData($request, $context);
+    }
+
+    public function testGetCountryDataThrowsExceptionWithoutCountryId(): void
+    {
+        $this->expectExceptionObject(RoutingException::missingRequestParameter('countryId'));
+
+        $this->controller->getCountryData(new Request(), Generator::generateSalesChannelContext());
+    }
+}
+
+/**
+ * @internal
+ */
+class CountryStateControllerTestClass extends CountryStateController
+{
+    use StorefrontControllerMockTrait;
+}

--- a/tests/unit/Storefront/Controller/CountryStateControllerTest.php
+++ b/tests/unit/Storefront/Controller/CountryStateControllerTest.php
@@ -56,6 +56,9 @@ class CountryStateControllerTest extends TestCase
 
     public function testGetCountryDataThrowsExceptionWithoutCountryId(): void
     {
+        $this->pageletLoader->expects($this->never())
+            ->method('load');
+
         $this->expectExceptionObject(RoutingException::missingRequestParameter('countryId'));
 
         $this->controller->getCountryData(new Request(), Generator::generateSalesChannelContext());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Symfony 7.4 deprecates `Request::get()`. CountryStateController still used it to read countryId.

### 2. What does this change do, exactly?

It replaces the deprecated `Request::get()` usage with explicit request bag access by reading countryId from the query bag and keeping the POST body fallback for backward compatibility in 6.7.

### 3. Describe each step to reproduce the issue or behaviour.

1. Call CountryStateController::getCountryData().
2. Pass countryId via query or POST data.
3. The controller reads the parameter without using deprecated Request::get().

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #17988

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
