### PR TITLE
refactor: make feature:dump unit-testable with an injected filesystem

### DIFF
--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -621,6 +621,7 @@ frame-ancestors 'none';
 
         <service id="Shopware\Core\Framework\Feature\Command\FeatureDumpCommand">
             <argument type="service" id="kernel"/>
+            <argument type="service" id="Symfony\Component\Filesystem\Filesystem"/>
 
             <tag name="console.command"/>
             <tag name="console.command" command="administration:dump:features"/>

--- a/src/Core/Framework/Feature/Command/FeatureDumpCommand.php
+++ b/src/Core/Framework/Feature/Command/FeatureDumpCommand.php
@@ -10,12 +10,8 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
-/**
- * @codeCoverageIgnore Unit-testing this command would require a real file write, as it dumps via file_put_contents directly - rewrite it with an injected (mockable) Filesystem, then replace this exemption with a unit test
- *
- * @see \Shopware\Tests\Integration\Core\Framework\Feature\Command\FeatureDumpCommandTest
- */
 #[AsCommand(name: 'feature:dump', description: 'Dumps all features', aliases: ['administration:dump:features'])]
 #[Package('framework')]
 class FeatureDumpCommand extends Command
@@ -23,8 +19,10 @@ class FeatureDumpCommand extends Command
     /**
      * @internal
      */
-    public function __construct(private readonly Kernel $kernel)
-    {
+    public function __construct(
+        private readonly Kernel $kernel,
+        private readonly Filesystem $filesystem,
+    ) {
         parent::__construct();
     }
 
@@ -37,7 +35,7 @@ class FeatureDumpCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        file_put_contents(
+        $this->filesystem->dumpFile(
             $this->kernel->getProjectDir() . '/var/config_js_features.json',
             json_encode(Feature::getAll(), \JSON_THROW_ON_ERROR)
         );

--- a/tests/unit/Core/Framework/Feature/Command/FeatureDumpCommandTest.php
+++ b/tests/unit/Core/Framework/Feature/Command/FeatureDumpCommandTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Feature\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Feature\Command\FeatureDumpCommand;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Kernel;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(FeatureDumpCommand::class)]
+class FeatureDumpCommandTest extends TestCase
+{
+    #[TestDox('All feature flags are dumped as JSON into var/config_js_features.json of the project')]
+    public function testDumpsAllFeatureFlagsToJsonFile(): void
+    {
+        $kernel = static::createStub(Kernel::class);
+        $kernel->method('getProjectDir')->willReturn('/project');
+
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem
+            ->expects($this->once())
+            ->method('dumpFile')
+            ->with(
+                '/project/var/config_js_features.json',
+                json_encode(Feature::getAll(), \JSON_THROW_ON_ERROR)
+            );
+
+        $commandTester = new CommandTester(new FeatureDumpCommand($kernel, $filesystem));
+
+        static::assertSame(Command::SUCCESS, $commandTester->execute([]));
+        static::assertStringContainsString('Successfully dumped js feature configuration', $commandTester->getDisplay());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

`feature:dump` writes `var/config_js_features.json` via `file_put_contents` directly, so it could not be unit-tested and carried a `@codeCoverageIgnore` exemption pointing at an integration test. Injecting a mockable filesystem removes the exemption.

### 2. What does this change do, exactly?

- Injects `Symfony\Component\Filesystem\Filesystem` (already a container service) into `FeatureDumpCommand` and dumps via `Filesystem::dumpFile()` instead of `file_put_contents`. The constructor is `@internal`, so the signature change is safe.
- Replaces the class-level `@codeCoverageIgnore` + `@see` with a unit test asserting the dump path and the encoded `Feature::getAll()` payload.
- Keeps the integration test, which verifies the container wiring and the real file round-trip end to end.

### 3. Describe each step to reproduce the issue or behaviour.

1. Before this change: `FeatureDumpCommand` appears in the unit-coverage report only through its `@codeCoverageIgnore` exemption.
2. After: `vendor/bin/phpunit tests/unit/Core/Framework/Feature/Command/FeatureDumpCommandTest.php` covers it, and `bin/console feature:dump` still writes `var/config_js_features.json`.

### 4. Please link to the relevant issues (if any).

- relates #18416

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
