### PR TITLE
feat: filter displayType and component improvements

### DIFF
--- a/src/Storefront/Resources/views/components/Sw/Button/index.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Button/index.html.twig
@@ -13,6 +13,7 @@
             buy: 'btn-buy',
             link: 'btn-link',
             inline: 'btn-link-inline',
+            filter: 'btn-filter',
         },
         size: {
             sm: 'btn-sm',

--- a/src/Storefront/Resources/views/components/Sw/Button/index.scss
+++ b/src/Storefront/Resources/views/components/Sw/Button/index.scss
@@ -1,5 +1,6 @@
-.btn {
+.sw-button {
     --bs-btn-disabled-color: var(--btn-link-disabled-color);
+    --bs-btn-focus-box-shadow: 0 0 0 0.125rem var(--bs-white), 0 0 0 var(--bs-focus-ring-width) var(--bs-focus-ring-color);
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -23,7 +24,6 @@
 
 .btn-link {
     --bs-btn-font-weight: var(--font-weight-semibold);
-    --bs-btn-focus-box-shadow: var(--input-btn-focus-box-shadow);
 }
 
 // Button styling with the appearance of a regular text link
@@ -32,7 +32,6 @@
     --bs-btn-hover-color: var(--btn-link-hover-color);
     --bs-btn-font-weight: var(--font-weight-normal);
     --bs-btn-font-size: inherit;
-    --bs-btn-focus-box-shadow: var(--input-btn-focus-box-shadow);
     --bs-btn-line-height: var(--line-height-base);
     --bs-btn-padding-y: 0;
     --bs-btn-padding-x: 0;
@@ -44,5 +43,24 @@
 
     &:hover {
         text-decoration: underline;
+    }
+}
+
+.btn-filter {
+    --bs-btn-color: var(--bs-body-color);
+    --bs-btn-hover-color: var(--bs-body-color);
+    --bs-btn-border-color: transparent;
+    --bs-btn-hover-border-color: var(--bs-border-color);
+    --bs-btn-active-border-color: var(--bs-border-color);
+    --bs-btn-active-bg: var(--bs-white);
+    --bs-btn-active-color: var(--bs-body-color);
+    --bs-btn-bg: var(--bs-gray-200);
+    --bs-btn-hover-bg: var(--bs-white);
+    font-weight: normal;
+    position: relative;
+    text-align: left;
+
+    .sw-icon {
+        margin-inline: var(--spacer-xs);
     }
 }

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.html.twig
@@ -5,28 +5,54 @@
 {% props
     filterName = '',
     slots = [],
+    displayType = 'dropdown',
 %}
 
+{% set filterItemId = 'filter-item-' ~ random() %}
+
+{% set itemCVA = cva({
+    base: 'sw-filter-item',
+    variants: {
+        displayType: {
+            dropdown: 'is--dropdown',
+            collapse: 'is--collapse',
+        },
+    },
+}) %}
+
 {% set defaultAttributes = {
-    class: 'sw-filter-item',
+    class: itemCVA.apply({ displayType }),
     'data-component': 'Sw:Filter:Item',
 } %}
 
+{% set contentAttributes = {
+    id: filterItemId,
+    class: displayType == 'dropdown' ? 'sw-filter-item__dropdown dropdown-menu' : 'sw-filter-item__collapse collapse',
+} %}
+
+{% set buttonAttributes = {
+    class: 'sw-filter-item__btn',
+    type: 'button',
+    variant: 'filter',
+    'data-bs-toggle': displayType == 'dropdown' ? 'dropdown' : 'collapse',
+    'aria-expanded': 'false',
+    'data-bs-offset': '0,-1',
+    'data-bs-auto-close': 'outside',
+} %}
+
+{% if displayType == 'collapse' %}
+    {% set buttonAttributes = buttonAttributes|merge({ 'data-bs-target': '#' ~ filterItemId }) %}
+{% endif %}
+
 <div {{ attributes.defaults(defaultAttributes) }}>
-    <button
-        class="sw-filter-item__btn btn btn-light"
-        type="button"
-        data-bs-toggle="dropdown"
-        aria-expanded="false"
-        data-bs-offset="0,0"
-        data-bs-auto-close="outside">
+    <twig:Sw:Button {{ ...attributes.defaults(buttonAttributes) }}>
         {{ filterName }}
         <span class="sw-filter-item__count badge text-bg-secondary is--hidden">0</span>
         <twig:Sw:Icon name="arrow-head-down" size="xs" />
         <twig:Sw:Icon name="arrow-head-up" size="xs" />
-    </button>
+    </twig:Sw:Button>
 
-    <div class="sw-filter-item__dropdown dropdown-menu p-0">
+    <div {{ attributes.defaults(contentAttributes) }}>
         {% block content %}
             <twig:Slot name="content"></twig:Slot>
         {% endblock %}

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -23,7 +23,7 @@
         height: var(--sw-filter-item-icon-size);
         margin-left: 0.5rem;
         position: absolute;
-        right: 0.8rem;
+        right: 0.5rem;
         top: 0.7rem;
         transition: var(--sw-filter-item-icon-transition);
     }

--- a/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Item.scss
@@ -1,6 +1,8 @@
 .sw-filter-item {
     --sw-filter-item-dropdown-min-width: 180px;
     --sw-filter-item-dropdown-max-width: 320px;
+    --sw-filter-item-icon-size: 0.8rem;
+    --sw-filter-item-icon-transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
 
     &.is--hidden {
         display: none;
@@ -14,61 +16,36 @@
 }
 
 .sw-filter-item__btn {
-    --bs-btn-color: var(--bs-body-color);
-    --bs-btn-hover-color: var(--bs-body-color);
-    --bs-btn-border-color: transparent;
-    --bs-btn-hover-border-color: var(--bs-border-color);
-    --bs-btn-active-border-color: var(--bs-border-color);
-    --bs-btn-active-bg: var(--bs-white);
-    --bs-btn-active-color: var(--bs-body-color);
-    --bs-btn-bg: var(--bs-gray-200);
-    --bs-btn-hover-bg: var(--bs-white);
-    font-weight: normal;
-    position: relative;
     padding-right: 2.2rem;
-    text-align: left;
 
-    &.btn .sw-icon {
-        width: 0.8rem;
-        height: 0.8rem;
+    .sw-icon {
+        width: var(--sw-filter-item-icon-size);
+        height: var(--sw-filter-item-icon-size);
         margin-left: 0.5rem;
         position: absolute;
         right: 0.8rem;
         top: 0.7rem;
-    }
-
-    &.is--more {
-        --bs-btn-border-color: transparent;
-        --bs-btn-hover-border-color: transparent;
-        --bs-btn-color: var(--bs-primary);
-        --bs-hover-color: var(--bs-primary);
+        transition: var(--sw-filter-item-icon-transition);
     }
 
     .sw-icon--default-arrow-head-up {
-        transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
         opacity: 0;
         transform: translateY(20px);
     }
 
     .sw-icon--default-arrow-head-down {
-        transition: all 0.3s cubic-bezier(0.65, 0, 0.35, 1);
         opacity: 1;
         transform: translateY(0);
     }
 
-    &::after {
-        display: block;
-        position: absolute;
-        content: '';
-        bottom: 0;
-        left: 0;
-        height: 2px;
-        background-color: red;
-    }
-
-    &.show {
+    &[aria-expanded="true"] {
         border-bottom-color: var(--bs-body-bg);
+        color: var(--bs-btn-active-color);
+        background-color: var(--bs-btn-active-bg);
+        border-color: var(--bs-btn-active-border-color);
+        // Ensure button is above dropdown to create the opened tab appearance
         z-index: 1001;
+        border-bottom-color: var(--bs-body-bg);
 
         .sw-icon--default-arrow-head-up {
             opacity: 1;
@@ -79,17 +56,26 @@
             opacity: 0;
             transform: translateY(-20px);
         }
+    }
+}
 
-        & + .dropdown-menu {
-            margin-top: -1px !important;
-        }
+.is--collapse {
+    .sw-filter-item__btn {
+        width: 100%;
     }
 }
 
 .sw-filter-item__dropdown {
-    min-width: var(--sw-filter-item-dropdown-min-width);
+    --bs-dropdown-min-width: var(--sw-filter-item-dropdown-min-width);
+    --bs-dropdown-padding-y: 0;
+    --bs-dropdown-box-shadow: 0 8px 8px rgba(0, 0, 0, 0.1);
     max-width: var(--sw-filter-item-dropdown-max-width);
-    box-shadow: 0 8px 8px rgba(0, 0, 0, 0.1);
+}
+
+.sw-filter-item__collapse {
+    border-left: var(--bs-border-width) solid var(--bs-border-color);
+    border-right: var(--bs-border-width) solid var(--bs-border-color);
+    border-bottom: var(--bs-border-width) solid var(--bs-border-color);
 }
 
 .sw-filter-item__count {

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.html.twig
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.html.twig
@@ -11,14 +11,25 @@
     showLayoutSwitch = true,
     visibleFilterCount = 3,
     slots = [],
+    displayType = 'dropdown',
 %}
 
 {% set filterPanelOptions = {
     visibleFilterCount: visibleFilterCount,
 } %}
 
+{% set panelCVA = cva({
+    base: 'sw-filter-panel container',
+    variants: {
+        displayType: {
+            dropdown: 'is--dropdown',
+            collapse: 'is--collapse',
+        },
+    },
+}) %}
+
 {% set defaultAttributes = {
-    class: 'sw-filter-panel container',
+    class: panelCVA.apply({ displayType }),
     'data-component': 'Sw:Filter:Panel',
     'data-component-options': filterPanelOptions|json_encode,
 } %}
@@ -34,7 +45,10 @@
         {% set manufacturersSorted = manufacturerAggregation.entities|sort((a, b) => a.translated.name|lower <=> b.translated.name|lower) %}
         {% set manufacturerFilterName = 'listing.filterManufacturerDisplayName'|trans|sw_sanitize %}
 
-        <twig:Sw:Filter:Item :filterName="manufacturerFilterName">
+        <twig:Sw:Filter:Item 
+            :filterName="manufacturerFilterName" 
+            :displayType="displayType"
+        >
             <twig:Sw:Filter:Type:MultiSelectFilter
                 name="manufacturer"
                 :displayName="manufacturerFilterName"
@@ -48,7 +62,10 @@
     {% if ratingAggregation is defined %}
         {% set ratingFilterName = 'listing.filterRatingDisplayName'|trans|sw_sanitize %}
 
-        <twig:Sw:Filter:Item :filterName="ratingFilterName">
+        <twig:Sw:Filter:Item 
+            :filterName="ratingFilterName" 
+            :displayType="displayType"
+        >
             <twig:Sw:Filter:Type:RatingFilter name="rating"></twig:Sw:Filter:Type:RatingFilter>
         </twig:Sw:Filter:Item>
     {% endif %}
@@ -58,7 +75,10 @@
     {% if priceAggregation is defined %}
         {% set priceFilterName = 'listing.filterPriceDisplayName'|trans|sw_sanitize %}
 
-        <twig:Sw:Filter:Item :filterName="priceFilterName">
+        <twig:Sw:Filter:Item 
+            :filterName="priceFilterName" 
+            :displayType="displayType"
+        >
             <twig:Sw:Filter:Type:RangeFilter
                 minKey="min-price"
                 maxKey="max-price"
@@ -73,7 +93,10 @@
 {% set propertiesFilter %}
     {% if propertiesAggregation.entities|length > 0 %}
         {% for property in propertiesAggregation.entities %}
-            <twig:Sw:Filter:Item :filterName="property.translated.name">
+            <twig:Sw:Filter:Item 
+                :filterName="property.translated.name" 
+                :displayType="displayType"
+            >
                 <twig:Sw:Filter:Type:MultiSelectFilter
                     name="properties"
                     :displayName="property.translated.name"
@@ -114,7 +137,7 @@
                 {{ filters[filter] }}
             {% endfor %}
         {% endblock %}
-    {% endset%}
+    {% endset %}
 
     <twig:Sw:Content:Offcanvas id="filter-offcanvas" title="{{ 'listing.filterTitle'|trans|sw_sanitize }}">
         <div class="sw-filter-panel__filter">
@@ -127,23 +150,27 @@
 
             {# Expand or collapse hidden filters #}
             {% if filterAggregations|length > visibleFilterCount %}
-                <button class="sw-filter-panel__filter-btn sw-filter-panel__expand btn-light btn d-none d-md-block">
+                <twig:Sw:Button 
+                    variant="filter" 
+                    class="sw-filter-panel__expand d-none d-md-block"
+                >
                     <span class="sw-filter-panel__expand-text">{{ 'listing.filterButtonMore'|trans|sw_sanitize }}</span>
                     <span class="sw-filter-panel__collapse-text">{{ 'listing.filterButtonLess'|trans|sw_sanitize }}</span>
                     <twig:Sw:Icon name="sliders-horizontal" size="xs" />
-                </button>
+                </twig:Sw:Button>
             {% endif %}
         </div>
     </twig:Sw:Content:Offcanvas>
 
     {# Offcanvas filter button for mobile #}
-    <button
-        class="sw-filter-panel__filter-btn btn-light btn d-block d-md-none"
+    <twig:Sw:Button
+        variant="filter"
+        class="d-block d-md-none"
         aria-controls="filter-offcanvas"
         data-bs-toggle="offcanvas"
         data-bs-target="#filter-offcanvas">
         {{ 'listing.filterTitle'|trans|sw_sanitize }} <twig:Sw:Icon name="sliders-horizontal" size="xs" />
-    </button>
+    </twig:Sw:Button>
 
     {% block actions %}
         <div class="sw-filter-panel__actions">

--- a/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
+++ b/src/Storefront/Resources/views/components/Sw/Filter/Panel.scss
@@ -19,36 +19,16 @@
     gap: 0.5rem;
 }
 
+.is--collapse .sw-filter-panel__filter {
+    flex-direction: column;
+    align-items: start;
+}
+
 .sw-filter-panel__actions {
     display: inline-flex;
     align-items: center;
     justify-content: end;
     gap: 0.5rem;
-}
-
-// Shared styles for filter buttons
-.sw-filter-panel__filter-btn {
-    --bs-btn-color: var(--bs-body-color);
-    --bs-btn-hover-color: var(--bs-body-color);
-    --bs-btn-border-color: transparent;
-    --bs-btn-hover-border-color: var(--bs-border-color);
-    --bs-btn-active-border-color: var(--bs-border-color);
-    --bs-btn-active-bg: var(--bs-white);
-    --bs-btn-active-color: var(--bs-body-color);
-    --bs-btn-bg: var(--bs-gray-200);
-    --bs-btn-hover-bg: var(--bs-white);
-    font-weight: normal;
-    position: relative;
-    padding-right: 2.2rem;
-
-    &.btn .sw-icon {
-        width: 0.8rem;
-        height: 0.8rem;
-        margin-left: 0.5rem;
-        position: absolute;
-        right: 0.8rem;
-        top: 0.7rem;
-    }
 }
 
 .sw-filter-panel__counter {

--- a/src/Storefront/Resources/views/components/Sw/Icon/index.scss
+++ b/src/Storefront/Resources/views/components/Sw/Icon/index.scss
@@ -17,7 +17,7 @@ Basic styling for icon component plus helper classes for sizing and colors.
     > svg {
         width: 100%;
         height: 100%;
-        vertical-align: middle;
+        vertical-align: -.125em;
         display: inline-block;
         fill: currentColor;
 


### PR DESCRIPTION
⚠️ **Only relevant for `feat/experience-studio`**

* Add `collapse` option to `Sw:Filter:Item` and `Sw:Filter:Panel` to allow rendering filters in a sidebar.
* Add CVA to toggle between collapse and dropdown classes.
* Remove duplicate filter button CSS in favour of a button variant.
* Remove unused debugging CSS.
* Use `Sw:Button` more consequently instead of arbitrary `<button>` with classes.

### Example

#### displayType: dropdown

<img width="271" height="133" alt="image" src="https://github.com/user-attachments/assets/3e4a3ca6-d37a-4487-8fe6-ec9be5d69a29" />

#### displayType: collapse

<img width="271" height="188" alt="image" src="https://github.com/user-attachments/assets/123d06d3-8b9a-454c-b0a8-380048a53ceb" />