### PR TITLE
fix: optimise breadcrumb visibility filters and loading by referrer

### DIFF
--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -51,7 +51,7 @@ class CategoryBreadcrumbBuilder
     public function getProductBreadcrumbUrls(string $productId, string $referrerCategoryId, SalesChannelContext $salesChannelContext): BreadcrumbCollection
     {
         $product = $this->loadProduct($productId, $salesChannelContext);
-        $category = $this->getCategoryForProduct($referrerCategoryId, $product, $salesChannelContext);
+        $category = $this->getProductCategoryByReferrer($referrerCategoryId, $product, $salesChannelContext);
         if ($category === null) {
             throw BreadcrumbException::categoryNotFoundForProduct($productId);
         }
@@ -68,16 +68,10 @@ class CategoryBreadcrumbBuilder
         $criteria = new Criteria([$categoryId]);
         $criteria->setTitle('breadcrumb::category::data');
 
-        $category = $this->categoryRepository
+        return $this->categoryRepository
             ->search($criteria, $context)
             ->getEntities()
             ->get($categoryId);
-
-        if (!$category instanceof CategoryEntity) {
-            return null;
-        }
-
-        return $category;
     }
 
     public function getProductSeoCategory(ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
@@ -97,8 +91,7 @@ class CategoryBreadcrumbBuilder
         $criteria = new Criteria();
         $criteria->setTitle('breadcrumb-builder');
         $criteria->setLimit(1);
-        $criteria->addFilter(new EqualsFilter('active', true));
-        $criteria->addFilter(new EqualsFilter('visible', true));
+        $criteria->addFilter($this->getCategoryVisibleForCustomerFilter($context));
 
         if ($categoryIds !== []) {
             $criteria->setIds($categoryIds);
@@ -107,10 +100,25 @@ class CategoryBreadcrumbBuilder
             $criteria->addFilter(new EqualsFilter('productAssignmentType', CategoryDefinition::PRODUCT_ASSIGNMENT_TYPE_PRODUCT_STREAM));
         }
 
-        $criteria->addFilter($this->getSalesChannelFilter($context->getSalesChannel()));
         $criteria->addSorting(new FieldSorting('level', FieldSorting::DESCENDING));
 
         return $this->categoryRepository->search($criteria, $context->getContext())->getEntities()->first();
+    }
+
+    public function getProductCategoryByReferrer(
+        string $referrerCategoryId,
+        SalesChannelProductEntity $product,
+        SalesChannelContext $salesChannelContext
+    ): ?CategoryEntity {
+        if (\in_array($referrerCategoryId, $product->getCategoryTree() ?? [], true)) {
+            $referrerCategory = $this->loadCategory($referrerCategoryId, $salesChannelContext->getContext());
+
+            if ($referrerCategory instanceof CategoryEntity && $this->isCategoryVisibleForCustomer($referrerCategory, $salesChannelContext)) {
+                return $referrerCategory;
+            }
+        }
+
+        return $this->getProductSeoCategory($product, $salesChannelContext);
     }
 
     public function getCategoryBreadcrumbUrls(CategoryEntity $category, Context $context, SalesChannelEntity $salesChannel): BreadcrumbCollection
@@ -186,19 +194,6 @@ class CategoryBreadcrumbBuilder
         return $product;
     }
 
-    private function getCategoryForProduct(
-        string $referrerCategoryId,
-        SalesChannelProductEntity $product,
-        SalesChannelContext $salesChannelContext
-    ): ?CategoryEntity {
-        $categoryIds = $product->getCategoryIds();
-        if ($categoryIds !== null && \in_array($referrerCategoryId, $categoryIds, true)) {
-            return $this->loadCategory($referrerCategoryId, $salesChannelContext->getContext());
-        }
-
-        return $this->getProductSeoCategory($product, $salesChannelContext);
-    }
-
     private function getMainCategory(ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
     {
         if ($mainCategory = $this->getMainCategoryFromProduct($product, $context)) {
@@ -218,10 +213,8 @@ class CategoryBreadcrumbBuilder
             ->setLimit(1)
             ->addFilter(new AndFilter([
                 new EqualsFilter('salesChannelId', $context->getSalesChannelId()),
-                new EqualsFilter('category.active', true),
-                new EqualsFilter('category.visible', true),
                 new EqualsAnyFilter('category.id', $categoryIds),
-                $this->getSalesChannelFilter($context->getSalesChannel(), 'category.path'),
+                $this->getCategoryVisibleForCustomerFilter($context, 'category.'),
             ]));
 
         $product = $context->getContext()->enableInheritance(fn (): ?ProductEntity => $this->productRepository->search($criteria, $context)->getEntities()->first());
@@ -240,34 +233,16 @@ class CategoryBreadcrumbBuilder
         }
 
         $category = $product->getMainCategories()->filterBySalesChannelId($context->getSalesChannelId())->first()?->getCategory();
-        $salesChannel = $context->getSalesChannel();
 
         if (
             !$category instanceof CategoryEntity
-            || !$category->getActive()
-            || !$category->getVisible()
             || !\in_array($category->getId(), $product->getCategoryIds() ?? [], true)
-            || array_intersect(\array_slice(explode('|', $category->getPath() ?? ''), 1, -1), array_filter([
-                $salesChannel->getNavigationCategoryId(),
-                $salesChannel->getServiceCategoryId(),
-                $salesChannel->getFooterCategoryId(),
-            ])) === []
+            || !$this->isCategoryVisibleForCustomer($category, $context)
         ) {
             return null;
         }
 
         return $category;
-    }
-
-    private function getSalesChannelFilter(SalesChannelEntity $salesChannel, string $field = 'path'): MultiFilter
-    {
-        $ids = array_filter([
-            $salesChannel->getNavigationCategoryId(),
-            $salesChannel->getServiceCategoryId(),
-            $salesChannel->getFooterCategoryId(),
-        ]);
-
-        return new OrFilter(array_map(static fn (string $id) => new ContainsFilter($field, '|' . $id . '|'), $ids));
     }
 
     /**
@@ -361,5 +336,44 @@ class CategoryBreadcrumbBuilder
         return array_filter($seoUrls, static function (array $seoUrl) use ($categoryId): bool {
             return $seoUrl['categoryId'] === $categoryId;
         });
+    }
+
+    private function isCategoryVisibleForCustomer(CategoryEntity $category, SalesChannelContext $context): bool
+    {
+        $salesChannel = $context->getSalesChannel();
+
+        if (!$category->getActive() || !$category->getVisible()) {
+            return false;
+        }
+
+        if (array_intersect(\array_slice(explode('|', $category->getPath() ?? ''), 1, -1), array_filter([
+            $salesChannel->getNavigationCategoryId(),
+            $salesChannel->getServiceCategoryId(),
+            $salesChannel->getFooterCategoryId(),
+        ])) === []) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getSalesChannelFilter(SalesChannelEntity $salesChannel, string $fieldPath = ''): MultiFilter
+    {
+        return new OrFilter(array_map(static fn (string $id) => new ContainsFilter($fieldPath . 'path', '|' . $id . '|'), array_filter([
+            $salesChannel->getNavigationCategoryId(),
+            $salesChannel->getServiceCategoryId(),
+            $salesChannel->getFooterCategoryId(),
+        ])));
+    }
+
+    private function getCategoryVisibleForCustomerFilter(SalesChannelContext $context, string $fieldPath = ''): AndFilter
+    {
+        $salesChannel = $context->getSalesChannel();
+
+        return new AndFilter([
+            new EqualsFilter($fieldPath . 'active', true),
+            new EqualsFilter($fieldPath . 'visible', true),
+            $this->getSalesChannelFilter($salesChannel, $fieldPath),
+        ]);
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -12,7 +12,6 @@ use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
 use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
-use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\Detail\Event\ResolveVariantIdEvent;
@@ -388,14 +387,14 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         return $criteria;
     }
 
-    private function getBreadcrumbCategory(Request $request, ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
+    private function getBreadcrumbCategory(Request $request, SalesChannelProductEntity $product, SalesChannelContext $context): ?CategoryEntity
     {
         if (Feature::isActive('BREADCRUMB_REWORK') || Feature::isActive('v6.8.0.0')) {
             if ($this->config->getBool('core.listing.buildBreadcrumbByReferrerCategory', $context->getSalesChannelId())) {
                 $referrerCategoryId = $request->query->get('referrerCategoryId');
 
-                if ($referrerCategoryId !== null && \in_array($referrerCategoryId, $product->getCategoryIds() ?? [], true)) {
-                    return $this->breadcrumbBuilder->loadCategory($referrerCategoryId, $context->getContext());
+                if ($referrerCategoryId !== null) {
+                    return $this->breadcrumbBuilder->getProductCategoryByReferrer($referrerCategoryId, $product, $context);
                 }
             }
         }

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
@@ -178,20 +179,26 @@ class CategoryBreadcrumbBuilderTest extends TestCase
                 static::assertNotNull($levelSorting);
                 static::assertSame(FieldSorting::DESCENDING, $levelSorting->getDirection());
 
-                static::assertTrue($criteria->hasEqualsFilter('visible'));
+                static::assertContains('visible', $criteria->getFilterFields());
+                static::assertContains('active', $criteria->getFilterFields());
+
+                $visibleActiveAndFilter = array_values(array_filter(
+                    $criteria->getFilters(),
+                    static fn (Filter $filter) => $filter instanceof AndFilter && \array_intersect(['visible', 'active'], $filter->getFields()) === ['visible', 'active']
+                ))[0] ?? null;
+
+                static::assertInstanceOf(AndFilter::class, $visibleActiveAndFilter);
 
                 $visibleFilter = array_values(array_filter(
-                    $criteria->getFilters(),
+                    $visibleActiveAndFilter->getQueries(),
                     static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'visible'
                 ))[0] ?? null;
 
                 static::assertInstanceOf(EqualsFilter::class, $visibleFilter);
                 static::assertTrue($visibleFilter->getValue());
 
-                static::assertTrue($criteria->hasEqualsFilter('active'));
-
                 $activeFilter = array_values(array_filter(
-                    $criteria->getFilters(),
+                    $visibleActiveAndFilter->getQueries(),
                     static fn (Filter $filter) => $filter instanceof EqualsFilter && $filter->getField() === 'active'
                 ))[0] ?? null;
 

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -600,8 +600,8 @@ class ProductDetailRouteTest extends TestCase
         SalesChannelProductEntity $product,
         bool $buildBreadcrumbByReferrerCategory,
         ?string $referrerCategoryId,
+        InvokedCount $getProductCategoryByReferrerCount,
         InvokedCount $getProductSeoCategoryCount,
-        InvokedCount $loadCategoryCount,
         ?CategoryEntity $breadcrumbCategory
     ): void {
         $productRepository = $this->createMock(SalesChannelRepository::class);
@@ -619,11 +619,11 @@ class ProductDetailRouteTest extends TestCase
             );
         $this->systemConfig->method('getBool')->willReturn($buildBreadcrumbByReferrerCategory);
         $breadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $breadcrumbBuilder->expects($getProductCategoryByReferrerCount)
+            ->method('getProductCategoryByReferrer')
+            ->willReturn($breadcrumbCategory);
         $breadcrumbBuilder->expects($getProductSeoCategoryCount)
             ->method('getProductSeoCategory')
-            ->willReturn($breadcrumbCategory);
-        $breadcrumbBuilder->expects($loadCategoryCount)
-            ->method('loadCategory')
             ->willReturn($breadcrumbCategory);
 
         $request = new Request();
@@ -641,6 +641,8 @@ class ProductDetailRouteTest extends TestCase
     {
         $defaultBreadcrumbCategory = new CategoryEntity();
         $defaultBreadcrumbCategory->setId(Uuid::randomHex());
+        $parentCategory = new CategoryEntity();
+        $parentCategory->setId(Uuid::randomHex());
         $secondCategory = new CategoryEntity();
         $secondCategory->setId(Uuid::randomHex());
         $thirdCategory = new CategoryEntity();
@@ -657,8 +659,8 @@ class ProductDetailRouteTest extends TestCase
             $product,
             false,
             null,
-            new InvokedCount(1),
             new InvokedCount(0),
+            new InvokedCount(1),
             $defaultBreadcrumbCategory,
         ];
 
@@ -666,8 +668,8 @@ class ProductDetailRouteTest extends TestCase
             $productWithoutCategories,
             false,
             null,
-            new InvokedCount(1),
             new InvokedCount(0),
+            new InvokedCount(1),
             null,
         ];
 
@@ -675,8 +677,8 @@ class ProductDetailRouteTest extends TestCase
             $product,
             true,
             null,
-            new InvokedCount(1),
             new InvokedCount(0),
+            new InvokedCount(1),
             $defaultBreadcrumbCategory,
         ];
 
@@ -684,9 +686,18 @@ class ProductDetailRouteTest extends TestCase
             $product,
             true,
             $secondCategory->getId(),
-            new InvokedCount(0),
             new InvokedCount(1),
+            new InvokedCount(0),
             $secondCategory,
+        ];
+
+        yield 'Load breadcrumb category by referrerCategoryId with enabled referrer feature and referrerCategoryId being a parent of a category assigned to the product' => [
+            $product,
+            true,
+            $parentCategory->getId(),
+            new InvokedCount(1),
+            new InvokedCount(0),
+            $parentCategory,
         ];
 
         yield 'Load default breadcrumb category with enabled referrer feature and unassigned referrerCategoryId' => [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- Unify visibility filters for breadcrumb categories
- Load parent referrer category as breadcrumb if leaf category is associated to product only

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
