### PR TITLE
fix(core): prevent Store API session initialization (backport: 6.6.x)

### DIFF
--- a/changelog/_unreleased/2026-07-17-prevent-store-api-session-initialization.md
+++ b/changelog/_unreleased/2026-07-17-prevent-store-api-session-initialization.md
@@ -1,0 +1,6 @@
+---
+title: Prevent Store API session initialization
+issue: #18319
+---
+# Core
+* Fixed a critical issue where Store API requests could initialize Symfony's lazy session factory, causing unnecessary session storage growth and potentially taking PHP session locks. Storefront session handling, including customer imitation, remains unchanged.

--- a/changelog/_unreleased/2026-07-17-prevent-store-api-session-initialization.md
+++ b/changelog/_unreleased/2026-07-17-prevent-store-api-session-initialization.md
@@ -3,4 +3,4 @@ title: Prevent Store API session initialization
 issue: #18319
 ---
 # Core
-* Fixed a critical issue where Store API requests could initialize Symfony's lazy session factory, causing unnecessary session storage growth and potentially taking PHP session locks. Storefront session handling, including customer imitation, remains unchanged.
+* Changed Store API session handling to fix a critical issue where requests could initialize Symfony's lazy session factory, causing unnecessary session storage growth and potentially taking PHP session locks. Storefront session handling, including customer imitation, remains unchanged.

--- a/src/Core/Checkout/Customer/Subscriber/CustomerLogoutSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerLogoutSubscriber.php
@@ -37,7 +37,8 @@ class CustomerLogoutSubscriber implements EventSubscriberInterface
 
         $mainRequest = $this->requestStack->getMainRequest();
 
-        if (!$mainRequest?->hasSession()) {
+        // Only clear an initialized storefront session. Store API requests use their context token directly.
+        if (!$mainRequest?->hasSession(true)) {
             return;
         }
 

--- a/src/Core/Checkout/Customer/Subscriber/CustomerTokenSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerTokenSubscriber.php
@@ -105,7 +105,8 @@ class CustomerTokenSubscriber implements EventSubscriberInterface
             'token' => $newToken,
         ]);
 
-        if (!$mainRequest->hasSession()) {
+        // Only migrate an initialized storefront session. Store API requests use their context token directly.
+        if (!$mainRequest->hasSession(true)) {
             return null;
         }
 

--- a/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
+++ b/src/Core/Checkout/Promotion/Subscriber/Storefront/StorefrontCartSubscriber.php
@@ -51,11 +51,16 @@ class StorefrontCartSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$mainRequest->hasSession()) {
+        if (!$mainRequest->hasSession(true)) {
             return;
         }
 
-        $mainRequest->getSession()->set(self::SESSION_KEY_PROMOTION_CODES, []);
+        $session = $mainRequest->getSession();
+        if (!$session->isStarted()) {
+            return;
+        }
+
+        $session->set(self::SESSION_KEY_PROMOTION_CODES, []);
     }
 
     /**

--- a/src/Core/Framework/DependencyInjection/services_test.xml
+++ b/src/Core/Framework/DependencyInjection/services_test.xml
@@ -129,6 +129,10 @@
 
         <service id="test.browser" alias="test.client" />
 
+        <service id="Shopware\Core\Framework\Test\TestCaseHelper\StoreApiSessionListener">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="test.client" class="Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser" shared="false" public="true">
             <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>

--- a/src/Core/Framework/Routing/SalesChannelRequestContextResolver.php
+++ b/src/Core/Framework/Routing/SalesChannelRequestContextResolver.php
@@ -50,7 +50,10 @@ class SalesChannelRequestContextResolver implements RequestContextResolverInterf
             $request->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, Random::getAlphanumericString(32));
         }
 
-        $session = $request->hasSession() ? $request->getSession() : null;
+        // $skipIfUninitialized = true is intentional: storefront sessions are started before context resolution,
+        // while Store API requests only have a lazy session factory and must remain stateless.
+        $session = $request->hasSession(true) ? $request->getSession() : null;
+        $session = $session?->isStarted() ? $session : null;
 
         // Retrieve context for current request
         $usedContextToken = (string) $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN);

--- a/src/Core/Framework/Test/TestCaseHelper/StoreApiSessionListener.php
+++ b/src/Core/Framework/Test/TestCaseHelper/StoreApiSessionListener.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\TestCaseHelper;
+
+use PHPUnit\Framework\Assert;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Ensures that Store API integration requests do not initialize Symfony's lazy session factory.
+ *
+ * Symfony's AbstractSessionListener attaches the factory during kernel.request at priority 128. Storefront requests
+ * deliberately initialize and start it later in StorefrontSubscriber::startSession() at priority 40, while Store API
+ * requests must leave the factory uninitialized.
+ *
+ * @internal
+ *
+ * @codeCoverageIgnore
+ *
+ * @see \Shopware\Tests\Integration\Core\System\Salutation\SalesChannel\SalutationRouteTest
+ */
+#[Package('framework')]
+class StoreApiSessionListener implements EventSubscriberInterface
+{
+    private const SESSION_INITIALIZED = '_test_store_api_session_initialized';
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::RESPONSE => ['recordSessionState', 0],
+            KernelEvents::TERMINATE => 'assertSessionIsNotInitialized',
+        ];
+    }
+
+    /**
+     * Records the application-visible state after request handling, but before Symfony's profiler runs.
+     *
+     * The profiler's kernel.response listener has priority -100 and calls Request::hasPreviousSession(), which can
+     * initialize the lazy factory when a session cookie exists. Recording at priority 0 prevents that test tooling
+     * from being mistaken for session usage by the Store API request itself.
+     */
+    public function recordSessionState(ResponseEvent $event): void
+    {
+        $request = $event->getRequest();
+        $routeScopes = $request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []);
+
+        if (!\is_array($routeScopes) || !\in_array(StoreApiRouteScope::ID, $routeScopes, true)) {
+            return;
+        }
+
+        $request->attributes->set(self::SESSION_INITIALIZED, $request->hasSession(true));
+    }
+
+    /**
+     * Asserts the recorded state after all response listeners have finished.
+     *
+     * The snapshot is used because the profiler may have initialized the session between kernel.response and
+     * kernel.terminate even though application code left the Store API request stateless.
+     *
+     * The assertion is intentionally deferred until kernel.terminate. An assertion thrown during kernel.response is
+     * still inside HttpKernel::handle() and can be converted into an exception response. KernelBrowser calls
+     * HttpKernel::terminate() after handle() returns, so the original assertion propagates directly to PHPUnit.
+     */
+    public function assertSessionIsNotInitialized(TerminateEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if (!$request->attributes->has(self::SESSION_INITIALIZED)) {
+            return;
+        }
+
+        Assert::assertFalse(
+            $request->attributes->getBoolean(self::SESSION_INITIALIZED),
+            \sprintf('Store API request "%s" initialized a session.', $request->getPathInfo())
+        );
+    }
+}

--- a/src/Core/System/SalesChannel/Context/CartRestorer.php
+++ b/src/Core/System/SalesChannel/Context/CartRestorer.php
@@ -156,7 +156,8 @@ class CartRestorer
     {
         $request = $this->requestStack->getMainRequest();
 
-        if (!$request?->hasSession()) {
+        // Only synchronize an initialized storefront session. Store API requests must remain stateless.
+        if (!$request?->hasSession(true)) {
             return;
         }
 

--- a/src/Storefront/Event/CartMergedSubscriber.php
+++ b/src/Storefront/Event/CartMergedSubscriber.php
@@ -38,13 +38,13 @@ class CartMergedSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if ($mainRequest->hasSession() === false) {
+        if (!$mainRequest->hasSession(true)) {
             return;
         }
 
         $session = $mainRequest->getSession();
 
-        if (!method_exists($session, 'getFlashBag')) {
+        if (!$session->isStarted() || !method_exists($session, 'getFlashBag')) {
             return;
         }
 

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -78,7 +78,8 @@ class StorefrontSubscriber implements EventSubscriberInterface
         if (!$mainRequest->attributes->get(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST)) {
             return;
         }
-        /** @phpstan-ignore shopware.unsafeRequestHasSession (using $skipIfUninitialized = false as session will be started intentionally later; this can take the PHP session lock and is limited to storefront routing starting the storefront session when needed.) */
+        // Calling hasSession() without $skipIfUninitialized is intentional: this method only handles storefront
+        // requests and starts the storefront session below, so taking the PHP session lock is expected and safe.
         if (!$mainRequest->hasSession()) {
             return;
         }

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -78,7 +78,7 @@ class StorefrontSubscriber implements EventSubscriberInterface
         if (!$mainRequest->attributes->get(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST)) {
             return;
         }
-
+        /** @phpstan-ignore shopware.unsafeRequestHasSession (using $skipIfUninitialized = false as session will be started intentionally later; this can take the PHP session lock and is limited to storefront routing starting the storefront session when needed.) */
         if (!$mainRequest->hasSession()) {
             return;
         }
@@ -137,8 +137,12 @@ class StorefrontSubscriber implements EventSubscriberInterface
         if (!$mainRequest->attributes->get(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST)) {
             return;
         }
+        if (!\in_array(StorefrontRouteScope::ID, $mainRequest->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []), true)) {
+            return;
+        }
 
-        if (!$mainRequest->hasSession()) {
+        // Storefront sessions are started during kernel.request, before customer login and logout events are dispatched.
+        if (!$mainRequest->hasSession(true)) {
             return;
         }
 

--- a/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
@@ -54,6 +54,40 @@ class SalesChannelRequestContextResolverTest extends TestCase
         $this->contextService = static::getContainer()->get(SalesChannelContextService::class);
     }
 
+    #[DataProvider('sessionStateProvider')]
+    public function testStoreApiRequestDoesNotInitializeSession(bool $sessionAlreadyInstantiated): void
+    {
+        $request = new Request(attributes: [
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => TestDefaults::SALES_CHANNEL,
+            PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => ['store-api'],
+        ]);
+        $request->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, Uuid::randomHex());
+
+        $storage = new MockArraySessionStorage();
+        $factoryCalls = 0;
+        $request->setSessionFactory(static function () use ($storage, &$factoryCalls): Session {
+            ++$factoryCalls;
+
+            return new Session($storage);
+        });
+
+        if ($sessionAlreadyInstantiated) {
+            $request->getSession();
+        }
+        $factoryCallsBeforeResolve = $factoryCalls;
+
+        static::getContainer()->get(SalesChannelRequestContextResolver::class)->resolve($request);
+
+        static::assertFalse($storage->isStarted());
+        static::assertSame($factoryCallsBeforeResolve, $factoryCalls);
+    }
+
+    public static function sessionStateProvider(): \Generator
+    {
+        yield 'request has only the lazy session factory' => [false];
+        yield 'session was instantiated but not started' => [true];
+    }
+
     public function testRequestSalesChannelCurrency(): void
     {
         $this->createTestSalesChannel();

--- a/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -33,6 +33,7 @@ class CartMergedSubscriberTest extends TestCase
     public function testMergedHintIsAdded(): void
     {
         $session = new Session(new MockArraySessionStorage());
+        $session->start();
         $request = new Request();
         $request->setSession($session);
         $requestStack = new RequestStack();

--- a/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/unit/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -29,6 +29,7 @@ class CartMergedSubscriberTest extends TestCase
     public function testMergedHintIsAdded(): void
     {
         $session = new Session(new MockArraySessionStorage());
+        $session->start();
         $request = new Request();
         $request->setSession($session);
         $requestStack = new RequestStack();

--- a/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedEvent;
 use Shopware\Core\Framework\Routing\Exception\CustomerNotLoggedInRoutingException;
 use Shopware\Core\Framework\Routing\KernelListenerPriorities;
 use Shopware\Core\Framework\Routing\RoutingException;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\Test\Generator;
@@ -331,7 +332,10 @@ class StorefrontSubscriberTest extends TestCase
 
     public function testUpdateSessionWithoutSession(): void
     {
-        $request = new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]);
+        $request = new Request(attributes: [
+            SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+            PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID],
+        ]);
         $requestStack = new RequestStack([$request]);
 
         (new StorefrontSubscriber(
@@ -346,7 +350,10 @@ class StorefrontSubscriberTest extends TestCase
 
     public function testUpdateSession(): void
     {
-        $request = new Request(attributes: [SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true]);
+        $request = new Request(attributes: [
+            SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+            PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StorefrontRouteScope::ID],
+        ]);
         $request->setSession(new Session(new MockArraySessionStorage()));
         $requestStack = new RequestStack([$request]);
 
@@ -359,5 +366,28 @@ class StorefrontSubscriberTest extends TestCase
 
         static::assertSame(self::TEST_CONTEXT_TOKEN, $request->getSession()->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
         static::assertSame(self::TEST_CONTEXT_TOKEN, $request->headers->get(PlatformRequest::HEADER_CONTEXT_TOKEN));
+    }
+
+    public function testDoesNotUpdateSessionForStoreApiRequest(): void
+    {
+        $request = new Request(attributes: [
+            SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+            PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID],
+        ]);
+        $factoryCalls = 0;
+        $request->setSessionFactory(static function () use (&$factoryCalls): Session {
+            ++$factoryCalls;
+
+            return new Session(new MockArraySessionStorage());
+        });
+
+        (new StorefrontSubscriber(
+            new RequestStack([$request]),
+            static::createStub(RouterInterface::class),
+            static::createStub(MaintenanceModeResolver::class),
+            new StaticSystemConfigService(),
+        ))->updateSession(self::TEST_CONTEXT_TOKEN);
+
+        static::assertSame(0, $factoryCalls);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The automatic backport of #18337 failed. The same Store API session initialization can occur on 6.6.x, causing unnecessary session storage growth and potentially taking PHP session locks.

### 2. What does this change do, exactly?

This manually backports the merged fix from #18337 while adapting it to the 6.6.x code and test layout. Store API request paths now avoid initializing Symfony's lazy session factory, storefront session handling remains unchanged, and a test-only listener asserts that Store API integration requests stay stateless. The release note uses the 6.6 `changelog/_unreleased` format.

### 3. Describe each step to reproduce the issue or behaviour.

1. Execute a Store API request that reaches one of the affected sales-channel or storefront subscribers.
2. Inspect the request's lazy session factory after the application response handling.
3. Without this change, the session can be initialized even though Store API authentication uses its context token; repeated requests can consequently create session storage and contend for PHP session locks.

### 4. Please link to the relevant issues (if any).

- relates #18319
- backports #18337

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/shopware/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
