### PR TITLE
feat: sdk action button multi support on media

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -279,6 +279,9 @@ cacheService.invalidateCaches({
 ### Plugins can use the global Meteor snackbar
 
 Administration plugins can now add and remove snackbars through `Shopware.Service('snackbarService')`. Use `addSnackbar()` with a Meteor snackbar configuration and `removeSnackbar(id)` to dismiss it. Composition API extensions can use the experimental `useSnackbar()` composable, which becomes stable with Shopware 6.8.
+### App action buttons in the Media Manager multiselect sidebar
+
+Apps can now surface a custom action button when multiple media are selected in the Media Manager. Registering an action button via the Admin SDK with `entity: 'media'` and `view: 'list'` renders it in the multiselect sidebar's quick-actions list. The button is only shown when **every** selected media item matches the configured `fileTypes` (case-insensitive; omit `fileTypes` to always show it), and the `callback` receives the full list of selected media entities (`{ id, url, fileName, mimeType, fileSize }`). This complements the existing single-item button (`view: 'item'`) and lets apps offer bulk operations — e.g. exporting or converting all selected files — without an extra API round-trip. No changes are required for existing single-item action buttons.
 
 ## Storefront
 

--- a/src/Administration/Resources/app/administration/blocks-list.json
+++ b/src/Administration/Resources/app/administration/blocks-list.json
@@ -3535,6 +3535,7 @@
  "sw_media_quickinfo_multiple_file_names_content",
  "sw_media_quickinfo_multiple_quickactions",
  "sw_media_quickinfo_multiple_quickactions_content",
+ "sw_media_quickinfo_multiple_quickactions_custom_action",
  "sw_media_quickinfo_multiple_quickactions_delete",
  "sw_media_quickinfo_multiple_quickactions_move",
  "sw_media_quickinfo_preview",

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -373,7 +373,6 @@ const missingTests = [
     'src/module/sw-manufacturer/default-search-configuration.js',
     'src/module/sw-manufacturer/index.js',
     'src/module/sw-media/component/sidebar/sw-media-quickinfo-metadata-item/index.js',
-    'src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/index.js',
     'src/module/sw-media/component/sidebar/sw-media-tag/index.js',
     'src/module/sw-media/component/sw-media-breadcrumbs/index.js',
     'src/module/sw-media/component/sw-media-collapse/index.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/index.js
@@ -58,6 +58,26 @@ export default {
             });
         },
 
+        mediaItems() {
+            return this.items.filter((item) => {
+                return item.getEntityName() === 'media';
+            });
+        },
+
+        extensionSdkButtons() {
+            if (this.mediaItems.length === 0) {
+                return [];
+            }
+
+            return Shopware.Store.get('actionButtons').buttons.filter((button) => {
+                if (button.entity !== 'media' || button.view !== 'list') {
+                    return false;
+                }
+
+                return !button.fileTypes?.length || this.mediaItems.every((item) => this.matchesFileTypes(button, item));
+            });
+        },
+
         isPrivate() {
             return this.items.some((item) => {
                 return item.private === true;
@@ -68,6 +88,26 @@ export default {
     methods: {
         onRemoveItemFromSelection(event) {
             this.$emit('media-item-selection-remove', event);
+        },
+
+        matchesFileTypes(action, item) {
+            return (
+                !action.fileTypes?.length ||
+                (!!item.fileExtension &&
+                    action.fileTypes.some((type) => type.toLowerCase() === item.fileExtension.toLowerCase()))
+            );
+        },
+
+        runAppAction(action) {
+            if (typeof action.callback !== 'function') {
+                return;
+            }
+
+            const items = this.mediaItems.map(({ id, url, fileName, mimeType, fileSize }) => {
+                return { id, url, fileName, mimeType, fileSize };
+            });
+
+            action.callback(items);
         },
 
         quickActionClassesDelete(disabled) {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.html.twig
@@ -68,6 +68,28 @@
                     {{ $t('sw-media.sidebar.actions.dissolve') }}
                 </li>
                 {% endblock %}
+
+                {% block sw_media_quickinfo_multiple_quickactions_custom_action %}
+                <template v-if="extensionSdkButtons.length > 0">
+                    <li
+                        v-for="action in extensionSdkButtons"
+                        :key="action.id"
+                        class="sw-media-sidebar__quickaction quickaction--custom"
+                        role="button"
+                        tabindex="0"
+                        @click="runAppAction(action)"
+                        @keydown.enter="runAppAction(action)"
+                    >
+                        <mt-icon
+                            v-if="action.meteorIcon"
+                            size="16px"
+                            :name="action.meteorIcon"
+                            class="sw-media-sidebar__quickactions-icon"
+                        />
+                        {{ $t(action.label) }}
+                    </li>
+                </template>
+                {% endblock %}
             </ul>
         </template>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-multiple/sw-media-quickinfo-multiple.spec.js
@@ -1,0 +1,198 @@
+/**
+ * @sw-package discovery
+ */
+import { mount } from '@vue/test-utils';
+import 'src/module/sw-media/mixin/media-sidebar-modal.mixin';
+
+function createMediaItem(overrides = {}) {
+    return {
+        id: 'media-id',
+        url: 'https://example.com/Test.png',
+        fileName: 'Test',
+        fileExtension: 'png',
+        fileSize: 12345,
+        mimeType: 'image/png',
+        private: false,
+        getEntityName: () => 'media',
+        ...overrides,
+    };
+}
+
+function createFolderItem(overrides = {}) {
+    return {
+        id: 'folder-id',
+        fileSize: 0,
+        getEntityName: () => 'media_folder',
+        ...overrides,
+    };
+}
+
+async function createWrapper(items = [createMediaItem()]) {
+    return mount(await wrapTestComponent('sw-media-quickinfo-multiple', { sync: true }), {
+        global: {
+            stubs: {
+                'sw-media-collapse': {
+                    template: '<div class="sw-media-collapse"><slot name="content"></slot></div>',
+                },
+                'sw-media-entity-mapper': true,
+                'sw-media-modal-delete': true,
+                'sw-media-modal-folder-dissolve': true,
+                'sw-media-modal-move': true,
+                'mt-icon': true,
+            },
+            provide: {
+                acl: {
+                    can: () => true,
+                },
+                mediaService: {},
+            },
+        },
+        props: {
+            items,
+            editable: true,
+        },
+    });
+}
+
+describe('module/sw-media/component/sidebar/sw-media-quickinfo-multiple', () => {
+    beforeEach(() => {
+        Shopware.Store.get('actionButtons').buttons = [];
+    });
+
+    it('should show list action button from apps', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+        });
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeTruthy();
+    });
+
+    it('should not show item action button in multiselect', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'item',
+            label: 'Convert models',
+        });
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeFalsy();
+    });
+
+    it('should not show action button when no media item matches the file types', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+            fileTypes: ['step'],
+        });
+
+        const wrapper = await createWrapper();
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeFalsy();
+    });
+
+    it('should show action button when all media items match the file types', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+            fileTypes: ['step'],
+        });
+
+        const wrapper = await createWrapper([
+            createMediaItem({ id: 'a', fileExtension: 'step' }),
+            createMediaItem({ id: 'b', fileExtension: 'step' }),
+        ]);
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeTruthy();
+    });
+
+    it('should not show action button when only some media items match the file types', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+            fileTypes: ['step'],
+        });
+
+        const wrapper = await createWrapper([
+            createMediaItem({ id: 'a', fileExtension: 'png' }),
+            createMediaItem({ id: 'b', fileExtension: 'step' }),
+        ]);
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeFalsy();
+    });
+
+    it('should not show action button when only folders are selected', async () => {
+        Shopware.Store.get('actionButtons').add({
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+        });
+
+        const wrapper = await createWrapper([createFolderItem()]);
+
+        expect(wrapper.find('.quickaction--custom').exists()).toBeFalsy();
+    });
+
+    it('should call the action button callback with all selected media items', async () => {
+        const callback = jest.fn();
+        const action = {
+            id: 'button-1',
+            name: 'media-button',
+            entity: 'media',
+            view: 'list',
+            label: 'Convert models',
+            fileTypes: ['step'],
+            callback,
+        };
+
+        const wrapper = await createWrapper([
+            createMediaItem({ id: 'a', fileExtension: 'step', fileName: 'First', url: 'https://example.com/First.step' }),
+            createMediaItem({ id: 'b', fileExtension: 'step', fileName: 'Model', url: 'https://example.com/Model.step' }),
+            createFolderItem(),
+        ]);
+
+        wrapper.vm.runAppAction(action);
+
+        expect(callback).toHaveBeenCalledWith([
+            {
+                id: 'a',
+                url: 'https://example.com/First.step',
+                fileName: 'First',
+                mimeType: 'image/png',
+                fileSize: 12345,
+            },
+            {
+                id: 'b',
+                url: 'https://example.com/Model.step',
+                fileName: 'Model',
+                mimeType: 'image/png',
+                fileSize: 12345,
+            },
+        ]);
+    });
+
+    it('should not fail when the action has no callback', async () => {
+        const wrapper = await createWrapper();
+
+        expect(() => wrapper.vm.runAppAction({ id: 'button-1', entity: 'media', view: 'list' })).not.toThrow();
+    });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We want to be able to run actions on multiple files for optimisation or conversion puposes.

### 2. What does this change do, exactly?
Allows placing action buttons through the SDK for multiple selected files in media manager.

<img width="395" height="576" alt="Screenshot 2026-07-14 at 13 43 53" src="https://github.com/user-attachments/assets/555571c5-bf2d-41b0-9d96-b9a8a1b4f2a7" />

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:

If the issue exists only in Jira, include a link to the Jira issue.
- Github issue: https://github.com/shopware/services-roadmap/issues/591
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
