### PR TITLE
fix: changelog release command for 6.6.x

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1871,31 +1871,6 @@ parameters:
 			path: src/Core/Framework/App/Validation/ManifestValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Framework/Changelog/Command/ChangelogChangeCommand.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Framework/Changelog/Command/ChangelogReleaseCommand.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Command\\\\CreateHydratorCommand\\:\\:renderClass\\(\\) has parameter \\$calls with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php

--- a/src/Core/Framework/Changelog/ChangelogException.php
+++ b/src/Core/Framework/Changelog/ChangelogException.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Changelog;
+
+use Shopware\Core\Framework\HttpException;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class ChangelogException extends HttpException
+{
+    private const INVALID_VERSION = 'CHANGELOG__INVALID_VERSION';
+
+    private const INVALID_CHANGELOG_FILE = 'CHANGELOG__INVALID_CHANGELOG_FILE';
+
+    private const RELEASE_ALREADY_EXISTS = 'CHANGELOG__RELEASE_ALREADY_EXISTS';
+
+    private const VERSION_REQUIRED = 'CHANGELOG__VERSION_REQUIRED';
+
+    private const INVALID_RELEASE_VERSION = 'CHANGELOG__INVALID_RELEASE_VERSION';
+
+    private const TITLE_REQUIRED = 'CHANGELOG__TITLE_REQUIRED';
+
+    private const INVALID_DATE = 'CHANGELOG__INVALID_DATE';
+
+    public static function invalidVersion(string $version): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_VERSION,
+            'Unable to generate next version number, supplied version seems invalid ({{ version }})',
+            ['version' => $version]
+        );
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    public static function invalidChangelogFile(string $path, array $errors): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_CHANGELOG_FILE,
+            'Invalid file at path: {{ path }}, errors: {{ errors }}',
+            ['path' => $path, 'errors' => implode(', ', $errors)]
+        );
+    }
+
+    public static function releaseAlreadyExists(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::RELEASE_ALREADY_EXISTS,
+            'A given version release existed already. Please specify another version or use "-f" to override the existing.'
+        );
+    }
+
+    public static function versionRequired(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::VERSION_REQUIRED,
+            'Version of release is required.'
+        );
+    }
+
+    public static function invalidReleaseVersion(string $version): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_RELEASE_VERSION,
+            'Invalid version of release ("{{ version }}"). It should be 4-digits type',
+            ['version' => $version]
+        );
+    }
+
+    public static function titleRequired(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::TITLE_REQUIRED,
+            'Title is required in changelog file'
+        );
+    }
+
+    public static function invalidDate(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_DATE,
+            'The date has to follow the format: YYYY-MM-DD'
+        );
+    }
+}

--- a/src/Core/Framework/Changelog/ChangelogParser.php
+++ b/src/Core/Framework/Changelog/ChangelogParser.php
@@ -16,6 +16,13 @@ class ChangelogParser
 
     public const REFERENCE_REGEX = '\((#[0-9]+)\)';
 
+    /**
+     * Matches a conventional commit subject for a user-facing change (feat / fix), capturing the
+     * trailing pull request number, e.g. "fix(scope)!: some description (#12345)".
+     * Compatible with both POSIX ERE (git --grep -E) and PCRE (preg_match).
+     */
+    public const RELEVANT_COMMIT_REGEX = '^(feat|fix)(\([^)]+\))?!?:.*\(#([0-9]+)\)';
+
     public function parse(SplFileInfo $file, string $rootDir): ChangelogDefinition
     {
         $content = trim($file->getContents());

--- a/src/Core/Framework/Changelog/Command/ChangelogChangeCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogChangeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Changelog\Command;
 
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\ChangelogSection;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseExporter;
 use Shopware\Core\Framework\Log\Package;
@@ -49,7 +50,7 @@ class ChangelogChangeCommand extends Command
 
         $version = $input->getArgument('version');
         if (!empty($version) && !preg_match("/^\d+(\.\d+){3}$/", $version)) {
-            throw new \RuntimeException('Invalid version of release. It should be 4-digits type');
+            throw ChangelogException::invalidReleaseVersion((string) $version);
         }
 
         $includeFeatureFlags = $input->getOption('include-feature-flags');

--- a/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Changelog\Command;
 
 use Shopware\Core\Framework\Changelog\ChangelogDefinition;
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogGenerator;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -53,7 +54,7 @@ class ChangelogCreateCommand extends Command
         $title = $input->getArgument('title')
             ?? $IOHelper->ask('A short meaningful title of your change', null, function ($title) {
                 if (!$title) {
-                    throw new \RuntimeException('Title is required in changelog file');
+                    throw ChangelogException::titleRequired();
                 }
 
                 return $title;
@@ -62,7 +63,7 @@ class ChangelogCreateCommand extends Command
         $date = $input->getOption('date')
             ?? $IOHelper->ask('The date in `YYYY-MM-DD` format which the change will be applied', $default['date'], function ($date) {
                 if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
-                    throw new \RuntimeException('The date has to follow the format: YYYY-MM-DD');
+                    throw ChangelogException::invalidDate();
                 }
 
                 return $date;

--- a/src/Core/Framework/Changelog/Command/ChangelogReleaseCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogReleaseCommand.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Changelog\Command;
 
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseCreator;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -46,13 +47,13 @@ class ChangelogReleaseCommand extends Command
         $version = $input->getArgument('version')
             ?? $IOHelper->ask('A version of release', null, function ($version) {
                 if (!$version) {
-                    throw new \RuntimeException('Version of release is required.');
+                    throw ChangelogException::versionRequired();
                 }
 
                 return $version;
             });
         if (!preg_match("/^\d+(\.\d+){3}$/", (string) $version)) {
-            throw new \RuntimeException('Invalid version of release ("' . $version . '"). It should be 4-digits type');
+            throw ChangelogException::invalidReleaseVersion((string) $version);
         }
 
         $force = $input->getOption('force');

--- a/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
@@ -57,21 +57,25 @@ class ChangelogProcessor
         $this->featureFlags = $flags;
     }
 
-    public function findLastestTag(): ?string
+    public function findLastestTag(?string $version = null): ?string
     {
-        $result = shell_exec('gh release list -R shopware/shopware --exclude-drafts --exclude-pre-releases --json tagName,isLatest');
-        if (!$result) {
+        if ($version === null || !preg_match('/^v?(\d+)\.(\d+)\./', $version, $matches)) {
             return null;
         }
 
-        $releases = json_decode($result, true) ?: [];
-        foreach ($releases as $release) {
-            if ($release['isLatest']) {
-                return $release['tagName'];
-            }
-        }
+        // Find the latest release tag on the same major.minor line that is reachable from HEAD.
+        // GitHub's global "isLatest" flag cannot be used here, as it points to the latest release
+        // across all branches (e.g. a 6.7.x tag while releasing 6.6.x), which is not an ancestor
+        // of the current branch and would yield a wrong commit range.
+        $tag = shell_exec(\sprintf(
+            'git -C %s describe --tags --abbrev=0 --match %s @ 2>/dev/null',
+            escapeshellarg($this->platformRoot ?? $this->projectDir),
+            escapeshellarg(\sprintf('v%d.%d.*', (int) $matches[1], (int) $matches[2]))
+        ));
 
-        return null;
+        $tag = $tag ? trim($tag) : '';
+
+        return $tag !== '' ? $tag : null;
     }
 
     /**
@@ -79,32 +83,45 @@ class ChangelogProcessor
      */
     public function getFixCommits(string $fromRef): array
     {
+        $root = $this->platformRoot ?? $this->projectDir;
+
         $cmd = \sprintf(
-            'git -C %s log --no-merges @ %s --pretty=format:%s -i -E --grep=%s',
-            escapeshellarg($this->platformRoot ?? $this->projectDir),
+            'git -C %s log --no-merges @ %s --pretty=format:%s -E --grep=%s',
+            escapeshellarg($root),
             escapeshellarg('^' . $fromRef),
             escapeshellarg('%h'),
-            escapeshellarg(ChangelogParser::FIXES_REGEX)
+            escapeshellarg(ChangelogParser::RELEVANT_COMMIT_REGEX)
         );
 
         $fixes = [];
 
         exec($cmd, $refs);
         foreach ($refs as $ref) {
-            $body = shell_exec('git -C ' . escapeshellarg($this->platformRoot ?? $this->projectDir) . ' log -n1 --pretty=format:%B ' . escapeshellarg($ref));
+            $subject = shell_exec(\sprintf(
+                'git -C %s log -n1 --pretty=format:%s %s',
+                escapeshellarg($root),
+                escapeshellarg('%s'),
+                escapeshellarg($ref)
+            ));
+            $subject = $subject ? trim($subject) : '';
 
-            if ($body && preg_match_all('/' . ChangelogParser::FIXES_REGEX . '/i', $body, $matches)) {
-                $fix = [
-                    'headline' => strtok($body, "\n") ?: '',
-                    'fixes' => $matches[3],
-                ];
-                $author = $this->findAuthor($matches[3][0]);
-                if ($author && !$this->isShopwareOrgMember($author['login'])) {
-                    $fix['author'] = $author;
-                }
-
-                $fixes[] = $fix;
+            if ($subject === '' || !preg_match('/' . ChangelogParser::RELEVANT_COMMIT_REGEX . '/', $subject, $matches)) {
+                continue;
             }
+
+            $pullRequest = '#' . $matches[3];
+
+            $fix = [
+                // Drop the trailing "(#12345)" reference; it is rendered separately as the link target.
+                'headline' => trim((string) preg_replace('/\s*\(#[0-9]+\)\s*$/', '', $subject)),
+                'fixes' => [$pullRequest],
+            ];
+            $author = $this->findAuthor($pullRequest);
+            if ($author && !$this->isShopwareOrgMember($author['login'])) {
+                $fix['author'] = $author;
+            }
+
+            $fixes[] = $fix;
         }
 
         return $fixes;

--- a/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Changelog\Processor;
 
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\ChangelogFile;
 use Shopware\Core\Framework\Changelog\ChangelogFileCollection;
 use Shopware\Core\Framework\Changelog\ChangelogParser;
@@ -170,7 +171,7 @@ class ChangelogProcessor
         [$superVersion, $majorVersion] = explode('.', $version);
 
         if (!is_numeric($superVersion) || !is_numeric($majorVersion)) {
-            throw new \InvalidArgumentException('Unable to generate next version number, supplied version seems invalid (' . $version . ')');
+            throw ChangelogException::invalidVersion($version);
         }
 
         $superVersion = (int) $superVersion;
@@ -210,9 +211,9 @@ class ChangelogProcessor
 
                 $violations = $this->validator->validate($definition);
                 if ($violations->count()) {
-                    $messages = \array_map(static fn (ConstraintViolationInterface $violation) => $violation->getMessage(), \iterator_to_array($violations));
+                    $messages = \array_map(static fn (ConstraintViolationInterface $violation) => (string) $violation->getMessage(), \iterator_to_array($violations));
 
-                    throw new \InvalidArgumentException(\sprintf('Invalid file at path: %s, errors: %s', $file->getRealPath(), \implode(', ', $messages)));
+                    throw ChangelogException::invalidChangelogFile((string) $file->getRealPath(), array_values($messages));
                 }
 
                 $featureFlagDefaultOn = false;

--- a/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
@@ -98,7 +98,7 @@ class ChangelogReleaseCreator extends ChangelogProcessor
             $printedIssues[$changelog->getDefinition()->getIssue()] = $changelog->getDefinition()->getIssue();
         }
 
-        $latestTag = $this->findLastestTag();
+        $latestTag = $this->findLastestTag($version);
         if ($latestTag) {
             foreach ($this->getFixCommits($latestTag) as $issue) {
                 if (isset($printedIssues[$issue['fixes'][0]])) {

--- a/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Changelog\Processor;
 
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\ChangelogFileCollection;
 use Shopware\Core\Framework\Log\Package;
 
@@ -19,7 +20,7 @@ class ChangelogReleaseCreator extends ChangelogProcessor
     public function release(string $version, bool $force = false, bool $dryRun = false): array
     {
         if (!$force && $this->existedRelease($version)) {
-            throw new \InvalidArgumentException('A given version release existed already. Please specify another version or use "-f" to override the existing.');
+            throw ChangelogException::releaseAlreadyExists();
         }
 
         $output = [];

--- a/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
+++ b/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Changelog\Command\ChangelogChangeCommand;
 use Shopware\Core\Framework\Changelog\Command\ChangelogCheckCommand;
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\Command\ChangelogReleaseCommand;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseCreator;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseExporter;
@@ -71,7 +72,7 @@ class ChangelogCommandTest extends TestCase
         return [
             [
                 __DIR__ . '/_fixture/stage/command-invalid',
-                \InvalidArgumentException::class,
+                ChangelogException::class,
                 [
                 ],
             ],
@@ -113,7 +114,7 @@ class ChangelogCommandTest extends TestCase
             'invalid-changelog' => [
                 __DIR__ . '/_fixture/stage/command-invalid',
                 '8.36.22.186',
-                \InvalidArgumentException::class,
+                ChangelogException::class,
                 [
                 ],
             ],

--- a/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
+++ b/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
@@ -4,9 +4,9 @@ namespace Shopware\Tests\Integration\Core\Framework\Changelog;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\Command\ChangelogChangeCommand;
 use Shopware\Core\Framework\Changelog\Command\ChangelogCheckCommand;
-use Shopware\Core\Framework\Changelog\ChangelogException;
 use Shopware\Core\Framework\Changelog\Command\ChangelogReleaseCommand;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseCreator;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseExporter;

--- a/tests/unit/Core/Framework/Changelog/ChangelogParserTest.php
+++ b/tests/unit/Core/Framework/Changelog/ChangelogParserTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Changelog;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Changelog\ChangelogParser;
+
+/**
+ * @internal
+ */
+#[CoversClass(ChangelogParser::class)]
+class ChangelogParserTest extends TestCase
+{
+    #[DataProvider('provideRelevantCommitSubjects')]
+    public function testRelevantCommitRegexMatchesConventionalCommits(string $subject, ?string $expectedPullRequest): void
+    {
+        $matched = preg_match('/' . ChangelogParser::RELEVANT_COMMIT_REGEX . '/', $subject, $matches);
+
+        if ($expectedPullRequest === null) {
+            static::assertSame(0, $matched, \sprintf('Subject should not match: %s', $subject));
+
+            return;
+        }
+
+        static::assertSame(1, $matched, \sprintf('Subject should match: %s', $subject));
+        static::assertSame($expectedPullRequest, $matches[3]);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string|null}>
+     */
+    public static function provideRelevantCommitSubjects(): iterable
+    {
+        yield 'feat with pull request' => ['feat: add a new thing (#123)', '123'];
+        yield 'fix with pull request' => ['fix: correct a thing (#456)', '456'];
+        yield 'fix with scope' => ['fix(link-category): implement redirect behaviour (#18154)', '18154'];
+        yield 'fix with breaking change marker' => ['fix(scope)!: drop a thing (#789)', '789'];
+        yield 'feat with breaking change marker' => ['feat!: change a thing (#321)', '321'];
+        yield 'backport keeps the merged pull request number' => ['fix: zugferd deliveries (backport #18095) (#18152)', '18152'];
+        yield 'backport with colon keeps the merged pull request number' => ['fix: enforce order (backport: 6.6.x) (#18191)', '18191'];
+
+        yield 'other conventional type is ignored' => ['chore: bump dependency (#333)', null];
+        yield 'ci type is ignored' => ['ci: post slack message on release (#18112)', null];
+        yield 'docs type is ignored' => ['docs: update readme (#444)', null];
+        yield 'fix without a pull request reference' => ['fix: correct a thing', null];
+        yield 'non conventional subject' => ['NEXT-12345 - fix something (#555)', null];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`bin/console changelog:release` did not fully work for `6.6.x` releases (see #15432). Moving the changelog files works, but the command has a second job: collecting merged pull requests that have **no** changelog file and appending them to `CHANGELOG.md`. On `6.6.x` this part silently produced nothing, so those PRs had to be found and added by hand. Two separate bugs caused it.

### 2. What does this change do, exactly?

Fixes both root causes and adds test coverage:

- **`findLastestTag()` is now branch-aware.** It previously relied on GitHub's global "latest release" flag (`gh release list … isLatest`), which points to the newest release across *all* branches — e.g. a `6.7.x` tag while releasing `6.6.x`. That tag is not an ancestor of the `6.6.x` branch, so the resulting commit range was wrong/empty. It now derives the previous release on the same `major.minor` line, reachable from `HEAD`, via `git describe --tags --abbrev=0 --match 'v6.6.*' @`, and takes the target version as an argument.
- **Relevant-commit detection updated to conventional commits.** The old `FIXES_REGEX` targeted the legacy commit scheme (`closes/fixes #NNN`, `NEXT-xxxxx`) and matched **none** of today's `feat:`/`fix:` commits. A dedicated `RELEVANT_COMMIT_REGEX` now matches conventional `feat`/`fix` subjects (including scopes and `!` breaking markers) and extracts the trailing pull-request number, correctly picking the merged PR from `… (backport #123) (#456)`. `FIXES_REGEX` is left untouched, as it is still used by the changelog-file parser.
- **Test:** adds a unit test (`tests/unit/Core/Framework/Changelog/ChangelogParserTest.php`) pinning the regex behaviour across scopes, breaking markers, backports, missing PR references, and non-relevant types (`chore`/`ci`/`docs`).

### 3. Describe each step to reproduce the issue or behaviour.

1. Check out `6.6.x` with merged `feat:`/`fix:` PRs since the last release that have no changelog file.
2. Run `php bin/console changelog:release 6.6.10.xx --dry-run`.
3. **Before:** the generated `CHANGELOG.md` section contains only entries from changelog files; the un-changelogged PRs are missing.
4. **After:** those PRs are appended as `*  [#<pr> - <subject>](https://github.com/shopware/shopware/issues/<pr>)`.

### 4. Please link to the relevant issues (if any).

- closes #15432

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes — *N/A: internal release tooling, no customer-facing change*
- [ ] I have written or adjusted the documentation according to my changes — *N/A*
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
