### PR TITLE
fix(checkout): preserve customer Sync API error pointers

### DIFF
--- a/src/Core/Checkout/Customer/Subscriber/CustomerEmailUniqueSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerEmailUniqueSubscriber.php
@@ -81,7 +81,7 @@ class CustomerEmailUniqueSubscriber implements EventSubscriberInterface
         foreach ($conflictingChecks as $check) {
             \assert($check->customerId !== null);
 
-            $this->addViolation($violations, $check->customerId, $check->email);
+            $this->addViolation($violations, $customerCommands[$check->customerId]->getPath(), $check->email);
         }
 
         $event->getExceptions()->add(new WriteConstraintViolationException($violations));
@@ -204,7 +204,7 @@ class CustomerEmailUniqueSubscriber implements EventSubscriberInterface
         return $states;
     }
 
-    private function addViolation(ConstraintViolationList $violations, string $customerId, string $email): void
+    private function addViolation(ConstraintViolationList $violations, string $path, string $email): void
     {
         $message = 'The email address {{ email }} is already in use.';
 
@@ -213,7 +213,7 @@ class CustomerEmailUniqueSubscriber implements EventSubscriberInterface
             $message,
             ['{{ email }}' => $email],
             null,
-            '/' . $customerId . '/email',
+            $path . '/email',
             $email,
             null,
             CustomerEmailUnique::CUSTOMER_EMAIL_NOT_UNIQUE,

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerEmailUniqueSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerEmailUniqueSubscriberTest.php
@@ -78,6 +78,27 @@ class CustomerEmailUniqueSubscriberTest extends TestCase
         static::assertSame(CustomerEmailUnique::CUSTOMER_EMAIL_NOT_UNIQUE, $content['errors'][0]['code']);
     }
 
+    public function testSyncApiCreateRejectsDuplicateEmailWithSyncOperationPointer(): void
+    {
+        $this->setCustomerBoundToSalesChannel(false);
+
+        $email = Uuid::randomHex() . '@example.com';
+        $this->createCustomer($email);
+
+        $this->getBrowser()->jsonRequest('POST', '/api/_action/sync', [[
+            'key' => 'write-customer',
+            'action' => 'upsert',
+            'entity' => 'customer',
+            'payload' => [$this->createCustomerPayload($email)],
+        ]]);
+
+        $response = $this->getBrowser()->getResponse();
+        $content = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), (string) $response->getContent());
+        static::assertSame('/write-customer/0/email', $content['errors'][0]['source']['pointer']);
+    }
+
     public function testRepositoryCreateAllowsDuplicateEmailForDifferentBoundSalesChannelsWhenCustomersAreBoundToSalesChannel(): void
     {
         $this->setCustomerBoundToSalesChannel(true);


### PR DESCRIPTION
### 1. Why is this change necessary?

Customer email uniqueness errors raised during Sync API writes currently point to the customer UUID instead of the submitted operation and payload item. API clients therefore cannot reliably map the validation error back to their import input.

### 2. What does this change do, exactly?

It preserves the DAL write command path when creating the customer-email uniqueness violation. A Sync API response now returns a pointer such as `/write-customer/0/email`.

An integration test covers a duplicate customer email sent through a named Sync API operation.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a non-guest customer with an email address.
2. Call `/api/_action/sync` with a named `customer` upsert operation containing another non-guest customer with that email address.
3. Observe that the uniqueness error points to `/<customer-id>/email` instead of the Sync operation payload.

### 4. Please link to the relevant issues (if any).

- relates #18164

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
