### PR TITLE
test: throwaway — verify vendor-bin Danger job (do not merge)

### DIFF
--- a/.github/workflows/01-danger.yml
+++ b/.github/workflows/01-danger.yml
@@ -1,6 +1,8 @@
 name: Danger
 on:
   pull_request_target:
+  push:
+    branches: [ci/danger-vendor-bin-verify]
 
 concurrency:
   group: danger-${{ github.event.pull_request.number }}
@@ -9,6 +11,9 @@ concurrency:
 jobs:
   pr:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Clone
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -31,4 +36,4 @@ jobs:
         run: vendor-bin/danger-php/vendor/bin/danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          GITHUB_PULL_REQUEST_ID: ${{ github.event.pull_request.number || 18288 }}

--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ After setting up [Shopware locally for development](https://developer.shopware.c
 The preferred way of extending Shopware is through the [App System](https://developer.shopware.com/docs/guides/plugins/apps/app-base-guide).
 If the feature you want to implement needs direct access to the Shopware process and the database, you can also use the [plugin system](https://developer.shopware.com/docs/guides/plugins/plugins/plugin-base-guide).    
 You can find an [overview and differentiation in the documentation](https://developer.shopware.com/docs/concepts/extensions).
+


### PR DESCRIPTION
Throwaway PR to verify the new vendor-bin Danger workflow from #18287 runs in CI (pull_request_target takes the workflow from the base branch, so basing this PR on `ci/danger-vendor-bin` executes the new job). Will be closed immediately after the run.