### PR TITLE
fix(administration): skip invalid snippet files instead of breaking the admin

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -59,6 +59,12 @@ The deprecated members keep working and will be replaced in Shopware 6.8. Migrat
 
 The new `sales_channel.maintenance_ip_allowlist` database column is added and kept in sync with the deprecated `maintenance_ip_whitelist` column. The deprecated field and column will be removed with Shopware 6.8.
 
+### Deprecated `BeforeCacheControlEvent` and the administration cache-control marker
+
+`Shopware\Core\Framework\Adapter\Cache\Http\Event\BeforeCacheControlEvent`, `Shopware\Administration\Controller\AdministrationController::CACHE_ID_HEADER` and `Shopware\Administration\Controller\AdministrationController::CACHE_ID_ADMINISTRATION` are deprecated and will be removed in Shopware 6.8.0.0, together with the internal dispatching and consuming code.
+
+The event and related headers only existed to skip the `CacheControlListener`. With the new caching (the `CACHE_REWORK` feature flag, which becomes the default in 6.8.0) the response `Cache-Control` headers will be returned to the calling client and whole construction will be removed.
+
 ### Deprecated core script response rendering
 
 `Shopware\Core\Framework\Script\Api\ScriptResponseFactoryFacade::render()` is deprecated and will be removed in Shopware 6.8.0.0.
@@ -278,6 +284,19 @@ The default storefront `robots.txt` now emits `Allow: /*referringSalesChannel=` 
 `Shopware\Storefront\Framework\Routing\AbstractDomainLoader::load()` is deprecated and will be removed with Shopware 6.8. Use the new `loadDomains()` method instead, which returns a `Shopware\Storefront\Framework\Routing\Struct\DomainCollection` of `Shopware\Storefront\Framework\Routing\Struct\DomainStruct` objects, keyed by domain URL.
 
 `loadDomains()` is already available: its default implementation builds the collection from `load()` for backward compatibility, but will become abstract with 6.8. If you decorate `AbstractDomainLoader`, implement `loadDomains()` in your decorator. If you consume the result, look up entries via the collection (e.g. `$domains->get($url)`) and access the values as objects (e.g. `$domain->url`) instead of array keys (`$domains[$url]['url']`).
+
+### FormFieldToggle can toggle related submit button labels
+
+The storefront `FormFieldToggle` plugin now supports optionally updating a related button label when the toggle value changes.
+
+This is useful for dynamic forms (for example subscribe vs unsubscribe flows) where hidden/visible field groups and the submit action label should stay in sync without introducing a dedicated custom plugin.
+
+For extension and theme developers, two optional data attributes are available on the controlling field:
+
+- `data-form-field-toggle-button-target`: CSS selector for the related button.
+- `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
+
+If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
 
 ## API
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -399,6 +399,10 @@ GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:storefront
 
 ## Administration
 
+### An invalid snippet file no longer breaks the Administration
+
+An invalid administration snippet JSON file (e.g. from a plugin) previously broke the whole Administration with a 500 error. Such files are now skipped and logged with their path; with `APP_DEBUG=1` loading still fails, naming the broken file. (shopware/shopware#8593)
+
 ### Reworked search behaviour options
 
 The "Search behaviour" card in `Settings > Search` presents the search mode as "Broad search (OR)" and "Exact search (AND)" with short one-line descriptions, replacing the previous "OR"/"AND" labels with example texts. The broad option is now listed first; the stored configuration (`product_search_config.andLogic`) and the template blocks are unchanged. Extensions that override the mode selection (e.g. Advanced Search) can swap the offered options based on their own configuration.

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -59,12 +59,6 @@ The deprecated members keep working and will be replaced in Shopware 6.8. Migrat
 
 The new `sales_channel.maintenance_ip_allowlist` database column is added and kept in sync with the deprecated `maintenance_ip_whitelist` column. The deprecated field and column will be removed with Shopware 6.8.
 
-### Deprecated `BeforeCacheControlEvent` and the administration cache-control marker
-
-`Shopware\Core\Framework\Adapter\Cache\Http\Event\BeforeCacheControlEvent`, `Shopware\Administration\Controller\AdministrationController::CACHE_ID_HEADER` and `Shopware\Administration\Controller\AdministrationController::CACHE_ID_ADMINISTRATION` are deprecated and will be removed in Shopware 6.8.0.0, together with the internal dispatching and consuming code.
-
-The event and related headers only existed to skip the `CacheControlListener`. With the new caching (the `CACHE_REWORK` feature flag, which becomes the default in 6.8.0) the response `Cache-Control` headers will be returned to the calling client and whole construction will be removed.
-
 ### Deprecated core script response rendering
 
 `Shopware\Core\Framework\Script\Api\ScriptResponseFactoryFacade::render()` is deprecated and will be removed in Shopware 6.8.0.0.
@@ -285,19 +279,6 @@ The default storefront `robots.txt` now emits `Allow: /*referringSalesChannel=` 
 
 `loadDomains()` is already available: its default implementation builds the collection from `load()` for backward compatibility, but will become abstract with 6.8. If you decorate `AbstractDomainLoader`, implement `loadDomains()` in your decorator. If you consume the result, look up entries via the collection (e.g. `$domains->get($url)`) and access the values as objects (e.g. `$domain->url`) instead of array keys (`$domains[$url]['url']`).
 
-### FormFieldToggle can toggle related submit button labels
-
-The storefront `FormFieldToggle` plugin now supports optionally updating a related button label when the toggle value changes.
-
-This is useful for dynamic forms (for example subscribe vs unsubscribe flows) where hidden/visible field groups and the submit action label should stay in sync without introducing a dedicated custom plugin.
-
-For extension and theme developers, two optional data attributes are available on the controlling field:
-
-- `data-form-field-toggle-button-target`: CSS selector for the related button.
-- `data-form-field-toggle-button-text`: Alternate button text that is applied when the toggle target is hidden.
-
-If those attributes are not provided, `FormFieldToggle` behaves exactly as before.
-
 ## API
 
 ### Store API OpenAPI: JSON schema files take precedence over generated entity schemas
@@ -398,10 +379,6 @@ GENERATE_SOURCEMAPS=true NODE_ENV=production composer build:js:storefront
 ```
 
 ## Administration
-
-### An invalid snippet file no longer breaks the Administration
-
-An invalid administration snippet JSON file (e.g. from a plugin) previously broke the whole Administration with a 500 error. Such files are now skipped and logged with their path; with `APP_DEBUG=1` loading still fails, naming the broken file. (shopware/shopware#8593)
 
 ### Reworked search behaviour options
 

--- a/src/Administration/DependencyInjection/services.php
+++ b/src/Administration/DependencyInjection/services.php
@@ -180,6 +180,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(TranslationConfig::class),
             service(TranslationLoader::class),
             service(HtmlSanitizer::class),
+            service('logger'),
+            param('kernel.debug'),
         ]);
 
     $services->set(CachedSnippetFinder::class)

--- a/src/Administration/Snippet/SnippetException.php
+++ b/src/Administration/Snippet/SnippetException.php
@@ -16,6 +16,7 @@ class SnippetException extends HttpException
     final public const SNIPPET_DUPLICATED_FIRST_LEVEL_KEY_EXCEPTION = 'SNIPPET__DUPLICATED_FIRST_LEVEL_KEY';
     final public const SNIPPET_EXTEND_OR_OVERWRITE_CORE_EXCEPTION = 'SNIPPET__EXTEND_OR_OVERWRITE_CORE';
     final public const SNIPPET_DEFAULT_LANGUAGE_NOT_GIVEN_EXCEPTION = 'SNIPPET__DEFAULT_LANGUAGE_NOT_GIVEN';
+    final public const SNIPPET_INVALID_FILE_EXCEPTION = 'SNIPPET__INVALID_SNIPPET_FILE';
 
     /**
      * @param array<string> $duplicatedKeys
@@ -57,6 +58,17 @@ class SnippetException extends HttpException
             self::SNIPPET_DEFAULT_LANGUAGE_NOT_GIVEN_EXCEPTION,
             'The following snippet file must always be provided when providing snippets: {{ defaultLanguage }}',
             ['defaultLanguage' => $defaultLanguage]
+        );
+    }
+
+    public static function invalidSnippetFile(string $filePath, \Throwable $previous): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::SNIPPET_INVALID_FILE_EXCEPTION,
+            'The administration snippet file "{{ filePath }}" is invalid: {{ message }}',
+            ['filePath' => $filePath, 'message' => $previous->getMessage()],
+            $previous
         );
     }
 }

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -4,6 +4,7 @@ namespace Shopware\Administration\Snippet;
 
 use Doctrine\DBAL\Connection;
 use League\Flysystem\Filesystem;
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
@@ -39,6 +40,8 @@ class SnippetFinder implements SnippetFinderInterface
         private readonly TranslationConfig $translationConfig,
         private readonly AbstractTranslationLoader $translationLoader,
         private readonly HtmlSanitizer $htmlSanitizer,
+        private readonly LoggerInterface $logger,
+        private readonly bool $debug,
     ) {
     }
 
@@ -242,8 +245,23 @@ class SnippetFinder implements SnippetFinderInterface
             } else {
                 $content = $this->translationReader->read($file->location);
             }
-            if ($content !== '') {
+
+            if ($content === '') {
+                continue;
+            }
+
+            try {
                 $snippets[] = \json_decode($content, true, 512, \JSON_THROW_ON_ERROR) ?? [];
+            } catch (\JsonException $e) {
+                if ($this->debug) {
+                    throw SnippetException::invalidSnippetFile($file->location, $e);
+                }
+
+                // a single broken snippet file (e.g. from a plugin) must not take down the whole administration
+                $this->logger->error(
+                    \sprintf('The administration snippet file "%s" is invalid and was skipped: %s', $file->location, $e->getMessage()),
+                    ['exception' => $e]
+                );
             }
         }
 

--- a/tests/integration/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/integration/Administration/Snippet/SnippetFinderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Shopware\Administration\Snippet\SnippetFinder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -44,6 +45,8 @@ class SnippetFinderTest extends TestCase
             $configLoader->load(),
             static::getContainer()->get(TranslationLoader::class),
             static::getContainer()->get(HtmlSanitizer::class),
+            new NullLogger(),
+            false,
         );
     }
 

--- a/tests/unit/Administration/Snippet/SnippetExceptionTest.php
+++ b/tests/unit/Administration/Snippet/SnippetExceptionTest.php
@@ -38,6 +38,18 @@ class SnippetExceptionTest extends TestCase
         static::assertSame(['defaultLanguage' => 'languageId'], $exception->getParameters());
     }
 
+    public function testInvalidSnippetFile(): void
+    {
+        $previous = new \JsonException('Syntax error');
+        $exception = SnippetException::invalidSnippetFile('/some/path/administration.json', $previous);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(SnippetException::SNIPPET_INVALID_FILE_EXCEPTION, $exception->getErrorCode());
+        static::assertSame('The administration snippet file "/some/path/administration.json" is invalid: Syntax error', $exception->getMessage());
+        static::assertSame(['filePath' => '/some/path/administration.json', 'message' => 'Syntax error'], $exception->getParameters());
+        static::assertSame($previous, $exception->getPrevious());
+    }
+
     public function testExtendOrOverwriteCore(): void
     {
         $exception = SnippetException::extendOrOverwriteCore(['id1', 'id2', 'id3']);

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -400,6 +400,43 @@ class SnippetFinderTest extends TestCase
         );
     }
 
+    #[TestDox('An empty snippet file is skipped without logging an error')]
+    public function testEmptySnippetFileIsSkipped(): void
+    {
+        $config = new TranslationConfig(
+            new Uri('http://localhost:8000'),
+            ['es-ES'],
+            ['activePlugin'],
+            new LanguageDtoCollection([new LanguageDto('es-ES', 'Español')]),
+            new PluginMappingCollection(),
+            new Uri('http://localhost:8000/metadata.json'),
+            ['de-DE'],
+        );
+        $loader = $this->getTranslationLoader($config);
+        $this->createSnippetFixtures($this->filesystem, $loader);
+
+        $emptyFilePath = Path::join($loader->getLocalePath('es-ES'), 'Platform', 'administration.json');
+        $this->filesystem->write($emptyFilePath, '');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->never())
+            ->method('error');
+
+        $snippetFinder = $this->getSnippetFinder(
+            kernel: $this->getKernelMock(pluginPaths: ['activePlugin'], activePluginPaths: ['activePlugin']),
+            connection: $this->getConnectionMock([]),
+            translationConfig: $config,
+            logger: $logger,
+        );
+
+        static::assertSame(
+            ['plugin_administration' => 'Plugin admin'],
+            $snippetFinder->findSnippets('es-ES'),
+            'snippets of intact files must survive an empty file'
+        );
+    }
+
     #[TestDox('In debug mode an invalid snippet file throws an exception naming the file')]
     public function testInvalidSnippetFileThrowsInDebugMode(): void
     {

--- a/tests/unit/Administration/Snippet/SnippetFinderTest.php
+++ b/tests/unit/Administration/Snippet/SnippetFinderTest.php
@@ -9,9 +9,13 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Shopware\Administration\Administration;
+use Shopware\Administration\Snippet\SnippetException;
 use Shopware\Administration\Snippet\SnippetFinder;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
@@ -33,6 +37,7 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Storefront\Storefront;
 use Shopware\Tests\Unit\Core\System\Snippet\Mock\TestPlugin;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @internal
@@ -355,6 +360,75 @@ class SnippetFinderTest extends TestCase
         ], $snippets);
     }
 
+    #[TestDox('An invalid snippet file is skipped and logged instead of breaking the administration')]
+    public function testInvalidSnippetFileIsSkippedAndLogged(): void
+    {
+        $config = new TranslationConfig(
+            new Uri('http://localhost:8000'),
+            ['es-ES'],
+            ['activePlugin'],
+            new LanguageDtoCollection([new LanguageDto('es-ES', 'Español')]),
+            new PluginMappingCollection(),
+            new Uri('http://localhost:8000/metadata.json'),
+            ['de-DE'],
+        );
+        $loader = $this->getTranslationLoader($config);
+        $this->createSnippetFixtures($this->filesystem, $loader);
+
+        $invalidFilePath = Path::join($loader->getLocalePath('es-ES'), 'Platform', 'administration.json');
+        $this->filesystem->write($invalidFilePath, '{');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger
+            ->expects($this->once())
+            ->method('error')
+            ->willReturnCallback(function (string $message) use ($invalidFilePath): void {
+                $this->assertStringContainsString($invalidFilePath, $message);
+            });
+
+        $snippetFinder = $this->getSnippetFinder(
+            kernel: $this->getKernelMock(pluginPaths: ['activePlugin'], activePluginPaths: ['activePlugin']),
+            connection: $this->getConnectionMock([]),
+            translationConfig: $config,
+            logger: $logger,
+        );
+
+        static::assertSame(
+            ['plugin_administration' => 'Plugin admin'],
+            $snippetFinder->findSnippets('es-ES'),
+            'snippets of intact files must survive an invalid file'
+        );
+    }
+
+    #[TestDox('In debug mode an invalid snippet file throws an exception naming the file')]
+    public function testInvalidSnippetFileThrowsInDebugMode(): void
+    {
+        $config = new TranslationConfig(
+            new Uri('http://localhost:8000'),
+            ['es-ES'],
+            [],
+            new LanguageDtoCollection([new LanguageDto('es-ES', 'Español')]),
+            new PluginMappingCollection(),
+            new Uri('http://localhost:8000/metadata.json'),
+            ['de-DE'],
+        );
+        $loader = $this->getTranslationLoader($config);
+        $this->createSnippetFixtures($this->filesystem, $loader);
+
+        $invalidFilePath = Path::join($loader->getLocalePath('es-ES'), 'Platform', 'administration.json');
+        $this->filesystem->write($invalidFilePath, '{');
+
+        $snippetFinder = $this->getSnippetFinder(
+            connection: $this->getConnectionMock([]),
+            translationConfig: $config,
+            debug: true,
+        );
+
+        $this->expectExceptionObject(SnippetException::invalidSnippetFile($invalidFilePath, new \JsonException('Syntax error')));
+
+        $snippetFinder->findSnippets('es-ES');
+    }
+
     public function testFinderSkipsExcludedLocales(): void
     {
         $config = new TranslationConfig(
@@ -417,6 +491,8 @@ class SnippetFinderTest extends TestCase
         (Kernel&Stub)|null $kernel = null,
         (Connection&Stub)|null $connection = null,
         ?TranslationConfig $translationConfig = null,
+        ?LoggerInterface $logger = null,
+        bool $debug = false,
     ): SnippetFinder {
         $config = $translationConfig ?? new TranslationConfig(
             new Uri('http://localhost:8000'),
@@ -442,6 +518,8 @@ class SnippetFinderTest extends TestCase
             $config,
             $translationLoader,
             $sanitizer,
+            $logger ?? new NullLogger(),
+            $debug,
         );
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

A syntactically invalid administration snippet JSON file — typically shipped by a plugin — makes `/api/_admin/snippets` fail with an unspecific 500 error, so the whole Administration no longer loads. One broken third-party file should not take down the admin, and the raw `JsonException` ("Syntax error") doesn't even name the offending file.

### 2. What does this change do, exactly?

- `SnippetFinder::parseFiles()` catches the `JsonException` per file: the invalid file is skipped and logged with its path, and the Administration loads with the snippets of all intact files.
- With `kernel.debug` (`APP_DEBUG=1`), it throws the new domain exception `SnippetException::invalidSnippetFile()` (`SNIPPET__INVALID_SNIPPET_FILE`) naming the broken file, so plugin developers notice the defect immediately instead of shipping it.
- `SnippetFinder` gains `LoggerInterface` + `bool $debug` constructor arguments (`@internal` class), wired in `services.php`.
- Adds a `RELEASE_INFO-6.7.md` entry.

Operational notes:

- With `APP_DEBUG=0` the degradation is invisible to admin users — the `error`-level log line naming the file is the signal to monitor.
- `CachedSnippetFinder` caches the merged result, so a skipped file's absence persists until the `admin-snippet` cache tag is invalidated. All realistic fix flows do that as a side effect (app snippet persist, plugin lifecycle, deployment `cache:clear`); the manual escape hatch is `bin/console cache:pool:invalidate-tags admin-snippet --pool=cache.object`.
- App snippets from the `app_administration_snippet` table are intentionally not guarded: they are machine-encoded JSON written by `AppAdministrationSnippetPersister`, not hand-editable files.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a plugin whose `Resources/app/administration/src/**` contains an `administration.json` (or `<locale>.json`) with invalid JSON.
2. Open the Administration: before, `/api/_admin/snippets` returns 500 and the admin never loads. After, the admin loads without the broken file's snippets, and the log contains an error naming the file. With `APP_DEBUG=1` the request still fails, but with `SNIPPET__INVALID_SNIPPET_FILE` and the file path.
3. `vendor/bin/phpunit tests/unit/Administration/Snippet` — covers both modes.

### 4. Please link to the relevant issues (if any).

- fixes #8593

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
