### PR TITLE
feat: Allow setting include-in-search on custom field in apps' manifest.xml

### DIFF
--- a/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
+++ b/src/Core/Framework/App/Manifest/Schema/manifest-3.0.xsd
@@ -305,6 +305,7 @@
             <xs:element name="position" type="xs:int" minOccurs="0" default="1"/>
             <xs:element name="allow-customer-write" type="xs:boolean" minOccurs="0" default="false"/>
             <xs:element name="allow-cart-expose" type="xs:boolean" minOccurs="0" default="false"/>
+            <xs:element name="include-in-search" type="xs:boolean" minOccurs="0" default="false"/>
         </xs:choice>
     </xs:group>
     <xs:complexType name="custom-field-int-type">

--- a/src/Core/System/CustomField/Xml/CustomFieldTypes/CustomFieldType.php
+++ b/src/Core/System/CustomField/Xml/CustomFieldTypes/CustomFieldType.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Util\XmlReader;
 /**
  * @internal
  *
- * @phpstan-type CustomFieldTypeArray array{name?: string, type?: string, config: array{label: array<string, string>, helpText: array<string, string>, customFieldPosition: int, validation?: 'required'}, allowCustomerWrite?: true, allowCartExpose?: true}
+ * @phpstan-type CustomFieldTypeArray array{name?: string, type?: string, config: array{label: array<string, string>, helpText: array<string, string>, customFieldPosition: int, validation?: 'required'}, allowCustomerWrite?: true, allowCartExpose?: true, includeInSearch?: true}
  */
 #[Package('framework')]
 abstract class CustomFieldType extends XmlElement
@@ -27,6 +27,8 @@ abstract class CustomFieldType extends XmlElement
     protected bool $allowCustomerWrite = false;
 
     protected bool $allowCartExpose = false;
+
+    protected bool $includeInSearch = false;
 
     protected int $position = 1;
 
@@ -64,6 +66,10 @@ abstract class CustomFieldType extends XmlElement
 
         if ($this->allowCartExpose) {
             $entityArray['allowCartExpose'] = true;
+        }
+
+        if ($this->includeInSearch) {
+            $entityArray['includeInSearch'] = true;
         }
 
         /** @phpstan-ignore-next-line because of the array method, PHPStan could not recognize the array shape correctly */
@@ -109,6 +115,11 @@ abstract class CustomFieldType extends XmlElement
     public function isAllowCartExpose(): bool
     {
         return $this->allowCartExpose;
+    }
+
+    public function isIncludeInSearch(): bool
+    {
+        return $this->includeInSearch;
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Indexing custom fields defined in apps via manifest.xml was not possible as the new field "includeInSearch" was not part of the schema or the app frameworks custom field type definition.

### 2. What does this change do, exactly?
This adds the setting "includeInSearch" for custom fields added via the app system, thereby allowing custom fields from apps to be indexed by open search.

### 3. Describe each step to reproduce the issue or behaviour.
Try setting `<include-in-search>true</include-in-search>` on a custom field in your app's manifest.xml. This causes an error.

### 4. Please link to the relevant issues (if any).
- closes #18323

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
