### PR TITLE
fix(checkout): restore set promotion rules from orders

### DIFF
--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -224,10 +224,12 @@
 
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetGroupScopeDiscountPackager">
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetScopeDiscountPackager">
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\RuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Promotion\Cart\CartPromotionsSubscriber">

--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetGroupScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetGroupScopeDiscountPackager.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager;
 
+use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupDefinition;
@@ -23,8 +24,10 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
     /**
      * @internal
      */
-    public function __construct(private readonly LineItemGroupBuilder $groupBuilder)
-    {
+    public function __construct(
+        private readonly LineItemGroupBuilder $groupBuilder,
+        private readonly AbstractRuleLoader $ruleLoader,
+    ) {
     }
 
     public function getDecorated(): DiscountPackager
@@ -43,7 +46,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
         /** @var array<mixed> $groups */
         $groups = $discount->getPayloadValue('setGroups');
 
-        $groupDefinitions = $this->buildGroupDefinitionList($groups);
+        $groupDefinitions = $this->buildGroupDefinitionList($groups, $context);
 
         $resultGroups = $this->groupBuilder->findGroupPackages($groupDefinitions, $cart, $context);
 
@@ -56,7 +59,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
         /** @var string $groupId */
         $groupId = $discount->getPayloadValue('groupId');
 
-        $definition = $this->getGroupDefinition($groupId, $groups);
+        $definition = $this->getGroupDefinition($groupId, $groups, $context);
 
         $result = $resultGroups->getResult($definition->getId());
 
@@ -88,7 +91,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
      *
      * @param array<mixed> $groups
      */
-    private function getGroupDefinition(string $groupId, array $groups): LineItemGroupDefinition
+    private function getGroupDefinition(string $groupId, array $groups, SalesChannelContext $context): LineItemGroupDefinition
     {
         $index = 1;
 
@@ -99,7 +102,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
                     $group['packagerKey'],
                     $group['value'],
                     $group['sorterKey'],
-                    $this->getRules($group['rules'] ?? null)
+                    $this->getRules($group['rules'] ?? null, $group['groupId'], $context)
                 );
             }
 
@@ -134,7 +137,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
      *
      * @return LineItemGroupDefinition[]
      */
-    private function buildGroupDefinitionList(array $groups): array
+    private function buildGroupDefinitionList(array $groups, SalesChannelContext $context): array
     {
         $definitions = [];
         foreach ($groups as $group) {
@@ -143,7 +146,7 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
                 $group['packagerKey'],
                 $group['value'],
                 $group['sorterKey'],
-                $this->getRules($group['rules'] ?? null)
+                $this->getRules($group['rules'] ?? null, $group['groupId'], $context)
             );
         }
 
@@ -153,13 +156,24 @@ class SetGroupScopeDiscountPackager extends DiscountPackager
     /**
      * @param RuleCollection|array<mixed>|null $rules
      */
-    private function getRules(RuleCollection|array|null $rules): RuleCollection
+    private function getRules(RuleCollection|array|null $rules, string $groupId, SalesChannelContext $context): RuleCollection
     {
         $rules ??= new RuleCollection();
-        if (!\is_array($rules)) {
-            return $rules;
+        if (!$rules instanceof RuleCollection) {
+            $loadedRules = $this->ruleLoader->load($context->getContext());
+            $resolvedRules = new RuleCollection();
+
+            foreach ($rules as $rule) {
+                if (!\is_array($rule) || !\is_string($rule['id'] ?? null) || ($loadedRule = $loadedRules->get($rule['id'])) === null) {
+                    throw PromotionException::promotionSetGroupNotFound($groupId);
+                }
+
+                $resolvedRules->add($loadedRule);
+            }
+
+            return $resolvedRules;
         }
 
-        return (new RuleCollection())->assignRecursive($rules);
+        return $rules;
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackager.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager;
 
+use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
@@ -12,6 +13,8 @@ use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackage;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackageCollection;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackager;
+use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -22,8 +25,10 @@ class SetScopeDiscountPackager extends DiscountPackager
     /**
      * @internal
      */
-    public function __construct(private readonly LineItemGroupBuilder $groupBuilder)
-    {
+    public function __construct(
+        private readonly LineItemGroupBuilder $groupBuilder,
+        private readonly AbstractRuleLoader $ruleLoader,
+    ) {
     }
 
     public function getDecorated(): DiscountPackager
@@ -45,7 +50,7 @@ class SetScopeDiscountPackager extends DiscountPackager
         /** @var array<string, mixed> $groups */
         $groups = $discount->getPayloadValue('setGroups');
 
-        $definitions = $this->buildGroupDefinitionList($groups);
+        $definitions = $this->buildGroupDefinitionList($groups, $context);
 
         $result = $this->groupBuilder->findGroupPackages($definitions, $cart, $context);
 
@@ -94,7 +99,7 @@ class SetScopeDiscountPackager extends DiscountPackager
      *
      * @return LineItemGroupDefinition[]
      */
-    private function buildGroupDefinitionList(array $groups): array
+    private function buildGroupDefinitionList(array $groups, SalesChannelContext $context): array
     {
         $definitions = [];
         foreach ($groups as $group) {
@@ -103,11 +108,35 @@ class SetScopeDiscountPackager extends DiscountPackager
                 $group['packagerKey'],
                 $group['value'],
                 $group['sorterKey'],
-                $group['rules']
+                $this->getRules($group['rules'] ?? null, $group['groupId'], $context)
             );
         }
 
         return $definitions;
+    }
+
+    /**
+     * @param RuleCollection|array<mixed>|null $rules
+     */
+    private function getRules(RuleCollection|array|null $rules, string $groupId, SalesChannelContext $context): RuleCollection
+    {
+        $rules ??= new RuleCollection();
+        if (!$rules instanceof RuleCollection) {
+            $loadedRules = $this->ruleLoader->load($context->getContext());
+            $resolvedRules = new RuleCollection();
+
+            foreach ($rules as $rule) {
+                if (!\is_array($rule) || !\is_string($rule['id'] ?? null) || ($loadedRule = $loadedRules->get($rule['id'])) === null) {
+                    throw PromotionException::promotionSetGroupNotFound($groupId);
+                }
+
+                $resolvedRules->add($loadedRule);
+            }
+
+            return $resolvedRules;
+        }
+
+        return $rules;
     }
 
     /**

--- a/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetGroupScopeDiscountPackagerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetGroupScopeDiscountPackagerTest.php
@@ -4,17 +4,20 @@ namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart\Discount\ScopePackage
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilderResult;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
+use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetGroupScopeDiscountPackager;
 use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
 
 /**
  * @internal
@@ -23,12 +26,20 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 class SetGroupScopeDiscountPackagerTest extends TestCase
 {
-    public function testFormatRuleCollection(): void
+    public function testResolvePersistedRuleCollection(): void
     {
+        $rule = new RuleEntity();
+        $rule->setId(Uuid::randomHex());
+        $rule->setName('Rule Name');
+        $rule->setPayload(new AlwaysValidRule());
+
+        $ruleLoader = static::createStub(AbstractRuleLoader::class);
+        $ruleLoader->method('load')->willReturn(new RuleCollection([$rule]));
+
         $builder = static::createStub(LineItemGroupBuilder::class);
         $builder
             ->method('findGroupPackages')
-            ->willReturnCallback(static function (array $groupDefinitions) {
+            ->willReturnCallback(static function (array $groupDefinitions) use ($rule) {
                 static::assertCount(4, $groupDefinitions);
                 static::assertInstanceOf(LineItemGroupDefinition::class, $groupDefinitions[0]);
                 static::assertInstanceOf(LineItemGroupDefinition::class, $groupDefinitions[1]);
@@ -41,7 +52,9 @@ class SetGroupScopeDiscountPackagerTest extends TestCase
                 $unset = $groupDefinitions[3]->getRules();
 
                 static::assertCount(1, $array);
-                static::assertSame('Rule Name', $array->first()?->getName());
+                static::assertSame($rule, $array->first());
+                static::assertSame('Rule Name', $array->first()->getName());
+                static::assertInstanceOf(AlwaysValidRule::class, $array->first()->getPayload());
                 static::assertCount(0, $collection);
                 static::assertCount(0, $null);
                 static::assertCount(0, $unset);
@@ -58,7 +71,7 @@ class SetGroupScopeDiscountPackagerTest extends TestCase
                     'packagerKey' => 'key',
                     'value' => 10,
                     'sorterKey' => 'ASC',
-                    'rules' => [['id' => Uuid::randomHex(), 'name' => 'Rule Name']],
+                    'rules' => [['id' => $rule->getId(), 'name' => 'Rule Name']],
                 ],
                 [
                     'groupId' => Uuid::randomHex(),
@@ -83,10 +96,10 @@ class SetGroupScopeDiscountPackagerTest extends TestCase
             ],
         ];
 
-        (new SetGroupScopeDiscountPackager($builder))->getMatchingItems(
+        (new SetGroupScopeDiscountPackager($builder, $ruleLoader))->getMatchingItems(
             new DiscountLineItem('label', new AbsolutePriceDefinition(10), $payload, null),
             new Cart('token'),
-            static::createStub(SalesChannelContext::class)
+            Generator::generateSalesChannelContext(),
         );
     }
 }

--- a/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackagerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackagerTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart\Discount\ScopePackager;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\AbstractRuleLoader;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilderResult;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupDefinition;
+use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
+use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
+use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
+use Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetScopeDiscountPackager;
+use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Content\Rule\RuleEntity;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Generator;
+
+/**
+ * @internal
+ */
+#[CoversClass(SetScopeDiscountPackager::class)]
+#[Package('checkout')]
+class SetScopeDiscountPackagerTest extends TestCase
+{
+    public function testResolvesRulesFromPersistedPayload(): void
+    {
+        $rule = new RuleEntity();
+        $rule->setId(Uuid::randomHex());
+        $rule->setPayload(new AlwaysValidRule());
+        $rules = new RuleCollection([$rule]);
+
+        $ruleLoader = static::createStub(AbstractRuleLoader::class);
+        $ruleLoader->method('load')->willReturn($rules);
+
+        $groupBuilder = static::createStub(LineItemGroupBuilder::class);
+        $groupBuilder->method('findGroupPackages')->willReturnCallback(static function (array $definitions) use ($rule): LineItemGroupBuilderResult {
+            static::assertCount(1, $definitions);
+            static::assertInstanceOf(LineItemGroupDefinition::class, $definitions[0]);
+            static::assertSame($rule, $definitions[0]->getRules()->first());
+            static::assertInstanceOf(AlwaysValidRule::class, $definitions[0]->getRules()->first()->getPayload());
+
+            return new LineItemGroupBuilderResult();
+        });
+
+        $serializedRules = json_decode(json_encode($rules, \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+
+        (new SetScopeDiscountPackager($groupBuilder, $ruleLoader))->getMatchingItems(
+            $this->createDiscount([['rules' => $serializedRules]]),
+            new Cart('token'),
+            Generator::generateSalesChannelContext(),
+        );
+    }
+
+    public function testKeepsRulesFromLiveCart(): void
+    {
+        $rules = new RuleCollection();
+
+        $ruleLoader = static::createMock(AbstractRuleLoader::class);
+        $ruleLoader->expects($this->never())->method('load');
+
+        $groupBuilder = static::createStub(LineItemGroupBuilder::class);
+        $groupBuilder->method('findGroupPackages')->willReturnCallback(static function (array $definitions) use ($rules): LineItemGroupBuilderResult {
+            static::assertInstanceOf(LineItemGroupDefinition::class, $definitions[0]);
+            static::assertSame($rules, $definitions[0]->getRules());
+
+            return new LineItemGroupBuilderResult();
+        });
+
+        (new SetScopeDiscountPackager($groupBuilder, $ruleLoader))->getMatchingItems(
+            $this->createDiscount([['rules' => $rules]]),
+            new Cart('token'),
+            Generator::generateSalesChannelContext(),
+        );
+    }
+
+    public function testFailsClosedWhenPersistedRuleCannotBeLoaded(): void
+    {
+        $groupId = Uuid::randomHex();
+
+        $ruleLoader = static::createStub(AbstractRuleLoader::class);
+        $ruleLoader->method('load')->willReturn(new RuleCollection());
+
+        static::expectExceptionObject(PromotionException::promotionSetGroupNotFound($groupId));
+
+        (new SetScopeDiscountPackager(static::createStub(LineItemGroupBuilder::class), $ruleLoader))->getMatchingItems(
+            $this->createDiscount([[
+                'groupId' => $groupId,
+                'rules' => [['id' => Uuid::randomHex()]],
+            ]]),
+            new Cart('token'),
+            Generator::generateSalesChannelContext(),
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $groups
+     */
+    private function createDiscount(array $groups): DiscountLineItem
+    {
+        $groups = array_map(static fn (array $group): array => $group + [
+            'groupId' => Uuid::randomHex(),
+            'packagerKey' => 'COUNT',
+            'value' => 1,
+            'sorterKey' => 'PRICE_ASC',
+        ], $groups);
+
+        return new DiscountLineItem(
+            'discount',
+            new AbsolutePriceDefinition(10),
+            [
+                'discountScope' => 'set',
+                'discountType' => 'absolute',
+                'setGroups' => $groups,
+            ],
+            null,
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Set-scope promotion line items store a `RuleCollection` in their payload. When an order is persisted, the JSON-backed order line-item payload serializes that collection into arrays. Restoring or recalculating the order then passes an array to `LineItemGroupDefinition`, which requires a `RuleCollection`, and crashes with a `TypeError`.

The existing set-group fallback converted arrays into entity shells, but did not restore executable rule payloads. This could prevent the restored promotion from matching its products correctly.

### 2. What does this change do, exactly?

The set and set-group scope packagers now resolve persisted rule IDs through the existing cached cart rule loader. Live-cart `RuleCollection` instances remain unchanged, while persisted arrays are restored as fully hydrated rule entities.

If a persisted rule cannot be resolved, calculation fails closed instead of treating the group as unrestricted. The service definitions inject the rule loader into both packagers, and regression tests cover JSON-restored rules, live-cart rules, and missing rules.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an active promotion with a product set and a rule restricting the products.
2. Add a discount with scope `set`, for example a “Buy 4 Get 1 Free” promotion.
3. Place an order containing enough matching products for the promotion.
4. Restore the sales-channel context from that order, edit/recalculate the order, or otherwise convert and process the order cart.
5. Without this change, promotion processing throws a `TypeError` because the persisted rules are arrays.
6. With this change, the rules are rehydrated and the promotion is processed normally.

### 4. Please link to the relevant issues (if any).

- closes #18366

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them