### PR TITLE
fix(api): pass entity collection to JSON:API encoder in listing responses

### DIFF
--- a/src/Core/Framework/Api/Response/Type/Api/JsonApiType.php
+++ b/src/Core/Framework/Api/Response/Type/Api/JsonApiType.php
@@ -111,7 +111,7 @@ class JsonApiType extends JsonFactoryBase
         $response = $this->serializer->encode(
             $criteria,
             $definition,
-            $searchResult,
+            $searchResult->getEntities(),
             $this->getApiBaseUrl($request),
             $rootNode
         );

--- a/tests/unit/Core/Framework/Api/Response/Type/Api/JsonApiTypeTest.php
+++ b/tests/unit/Core/Framework/Api/Response/Type/Api/JsonApiTypeTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Api\Response\Type\Api;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Framework\Api\Response\Type\Api\JsonApiType;
+use Shopware\Core\Framework\Api\Serializer\JsonApiEncoder;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Api\StructEncoder;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(JsonApiType::class)]
+class JsonApiTypeTest extends TestCase
+{
+    public function testCreateListingResponseEncodesEntities(): void
+    {
+        $definition = new ProductDefinition();
+        $definition->compile(static::createStub(DefinitionInstanceRegistry::class));
+
+        $product = (new ProductEntity())->assign([
+            'id' => 'product-id',
+            '_uniqueIdentifier' => 'product-id',
+        ]);
+
+        $searchResult = new EntitySearchResult(
+            ProductDefinition::ENTITY_NAME,
+            1,
+            new ProductCollection([$product]),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+
+        $type = new JsonApiType(new JsonApiEncoder(), static::createStub(StructEncoder::class));
+
+        $response = $type->createListingResponse(
+            new Criteria(),
+            $searchResult,
+            $definition,
+            Request::create('/api/product'),
+            Context::createDefaultContext()
+        );
+
+        static::assertSame(200, $response->getStatusCode());
+
+        $content = $response->getContent();
+        static::assertIsString($content);
+        $decoded = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(1, $decoded['meta']['total']);
+        static::assertCount(1, $decoded['data']);
+        static::assertSame('product-id', $decoded['data'][0]['id']);
+        static::assertSame(ProductDefinition::ENTITY_NAME, $decoded['data'][0]['type']);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`JsonApiType::createListingResponse` still hands the raw `EntitySearchResult` to `JsonApiEncoder`, whose `encodeData()` iterates it directly. `EntitySearchResult::getIterator()` was deprecated in #17101 and throws under `FEATURE_ALL=major` — so **every Admin API JSON:API listing response returns a 500** in major mode (surfaced by `ProductApiTest::testIncludesWithJsonApi` / `testIncludesWithRelationships` in the `integration-major` nightly, #17973).

### 2. What does this change do, exactly?

Passes `$searchResult->getEntities()` to the encoder instead of the search result itself — mirroring what `JsonType::createListingResponse` already does since #17101. Pagination links and the meta block keep reading from the search result through its non-deprecated getters (`getTotal()`, `getCriteria()`, `getStates()`); the encoder's `encode()` signature already accepts an `EntityCollection`, so no encoder change is needed.

### 3. Describe each step to reproduce the issue or behaviour.

```bash
APP_ENV=test FEATURE_ALL=major BLUE_GREEN_DEPLOYMENT=1 vendor/bin/phpunit --testsuite integration \
  --filter 'ProductApiTest::testIncludesWithJsonApi|ProductApiTest::testIncludesWithRelationships'
```

Without this change both tests fail with HTTP 500 (`FRAMEWORK__FEATURE_ERROR`: `EntitySearchResult::getIterator()` deprecated); with it they pass, and they keep passing without the flag (verified locally, plus the full serializer unit suite).

### 4. Please link to the relevant issues (if any).

- relates #17973

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
