### PR TITLE
ci(snippets): Disallow global.default re-definitions

### DIFF
--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-global-default-use.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-global-default-use.js
@@ -161,27 +161,33 @@ module.exports = {
         type: 'suggestion',
         docs: {
             description: 'Disallow snippet values that are identical to a `global.default` translation in every locale; '
-                + 'reference the `global.default` snippet instead of redefining it.',
+                + 'reference the `global.default` snippet instead of redefining it. Also disallow defining '
+                + '`global.default` keys outside the central Administration snippets.',
             recommended: true,
         },
         schema: [],
         messages: {
             useGlobalDefault: 'Snippet Key `{{key}}` duplicates `global.default.{{defaultKey}}`. '
                 + 'Please remove it and use `global.default.{{defaultKey}}` instead ({{file}}).',
+            noGlobalDefaultDefinition: 'Snippet Key `{{key}}` is defined in the reserved `global.default` namespace. '
+                + 'Only the central Administration snippets (`src/app/snippet`) may define `global.default` keys. '
+                + 'Either reference an existing `global.default` snippet directly or define the snippet '
+                + 'in your own namespace ({{file}}).',
         },
     },
 
     create(context) {
         const cwd = context.cwd ?? process.cwd();
-        const { map, baseLocale } = getDuplicates(cwd);
-        if (!map.size) {
-            return {};
-        }
-
         const filename = context.filename ?? context.getFilename();
+        const isCentralFile = path.dirname(path.resolve(filename)) === GLOBAL_DEFAULT_DIR;
+        const allowList = loadAllowList(cwd);
+
+        const { map, baseLocale } = getDuplicates(cwd);
 
         // Report each duplicate once, on the base-locale file — the key exists in every locale (all-locale gate), so per-locale reporting would only duplicate each finding.
-        if (path.basename(filename, '.json') !== baseLocale) {
+        const reportDuplicates = map.size > 0 && path.basename(filename, '.json') === baseLocale;
+
+        if (isCentralFile && !reportDuplicates) {
             return {};
         }
 
@@ -197,6 +203,25 @@ module.exports = {
                 }
 
                 const dottedKey = keyPath.join('.');
+
+                if (dottedKey.startsWith('global.default.')) {
+                    if (!isCentralFile && !isAllowed(dottedKey, allowList)) {
+                        context.report({
+                            node,
+                            messageId: 'noGlobalDefaultDefinition',
+                            data: {
+                                key: dottedKey,
+                                file: relativeFile,
+                            },
+                        });
+                    }
+                    return;
+                }
+
+                if (!reportDuplicates) {
+                    return;
+                }
+
                 const defaultKey = map.get(dottedKey);
                 if (!defaultKey) {
                     return;

--- a/src/Administration/Resources/app/administration/src/module/sw-login/snippet/de.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/snippet/de.json
@@ -59,9 +59,6 @@
   "global": {
     "sw-admin-menu": {
       "textShopwareAdmin": "Shopware Administration"
-    },
-    "default": {
-      "error": "Fehler"
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-login/snippet/en.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/snippet/en.json
@@ -59,9 +59,6 @@
   "global": {
     "sw-admin-menu": {
       "textShopwareAdmin": "Shopware Administration"
-    },
-    "default": {
-      "error": "Error"
     }
   }
 }

--- a/src/Storefront/Resources/app/storefront/eslint-rules/core-rules/require-global-default-use.js
+++ b/src/Storefront/Resources/app/storefront/eslint-rules/core-rules/require-global-default-use.js
@@ -170,7 +170,8 @@ module.exports = {
         type: 'suggestion',
         docs: {
             description: 'Disallow snippet values that are identical to a `global.default` translation in every locale; '
-                + 'reference the `global.default` snippet instead of redefining it.',
+                + 'reference the `global.default` snippet instead of redefining it. Also disallow defining '
+                + '`global.default` keys outside the core Storefront snippets.',
             recommended: true,
         },
         schema: [
@@ -185,22 +186,27 @@ module.exports = {
         messages: {
             useGlobalDefault: 'Snippet Key `{{key}}` duplicates `global.default.{{defaultKey}}`. '
                 + 'Please remove it and use `global.default.{{defaultKey}}` instead ({{file}}).',
+            noGlobalDefaultDefinition: 'Snippet Key `{{key}}` is defined in the reserved `global.default` namespace. '
+                + 'Only the core Storefront snippets (`Resources/snippet/storefront.*.json`) may define '
+                + '`global.default` keys. Either reference an existing `global.default` snippet directly '
+                + 'or define the snippet in your own namespace ({{file}}).',
         },
     },
 
     create(context) {
         const cwd = context.cwd ?? process.cwd();
         const snippetRoot = context.options[0]?.snippetRoot ?? '.';
-        const { map, baseLocale } = getDuplicates(cwd, snippetRoot);
-        if (!map.size) {
-            return {};
-        }
-
         const filename = context.filename ?? context.getFilename();
+        const isCentralFile = path.dirname(path.resolve(filename)) === GLOBAL_DEFAULT_DIR;
+        const allowList = loadAllowList(cwd);
+
+        const { map, baseLocale } = getDuplicates(cwd, snippetRoot);
 
         // Report each duplicate once, on the base-locale file — the key exists in every locale (all-locale gate), so per-locale reporting would only duplicate each finding.
         const localeMatch = /\.([a-zA-Z-]+)\.json$/.exec(path.basename(filename));
-        if (!localeMatch || localeMatch[1] !== baseLocale) {
+        const reportDuplicates = map.size > 0 && localeMatch !== null && localeMatch[1] === baseLocale;
+
+        if (isCentralFile && !reportDuplicates) {
             return {};
         }
 
@@ -216,6 +222,25 @@ module.exports = {
                 }
 
                 const dottedKey = keyPath.join('.');
+
+                if (dottedKey.startsWith('global.default.')) {
+                    if (!isCentralFile && !isAllowed(dottedKey, allowList)) {
+                        context.report({
+                            node,
+                            messageId: 'noGlobalDefaultDefinition',
+                            data: {
+                                key: dottedKey,
+                                file: relativeFile,
+                            },
+                        });
+                    }
+                    return;
+                }
+
+                if (!reportDuplicates) {
+                    return;
+                }
+
                 const defaultKey = map.get(dottedKey);
                 if (!defaultKey) {
                     return;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
People are re-defining global.default snippets to avoid the breaking pipeline, which is not how it is intended

### 2. What does this change do, exactly?
Disallow extra definitions of global.default

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- [Example Pipeline Fail](https://github.com/shopware/shopware/actions/runs/29253569390/job/86827920232?pr=18271)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
