### PR TITLE
feat(framework): refine Danger rules and forbid inline rules in the config

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -7,6 +7,7 @@ use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\DangerConfigChanged;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\DeprecatedChangelogFormat;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\EntityRepositoryInFrontendLayer;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\IgnoredPhpstanErrorsInTouchedFiles;
+use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\InlineRuleInDangerConfig;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\InvalidFileNameCharacters;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\LegacyTestsInSrc;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\MissingIntegrationTestInSplitSuite;
@@ -28,6 +29,7 @@ foreach (glob(__DIR__ . '/src/Core/DevOps/StaticAnalyze/Danger/Rules/*.php') ?: 
 return (new Config())
     ->useThreadOn(Config::REPORT_LEVEL_WARNING)
     ->useRule(new DangerConfigChanged())
+    ->useRule(new InlineRuleInDangerConfig())
     ->useRule(new DeprecatedChangelogFormat())
     ->useRule(new MissingReleaseInfo())
     ->useRule(new IgnoredPhpstanErrorsInTouchedFiles())

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/DangerConfigChanged.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/DangerConfigChanged.php
@@ -6,18 +6,30 @@ use Danger\Context;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * Danger always executes the `.danger.php` of the target branch, so changes to it in a pull
- * request are not applied to that same pull request's Danger run.
+ * Danger always executes the config, rule classes and runner package of the target branch, so
+ * changes to them in a pull request are not applied to that same pull request's Danger run.
  *
  * @internal
  */
 #[Package('framework')]
 class DangerConfigChanged
 {
+    private const WATCHED_PATTERNS = [
+        '.danger.php',
+        'src/Core/DevOps/StaticAnalyze/Danger/*',
+        'vendor-bin/danger-php/*',
+    ];
+
     public function __invoke(Context $context): void
     {
-        if ($context->platform->pullRequest->getFiles()->has('.danger.php')) {
-            $context->notice('Any changes to .danger.php will not be reflected in your pull request. Commit your changes separately.');
+        $files = $context->platform->pullRequest->getFiles();
+
+        foreach (self::WATCHED_PATTERNS as $pattern) {
+            if ($files->matches($pattern)->count() > 0) {
+                $context->notice('Changes to the Danger config, rules or runner (`.danger.php`, `src/Core/DevOps/StaticAnalyze/Danger`, `vendor-bin/danger-php`) are not applied to this pull request\'s own Danger run. They take effect for pull requests opened or updated after the merge.');
+
+                return;
+            }
         }
     }
 }

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/InlineRuleInDangerConfig.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/InlineRuleInDangerConfig.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\Danger\Rules;
+
+use Danger\Context;
+use Danger\Struct\File;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * `.danger.php` must stay declarative: rules live as classes in
+ * src/Core/DevOps/StaticAnalyze/Danger/Rules (where they get unit tests and PHPStan coverage),
+ * not as closures or anonymous classes inlined into the config.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class InlineRuleInDangerConfig
+{
+    /**
+     * Matches added lines that pass anything but a `new ClassName(...)` to useRule() (closures,
+     * arrow functions, variables, anonymous classes), or that define a closure or anonymous
+     * class anywhere in the config.
+     */
+    private const INLINE_RULE_PATTERN = '/^\+.*(?:->useRule\([^\S\n]*(?!new\s+[A-Z\\\\])\S|\bfunction\s*\(|\bfn\s*\(|\bnew\s+class\b)/m';
+
+    public function __invoke(Context $context): void
+    {
+        $inlineRules = $context->platform->pullRequest->getFiles()
+            ->filter(static fn (File $file): bool => $file->name === '.danger.php'
+                && preg_match(self::INLINE_RULE_PATTERN, $file->patch) === 1);
+
+        if ($inlineRules->count() <= 0) {
+            return;
+        }
+
+        $context->failure(
+            'Please do not define Danger rules inline in `.danger.php`. Implement the rule as a class in'
+            . ' `src/Core/DevOps/StaticAnalyze/Danger/Rules` with a unit test, and register it via'
+            . ' `->useRule(new MyRule())`.'
+        );
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php
@@ -21,8 +21,35 @@ class MissingReleaseInfo
     {
         $files = $context->platform->pullRequest->getFiles();
 
+        if ($files->count() > 0 && $this->isTestOnly($files->getKeys())) {
+            return;
+        }
+
         if ($files->matches($this->releaseInfoFile)->count() === 0) {
             $context->warning('The Pull Request doesn\'t contain any release info, if your changes are relevant for external developers please add an entry to the release info file, including the consequences of the change and how it affects external developers. For detailed infos please refer to the [release documentation guide](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md).');
         }
+    }
+
+    /**
+     * Changes confined to the test trees are never relevant for external developers.
+     *
+     * @param list<string|int> $fileNames
+     */
+    private function isTestOnly(array $fileNames): bool
+    {
+        foreach ($fileNames as $fileName) {
+            $isTestFile = match (true) {
+                str_starts_with((string) $fileName, 'tests/unit/'),
+                str_starts_with((string) $fileName, 'tests/integration/'),
+                str_starts_with((string) $fileName, 'tests/devops/') => true,
+                default => false,
+            };
+
+            if (!$isTestFile) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php
@@ -21,7 +21,7 @@ class MissingReleaseInfo
     {
         $files = $context->platform->pullRequest->getFiles();
 
-        if ($files->count() > 0 && $this->isTestOnly($files->getKeys())) {
+        if ($files->count() > 0 && $this->isNeverExternallyRelevant($files->getKeys())) {
             return;
         }
 
@@ -31,21 +31,21 @@ class MissingReleaseInfo
     }
 
     /**
-     * Changes confined to the test trees are never relevant for external developers.
+     * Changes confined to the test suites or the static-analysis tooling are never relevant
+     * for external developers.
      *
-     * @param list<string|int> $fileNames
+     * @param array<string|int> $fileNames
      */
-    private function isTestOnly(array $fileNames): bool
+    private function isNeverExternallyRelevant(array $fileNames): bool
     {
         foreach ($fileNames as $fileName) {
-            $isTestFile = match (true) {
-                str_starts_with((string) $fileName, 'tests/unit/'),
-                str_starts_with((string) $fileName, 'tests/integration/'),
-                str_starts_with((string) $fileName, 'tests/devops/') => true,
+            $isIrrelevant = match (true) {
+                str_starts_with((string) $fileName, 'tests/'),
+                str_starts_with((string) $fileName, 'src/Core/DevOps/StaticAnalyze/') => true,
                 default => false,
             };
 
-            if (!$isTestFile) {
+            if (!$isIrrelevant) {
                 return false;
             }
         }

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/DangerConfigChangedTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/DangerConfigChangedTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Rules;
 
 use Danger\Context;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\DangerConfigChanged;
@@ -17,26 +18,41 @@ use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPullRequest;
 #[CoversClass(DangerConfigChanged::class)]
 class DangerConfigChangedTest extends TestCase
 {
-    #[TestDox('Notices that .danger.php changes do not apply to the same pull request')]
-    public function testNoticesWhenDangerConfigIsTouched(): void
+    #[TestDox('Notices that Danger config, rule and runner changes do not apply to the same pull request')]
+    #[DataProvider('touchedFileProvider')]
+    public function testSelfChangeNotice(string $fileName, bool $expectNotice): void
     {
-        $context = new Context(new StubPlatform(new StubPullRequest([new StubFile('.danger.php')])));
+        $context = new Context(new StubPlatform(new StubPullRequest([new StubFile($fileName)])));
 
         (new DangerConfigChanged())($context);
 
-        static::assertSame(
-            ['Any changes to .danger.php will not be reflected in your pull request. Commit your changes separately.'],
-            $context->getNotices()
-        );
+        static::assertSame($expectNotice, $context->hasNotices());
+        if ($expectNotice) {
+            static::assertStringContainsString('not applied to this pull request\'s own Danger run', $context->getNotices()[0]);
+        }
     }
 
-    #[TestDox('Stays silent when .danger.php is untouched')]
-    public function testSilentWithoutDangerConfigChange(): void
+    public static function touchedFileProvider(): \Generator
     {
-        $context = new Context(new StubPlatform(new StubPullRequest([new StubFile('src/Core/Framework/Framework.php')])));
+        yield 'the danger config itself notices' => ['.danger.php', true];
+        yield 'an extracted rule class notices' => ['src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTests.php', true];
+        yield 'the runner package manifest notices' => ['vendor-bin/danger-php/composer.json', true];
+        yield 'other vendor-bin packages do not notice' => ['vendor-bin/rector/composer.json', false];
+        yield 'sibling StaticAnalyze code does not notice' => ['src/Core/DevOps/StaticAnalyze/PHPStan/Rules/RestrictNamespacesRule.php', false];
+        yield 'unrelated source files do not notice' => ['src/Core/Framework/Framework.php', false];
+    }
+
+    #[TestDox('Emits the notice only once when several watched files are touched')]
+    public function testSingleNoticeForMultipleMatches(): void
+    {
+        $context = new Context(new StubPlatform(new StubPullRequest([
+            new StubFile('.danger.php'),
+            new StubFile('src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTests.php'),
+            new StubFile('vendor-bin/danger-php/composer.json'),
+        ])));
 
         (new DangerConfigChanged())($context);
 
-        static::assertFalse($context->hasReports());
+        static::assertCount(1, $context->getNotices());
     }
 }

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/InlineRuleInDangerConfigTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/InlineRuleInDangerConfigTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Rules;
+
+use Danger\Context;
+use Danger\Struct\File;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\InlineRuleInDangerConfig;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubFile;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPlatform;
+use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPullRequest;
+
+/**
+ * @internal
+ */
+#[CoversClass(InlineRuleInDangerConfig::class)]
+class InlineRuleInDangerConfigTest extends TestCase
+{
+    #[TestDox('Fails for inline rules added to .danger.php, allows class registrations, removals and other files')]
+    #[DataProvider('patchProvider')]
+    public function testInlineRuleDetection(string $fileName, string $patch, bool $expectFailure): void
+    {
+        $context = new Context(new StubPlatform(new StubPullRequest([
+            new StubFile($fileName, File::STATUS_MODIFIED, '', $patch),
+        ])));
+
+        (new InlineRuleInDangerConfig())($context);
+
+        static::assertSame($expectFailure, $context->hasFailures());
+        if ($expectFailure) {
+            static::assertStringContainsString('src/Core/DevOps/StaticAnalyze/Danger/Rules', $context->getFailures()[0]);
+        }
+    }
+
+    public static function patchProvider(): \Generator
+    {
+        yield 'added closure rule fails' => [
+            '.danger.php',
+            "+    ->useRule(function (Context \$context): void {\n+        \$context->notice('x');\n+    })",
+            true,
+        ];
+        yield 'added static closure rule fails' => [
+            '.danger.php',
+            '+    ->useRule(static function (Context $context): void {})',
+            true,
+        ];
+        yield 'added arrow function rule fails' => [
+            '.danger.php',
+            '+    ->useRule(fn (Context $context) => $context->notice(\'x\'))',
+            true,
+        ];
+        yield 'added anonymous class rule fails' => [
+            '.danger.php',
+            '+    ->useRule(new class {',
+            true,
+        ];
+        yield 'added variable rule fails' => [
+            '.danger.php',
+            '+    ->useRule($myRule)',
+            true,
+        ];
+        yield 'closure on its own added line fails, useRule split across lines' => [
+            '.danger.php',
+            "+    ->useRule(\n+        function (Context \$context): void {}\n+    )",
+            true,
+        ];
+        yield 'added class registration passes' => [
+            '.danger.php',
+            '+    ->useRule(new MissingReleaseInfo())',
+            false,
+        ];
+        yield 'added fully qualified class registration passes' => [
+            '.danger.php',
+            '+    ->useRule(new \Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\MissingReleaseInfo())',
+            false,
+        ];
+        yield 'class registration split across lines passes' => [
+            '.danger.php',
+            "+    ->useRule(\n+        new MissingReleaseInfo()\n+    )",
+            false,
+        ];
+        yield 'removed inline rule passes' => [
+            '.danger.php',
+            '-    ->useRule(function (Context $context): void {})',
+            false,
+        ];
+        yield 'closure in a rule class passes, only the config is checked' => [
+            'src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php',
+            '+        $files->filter(fn (File $file): bool => true);',
+            false,
+        ];
+    }
+}

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfoTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfoTest.php
@@ -55,9 +55,9 @@ class MissingReleaseInfoTest extends TestCase
     /**
      * @param list<string> $touchedFiles
      */
-    #[TestDox('Test-only pull requests are never relevant for external developers and skip the warning')]
-    #[DataProvider('suiteOnlyFilesProvider')]
-    public function testTestOnlyPullRequests(array $touchedFiles, bool $expectWarning): void
+    #[TestDox('Pull requests confined to tests or static-analysis tooling are never relevant for external developers and skip the warning')]
+    #[DataProvider('neverExternallyRelevantFilesProvider')]
+    public function testNeverExternallyRelevantPullRequests(array $touchedFiles, bool $expectWarning): void
     {
         $files = array_map(static fn (string $name): StubFile => new StubFile($name), $touchedFiles);
         $context = new Context(new StubPlatform(new StubPullRequest($files)));
@@ -67,26 +67,23 @@ class MissingReleaseInfoTest extends TestCase
         static::assertSame($expectWarning, $context->hasWarnings());
     }
 
-    public static function suiteOnlyFilesProvider(): \Generator
+    public static function neverExternallyRelevantFilesProvider(): \Generator
     {
-        yield 'unit-test-only change skips the warning' => [
+        yield 'test-only change skips the warning' => [
             ['tests/unit/Core/Checkout/Cart/CartCalculatorTest.php'],
             false,
         ];
-        yield 'integration-test-only change skips the warning' => [
-            ['tests/integration/Core/Framework/Api/SyncControllerTest.php'],
-            false,
-        ];
-        yield 'devops-test-only change skips the warning' => [
-            ['tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/SomeRuleTest.php'],
-            false,
-        ];
-        yield 'a mix of the three test suites skips the warning' => [
+        yield 'change across several test suites skips the warning' => [
             [
                 'tests/unit/Core/Checkout/Cart/CartCalculatorTest.php',
                 'tests/integration/Core/Framework/Api/SyncControllerTest.php',
+                'tests/migration/Core/V6_7/Migration1752000000AddFooTest.php',
                 'tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/SomeRuleTest.php',
             ],
+            false,
+        ];
+        yield 'static-analysis tooling change skips the warning' => [
+            ['src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfo.php'],
             false,
         ];
         yield 'tests mixed with src changes still warn' => [
@@ -96,8 +93,22 @@ class MissingReleaseInfoTest extends TestCase
             ],
             true,
         ];
-        yield 'migration tests are not exempt, migrations can be externally relevant' => [
-            ['tests/migration/Core/V6_7/Migration1752000000AddFooTest.php'],
+        yield 'tests mixed with a composer.json change still warn' => [
+            [
+                'tests/unit/Core/Checkout/Cart/CartCalculatorTest.php',
+                'composer.json',
+            ],
+            true,
+        ];
+        yield 'static-analysis tooling mixed with other src changes still warns' => [
+            [
+                'src/Core/DevOps/StaticAnalyze/PHPStan/Rules/SomeRule.php',
+                'src/Core/Checkout/Cart/CartCalculator.php',
+            ],
+            true,
+        ];
+        yield 'sibling DevOps code outside StaticAnalyze still warns' => [
+            ['src/Core/DevOps/System/Command/SystemDumpDatabaseCommand.php'],
             true,
         ];
     }

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfoTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingReleaseInfoTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Rules;
 
 use Danger\Context;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\Danger\Rules\MissingReleaseInfo;
@@ -49,5 +50,55 @@ class MissingReleaseInfoTest extends TestCase
         (new MissingReleaseInfo('RELEASE_INFO-6.8.md'))($context);
 
         static::assertFalse($context->hasReports());
+    }
+
+    /**
+     * @param list<string> $touchedFiles
+     */
+    #[TestDox('Test-only pull requests are never relevant for external developers and skip the warning')]
+    #[DataProvider('suiteOnlyFilesProvider')]
+    public function testTestOnlyPullRequests(array $touchedFiles, bool $expectWarning): void
+    {
+        $files = array_map(static fn (string $name): StubFile => new StubFile($name), $touchedFiles);
+        $context = new Context(new StubPlatform(new StubPullRequest($files)));
+
+        (new MissingReleaseInfo())($context);
+
+        static::assertSame($expectWarning, $context->hasWarnings());
+    }
+
+    public static function suiteOnlyFilesProvider(): \Generator
+    {
+        yield 'unit-test-only change skips the warning' => [
+            ['tests/unit/Core/Checkout/Cart/CartCalculatorTest.php'],
+            false,
+        ];
+        yield 'integration-test-only change skips the warning' => [
+            ['tests/integration/Core/Framework/Api/SyncControllerTest.php'],
+            false,
+        ];
+        yield 'devops-test-only change skips the warning' => [
+            ['tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/SomeRuleTest.php'],
+            false,
+        ];
+        yield 'a mix of the three test suites skips the warning' => [
+            [
+                'tests/unit/Core/Checkout/Cart/CartCalculatorTest.php',
+                'tests/integration/Core/Framework/Api/SyncControllerTest.php',
+                'tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/SomeRuleTest.php',
+            ],
+            false,
+        ];
+        yield 'tests mixed with src changes still warn' => [
+            [
+                'tests/unit/Core/Checkout/Cart/CartCalculatorTest.php',
+                'src/Core/Checkout/Cart/CartCalculator.php',
+            ],
+            true,
+        ];
+        yield 'migration tests are not exempt, migrations can be externally relevant' => [
+            ['tests/migration/Core/V6_7/Migration1752000000AddFooTest.php'],
+            true,
+        ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

2 Danger rules give unhelpful output:

- the self-change notice only covers `.danger.php`, but Danger executes the target branch's code (`pull_request_target` + base-ref checkout), so after #18291 the same "not applied to this PR" caveat holds for `src/Core/DevOps/StaticAnalyze/Danger/` and `vendor-bin/danger-php/` without any hint.

- the release-info warning fires on test-only PRs, which are never relevant for external developers.

Additionally, now that #18291 extracted all rules into classes, nothing prevents inline rules from creeping back into `.danger.php` — and PHPStan cannot guard against that, since the root-level config file is outside its analysed paths.

**Stacked on #18291** (base branch `ci/danger-rule-extraction`) — kept separate because #18291 is a strict 1:1 refactor and this changes rule output.

### 2. What does this change do, exactly?

- Extends `DangerConfigChanged` to also watch `src/Core/DevOps/StaticAnalyze/Danger/*` and `vendor-bin/danger-php/*`, with an updated message; emitted once per PR.
- `MissingReleaseInfo` skips the warning when every changed file lives under `tests/` and `src/Core/DevOps/StaticAnalyze/`
- Adds a new `InlineRuleInDangerConfig` rule that fails the Danger run when a PR adds an inline rule to `.danger.php` — a closure, arrow function, variable, or anonymous class passed to `useRule()`, or a closure/anonymous class defined anywhere in the config. Rules belong in `src/Core/DevOps/StaticAnalyze/Danger/Rules` as unit-tested classes registered via `->useRule(new MyRule())`.
- Updates/adds the rules' tests.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a PR touching only `src/Core/DevOps/StaticAnalyze/Danger/Rules/…` or `vendor-bin/danger-php/composer.json`: no hint that the change is not applied to the PR's own Danger run. With this change, such PRs get the same notice as `.danger.php` changes.
2. Open a test-only PR: it gets the release-info warning although there is nothing to document. With this change, it does not.
3. Open a PR adding `->useRule(function (Context $context) { … })` to `.danger.php`: nothing objects. With this change, the Danger run fails and points to the Rules directory.
4. `vendor/bin/phpunit tests/unit/Core/DevOps/StaticAnalyze/Danger` — green.

### 4. Please link to the relevant issues (if any).

- relates #18280
- depends on #18291 (stacked)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
