### PR TITLE
ci: Add rector CI job

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -109,6 +109,38 @@ jobs:
           path: var/cache/phpstan
           key: "phpstan-result-cache-${{ github.run_id }}"
 
+  rector:
+    needs:
+      - markdown-only-changes
+    if: ${{ needs.markdown-only-changes.outputs.docs_only != 'true' }}
+    runs-on: ubuntu-24.04
+    name: "Rector"
+    steps:
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+          keep-composer-tools: "true"
+
+      - name: "Restore result cache"
+        uses: actions/cache/restore@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        with:
+          path: var/cache/rector
+          key: "rector-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            rector-result-cache-
+
+      - name: Rector
+        run: composer rector
+
+      - name: "Save result cache"
+        uses: actions/cache/save@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+        if: always()
+        with:
+          path: var/cache/rector
+          key: "rector-result-cache-${{ github.run_id }}"
+
   bc-checker:
     needs:
       - markdown-only-changes
@@ -371,5 +403,5 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           # allowed-failures: docs, linters
-          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, phpstan, openapi-lint, phpunit, license-check, composer-audit, bc-checker' || '' }}
+          allowed-skips: ${{ needs.markdown-only-changes.outputs.docs_only == 'true' && 'lint, phpstan, rector, openapi-lint, phpunit, license-check, composer-audit, bc-checker' || '' }}
           jobs: ${{ toJSON(needs) }}

--- a/composer.json
+++ b/composer.json
@@ -401,16 +401,6 @@
             "@php bin/console theme:compile --sync || true"
         ],
         "check:license": "bash -c \"vendor/bin/composer-license-checker check -a $(sed -z 's/\\n/ -a /g' .allowed-licenses)\"",
-        "ecs": [
-            "echo \"\\e[31mDeprecated! Use 'cs' instead\n\\e[0m\"",
-            "php-cs-fixer fix --dry-run --diff"
-        ],
-        "cs": "php-cs-fixer fix --dry-run --diff",
-        "ecs-fix": [
-            "echo \"\\e[31mDeprecated! Use 'cs-fix' instead\n\\e[0m\"",
-            "php-cs-fixer fix -v"
-        ],
-        "cs-fix": "php-cs-fixer fix -v",
         "eslint": [
             "@eslint:admin",
             "@eslint:storefront",
@@ -487,6 +477,16 @@
         "npm:storefront:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Storefront/Resources/app/storefront; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
         "phpbench": "phpbench run --report=compressed",
         "dependency-analyzer":  "composer-dependency-analyser",
+        "ecs": [
+            "echo \"\\e[31mDeprecated! Use 'cs' instead\n\\e[0m\"",
+            "php-cs-fixer fix --dry-run --diff"
+        ],
+        "cs": "php-cs-fixer fix --dry-run --diff",
+        "ecs-fix": [
+            "echo \"\\e[31mDeprecated! Use 'cs-fix' instead\n\\e[0m\"",
+            "php-cs-fixer fix -v"
+        ],
+        "cs-fix": "php-cs-fixer fix -v",
         "phpstan": [
             "Composer\\Config::disableProcessTimeout",
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
@@ -496,6 +496,10 @@
             "php src/Core/DevOps/StaticAnalyze/print-ignored-errors-by-area.php phpstan-baseline.neon"
         ],
         "rector": [
+            "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
+            "rector process --dry-run"
+        ],
+        "rector-fix": [
             "@php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php",
             "rector process"
         ],

--- a/rector.php
+++ b/rector.php
@@ -1,12 +1,13 @@
 <?php declare(strict_types=1);
 
+use Rector\Caching\ValueObject\Storage\FileCacheStorage;
 use Rector\CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector;
 use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodeQuality\Rector\Identical\StrlenZeroToIdenticalEmptyStringRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
-use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
 use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
@@ -23,7 +24,10 @@ return RectorConfig::configure()
         '**/node_modules/*',
         '**/Resources/*',
     ])
-    ->withCache(__DIR__ . '/var/cache/rector')
+    ->withCache(
+        cacheDirectory: __DIR__ . '/var/cache/rector',
+        cacheClass: FileCacheStorage::class,
+    )
     ->withRules([
         ClassConstantToSelfClassRector::class,
         DisallowedEmptyRuleFixerRector::class,

--- a/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
+++ b/src/Core/Content/Product/Cms/ProductSlider/StaticProductProcessor.php
@@ -78,7 +78,7 @@ class StaticProductProcessor extends AbstractProductSliderProcessor
         }
 
         $criteriaIds = array_unique($searchResult->getCriteria()->getIds());
-        if (\count($criteriaIds) > 0 && \count($searchResult->getCriteria()->getSorting()) === 0) {
+        if ($criteriaIds !== [] && $searchResult->getCriteria()->getSorting() === []) {
             $configuredIds = $slot->getFieldConfig()->get('products')?->getArrayValue() ?? [];
             usort(
                 $criteriaIds,

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoAnyInvocationMatcherRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Tests/NoAnyInvocationMatcherRule.php
@@ -63,7 +63,7 @@ class NoAnyInvocationMatcherRule implements Rule
         $isAny = ($matcher instanceof MethodCall || $matcher instanceof StaticCall)
             && $matcher->name instanceof Identifier
             && $matcher->name->name === 'any'
-            && \count($matcher->getArgs()) === 0;
+            && $matcher->getArgs() === [];
 
         if (!$isAny) {
             return [];

--- a/src/Core/Framework/App/Lifecycle/AppManager.php
+++ b/src/Core/Framework/App/Lifecycle/AppManager.php
@@ -578,7 +578,7 @@ class AppManager
     private function ensureMeetsRequirements(Manifest $manifest): void
     {
         $violations = $this->requirementsValidator->validate($manifest);
-        if (\count($violations) > 0) {
+        if ($violations !== []) {
             throw AppException::requirementsNotMet(...$violations);
         }
     }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -1285,12 +1285,10 @@ class Configuration implements ConfigurationInterface
             ->end()
             ->validate()
             ->ifFalse(
-                static fn (array $v) => \count(
-                    array_filter(
-                        array_keys($v),
-                        static fn (string $key) => $key !== 'default' && !Uuid::isValid($key)
-                    )
-                ) === 0
+                static fn (array $v) => array_filter(
+                    array_keys($v),
+                    static fn (string $key) => $key !== 'default' && !Uuid::isValid($key)
+                ) === []
             )
             ->thenInvalid('Key must be "default" or a valid UUID')
             ->end();

--- a/src/Core/Migration/V6_7/Migration1778573083ConvertCategoryNameBlockToDedicatedElement.php
+++ b/src/Core/Migration/V6_7/Migration1778573083ConvertCategoryNameBlockToDedicatedElement.php
@@ -28,7 +28,7 @@ class Migration1778573083ConvertCategoryNameBlockToDedicatedElement extends Migr
             ['name' => 'Category name', 'type' => 'text']
         );
 
-        if (\count($blocks) === 0) {
+        if ($blocks === []) {
             return;
         }
 

--- a/src/Core/System/Locale/SystemCheck/LocalesReadinessCheck.php
+++ b/src/Core/System/Locale/SystemCheck/LocalesReadinessCheck.php
@@ -40,7 +40,7 @@ class LocalesReadinessCheck extends BaseCheck
             static fn (string $locale) => !LocaleHelper::isLocale($locale)
         );
 
-        $status = \count($invalidLocales) === 0 ? Status::OK : Status::WARNING;
+        $status = $invalidLocales === [] ? Status::OK : Status::WARNING;
 
         return new Result(
             $this->name(),

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
@@ -83,10 +83,10 @@ class ProductListingLoaderTest extends TestCase
             ->method('searchIds')
             ->willReturnCallback(function (Criteria $criteria): IdSearchResult {
                 static::assertCount(1, $criteria->getGroupFields());
-                static::assertTrue(\count(array_filter(
+                static::assertTrue(array_filter(
                     $criteria->getFilters(),
                     static fn ($filter): bool => $filter instanceof NotEqualsFilter && $filter->getField() === 'displayGroup'
-                )) > 0);
+                ) !== []);
 
                 return $this->createIdSearchResult($criteria, [
                     'red-l' => ['score' => 10.0],
@@ -146,10 +146,10 @@ class ProductListingLoaderTest extends TestCase
             ->method('searchIds')
             ->willReturnCallback(function (Criteria $criteria): IdSearchResult {
                 static::assertCount(0, $criteria->getGroupFields());
-                static::assertFalse(\count(array_filter(
+                static::assertFalse(array_filter(
                     $criteria->getFilters(),
                     static fn ($filter): bool => $filter instanceof NotEqualsFilter && $filter->getField() === 'displayGroup'
-                )) > 0);
+                ) !== []);
 
                 return $this->createIdSearchResult($criteria, [
                     'variant-a' => ['score' => 10.0],


### PR DESCRIPTION
### 1. Why is this change necessary?

Rector is a handy tool to easily enforce modern code style and syntax. It has several built-in rules for modern Symfony, PHP and others. 

### 2. What does this change do, exactly?

- Add a rector CI job
- Fix current problems

### 3. Issues

Fixes https://github.com/shopware/shopware/issues/18231

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
