### PR TITLE
docs(core): document env placeholder config limitations

### DIFF
--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -18,6 +18,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 #[Package('framework')]
 class Configuration implements ConfigurationInterface
 {
+    private const ENV_PLACEHOLDER_NOT_SUPPORTED = 'Runtime environment variable placeholders such as "%env(int:VALUE)%" are not supported for this option. Configure a literal value instead.';
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('shopware');
@@ -142,7 +144,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('batch_write_size')
                     ->defaultValue(250)
                     ->min(1)
-                    ->info('Batch size for writing files simultaneously using AsyncAwsS3WriteBatchAdapter')
+                    ->info('Batch size for writing files simultaneously using AsyncAwsS3WriteBatchAdapter. ' . self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
             ->end();
 
@@ -308,6 +310,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('batchsize')
                     ->min(1)
                     ->defaultValue(100)
+                    ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
                 ->arrayNode('scheduled_task')
                     ->children()
@@ -365,6 +368,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(5)
                             ->min(1)
                             ->max(10080)
+                            ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                             ->end()
                     ->end()
                 ->end()
@@ -862,16 +866,19 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('batch_size')
                     ->min(1)
                     ->defaultValue(125)
+                    ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
                 ->integerNode('max_rule_prices')
                     ->min(1)
                     ->defaultValue(100)
+                    ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
                 ->arrayNode('versioning')
                     ->children()
                         ->integerNode('expire_days')
                             ->min(1)
                             ->defaultValue(30)
+                            ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                             ->end()
                 ->end()
             ->end();
@@ -892,6 +899,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('expire_days')
                     ->min(1)
                     ->defaultValue(120)
+                    ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
                 ->arrayNode('storage')
                     ->children()
@@ -921,6 +929,7 @@ class Configuration implements ConfigurationInterface
                         ->integerNode('expire_days')
                             ->min(1)
                             ->defaultValue(30)
+                            ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                     ->end()
             ->end();
 
@@ -963,6 +972,7 @@ class Configuration implements ConfigurationInterface
                 ->integerNode('expire_days')
                     ->min(1)
                     ->defaultValue(120)
+                    ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                 ->end()
             ->end();
 
@@ -987,6 +997,7 @@ class Configuration implements ConfigurationInterface
                     ->integerNode('relevant_keyword_count')
                         ->min(1)
                         ->defaultValue(8)
+                        ->info(self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                     ->end()
                 ->end()
             ->end();
@@ -1626,7 +1637,7 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue([])
                 ->end()
                 ->integerNode('app_tool_timeout')
-                    ->info('Timeout in seconds for app webhook MCP tool calls.')
+                    ->info('Timeout in seconds for app webhook MCP tool calls. ' . self::ENV_PLACEHOLDER_NOT_SUPPORTED)
                     ->defaultValue(10)
                     ->min(1)
                 ->end()


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware configuration options with a positive minimum-value constraint cannot use runtime environment variable placeholders. The generated configuration reference currently does not communicate this limitation.

### 2. What does this change do, exactly?

It adds one shared explanatory message to all 11 affected configuration nodes. The message is included in the output of `bin/console config:dump-reference shopware` and tells operators to configure a literal value instead.

The general developer documentation is updated separately in shopware/docs#2379.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure `shopware.cart.expire_days` as `%env(int:CART_EXPIRE_DAYS)%`.
2. Compile the container or run a console command.
3. Symfony validates its integer placeholder value of `0` against `min(1)` and rejects the configuration.

### 4. Please link to the relevant issues (if any).

- relates #18256
- documentation: shopware/docs#2379

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them