### PR TITLE
ci: don't set release as latest while preparing the release

### DIFF
--- a/.github/bin/create_github_release.bash
+++ b/.github/bin/create_github_release.bash
@@ -42,7 +42,8 @@ draft_release_payload() {
     body: ([env.release_message_header, env.changelog_entries] | join("\n\n")),
     draft: true,
     prerelease: false,
-    generate_release_notes: false
+    generate_release_notes: false,
+    make_latest: "false"
   }'
 }
 

--- a/.github/workflows/01-danger.yml
+++ b/.github/workflows/01-danger.yml
@@ -11,10 +11,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
-      - name: Danger
-        uses: docker://ghcr.io/shyim/danger-php:latest
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
-          args: ci
+          php-version: 8.2
+          extensions: ctype, intl, mbstring
+          coverage: none
+
+      - name: Install Danger
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          working-directory: vendor-bin/danger-php
+
+      - name: Danger
+        run: vendor-bin/danger-php/vendor/bin/danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}

--- a/vendor-bin/danger-php/composer.json
+++ b/vendor-bin/danger-php/composer.json
@@ -1,0 +1,11 @@
+{
+    "require-dev": {
+        "shyim/danger-php": "^0.3.13"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        },
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the Releases for `6.6.x` get set as `latest` and when we don't correct this, the 6.6 Release will be marked as latest Shopware 6 Release.

### 2. What does this change do, exactly?
Set the `make_latest` to `false`.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new release