### PR TITLE
test: sweep deprecated EntitySearchResult accessors from storefront integration tests

### DIFF
--- a/src/Core/DevOps/Resources/generated/custom-endpoint-script-services-reference.md
+++ b/src/Core/DevOps/Resources/generated/custom-endpoint-script-services-reference.md
@@ -241,7 +241,7 @@ The `response` service allows you to create HTTP-Responses.
     * Fetch a product, add it to the page and return a rendered response.
 
         ```twig
-        {% set product = services.store.search('product', { 'ids': [productId]}).first %}
+        {% set product = services.store.search('product', { 'ids': [productId]}).getEntities().first %}
 		
 		{% do hook.page.addExtension('myProduct', product) %}
 		

--- a/tests/integration/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/tests/integration/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -198,7 +198,7 @@ class StorefrontCartFacadeTest extends TestCase
         $shippingMethodeRepository = $this->getContainer()->get('shipping_method.repository');
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('name', 'Standard'));
-        $shippingMethod = $shippingMethodeRepository->search($criteria, Context::createDefaultContext())->first();
+        $shippingMethod = $shippingMethodeRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(ShippingMethodEntity::class, $shippingMethod);
 
@@ -214,7 +214,7 @@ class StorefrontCartFacadeTest extends TestCase
         $paymentMethodRepository = $this->getContainer()->get('payment_method.repository');
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('handlerIdentifier', 'Shopware\Core\Checkout\Payment\Cart\PaymentHandler\CashPayment'));
-        $paymentMethod = $paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
+        $paymentMethod = $paymentMethodRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(PaymentMethodEntity::class, $paymentMethod);
 
@@ -228,7 +228,7 @@ class StorefrontCartFacadeTest extends TestCase
         $paymentMethodRepository = $this->getContainer()->get('payment_method.repository');
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', $technicalName));
-        $paymentMethod = $paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
+        $paymentMethod = $paymentMethodRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(PaymentMethodEntity::class, $paymentMethod);
 

--- a/tests/integration/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
+++ b/tests/integration/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
@@ -134,7 +134,7 @@ class CustomerGroupSubscriberTest extends TestCase
     {
         $s1 = $this->createSalesChannel()['id'];
 
-        $languageIds = array_values(static::getContainer()->get('language.repository')->search(new Criteria(), Context::createDefaultContext())->getIds());
+        $languageIds = array_values(static::getContainer()->get('language.repository')->search(new Criteria(), Context::createDefaultContext())->getEntities()->getIds());
 
         $upsertLanguages = [];
         foreach ($languageIds as $id) {

--- a/tests/integration/Storefront/Controller/AddressControllerTest.php
+++ b/tests/integration/Storefront/Controller/AddressControllerTest.php
@@ -92,7 +92,7 @@ class AddressControllerTest extends TestCase
 
         /** @var EntityRepository<CustomerAddressCollection> $repository */
         $repository = static::getContainer()->get('customer_address.repository');
-        $address = $repository->search($criteria, $context->getContext())
+        $address = $repository->search($criteria, $context->getContext())->getEntities()
             ->get($id2);
 
         static::assertInstanceOf(CustomerAddressEntity::class, $address);
@@ -104,7 +104,7 @@ class AddressControllerTest extends TestCase
         /** @var EntityRepository<CustomerAddressCollection> $repository */
         $repository = static::getContainer()->get('customer_address.repository');
         $exists = $repository
-            ->search($criteria, $context->getContext())
+            ->search($criteria, $context->getContext())->getEntities()
             ->has($id2);
 
         static::assertFalse($exists);

--- a/tests/integration/Storefront/Controller/AuthControllerTest.php
+++ b/tests/integration/Storefront/Controller/AuthControllerTest.php
@@ -458,7 +458,7 @@ class AuthControllerTest extends TestCase
             Context::createDefaultContext()
         );
 
-        static::assertCount(0, $logEntries);
+        static::assertCount(0, $logEntries->getEntities());
         $logger->setHandlers($handlers);
     }
 
@@ -835,7 +835,7 @@ class AuthControllerTest extends TestCase
 
         $repo->create([$customer], Context::createDefaultContext());
 
-        return $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        return $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
     }
 
     private function getAuthController(?AbstractSendPasswordRecoveryMailRoute $sendPasswordRecoveryMailRoute = null): AuthController

--- a/tests/integration/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/integration/Storefront/Controller/CheckoutControllerTest.php
@@ -343,7 +343,7 @@ class CheckoutControllerTest extends TestCase
     {
         /** @var EntityRepository<ShippingMethodCollection> */
         $shippingMethodRepository = static::getContainer()->get('shipping_method.repository');
-        $shippingMethods = $shippingMethodRepository->search(new Criteria(), Context::createDefaultContext());
+        $shippingMethods = $shippingMethodRepository->search(new Criteria(), Context::createDefaultContext())->getEntities();
         $standardShippingMethodId = $shippingMethods->filter(static fn (ShippingMethodEntity $sm) => $sm->getTechnicalName() === 'shipping_standard')->first()?->getId();
         $expressShippingMethodId = $shippingMethods->filter(static fn (ShippingMethodEntity $sm) => $sm->getTechnicalName() === 'shipping_express')->first()?->getId();
         static::assertNotNull($standardShippingMethodId, 'Standard shipping method not found');
@@ -351,7 +351,7 @@ class CheckoutControllerTest extends TestCase
 
         /** @var EntityRepository<PaymentMethodCollection> */
         $paymentMethodRepository = static::getContainer()->get('payment_method.repository');
-        $paymentMethods = $paymentMethodRepository->search(new Criteria(), Context::createDefaultContext());
+        $paymentMethods = $paymentMethodRepository->search(new Criteria(), Context::createDefaultContext())->getEntities();
         $cashOnDeliveryPaymentMethodId = $paymentMethods->filter(static fn (PaymentMethodEntity $pm) => $pm->getTechnicalName() === 'payment_cashpayment')->first()?->getId();
         $paidInAdvancePaymentMethodId = $paymentMethods->filter(static fn (PaymentMethodEntity $pm) => $pm->getTechnicalName() === 'payment_prepayment')->first()?->getId();
         $invoicePaymentMethodId = $paymentMethods->filter(static fn (PaymentMethodEntity $pm) => $pm->getTechnicalName() === 'payment_invoicepayment')->first()?->getId();

--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -483,7 +483,7 @@ class ControllerRateLimiterTest extends TestCase
         $orderRepository = static::getContainer()->get('order.repository');
         $orderRepository->create($orderData, $this->context);
 
-        $order = $orderRepository->search(new Criteria([$orderId]), $this->context)->first();
+        $order = $orderRepository->search(new Criteria([$orderId]), $this->context)->getEntities()->first();
 
         static::assertNotNull($order);
         static::assertInstanceOf(OrderEntity::class, $order);

--- a/tests/integration/Storefront/Controller/LandingPageControllerTest.php
+++ b/tests/integration/Storefront/Controller/LandingPageControllerTest.php
@@ -54,7 +54,7 @@ class LandingPageControllerTest extends TestCase
                     new EqualsFilter('domains.url', $_SERVER['APP_URL'])
                 ),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         $data = [
             'id' => $this->ids->create('landing-page'),

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -150,7 +150,7 @@ class NavigationControllerTest extends TestCase
                 new EqualsFilter('domains.url', $_SERVER['APP_URL'])
             ),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
 
@@ -178,7 +178,7 @@ class NavigationControllerTest extends TestCase
         $salesChannel = static::getContainer()->get('sales_channel.repository')->search(
             new Criteria([$salesChannelId]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         $categoryId = $this->ids->create('out-of-range-category');
 
@@ -234,7 +234,7 @@ class NavigationControllerTest extends TestCase
                 new EqualsFilter('isCanonical', true)
             ),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertNotNull(
             $seoUrl,
@@ -252,7 +252,7 @@ class NavigationControllerTest extends TestCase
         $salesChannel = static::getContainer()->get('sales_channel.repository')->search(
             new Criteria([$salesChannelId]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::getContainer()->get('category.repository')->create([[
             'id' => $this->ids->create('issue-13510-intermediate'),

--- a/tests/integration/Storefront/Controller/NewsletterControllerTest.php
+++ b/tests/integration/Storefront/Controller/NewsletterControllerTest.php
@@ -62,7 +62,7 @@ class NewsletterControllerTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', 'nltest@example.com'));
         /** @var NewsletterRecipientEntity $recipientEntry */
-        $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->first();
+        $recipientEntry = $repo->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertSame('direct', (string) $recipientEntry->getStatus());
         $this->validateRecipientData($recipientEntry);

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -652,7 +652,7 @@ class ProductControllerTest extends TestCase
 
         $repo->create([$customer], Context::createDefaultContext());
 
-        $entity = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        $entity = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(CustomerEntity::class, $entity);
 

--- a/tests/integration/Storefront/Controller/WishlistControllerTest.php
+++ b/tests/integration/Storefront/Controller/WishlistControllerTest.php
@@ -342,7 +342,7 @@ class WishlistControllerTest extends TestCase
 
         $repo->create([$customer], Context::createDefaultContext());
 
-        $entity = $repo->search(new Criteria([$this->customerId]), Context::createDefaultContext())->first();
+        $entity = $repo->search(new Criteria([$this->customerId]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(CustomerEntity::class, $entity);
 

--- a/tests/integration/Storefront/Controller/fixtures/Apps/storefront-endpoint-cases/Resources/scripts/storefront-render/script.twig
+++ b/tests/integration/Storefront/Controller/fixtures/Apps/storefront-endpoint-cases/Resources/scripts/storefront-render/script.twig
@@ -1,6 +1,6 @@
 {% set productId = hook.query['product-id'] %}
 
-{% set product = services.store.search('product', { 'ids': [productId]}).first %}
+{% set product = services.store.search('product', { 'ids': [productId]}).getEntities().first %}
 
 {% do hook.page.addExtension('myProduct', product) %}
 

--- a/tests/integration/Storefront/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
@@ -53,7 +53,7 @@ class MainCategoryExtensionTest extends TestCase
         $criteria->addAssociation('mainCategories');
 
         /** @var ProductEntity $product */
-        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->first();
+        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertNotNull($product->getMainCategories());
         static::assertInstanceOf(MainCategoryCollection::class, $product->getMainCategories());

--- a/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
@@ -146,7 +146,7 @@ class SeoUrlTest extends TestCase
         $criteria->addAssociation('seoUrls');
 
         /** @var ProductEntity $product */
-        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->first();
+        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertInstanceOf(SeoUrlCollection::class, $product->getSeoUrls());
 
@@ -174,7 +174,7 @@ class SeoUrlTest extends TestCase
         $criteria->addAssociation('seoUrls');
 
         /** @var ProductEntity $product */
-        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->first();
+        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertInstanceOf(SeoUrlCollection::class, $product->getSeoUrls());
 
@@ -425,7 +425,7 @@ class SeoUrlTest extends TestCase
         $criteria->getAssociation('seoUrls')->setLimit(10);
 
         /** @var ProductEntity $product */
-        $product = $productRepo->search($criteria, Context::createDefaultContext())->first();
+        $product = $productRepo->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(SeoUrlCollection::class, $product->getSeoUrls());
     }
@@ -466,7 +466,7 @@ class SeoUrlTest extends TestCase
             ->setLimit(10)
             ->addFilter(new EqualsFilter('isCanonical', null));
 
-        $products = $productRepo->search($criteria, Context::createDefaultContext());
+        $products = $productRepo->search($criteria, Context::createDefaultContext())->getEntities();
         static::assertNotEmpty($products);
 
         /** @var ProductEntity $product */
@@ -581,7 +581,7 @@ class SeoUrlTest extends TestCase
             $criteria->addAssociation('seoUrls');
 
             /** @var CategoryEntity $category */
-            $category = $categoryRepository->search($criteria, $context)->first();
+            $category = $categoryRepository->search($criteria, $context)->getEntities()->first();
             static::assertSame($case['categoryId'], $category->getId());
 
             /** @var SeoUrlCollection $seoUrls */

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
@@ -65,7 +65,8 @@ class ProductPageSeoUrlRouteTest extends TestCase
 
         $channels = static::getContainer()
             ->get('sales_channel.repository')
-            ->search(new Criteria([$salesChannelId]), $context);
+            ->search(new Criteria([$salesChannelId]), $context)
+            ->getEntities();
 
         $channel = $channels->get($salesChannelId);
 

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/SeoUrlUpdateListenerTest.php
@@ -487,7 +487,7 @@ class SeoUrlUpdateListenerTest extends TestCase
 
         $criteria = new Criteria([$id1, $id2]);
         $criteria->addAssociation('seoUrls');
-        $products = $this->productRepository->search($criteria, Context::createDefaultContext());
+        $products = $this->productRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         /** @var ProductEntity $first */
         $first = $products->first();
@@ -562,7 +562,7 @@ class SeoUrlUpdateListenerTest extends TestCase
 
         $criteria = new Criteria([$parentId, $child1Id, $child2Id]);
         $criteria->addAssociation('seoUrls');
-        $products = $this->productRepository->search($criteria, Context::createDefaultContext());
+        $products = $this->productRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         /** @var ProductEntity $parent */
         $parent = $products->get($parentId);
@@ -622,7 +622,7 @@ class SeoUrlUpdateListenerTest extends TestCase
         // we don't check parent category here, because it's the home page and therefore has no seo url
         $criteria = new Criteria([$child1Id, $child2Id]);
         $criteria->addAssociation('seoUrls');
-        $categories = $categoryRepository->search($criteria, Context::createDefaultContext());
+        $categories = $categoryRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         // check that seo Urls are empty, as the categories are not assigned to a sales channel yet
         $child1 = $categories->get($child1Id);
@@ -652,7 +652,7 @@ class SeoUrlUpdateListenerTest extends TestCase
         // we don't check parent category here, because it's the home page and therefore has no seo url
         $criteria = new Criteria([$child1Id, $child2Id]);
         $criteria->addAssociation('seoUrls');
-        $categories = $categoryRepository->search($criteria, Context::createDefaultContext());
+        $categories = $categoryRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         $child1 = $categories->get($child1Id);
         static::assertInstanceOf(CategoryEntity::class, $child1);
@@ -720,7 +720,7 @@ class SeoUrlUpdateListenerTest extends TestCase
         $criteria->addAssociation('seoUrls');
 
         /** @var ProductEntity $product */
-        $product = $productRepo->search($criteria, Context::createDefaultContext())->first();
+        $product = $productRepo->search($criteria, Context::createDefaultContext())->getEntities()->first();
         /** @var SeoUrlCollection $seoUrls */
         $seoUrls = $product->getSeoUrls();
         static::assertInstanceOf(SeoUrlCollection::class, $seoUrls);

--- a/tests/integration/Storefront/Integration/ProductVisibilityTest.php
+++ b/tests/integration/Storefront/Integration/ProductVisibilityTest.php
@@ -98,7 +98,7 @@ class ProductVisibilityTest extends TestCase
             ->getResult();
 
         static::assertSame(1, $data->getTotal());
-        static::assertTrue($data->has($this->productId3));
+        static::assertTrue($data->getEntities()->has($this->productId3));
 
         $salesChannelContext = $this->contextFactory->create(Uuid::randomHex(), $this->salesChannelId2);
 
@@ -108,7 +108,7 @@ class ProductVisibilityTest extends TestCase
             ->getResult();
 
         static::assertSame(1, $data->getTotal());
-        static::assertTrue($data->has($this->productId1));
+        static::assertTrue($data->getEntities()->has($this->productId1));
     }
 
     public function testVisibilityInSearch(): void
@@ -119,16 +119,16 @@ class ProductVisibilityTest extends TestCase
 
         $page = $this->searchPageLoader->load($request, $salesChannelContext);
 
-        static::assertCount(2, $page->getListing());
-        static::assertTrue($page->getListing()->has($this->productId2));
-        static::assertTrue($page->getListing()->has($this->productId3));
+        static::assertCount(2, $page->getListing()->getEntities());
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId2));
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId3));
 
         $salesChannelContext = $this->contextFactory->create(Uuid::randomHex(), $this->salesChannelId2);
         $page = $this->searchPageLoader->load($request, $salesChannelContext);
 
-        static::assertCount(2, $page->getListing());
-        static::assertTrue($page->getListing()->has($this->productId1));
-        static::assertTrue($page->getListing()->has($this->productId2));
+        static::assertCount(2, $page->getListing()->getEntities());
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId1));
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId2));
     }
 
     public function testVisibilityOnProductPage(): void
@@ -181,16 +181,16 @@ class ProductVisibilityTest extends TestCase
 
         $page = $this->suggestPageLoader->load($request, $salesChannelContext);
 
-        static::assertCount(2, $page->getSearchResult());
-        static::assertTrue($page->getSearchResult()->has($this->productId2));
-        static::assertTrue($page->getSearchResult()->has($this->productId3));
+        static::assertCount(2, $page->getSearchResult()->getEntities());
+        static::assertTrue($page->getSearchResult()->getEntities()->has($this->productId2));
+        static::assertTrue($page->getSearchResult()->getEntities()->has($this->productId3));
 
         $salesChannelContext = $this->contextFactory->create(Uuid::randomHex(), $this->salesChannelId2);
         $page = $this->searchPageLoader->load($request, $salesChannelContext);
 
-        static::assertCount(2, $page->getListing());
-        static::assertTrue($page->getListing()->has($this->productId1));
-        static::assertTrue($page->getListing()->has($this->productId2));
+        static::assertCount(2, $page->getListing()->getEntities());
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId1));
+        static::assertTrue($page->getListing()->getEntities()->has($this->productId2));
     }
 
     private function insertData(): void

--- a/tests/integration/Storefront/Page/Account/AccountOrderPageLoaderTest.php
+++ b/tests/integration/Storefront/Page/Account/AccountOrderPageLoaderTest.php
@@ -126,7 +126,7 @@ class AccountOrderPageLoaderTest extends TestCase
             $salesChannel
         );
 
-        $order = $page->getOrders()->first();
+        $order = $page->getOrders()->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
         static::assertNotNull($order->getPrimaryOrderDelivery());

--- a/tests/integration/Storefront/Page/Account/OrderPageTest.php
+++ b/tests/integration/Storefront/Page/Account/OrderPageTest.php
@@ -27,7 +27,7 @@ class OrderPageTest extends TestCase
 
         $page = $this->getPageLoader()->load($request, $context);
 
-        static::assertCount(0, $page->getOrders());
+        static::assertCount(0, $page->getOrders()->getEntities());
         self::assertPageEvent(AccountOrderPageLoadedEvent::class, $event, $context, $request, $page);
     }
 
@@ -51,7 +51,7 @@ class OrderPageTest extends TestCase
 
         $page = $this->getPageLoader()->load($request, $context);
 
-        static::assertCount(1, $page->getOrders());
+        static::assertCount(1, $page->getOrders()->getEntities());
         self::assertPageEvent(AccountOrderPageLoadedEvent::class, $event, $context, $request, $page);
     }
 

--- a/tests/integration/Storefront/Page/SearchPageTest.php
+++ b/tests/integration/Storefront/Page/SearchPageTest.php
@@ -31,7 +31,7 @@ class SearchPageTest extends TestCase
 
         $page = $this->getPageLoader()->load($request, $context);
 
-        static::assertEmpty($page->getListing());
+        static::assertEmpty($page->getListing()->getEntities());
         static::assertSame(self::TEST_TERM, $page->getSearchTerm());
         self::assertPageEvent(SearchPageLoadedEvent::class, $homePageLoadedEvent, $context, $request, $page);
     }

--- a/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
@@ -114,6 +114,6 @@ class ThemeAppLifecycleHandlerTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', $technicalName));
 
-        return $this->themeRepository->search($criteria, $this->context)->getElements();
+        return $this->themeRepository->search($criteria, $this->context)->getEntities()->getElements();
     }
 }

--- a/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
@@ -445,7 +445,7 @@ class ThemeLifecycleServiceTest extends TestCase
         // check whether the theme is no longer in the table and the associated media have been deleted
         static::assertFalse($this->hasTheme($bundle));
         static::assertCount(0, $this->mediaRepository->searchIds(new Criteria($ids), Context::createDefaultContext())->getIds());
-        static::assertCount(0, $this->themeRepository->search(new Criteria([$childId, $themeEntity->getId()]), $this->context));
+        static::assertCount(0, $this->themeRepository->search(new Criteria([$childId, $themeEntity->getId()]), $this->context)->getEntities());
     }
 
     private function getThemeConfig(): StorefrontPluginConfiguration
@@ -492,7 +492,7 @@ class ThemeLifecycleServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('fileName', $fileName));
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->first();
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertInstanceOf(MediaEntity::class, $media);
 
         return $media;
@@ -503,7 +503,7 @@ class ThemeLifecycleServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('fileName', $fileName));
 
-        $media = $this->mediaRepository->search($criteria, $this->context)->first();
+        $media = $this->mediaRepository->search($criteria, $this->context)->getEntities()->first();
         static::assertNull($media);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`EntitySearchResult`'s inherited collection API (`first()`, `get()`, `count()`, iteration, …) is deprecated for v6.8 and throws under `FEATURE_ALL=major`, so the Storefront integration tests still using the old idiom fail only in the integration-major nightly.

### 2. What does this change do, exactly?

- Migrates every deprecated accessor in `tests/integration/Storefront/` to `->getEntities()->…`: chained calls after `->search(…)`, variable-held results (`assertCount`, `has()`, `filter()`, `first()`/`last()`/`get()`), and page-object results (`ProductListingResult`, `StorefrontSearchResult`) in `ProductVisibilityTest`, `OrderPageTest`, `SearchPageTest`, and friends.
- Updates the paired script fixture `storefront-endpoint-cases/…/storefront-render/script.twig` to `.getEntities().first` (explicit method-call brackets) and regenerates `custom-endpoint-script-services-reference.md` via `bin/console docs:generate-scripts-reference` — both must move together or `ScriptReferenceGeneratorTest` fails. The public shopware/docs copy needs the same follow-up.
- `IdSearchResult` calls (`searchIds()`) are untouched, as that API is not deprecated.

Verified with the whole `tests/integration/Storefront` suite under `FEATURE_ALL=major` and with flags off, iterating until no `EntitySearchResult` deprecation throws remain. One known exception: `LandingPageLoaderTest::testLoad` still fails under major flags because production code (`LandingPageRoute::load()`) calls `first()` on a search result — that straggler is tracked via #18387 and needs a production fix, not a test change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Storefront` on trunk: tests throw `FeatureException: Tried to access deprecated functionality: … EntitySearchResult::first()/count()/has() …`.
2. With this change, no such throw remains in the suite (except the production-side `LandingPageRoute` case above).

### 4. Please link to the relevant issues (if any).

- closes #18392

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
