### PR TITLE
ci: run Danger from vendor-bin instead of the third-party docker image

### DIFF
--- a/.github/workflows/01-danger.yml
+++ b/.github/workflows/01-danger.yml
@@ -15,10 +15,20 @@ jobs:
         with:
             ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Danger
-        uses: docker://ghcr.io/shyim/danger-php:latest
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
-          args: ci
+          php-version: 8.2
+          extensions: ctype, intl, mbstring
+          coverage: none
+
+      - name: Install Danger
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          working-directory: vendor-bin/danger-php
+
+      - name: Danger
+        run: vendor-bin/danger-php/vendor/bin/danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/vendor-bin/danger-php/composer.json
+++ b/vendor-bin/danger-php/composer.json
@@ -1,5 +1,5 @@
 {
-    "require": {
+    "require-dev": {
         "shyim/danger-php": "^0.3.13"
     },
     "config": {

--- a/vendor-bin/danger-php/composer.json
+++ b/vendor-bin/danger-php/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "shyim/danger-php": "^0.3.13"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        },
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The Danger job runs `docker://ghcr.io/shyim/danger-php:latest` — a mutable tag, so upstream fixes only reach us after an upstream release + image publish, and there is no visibility or control over which version actually runs. The transient 502 "Unicorn!" failures analysed in #18259 were fixed upstream (shyim/danger-php#909, released in 0.3.13), and this switch is how we pick that fix up.

### 2. What does this change do, exactly?

Runs Danger via the established `vendor-bin` pattern (as for `rector` and `roave-backward-compatibility-check`) instead of the docker image — phase 1 of #18280, a pure runner swap:

- **`vendor-bin/danger-php/composer.json`** (new): requires `shyim/danger-php: ^0.3.13` — the floor guarantees the #18259 retry fix. `allow-plugins: {"php-http/discovery": false}` deterministically disables the only composer plugin in the tree, so no third-party plugin code runs in the `pull_request_target` job.
- **`.github/workflows/01-danger.yml`**: replaces the docker step with `setup-php` (8.2, `ctype, intl, mbstring` — the extensions the dependency tree needs per `composer check-platform-reqs`, since danger-php replaces the symfony polyfills) → `ramsey/composer-install` on `vendor-bin/danger-php` (cached) → `vendor-bin/danger-php/vendor/bin/danger ci`. Action SHA pins match `php.yml`; trigger, checkout, env vars, and the concurrency group from #18260 are unchanged.

`.danger.php` and all rules are untouched. No `src/`, `tests/`, root `composer.json`, or PHPStan changes — rule extraction is phase 2 of #18280.

Note: since the job is `pull_request_target`, the workflow file is taken from the default branch — this PR still runs the old docker-based Danger; the swap takes effect for PRs opened after merge.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open any PR and watch the `Danger / pr` job: it runs whatever version `latest` currently points to, with no visibility or control over when that changes.
2. With this change: `composer install -d vendor-bin/danger-php` (cached), then `vendor-bin/danger-php/vendor/bin/danger ci`.
3. Verified locally: fresh `composer install --no-interaction` resolves danger-php 0.3.13 (also under a PHP 8.2 platform check), and `vendor-bin/danger-php/vendor/bin/danger github-local <PR-URL>` executes the full `.danger.php` ruleset against a live PR with the expected results.
4. Verified in CI: [this run](https://github.com/shopware/shopware/actions/runs/29264702149) executed the new job end-to-end on a (since-closed) throwaway PR via a temporary `push` trigger — Clone → Setup PHP → Install Danger → Danger, all green in 29s, with the Danger comment posted.

### 4. Please link to the relevant issues (if any).

- relates #18280 (implements phase 1)
- relates #18259, #18260
- supersedes #10241

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them



