### PR TITLE
feat: add --full and granular scaffold flags to theme:create

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -477,6 +477,9 @@ For extension and theme developers, two optional data attributes are available o
 - `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
 
 If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
+### `theme:create --extended` scaffolds a config, snippet files, and an SCSS structure
+
+`bin/console theme:create` accepts a new `--extended` flag. In addition to the existing skeleton, it now generates `src/Resources/config/config.xml`, storefront snippet files (`src/Resources/snippet/storefront.{de-DE,en-GB}.json`), and a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) referenced from `base.scss`. Default `theme:create` output (without the flag) is unchanged. The generated `composer.json` also now sets a real package name (`custom/<theme-name>` instead of a hardcoded placeholder) and pins `shopware/core`.
 
 ## API
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -478,8 +478,9 @@ For extension and theme developers, two optional data attributes are available o
 
 If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
 ### `theme:create --extended` scaffolds a config, snippet files, and an SCSS structure
+### `theme:create` gains `--full` and granular scaffold flags
 
-`bin/console theme:create` accepts a new `--extended` flag. In addition to the existing skeleton, it now generates `src/Resources/config/config.xml`, storefront snippet files (`src/Resources/snippet/storefront.{de-DE,en-GB}.json`), and a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) referenced from `base.scss`. Default `theme:create` output (without the flag) is unchanged. The generated `composer.json` also now sets a real package name (`custom/<theme-name>` instead of a hardcoded placeholder) and pins `shopware/core`.
+`bin/console theme:create` accepts new options to scaffold more than the default skeleton: `--with-config` generates `src/Resources/config/config.xml`, `--with-snippets` generates storefront snippet files (`src/Resources/snippet/storefront.{de-DE,en-GB}.json`), and `--with-scss` generates a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) referenced from `base.scss`. `--full` is shorthand for all three combined. Default `theme:create` output (without any of these flags) is unchanged. The generated `composer.json` also now sets a real package name (`custom/<theme-name>` instead of a hardcoded placeholder) and pins `shopware/core`.
 
 ## API
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -72,6 +72,10 @@ Cron-driven product export generation no longer derives the next run from `gener
 
 ## Storefront
 
+### `theme:create` gains `--full` and granular scaffold flags
+
+`bin/console theme:create` accepts new options to scaffold more than the default skeleton: `--with-config` generates `src/Resources/config/config.xml`, `--with-snippets` generates storefront snippet files (`src/Resources/snippet/storefront.{de-DE,en-GB}.json`), and `--with-scss` generates a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) referenced from `base.scss`. `--full` is shorthand for all three combined. Default `theme:create` output (without any of these flags) is unchanged. The generated `composer.json` also now sets a real package name (`custom/<theme-name>` instead of a hardcoded placeholder) and pins `shopware/core`.
+
 ## App System
 
 ## Hosting & Configuration
@@ -477,10 +481,6 @@ For extension and theme developers, two optional data attributes are available o
 - `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
 
 If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
-### `theme:create --extended` scaffolds a config, snippet files, and an SCSS structure
-### `theme:create` gains `--full` and granular scaffold flags
-
-`bin/console theme:create` accepts new options to scaffold more than the default skeleton: `--with-config` generates `src/Resources/config/config.xml`, `--with-snippets` generates storefront snippet files (`src/Resources/snippet/storefront.{de-DE,en-GB}.json`), and `--with-scss` generates a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) referenced from `base.scss`. `--full` is shorthand for all three combined. Default `theme:create` output (without any of these flags) is unchanged. The generated `composer.json` also now sets a real package name (`custom/<theme-name>` instead of a hardcoded placeholder) and pins `shopware/core`.
 
 ## API
 

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -38,7 +38,10 @@ class ThemeCreateCommand extends Command
         $this
             ->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name')
             ->addOption('static', null, null, 'Theme will be created in the static-plugins folder')
-            ->addOption('extended', null, null, 'Also scaffold a theme config, snippet files, and an SCSS folder structure');
+            ->addOption('full', null, null, 'Also scaffold a theme config, snippet files, and an SCSS folder structure (shorthand for --with-config --with-snippets --with-scss)')
+            ->addOption('with-config', null, null, 'Also scaffold a theme config.xml')
+            ->addOption('with-snippets', null, null, 'Also scaffold storefront snippet files')
+            ->addOption('with-scss', null, null, 'Also scaffold an SCSS 7-1 folder structure');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -46,7 +49,10 @@ class ThemeCreateCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $themeName = $input->getArgument('theme-name');
         $staticPrefix = $input->getOption('static') ? 'static-' : '';
-        $extended = (bool) $input->getOption('extended');
+        $full = (bool) $input->getOption('full');
+        $withConfig = $full || $input->getOption('with-config');
+        $withSnippets = $full || $input->getOption('with-snippets');
+        $withScss = $full || $input->getOption('with-scss');
 
         if (!$themeName) {
             $question = new Question('Please enter a theme name: ');
@@ -93,13 +99,19 @@ class ThemeCreateCommand extends Command
             $this->createDirectory($directory . '/src/Resources/app/storefront/dist/storefront/js');
             $this->createDirectory($directory . '/src/Resources/app/storefront/dist/storefront/js/' . $snakeCaseName);
 
-            if ($extended) {
+            if ($withScss) {
                 $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/abstracts');
                 $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/base');
                 $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/components');
                 $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/layout');
                 $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/pages');
+            }
+
+            if ($withConfig) {
                 $this->createDirectory($directory . '/src/Resources/config');
+            }
+
+            if ($withSnippets) {
                 $this->createDirectory($directory . '/src/Resources/snippet');
             }
         } catch (ThemeException $e) {
@@ -140,10 +152,16 @@ class ThemeCreateCommand extends Command
         $this->filesystem->touch($directory . '/src/Resources/app/storefront/src/main.js');
         $this->filesystem->touch($directory . '/src/Resources/app/storefront/dist/storefront/js/' . $snakeCaseName . '/' . $snakeCaseName . '.js');
 
-        if ($extended) {
+        if ($withConfig) {
             $this->filesystem->dumpFile($directory . '/src/Resources/config/config.xml', $this->getConfigTemplate());
+        }
+
+        if ($withSnippets) {
             $this->filesystem->dumpFile($directory . '/src/Resources/snippet/storefront.de-DE.json', $this->getSnippetTemplate());
             $this->filesystem->dumpFile($directory . '/src/Resources/snippet/storefront.en-GB.json', $this->getSnippetTemplate());
+        }
+
+        if ($withScss) {
             $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/base.scss', $this->getBaseScssTemplate());
             $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/abstracts/_variables.scss', "// Theme-specific SCSS variables.\n");
             $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/abstracts/_mixins.scss', "// Theme-specific SCSS mixins.\n");

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -37,7 +37,8 @@ class ThemeCreateCommand extends Command
     {
         $this
             ->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name')
-            ->addOption('static', null, null, 'Theme will be created in the static-plugins folder');
+            ->addOption('static', null, null, 'Theme will be created in the static-plugins folder')
+            ->addOption('extended', null, null, 'Also scaffold a theme config, snippet files, and an SCSS folder structure');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,6 +46,7 @@ class ThemeCreateCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $themeName = $input->getArgument('theme-name');
         $staticPrefix = $input->getOption('static') ? 'static-' : '';
+        $extended = (bool) $input->getOption('extended');
 
         if (!$themeName) {
             $question = new Question('Please enter a theme name: ');
@@ -90,6 +92,16 @@ class ThemeCreateCommand extends Command
             $this->createDirectory($directory . '/src/Resources/app/storefront/dist/storefront');
             $this->createDirectory($directory . '/src/Resources/app/storefront/dist/storefront/js');
             $this->createDirectory($directory . '/src/Resources/app/storefront/dist/storefront/js/' . $snakeCaseName);
+
+            if ($extended) {
+                $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/abstracts');
+                $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/base');
+                $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/components');
+                $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/layout');
+                $this->createDirectory($directory . '/src/Resources/app/storefront/src/scss/pages');
+                $this->createDirectory($directory . '/src/Resources/config');
+                $this->createDirectory($directory . '/src/Resources/snippet');
+            }
         } catch (ThemeException $e) {
             $io->error($e->getMessage());
 
@@ -102,8 +114,8 @@ class ThemeCreateCommand extends Command
         $variableOverridesFile = $directory . '/src/Resources/app/storefront/src/scss/overrides.scss';
 
         $composer = str_replace(
-            ['#namespace#', '#class#'],
-            [$pluginName, $pluginName],
+            ['#namespace#', '#class#', '#composer-name#'],
+            [$pluginName, $pluginName, 'custom/' . $snakeCaseName],
             $this->getComposerTemplate()
         );
 
@@ -125,9 +137,26 @@ class ThemeCreateCommand extends Command
         $this->filesystem->dumpFile($variableOverridesFile, $this->getVariableOverridesTemplate());
 
         $this->filesystem->touch($directory . '/src/Resources/app/storefront/src/assets/.gitkeep');
-        $this->filesystem->touch($directory . '/src/Resources/app/storefront/src/scss/base.scss');
         $this->filesystem->touch($directory . '/src/Resources/app/storefront/src/main.js');
         $this->filesystem->touch($directory . '/src/Resources/app/storefront/dist/storefront/js/' . $snakeCaseName . '/' . $snakeCaseName . '.js');
+
+        if ($extended) {
+            $this->filesystem->dumpFile($directory . '/src/Resources/config/config.xml', $this->getConfigTemplate());
+            $this->filesystem->dumpFile($directory . '/src/Resources/snippet/storefront.de-DE.json', $this->getSnippetTemplate());
+            $this->filesystem->dumpFile($directory . '/src/Resources/snippet/storefront.en-GB.json', $this->getSnippetTemplate());
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/base.scss', $this->getBaseScssTemplate());
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/abstracts/_variables.scss', "// Theme-specific SCSS variables.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/abstracts/_mixins.scss', "// Theme-specific SCSS mixins.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/base/_reset.scss', "// Base element resets.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/base/_typography.scss', "// Base typography styles.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/components/_buttons.scss', "// Button component styles.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/layout/_header.scss', "// Header layout styles.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/layout/_footer.scss', "// Footer layout styles.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/layout/_navigation.scss', "// Navigation layout styles.\n");
+            $this->filesystem->dumpFile($directory . '/src/Resources/app/storefront/src/scss/pages/_home.scss', "// Homepage-specific styles.\n");
+        } else {
+            $this->filesystem->touch($directory . '/src/Resources/app/storefront/src/scss/base.scss');
+        }
 
         return self::SUCCESS;
     }
@@ -161,10 +190,13 @@ EOL;
     {
         return <<<EOL
 {
-  "name": "swag/theme-skeleton",
+  "name": "#composer-name#",
   "description": "Theme skeleton plugin",
   "type": "shopware-platform-plugin",
   "license": "MIT",
+  "require": {
+    "shopware/core": "~6.7.0"
+  },
   "autoload": {
     "psr-4": {
       "#namespace#\\\\": "src/"
@@ -178,6 +210,58 @@ EOL;
     }
   }
 }
+EOL;
+    }
+
+    private function getConfigTemplate(): string
+    {
+        return <<<EOL
+<?xml version="1.0" encoding="UTF-8"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
+
+    <card>
+        <title>Theme configuration</title>
+
+        <input-field type="text">
+            <name>exampleField</name>
+            <label>Example field</label>
+        </input-field>
+    </card>
+
+</config>
+EOL;
+    }
+
+    private function getSnippetTemplate(): string
+    {
+        return <<<EOL
+{
+}
+EOL;
+    }
+
+    private function getBaseScssTemplate(): string
+    {
+        return <<<EOL
+// Abstracts
+@import "abstracts/variables";
+@import "abstracts/mixins";
+
+// Base
+@import "base/reset";
+@import "base/typography";
+
+// Components
+@import "components/buttons";
+
+// Layout
+@import "layout/header";
+@import "layout/footer";
+@import "layout/navigation";
+
+// Pages
+@import "pages/home";
 EOL;
     }
 

--- a/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
@@ -79,13 +79,13 @@ class ThemeCreateCommandTest extends TestCase
         static::assertFileExists($expectedDirectory . 'Resources/theme.json');
     }
 
-    public function testSuccessfulCreateExtendedCommand(): void
+    public function testSuccessfulCreateFullCommand(): void
     {
         $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
 
         $commandTester = $this->getCommandTester();
 
-        $commandTester->execute(['theme-name' => self::THEME_NAME, '--extended' => true]);
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--full' => true]);
         $result = preg_replace('/\s+/', ' ', trim($commandTester->getDisplay(true)));
 
         static::assertIsString($result);
@@ -111,6 +111,47 @@ class ThemeCreateCommandTest extends TestCase
         static::assertIsString($baseScssContent);
         static::assertStringContainsString('@import "abstracts/variables";', $baseScssContent);
         static::assertStringContainsString('@import "pages/home";', $baseScssContent);
+    }
+
+    public function testSuccessfulCreateWithConfigOnly(): void
+    {
+        $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
+
+        $commandTester = $this->getCommandTester();
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--with-config' => true]);
+
+        static::assertFileExists($expectedDirectory . 'Resources/config/config.xml');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/snippet');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/app/storefront/src/scss/abstracts');
+        static::assertFileExists($expectedDirectory . 'Resources/app/storefront/src/scss/base.scss');
+    }
+
+    public function testSuccessfulCreateWithSnippetsOnly(): void
+    {
+        $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
+
+        $commandTester = $this->getCommandTester();
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--with-snippets' => true]);
+
+        static::assertFileExists($expectedDirectory . 'Resources/snippet/storefront.de-DE.json');
+        static::assertFileExists($expectedDirectory . 'Resources/snippet/storefront.en-GB.json');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/config');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/app/storefront/src/scss/abstracts');
+    }
+
+    public function testSuccessfulCreateWithScssOnly(): void
+    {
+        $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
+
+        $commandTester = $this->getCommandTester();
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--with-scss' => true]);
+
+        $scssBase = $expectedDirectory . 'Resources/app/storefront/src/scss/';
+        static::assertFileExists($scssBase . 'base.scss');
+        static::assertFileExists($scssBase . 'abstracts/_variables.scss');
+        static::assertFileExists($scssBase . 'pages/_home.scss');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/config');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/snippet');
     }
 
     public function testCommandFailsWhenDirectoryCannotBeCreated(): void

--- a/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
@@ -36,7 +36,8 @@ class ThemeCreateCommandTest extends TestCase
 
     public function testSuccessfulCreateCommand(): void
     {
-        $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
+        $pluginDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME;
+        $expectedDirectory = $pluginDirectory . '/src/';
 
         $commandTester = $this->getCommandTester();
 
@@ -49,6 +50,16 @@ class ThemeCreateCommandTest extends TestCase
         static::assertFileExists($expectedDirectory . 'TestPlugin.php');
         static::assertDirectoryExists($expectedDirectory . 'Resources');
         static::assertFileExists($expectedDirectory . 'Resources/theme.json');
+
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/config');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/snippet');
+        static::assertDirectoryDoesNotExist($expectedDirectory . 'Resources/app/storefront/src/scss/abstracts');
+
+        $composerJson = file_get_contents($pluginDirectory . '/composer.json');
+        static::assertIsString($composerJson);
+        $composer = json_decode($composerJson, true, flags: \JSON_THROW_ON_ERROR);
+        static::assertSame('custom/test-plugin', $composer['name']);
+        static::assertSame('~6.7.0', $composer['require']['shopware/core']);
     }
 
     public function testSuccessfulCreateAsStaticCommand(): void
@@ -66,6 +77,40 @@ class ThemeCreateCommandTest extends TestCase
         static::assertFileExists($expectedDirectory . 'TestPlugin.php');
         static::assertDirectoryExists($expectedDirectory . 'Resources');
         static::assertFileExists($expectedDirectory . 'Resources/theme.json');
+    }
+
+    public function testSuccessfulCreateExtendedCommand(): void
+    {
+        $expectedDirectory = $this->projectDir . 'custom/plugins/' . self::THEME_NAME . '/src/';
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--extended' => true]);
+        $result = preg_replace('/\s+/', ' ', trim($commandTester->getDisplay(true)));
+
+        static::assertIsString($result);
+        static::assertStringContainsString('Creating theme structure under', $result);
+
+        static::assertFileExists($expectedDirectory . 'Resources/config/config.xml');
+        static::assertFileExists($expectedDirectory . 'Resources/snippet/storefront.de-DE.json');
+        static::assertFileExists($expectedDirectory . 'Resources/snippet/storefront.en-GB.json');
+
+        $scssBase = $expectedDirectory . 'Resources/app/storefront/src/scss/';
+        static::assertFileExists($scssBase . 'base.scss');
+        static::assertFileExists($scssBase . 'abstracts/_variables.scss');
+        static::assertFileExists($scssBase . 'abstracts/_mixins.scss');
+        static::assertFileExists($scssBase . 'base/_reset.scss');
+        static::assertFileExists($scssBase . 'base/_typography.scss');
+        static::assertFileExists($scssBase . 'components/_buttons.scss');
+        static::assertFileExists($scssBase . 'layout/_header.scss');
+        static::assertFileExists($scssBase . 'layout/_footer.scss');
+        static::assertFileExists($scssBase . 'layout/_navigation.scss');
+        static::assertFileExists($scssBase . 'pages/_home.scss');
+
+        $baseScssContent = file_get_contents($scssBase . 'base.scss');
+        static::assertIsString($baseScssContent);
+        static::assertStringContainsString('@import "abstracts/variables";', $baseScssContent);
+        static::assertStringContainsString('@import "pages/home";', $baseScssContent);
     }
 
     public function testCommandFailsWhenDirectoryCannotBeCreated(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

`theme:create` only scaffolds a minimal skeleton: composer.json, the plugin bootstrap class, theme.json, an empty overrides.scss/base.scss, and an empty main.js. Real themes almost always need a config.xml (theme settings screen), snippet files, and some SCSS organization, none of which are generated today — theme authors end up copying these by hand from other themes of varying quality and age.

### 2. What does this change do, exactly?

Adds granular scaffold flags to `theme:create`, plus a `--full` shorthand for all of them combined:
- `--with-config` generates `src/Resources/config/config.xml` — a minimal starter config card.
- `--with-snippets` generates `src/Resources/snippet/storefront.{de-DE,en-GB}.json` — empty snippet files, using the current filename-based auto-discovery convention (no PHP class or services.xml registration needed on current trunk).
- `--with-scss` generates a starter SCSS 7-1 folder structure (`abstracts/`, `base/`, `components/`, `layout/`, `pages/`) with one representative partial per folder, wired into a real `base.scss` aggregator.
- `--full` is shorthand for `--with-config --with-snippets --with-scss` combined.

Default `theme:create` output (without any of these flags) is unchanged.

Also fixes a pre-existing bug in the generated `composer.json`: it previously hardcoded `"name": "swag/theme-skeleton"` regardless of the theme name, and declared no `shopware/core` version constraint at all. This fix applies unconditionally (with or without the new flags), since it's correcting existing broken output rather than adding new scaffolding.

### 3. Describe each step to reproduce the issue or behaviour.

1. `bin/console theme:create MyTheme` — output is unchanged from before this PR.
2. `bin/console theme:create MyTheme --with-config` — additionally creates `src/Resources/config/config.xml`.
3. `bin/console theme:create MyTheme --with-snippets` — additionally creates the two snippet JSON files.
4. `bin/console theme:create MyTheme --with-scss` — additionally creates the SCSS folder structure described above.
5. `bin/console theme:create MyTheme --full` — creates all three at once.
6. Inspect `composer.json` in any case — `name` is now `custom/my-theme` and `require.shopware/core` is set, instead of the previous hardcoded placeholder.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
