### PR TITLE
feat(core): POC - add age verification CMS element

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,6 +2,14 @@
 
 ## Core
 
+### New "Age verification" Shopping Experiences (CMS) element
+
+A new CMS element `age-verification` is available in the Shopping Experiences editor (under the "Text" block category). Merchants can place it on any CMS layout (home, category, product, or landing page) to show a blocking age gate before the page content becomes accessible — useful for shops selling age-restricted goods (alcohol, tobacco, etc.).
+
+The element renders a Bootstrap modal in the storefront with a confirm and a decline action. Confirming stores the choice in the strictly-necessary `age-verified` cookie (registered as a hidden entry in the required cookie group) for a configurable number of days; declining redirects to a configurable URL or back to the previous page. All texts (title, content, button labels) are per-language slot configuration and fall back to translated defaults derived from a configurable minimum age when left empty.
+
+**Extension developers:** the element follows the standard CMS element pattern and can be extended like any other. The struct `Shopware\Core\Content\Cms\SalesChannel\Struct\AgeVerificationStruct` (API alias `cms_age_verification`) is exposed as `element.data` in the storefront template `@Storefront/storefront/element/cms-element-age-verification.html.twig`, and the storefront behavior lives in the overridable `AgeVerification` plugin. The gate is client-side, so it is a soft (SEO-friendly) age gate, not a hard access restriction.
+
 ### Text-based media is stored and served with an explicit charset
 
 Text-based media files (`text/plain`, `text/csv`, `text/html`, `text/xml`, `application/json`, `application/xml`) are now written to storage with an explicit `Content-Type: …; charset=utf-8`. Previously the charset was missing, so serving such a file directly from object storage / CDN made browsers fall back to a non-UTF-8 encoding and render umlauts and other multi-byte characters as mojibake. This applies to both the server-side upload path and the presigned direct-to-S3 upload path. The `mimeType` persisted on the media entity stays bare (without the charset parameter), so no code reading it needs to change.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -2,14 +2,6 @@
 
 ## Core
 
-### New "Age verification" Shopping Experiences (CMS) element
-
-A new CMS element `age-verification` is available in the Shopping Experiences editor (under the "Text" block category). Merchants can place it on any CMS layout (home, category, product, or landing page) to show a blocking age gate before the page content becomes accessible — useful for shops selling age-restricted goods (alcohol, tobacco, etc.).
-
-The element renders a Bootstrap modal in the storefront with a confirm and a decline action. Confirming stores the choice in the strictly-necessary `age-verified` cookie (registered as a hidden entry in the required cookie group) for a configurable number of days; declining redirects to a configurable URL or back to the previous page. All texts (title, content, button labels) are per-language slot configuration and fall back to translated defaults derived from a configurable minimum age when left empty.
-
-**Extension developers:** the element follows the standard CMS element pattern and can be extended like any other. The struct `Shopware\Core\Content\Cms\SalesChannel\Struct\AgeVerificationStruct` (API alias `cms_age_verification`) is exposed as `element.data` in the storefront template `@Storefront/storefront/element/cms-element-age-verification.html.twig`, and the storefront behavior lives in the overridable `AgeVerification` plugin. The gate is client-side, so it is a soft (SEO-friendly) age gate, not a hard access restriction.
-
 ### Text-based media is stored and served with an explicit charset
 
 Text-based media files (`text/plain`, `text/csv`, `text/html`, `text/xml`, `application/json`, `application/xml`) are now written to storage with an explicit `Content-Type: …; charset=utf-8`. Previously the charset was missing, so serving such a file directly from object storage / CDN made browsers fall back to a non-UTF-8 encoding and render umlauts and other multi-byte characters as mojibake. This applies to both the server-side upload path and the presigned direct-to-S3 upload path. The `mimeType` persisted on the media entity stays bare (without the charset parameter), so no code reading it needs to change.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
@@ -33,6 +33,7 @@ import './sidebar/sidebar-filter';
 import './sidebar/category-navigation';
 
 import './text/text';
+import './text/age-verification';
 import './text/text-hero';
 import './text/text-teaser';
 import './text/text-teaser-section';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/component/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/component/index.ts
@@ -1,0 +1,9 @@
+import template from './sw-cms-block-age-verification.html.twig';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/component/sw-cms-block-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/component/sw-cms-block-age-verification.html.twig
@@ -1,0 +1,5 @@
+<div class="sw-cms-block-age-verification">
+    <slot name="content">
+        {% block sw_cms_block_age_verification_slot_content %}{% endblock %}
+    </slot>
+</div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/index.spec.js
@@ -1,0 +1,13 @@
+/**
+ * @sw-package discovery
+ */
+import { runCmsBlockRegistryTest } from 'src/module/sw-cms/test-utils';
+
+describe('src/module/sw-cms/blocks/text/age-verification', () => {
+    runCmsBlockRegistryTest({
+        import: 'src/module/sw-cms/blocks/text/age-verification',
+        name: 'age-verification',
+        component: 'sw-cms-block-age-verification',
+        preview: 'sw-cms-preview-age-verification',
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-block-age-verification', () => import('./component'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-preview-age-verification', () => import('./preview'));
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Service('cmsService').registerCmsBlock({
+    name: 'age-verification',
+    label: 'sw-cms.blocks.text.ageVerification.label',
+    category: 'text',
+    component: 'sw-cms-block-age-verification',
+    previewComponent: 'sw-cms-preview-age-verification',
+    defaultConfig: {
+        marginBottom: '20px',
+        marginTop: '20px',
+        marginLeft: null,
+        marginRight: null,
+        sizingMode: 'boxed',
+    },
+    slots: {
+        content: 'age-verification',
+    },
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/index.ts
@@ -1,0 +1,10 @@
+import template from './sw-cms-preview-age-verification.html.twig';
+import './sw-cms-preview-age-verification.scss';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/sw-cms-preview-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/sw-cms-preview-age-verification.html.twig
@@ -1,0 +1,17 @@
+{% block sw_cms_preview_age_verification %}
+<div class="sw-cms-preview-age-verification">
+    <div class="sw-cms-preview-age-verification__dialog">
+        <div class="sw-cms-preview-age-verification__title">
+            18+
+        </div>
+        <div class="sw-cms-preview-age-verification__lines">
+            <span></span>
+            <span></span>
+        </div>
+        <div class="sw-cms-preview-age-verification__actions">
+            <span class="is--primary"></span>
+            <span></span>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/sw-cms-preview-age-verification.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/age-verification/preview/sw-cms-preview-age-verification.scss
@@ -1,0 +1,62 @@
+.sw-cms-preview-age-verification {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    min-height: 90px;
+    padding: 12px;
+    background-color: #e9edf2;
+
+    &__dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        align-items: center;
+        width: 70%;
+        padding: 10px;
+        background-color: #fff;
+        border-radius: 4px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 10%);
+    }
+
+    &__title {
+        font-size: 15px;
+        font-weight: 700;
+        color: #0870ff;
+    }
+
+    &__lines {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        width: 100%;
+
+        span {
+            height: 4px;
+            background-color: #d1d9e0;
+            border-radius: 2px;
+
+            &:last-child {
+                width: 70%;
+                margin: 0 auto;
+            }
+        }
+    }
+
+    &__actions {
+        display: flex;
+        gap: 6px;
+
+        span {
+            width: 26px;
+            height: 8px;
+            background-color: #d1d9e0;
+            border-radius: 2px;
+
+            &.is--primary {
+                background-color: #0870ff;
+            }
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/component.spec.js
@@ -1,0 +1,65 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
+
+async function createWrapper(config) {
+    return mount(
+        await wrapTestComponent('sw-cms-el-age-verification', {
+            sync: true,
+        }),
+        {
+            global: {
+                provide: {
+                    cmsService: Shopware.Service('cmsService'),
+                },
+            },
+            props: {
+                element: {
+                    config,
+                },
+            },
+        },
+    );
+}
+
+describe('src/module/sw-cms/elements/age-verification/component', () => {
+    beforeAll(async () => {
+        await setupCmsEnvironment();
+    });
+
+    it('renders the configured title and content', async () => {
+        const wrapper = await createWrapper({
+            minimumAge: { value: 18 },
+            title: { value: 'Please confirm your age' },
+            content: { value: 'Custom notice' },
+            confirmButtonText: { value: 'Yes' },
+            declineButtonText: { value: 'No' },
+            declineUrl: { value: '' },
+            cookieLifetime: { value: 30 },
+        });
+
+        expect(wrapper.text()).toContain('Please confirm your age');
+        expect(wrapper.text()).toContain('Custom notice');
+        expect(wrapper.text()).toContain('Yes');
+        expect(wrapper.text()).toContain('No');
+    });
+
+    it('falls back to default translated texts when fields are empty', async () => {
+        const wrapper = await createWrapper({
+            minimumAge: { value: 21 },
+            title: { value: '' },
+            content: { value: '' },
+            confirmButtonText: { value: '' },
+            declineButtonText: { value: '' },
+            declineUrl: { value: '' },
+            cookieLifetime: { value: 30 },
+        });
+
+        // Snippets are not loaded in the unit environment, so $t returns the key.
+        // Seeing the default keys proves the empty fields fell back to the translated defaults.
+        expect(wrapper.text()).toContain('sw-cms.elements.ageVerification.preview.title');
+        expect(wrapper.text()).toContain('sw-cms.elements.ageVerification.preview.content');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/index.js
@@ -1,0 +1,26 @@
+import template from './sw-cms-el-age-verification.html.twig';
+import './sw-cms-el-age-verification.scss';
+
+const { Mixin } = Shopware;
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+
+    mixins: [
+        Mixin.getByName('cms-element'),
+    ],
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            this.initElementConfig('age-verification');
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/sw-cms-el-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/sw-cms-el-age-verification.html.twig
@@ -1,0 +1,28 @@
+{% block sw_cms_el_age_verification %}
+<div class="sw-cms-el-age-verification">
+    <div class="sw-cms-el-age-verification__dialog">
+        {% block sw_cms_el_age_verification_title %}
+        <h3 class="sw-cms-el-age-verification__title">
+            {{ element.config.title.value || $t('sw-cms.elements.ageVerification.preview.title') }}
+        </h3>
+        {% endblock %}
+
+        {% block sw_cms_el_age_verification_content %}
+        <p class="sw-cms-el-age-verification__content">
+            {{ element.config.content.value || $t('sw-cms.elements.ageVerification.preview.content', { age: element.config.minimumAge.value }) }}
+        </p>
+        {% endblock %}
+
+        {% block sw_cms_el_age_verification_actions %}
+        <div class="sw-cms-el-age-verification__actions">
+            <span class="sw-cms-el-age-verification__button is--primary">
+                {{ element.config.confirmButtonText.value || $t('sw-cms.elements.ageVerification.preview.confirm', { age: element.config.minimumAge.value }) }}
+            </span>
+            <span class="sw-cms-el-age-verification__button">
+                {{ element.config.declineButtonText.value || $t('sw-cms.elements.ageVerification.preview.decline') }}
+            </span>
+        </div>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/sw-cms-el-age-verification.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/component/sw-cms-el-age-verification.scss
@@ -1,0 +1,47 @@
+.sw-cms-el-age-verification {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 180px;
+    padding: 24px;
+    background-color: var(--color-background-primary-default, #f9fafb);
+
+    &__dialog {
+        width: 100%;
+        max-width: 420px;
+        padding: 24px;
+        text-align: center;
+        background-color: var(--color-elements-primary-default, #fff);
+        border: 1px solid var(--color-border-primary-default, #d1d9e0);
+        border-radius: 8px;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 8%);
+    }
+
+    &__title {
+        margin-bottom: 8px;
+    }
+
+    &__content {
+        margin-bottom: 16px;
+        color: var(--color-text-secondary-default, #52667a);
+    }
+
+    &__actions {
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+    }
+
+    &__button {
+        padding: 8px 16px;
+        border: 1px solid var(--color-border-primary-default, #d1d9e0);
+        border-radius: 4px;
+
+        &.is--primary {
+            color: #fff;
+            background-color: var(--color-interactive-primary-default, #0870ff);
+            border-color: var(--color-interactive-primary-default, #0870ff);
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/config.spec.js
@@ -1,0 +1,61 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
+
+async function createWrapper() {
+    return mount(
+        await wrapTestComponent('sw-cms-el-config-age-verification', {
+            sync: true,
+        }),
+        {
+            global: {
+                provide: {
+                    cmsService: Shopware.Service('cmsService'),
+                },
+                stubs: {
+                    'mt-number-field': true,
+                    'mt-text-field': true,
+                    'mt-textarea': true,
+                },
+            },
+            props: {
+                element: {
+                    config: {
+                        minimumAge: { value: 18 },
+                        title: { value: '' },
+                        content: { value: '' },
+                        confirmButtonText: { value: '' },
+                        declineButtonText: { value: '' },
+                        declineUrl: { value: '' },
+                        cookieLifetime: { value: 30 },
+                    },
+                },
+            },
+        },
+    );
+}
+
+describe('src/module/sw-cms/elements/age-verification/config', () => {
+    beforeAll(async () => {
+        await setupCmsEnvironment();
+    });
+
+    it('should update the config value and emit element-update on change', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onFieldChange('minimumAge', 21);
+
+        expect(wrapper.vm.element.config.minimumAge.value).toBe(21);
+        expect(wrapper.emitted('element-update')).toBeTruthy();
+    });
+
+    it('should not emit element-update when the value is unchanged', async () => {
+        const wrapper = await createWrapper();
+
+        wrapper.vm.onFieldChange('minimumAge', 18);
+
+        expect(wrapper.emitted('element-update')).toBeFalsy();
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/index.js
@@ -1,0 +1,37 @@
+import template from './sw-cms-el-config-age-verification.html.twig';
+import './sw-cms-el-config-age-verification.scss';
+
+const { Mixin } = Shopware;
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+
+    emits: ['element-update'],
+
+    mixins: [
+        Mixin.getByName('cms-element'),
+    ],
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            this.initElementConfig('age-verification');
+        },
+
+        onFieldChange(field, value) {
+            if (this.element.config[field].value === value) {
+                return;
+            }
+
+            this.element.config[field].value = value;
+            this.$emit('element-update', this.element);
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/sw-cms-el-config-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/sw-cms-el-config-age-verification.html.twig
@@ -1,0 +1,71 @@
+{% block sw_cms_el_config_age_verification %}
+<div class="sw-cms-el-config-age-verification">
+    {% block sw_cms_el_config_age_verification_minimum_age %}
+    <mt-number-field
+        :model-value="element.config.minimumAge.value"
+        number-type="int"
+        :min="1"
+        :label="$t('sw-cms.elements.ageVerification.config.minimumAge')"
+        :help-text="$t('sw-cms.elements.ageVerification.config.minimumAgeHelp')"
+        @update:model-value="(value) => onFieldChange('minimumAge', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_title %}
+    <mt-text-field
+        :model-value="element.config.title.value"
+        :label="$t('sw-cms.elements.ageVerification.config.title')"
+        :placeholder="$t('sw-cms.elements.ageVerification.preview.title')"
+        @update:model-value="(value) => onFieldChange('title', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_content %}
+    <mt-textarea
+        :model-value="element.config.content.value"
+        :label="$t('sw-cms.elements.ageVerification.config.content')"
+        :placeholder="$t('sw-cms.elements.ageVerification.config.contentPlaceholder')"
+        @update:model-value="(value) => onFieldChange('content', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_confirm_button %}
+    <mt-text-field
+        :model-value="element.config.confirmButtonText.value"
+        :label="$t('sw-cms.elements.ageVerification.config.confirmButtonText')"
+        :placeholder="$t('sw-cms.elements.ageVerification.config.confirmButtonTextPlaceholder')"
+        @update:model-value="(value) => onFieldChange('confirmButtonText', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_decline_button %}
+    <mt-text-field
+        :model-value="element.config.declineButtonText.value"
+        :label="$t('sw-cms.elements.ageVerification.config.declineButtonText')"
+        :placeholder="$t('sw-cms.elements.ageVerification.config.declineButtonTextPlaceholder')"
+        @update:model-value="(value) => onFieldChange('declineButtonText', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_decline_url %}
+    <mt-text-field
+        :model-value="element.config.declineUrl.value"
+        :label="$t('sw-cms.elements.ageVerification.config.declineUrl')"
+        :help-text="$t('sw-cms.elements.ageVerification.config.declineUrlHelp')"
+        placeholder="https://"
+        @update:model-value="(value) => onFieldChange('declineUrl', value)"
+    />
+    {% endblock %}
+
+    {% block sw_cms_el_config_age_verification_cookie_lifetime %}
+    <mt-number-field
+        :model-value="element.config.cookieLifetime.value"
+        number-type="int"
+        :min="1"
+        :label="$t('sw-cms.elements.ageVerification.config.cookieLifetime')"
+        :help-text="$t('sw-cms.elements.ageVerification.config.cookieLifetimeHelp')"
+        @update:model-value="(value) => onFieldChange('cookieLifetime', value)"
+    />
+    {% endblock %}
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/sw-cms-el-config-age-verification.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/config/sw-cms-el-config-age-verification.scss
@@ -1,0 +1,5 @@
+.sw-cms-el-config-age-verification {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/index.spec.js
@@ -1,0 +1,22 @@
+/**
+ * @sw-package discovery
+ */
+import 'src/module/sw-cms/service/cms.service';
+import './index';
+
+describe('src/module/sw-cms/elements/age-verification/index.ts', () => {
+    it('should register components correctly', () => {
+        expect(Shopware.Component.getComponentRegistry().has('sw-cms-el-age-verification')).toBe(true);
+        expect(Shopware.Component.getComponentRegistry().has('sw-cms-el-preview-age-verification')).toBe(true);
+        expect(Shopware.Component.getComponentRegistry().has('sw-cms-el-config-age-verification')).toBe(true);
+        expect(Object.keys(Shopware.Service('cmsService').getCmsElementRegistry())).toContain('age-verification');
+    });
+
+    it('should register sensible default config', () => {
+        const element = Shopware.Service('cmsService').getCmsElementConfigByName('age-verification');
+
+        expect(element.defaultConfig.minimumAge.value).toBe(18);
+        expect(element.defaultConfig.cookieLifetime.value).toBe(30);
+        expect(element.defaultConfig.title.value).toBe('');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/index.ts
@@ -1,0 +1,57 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-age-verification', () => import('./component'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-preview-age-verification', () => import('./preview'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-config-age-verification', () => import('./config'));
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Service('cmsService').registerCmsElement({
+    name: 'age-verification',
+    label: 'sw-cms.elements.ageVerification.label',
+    component: 'sw-cms-el-age-verification',
+    configComponent: 'sw-cms-el-config-age-verification',
+    previewComponent: 'sw-cms-el-preview-age-verification',
+    defaultConfig: {
+        minimumAge: {
+            source: 'static',
+            value: 18,
+        },
+        title: {
+            source: 'static',
+            value: '',
+        },
+        content: {
+            source: 'static',
+            value: '',
+        },
+        confirmButtonText: {
+            source: 'static',
+            value: '',
+        },
+        declineButtonText: {
+            source: 'static',
+            value: '',
+        },
+        declineUrl: {
+            source: 'static',
+            value: '',
+        },
+        cookieLifetime: {
+            source: 'static',
+            value: 30,
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/index.ts
@@ -1,0 +1,10 @@
+import template from './sw-cms-el-preview-age-verification.html.twig';
+import './sw-cms-el-preview-age-verification.scss';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/preview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/preview.spec.js
@@ -1,0 +1,20 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+
+async function createWrapper() {
+    return mount(
+        await wrapTestComponent('sw-cms-el-preview-age-verification', {
+            sync: true,
+        }),
+    );
+}
+
+describe('src/module/sw-cms/elements/age-verification/preview', () => {
+    it('renders the age verification preview', async () => {
+        const wrapper = await createWrapper();
+        expect(wrapper.classes()).toContain('sw-cms-el-preview-age-verification');
+        expect(wrapper.text()).toContain('18+');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/sw-cms-el-preview-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/sw-cms-el-preview-age-verification.html.twig
@@ -1,0 +1,17 @@
+{% block sw_cms_el_preview_age_verification %}
+<div class="sw-cms-el-preview-age-verification">
+    <div class="sw-cms-el-preview-age-verification__dialog">
+        <div class="sw-cms-el-preview-age-verification__title">
+            18+
+        </div>
+        <div class="sw-cms-el-preview-age-verification__lines">
+            <span></span>
+            <span></span>
+        </div>
+        <div class="sw-cms-el-preview-age-verification__actions">
+            <span class="is--primary"></span>
+            <span></span>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/sw-cms-el-preview-age-verification.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/age-verification/preview/sw-cms-el-preview-age-verification.scss
@@ -1,0 +1,61 @@
+.sw-cms-el-preview-age-verification {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: 12px;
+    background-color: #e9edf2;
+
+    &__dialog {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        align-items: center;
+        width: 80%;
+        padding: 12px;
+        background-color: #fff;
+        border-radius: 4px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 10%);
+    }
+
+    &__title {
+        font-size: 16px;
+        font-weight: 700;
+        color: #0870ff;
+    }
+
+    &__lines {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        width: 100%;
+
+        span {
+            height: 4px;
+            background-color: #d1d9e0;
+            border-radius: 2px;
+
+            &:last-child {
+                width: 70%;
+                margin: 0 auto;
+            }
+        }
+    }
+
+    &__actions {
+        display: flex;
+        gap: 6px;
+
+        span {
+            width: 28px;
+            height: 8px;
+            background-color: #d1d9e0;
+            border-radius: 2px;
+
+            &.is--primary {
+                background-color: #0870ff;
+            }
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
@@ -2,6 +2,7 @@
  * @sw-package discovery
  */
 
+import './age-verification';
 import './buy-box';
 import './category-name';
 import './cross-selling';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de.json
@@ -659,6 +659,30 @@
         "config": {
           "warning": "Ungefilterter HTML-Code kann zu Sicherheitsrisiken führen. Bitte füge nur HTML-Code von vertrauenswürdigen Quellen ein und teste deine Änderung vor der Veröffentlichung."
         }
+      },
+      "ageVerification": {
+        "label": "Altersverifikation",
+        "config": {
+          "minimumAge": "Mindestalter",
+          "minimumAgeHelp": "Das erforderliche Mindestalter zum Ansehen der Seite. Wird in den Standardtexten unten verwendet.",
+          "title": "Titel",
+          "content": "Inhalt",
+          "contentPlaceholder": "Leer lassen, um den Standardtext basierend auf dem Mindestalter zu verwenden.",
+          "confirmButtonText": "Text des Bestätigungsbuttons",
+          "confirmButtonTextPlaceholder": "Leer lassen, um die Standardbeschriftung zu verwenden.",
+          "declineButtonText": "Text des Ablehnungsbuttons",
+          "declineButtonTextPlaceholder": "Leer lassen, um die Standardbeschriftung zu verwenden.",
+          "declineUrl": "Weiterleitungs-URL bei Ablehnung",
+          "declineUrlHelp": "Wohin Besucher bei Ablehnung geleitet werden. Leer lassen, um sie zur vorherigen Seite zurückzuschicken.",
+          "cookieLifetime": "Auswahl merken (Tage)",
+          "cookieLifetimeHelp": "Wie viele Tage die Bestätigung gespeichert wird, bevor Besucher erneut gefragt werden."
+        },
+        "preview": {
+          "title": "Altersverifikation",
+          "content": "Du musst mindestens {age} Jahre alt sein, um diese Seite anzusehen.",
+          "confirm": "Ich bin {age} oder älter",
+          "decline": "Verlassen"
+        }
       }
     },
     "blocks": {
@@ -745,6 +769,9 @@
       "text": {
         "text": {
           "label": "Text"
+        },
+        "ageVerification": {
+          "label": "Altersverifikation"
         },
         "textHero": {
           "label": "Text-Banner"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en.json
@@ -659,6 +659,30 @@
         "config": {
           "warning": "Unfiltered HTML code can lead to security risks. Please only insert HTML code from trusted sources and test your changes before publishing them."
         }
+      },
+      "ageVerification": {
+        "label": "Age verification",
+        "config": {
+          "minimumAge": "Minimum age",
+          "minimumAgeHelp": "The minimum age required to view the page. Used in the default texts below.",
+          "title": "Title",
+          "content": "Content",
+          "contentPlaceholder": "Leave empty to use the default text based on the minimum age.",
+          "confirmButtonText": "Confirm button text",
+          "confirmButtonTextPlaceholder": "Leave empty to use the default confirmation label.",
+          "declineButtonText": "Decline button text",
+          "declineButtonTextPlaceholder": "Leave empty to use the default decline label.",
+          "declineUrl": "Decline redirect URL",
+          "declineUrlHelp": "Where visitors are sent when they decline. Leave empty to send them back to the previous page.",
+          "cookieLifetime": "Remember choice (days)",
+          "cookieLifetimeHelp": "How many days the confirmation is stored before visitors are asked again."
+        },
+        "preview": {
+          "title": "Age verification",
+          "content": "You must be at least {age} years old to view this page.",
+          "confirm": "I am {age} or older",
+          "decline": "Leave"
+        }
       }
     },
     "blocks": {
@@ -745,6 +769,9 @@
       "text": {
         "text": {
           "label": "Text"
+        },
+        "ageVerification": {
+          "label": "Age verification"
         },
         "textHero": {
           "label": "Text banner"

--- a/src/Core/Content/Cms/Cookie/AgeVerificationCookieCollectListener.php
+++ b/src/Core/Content/Cms/Cookie/AgeVerificationCookieCollectListener.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Cookie;
+
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Content\Cookie\Service\CookieProvider;
+use Shopware\Core\Content\Cookie\Struct\CookieEntry;
+use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * Registers the strictly-necessary "age-verified" cookie set by the age verification CMS element.
+ * It is added as a hidden entry to the required group: classified for the cookie machinery, but not
+ * rendered as a toggle, mirroring the cookie-preference entry in the CookieProvider.
+ *
+ * @internal
+ */
+#[Package('discovery')]
+class AgeVerificationCookieCollectListener
+{
+    public const COOKIE_NAME = 'age-verified';
+
+    public function __invoke(CookieGroupCollectEvent $event): void
+    {
+        $requiredGroup = $event->cookieGroupCollection->get(CookieProvider::SNIPPET_NAME_COOKIE_GROUP_REQUIRED);
+        if (!$requiredGroup) {
+            return;
+        }
+
+        $entries = $requiredGroup->getEntries();
+        if ($entries === null) {
+            $entries = new CookieEntryCollection();
+            $requiredGroup->setEntries($entries);
+        }
+
+        $entry = new CookieEntry(self::COOKIE_NAME);
+        $entry->name = 'cookie.groupRequiredAgeVerification';
+        $entry->value = '1';
+        $entry->expiration = 30;
+        $entry->hidden = true;
+
+        $entries->add($entry);
+    }
+}

--- a/src/Core/Content/Cms/DataResolver/Element/AgeVerificationCmsElementResolver.php
+++ b/src/Core/Content/Cms/DataResolver/Element/AgeVerificationCmsElementResolver.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\DataResolver\Element;
+
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\AgeVerificationStruct;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('discovery')]
+class AgeVerificationCmsElementResolver extends AbstractCmsElementResolver
+{
+    /**
+     * @internal
+     */
+    public function __construct()
+    {
+    }
+
+    public function getType(): string
+    {
+        return 'age-verification';
+    }
+
+    public function collect(CmsSlotEntity $slot, ResolverContext $resolverContext): ?CriteriaCollection
+    {
+        return null;
+    }
+
+    public function enrich(CmsSlotEntity $slot, ResolverContext $resolverContext, ElementDataCollection $result): void
+    {
+        $struct = new AgeVerificationStruct();
+        $slot->setData($struct);
+
+        $fieldConfig = $slot->getFieldConfig();
+
+        $minimumAge = $fieldConfig->get('minimumAge');
+        if ($minimumAge !== null && $minimumAge->getValue() !== null && $minimumAge->getIntValue() > 0) {
+            $struct->setMinimumAge($minimumAge->getIntValue());
+        }
+
+        $cookieLifetime = $fieldConfig->get('cookieLifetime');
+        if ($cookieLifetime !== null && $cookieLifetime->getValue() !== null && $cookieLifetime->getIntValue() > 0) {
+            $struct->setCookieLifetime($cookieLifetime->getIntValue());
+        }
+
+        $struct->setTitle($this->getStaticString($fieldConfig->get('title')));
+        $struct->setContent($this->getStaticString($fieldConfig->get('content')));
+        $struct->setConfirmButtonText($this->getStaticString($fieldConfig->get('confirmButtonText')));
+        $struct->setDeclineButtonText($this->getStaticString($fieldConfig->get('declineButtonText')));
+        $struct->setDeclineUrl($this->getStaticString($fieldConfig->get('declineUrl')));
+    }
+
+    private function getStaticString(?FieldConfig $config): ?string
+    {
+        if ($config === null || !$config->isStatic()) {
+            return null;
+        }
+
+        $value = $config->getStringValue();
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/src/Core/Content/Cms/SalesChannel/Struct/AgeVerificationStruct.php
+++ b/src/Core/Content/Cms/SalesChannel/Struct/AgeVerificationStruct.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\SalesChannel\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('discovery')]
+class AgeVerificationStruct extends Struct
+{
+    protected int $minimumAge = 18;
+
+    protected ?string $title = null;
+
+    protected ?string $content = null;
+
+    protected ?string $confirmButtonText = null;
+
+    protected ?string $declineButtonText = null;
+
+    protected ?string $declineUrl = null;
+
+    protected int $cookieLifetime = 30;
+
+    public function getMinimumAge(): int
+    {
+        return $this->minimumAge;
+    }
+
+    public function setMinimumAge(int $minimumAge): void
+    {
+        $this->minimumAge = $minimumAge;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(?string $content): void
+    {
+        $this->content = $content;
+    }
+
+    public function getConfirmButtonText(): ?string
+    {
+        return $this->confirmButtonText;
+    }
+
+    public function setConfirmButtonText(?string $confirmButtonText): void
+    {
+        $this->confirmButtonText = $confirmButtonText;
+    }
+
+    public function getDeclineButtonText(): ?string
+    {
+        return $this->declineButtonText;
+    }
+
+    public function setDeclineButtonText(?string $declineButtonText): void
+    {
+        $this->declineButtonText = $declineButtonText;
+    }
+
+    public function getDeclineUrl(): ?string
+    {
+        return $this->declineUrl;
+    }
+
+    public function setDeclineUrl(?string $declineUrl): void
+    {
+        $this->declineUrl = $declineUrl;
+    }
+
+    public function getCookieLifetime(): int
+    {
+        return $this->cookieLifetime;
+    }
+
+    public function setCookieLifetime(int $cookieLifetime): void
+    {
+        $this->cookieLifetime = $cookieLifetime;
+    }
+
+    public function getApiAlias(): string
+    {
+        return 'cms_age_verification';
+    }
+}

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -46,6 +46,14 @@
             <tag name="shopware.cms.data_resolver"/>
         </service>
 
+        <service id="Shopware\Core\Content\Cms\DataResolver\Element\AgeVerificationCmsElementResolver">
+            <tag name="shopware.cms.data_resolver"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Cms\Cookie\AgeVerificationCookieCollectListener">
+            <tag name="kernel.event_listener"/>
+        </service>
+
         <service id="Shopware\Core\Content\Cms\DataResolver\Element\FormCmsElementResolver">
             <tag name="shopware.cms.data_resolver"/>
             <argument type="service" id="Shopware\Core\System\Salutation\SalesChannel\SalutationRoute"/>

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -102,6 +102,7 @@ PluginManager.register('FormCmsHandler', () => import('src/plugin/forms/form-cms
 PluginManager.register('CountryStateSelect', () => import('src/plugin/forms/form-country-state-select.plugin'), '[data-country-state-select]');
 PluginManager.register('ClearInput', () => import('src/plugin/clear-input-button/clear-input.plugin'), '[data-clear-input]'); // Not used in core, but implemented for plugins
 PluginManager.register('CmsVideo', () => import('src/plugin/cms-video/cms-video.plugin'), '[data-cms-video-element]');
+PluginManager.register('AgeVerification', () => import('src/plugin/age-verification/age-verification.plugin'), '[data-age-verification]');
 PluginManager.register('BuyBox', () => import('src/plugin/buy-box/buy-box.plugin'), '[data-buy-box]');
 PluginManager.register('BasicCaptcha', () => import('src/plugin/captcha/basic-captcha.plugin'), '[data-basic-captcha]');
 PluginManager.register('QuantitySelector', () => import('src/plugin/quantity-selector/quantity-selector.plugin'), '[data-quantity-selector]');

--- a/src/Storefront/Resources/app/storefront/src/plugin/age-verification/age-verification.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/age-verification/age-verification.plugin.js
@@ -1,0 +1,90 @@
+import Plugin from 'src/plugin-system/plugin.class';
+import CookieStorage from 'src/helper/storage/cookie-storage.helper';
+
+/**
+ * Ensures only a single age verification modal is opened per page view, even when the
+ * element is placed on a layout more than once.
+ *
+ * @type {boolean}
+ */
+let modalAlreadyOpened = false;
+
+export default class AgeVerificationPlugin extends Plugin {
+    static options = {
+        /**
+         * Name of the cookie that stores the confirmation.
+         */
+        cookieName: 'age-verified',
+
+        /**
+         * Lifetime of the confirmation cookie in days.
+         */
+        cookieLifetime: 30,
+
+        /**
+         * URL the visitor is redirected to when declining. Falls back to the previous page when empty.
+         */
+        declineUrl: '',
+
+        confirmButtonSelector: '.js-age-verification-confirm',
+
+        declineButtonSelector: '.js-age-verification-decline',
+    };
+
+    init() {
+        if (this._isConfirmed() || modalAlreadyOpened) {
+            return;
+        }
+
+        modalAlreadyOpened = true;
+
+        this._modal = new window.bootstrap.Modal(this.el, {
+            backdrop: 'static',
+            keyboard: false,
+        });
+
+        this._registerEvents();
+        this._modal.show();
+    }
+
+    _isConfirmed() {
+        return CookieStorage.getItem(this.options.cookieName) === '1';
+    }
+
+    _registerEvents() {
+        const confirmButton = this.el.querySelector(this.options.confirmButtonSelector);
+        const declineButton = this.el.querySelector(this.options.declineButtonSelector);
+
+        if (confirmButton) {
+            confirmButton.addEventListener('click', this._onConfirm.bind(this));
+        }
+
+        if (declineButton) {
+            declineButton.addEventListener('click', this._onDecline.bind(this));
+        }
+    }
+
+    _onConfirm() {
+        CookieStorage.setItem(this.options.cookieName, '1', this.options.cookieLifetime);
+        this._modal.hide();
+    }
+
+    _onDecline() {
+        if (this.options.declineUrl) {
+            this._redirect(this.options.declineUrl);
+
+            return;
+        }
+
+        window.history.back();
+    }
+
+    /**
+     * Thin wrapper so tests can spy on navigation without mocking window.location.
+     *
+     * @param {string} url
+     */
+    _redirect(url) {
+        window.location.assign(url);
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/base.scss
@@ -36,6 +36,7 @@ https://sass-guidelin.es/#the-7-1-pattern
 /*
  * Components
  * ---------- */
+@import 'component/age-verification';
 @import 'component/alert';
 @import 'component/card';
 @import 'component/category-navigation';

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_age-verification.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_age-verification.scss
@@ -1,0 +1,19 @@
+/*
+Age verification CMS element
+==================================================
+*/
+.age-verification-modal {
+    .age-verification-modal-header {
+        justify-content: center;
+        border-bottom: 0;
+    }
+
+    .age-verification-modal-body {
+        text-align: center;
+    }
+
+    .age-verification-modal-footer {
+        justify-content: center;
+        border-top: 0;
+    }
+}

--- a/src/Storefront/Resources/app/storefront/test/plugin/age-verification/age-verification.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/age-verification/age-verification.plugin.test.js
@@ -1,0 +1,108 @@
+/**
+ * @package discovery
+ */
+describe('AgeVerificationPlugin tests', () => {
+    let AgeVerificationPlugin;
+    let element;
+    const showMock = jest.fn();
+    const hideMock = jest.fn();
+
+    function createElement() {
+        document.body.innerHTML = `
+            <div class="age-verification-modal" data-age-verification="true">
+                <button class="js-age-verification-confirm">Confirm</button>
+                <button class="js-age-verification-decline">Decline</button>
+            </div>
+        `;
+
+        return document.querySelector('.age-verification-modal');
+    }
+
+    function clearCookies() {
+        document.cookie.split(';').forEach((cookie) => {
+            const name = cookie.split('=')[0].trim();
+            document.cookie = `${name}=;expires=${new Date(0).toUTCString()};path=/`;
+        });
+    }
+
+    beforeEach(() => {
+        jest.resetModules();
+        clearCookies();
+
+        showMock.mockClear();
+        hideMock.mockClear();
+
+        window.bootstrap = {
+            Modal: jest.fn().mockImplementation(() => ({
+                show: showMock,
+                hide: hideMock,
+            })),
+        };
+
+        element = createElement();
+
+        AgeVerificationPlugin = require('src/plugin/age-verification/age-verification.plugin').default;
+    });
+
+    it('opens the modal when the confirmation cookie is absent', () => {
+        new AgeVerificationPlugin(element);
+
+        expect(window.bootstrap.Modal).toHaveBeenCalledWith(element, {
+            backdrop: 'static',
+            keyboard: false,
+        });
+        expect(showMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not open the modal when the confirmation cookie is set', () => {
+        document.cookie = 'age-verified=1;path=/';
+
+        new AgeVerificationPlugin(element);
+
+        expect(window.bootstrap.Modal).not.toHaveBeenCalled();
+        expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('stores the cookie and hides the modal on confirm', () => {
+        new AgeVerificationPlugin(element, { cookieLifetime: 30 });
+
+        element.querySelector('.js-age-verification-confirm').click();
+
+        expect(document.cookie).toContain('age-verified=1');
+        expect(hideMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('redirects to the configured decline url on decline', () => {
+        const redirectSpy = jest.spyOn(AgeVerificationPlugin.prototype, '_redirect').mockImplementation(() => {});
+
+        new AgeVerificationPlugin(element, { declineUrl: 'https://example.com/too-young' });
+
+        element.querySelector('.js-age-verification-decline').click();
+
+        expect(redirectSpy).toHaveBeenCalledWith('https://example.com/too-young');
+
+        redirectSpy.mockRestore();
+    });
+
+    it('navigates back on decline when no decline url is configured', () => {
+        window.history.back = jest.fn();
+
+        new AgeVerificationPlugin(element, { declineUrl: '' });
+
+        element.querySelector('.js-age-verification-decline').click();
+
+        expect(window.history.back).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens only a single modal even with multiple elements on the page', () => {
+        document.body.innerHTML = `
+            <div class="age-verification-modal age-verification-modal--first" data-age-verification="true"></div>
+            <div class="age-verification-modal age-verification-modal--second" data-age-verification="true"></div>
+        `;
+
+        new AgeVerificationPlugin(document.querySelector('.age-verification-modal--first'));
+        new AgeVerificationPlugin(document.querySelector('.age-verification-modal--second'));
+
+        expect(window.bootstrap.Modal).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/Storefront/Resources/snippet/storefront.de.json
+++ b/src/Storefront/Resources/snippet/storefront.de.json
@@ -799,6 +799,7 @@
     "groupRequiredTimezone": "Zeitzone",
     "groupRequiredCookieHash": "Cookie-Konfiguration-Hash",
     "groupRequiredAccepted": "Cookie-Einstellungen",
+    "groupRequiredAgeVerification": "Altersverifikation",
     "groupRequiredCaptcha": "CAPTCHA-Integration",
     "groupStatistical": "Statistiken",
     "groupStatisticalDescription": "Für Statistiken und Shop-Performance-Metriken genutzte Cookies.",
@@ -858,6 +859,12 @@
       }
     },
     "cms": {
+      "ageVerification": {
+        "defaultTitle": "Altersverifikation",
+        "defaultContent": "Du musst mindestens %minimumAge% Jahre alt sein, um diese Seite anzusehen.",
+        "defaultConfirm": "Ich bin %minimumAge% oder älter",
+        "defaultDecline": "Verlassen"
+      },
       "video": {
         "notSupported": "Dein Browser unterstützt das Abspielen von HTML5-Videos nicht.",
         "ariaLabelPlay": "Video abspielen"

--- a/src/Storefront/Resources/snippet/storefront.en.json
+++ b/src/Storefront/Resources/snippet/storefront.en.json
@@ -799,6 +799,7 @@
     "groupRequiredTimezone": "Timezone",
     "groupRequiredCookieHash": "Cookie-Configuration-Hash",
     "groupRequiredAccepted": "Cookie preferences",
+    "groupRequiredAgeVerification": "Age verification",
     "groupRequiredCaptcha": "CAPTCHA integration",
     "groupStatistical": "Statistics",
     "groupStatisticalDescription": "Cookies used for statistics and shop performance metrics.",
@@ -858,6 +859,12 @@
       }
     },
     "cms": {
+      "ageVerification": {
+        "defaultTitle": "Age verification",
+        "defaultContent": "You must be at least %minimumAge% years old to view this page.",
+        "defaultConfirm": "I am %minimumAge% or older",
+        "defaultDecline": "Leave"
+      },
       "video": {
         "notSupported": "Your browser does not support the HTML5 video tag.",
         "ariaLabelPlay": "Play video"

--- a/src/Storefront/Resources/views/storefront/block/cms-block-age-verification.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-age-verification.html.twig
@@ -1,0 +1,9 @@
+{% block block_age_verification %}
+    {% set element = block.slots.getSlot('content') %}
+
+    <div class="col-12" data-cms-element-id="{{ element.id }}">
+        {% block block_age_verification_inner %}
+            {% sw_include '@Storefront/storefront/element/cms-element-' ~ element.type ~ '.html.twig' ignore missing %}
+        {% endblock %}
+    </div>
+{% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-age-verification.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-age-verification.html.twig
@@ -1,10 +1,10 @@
 {% block element_age_verification %}
     {% set minimumAge = element.data.minimumAge ?? 18 %}
 
-    {% set ageVerificationTitle = element.data.title ?: 'cms.ageVerification.defaultTitle'|trans({'%minimumAge%': minimumAge})|trim %}
-    {% set ageVerificationContent = element.data.content ?: 'cms.ageVerification.defaultContent'|trans({'%minimumAge%': minimumAge})|trim %}
-    {% set ageVerificationConfirm = element.data.confirmButtonText ?: 'cms.ageVerification.defaultConfirm'|trans({'%minimumAge%': minimumAge})|trim %}
-    {% set ageVerificationDecline = element.data.declineButtonText ?: 'cms.ageVerification.defaultDecline'|trans|trim %}
+    {% set ageVerificationTitle = element.data.title ?: 'component.cms.ageVerification.defaultTitle'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationContent = element.data.content ?: 'component.cms.ageVerification.defaultContent'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationConfirm = element.data.confirmButtonText ?: 'component.cms.ageVerification.defaultConfirm'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationDecline = element.data.declineButtonText ?: 'component.cms.ageVerification.defaultDecline'|trans|trim %}
 
     {% set ageVerificationOptions = {
         cookieName: 'age-verified',

--- a/src/Storefront/Resources/views/storefront/element/cms-element-age-verification.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-age-verification.html.twig
@@ -1,0 +1,56 @@
+{% block element_age_verification %}
+    {% set minimumAge = element.data.minimumAge ?? 18 %}
+
+    {% set ageVerificationTitle = element.data.title ?: 'cms.ageVerification.defaultTitle'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationContent = element.data.content ?: 'cms.ageVerification.defaultContent'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationConfirm = element.data.confirmButtonText ?: 'cms.ageVerification.defaultConfirm'|trans({'%minimumAge%': minimumAge})|trim %}
+    {% set ageVerificationDecline = element.data.declineButtonText ?: 'cms.ageVerification.defaultDecline'|trans|trim %}
+
+    {% set ageVerificationOptions = {
+        cookieName: 'age-verified',
+        cookieLifetime: element.data.cookieLifetime ?? 30,
+        declineUrl: element.data.declineUrl
+    } %}
+
+    <div class="cms-element-{{ element.type }}">
+        {% block element_age_verification_modal %}
+            <div class="age-verification-modal modal fade"
+                 tabindex="-1"
+                 aria-hidden="true"
+                 aria-labelledby="ageVerificationTitle-{{ element.id }}"
+                 data-age-verification="true"
+                 data-age-verification-options="{{ ageVerificationOptions|json_encode }}">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        {% block element_age_verification_header %}
+                            <div class="modal-header age-verification-modal-header">
+                                <h5 class="modal-title" id="ageVerificationTitle-{{ element.id }}">
+                                    {{ ageVerificationTitle }}
+                                </h5>
+                            </div>
+                        {% endblock %}
+
+                        {% block element_age_verification_body %}
+                            <div class="modal-body age-verification-modal-body">
+                                {{ ageVerificationContent|nl2br }}
+                            </div>
+                        {% endblock %}
+
+                        {% block element_age_verification_footer %}
+                            <div class="modal-footer age-verification-modal-footer">
+                                <button type="button"
+                                        class="btn btn-primary js-age-verification-confirm">
+                                    {{ ageVerificationConfirm }}
+                                </button>
+                                <button type="button"
+                                        class="btn btn-outline-secondary js-age-verification-decline">
+                                    {{ ageVerificationDecline }}
+                                </button>
+                            </div>
+                        {% endblock %}
+                    </div>
+                </div>
+            </div>
+        {% endblock %}
+    </div>
+{% endblock %}

--- a/tests/unit/Core/Content/Cms/Cookie/AgeVerificationCookieCollectListenerTest.php
+++ b/tests/unit/Core/Content/Cms/Cookie/AgeVerificationCookieCollectListenerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Cookie;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Cookie\AgeVerificationCookieCollectListener;
+use Shopware\Core\Content\Cookie\Event\CookieGroupCollectEvent;
+use Shopware\Core\Content\Cookie\Service\CookieProvider;
+use Shopware\Core\Content\Cookie\Struct\CookieGroup;
+use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
+use Shopware\Core\Test\Generator;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(AgeVerificationCookieCollectListener::class)]
+class AgeVerificationCookieCollectListenerTest extends TestCase
+{
+    private AgeVerificationCookieCollectListener $listener;
+
+    protected function setUp(): void
+    {
+        $this->listener = new AgeVerificationCookieCollectListener();
+    }
+
+    public function testCookieIsAddedToRequiredGroupAsHiddenEntry(): void
+    {
+        $requiredGroup = new CookieGroup(CookieProvider::SNIPPET_NAME_COOKIE_GROUP_REQUIRED);
+
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection([$requiredGroup]),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $this->listener->__invoke($event);
+
+        $entry = $event->cookieGroupCollection
+            ->get(CookieProvider::SNIPPET_NAME_COOKIE_GROUP_REQUIRED)
+            ?->getEntries()
+            ?->get(AgeVerificationCookieCollectListener::COOKIE_NAME);
+
+        static::assertNotNull($entry);
+        static::assertTrue($entry->hidden);
+        static::assertSame('1', $entry->value);
+        static::assertSame('cookie.groupRequiredAgeVerification', $entry->name);
+    }
+
+    public function testNothingHappensWhenRequiredGroupIsMissing(): void
+    {
+        $event = new CookieGroupCollectEvent(
+            new CookieGroupCollection([new CookieGroup('some-other-group')]),
+            new Request(),
+            Generator::generateSalesChannelContext()
+        );
+
+        $this->listener->__invoke($event);
+
+        static::assertCount(1, $event->cookieGroupCollection);
+        static::assertNull(
+            $event->cookieGroupCollection->get('some-other-group')?->getEntries()
+        );
+    }
+}

--- a/tests/unit/Core/Content/Cms/DataResolver/Element/AgeVerificationCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/Element/AgeVerificationCmsElementResolverTest.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\DataResolver\Element;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\Element\AgeVerificationCmsElementResolver;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
+use Shopware\Core\Content\Cms\DataResolver\FieldConfigCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Cms\SalesChannel\Struct\AgeVerificationStruct;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(AgeVerificationCmsElementResolver::class)]
+class AgeVerificationCmsElementResolverTest extends TestCase
+{
+    private AgeVerificationCmsElementResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new AgeVerificationCmsElementResolver();
+    }
+
+    public function testType(): void
+    {
+        static::assertSame('age-verification', $this->resolver->getType());
+    }
+
+    public function testCollectReturnsNull(): void
+    {
+        $slot = $this->createSlot();
+        $slot->setFieldConfig(new FieldConfigCollection());
+
+        static::assertNull($this->resolver->collect($slot, $this->createResolverContext()));
+    }
+
+    public function testEnrichWithEmptyConfigUsesDefaults(): void
+    {
+        $slot = $this->createSlot();
+        $slot->setFieldConfig(new FieldConfigCollection());
+
+        $this->resolver->enrich($slot, $this->createResolverContext(), new ElementDataCollection());
+
+        $struct = $slot->getData();
+        static::assertInstanceOf(AgeVerificationStruct::class, $struct);
+        static::assertSame(18, $struct->getMinimumAge());
+        static::assertSame(30, $struct->getCookieLifetime());
+        static::assertNull($struct->getTitle());
+        static::assertNull($struct->getContent());
+        static::assertNull($struct->getConfirmButtonText());
+        static::assertNull($struct->getDeclineButtonText());
+        static::assertNull($struct->getDeclineUrl());
+    }
+
+    public function testEnrichWithStaticConfig(): void
+    {
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('minimumAge', FieldConfig::SOURCE_STATIC, 21));
+        $fieldConfig->add(new FieldConfig('cookieLifetime', FieldConfig::SOURCE_STATIC, 90));
+        $fieldConfig->add(new FieldConfig('title', FieldConfig::SOURCE_STATIC, 'Age check'));
+        $fieldConfig->add(new FieldConfig('content', FieldConfig::SOURCE_STATIC, 'You must be of legal drinking age.'));
+        $fieldConfig->add(new FieldConfig('confirmButtonText', FieldConfig::SOURCE_STATIC, 'Yes'));
+        $fieldConfig->add(new FieldConfig('declineButtonText', FieldConfig::SOURCE_STATIC, 'No'));
+        $fieldConfig->add(new FieldConfig('declineUrl', FieldConfig::SOURCE_STATIC, 'https://www.google.com'));
+
+        $slot = $this->createSlot();
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $this->createResolverContext(), new ElementDataCollection());
+
+        $struct = $slot->getData();
+        static::assertInstanceOf(AgeVerificationStruct::class, $struct);
+        static::assertSame(21, $struct->getMinimumAge());
+        static::assertSame(90, $struct->getCookieLifetime());
+        static::assertSame('Age check', $struct->getTitle());
+        static::assertSame('You must be of legal drinking age.', $struct->getContent());
+        static::assertSame('Yes', $struct->getConfirmButtonText());
+        static::assertSame('No', $struct->getDeclineButtonText());
+        static::assertSame('https://www.google.com', $struct->getDeclineUrl());
+    }
+
+    public function testEmptyStringsFallBackToNull(): void
+    {
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('title', FieldConfig::SOURCE_STATIC, ''));
+        $fieldConfig->add(new FieldConfig('content', FieldConfig::SOURCE_STATIC, ''));
+
+        $slot = $this->createSlot();
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $this->createResolverContext(), new ElementDataCollection());
+
+        $struct = $slot->getData();
+        static::assertInstanceOf(AgeVerificationStruct::class, $struct);
+        static::assertNull($struct->getTitle());
+        static::assertNull($struct->getContent());
+    }
+
+    public function testInvalidMinimumAgeKeepsDefault(): void
+    {
+        $fieldConfig = new FieldConfigCollection();
+        $fieldConfig->add(new FieldConfig('minimumAge', FieldConfig::SOURCE_STATIC, 0));
+        $fieldConfig->add(new FieldConfig('cookieLifetime', FieldConfig::SOURCE_STATIC, null));
+
+        $slot = $this->createSlot();
+        $slot->setFieldConfig($fieldConfig);
+
+        $this->resolver->enrich($slot, $this->createResolverContext(), new ElementDataCollection());
+
+        $struct = $slot->getData();
+        static::assertInstanceOf(AgeVerificationStruct::class, $struct);
+        static::assertSame(18, $struct->getMinimumAge());
+        static::assertSame(30, $struct->getCookieLifetime());
+    }
+
+    private function createSlot(): CmsSlotEntity
+    {
+        $slot = new CmsSlotEntity();
+        $slot->setUniqueIdentifier('id');
+        $slot->setType('age-verification');
+        $slot->setConfig([]);
+
+        return $slot;
+    }
+
+    private function createResolverContext(): ResolverContext
+    {
+        return new ResolverContext(static::createStub(SalesChannelContext::class), new Request());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Merchants selling age-restricted goods (alcohol, tobacco, FSK-18 content, …) regularly need to gate their shop behind an age confirmation. Today this requires a third-party app or a custom theme. This is a recurring, compliance-relevant need that fits naturally into Shopping Experiences, so it belongs in the core CMS toolbox rather than in every project's plugin.

### 2. What does this change do, exactly?

Adds a new CMS element `age-verification` (available in the Shopping Experiences editor under the **Text** block category):

- **Storefront**: renders a Bootstrap modal with a confirm and a decline action. Confirming stores the choice in the strictly-necessary `age-verified` cookie for a configurable number of days; declining redirects to a configurable URL, or back to the previous page when none is set. A single modal opens per page view even if the element is placed multiple times.
- **Configuration**: `minimumAge`, optional `title`/`content`/button labels, `declineUrl`, and cookie lifetime. All texts are per-language slot config and fall back to translated defaults derived from the minimum age when left empty.
- **Privacy**: the cookie is registered via `CookieGroupCollectEvent` as a *hidden* entry in the required group, matching the `cookie-preference` precedent — correctly classified as strictly-necessary without adding a visible cookie line for shops that don't use the element.
- **Additive only**: no new database tables, migrations, or settings pages. Follows the existing CMS element pattern (`AgeVerificationStruct` / `AgeVerificationCmsElementResolver`) so it is extensible like any other element. The gate is client-side, i.e. a soft (SEO-friendly) age gate.

### 3. Describe each step to reproduce the issue or behaviour.

1. In the Administration, open **Content → Shopping Experiences** and edit or create a layout.
2. Add the **Age verification** element (Text category). Optionally set the minimum age, texts, decline URL, and cookie lifetime.
3. Assign the layout to a category/product/landing page and open it in the storefront.
4. Observe the blocking modal. Confirm → the modal closes and the `age-verified` cookie is set; reloading no longer shows it until the cookie expires.
5. Decline → you are redirected to the configured URL (or back to the previous page).

### 4. Please link to the relevant issues (if any).

<!-- none -->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
