### PR TITLE
fix: use non-deprecated EntitySearchResult accessors in landing page route, guest conversion and sitemap generation

### DIFF
--- a/src/Core/Checkout/Customer/Api/ConvertGuestController.php
+++ b/src/Core/Checkout/Customer/Api/ConvertGuestController.php
@@ -52,7 +52,7 @@ class ConvertGuestController
     )]
     public function convert(Request $request, Context $context, string $customerId): NoContentResponse
     {
-        $customer = $this->customerRepository->search(new Criteria([$customerId]), $context)->first();
+        $customer = $this->customerRepository->search(new Criteria([$customerId]), $context)->getEntities()->first();
 
         if (!$customer instanceof CustomerEntity) {
             throw CustomerException::customerNotFoundByIdException($customerId);

--- a/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/LandingPageRoute.php
@@ -79,7 +79,7 @@ class LandingPageRoute extends AbstractLandingPageRoute
             $resolverContext
         );
 
-        $cmsPage = $pages->first();
+        $cmsPage = $pages->getEntities()->first();
         if ($cmsPage === null) {
             throw LandingPageException::notFound($pageId);
         }

--- a/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+++ b/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
@@ -74,7 +74,7 @@ class SitemapGenerateCommand extends Command
             new SitemapSalesChannelCriteriaEvent($criteria, $context)
         );
 
-        $salesChannels = $this->salesChannelRepository->search($criteria, $context);
+        $salesChannels = $this->salesChannelRepository->search($criteria, $context)->getEntities();
 
         foreach ($salesChannels as $salesChannel) {
             $languageIds = $salesChannel->getDomains()?->map(static fn (SalesChannelDomainEntity $salesChannelDomain) => $salesChannelDomain->getLanguageId()) ?? [];

--- a/tests/integration/Core/Checkout/Customer/Api/ConvertGuestControllerTest.php
+++ b/tests/integration/Core/Checkout/Customer/Api/ConvertGuestControllerTest.php
@@ -81,7 +81,7 @@ class ConvertGuestControllerTest extends TestCase
         $customerId = $this->createCustomer('test@test.com', guest: true);
 
         $customer = $this->customerRepository
-            ->search(new Criteria([$customerId]), $context)
+            ->search(new Criteria([$customerId]), $context)->getEntities()
             ->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);
@@ -111,7 +111,7 @@ class ConvertGuestControllerTest extends TestCase
 
         $this->controller->convert($request, Context::createDefaultContext(), $customerId);
 
-        $customer = $this->customerRepository->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertNull($caughtEvent);
         static::assertInstanceOf(CustomerEntity::class, $customer);
@@ -135,7 +135,7 @@ class ConvertGuestControllerTest extends TestCase
 
         $this->controller->convert($request, Context::createDefaultContext(), $customerId);
 
-        $customer = $this->customerRepository->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(CustomerAccountRecoverRequestEvent::class, $caughtEvent);
         static::assertInstanceOf(CustomerEntity::class, $customer);

--- a/tests/unit/Core/Checkout/Customer/Api/ConvertGuestControllerTest.php
+++ b/tests/unit/Core/Checkout/Customer/Api/ConvertGuestControllerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Api\ConvertGuestController;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractConvertGuestRoute;
@@ -39,8 +40,8 @@ class ConvertGuestControllerTest extends TestCase
         $repository = static::createStub(EntityRepository::class);
 
         $searchResult = static::createStub(EntitySearchResult::class);
-        $searchResult->method('first')
-            ->willReturn($customer);
+        $searchResult->method('getEntities')
+            ->willReturn(new CustomerCollection([$customer]));
 
         $repository->method('search')
             ->willReturn($searchResult);
@@ -105,7 +106,7 @@ class ConvertGuestControllerTest extends TestCase
         $repository = static::createStub(EntityRepository::class);
 
         $searchResult = static::createStub(EntitySearchResult::class);
-        $searchResult->method('first')->willReturn(null);
+        $searchResult->method('getEntities')->willReturn(new CustomerCollection());
 
         $repository->method('search')->willReturn($searchResult);
 
@@ -133,7 +134,7 @@ class ConvertGuestControllerTest extends TestCase
         $repository = static::createStub(EntityRepository::class);
 
         $searchResult = static::createStub(EntitySearchResult::class);
-        $searchResult->method('first')->willReturn($customer);
+        $searchResult->method('getEntities')->willReturn(new CustomerCollection([$customer]));
 
         $repository->method('search')->willReturn($searchResult);
 
@@ -197,7 +198,7 @@ class ConvertGuestControllerTest extends TestCase
         $repository = static::createStub(EntityRepository::class);
 
         $searchResult = static::createStub(EntitySearchResult::class);
-        $searchResult->method('first')->willReturn($customer);
+        $searchResult->method('getEntities')->willReturn(new CustomerCollection([$customer]));
 
         $repository->method('search')->willReturn($searchResult);
 

--- a/tests/unit/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
+++ b/tests/unit/Core/Content/LandingPage/SalesChannel/LandingPageRouteTest.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\LandingPage\SalesChannel;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\CmsPageCollection;
+use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
+use Shopware\Core\Content\Cms\Service\EntityCmsSlotConfigInheritanceBuilder;
+use Shopware\Core\Content\LandingPage\LandingPageCollection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Content\LandingPage\LandingPageEntity;
+use Shopware\Core\Content\LandingPage\LandingPageException;
+use Shopware\Core\Content\LandingPage\SalesChannel\LandingPageRoute;
+use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticSalesChannelRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(LandingPageRoute::class)]
+class LandingPageRouteTest extends TestCase
+{
+    private MockObject&SalesChannelCmsPageLoaderInterface $cmsPageLoader;
+
+    private SalesChannelContext $salesChannelContext;
+
+    protected function setUp(): void
+    {
+        $this->cmsPageLoader = $this->createMock(SalesChannelCmsPageLoaderInterface::class);
+
+        $salesChannelContext = static::createStub(SalesChannelContext::class);
+        $salesChannelContext->method('getSalesChannelId')->willReturn(Uuid::randomHex());
+        $salesChannelContext->method('getLanguageId')->willReturn(Uuid::randomHex());
+        $salesChannelContext->method('getContext')->willReturn(Context::createDefaultContext());
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    #[TestDox('The resolved cms page is loaded onto the landing page')]
+    public function testLoadsLandingPageWithCmsPage(): void
+    {
+        $landingPage = $this->createLandingPage(withCmsPage: true);
+        $cmsPage = new CmsPageEntity();
+        $cmsPage->setId($landingPage->getCmsPageId() ?? '');
+
+        $this->cmsPageLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($this->createCmsPageResult(new CmsPageCollection([$cmsPage])));
+
+        $response = $this->createRoute($landingPage)->load($landingPage->getId(), new Request(), $this->salesChannelContext);
+
+        static::assertSame($landingPage, $response->getLandingPage());
+        static::assertSame($cmsPage, $response->getLandingPage()->getCmsPage());
+    }
+
+    #[TestDox('A landing page without an assigned cms page is returned without loading one')]
+    public function testLoadsLandingPageWithoutCmsPageId(): void
+    {
+        $landingPage = $this->createLandingPage(withCmsPage: false);
+
+        $this->cmsPageLoader->expects($this->never())->method('load');
+
+        $response = $this->createRoute($landingPage)->load($landingPage->getId(), new Request(), $this->salesChannelContext);
+
+        static::assertSame($landingPage, $response->getLandingPage());
+        static::assertNull($response->getLandingPage()->getCmsPage());
+    }
+
+    #[TestDox('An unresolvable cms page fails the route')]
+    public function testThrowsWhenCmsPageCannotBeLoaded(): void
+    {
+        $landingPage = $this->createLandingPage(withCmsPage: true);
+
+        $this->cmsPageLoader
+            ->expects($this->once())
+            ->method('load')
+            ->willReturn($this->createCmsPageResult(new CmsPageCollection()));
+
+        $this->expectExceptionObject(LandingPageException::notFound($landingPage->getCmsPageId() ?? ''));
+
+        $this->createRoute($landingPage)->load($landingPage->getId(), new Request(), $this->salesChannelContext);
+    }
+
+    #[TestDox('An unknown landing page id fails the route')]
+    public function testThrowsWhenLandingPageIsNotFound(): void
+    {
+        $missingId = Uuid::randomHex();
+
+        $this->cmsPageLoader->expects($this->never())->method('load');
+
+        /** @var StaticSalesChannelRepository<LandingPageCollection> $repository */
+        $repository = new StaticSalesChannelRepository([new LandingPageCollection()]);
+
+        $route = new LandingPageRoute(
+            $repository,
+            $this->cmsPageLoader,
+            new EntityCmsSlotConfigInheritanceBuilder(static::createStub(Connection::class)),
+            static::createStub(LandingPageDefinition::class),
+            static::createStub(CacheTagCollector::class)
+        );
+
+        $this->expectExceptionObject(LandingPageException::notFound($missingId));
+
+        $route->load($missingId, new Request(), $this->salesChannelContext);
+    }
+
+    private function createRoute(LandingPageEntity $landingPage): LandingPageRoute
+    {
+        /** @var StaticSalesChannelRepository<LandingPageCollection> $repository */
+        $repository = new StaticSalesChannelRepository([new LandingPageCollection([$landingPage])]);
+
+        return new LandingPageRoute(
+            $repository,
+            $this->cmsPageLoader,
+            new EntityCmsSlotConfigInheritanceBuilder(static::createStub(Connection::class)),
+            static::createStub(LandingPageDefinition::class),
+            static::createStub(CacheTagCollector::class)
+        );
+    }
+
+    /**
+     * @return EntitySearchResult<CmsPageCollection>
+     */
+    private function createCmsPageResult(CmsPageCollection $pages): EntitySearchResult
+    {
+        return new EntitySearchResult(
+            'cms_page',
+            $pages->count(),
+            $pages,
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+    }
+
+    private function createLandingPage(bool $withCmsPage): LandingPageEntity
+    {
+        $landingPage = new LandingPageEntity();
+        $landingPage->setId(Uuid::randomHex());
+        $landingPage->setUniqueIdentifier($landingPage->getId());
+        if ($withCmsPage) {
+            $landingPage->setCmsPageId(Uuid::randomHex());
+        }
+
+        return $landingPage;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

#17101 deprecated `EntitySearchResult`'s inherited collection accessors and migrated production callers, but missed three call sites. Under `FEATURE_ALL=major` all of them throw `FeatureException` in shipping code: every landing-page storefront request, every admin guest-customer conversion, and every `sitemap:generate` run fails.

### 2. What does this change do, exactly?

- `LandingPageRoute::load()`: `$pages->first()` → `$pages->getEntities()->first()` (line 101 of the same file was already migrated by #17101 — this one was missed).
- `ConvertGuestController::convert()`: `->search(…)->first()` → `->search(…)->getEntities()->first()`.
- `SitemapGenerateCommand::execute()`: iterates `->search(…)->getEntities()` instead of the raw search result (uncovered by the content test sweep #18422; its integration test passes under major flags with the fix).
- Updates the `ConvertGuestControllerTest` unit stubs from `method('first')` to `method('getEntities')` returning a real `CustomerCollection`, and migrates three test-side `->first()` calls in the checkout integration test that would otherwise mask the verification under major flags.

Verified `LandingPageRouteTest`, the storefront `LandingPageLoaderTest`, and `ConvertGuestControllerTest` (unit + integration) with `FEATURE_ALL=major` and with flags off — all green.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Storefront/Page/LandingPage/LandingPageLoaderTest.php` on trunk.
2. It errors with `Tried to access deprecated functionality: Method "…EntitySearchResult::first()" is deprecated`, thrown from `LandingPageRoute.php`; the same happens for guest conversion via `ConvertGuestControllerTest`.

### 4. Please link to the relevant issues (if any).

- relates #18387

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

