### PR TITLE
feat: support sw-app-user-id permission intersection for standard integrations

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -5,6 +5,9 @@
 ### Cloning an entity no longer fails on the write-protected `wasModifiedByUser` field
 
 Cloning any entity that carries a `wasModifiedByUser` field previously always failed with `FRAMEWORK__WRITE_CONSTRAINT_VIOLATION` on `wasModifiedByUser`, because the clone copied that write-protected field's value into the insert payload. In the Core this affected mail templates (e.g. via `POST /api/_action/clone/mail-template/{id}`), and it applies equally to any extension entity using the field. The clone process now omits the field, so the cloned entity is correctly created as a fresh, non-user-modified record. (shopware/shopware#18233)
+### Standard integrations now honor `sw-app-user-id`
+
+Admin API requests authenticated with a standard integration access key now support the `sw-app-user-id` header the same way app integrations already do. When the header contains a valid user id, the resolved permissions are restricted to the intersection of the integration ACL privileges and the user's ACL privileges. Invalid or empty `sw-app-user-id` values continue to be ignored.
 
 ### Cache invalidated on cross-selling updates and deletions
 

--- a/src/Core/Framework/Routing/ApiRequestContextResolver.php
+++ b/src/Core/Framework/Routing/ApiRequestContextResolver.php
@@ -277,6 +277,13 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
         }
 
         if ($userId !== null && $integrationId !== null) {
+            if ($this->isAdminIntegration($integrationId)) {
+                $source->setPermissions($this->withDefaultUserPrivileges($this->fetchPermissions($userId)));
+                $source->setIsAdmin($this->isAdmin($userId));
+
+                return $source;
+            }
+
             $permissions = $this->fetchIntegrationPermissions($integrationId);
 
             if (!$this->isAdmin($userId)) {

--- a/src/Core/Framework/Routing/ApiRequestContextResolver.php
+++ b/src/Core/Framework/Routing/ApiRequestContextResolver.php
@@ -160,11 +160,11 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
             $integrationId = $this->getIntegrationIdByAccessKey($clientId);
 
             $userId = $request->headers->get(PlatformRequest::HEADER_APP_USER_ID, '');
-            if ($userId === '') {
+            if ($userId === '' || !Uuid::isValid((string) $userId)) {
                 $userId = null;
             }
 
-            if ($userId !== null && !$this->userAppIntegrationHeaderPrivileged($userId, $integrationId)) {
+            if ($userId !== null && $this->isAppIntegration($integrationId) && !$this->userAppIntegrationHeaderPrivileged($userId, $integrationId)) {
                 $userId = null;
             }
 
@@ -272,6 +272,22 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
 
             $source->setIsAdmin(false);
             $source->setPermissions($appPermissions);
+
+            return $source;
+        }
+
+        if ($userId !== null && $integrationId !== null) {
+            $permissions = $this->fetchIntegrationPermissions($integrationId);
+
+            if (!$this->isAdmin($userId)) {
+                $permissions = array_intersect(
+                    $permissions,
+                    $this->fetchPermissions($userId)
+                );
+            }
+
+            $source->setIsAdmin(false);
+            $source->setPermissions($permissions);
 
             return $source;
         }
@@ -431,6 +447,11 @@ class ApiRequestContextResolver implements RequestContextResolverInterface
         }
 
         return $name;
+    }
+
+    private function isAppIntegration(string $integrationId): bool
+    {
+        return $this->fetchAppNameByIntegrationId($integrationId) !== null;
     }
 
     /**

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -691,6 +691,94 @@ class ApiRequestContextResolverTest extends TestCase
         static::assertTrue($source->isAllowed('product:read'));
     }
 
+    public function testAdminIntegrationUserIdHeaderUsesUserPermissionsForNonAdminUser(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $ids = new IdsCollection();
+
+        $user = $this->createUser([
+            'user-role' => ['product:read', 'category:read'],
+        ], false);
+
+        $integrationId = $ids->create('integration');
+        $integrationAccessKey = AccessKeyHelper::generateAccessKey('integration');
+        $connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'access_key' => $integrationAccessKey,
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'label' => 'test integration',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'admin' => 1,
+        ]);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $integrationAccessKey);
+        $request->headers->set(PlatformRequest::HEADER_APP_USER_ID, $user->getUserId());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+
+        $this->resolver->resolve($request);
+
+        static::assertTrue($request->attributes->has(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT));
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+        static::assertInstanceOf(AdminApiSource::class, $context->getSource());
+
+        $source = $context->getSource();
+
+        static::assertSame($user->getUserId(), $source->getUserId());
+        static::assertSame($integrationId, $source->getIntegrationId());
+        static::assertFalse($source->isAdmin());
+
+        static::assertTrue($source->isAllowed('product:read'));
+        static::assertTrue($source->isAllowed('category:read'));
+        static::assertTrue($source->isAllowed('currency:read'));
+        static::assertFalse($source->isAllowed('media:read'));
+    }
+
+    public function testAdminIntegrationUserIdHeaderKeepsAdminAccessForAdminUser(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $ids = new IdsCollection();
+
+        $user = $this->createUser([], true);
+
+        $integrationId = $ids->create('integration');
+        $integrationAccessKey = AccessKeyHelper::generateAccessKey('integration');
+        $connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'access_key' => $integrationAccessKey,
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'label' => 'test integration',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'admin' => 1,
+        ]);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $integrationAccessKey);
+        $request->headers->set(PlatformRequest::HEADER_APP_USER_ID, $user->getUserId());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+
+        $this->resolver->resolve($request);
+
+        static::assertTrue($request->attributes->has(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT));
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+        static::assertInstanceOf(AdminApiSource::class, $context->getSource());
+
+        $source = $context->getSource();
+
+        static::assertSame($user->getUserId(), $source->getUserId());
+        static::assertSame($integrationId, $source->getIntegrationId());
+        static::assertTrue($source->isAdmin());
+
+        static::assertTrue($source->isAllowed('product:read'));
+        static::assertTrue($source->isAllowed('order:read'));
+    }
+
     public function testAppUserIdHeaderWithIntersectedPermissions(): void
     {
         $connection = static::getContainer()->get(Connection::class);

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -557,6 +557,140 @@ class ApiRequestContextResolverTest extends TestCase
         static::assertArrayHasKey('data', $response);
     }
 
+    public function testIntegrationUserIdHeaderWithIntersectedPermissions(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $ids = new IdsCollection();
+
+        $user = $this->createUser([
+            'user-role' => ['product:read', 'product:write', 'category:read'],
+        ], false);
+
+        $integrationId = $ids->create('integration');
+        $integrationAccessKey = AccessKeyHelper::generateAccessKey('integration');
+        $connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'access_key' => $integrationAccessKey,
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'label' => 'test integration',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'admin' => 0,
+        ]);
+
+        $this->addRoleToIntegration($integrationId, ['product:read', 'media:read', 'category:read']);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $integrationAccessKey);
+        $request->headers->set(PlatformRequest::HEADER_APP_USER_ID, $user->getUserId());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+
+        $this->resolver->resolve($request);
+
+        static::assertTrue($request->attributes->has(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT));
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+        static::assertInstanceOf(AdminApiSource::class, $context->getSource());
+
+        $source = $context->getSource();
+
+        static::assertSame($user->getUserId(), $source->getUserId());
+        static::assertSame($integrationId, $source->getIntegrationId());
+        static::assertFalse($source->isAdmin());
+
+        static::assertTrue($source->isAllowed('product:read'));
+        static::assertTrue($source->isAllowed('category:read'));
+        static::assertFalse($source->isAllowed('product:write'));
+        static::assertFalse($source->isAllowed('media:read'));
+        static::assertFalse($source->isAllowed('order:read'));
+    }
+
+    public function testIntegrationUserIdHeaderWithAdminUserKeepsIntegrationPermissions(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $ids = new IdsCollection();
+
+        $user = $this->createUser([], true);
+
+        $integrationId = $ids->create('integration');
+        $integrationAccessKey = AccessKeyHelper::generateAccessKey('integration');
+        $connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'access_key' => $integrationAccessKey,
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'label' => 'test integration',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'admin' => 0,
+        ]);
+
+        $this->addRoleToIntegration($integrationId, ['product:read', 'media:read']);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $integrationAccessKey);
+        $request->headers->set(PlatformRequest::HEADER_APP_USER_ID, $user->getUserId());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+
+        $this->resolver->resolve($request);
+
+        static::assertTrue($request->attributes->has(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT));
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+        static::assertInstanceOf(AdminApiSource::class, $context->getSource());
+
+        $source = $context->getSource();
+
+        static::assertSame($user->getUserId(), $source->getUserId());
+        static::assertSame($integrationId, $source->getIntegrationId());
+        static::assertFalse($source->isAdmin());
+
+        static::assertTrue($source->isAllowed('product:read'));
+        static::assertTrue($source->isAllowed('media:read'));
+        static::assertFalse($source->isAllowed('category:read'));
+    }
+
+    public function testIntegrationUserIdHeaderWithInvalidUserIdIsIgnored(): void
+    {
+        $connection = static::getContainer()->get(Connection::class);
+        $ids = new IdsCollection();
+
+        $integrationId = $ids->create('integration');
+        $integrationAccessKey = AccessKeyHelper::generateAccessKey('integration');
+        $connection->insert('integration', [
+            'id' => Uuid::fromHexToBytes($integrationId),
+            'access_key' => $integrationAccessKey,
+            'secret_access_key' => TestDefaults::HASHED_PASSWORD,
+            'label' => 'test integration',
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'admin' => 0,
+        ]);
+
+        $this->addRoleToIntegration($integrationId, ['product:read']);
+
+        $request = new Request();
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_ACCESS_TOKEN_ID, 'test');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_OAUTH_CLIENT_ID, $integrationAccessKey);
+        $request->headers->set(PlatformRequest::HEADER_APP_USER_ID, 'not-a-valid-user-id');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, [ApiRouteScope::ID]);
+
+        $this->resolver->resolve($request);
+
+        static::assertTrue($request->attributes->has(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT));
+
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
+        static::assertInstanceOf(Context::class, $context);
+        static::assertInstanceOf(AdminApiSource::class, $context->getSource());
+
+        $source = $context->getSource();
+
+        static::assertNull($source->getUserId());
+        static::assertSame($integrationId, $source->getIntegrationId());
+        static::assertFalse($source->isAdmin());
+        static::assertTrue($source->isAllowed('product:read'));
+    }
+
     public function testAppUserIdHeaderWithIntersectedPermissions(): void
     {
         $connection = static::getContainer()->get(Connection::class);


### PR DESCRIPTION

### 1. Why is this change necessary?

Requests authenticated with a standard integration currently ignore the intended "act on behalf of user" permission model when `sw-app-user-id` is provided.

The permission intersection already works for app integrations, but standard integrations still resolve permissions only from the integration itself. This creates inconsistent behavior for the same header and prevents consumers from restricting requests to the effective intersection of integration and user privileges.

### 2. What does this change do, exactly?

This change extends `ApiRequestContextResolver` so that standard integrations also support `sw-app-user-id`.

When a request is authenticated with a standard integration and contains a valid `sw-app-user-id`, the resolved `AdminApiSource` now uses the intersection of:
- the integration ACL privileges
- the user ACL privileges

For admin users, privileges are still limited to the integration privileges and are not elevated to full admin access.

The change also keeps existing app integration behavior unchanged and ignores empty or invalid `sw-app-user-id` values.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a standard integration with a limited ACL role, for example `product:read` and `media:read`.
2. Create a non-admin user with a different limited ACL role, for example `product:read`, `product:write`, and `category:read`.
3. Send an Admin API request authenticated with the standard integration credentials.
4. Add the `sw-app-user-id` header with the user ID from step 2.
5. Observe that before this change the request does not use the intended permission intersection and the header is effectively not supported for standard integrations.
6. After this change, the resolved permissions are restricted to the intersection, for example `product:read` only.

### 4. Please link to the relevant issues (if any).

- closes #18242

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
