### PR TITLE
fix: Correct currency in order finish page

### DIFF
--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
@@ -117,7 +117,8 @@ class CheckoutFinishPageLoader
             ->addAssociation('lineItems.cover')
             ->addAssociation('billingAddress.salutation')
             ->addAssociation('billingAddress.country')
-            ->addAssociation('billingAddress.countryState');
+            ->addAssociation('billingAddress.countryState')
+            ->addAssociation('currency');
 
         if (!Feature::isActive('v6.8.0.0')) {
             $criteria

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/tax-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/tax-price.html.twig
@@ -16,7 +16,11 @@
                 &minus;
             {% endif %}
 
-            {{ calculatedTaxValue|abs|currency }}
+            {% if displayMode === 'order' %}
+                {{ calculatedTaxValue|abs|currency(order.currency.isoCode) }}
+            {% else %}
+                {{ calculatedTaxValue|abs|currency }}
+            {% endif %}
             <br>
         {% endfor %}
     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/tax-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/tax-price.html.twig
@@ -16,11 +16,8 @@
                 &minus;
             {% endif %}
 
-            {% if displayMode === 'order' %}
-                {{ calculatedTaxValue|abs|currency(order.currency.isoCode) }}
-            {% else %}
-                {{ calculatedTaxValue|abs|currency }}
-            {% endif %}
+            {% set isoCode = page.order.currency.isoCode ?? context.currency.isoCode %}
+            {{ calculatedTaxValue|abs|currency(isoCode) }}
             <br>
         {% endfor %}
     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
@@ -31,7 +31,9 @@
                                     redirectTo: 'frontend.checkout.confirm.page',
                                     showTaxPrice: showTaxPrice,
                                     showRemoveButton: false,
-                                    showSubtotal: showSubtotal
+                                    showSubtotal: showSubtotal,
+                                    displayMode: 'order',
+                                    order: page.order
                                 } %}
                             {% endblock %}
                         {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary.html.twig
@@ -2,8 +2,10 @@
     <div class="checkout-aside-summary-container">
         {% if page.cart %}
             {% set summary = page.cart %}
+            {% set isoCode = context.currency.isoCode %}
         {% elseif page.order %}
             {% set summary = page.order %}
+            {% set isoCode = page.order.currency.isoCode %}
         {% endif %}
 
         {% set displayRounded = context.totalRounding.interval != 0.01 or context.totalRounding.decimals != context.itemRounding.decimals %}
@@ -19,7 +21,7 @@
             <div class="cart-live-update visually-hidden" role="alert" aria-live="assertive">
                 {{ 'checkout.cartScreenReaderUpdate'|trans({
                     '%count%': summary.lineItems|length,
-                    '%total%': total|currency,
+                    '%total%': total|currency(isoCode),
                 })|sw_sanitize }}
             </div>
         {% endblock %}
@@ -27,41 +29,45 @@
         <dl class="row checkout-aside-summary-list g-0 {% if displayRounded %}display-rounded{% endif %}">
             {% block page_checkout_summary_inner %}
 
-                {% sw_include '@Storefront/storefront/page/checkout/summary/summary-position.html.twig' with { summary: summary } %}
+                {% sw_include '@Storefront/storefront/page/checkout/summary/summary-position.html.twig' with { summary: summary, isoCode: isoCode } %}
 
-                {% sw_include '@Storefront/storefront/page/checkout/summary/summary-shipping.html.twig' with { summary: summary } %}
+                {% sw_include '@Storefront/storefront/page/checkout/summary/summary-shipping.html.twig' with { summary: summary, isoCode: isoCode } %}
 
                 {% if summary.price.taxStatus == 'gross' %}
                     {% sw_include '@Storefront/storefront/page/checkout/summary/summary-total.html.twig' with {
                         total: total,
-                        decimals: decimals
+                        decimals: decimals,
+                        isoCode: isoCode
                     } %}
 
                     {% if displayRounded %}
                         {% sw_include '@Storefront/storefront/page/checkout/summary/summary-total-rounded.html.twig' with {
                             summary: summary,
-                            decimals: context.totalRounding.decimals
+                            decimals: context.totalRounding.decimals,
+                            isoCode: isoCode
                         } %}
                     {% endif %}
 
-                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-net.html.twig' with { summary: summary } %}
+                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-net.html.twig' with { summary: summary, isoCode: isoCode } %}
 
-                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-tax.html.twig' with { summary: summary } %}
+                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-tax.html.twig' with { summary: summary, isoCode: isoCode } %}
                 {% else %}
 
-                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-net.html.twig' with { summary: summary } %}
+                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-net.html.twig' with { summary: summary, isoCode: isoCode } %}
 
-                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-tax.html.twig' with { summary: summary } %}
+                    {% sw_include '@Storefront/storefront/page/checkout/summary/summary-tax.html.twig' with { summary: summary, isoCode: isoCode } %}
 
                     {% sw_include '@Storefront/storefront/page/checkout/summary/summary-total.html.twig' with {
                         total: total,
-                        decimals: decimals
+                        decimals: decimals,
+                        isoCode: isoCode
                     } %}
 
                     {% if displayRounded %}
                         {% sw_include '@Storefront/storefront/page/checkout/summary/summary-total-rounded.html.twig' with {
                             summary: summary,
-                            decimals: context.totalRounding.decimals
+                            decimals: context.totalRounding.decimals,
+                            isoCode: isoCode
                         } %}
                     {% endif %}
                 {% endif %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-net.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-net.html.twig
@@ -7,7 +7,7 @@
 
     {% block page_checkout_summary_net_value %}
         <dd class="col-5 checkout-aside-summary-value summary-net">
-            {{ summary.price.netPrice|currency }}
+            {{ summary.price.netPrice|currency(isoCode) }}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-position.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-position.html.twig
@@ -7,7 +7,7 @@
 
     {% block page_checkout_summary_position_value %}
         <dd class="col-5 checkout-aside-summary-value">
-            {{ summary.price.positionPrice|currency }}
+            {{ summary.price.positionPrice|currency(isoCode) }}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-shipping.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-shipping.html.twig
@@ -14,7 +14,7 @@
                         &minus;
                     {% endif %}
 
-                    {{ deliveryPrice|abs|currency }}
+                    {{ deliveryPrice|abs|currency(isoCode) }}
                 </dd>
             {% endblock %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-tax.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-tax.html.twig
@@ -12,7 +12,7 @@
 
             {% block page_checkout_summary_tax_value %}
                 <dd class="col-5 checkout-aside-summary-value summary-tax">
-                    {{ taxItem.tax|currency }}
+                    {{ taxItem.tax|currency(isoCode) }}
                 </dd>
             {% endblock %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total-rounded.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total-rounded.html.twig
@@ -7,7 +7,7 @@
 
     {% block page_checkout_summary_total_rounded_value %}
         <dd class="col-5 checkout-aside-summary-value checkout-aside-summary-total-rounded">
-            {{ summary.price.totalPrice|currency(decimals=decimals) }}
+            {{ summary.price.totalPrice|currency(currencyIsoCode=isoCode, decimals=decimals) }}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total.html.twig
@@ -7,7 +7,7 @@
 
     {% block page_checkout_summary_total_value %}
         <dd class="col-5 checkout-aside-summary-value checkout-aside-summary-total">
-            {{ summary.price.rawTotal|currency }}
+            {{ summary.price.rawTotal|currency(isoCode) }}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/tests/unit/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoaderTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -198,7 +199,7 @@ class CheckoutFinishPageLoaderTest extends TestCase
         ]);
 
         try {
-            $this->createLoader($pageLoader, $this->getOrderRouteWithValidOrder($orderId))->load(
+            $this->createLoader($pageLoader, $this->getOrderRouteWithValidOrder($orderId, criteriaOrderId: 'invalid-order-id'))->load(
                 $request,
                 Generator::generateSalesChannelContext(),
             );
@@ -229,8 +230,12 @@ class CheckoutFinishPageLoaderTest extends TestCase
         );
     }
 
-    private function getOrderRouteWithValidOrder(string $orderId, ?CashRoundingConfig $itemRounding = null, ?CashRoundingConfig $totalRounding = null): OrderRoute
-    {
+    private function getOrderRouteWithValidOrder(
+        string $orderId,
+        ?CashRoundingConfig $itemRounding = null,
+        ?CashRoundingConfig $totalRounding = null,
+        ?string $criteriaOrderId = null,
+    ): OrderRoute {
         $order = new OrderEntity();
         $order->setId($orderId);
 
@@ -256,9 +261,31 @@ class CheckoutFinishPageLoaderTest extends TestCase
             ->method('getOrders')
             ->willReturn($searchResult);
 
+        $expectedCriteria = (new Criteria([$criteriaOrderId ?? $orderId]))
+            ->addFilter(new EqualsFilter('order.orderCustomer.customerId', Generator::CUSTOMER))
+            ->addAssociation('primaryOrderDelivery.shippingMethod')
+            ->addAssociation('primaryOrderDelivery.shippingOrderAddress.salutation')
+            ->addAssociation('primaryOrderDelivery.shippingOrderAddress.country')
+            ->addAssociation('primaryOrderDelivery.shippingOrderAddress.countryState')
+            ->addAssociation('primaryOrderTransaction.paymentMethod')
+            ->addAssociation('lineItems.cover')
+            ->addAssociation('billingAddress.salutation')
+            ->addAssociation('billingAddress.country')
+            ->addAssociation('billingAddress.countryState')
+            ->addAssociation('currency');
+
         $orderRoute = $this->createMock(OrderRoute::class);
         $orderRoute->expects($this->once())
             ->method('load')
+            ->with(
+                static::isInstanceOf(Request::class),
+                static::isInstanceOf(SalesChannelContext::class),
+                static::callback(static function (Criteria $criteria) use ($expectedCriteria): bool {
+                    static::assertSame((string) $expectedCriteria, (string) $criteria);
+
+                    return true;
+                }),
+            )
             ->willReturn($orderRouteResponse);
 
         return $orderRoute;


### PR DESCRIPTION
This pull request updates the checkout summary and order display to consistently show prices in the correct currency, especially when viewing orders with a different currency than the storefront default. The main changes ensure that all price-related fields use the order's currency ISO code throughout the checkout and order finish pages, and that the backend provides the necessary currency association for orders.

**Currency Handling Improvements:**

* All price displays in checkout summary templates (`summary.html.twig` and partials) now explicitly use the correct currency ISO code, ensuring accurate formatting for both cart and order views. This includes totals, net prices, taxes, shipping, and position prices. [[1]](diffhunk://#diff-f001621e9b9728cd1471e5c718f0b2e09a8715f551863112b79e22087d9558f2R5-R8) [[2]](diffhunk://#diff-f001621e9b9728cd1471e5c718f0b2e09a8715f551863112b79e22087d9558f2L22-R70) [[3]](diffhunk://#diff-ac50378b72a7a4f6509133f7c76a6e02100884b2742eebf4671a0bfe1b5756c7L10-R10) [[4]](diffhunk://#diff-7c3e670c28c0e9119560a211236dd441824dcc1d29e515f0e6a1a30259d7ad1aL10-R10) [[5]](diffhunk://#diff-900cbb5b6ff62606680335e1ee1b8f1f825ccdade4bc4ca7df2e5744071a1cebL17-R17) [[6]](diffhunk://#diff-d8ea12425338a01f9f518740c2b12e6d029704e35d165f6f6a5354a8566dc10aL15-R15) [[7]](diffhunk://#diff-f6652bdbe0cbe60c8294078718a2da755ac7ee1b62e5679112787fcb3c6fed94L10-R10) [[8]](diffhunk://#diff-68e370abaab77a27790f6ba4edbb25f25c27d5496bb6ca8975cb7a267034c669L10-R10)

* The tax price element now uses the order's currency when in "order" display mode, preventing mismatches in currency formatting after checkout.

**Template and Data Flow Adjustments:**

* The `displayMode` and `order` variables are now passed to line item components on the order finish page, enabling them to access and display the correct currency.

**Backend Support:**

* The order loader in `CheckoutFinishPageLoader.php` now fetches the `currency` association with the order, ensuring the order's currency is available in the frontend.<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
