### PR TITLE
fix(webhook): keep stream rows alive so orphan cleanup can't strand fresh deliveries (#16565)

### DIFF
--- a/src/Core/Framework/Webhook/Outbox/StreamLockService.php
+++ b/src/Core/Framework/Webhook/Outbox/StreamLockService.php
@@ -186,6 +186,8 @@ class StreamLockService
     /**
      * Deletes webhook_stream rows that have no corresponding webhook_delivery rows,
      * are unlocked or past their lease, and are older than {@see self::ORPHAN_GRACE_SECONDS}.
+     *
+     * Delivery writes refresh `created_at`, restarting the stream's cleanup grace window.
      */
     public function deleteOrphanedStreams(int $batchSize): int
     {

--- a/src/Core/Framework/Webhook/Outbox/WebhookOutboxStore.php
+++ b/src/Core/Framework/Webhook/Outbox/WebhookOutboxStore.php
@@ -504,8 +504,10 @@ class WebhookOutboxStore
             ['sequence' => $sequence, 'id' => $eventLogId]
         );
 
+        // Restart the stream's cleanup grace window on every delivery write.
         $this->connection->executeStatement(
-            'INSERT IGNORE INTO webhook_stream (id, partition_key, created_at) VALUES (:id, :pk, :now)',
+            'INSERT INTO webhook_stream (id, partition_key, created_at) VALUES (:id, :pk, :now)
+             ON DUPLICATE KEY UPDATE created_at = :now',
             [
                 'id' => Uuid::randomBytes(),
                 'pk' => $insert->partitionKey,

--- a/tests/integration/Core/Framework/Webhook/Outbox/WebhookOutboxStoreTest.php
+++ b/tests/integration/Core/Framework/Webhook/Outbox/WebhookOutboxStoreTest.php
@@ -14,8 +14,10 @@ use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Outbox\DeliveryResponse;
 use Shopware\Core\Framework\Webhook\Outbox\OutboxEntry;
 use Shopware\Core\Framework\Webhook\Outbox\OutboxInsert;
+use Shopware\Core\Framework\Webhook\Outbox\StreamLockService;
 use Shopware\Core\Framework\Webhook\Outbox\WebhookOutboxStore;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\Clock\MockClock;
 
 /**
  * @internal
@@ -680,6 +682,39 @@ class WebhookOutboxStoreTest extends TestCase
 
         static::assertSame([], $this->store->fetchDue($partitionKey, [WebhookEventLogDefinition::STATUS_QUEUED, WebhookEventLogDefinition::STATUS_PENDING_RETRY], 10));
         static::assertNull($this->store->markRunning($this->ids->get('evt-1')));
+    }
+
+    public function testDeliveryWriteRestartsOrphanCleanupGracePeriod(): void
+    {
+        $clock = new MockClock(new \DateTimeImmutable('2024-01-01 12:00:00'));
+        $store = new WebhookOutboxStore($this->connection, $clock);
+        $streamLockService = new StreamLockService($this->connection, $clock);
+
+        $this->createWebhook('wh-1');
+        $message = $this->createMessage('evt-1', 'wh-1');
+        $partitionKey = Hasher::hashBinary($message->getPartitionKey(), 'xxh128');
+
+        $this->connection->insert('webhook_stream', [
+            'id' => Uuid::randomBytes(),
+            'partition_key' => $partitionKey,
+            'created_at' => $clock->now()
+                ->modify(\sprintf('-%d seconds', StreamLockService::ORPHAN_GRACE_SECONDS + 1))
+                ->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        static::assertNotNull($store->recordOutboxEntry($this->toEntry($message)));
+
+        // Remove the delivery so cleanup must rely on the refreshed grace window.
+        $this->connection->executeStatement(
+            'DELETE FROM webhook_delivery WHERE partition_key = :pk',
+            ['pk' => $partitionKey]
+        );
+
+        $streamLockService->deleteOrphanedStreams(100);
+        static::assertNotFalse(
+            $this->connection->fetchOne('SELECT 1 FROM webhook_stream WHERE partition_key = :pk', ['pk' => $partitionKey]),
+            'a delivery write must restart the stream cleanup grace period'
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

A pre-existing Phase 1 concurrency bug in the webhook outbox transport, found while exercising Phase 2 (#16565) but **independent of it** — health-agnostic and reachable on `trunk` today, with or without `WEBHOOKS_REWORK`.

`StreamLockService::deleteOrphanedStreams` runs its "no deliveries left" check as a snapshot (consistent) read, so a delivery committed while the cleanup scans is invisible to it. With a plain `INSERT IGNORE`, the cleanup could delete a partition's `webhook_stream` row right after a delivery write — stranding a committed, claimable delivery that no partition claim can ever reach (claims join `webhook_stream`).

- **Fix** — delivery writes now refresh the stream row's `created_at` (`INSERT … ON DUPLICATE KEY UPDATE created_at`), and the cleanup's age predicate is a current read of the target row, so any partition written inside the grace window is undeletable in every interleaving.
- **Test** — `WebhookOutboxStoreTest::testDeliveryWriteRefreshesTheStreamRowAgainstOrphanCleanup` fails on the unfixed code and passes after.

`composer phpstan` and the outbox integration suite are green.

relates #16565

### Checklist
- [x] Tests written and verified to fail without the change
- [ ] Release notes — N/A: internal transport bug fix, no external contract change
- [x] Comments for non-obvious lines
- [x] Contribution requirements met

> [!important]
> Standalone Phase 1 bug fix on already-merged transport code (base `trunk`), surfaced during the #16565 E2E harness — merges independently of the Phase 2 stack.
