### PR TITLE
fix(app): only dispatch ShopIdChangedEvent when the shop id changes

### DIFF
--- a/src/Core/Framework/App/ShopId/ShopIdChangedEvent.php
+++ b/src/Core/Framework/App/ShopId/ShopIdChangedEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\App\ShopId;
 
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -15,5 +16,8 @@ class ShopIdChangedEvent extends Event
         public readonly ShopId $newShopId,
         public readonly ?ShopId $oldShopId
     ) {
+        if ($oldShopId !== null && $oldShopId->id === $newShopId->id) {
+            throw AppException::invalidArgument('ShopIdChangedEvent requires a changed shop id');
+        }
     }
 }

--- a/src/Core/Framework/App/ShopId/ShopIdProvider.php
+++ b/src/Core/Framework/App/ShopId/ShopIdProvider.php
@@ -96,7 +96,12 @@ class ShopIdProvider implements ResetInterface
         }
 
         $this->systemConfigService->set(self::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $shopId->toArray(), null, false);
-        $this->eventDispatcher->dispatch(new ShopIdChangedEvent($shopId, $oldShopId));
+
+        // A regeneration can keep the id while refreshing fingerprints (APP_URL move, V1->V2 upgrade);
+        // that is not a change of shop identity, so the event only fires when the id actually differs.
+        if ($oldShopId?->id !== $shopId->id) {
+            $this->eventDispatcher->dispatch(new ShopIdChangedEvent($shopId, $oldShopId));
+        }
 
         $this->shopId = $shopId;
     }

--- a/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/unit/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Unit\Core\Framework\App\ShopId;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Exception\ShopIdChangeSuggestedException;
 use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
@@ -20,22 +19,16 @@ use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
 
 /**
  * @internal
- *
- * @phpstan-import-type ShopIdV1Config from ShopId
  */
 #[CoversClass(ShopIdProvider::class)]
 class ShopIdProviderTest extends TestCase
 {
-    /**
-     * @param ShopIdV1Config|null $shopIdV1Config
-     */
-    #[DataProvider('oldShopIdsProvider')]
-    public function testGeneratesNewShopIdV2(?array $shopIdV1Config): void
+    public function testGeneratesNewShopIdV2WhenNoOldShopIdPresent(): void
     {
         $systemConfigService = $this->createMock(SystemConfigService::class);
         $systemConfigService->expects($matcher = $this->exactly(6))
             ->method('get')
-            ->willReturnCallback(static function (...$parameters) use ($matcher, $shopIdV1Config) {
+            ->willReturnCallback(static function (...$parameters) use ($matcher) {
                 if ($matcher->numberOfInvocations() === 1 || $matcher->numberOfInvocations() === 3 || $matcher->numberOfInvocations() === 5) {
                     static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY_V2, $parameters[0]);
 
@@ -45,7 +38,7 @@ class ShopIdProviderTest extends TestCase
                 if ($matcher->numberOfInvocations() === 2 || $matcher->numberOfInvocations() === 4 || $matcher->numberOfInvocations() === 6) {
                     static::assertSame(ShopIdProvider::SHOP_ID_SYSTEM_CONFIG_KEY, $parameters[0]);
 
-                    return \is_array($shopIdV1Config) ? (array) ShopId::v1($shopIdV1Config['value'], $shopIdV1Config['app_url']) : null;
+                    return null;
                 }
 
                 static::fail(\sprintf('SystemConfigService was not expected to be called more than %s times', $matcher->numberOfInvocations()));
@@ -72,8 +65,7 @@ class ShopIdProviderTest extends TestCase
 
         $shopIdChangedEvent = $eventDispatcher->getEvents()[0] ?? null;
         static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
-        static::assertSame($shopIdV1Config['value'] ?? null, $shopIdChangedEvent->oldShopId?->id);
-        static::assertSame($shopIdV1Config['app_url'] ?? null, $shopIdChangedEvent->oldShopId?->getFingerprint(AppUrl::IDENTIFIER) ?? null);
+        static::assertNull($shopIdChangedEvent->oldShopId);
         static::assertSame($shopId->id, $shopIdChangedEvent->newShopId->id);
     }
 
@@ -121,12 +113,8 @@ class ShopIdProviderTest extends TestCase
 
         $upgradedShopId = $provider->getShopId();
 
-        static::assertCount(2, $eventDispatcher->getEvents());
-
-        $shopIdChangedEvent = $eventDispatcher->getEvents()[0] ?? null;
-        static::assertInstanceOf(ShopIdChangedEvent::class, $shopIdChangedEvent);
-        static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->oldShopId?->id);
-        static::assertSame($shopIdV1Config['value'], $shopIdChangedEvent->newShopId->id);
+        // The id is preserved across the V1->V2 upgrade, so no ShopIdChangedEvent is dispatched.
+        static::assertCount(0, $eventDispatcher->getEvents());
         static::assertSame($shopIdV1Config['value'], $upgradedShopId->id);
     }
 
@@ -211,12 +199,14 @@ class ShopIdProviderTest extends TestCase
 
         $provider = new ShopIdProvider(
             $systemConfigService,
-            new CollectingEventDispatcher(),
+            $eventDispatcher = new CollectingEventDispatcher(),
             $connection,
             $fingerprintGenerator,
         );
 
         static::assertSame($shopId->id, $provider->getShopId()->id);
+        // Fingerprints changed but the id is reused, so this is not a shop identity change.
+        static::assertCount(0, $eventDispatcher->getEvents());
     }
 
     public function testDeletesShopId(): void
@@ -245,11 +235,5 @@ class ShopIdProviderTest extends TestCase
 
         static::assertCount(1, $eventDispatcher->getEvents());
         static::assertInstanceOf(ShopIdDeletedEvent::class, $eventDispatcher->getEvents()[0]);
-    }
-
-    public static function oldShopIdsProvider(): \Generator
-    {
-        yield 'old shop id NOT present' => [null];
-        yield 'old shop id IS present' => [['value' => '1234567890', 'app_url' => 'https://foo.bar']];
     }
 }


### PR DESCRIPTION
`ShopIdProvider::setShopId()` dispatched `ShopIdChangedEvent` on every id regeneration — including the paths that deliberately keep the id (APP_URL move, V1→V2 config upgrade, fingerprint refresh with no apps). A same-id regeneration is not a change of shop identity, yet the only live consumer, `RememberDeletedAppsSecretSubscriber`, reacts by purging stored deleted-app secrets that are valid *only* on the same id — so it discarded still-valid secrets.

This guards the single dispatch site on the id actually changing, and makes the event self-validating so it can no longer represent a no-op change.

### 1. Why is this change necessary?

`ShopIdChangedEvent` fired even when the shop id did not change. Its one wired subscriber purges deleted-app secrets on the assumption that a change means re-registration under a new identity; on a same-id regeneration that assumption is false and the purge destroys secrets that are still valid.

### 2. What does this change do, exactly?

- `ShopIdProvider::setShopId()` only dispatches `ShopIdChangedEvent` when `$oldShopId?->id !== $shopId->id`. In practice the event now fires only on a genuine identity change (first-ever generation); V1→V2 upgrade, fingerprint refresh, and permanent-move no longer emit it.
- `ShopIdChangedEvent` self-validates in its constructor: it throws `AppException::invalidArgument` if `oldShopId->id === newShopId->id`, so a future caller cannot dispatch a no-op change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Store a shop id, then trigger a regeneration that keeps the id (e.g. a V1→V2 config upgrade, or a "move shop permanently" / APP_URL change).
2. Before this change: `ShopIdChangedEvent` is dispatched and `RememberDeletedAppsSecretSubscriber` purges the stored deleted-app secrets even though the id is unchanged.
3. After this change: no event is dispatched, and the secrets are retained.

### 4. Please link to the relevant issues (if any).

<!-- none -->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - `ShopIdChangedEvent` is `@internal`; this behavioural change is not relevant for external developers, so no RELEASE_INFO / UPGRADE entry is added.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
