### PR TITLE
fix(administration): stop all Vite development processes

### DIFF
--- a/src/Administration/Resources/app/administration/build.ts
+++ b/src/Administration/Resources/app/administration/build.ts
@@ -4,7 +4,7 @@
 
 import { spawn } from 'child_process';
 import { build } from 'vite';
-import concurrently from 'concurrently';
+import { startDevelopmentProcesses } from './build/vite-plugins/development-process-runner';
 import { exportViteServerMapping } from './build/vite-plugins/utils';
 
 async function runPluginsBuild(): Promise<void> {
@@ -54,27 +54,40 @@ async function main() {
             process.exit(1);
         }
     } else if (mode === 'development') {
+        const wasStdinRaw = process.stdin.isTTY && process.stdin.isRaw;
+        const restoreTerminal = () => {
+            if (process.stdin.isTTY) {
+                process.stdin.setRawMode(wasStdinRaw);
+            }
+        };
+
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+            // eslint-disable-next-line listeners/no-inline-function-event-listener,listeners/no-missing-remove-event-listener
+            process.stdin.on('data', (key: Buffer | string) => {
+                if (key.toString() === '\u0003') {
+                    restoreTerminal();
+                    process.kill(process.pid, 'SIGINT');
+                }
+            });
+        }
+
         // Run both processes concurrently in development mode
-        const { result } = concurrently([
-            {
-                command: 'ts-node -T build/plugins.vite.ts',
-                name: 'Extensions',
-                prefixColor: 'yellow',
-            },
-            {
-                command: 'vite',
-                name: 'Administration',
-                prefixColor: 'blue',
-            },
-        ]);
+        const { result } = startDevelopmentProcesses();
 
         result.then(
-            () => process.exit(0),
+            () => {
+                restoreTerminal();
+                process.exit(0);
+            },
             (error) => {
+                restoreTerminal();
                 console.error('Development process failed:', error);
                 process.exit(1);
             },
         );
+
+        process.once('exit', restoreTerminal);
     } else {
         console.error('Invalid VITE_MODE. Must be either "production" or "development"');
         process.exit(1);

--- a/src/Administration/Resources/app/administration/build.ts
+++ b/src/Administration/Resources/app/administration/build.ts
@@ -65,7 +65,7 @@ async function main() {
             process.stdin.setRawMode(true);
             // eslint-disable-next-line listeners/no-inline-function-event-listener,listeners/no-missing-remove-event-listener
             process.stdin.on('data', (key: Buffer | string) => {
-                if (key.toString() === '\u0003') {
+                if (key.toString().includes('\u0003')) {
                     restoreTerminal();
                     process.kill(process.pid, 'SIGINT');
                 }

--- a/src/Administration/Resources/app/administration/build/vite-plugins/development-process-runner.spec.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/development-process-runner.spec.ts
@@ -1,0 +1,34 @@
+import concurrently from 'concurrently';
+import { startDevelopmentProcesses } from './development-process-runner';
+
+jest.mock('concurrently', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        commands: [],
+        result: Promise.resolve([]),
+    })),
+}));
+
+describe('development-process-runner', () => {
+    it('lets the wrapper manage signals without forwarding stdin', () => {
+        startDevelopmentProcesses();
+
+        expect(concurrently).toHaveBeenCalledWith(
+            [
+                {
+                    command: 'ts-node -T build/plugins.vite.ts',
+                    name: 'Extensions',
+                    prefixColor: 'yellow',
+                },
+                {
+                    command: 'vite',
+                    name: 'Administration',
+                    prefixColor: 'blue',
+                },
+            ],
+            {
+                killOthers: ['failure'],
+            },
+        );
+    });
+});

--- a/src/Administration/Resources/app/administration/build/vite-plugins/development-process-runner.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/development-process-runner.ts
@@ -1,0 +1,29 @@
+/**
+ * @sw-package framework
+ */
+
+import concurrently from 'concurrently';
+
+/**
+ * @private
+ */
+export function startDevelopmentProcesses() {
+    return concurrently(
+        [
+            {
+                command: 'ts-node -T build/plugins.vite.ts',
+                name: 'Extensions',
+                prefixColor: 'yellow',
+            },
+            {
+                command: 'vite',
+                name: 'Administration',
+                prefixColor: 'blue',
+            },
+        ],
+        {
+            // concurrently forwards process signals to the complete child process trees.
+            killOthers: ['failure'],
+        },
+    );
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration watcher starts the main Vite server and an extension runner that can host multiple Vite servers in one Node process. When the watcher is executed through the project command wrapper, Ctrl+C needs to be handled by the Node orchestration layer so that all development processes stop together and the terminal state is restored.

<img width="595" height="60" alt="Screendrop_2026-07-16-08-49-25" src="https://github.com/user-attachments/assets/5efaa6df-d932-4967-8032-91a82678dd2a" />



### 2. What does this change do, exactly?

The Administration build wrapper now captures Ctrl+C without forwarding stdin to either child command and emits `SIGINT` for `concurrently` to propagate to the complete child process trees. It restores the previous terminal raw mode during shutdown and stops the remaining watcher if one development process fails.

The process configuration is extracted into a private helper with Jest coverage. The change was additionally verified with the real `bin/exec-with-env npm run dev` command, `composer eslint:admin`, and `composer format:admin`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable multiple extensions with Administration entry points.
2. Run `composer watch:admin`.
3. Wait until the Administration and extension Vite servers are running.
4. Press Ctrl+C.
5. Observe that the wrapper now stops both child process trees, exits successfully, and leaves no Vite processes or listening development ports behind.

### 4. Please link to the relevant issues (if any).

No linked issue.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
