### PR TITLE
test: resolve invalid coverage targets in the migration suite

### DIFF
--- a/tests/devops/Core/Migration/MigrationNameAndTimestampTest.php
+++ b/tests/devops/Core/Migration/MigrationNameAndTimestampTest.php
@@ -1,11 +1,9 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Migration\Core;
+namespace Shopware\Tests\DevOps\Core\Migration;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
@@ -13,7 +11,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
  * @internal
  */
 #[Package('framework')]
-#[CoversClass(MigrationCollection::class)]
 class MigrationNameAndTimestampTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/migration/Core/MigrationForeignDefaultLanguageTest.php
+++ b/tests/migration/Core/MigrationForeignDefaultLanguageTest.php
@@ -3,7 +3,7 @@
 namespace Shopware\Tests\Migration\Core;
 
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
@@ -19,11 +19,15 @@ use Shopware\Tests\Migration\MigrationUntouchedDbTestTrait;
 
 /**
  * @internal
+ *
+ * MigrationCollection would be the natural covers target, but the migration job scopes
+ * the coverage source to the src/*\/Migration directories, so no Framework class is a
+ * valid target here; the replayed migrations must not receive smoke-level attribution either.
  */
 #[Package('framework')]
 #[Group('slow')]
 #[RunTestsInSeparateProcesses]
-#[CoversClass(MigrationCollection::class)]
+#[CoversNothing]
 class MigrationForeignDefaultLanguageTest extends TestCase
 {
     use DatabaseTransactionBehaviour;


### PR DESCRIPTION
### 1. Why is this change necessary?

Under PHPUnit 12 the migration suite emits 4 `is not a valid target for code coverage` warnings, all from `#[CoversClass(MigrationCollection::class)]` on the two remaining infrastructure tests in `tests/migration/Core/`. 

The target can never be valid there: the migration CI job scopes the coverage source to the `src/*/Migration` directories, so no `Framework` class is coverable in that suite. PHPUnit 11 does not validate covers targets, which is why only PHPUnit 12 runs surface this.

### 2. What does this change do, exactly?

- Moves `MigrationNameAndTimestampTest` to `tests/devops/Core/Migration/`: it is a codebase-conformance check (migration class names must embed their creation timestamp), which is the devops suite's purpose. Like its neighbours there it carries no covers attribute.
- Keeps `MigrationForeignDefaultLanguageTest` in the migration suite (it replays every migration against fresh foreign-default-language databases) and replaces the invalid `CoversClass` with an explicit `#[CoversNothing]`, with a docblock explaining why: no valid target exists in the migration job, and the replayed migrations must not receive smoke-level coverage attribution.

### 3. Describe each step to reproduce the issue or behaviour.

Run the migration suite with coverage under PHPUnit 12: 4 warnings (1 from `MigrationNameAndTimestampTest`, 3 from `MigrationForeignDefaultLanguageTest`); with this change, none. Both tests verified green from their new locations (4 tests, 1739 assertions).

### 4. Please link to the relevant issues (if any).

- relates #18344
- relates #18012

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (attribute/location change only, no runtime surface)
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under "Upcoming" for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
