### PR TITLE
test(checkout): verify auto-confirmed T&C summary text on v6.8

### DIFF
--- a/tests/acceptance/tests/Checkout/CheckoutTermsAutoConfirmation.spec.ts
+++ b/tests/acceptance/tests/Checkout/CheckoutTermsAutoConfirmation.spec.ts
@@ -1,0 +1,38 @@
+import { test, translate } from '@fixtures/AcceptanceTest';
+
+test('As a customer, I can see that T&C is auto-confirmed via summary text instead of a checkbox', {
+    tag: ['@Checkout', '@Storefront'],
+}, async ({
+    ShopCustomer,
+    TestDataService,
+    FeatureService,
+    StorefrontProductDetail,
+    StorefrontCheckoutConfirm,
+    StorefrontCheckoutFinish,
+    Login,
+    AddProductToCart,
+    ProceedFromProductToCheckout,
+    SelectPaymentMethod,
+    SelectShippingMethod,
+    SubmitOrder,
+}) => {
+    // Skip entirely unless 6.8 behavior exists.
+    test.skip(!(await FeatureService.isEnabled('V6_8_0_0')), 'v6.8.0.0 only');
+    // Make sure that config to show T&C checkbox is disabled
+    await TestDataService.setSystemConfig({'core.cart.showTosCheckbox': false});
+
+    const product = await TestDataService.createBasicProduct();
+    await ShopCustomer.attemptsTo(Login());
+    await ShopCustomer.goesTo(StorefrontProductDetail.url(product));
+    await ShopCustomer.attemptsTo(AddProductToCart(product));
+    await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());
+    // Verify that Terms and Conditions and cancellation policy text display
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAndConditionsCheckbox).toBeHidden();
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAutoConfirmedText).toContainText(translate('storefront:checkout:confirm.autoConfirmTermsText'));
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.termsAutoConfirmedText.getByRole('button')).toHaveCount(2);
+    // Verify the order still goes through without ticking anything.
+    await ShopCustomer.attemptsTo(SelectPaymentMethod('Invoice'));
+    await ShopCustomer.attemptsTo(SelectShippingMethod('Standard'));
+    await ShopCustomer.attemptsTo(SubmitOrder());
+    await ShopCustomer.expects(StorefrontCheckoutFinish.headline).toBeVisible();
+});


### PR DESCRIPTION
### 1. Why is this change necessary?

From v6.8 (`V6_8_0_0`) the checkout confirm page no longer shows a mandatory T&C checkbox by default; it shows an auto-confirmation summary text instead. This adds acceptance coverage for that new behaviour (#18176).

### 2. What does this change do, exactly?

Adds a flag-gated acceptance spec that, on a `V6_8_0_0` build with `core.cart.showTosCheckbox=false`, asserts the T&C checkbox is hidden, the auto-confirm summary text is shown, and the order still completes.

> ⚠️ **Draft — blocked on** shopware/acceptance-test-suite#659.
> The spec depends on a new `@shopware-ag/acceptance-test-suite` release (presence-aware `ConfirmTermsAndConditions` task, `termsAutoConfirmedText` locator, `autoConfirmTermsText` snippet). Once that PR is released I'll bump `tests/acceptance/package.json` to the new version and mark this ready.

### 3. Describe each step to reproduce the issue or behaviour.

Run against a next-major instance (`FEATURE_ALL=major`):
`npx playwright test --project=Platform CheckoutTermsAutoConfirmation.spec.ts`

### 4. Please link to the relevant issues (if any).
- closes #18176
- relates to shopware/acceptance-test-suite#<ATS_PR_NUMBER>
### 5. Checklist
- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
