### PR TITLE
fix(checkout): correct German translation of password-changed mail template

### DIFF
--- a/src/Core/Migration/V6_7/Migration1763377570CreatePasswordChangeMailTemplate.php
+++ b/src/Core/Migration/V6_7/Migration1763377570CreatePasswordChangeMailTemplate.php
@@ -97,7 +97,7 @@ class Migration1763377570CreatePasswordChangeMailTemplate extends MigrationStep
                 [
                     'mail_template_type_id' => $templateTypeId,
                     'language_id' => $germanLanguageId,
-                    'name' => 'Kunden-Password geändert',
+                    'name' => 'Kunden-Passwort geändert',
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 ]
             );
@@ -164,7 +164,7 @@ class Migration1763377570CreatePasswordChangeMailTemplate extends MigrationStep
             $connection->insert(
                 'mail_template_translation',
                 [
-                    'subject' => 'Kunden-Password geändert',
+                    'subject' => 'Kunden-Passwort geändert',
                     'sender_name' => '{{ salesChannel.name }}',
                     'content_html' => '',
                     'content_plain' => '',

--- a/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
+++ b/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
@@ -17,7 +17,7 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
 
     private const CORRECT_GERMAN_NAME = 'Kunden-Passwort geändert';
 
-    private const GERMAN_LANGUAGE_ISO = 'de-DE';
+    private const GERMAN_LOCALE_PREFIX = 'de-%';
 
     public function getCreationTimestamp(): int
     {
@@ -27,7 +27,8 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
     public function update(Connection $connection): void
     {
         // Migration1763377570 picked its German target language via the de-DE translation code,
-        // so the repair must match over the same relation instead of the language's own locale.
+        // so the repair matches over the same relation instead of the language's own locale.
+        // The de-% prefix also covers broken values copied into other German-variant languages.
         $connection->executeStatement(
             'UPDATE `mail_template_type_translation` AS `translation`
              INNER JOIN `mail_template_type` AS `type` ON `type`.`id` = `translation`.`mail_template_type_id`
@@ -35,11 +36,11 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
              INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
              SET `translation`.`name` = :correctName
              WHERE `type`.`technical_name` = :technicalName
-                 AND `locale`.`code` = :germanIso
+                 AND `locale`.`code` LIKE :germanLocalePrefix
                  AND `translation`.`name` = :wrongName',
             [
                 'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
-                'germanIso' => self::GERMAN_LANGUAGE_ISO,
+                'germanLocalePrefix' => self::GERMAN_LOCALE_PREFIX,
                 'wrongName' => self::WRONG_GERMAN_NAME,
                 'correctName' => self::CORRECT_GERMAN_NAME,
             ],
@@ -53,11 +54,11 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
              INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
              SET `translation`.`subject` = :correctSubject
              WHERE `type`.`technical_name` = :technicalName
-                 AND `locale`.`code` = :germanIso
+                 AND `locale`.`code` LIKE :germanLocalePrefix
                  AND `translation`.`subject` = :wrongSubject',
             [
                 'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
-                'germanIso' => self::GERMAN_LANGUAGE_ISO,
+                'germanLocalePrefix' => self::GERMAN_LOCALE_PREFIX,
                 'wrongSubject' => self::WRONG_GERMAN_NAME,
                 'correctSubject' => self::CORRECT_GERMAN_NAME,
             ],

--- a/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
+++ b/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Customer\Event\CustomerPasswordChangedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class Migration1784276129RepairPasswordChangedMailTranslations extends MigrationStep
+{
+    private const WRONG_GERMAN_NAME = 'Kunden-Password geändert';
+
+    private const CORRECT_GERMAN_NAME = 'Kunden-Passwort geändert';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1784276129;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $mailTemplateTypeId = $connection->fetchOne(
+            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
+            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
+        );
+
+        if (!\is_string($mailTemplateTypeId)) {
+            return;
+        }
+
+        $connection->executeStatement(
+            'UPDATE `mail_template_type_translation`
+             SET `name` = :correctName
+             WHERE `mail_template_type_id` = :mailTemplateTypeId AND `name` = :wrongName',
+            [
+                'mailTemplateTypeId' => $mailTemplateTypeId,
+                'wrongName' => self::WRONG_GERMAN_NAME,
+                'correctName' => self::CORRECT_GERMAN_NAME,
+            ],
+        );
+
+        $connection->executeStatement(
+            'UPDATE `mail_template_translation`
+             SET `subject` = :correctSubject
+             WHERE `subject` = :wrongSubject AND `mail_template_id` IN (
+                 SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :mailTemplateTypeId
+             )',
+            [
+                'mailTemplateTypeId' => $mailTemplateTypeId,
+                'wrongSubject' => self::WRONG_GERMAN_NAME,
+                'correctSubject' => self::CORRECT_GERMAN_NAME,
+            ],
+        );
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
+++ b/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Checkout\Customer\Event\CustomerPasswordChangedEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
 
@@ -17,8 +16,6 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
 
     private const CORRECT_GERMAN_NAME = 'Kunden-Passwort geändert';
 
-    private const GERMAN_LOCALE_PREFIX = 'de-%';
-
     public function getCreationTimestamp(): int
     {
         return 1784276129;
@@ -26,39 +23,19 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
 
     public function update(Connection $connection): void
     {
-        // Migration1763377570 picked its German target language via the de-DE translation code,
-        // so the repair matches over the same relation instead of the language's own locale.
-        // The de-% prefix also covers broken values copied into other German-variant languages.
+        // The broken literal only ever originated from Migration1763377570, so every
+        // occurrence is incorrect - including copies in other languages or templates.
         $connection->executeStatement(
-            'UPDATE `mail_template_type_translation` AS `translation`
-             INNER JOIN `mail_template_type` AS `type` ON `type`.`id` = `translation`.`mail_template_type_id`
-             INNER JOIN `language` ON `language`.`id` = `translation`.`language_id`
-             INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
-             SET `translation`.`name` = :correctName
-             WHERE `type`.`technical_name` = :technicalName
-                 AND `locale`.`code` LIKE :germanLocalePrefix
-                 AND `translation`.`name` = :wrongName',
+            'UPDATE `mail_template_type_translation` SET `name` = :correctName WHERE `name` = :wrongName',
             [
-                'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
-                'germanLocalePrefix' => self::GERMAN_LOCALE_PREFIX,
                 'wrongName' => self::WRONG_GERMAN_NAME,
                 'correctName' => self::CORRECT_GERMAN_NAME,
             ],
         );
 
         $connection->executeStatement(
-            'UPDATE `mail_template_translation` AS `translation`
-             INNER JOIN `mail_template` AS `template` ON `template`.`id` = `translation`.`mail_template_id`
-             INNER JOIN `mail_template_type` AS `type` ON `type`.`id` = `template`.`mail_template_type_id`
-             INNER JOIN `language` ON `language`.`id` = `translation`.`language_id`
-             INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
-             SET `translation`.`subject` = :correctSubject
-             WHERE `type`.`technical_name` = :technicalName
-                 AND `locale`.`code` LIKE :germanLocalePrefix
-                 AND `translation`.`subject` = :wrongSubject',
+            'UPDATE `mail_template_translation` SET `subject` = :correctSubject WHERE `subject` = :wrongSubject',
             [
-                'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
-                'germanLocalePrefix' => self::GERMAN_LOCALE_PREFIX,
                 'wrongSubject' => self::WRONG_GERMAN_NAME,
                 'correctSubject' => self::CORRECT_GERMAN_NAME,
             ],

--- a/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
+++ b/src/Core/Migration/V6_7/Migration1784276129RepairPasswordChangedMailTranslations.php
@@ -17,6 +17,8 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
 
     private const CORRECT_GERMAN_NAME = 'Kunden-Passwort geändert';
 
+    private const GERMAN_LANGUAGE_ISO = 'de-DE';
+
     public function getCreationTimestamp(): int
     {
         return 1784276129;
@@ -24,34 +26,38 @@ class Migration1784276129RepairPasswordChangedMailTranslations extends Migration
 
     public function update(Connection $connection): void
     {
-        $mailTemplateTypeId = $connection->fetchOne(
-            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
-            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
-        );
-
-        if (!\is_string($mailTemplateTypeId)) {
-            return;
-        }
-
+        // Migration1763377570 picked its German target language via the de-DE translation code,
+        // so the repair must match over the same relation instead of the language's own locale.
         $connection->executeStatement(
-            'UPDATE `mail_template_type_translation`
-             SET `name` = :correctName
-             WHERE `mail_template_type_id` = :mailTemplateTypeId AND `name` = :wrongName',
+            'UPDATE `mail_template_type_translation` AS `translation`
+             INNER JOIN `mail_template_type` AS `type` ON `type`.`id` = `translation`.`mail_template_type_id`
+             INNER JOIN `language` ON `language`.`id` = `translation`.`language_id`
+             INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
+             SET `translation`.`name` = :correctName
+             WHERE `type`.`technical_name` = :technicalName
+                 AND `locale`.`code` = :germanIso
+                 AND `translation`.`name` = :wrongName',
             [
-                'mailTemplateTypeId' => $mailTemplateTypeId,
+                'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
+                'germanIso' => self::GERMAN_LANGUAGE_ISO,
                 'wrongName' => self::WRONG_GERMAN_NAME,
                 'correctName' => self::CORRECT_GERMAN_NAME,
             ],
         );
 
         $connection->executeStatement(
-            'UPDATE `mail_template_translation`
-             SET `subject` = :correctSubject
-             WHERE `subject` = :wrongSubject AND `mail_template_id` IN (
-                 SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :mailTemplateTypeId
-             )',
+            'UPDATE `mail_template_translation` AS `translation`
+             INNER JOIN `mail_template` AS `template` ON `template`.`id` = `translation`.`mail_template_id`
+             INNER JOIN `mail_template_type` AS `type` ON `type`.`id` = `template`.`mail_template_type_id`
+             INNER JOIN `language` ON `language`.`id` = `translation`.`language_id`
+             INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id`
+             SET `translation`.`subject` = :correctSubject
+             WHERE `type`.`technical_name` = :technicalName
+                 AND `locale`.`code` = :germanIso
+                 AND `translation`.`subject` = :wrongSubject',
             [
-                'mailTemplateTypeId' => $mailTemplateTypeId,
+                'technicalName' => CustomerPasswordChangedEvent::EVENT_NAME,
+                'germanIso' => self::GERMAN_LANGUAGE_ISO,
                 'wrongSubject' => self::WRONG_GERMAN_NAME,
                 'correctSubject' => self::CORRECT_GERMAN_NAME,
             ],

--- a/tests/migration/Core/V6_7/Migration1763377570CreatePasswordChangeMailTemplateTest.php
+++ b/tests/migration/Core/V6_7/Migration1763377570CreatePasswordChangeMailTemplateTest.php
@@ -51,6 +51,21 @@ class Migration1763377570CreatePasswordChangeMailTemplateTest extends TestCase
 
         $mailTemplate = $connection->fetchAllAssociative('SELECT * FROM `mail_template` WHERE `mail_template_type_id` = :template', ['template' => $mailTemplateType[0]['id']]);
         static::assertCount(1, $mailTemplate);
+
+        $germanLanguageId = $connection->fetchOne(
+            'SELECT `language`.`id` FROM `language` INNER JOIN `locale` ON `locale`.`id` = `language`.`translation_code_id` WHERE `locale`.`code` = :iso',
+            ['iso' => 'de-DE']
+        );
+        static::assertIsString($germanLanguageId);
+
+        static::assertSame('Kunden-Passwort geändert', $connection->fetchOne(
+            'SELECT `name` FROM `mail_template_type_translation` WHERE `mail_template_type_id` = :typeId AND `language_id` = :languageId',
+            ['typeId' => $mailTemplateType[0]['id'], 'languageId' => $germanLanguageId]
+        ));
+        static::assertSame('Kunden-Passwort geändert', $connection->fetchOne(
+            'SELECT `subject` FROM `mail_template_translation` WHERE `mail_template_id` = :templateId AND `language_id` = :languageId',
+            ['templateId' => $mailTemplate[0]['id'], 'languageId' => $germanLanguageId]
+        ));
     }
 
     private function rollback(Connection $connection): void

--- a/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
+++ b/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
@@ -6,8 +6,10 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerPasswordChangedEvent;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1784276129RepairPasswordChangedMailTranslations;
 use Shopware\Tests\Migration\MigrationTestTrait;
 
@@ -80,6 +82,40 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         static::assertSame('Ihr Passwort wurde geändert', $this->fetchGermanSubject($mailTemplateTypeId, $deLanguageId));
     }
 
+    public function testUpdateRepairsRegionalLanguageWithGermanTranslationCode(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+        $languageId = $this->createLanguage('de-CH', 'de-DE');
+
+        $this->connection->insert('mail_template_type_translation', [
+            'mail_template_type_id' => $mailTemplateTypeId,
+            'language_id' => $languageId,
+            'name' => 'Kunden-Password geändert',
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        $mailTemplateId = $this->connection->fetchOne(
+            'SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId',
+            ['typeId' => $mailTemplateTypeId],
+        );
+        static::assertIsString($mailTemplateId);
+
+        $this->connection->insert('mail_template_translation', [
+            'mail_template_id' => $mailTemplateId,
+            'language_id' => $languageId,
+            'subject' => 'Kunden-Password geändert',
+            'sender_name' => '{{ salesChannel.name }}',
+            'content_html' => '',
+            'content_plain' => '',
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanTypeName($mailTemplateTypeId, $languageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanSubject($mailTemplateTypeId, $languageId));
+    }
+
     public function testUpdateWithoutPasswordChangedMailTemplateTypeDoesNothing(): void
     {
         $mailTemplateTypeId = $this->getMailTemplateTypeId();
@@ -99,6 +135,29 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
             'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
             ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
         ));
+    }
+
+    private function createLanguage(string $localeCode, string $translationCode): string
+    {
+        $languageId = Uuid::randomBytes();
+
+        $this->connection->insert('language', [
+            'id' => $languageId,
+            'name' => $localeCode,
+            'locale_id' => $this->fetchLocaleId($localeCode),
+            'translation_code_id' => $this->fetchLocaleId($translationCode),
+            'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+
+        return $languageId;
+    }
+
+    private function fetchLocaleId(string $code): string
+    {
+        $localeId = $this->connection->fetchOne('SELECT `id` FROM `locale` WHERE `code` = :code LIMIT 1', ['code' => $code]);
+        static::assertIsString($localeId);
+
+        return $localeId;
     }
 
     private function getMailTemplateTypeId(): string

--- a/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
+++ b/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Event\CustomerPasswordChangedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_7\Migration1784276129RepairPasswordChangedMailTranslations;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(Migration1784276129RepairPasswordChangedMailTranslations::class)]
+class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertSame(1784276129, (new Migration1784276129RepairPasswordChangedMailTranslations())->getCreationTimestamp());
+    }
+
+    public function testUpdateRepairsDenglishGermanTranslations(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+        $deLanguageId = $this->fetchLanguageId($this->connection, 'de-DE');
+        static::assertIsString($deLanguageId);
+
+        $this->connection->executeStatement(
+            'UPDATE `mail_template_type_translation` SET `name` = :name WHERE `mail_template_type_id` = :typeId AND `language_id` = :languageId',
+            ['name' => 'Kunden-Password geändert', 'typeId' => $mailTemplateTypeId, 'languageId' => $deLanguageId],
+        );
+        $this->connection->executeStatement(
+            'UPDATE `mail_template_translation` SET `subject` = :subject WHERE `language_id` = :languageId AND `mail_template_id` IN (
+                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
+            )',
+            ['subject' => 'Kunden-Password geändert', 'typeId' => $mailTemplateTypeId, 'languageId' => $deLanguageId],
+        );
+
+        $migration = new Migration1784276129RepairPasswordChangedMailTranslations();
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanTypeName($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanSubject($mailTemplateTypeId, $deLanguageId));
+    }
+
+    public function testUpdateKeepsCustomizedGermanTranslations(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+        $deLanguageId = $this->fetchLanguageId($this->connection, 'de-DE');
+        static::assertIsString($deLanguageId);
+
+        $this->connection->executeStatement(
+            'UPDATE `mail_template_type_translation` SET `name` = :name WHERE `mail_template_type_id` = :typeId AND `language_id` = :languageId',
+            ['name' => 'Passwort-Info', 'typeId' => $mailTemplateTypeId, 'languageId' => $deLanguageId],
+        );
+        $this->connection->executeStatement(
+            'UPDATE `mail_template_translation` SET `subject` = :subject WHERE `language_id` = :languageId AND `mail_template_id` IN (
+                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
+            )',
+            ['subject' => 'Ihr Passwort wurde geändert', 'typeId' => $mailTemplateTypeId, 'languageId' => $deLanguageId],
+        );
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertSame('Passwort-Info', $this->fetchGermanTypeName($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Ihr Passwort wurde geändert', $this->fetchGermanSubject($mailTemplateTypeId, $deLanguageId));
+    }
+
+    public function testUpdateWithoutPasswordChangedMailTemplateTypeDoesNothing(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+
+        $this->connection->executeStatement(
+            'DELETE FROM `mail_template_translation` WHERE `mail_template_id` IN (
+                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
+            )',
+            ['typeId' => $mailTemplateTypeId],
+        );
+        $this->connection->executeStatement('DELETE FROM `mail_template` WHERE `mail_template_type_id` = :typeId', ['typeId' => $mailTemplateTypeId]);
+        $this->connection->executeStatement('DELETE FROM `mail_template_type` WHERE `id` = :typeId', ['typeId' => $mailTemplateTypeId]);
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertFalse($this->connection->fetchOne(
+            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
+            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
+        ));
+    }
+
+    private function getMailTemplateTypeId(): string
+    {
+        $mailTemplateTypeId = $this->connection->fetchOne(
+            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
+            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
+        );
+        static::assertIsString($mailTemplateTypeId);
+
+        return $mailTemplateTypeId;
+    }
+
+    private function fetchGermanTypeName(string $mailTemplateTypeId, string $languageId): string
+    {
+        $name = $this->connection->fetchOne(
+            'SELECT `name` FROM `mail_template_type_translation` WHERE `mail_template_type_id` = :typeId AND `language_id` = :languageId',
+            ['typeId' => $mailTemplateTypeId, 'languageId' => $languageId],
+        );
+        static::assertIsString($name);
+
+        return $name;
+    }
+
+    private function fetchGermanSubject(string $mailTemplateTypeId, string $languageId): string
+    {
+        $subject = $this->connection->fetchOne(
+            'SELECT `subject` FROM `mail_template_translation` WHERE `language_id` = :languageId AND `mail_template_id` IN (
+                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
+            )',
+            ['typeId' => $mailTemplateTypeId, 'languageId' => $languageId],
+        );
+        static::assertIsString($subject);
+
+        return $subject;
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
+++ b/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
@@ -55,8 +55,8 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         $migration->update($this->connection);
         $migration->update($this->connection);
 
-        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanTypeName($mailTemplateTypeId, $deLanguageId));
-        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanSubject($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchTypeName($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchSubject($mailTemplateTypeId, $deLanguageId));
     }
 
     public function testUpdateKeepsCustomizedGermanTranslations(): void
@@ -78,15 +78,69 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
 
         (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
 
-        static::assertSame('Passwort-Info', $this->fetchGermanTypeName($mailTemplateTypeId, $deLanguageId));
-        static::assertSame('Ihr Passwort wurde geändert', $this->fetchGermanSubject($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Passwort-Info', $this->fetchTypeName($mailTemplateTypeId, $deLanguageId));
+        static::assertSame('Ihr Passwort wurde geändert', $this->fetchSubject($mailTemplateTypeId, $deLanguageId));
     }
 
     public function testUpdateRepairsRegionalLanguageWithGermanTranslationCode(): void
     {
         $mailTemplateTypeId = $this->getMailTemplateTypeId();
         $languageId = $this->createLanguage('de-CH', 'de-DE');
+        $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
 
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertSame('Kunden-Passwort geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
+    }
+
+    public function testUpdateRepairsCopiedTranslationsOfGermanVariantLanguages(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+        $languageId = $this->createLanguage('de-AT', 'de-AT');
+        $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertSame('Kunden-Passwort geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
+        static::assertSame('Kunden-Passwort geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
+    }
+
+    public function testUpdateIgnoresBrokenValuesOfNonGermanLanguages(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+        $languageId = $this->createLanguage('nl-NL', 'nl-NL');
+        $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertSame('Kunden-Password geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
+        static::assertSame('Kunden-Password geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
+    }
+
+    public function testUpdateWithoutPasswordChangedMailTemplateTypeDoesNothing(): void
+    {
+        $mailTemplateTypeId = $this->getMailTemplateTypeId();
+
+        $this->connection->executeStatement(
+            'DELETE FROM `mail_template_translation` WHERE `mail_template_id` IN (
+                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
+            )',
+            ['typeId' => $mailTemplateTypeId],
+        );
+        $this->connection->executeStatement('DELETE FROM `mail_template` WHERE `mail_template_type_id` = :typeId', ['typeId' => $mailTemplateTypeId]);
+        $this->connection->executeStatement('DELETE FROM `mail_template_type` WHERE `id` = :typeId', ['typeId' => $mailTemplateTypeId]);
+
+        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
+
+        static::assertFalse($this->connection->fetchOne(
+            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
+            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
+        ));
+    }
+
+    private function seedBrokenTranslationsForLanguage(string $mailTemplateTypeId, string $languageId): void
+    {
         $this->connection->insert('mail_template_type_translation', [
             'mail_template_type_id' => $mailTemplateTypeId,
             'language_id' => $languageId,
@@ -109,32 +163,6 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
             'content_plain' => '',
             'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
-
-        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
-
-        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanTypeName($mailTemplateTypeId, $languageId));
-        static::assertSame('Kunden-Passwort geändert', $this->fetchGermanSubject($mailTemplateTypeId, $languageId));
-    }
-
-    public function testUpdateWithoutPasswordChangedMailTemplateTypeDoesNothing(): void
-    {
-        $mailTemplateTypeId = $this->getMailTemplateTypeId();
-
-        $this->connection->executeStatement(
-            'DELETE FROM `mail_template_translation` WHERE `mail_template_id` IN (
-                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
-            )',
-            ['typeId' => $mailTemplateTypeId],
-        );
-        $this->connection->executeStatement('DELETE FROM `mail_template` WHERE `mail_template_type_id` = :typeId', ['typeId' => $mailTemplateTypeId]);
-        $this->connection->executeStatement('DELETE FROM `mail_template_type` WHERE `id` = :typeId', ['typeId' => $mailTemplateTypeId]);
-
-        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
-
-        static::assertFalse($this->connection->fetchOne(
-            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
-            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
-        ));
     }
 
     private function createLanguage(string $localeCode, string $translationCode): string
@@ -171,7 +199,7 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         return $mailTemplateTypeId;
     }
 
-    private function fetchGermanTypeName(string $mailTemplateTypeId, string $languageId): string
+    private function fetchTypeName(string $mailTemplateTypeId, string $languageId): string
     {
         $name = $this->connection->fetchOne(
             'SELECT `name` FROM `mail_template_type_translation` WHERE `mail_template_type_id` = :typeId AND `language_id` = :languageId',
@@ -182,7 +210,7 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         return $name;
     }
 
-    private function fetchGermanSubject(string $mailTemplateTypeId, string $languageId): string
+    private function fetchSubject(string $mailTemplateTypeId, string $languageId): string
     {
         $subject = $this->connection->fetchOne(
             'SELECT `subject` FROM `mail_template_translation` WHERE `language_id` = :languageId AND `mail_template_id` IN (

--- a/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
+++ b/tests/migration/Core/V6_7/Migration1784276129RepairPasswordChangedMailTranslationsTest.php
@@ -82,61 +82,16 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         static::assertSame('Ihr Passwort wurde geändert', $this->fetchSubject($mailTemplateTypeId, $deLanguageId));
     }
 
-    public function testUpdateRepairsRegionalLanguageWithGermanTranslationCode(): void
+    public function testUpdateRepairsCopiedTranslationsOfAnyLanguage(): void
     {
         $mailTemplateTypeId = $this->getMailTemplateTypeId();
-        $languageId = $this->createLanguage('de-CH', 'de-DE');
+        $languageId = $this->createLanguage('nl-NL');
         $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
 
         (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
 
         static::assertSame('Kunden-Passwort geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
         static::assertSame('Kunden-Passwort geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
-    }
-
-    public function testUpdateRepairsCopiedTranslationsOfGermanVariantLanguages(): void
-    {
-        $mailTemplateTypeId = $this->getMailTemplateTypeId();
-        $languageId = $this->createLanguage('de-AT', 'de-AT');
-        $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
-
-        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
-
-        static::assertSame('Kunden-Passwort geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
-        static::assertSame('Kunden-Passwort geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
-    }
-
-    public function testUpdateIgnoresBrokenValuesOfNonGermanLanguages(): void
-    {
-        $mailTemplateTypeId = $this->getMailTemplateTypeId();
-        $languageId = $this->createLanguage('nl-NL', 'nl-NL');
-        $this->seedBrokenTranslationsForLanguage($mailTemplateTypeId, $languageId);
-
-        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
-
-        static::assertSame('Kunden-Password geändert', $this->fetchTypeName($mailTemplateTypeId, $languageId));
-        static::assertSame('Kunden-Password geändert', $this->fetchSubject($mailTemplateTypeId, $languageId));
-    }
-
-    public function testUpdateWithoutPasswordChangedMailTemplateTypeDoesNothing(): void
-    {
-        $mailTemplateTypeId = $this->getMailTemplateTypeId();
-
-        $this->connection->executeStatement(
-            'DELETE FROM `mail_template_translation` WHERE `mail_template_id` IN (
-                SELECT `id` FROM `mail_template` WHERE `mail_template_type_id` = :typeId
-            )',
-            ['typeId' => $mailTemplateTypeId],
-        );
-        $this->connection->executeStatement('DELETE FROM `mail_template` WHERE `mail_template_type_id` = :typeId', ['typeId' => $mailTemplateTypeId]);
-        $this->connection->executeStatement('DELETE FROM `mail_template_type` WHERE `id` = :typeId', ['typeId' => $mailTemplateTypeId]);
-
-        (new Migration1784276129RepairPasswordChangedMailTranslations())->update($this->connection);
-
-        static::assertFalse($this->connection->fetchOne(
-            'SELECT `id` FROM `mail_template_type` WHERE `technical_name` = :technicalName',
-            ['technicalName' => CustomerPasswordChangedEvent::EVENT_NAME],
-        ));
     }
 
     private function seedBrokenTranslationsForLanguage(string $mailTemplateTypeId, string $languageId): void
@@ -165,7 +120,7 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
         ]);
     }
 
-    private function createLanguage(string $localeCode, string $translationCode): string
+    private function createLanguage(string $localeCode): string
     {
         $languageId = Uuid::randomBytes();
 
@@ -173,7 +128,7 @@ class Migration1784276129RepairPasswordChangedMailTranslationsTest extends TestC
             'id' => $languageId,
             'name' => $localeCode,
             'locale_id' => $this->fetchLocaleId($localeCode),
-            'translation_code_id' => $this->fetchLocaleId($translationCode),
+            'translation_code_id' => $this->fetchLocaleId($localeCode),
             'created_at' => (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The password-changed mail template ships a denglish German name/subject: `Kunden-Password geändert`.

### 2. What does this change do, exactly?

Corrects both strings to `Kunden-Passwort geändert` in `Migration1763377570CreatePasswordChangeMailTemplate` (new installations) and adds `Migration1784276129RepairPasswordChangedMailTranslations` to repair existing installations — only rows still holding the broken default are updated, customized values stay untouched.

### 3. Describe each step to reproduce the issue or behaviour.

1. Change a customer password in a German shop.
2. The confirmation mail subject (and the mail template type name in the admin) reads `Kunden-Password geändert`.

### 4. Please link to the relevant issues (if any).

- closes #18078

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
