### PR TITLE
fix: fix discovery integration tests for the v6.8 major nightly

### DIFF
--- a/src/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriber.php
+++ b/src/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriber.php
@@ -64,7 +64,7 @@ class VideoCoverCleanupSubscriber implements EventSubscriberInterface
 
         $updates = [];
 
-        foreach ($mediaWithMetaData as $media) {
+        foreach ($mediaWithMetaData->getEntities() as $media) {
             $metaData = $media->getMetaData();
             if ($metaData === null) {
                 continue;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -97,7 +97,7 @@ class MediaRepositoryTest extends TestCase
         });
 
         static::assertNotNull($media);
-        static::assertCount(0, $media);
+        static::assertCount(0, $media->getEntities());
     }
 
     public function testDeletePrivateMedia(): void
@@ -132,6 +132,7 @@ class MediaRepositoryTest extends TestCase
 
         $media = static::getContainer()->get('media.repository')
             ->search(new Criteria([$ids->get('media')]), $context)
+            ->getEntities()
             ->first();
 
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -214,7 +215,7 @@ class MediaRepositoryTest extends TestCase
         $media = $this->context->scope(Context::USER_SCOPE, static fn (Context $context) => $mediaRepository->search(new Criteria([$mediaId]), $context));
 
         static::assertInstanceOf(EntitySearchResult::class, $media);
-        static::assertCount(0, $media);
+        static::assertCount(0, $media->getEntities());
 
         $documentRepository = $this->documentRepository;
         $document = null;
@@ -224,8 +225,8 @@ class MediaRepositoryTest extends TestCase
             $document = $documentRepository->search($criteria, $context);
         });
         static::assertNotNull($document);
-        static::assertCount(1, $document);
-        $document = $document->get($documentId);
+        static::assertCount(1, $document->getEntities());
+        $document = $document->getEntities()->get($documentId);
         static::assertInstanceOf(DocumentEntity::class, $document);
         $media = $document->getDocumentMediaFile();
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -256,7 +257,7 @@ class MediaRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame($mediaId, $media->getId());
@@ -278,7 +279,7 @@ class MediaRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $mediaPath = $media->getPath();
@@ -322,7 +323,7 @@ class MediaRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $mediaPath = $media->getPath();
@@ -384,9 +385,9 @@ class MediaRepositoryTest extends TestCase
             ),
             $this->context
         );
-        $firstMedia = $read->get($firstId);
+        $firstMedia = $read->getEntities()->get($firstId);
         static::assertInstanceOf(MediaEntity::class, $firstMedia);
-        $secondMedia = $read->get($secondId);
+        $secondMedia = $read->getEntities()->get($secondId);
         static::assertInstanceOf(MediaEntity::class, $secondMedia);
 
         $firstPath = $firstMedia->getPath();
@@ -439,7 +440,7 @@ class MediaRepositoryTest extends TestCase
         );
 
         $read = $this->mediaRepository->search(new Criteria([$secondId]), $this->context);
-        $secondMedia = $read->get($secondId);
+        $secondMedia = $read->getEntities()->get($secondId);
         static::assertInstanceOf(MediaEntity::class, $secondMedia);
 
         $secondPath = $secondMedia->getPath();
@@ -530,7 +531,7 @@ class MediaRepositoryTest extends TestCase
             ],
         ]], $this->context);
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $mediaUrl = $media->getPath();
@@ -623,7 +624,7 @@ class MediaRepositoryTest extends TestCase
         );
         $criteria = new Criteria([$mediaId]);
         $criteria->addFields(['id', 'url']);
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($mediaId);
 
         static::assertSame('http://some.domain/media.png', $media?->get('url'));
     }
@@ -644,14 +645,14 @@ class MediaRepositoryTest extends TestCase
             $this->context
         );
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame('https://localhost:8000/image.jpg', $media->getPath());
 
         $this->context->addState(MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
         $this->mediaRepository->delete([['id' => $mediaId]], $this->context);
 
-        $deletedMedia = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $deletedMedia = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertNull($deletedMedia);
     }
 
@@ -686,7 +687,7 @@ class MediaRepositoryTest extends TestCase
 
         $criteria = new Criteria([$mediaId]);
         $criteria->addAssociation('thumbnails');
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame('https://localhost:8000/image.jpg', $media->getPath());
         static::assertInstanceOf(MediaThumbnailCollection::class, $media->getThumbnails());
@@ -699,7 +700,7 @@ class MediaRepositoryTest extends TestCase
         $this->context->addState(MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
         $this->mediaRepository->delete([['id' => $mediaId]], $this->context);
 
-        $deletedMedia = $this->mediaRepository->search($criteria, $this->context)->get($mediaId);
+        $deletedMedia = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($mediaId);
         static::assertNull($deletedMedia);
     }
 

--- a/tests/integration/Core/Content/Media/MediaFolderServiceTest.php
+++ b/tests/integration/Core/Content/Media/MediaFolderServiceTest.php
@@ -74,6 +74,7 @@ class MediaFolderServiceTest extends TestCase
 
         $mediaFolder = $this->mediaFolderRepo
             ->search(new Criteria(array_filter([$mediaFolderId])), $this->context)
+            ->getEntities()
             ->get($mediaFolderId);
         static::assertInstanceOf(MediaFolderEntity::class, $mediaFolder);
 
@@ -433,6 +434,7 @@ class MediaFolderServiceTest extends TestCase
     {
         $folder = $this->mediaFolderRepo
             ->search(new Criteria([$folderId]), $this->context)
+            ->getEntities()
             ->get($folderId);
         static::assertInstanceOf(MediaFolderEntity::class, $folder);
 
@@ -445,13 +447,14 @@ class MediaFolderServiceTest extends TestCase
         static::assertIsString($mediaFolderId);
         $folder = $this->mediaFolderRepo
             ->search(new Criteria(array_filter([$mediaFolderId])), $this->context)
+            ->getEntities()
             ->get($mediaFolderId);
         static::assertNull($folder);
     }
 
     private function assertMediaHasNoFolder(MediaEntity $media): void
     {
-        $media = $this->mediaRepo->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $media = $this->mediaRepo->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertNull($media->getMediaFolderId());
@@ -459,7 +462,7 @@ class MediaFolderServiceTest extends TestCase
 
     private function assertMediaHasParentFolder(MediaEntity $media, string $parentId): void
     {
-        $media = $this->mediaRepo->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $media = $this->mediaRepo->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame($parentId, $media->getMediaFolderId());
@@ -467,13 +470,13 @@ class MediaFolderServiceTest extends TestCase
 
     private function assertConfigIsDeleted(string $configId): void
     {
-        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->get($configId);
+        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->getEntities()->get($configId);
         static::assertNull($config);
     }
 
     private function assertConfigStillExists(string $configId): void
     {
-        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->get($configId);
+        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->getEntities()->get($configId);
         static::assertNotNull($config);
     }
 

--- a/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
+++ b/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
@@ -79,7 +79,7 @@ class GenerateThumbnailsHandlerTest extends TestCase
         ], $this->context);
 
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         $this->getPublicFilesystem()->writeStream(
             $media->getPath(),
@@ -96,7 +96,7 @@ class GenerateThumbnailsHandlerTest extends TestCase
         $criteria->addAssociation('thumbnails');
 
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
         $mediaThumbnailCollection = $media->getThumbnails();
         static::assertNotNull($mediaThumbnailCollection);
         static::assertCount(2, $mediaThumbnailCollection);
@@ -138,7 +138,7 @@ class GenerateThumbnailsHandlerTest extends TestCase
         ], $this->context);
 
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         $url = $media->getPath();
 
@@ -158,7 +158,7 @@ class GenerateThumbnailsHandlerTest extends TestCase
         $criteria->addAssociation('mediaFolder.configuration.thumbnailSizes');
 
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
         $mediaThumbnailCollection = $media->getThumbnails();
         static::assertNotNull($mediaThumbnailCollection);
         static::assertCount(2, $mediaThumbnailCollection);

--- a/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -173,7 +173,7 @@ class ThumbnailServiceTest extends TestCase
         $criteria = new Criteria([$media->getId()]);
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaFolderEntity::class, $media->getMediaFolder());
         static::assertInstanceOf(MediaFolderConfigurationEntity::class, $media->getMediaFolder()->getConfiguration());
@@ -204,7 +204,7 @@ class ThumbnailServiceTest extends TestCase
         $this->runWorker();
 
         /** @var MediaEntity $updatedMedia */
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         $thumbnails = $updatedMedia->getThumbnails();
         static::assertInstanceOf(MediaThumbnailCollection::class, $thumbnails);
@@ -240,7 +240,7 @@ class ThumbnailServiceTest extends TestCase
         $this->thumbnailService->updateThumbnails($media, $this->context, false);
 
         /** @var MediaEntity $updatedMedia */
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->get($media->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$media->getId()]), $this->context)->getEntities()->get($media->getId());
 
         $thumbnails = $updatedMedia->getThumbnails();
         static::assertInstanceOf(MediaThumbnailCollection::class, $thumbnails);
@@ -293,7 +293,7 @@ class ThumbnailServiceTest extends TestCase
         );
 
         /** @var MediaEntity $media */
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
 
         $mediaUrl = $media->getPath();
 
@@ -314,7 +314,7 @@ class ThumbnailServiceTest extends TestCase
         $this->runWorker();
 
         // refresh entity
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
 
         static::assertInstanceOf(MediaEntity::class, $media);
         $thumbnails = $media->getThumbnails();
@@ -402,7 +402,7 @@ class ThumbnailServiceTest extends TestCase
         $criteria->addAssociation('thumbnails');
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $resource = fopen(__DIR__ . '/../fixtures/shopware-logo.png', 'r');
@@ -419,6 +419,7 @@ class ThumbnailServiceTest extends TestCase
 
         $media = $this->mediaRepository
             ->search($criteria, $this->context)
+            ->getEntities()
             ->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -477,7 +478,7 @@ class ThumbnailServiceTest extends TestCase
         $criteria->addAssociation('thumbnails');
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
 
@@ -494,6 +495,7 @@ class ThumbnailServiceTest extends TestCase
 
         $media = $this->mediaRepository
             ->search($criteria, $this->context)
+            ->getEntities()
             ->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -550,7 +552,7 @@ class ThumbnailServiceTest extends TestCase
         $criteria->addAssociation('thumbnails');
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
 
@@ -570,6 +572,7 @@ class ThumbnailServiceTest extends TestCase
 
         $media = $this->mediaRepository
             ->search($criteria, $this->context)
+            ->getEntities()
             ->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -627,7 +630,7 @@ class ThumbnailServiceTest extends TestCase
         $criteria->addAssociation('thumbnails');
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->get($media->getId());
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
 
@@ -648,6 +651,7 @@ class ThumbnailServiceTest extends TestCase
 
         $media = $this->mediaRepository
             ->search($criteria, $this->context)
+            ->getEntities()
             ->get($media->getId());
 
         static::assertInstanceOf(MediaEntity::class, $media);
@@ -700,6 +704,7 @@ class ThumbnailServiceTest extends TestCase
 
         $media = static::getContainer()->get('media.repository')
             ->search(new Criteria([$ids->get('media')]), Context::createDefaultContext())
+            ->getEntities()
             ->first();
 
         static::assertInstanceOf(MediaEntity::class, $media);

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Sitemap\Provider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider;
@@ -320,6 +321,7 @@ class ProductUrlProviderTest extends TestCase
 
         return [
             'stock' => 100,
+            'type' => ProductDefinition::TYPE_PHYSICAL,
             'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 15, 'net' => 10, 'linked' => false]],
             'tax' => ['id' => $taxId],
             'manufacturer' => ['name' => 'test'],

--- a/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelMaintenanceIpAllowlistSyncSubscriberTest.php
+++ b/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelMaintenanceIpAllowlistSyncSubscriberTest.php
@@ -6,16 +6,15 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
-use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
  */
-#[DisabledFeatures(['v6.8.0.0'])]
 class SalesChannelMaintenanceIpAllowlistSyncSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;
@@ -30,6 +29,8 @@ class SalesChannelMaintenanceIpAllowlistSyncSubscriberTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.8.0.0', $this);
+
         $this->connection = static::getContainer()->get(Connection::class);
         $this->repository = static::getContainer()->get('sales_channel.repository');
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The restored `integration-major` nightly (PHPUnit integration suite with `FEATURE_ALL=major`, v6.8 flags active) fails across the discovery-owned shards (issue #17976, tracking #17978). The tests and one core subscriber still use DAL APIs that are deprecated and throw under `v6.8.0.0`.

### 2. What does this change do, exactly?

Migrate the deprecated `EntitySearchResult::get()`, `first()`, `count()` and `getIterator()` calls to `getEntities()`. `ProductUrlProviderTest` now sets `type` on its product fixtures.
`SalesChannelMaintenanceIpAllowlistSyncSubscriberTest` guards with `Feature::skipTestIfActive('v6.8.0.0', $this)`.

### 3. Describe each step to reproduce the issue or behaviour.

Run the affected suite against a destructively-migrated (major) test DB with the v6.8 flag active:

```
FEATURE_ALL=major V6_8_0_0=1 BLUE_GREEN_DEPLOYMENT=1 FORCE_INSTALL=true composer init:testdb
FEATURE_ALL=major V6_8_0_0=1 BLUE_GREEN_DEPLOYMENT=1 vendor/bin/phpunit \
  tests/integration/Core/Content/Media tests/integration/Core/Content/Sitemap \
  tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelMaintenanceIpAllowlistSyncSubscriberTest.php
```

### 4. Please link to the relevant issues (if any).

- relates #17978
- fixes https://github.com/shopware/shopware/issues/17976

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfilled them
