### PR TITLE
test: sweep deprecated EntitySearchResult accessors from checkout integration tests

### DIFF
--- a/tests/integration/Core/Checkout/Cart/Delivery/DeliveryProcessorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Delivery/DeliveryProcessorTest.php
@@ -55,7 +55,7 @@ class DeliveryProcessorTest extends TestCase
         $shippingMethodCriteria->addAssociation('deliveryTime');
 
         $this->salesChannelContext->assign([
-            'shippingMethod' => static::getContainer()->get('shipping_method.repository')->search($shippingMethodCriteria, $this->salesChannelContext->getContext())->first(),
+            'shippingMethod' => static::getContainer()->get('shipping_method.repository')->search($shippingMethodCriteria, $this->salesChannelContext->getContext())->getEntities()->first(),
         ]);
 
         $shippingMethodPriceEntity = new ShippingMethodPriceEntity();

--- a/tests/integration/Core/Checkout/Cart/Order/OrderRecalculationControllerTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/OrderRecalculationControllerTest.php
@@ -59,7 +59,7 @@ class OrderRecalculationControllerTest extends TestCase
 
         $this->context->assign(['versionId' => $versionId]);
 
-        $order = $this->orderRepository->search(new Criteria(), $this->context)->first();
+        $order = $this->orderRepository->search(new Criteria(), $this->context)->getEntities()->first();
         static::assertInstanceOf(OrderEntity::class, $order);
 
         static::assertSame(Response::HTTP_NOT_FOUND, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -303,7 +303,7 @@ class RecalculationServiceTest extends TestCase
             ->addAssociation('deliveries.shippingOrderAddress.country')
             ->addAssociation('deliveries.shippingOrderAddress.countryState');
 
-        $order = $this->orderRepository->search($criteria, $this->context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getNestedLineItems());
 
@@ -422,7 +422,7 @@ class RecalculationServiceTest extends TestCase
 
         // read order
         $versionContext = $this->context->createWithVersionId($versionId);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->get($orderId);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertNotNull($order->getOrderCustomer());
@@ -467,7 +467,7 @@ class RecalculationServiceTest extends TestCase
 
         // read order
         $versionContext = $this->context->createWithVersionId($versionId);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->get($orderId);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertSame($this->getDeDeLanguageId(), $order->getLanguageId());
@@ -515,7 +515,7 @@ class RecalculationServiceTest extends TestCase
 
         // read order
         $versionContext = $this->context->createWithVersionId($versionId);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->get($orderId);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $versionContext)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertNotNull($order->getOrderCustomer());
@@ -628,7 +628,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
         static::assertSame('test comment', $order->getCustomerComment());
@@ -781,7 +781,7 @@ class RecalculationServiceTest extends TestCase
         // create order
         $cart = $this->generateDemoCart();
 
-        $shippingMethod = $this->shippingMethodRepository->search(new Criteria(), $this->context)->first();
+        $shippingMethod = $this->shippingMethodRepository->search(new Criteria(), $this->context)->getEntities()->first();
         static::assertInstanceOf(ShippingMethodEntity::class, $shippingMethod);
 
         $cart->setDeliveries(new DeliveryCollection([
@@ -901,7 +901,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertNotNull($order->getLineItems());
@@ -931,7 +931,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertNotNull($order->getLineItems());
@@ -962,7 +962,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertNotNull($order->getLineItems());
@@ -1014,7 +1014,7 @@ class RecalculationServiceTest extends TestCase
         // read merged order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
 
@@ -1048,7 +1048,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
-        $deliveries = $this->orderDeliveryRepository->search($criteria, $versionContext);
+        $deliveries = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities();
 
         static::assertCount(1, $deliveries);
 
@@ -1078,7 +1078,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
-        $deliveries = $this->orderDeliveryRepository->search($criteria, $versionContext);
+        $deliveries = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities();
 
         $delivery = $deliveries->first();
         static::assertNotNull($delivery);
@@ -1120,7 +1120,7 @@ class RecalculationServiceTest extends TestCase
             ->addAssociation('deliveries.shippingOrderAddress.country')
             ->addAssociation('deliveries.shippingOrderAddress.countryState');
 
-        $order = $this->orderRepository->search($criteria, $this->context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->get($orderId);
         static::assertInstanceOf(OrderEntity::class, $order);
 
         $lineItemWithInactiveProduct = $order->getLineItems()?->filter(
@@ -1142,7 +1142,7 @@ class RecalculationServiceTest extends TestCase
         static::getContainer()->get(RecalculationService::class)->recalculate($orderId, $versionContext, $options);
 
         // Assert
-        $order = $this->orderRepository->search($criteria, $versionContext)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $versionContext)->getEntities()->get($orderId);
         static::assertInstanceOf(OrderEntity::class, $order);
 
         $lineItemWithInactiveProduct = $order->getLineItems()?->filter(
@@ -1173,7 +1173,7 @@ class RecalculationServiceTest extends TestCase
             ->addAssociation('deliveries.shippingOrderAddress.country')
             ->addAssociation('deliveries.shippingOrderAddress.countryState');
 
-        $order = $this->orderRepository->search($criteria, $this->context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         static::assertSame(224.07, $order->getPrice()->getNetPrice());
@@ -1184,7 +1184,7 @@ class RecalculationServiceTest extends TestCase
 
         static::getContainer()->get(RecalculationService::class)->recalculate($orderId, $versionContext);
 
-        $order = $this->orderRepository->search($criteria, $this->context)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getPrice());
 
@@ -1214,7 +1214,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
 
-        $shippingCosts = $this->orderDeliveryRepository->search($criteria, $versionContext)->first()?->getShippingCosts();
+        $shippingCosts = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities()->first()?->getShippingCosts();
         static::assertNotNull($shippingCosts);
 
         static::assertSame(1, $shippingCosts->getQuantity());
@@ -1244,7 +1244,7 @@ class RecalculationServiceTest extends TestCase
         $criteria->getAssociation('shippingMethod')->addAssociation('prices');
 
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
-        $shippingMethod = $this->orderDeliveryRepository->search($criteria, $versionContext)->first()?->getShippingMethod();
+        $shippingMethod = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities()->first()?->getShippingMethod();
         static::assertNotNull($shippingMethod);
 
         $firstPriceRule = $shippingMethod->getPrices()->first();
@@ -1279,7 +1279,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
 
-        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->first();
+        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities()->first();
         static::assertNotNull($delivery);
         static::assertSame(1, $delivery->getShippingCosts()->getQuantity());
         static::assertSame(15.0, $delivery->getShippingCosts()->getUnitPrice());
@@ -1306,7 +1306,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
-        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->first();
+        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities()->first();
         static::assertNotNull($delivery);
         static::assertSame(1, $delivery->getShippingCosts()->getQuantity());
         static::assertSame(9.99, $delivery->getShippingCosts()->getUnitPrice());
@@ -1333,7 +1333,7 @@ class RecalculationServiceTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('order_delivery.orderId', $orderId));
-        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->first();
+        $delivery = $this->orderDeliveryRepository->search($criteria, $versionContext)->getEntities()->first();
         static::assertNotNull($delivery);
         static::assertSame(1, $delivery->getShippingCosts()->getQuantity());
         static::assertSame(15.0, $delivery->getShippingCosts()->getUnitPrice());
@@ -1354,7 +1354,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getAddresses());
 
@@ -1396,7 +1396,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getAddresses());
         $orderAddress = $order->getAddresses()->first();
@@ -1439,7 +1439,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
 
-        $order = $this->orderRepository->search($criteria, $versionContext)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $versionContext)->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
         static::assertSame($order->getLineItems()->count(), 2);
@@ -1448,7 +1448,7 @@ class RecalculationServiceTest extends TestCase
         $ids = $order->getLineItems()->fmap(static fn (OrderLineItemEntity $lineItem) => ['id' => $lineItem->getId()]);
         static::getContainer()->get('order_line_item.repository')->delete(array_values($ids), $versionContext);
 
-        $order = $this->orderRepository->search($criteria, $versionContext)->get($orderId);
+        $order = $this->orderRepository->search($criteria, $versionContext)->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
         static::assertSame($order->getLineItems()->count(), 0);
@@ -1870,7 +1870,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
 
@@ -1930,7 +1930,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotNull($order);
         static::assertNotNull($order->getLineItems());
 
@@ -1997,7 +1997,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotEmpty($order);
         static::assertNotNull($order->getLineItems());
         static::assertSame($oldTotal + $creditAmount, $order->getAmountTotal());
@@ -2046,7 +2046,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotEmpty($order);
         static::assertNotNull($order->getLineItems());
         static::assertCount(3, $order->getLineItems());
@@ -2094,7 +2094,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
         $criteria->addAssociation('deliveries');
-        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotEmpty($order);
         static::assertNotNull($order->getLineItems());
         static::assertCount(3, $order->getLineItems());
@@ -2140,7 +2140,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotEmpty($order);
         static::assertNotNull($order->getLineItems());
         static::assertCount(3, $order->getLineItems());
@@ -2189,7 +2189,7 @@ class RecalculationServiceTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('deliveries');
-        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->get($orderId);
+        $order = $orderRepository->search($criteria, $this->context->createWithVersionId($versionId))->getEntities()->get($orderId);
         static::assertNotEmpty($order);
         static::assertNotNull($order->getDeliveries());
         static::assertCount(2, $order->getDeliveries());
@@ -2372,7 +2372,7 @@ class RecalculationServiceTest extends TestCase
         $criteria = new Criteria([$shippingMethodId]);
         $criteria->addAssociation('priceRules');
 
-        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->get($shippingMethodId);
+        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->getEntities()->get($shippingMethodId);
         static::assertNotNull($shippingMethod);
 
         return $shippingMethod;
@@ -2456,7 +2456,7 @@ class RecalculationServiceTest extends TestCase
         $criteria->addAssociation('prices');
         $criteria->addAssociation('deliveryTime');
 
-        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->get($shippingMethodId);
+        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->getEntities()->get($shippingMethodId);
         static::assertNotNull($shippingMethod);
 
         return $shippingMethod;
@@ -2540,7 +2540,7 @@ class RecalculationServiceTest extends TestCase
         $criteria->addAssociation('priceRules');
         $criteria->addAssociation('deliveryTime');
 
-        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->get($shippingMethodId);
+        $shippingMethod = $this->shippingMethodRepository->search($criteria, $this->context)->getEntities()->get($shippingMethodId);
         static::assertNotNull($shippingMethod);
 
         return $shippingMethod;

--- a/tests/integration/Core/Checkout/Cart/Order/SetPaymentOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/SetPaymentOrderRouteTest.php
@@ -79,7 +79,7 @@ class SetPaymentOrderRouteTest extends TestCase
 
         $this->setPaymentOrderRoute->setPayment($request, $context);
 
-        $order = $this->orderRepository->search(new Criteria(), $context->getContext())->first();
+        $order = $this->orderRepository->search(new Criteria(), $context->getContext())->getEntities()->first();
         static::assertInstanceOf(OrderEntity::class, $order);
         static::assertNotNull($order->getPrimaryOrderTransactionId());
     }
@@ -121,7 +121,7 @@ class SetPaymentOrderRouteTest extends TestCase
         $criteria = new Criteria();
         $criteria->addAssociations(['primaryOrderTransaction', 'transactions']);
 
-        $order = $this->orderRepository->search($criteria, $context->getContext())->first();
+        $order = $this->orderRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
         static::assertNotNull($order->getPrimaryOrderTransactionId());
@@ -172,7 +172,7 @@ class SetPaymentOrderRouteTest extends TestCase
         $criteria = new Criteria();
         $criteria->addAssociations(['primaryOrderTransaction', 'transactions']);
 
-        $order = $this->orderRepository->search($criteria, $context->getContext())->first();
+        $order = $this->orderRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
         static::assertNotNull($order->getPrimaryOrderTransactionId());
@@ -214,7 +214,7 @@ class SetPaymentOrderRouteTest extends TestCase
             'customerNumber' => 'not',
         ]], Context::createDefaultContext());
 
-        return $this->customerRepository->search(new Criteria([$id1]), Context::createDefaultContext())->first();
+        return $this->customerRepository->search(new Criteria([$id1]), Context::createDefaultContext())->getEntities()->first();
     }
 
     /**

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionDiscountCompositionTest.php
@@ -183,7 +183,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $this->orderWithPromotion($code, [$productId1, $productId2], $context);
 
         $promotion = $this->promotionRepository
-            ->search(new Criteria([$promotionId]), Context::createDefaultContext())
+            ->search(new Criteria([$promotionId]), Context::createDefaultContext())->getEntities()
             ->get($promotionId);
 
         static::assertInstanceOf(PromotionEntity::class, $promotion);
@@ -200,7 +200,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $this->orderWithPromotion($code, [$productId1, $productId2], $context);
 
         $promotion = $this->promotionRepository
-            ->search(new Criteria([$promotionId]), Context::createDefaultContext())
+            ->search(new Criteria([$promotionId]), Context::createDefaultContext())->getEntities()
             ->get($promotionId);
         static::assertNotNull($promotion);
 
@@ -223,7 +223,7 @@ class PromotionDiscountCompositionTest extends TestCase
         $this->orderWithPromotion($code, [$productId1, $productId2], $context2);
 
         $promotion = $this->promotionRepository
-            ->search(new Criteria([$promotionId]), Context::createDefaultContext())
+            ->search(new Criteria([$promotionId]), Context::createDefaultContext())->getEntities()
             ->get($promotionId);
         static::assertNotNull($promotion);
 

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionExtensionCodesTest.php
@@ -324,7 +324,7 @@ class PromotionExtensionCodesTest extends TestCase
 
         /** @var OrderEntity $order */
         $order = static::getContainer()->get('order.repository')
-            ->search($criteria, $context->getContext())
+            ->search($criteria, $context->getContext())->getEntities()
             ->get($orderId);
         static::assertNotNull($order);
 

--- a/tests/integration/Core/Checkout/Cart/Rule/CartAmountRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/CartAmountRuleTest.php
@@ -89,6 +89,6 @@ class CartAmountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 }

--- a/tests/integration/Core/Checkout/Cart/Rule/CartHasFreeDeliveryItemRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/CartHasFreeDeliveryItemRuleTest.php
@@ -157,7 +157,7 @@ class CartHasFreeDeliveryItemRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     #[DataProvider('getLineItemFreeDeliveryTestData')]

--- a/tests/integration/Core/Checkout/Cart/Rule/CartTaxDisplayRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/CartTaxDisplayRuleTest.php
@@ -64,7 +64,7 @@ class CartTaxDisplayRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testThatTaxStateMatches(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/GoodsCountRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/GoodsCountRuleTest.php
@@ -97,7 +97,7 @@ class GoodsCountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testCreateRuleWithFilter(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/GoodsPriceRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/GoodsPriceRuleTest.php
@@ -98,7 +98,7 @@ class GoodsPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testValidateWithIntAmount(): void
@@ -122,7 +122,7 @@ class GoodsPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testAvailableOperators(): void
@@ -184,7 +184,7 @@ class GoodsPriceRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -231,7 +231,7 @@ class GoodsPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testCreateRuleWithFilter(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemGoodsTotalRuleTest.php
@@ -181,7 +181,7 @@ class LineItemGoodsTotalRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -228,7 +228,7 @@ class LineItemGoodsTotalRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testCreateRuleWithFilter(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemRuleTest.php
@@ -171,7 +171,7 @@ class LineItemRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testNotMatchesWithoutId(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemTagRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemTagRuleTest.php
@@ -161,6 +161,6 @@ class LineItemTagRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 }

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemTotalPriceRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemTotalPriceRuleTest.php
@@ -102,7 +102,7 @@ class LineItemTotalPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testValidateWithIntAmount(): void
@@ -126,7 +126,7 @@ class LineItemTotalPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testAvailableOperators(): void
@@ -188,7 +188,7 @@ class LineItemTotalPriceRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -235,7 +235,7 @@ class LineItemTotalPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     #[DataProvider('getMatchingRuleTestData')]

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemUnitPriceRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemUnitPriceRuleTest.php
@@ -99,7 +99,7 @@ class LineItemUnitPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testValidateWithIntAmount(): void
@@ -123,7 +123,7 @@ class LineItemUnitPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testAvailableOperators(): void
@@ -185,7 +185,7 @@ class LineItemUnitPriceRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -232,7 +232,7 @@ class LineItemUnitPriceRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     #[DataProvider('getMatchingRuleTestData')]

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemWithQuantityRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemWithQuantityRuleTest.php
@@ -212,7 +212,7 @@ class LineItemWithQuantityRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -261,7 +261,7 @@ class LineItemWithQuantityRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     #[DataProvider('matchProvider')]

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemsInCartCountRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemsInCartCountRuleTest.php
@@ -147,7 +147,7 @@ class LineItemsInCartCountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testRuleMatchWithoutItemsInCart(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
@@ -94,7 +94,7 @@ class PaymentMethodRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     /**

--- a/tests/integration/Core/Checkout/Cart/Rule/PromotionCodeOfTypeRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/PromotionCodeOfTypeRuleTest.php
@@ -142,7 +142,7 @@ class PromotionCodeOfTypeRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     #[DataProvider('getCartRuleScopeTestData')]

--- a/tests/integration/Core/Checkout/Cart/Rule/PromotionValueRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/PromotionValueRuleTest.php
@@ -99,7 +99,7 @@ class PromotionValueRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testValidateWithIntAmount(): void
@@ -123,7 +123,7 @@ class PromotionValueRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testAvailableOperators(): void
@@ -185,7 +185,7 @@ class PromotionValueRuleTest extends TestCase
             $this->conditionRepository->search(
                 new Criteria([$conditionIdEq, $conditionIdNEq, $conditionIdLTE, $conditionIdGTE]),
                 $this->context
-            )
+            )->getEntities()
         );
     }
 
@@ -232,7 +232,7 @@ class PromotionValueRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testCreateRuleWithFilter(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/PromotionsInCartCountRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/PromotionsInCartCountRuleTest.php
@@ -148,7 +148,7 @@ class PromotionsInCartCountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     public function testRuleMatchWithoutItemsInCart(): void

--- a/tests/integration/Core/Checkout/Cart/Rule/ShippingMethodRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/ShippingMethodRuleTest.php
@@ -94,7 +94,7 @@ class ShippingMethodRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     /**

--- a/tests/integration/Core/Checkout/Customer/AccountServiceEventTest.php
+++ b/tests/integration/Core/Checkout/Customer/AccountServiceEventTest.php
@@ -179,7 +179,7 @@ class AccountServiceEventTest extends TestCase
         $customer = $this->customerRepository->search(
             (new Criteria())->addFilter(new EqualsFilter('email', $email)),
             $this->salesChannelContext->getContext()
-        )->first();
+        )->getEntities()->first();
 
         $this->salesChannelContext->assign(['customer' => $customer]);
 

--- a/tests/integration/Core/Checkout/Customer/DeleteUnusedGuestCustomerServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/DeleteUnusedGuestCustomerServiceTest.php
@@ -65,9 +65,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
 
         static::assertSame(0, $this->service->countUnusedCustomers($context));
 
-        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context);
+        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context)->getEntities();
 
-        static::assertSame(0, $result->getTotal());
+        static::assertCount(0, $result);
     }
 
     public function testItDoesOnlyDeleteGuestCustomers(): void
@@ -97,9 +97,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
         $result = $customerRepository->search(new Criteria([
             $this->ids->get('10000'),
             $this->ids->get('10001'),
-        ]), $context);
+        ]), $context)->getEntities();
 
-        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         /** @var CustomerEntity $entity */
         $entity = $result->first();
@@ -136,9 +136,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
         $result = $customerRepository->search(new Criteria([
             $this->ids->get('10000'),
             $this->ids->get('10001'),
-        ]), $context);
+        ]), $context)->getEntities();
 
-        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         /** @var CustomerEntity $entity */
         $entity = $result->first();
@@ -176,9 +176,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
         $result = $customerRepository->search(new Criteria([
             $this->ids->get('10000'),
             $this->ids->get('10001'),
-        ]), $context);
+        ]), $context)->getEntities();
 
-        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         /** @var CustomerEntity $entity */
         $entity = $result->first();
@@ -208,9 +208,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
 
         static::assertSame(0, $this->service->countUnusedCustomers($context));
 
-        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context);
+        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context)->getEntities();
 
-        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         /** @var CustomerEntity $entity */
         $entity = $result->first();
@@ -240,9 +240,9 @@ class DeleteUnusedGuestCustomerServiceTest extends TestCase
 
         static::assertSame(0, $this->service->countUnusedCustomers($context));
 
-        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context);
+        $result = $customerRepository->search(new Criteria([$this->ids->get('10000')]), $context)->getEntities();
 
-        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result);
 
         /** @var CustomerEntity $entity */
         $entity = $result->first();

--- a/tests/integration/Core/Checkout/Customer/Rule/BillingCountryRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/BillingCountryRuleTest.php
@@ -157,7 +157,7 @@ class BillingCountryRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
 
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);

--- a/tests/integration/Core/Checkout/Customer/Rule/BillingStateRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/BillingStateRuleTest.php
@@ -64,7 +64,7 @@ class BillingStateRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/BillingStreetRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/BillingStreetRuleTest.php
@@ -131,7 +131,7 @@ class BillingStreetRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/BillingZipCodeRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/BillingZipCodeRuleTest.php
@@ -207,7 +207,7 @@ class BillingZipCodeRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }
@@ -256,7 +256,7 @@ class BillingZipCodeRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/CustomerGroupRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/CustomerGroupRuleTest.php
@@ -153,7 +153,7 @@ class CustomerGroupRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/CustomerNumberRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/CustomerNumberRuleTest.php
@@ -141,7 +141,7 @@ class CustomerNumberRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
@@ -88,7 +88,7 @@ class CustomerTagRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/DaysSinceLastOrderRuleTest.php
@@ -128,7 +128,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }
@@ -179,7 +179,7 @@ class DaysSinceLastOrderRuleTest extends TestCase
         $result = $customerRepository->search(
             new Criteria([$orderData[0]['orderCustomer']['customer']['id']]),
             $defaultContext
-        );
+        )->getEntities();
 
         static::assertNotNull($result->first());
         static::assertSame(1, $result->first()->getOrderCount());

--- a/tests/integration/Core/Checkout/Customer/Rule/DifferentAddressesRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/DifferentAddressesRuleTest.php
@@ -66,7 +66,7 @@ class DifferentAddressesRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/EmailRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/EmailRuleTest.php
@@ -132,7 +132,7 @@ class EmailRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/IsGuestCustomerRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/IsGuestCustomerRuleTest.php
@@ -65,7 +65,7 @@ class IsGuestCustomerRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/IsNewsletterRecipientRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/IsNewsletterRecipientRuleTest.php
@@ -65,7 +65,7 @@ class IsNewsletterRecipientRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/OrderCountRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/OrderCountRuleTest.php
@@ -161,7 +161,7 @@ class OrderCountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/OrderTotalAmountRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/OrderTotalAmountRuleTest.php
@@ -148,7 +148,7 @@ class OrderTotalAmountRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }
@@ -199,7 +199,7 @@ class OrderTotalAmountRuleTest extends TestCase
         $result = $customerRepository->search(
             new Criteria([$orderData[0]['orderCustomer']['customer']['id']]),
             $defaultContext
-        );
+        )->getEntities();
 
         static::assertNotNull($result->first());
         static::assertSame(1, $result->first()->getOrderCount());
@@ -219,7 +219,7 @@ class OrderTotalAmountRuleTest extends TestCase
         $result = $customerRepository->search(
             new Criteria([$orderData[0]['orderCustomer']['customer']['id']]),
             $defaultContext
-        );
+        )->getEntities();
 
         static::assertNotNull($result->first());
         static::assertSame(0, $result->first()->getOrderCount());
@@ -262,7 +262,7 @@ class OrderTotalAmountRuleTest extends TestCase
         $result = $customerRepository->search(
             new Criteria([$orderData[0]['orderCustomer']['customer']['id']]),
             $defaultContext
-        );
+        )->getEntities();
 
         static::assertNotNull($result->first());
         static::assertSame(1, $result->first()->getOrderCount());
@@ -276,7 +276,7 @@ class OrderTotalAmountRuleTest extends TestCase
         $result = $customerRepository->search(
             new Criteria([$orderData[0]['orderCustomer']['customer']['id']]),
             $defaultContext
-        );
+        )->getEntities();
 
         static::assertNotNull($result->first());
         static::assertSame(0, $result->first()->getOrderCount());

--- a/tests/integration/Core/Checkout/Customer/Rule/ShippingCityRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/ShippingCityRuleTest.php
@@ -133,7 +133,7 @@ class ShippingCityRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/ShippingCountryRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/ShippingCountryRuleTest.php
@@ -87,7 +87,7 @@ class ShippingCountryRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/ShippingStateRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/ShippingStateRuleTest.php
@@ -159,7 +159,7 @@ class ShippingStateRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/ShippingStreetRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/ShippingStreetRuleTest.php
@@ -131,7 +131,7 @@ class ShippingStreetRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/Rule/ShippingZipCodeRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/ShippingZipCodeRuleTest.php
@@ -208,7 +208,7 @@ class ShippingZipCodeRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }
@@ -257,7 +257,7 @@ class ShippingZipCodeRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->ruleRepository->delete([['id' => $ruleId]], $this->context);
         $this->conditionRepository->delete([['id' => $id]], $this->context);
     }

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -216,7 +216,7 @@ class AccountServiceTest extends TestCase
         $customer = $this
             ->getContainer()
             ->get('customer.repository')
-            ->search(new Criteria([$idCustomer]), $context->getContext())
+            ->search(new Criteria([$idCustomer]), $context->getContext())->getEntities()
             ->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertNull($customer->getLegacyPassword());

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRouteTest.php
@@ -658,7 +658,7 @@ class ChangeCustomerProfileRouteTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('id', $this->customerId));
 
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($customer);
 
         $customerDefinition = new CustomerDefinition();
@@ -823,7 +823,7 @@ class ChangeCustomerProfileRouteTest extends TestCase
     {
         $criteria = new Criteria([$this->customerId]);
 
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($customer);
 
         return $customer;

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeEmailRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ChangeEmailRouteTest.php
@@ -183,7 +183,7 @@ class ChangeEmailRouteTest extends TestCase
         $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
         $criteria = (new Criteria())->addFilter(new EqualsFilter('customerId', $this->customerId));
-        $ids = $customerRecoveryRepository->search($criteria, Context::createDefaultContext());
+        $ids = $customerRecoveryRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         static::assertSame('test@fooware.de', $response['email']);
         static::assertCount(0, $ids);

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
@@ -71,7 +71,7 @@ class ConvertGuestRouteTest extends TestCase
         $customer = $this->customerRepository->search(
             (new Criteria())->addFilter(new EqualsFilter('email', 'guest@example.com')),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertFalse($customer->getGuest());

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/LogoutRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/LogoutRouteTest.php
@@ -209,7 +209,7 @@ class LogoutRouteTest extends TestCase
         $customerId = $this->createCustomer();
         $customer = static::getContainer()
             ->get('customer.repository')
-            ->search(new Criteria(), Context::createDefaultContext())
+            ->search(new Criteria(), Context::createDefaultContext())->getEntities()
             ->get($customerId);
         static::assertInstanceOf(CustomerEntity::class, $customer);
         $customer->setGuest(false);
@@ -247,7 +247,7 @@ class LogoutRouteTest extends TestCase
         $customerId = $this->createCustomer();
         $customer = static::getContainer()
             ->get('customer.repository')
-            ->search(new Criteria(), Context::createDefaultContext())
+            ->search(new Criteria(), Context::createDefaultContext())->getEntities()
             ->get($customerId);
         static::assertInstanceOf(CustomerEntity::class, $customer);
         $customer->setGuest(true);

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/MergeWishlistProductRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/MergeWishlistProductRouteTest.php
@@ -125,8 +125,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(2, $wishlistProduct->getEntities());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(2, $wishlistProduct);
     }
 
     public function testMergeThreeProductShouldReturnSuccessNoWishlistExisted(): void
@@ -150,8 +150,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(2, $wishlistProduct->getEntities());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(2, $wishlistProduct);
     }
 
     public function testMergeProductShouldThrowCustomerNotLoggedInException(): void
@@ -175,8 +175,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame('Forbidden', $errors['title']);
         static::assertSame('Customer is not logged in.', $errors['detail']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertNull($wishlistProduct->getEntities()->first());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertNull($wishlistProduct->first());
     }
 
     public function testMergeProductShouldThrowCustomerWishlistNotActivatedException(): void
@@ -200,8 +200,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame('Forbidden', $errors['title']);
         static::assertSame('Wishlist is not activated!', $errors['detail']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertNull($wishlistProduct->getEntities()->first());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertNull($wishlistProduct->first());
     }
 
     public function testMergeProductShouldSuccessWithNoProductInsert(): void
@@ -220,8 +220,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertNull($wishlistProduct->getEntities()->first());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertNull($wishlistProduct->first());
     }
 
     public function testMergeProductShouldReturnSuccessAlreadyWishlistExisted(): void
@@ -244,8 +244,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertSame($productData, $wishlistProduct->getEntities()->first()?->getProductId());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertSame($productData, $wishlistProduct->first()?->getProductId());
     }
 
     public function testMergeProductShouldReturnSuccessAlreadyProductWishlistExisted(): void
@@ -268,8 +268,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(2, $wishlistProduct->getEntities());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(2, $wishlistProduct);
     }
 
     public function testMergeProductShouldReturnSuccessSameProductWishlistExisted(): void
@@ -291,9 +291,9 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(1, $wishlistProduct->getEntities());
-        static::assertSame($alreadyProductData, $wishlistProduct->getEntities()->first()?->getProductId());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(1, $wishlistProduct);
+        static::assertSame($alreadyProductData, $wishlistProduct->first()?->getProductId());
     }
 
     public function testMergeProductsWithEmptyWishlistAndEmptyMergeRequest(): void
@@ -313,8 +313,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(0, $wishlistProduct->getEntities());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(0, $wishlistProduct);
     }
 
     public function testMergeProductsWithNonEmptyWishlistAndEmptyMergeRequest(): void
@@ -335,8 +335,8 @@ class MergeWishlistProductRouteTest extends TestCase
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
 
-        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context);
-        static::assertCount(1, $wishlistProduct->getEntities());
+        $wishlistProduct = $this->wishlistProductRepository->search(new Criteria(), $this->context)->getEntities();
+        static::assertCount(1, $wishlistProduct);
     }
 
     private function createProduct(Context $context): string

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -376,7 +376,7 @@ class RegisterRouteTest extends TestCase
         static::assertSame('401', $responseData['errors'][0]['status']);
 
         $criteria = new Criteria([$customerId]);
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
         $this->browser
@@ -446,7 +446,7 @@ class RegisterRouteTest extends TestCase
         $customerId = $response['id'];
 
         $criteria = new Criteria([$customerId]);
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
         $this->browser->request('POST', '/store-api/account/register-confirm', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['hash' => $customer->getHash(), 'em' => Hasher::hash('teg-reg@example.com', 'sha1')], \JSON_THROW_ON_ERROR));
@@ -566,7 +566,7 @@ class RegisterRouteTest extends TestCase
         $customerId = $response['id'];
 
         $criteria = new Criteria([$customerId]);
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
         $this->browser
@@ -626,7 +626,7 @@ class RegisterRouteTest extends TestCase
 
         static::assertSame('customer', $response['apiAlias']);
 
-        $customer = $this->customerRepository->search(new Criteria([$response['id']]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$response['id']]), Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
         static::assertSame($this->ids->get('group'), $customer->getRequestedGroupId());
@@ -1159,7 +1159,7 @@ class RegisterRouteTest extends TestCase
         $criteria = new Criteria([$response['id']]);
         $criteria->addAssociation('addresses');
 
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
@@ -1421,7 +1421,7 @@ class RegisterRouteTest extends TestCase
         $criteria = new Criteria([$response['id']]);
         $criteria->addAssociation('salutation');
 
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);
 

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
@@ -184,7 +184,7 @@ class ResetPasswordRouteTest extends TestCase
         $criteria = new Criteria([$customerId]);
 
         /** @var CustomerEntity $customer */
-        $customer = static::getContainer()->get('customer.repository')->search($criteria, Context::createDefaultContext())->first();
+        $customer = static::getContainer()->get('customer.repository')->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertNull($customer->getLegacyEncoder());
         static::assertNull($customer->getLegacyPassword());
@@ -290,7 +290,7 @@ class ResetPasswordRouteTest extends TestCase
     {
         $criteria = new Criteria([$customerId]);
 
-        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
 
         return $customer;

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/UpsertAddressRouteTest.php
@@ -104,7 +104,7 @@ class UpsertAddressRouteTest extends TestCase
         }
 
         // Check existence
-        $address = $this->addressRepository->search(new Criteria([$content['id']]), Context::createDefaultContext())->first();
+        $address = $this->addressRepository->search(new Criteria([$content['id']]), Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerAddressEntity::class, $address);
         $serializedAddress = $address->jsonSerialize();
 
@@ -222,7 +222,7 @@ class UpsertAddressRouteTest extends TestCase
         }
 
         // Check existence
-        $address = $this->addressRepository->search(new Criteria([$response['id']]), Context::createDefaultContext())->first();
+        $address = $this->addressRepository->search(new Criteria([$response['id']]), Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerAddressEntity::class, $address);
 
         foreach ($data as $key => $val) {

--- a/tests/integration/Core/Checkout/Customer/Service/DoubleOptInServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/Service/DoubleOptInServiceTest.php
@@ -189,7 +189,7 @@ class DoubleOptInServiceTest extends TestCase
     private function fetchCustomer(string $id): CustomerEntity
     {
         $customer = static::getContainer()->get('customer.repository')
-            ->search(new Criteria([$id]), Context::createDefaultContext())
+            ->search(new Criteria([$id]), Context::createDefaultContext())->getEntities()
             ->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);

--- a/tests/integration/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/Service/ProductReviewCountServiceTest.php
@@ -53,7 +53,7 @@ class ProductReviewCountServiceTest extends TestCase
 
         $customerRepo = static::getContainer()->get('customer.repository');
         /** @var CustomerCollection $customers */
-        $customers = $customerRepo->search(new Criteria([$this->ids->get('c1'), $this->ids->get('c2')]), Context::createDefaultContext());
+        $customers = $customerRepo->search(new Criteria([$this->ids->get('c1'), $this->ids->get('c2')]), Context::createDefaultContext())->getEntities();
 
         $firstCustomer = $customers->get($this->ids->get('c1'));
         static::assertInstanceOf(CustomerEntity::class, $firstCustomer);

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriberTest.php
@@ -73,7 +73,7 @@ class CustomerChangePasswordSubscriberTest extends TestCase
         $criteria->addFilter(new EqualsFilter('id', $customerId));
 
         /** @var CustomerEntity $customer */
-        $customer = $this->customerRepository->search($criteria, $context)->first();
+        $customer = $this->customerRepository->search($criteria, $context)->getEntities()->first();
 
         static::assertNotNull($customer->getPassword());
         static::assertNull($customer->getLegacyPassword());
@@ -104,7 +104,7 @@ class CustomerChangePasswordSubscriberTest extends TestCase
         $criteria->addFilter(new EqualsFilter('id', $customerId));
 
         /** @var CustomerEntity $customer */
-        $customer = $this->customerRepository->search($criteria, $context)->first();
+        $customer = $this->customerRepository->search($criteria, $context)->getEntities()->first();
 
         static::assertNull($customer->getPassword());
         static::assertNotNull($customer->getLegacyPassword());

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerSalutationSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerSalutationSubscriberTest.php
@@ -54,7 +54,7 @@ class CustomerSalutationSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertNotNull($customer->getSalutationId());
     }
@@ -77,7 +77,7 @@ class CustomerSalutationSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertNull($customer->getSalutationId());
     }

--- a/tests/integration/Core/Checkout/Customer/Subscriber/ProductReviewSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/ProductReviewSubscriberTest.php
@@ -69,7 +69,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(1, $customer->getReviewCount());
     }
@@ -81,7 +81,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(1, $customer->getReviewCount());
 
@@ -90,7 +90,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(0, $customer->getReviewCount());
     }
@@ -102,7 +102,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(1, $customer->getReviewCount());
 
@@ -116,7 +116,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(1, $customer->getReviewCount());
 
@@ -130,7 +130,7 @@ class ProductReviewSubscriberTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $customer);
         static::assertSame(2, $customer->getReviewCount());
     }

--- a/tests/integration/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentificationValidatorTest.php
+++ b/tests/integration/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentificationValidatorTest.php
@@ -356,7 +356,7 @@ class CustomerVatIdentificationValidatorTest extends TestCase
         /** @var EntityRepository<CountryCollection> $repo */
         $repo = static::getContainer()->get('country.repository');
 
-        $countries = $repo->search($criteria, $context)->fmap(static function (CountryEntity $country) {
+        $countries = $repo->search($criteria, $context)->getEntities()->fmap(static function (CountryEntity $country) {
             return $country->getIso();
         });
 

--- a/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentControllerTest.php
@@ -115,7 +115,7 @@ class DocumentControllerTest extends TestCase
         /** @var EntityRepository<DocumentTypeCollection> $documentTypeRepository */
         $documentTypeRepository = static::getContainer()->get('document_type.repository');
         $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', 'invoice'));
-        $type = $documentTypeRepository->search($criteria, $context)->first();
+        $type = $documentTypeRepository->search($criteria, $context)->getEntities()->first();
         static::assertNotNull($type);
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
@@ -171,7 +171,7 @@ class DocumentControllerTest extends TestCase
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
 
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $this->context)->get($orderId);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         $deepLinkCode = $order->getDeepLinkCode();
@@ -208,7 +208,7 @@ class DocumentControllerTest extends TestCase
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
 
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $this->context)->get($orderId);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $this->context)->getEntities()->get($orderId);
         static::assertNotNull($order);
 
         TestUser::createNewTestUser(
@@ -531,7 +531,7 @@ class DocumentControllerTest extends TestCase
         ];
 
         $this->orderRepository->upsert([$order], $context);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->getEntities()->first();
         static::assertInstanceOf(OrderEntity::class, $order);
 
         return $order;

--- a/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
+++ b/tests/integration/Core/Checkout/Document/DocumentGeneratorControllerTest.php
@@ -111,7 +111,7 @@ class DocumentGeneratorControllerTest extends TestCase
 
         $documentTypeRepository = static::getContainer()->get('document_type.repository');
         $criteria = (new Criteria())->addFilter(new EqualsFilter('technicalName', 'invoice'));
-        $type = $documentTypeRepository->search($criteria, $context)->first();
+        $type = $documentTypeRepository->search($criteria, $context)->getEntities()->first();
         static::assertInstanceOf(DocumentTypeEntity::class, $type);
         $cart = $this->generateDemoCart(2);
         $orderId = $this->persistCart($cart);
@@ -459,7 +459,7 @@ class DocumentGeneratorControllerTest extends TestCase
 
         $this->orderRepository->upsert([$order], $context);
 
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->getEntities()->first();
 
         static::assertNotNull($order);
 

--- a/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -267,7 +267,7 @@ class InvoiceRendererTest extends TestCase
                 ]], Context::createDefaultContext());
 
                 $criteria = OrderDocumentCriteriaFactory::create([$operation->getOrderId()]);
-                $order = $container->get('order.repository')->search($criteria, Context::createDefaultContext())->get($operation->getOrderId());
+                $order = $container->get('order.repository')->search($criteria, Context::createDefaultContext())->getEntities()->get($operation->getOrderId());
                 static::assertInstanceOf(OrderEntity::class, $order);
 
                 $context = clone Context::createDefaultContext();

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -111,7 +111,7 @@ class DocumentGeneratorTest extends TestCase
             ->addAssociation('documentMediaFile');
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentStruct->getId());
 
         static::assertNotNull($document);
@@ -144,7 +144,7 @@ class DocumentGeneratorTest extends TestCase
         $this->expectException(DocumentException::class);
 
         /** @var OrderEntity $order */
-        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->first();
+        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->getEntities()->first();
 
         $operation = new DocumentGenerateOperation($this->orderId);
         $operation->assign([
@@ -161,7 +161,7 @@ class DocumentGeneratorTest extends TestCase
 
     public function testPreviewInvoice(): void
     {
-        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->first();
+        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->getEntities()->first();
         static::assertNotNull($order);
         static::assertInstanceOf(OrderEntity::class, $order);
 
@@ -174,7 +174,7 @@ class DocumentGeneratorTest extends TestCase
 
     public function testPreviewStorno(): void
     {
-        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->first();
+        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->orderId]), $this->context)->getEntities()->first();
         static::assertNotNull($order);
         static::assertInstanceOf(OrderEntity::class, $order);
         $orderCustomer = $order->getOrderCustomer();
@@ -277,7 +277,7 @@ class DocumentGeneratorTest extends TestCase
 
         $this->documentGenerator->upload($documentId, $this->context, $uploadFileRequest);
 
-        $document = $this->documentRepository->search(new Criteria([$documentId]), $this->context)->get($documentId);
+        $document = $this->documentRepository->search(new Criteria([$documentId]), $this->context)->getEntities()->get($documentId);
 
         static::assertNotNull($document);
         static::assertNotNull($document->getDocumentMediaFileId());
@@ -341,7 +341,7 @@ class DocumentGeneratorTest extends TestCase
             ->addAssociation('documentMediaFile');
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentStruct->getId());
 
         static::assertNotNull($document);
@@ -369,7 +369,7 @@ class DocumentGeneratorTest extends TestCase
         static::assertNotNull($invoiceStruct);
         static::assertTrue(Uuid::isValid($invoiceStruct->getId()));
 
-        $invoice = $this->documentRepository->search(new Criteria([$invoiceStruct->getId()]), $this->context)->get($invoiceStruct->getId());
+        $invoice = $this->documentRepository->search(new Criteria([$invoiceStruct->getId()]), $this->context)->getEntities()->get($invoiceStruct->getId());
 
         static::assertNotNull($invoice);
         // create a cancellation invoice which references the invoice
@@ -380,7 +380,7 @@ class DocumentGeneratorTest extends TestCase
         static::assertNotNull($stornoStruct);
         static::assertTrue(Uuid::isValid($stornoStruct->getId()));
 
-        $storno = $this->documentRepository->search(new Criteria([$stornoStruct->getId()]), $this->context)->get($stornoStruct->getId());
+        $storno = $this->documentRepository->search(new Criteria([$stornoStruct->getId()]), $this->context)->getEntities()->get($stornoStruct->getId());
 
         static::assertNotNull($storno);
         static::assertSame($invoice->getId(), $storno->getReferencedDocumentId());
@@ -425,7 +425,7 @@ class DocumentGeneratorTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('technicalName', DeliveryNoteRenderer::TYPE));
 
-        $documentType = $documentTypeRepository->search($criteria, $this->context)->first();
+        $documentType = $documentTypeRepository->search($criteria, $this->context)->getEntities()->first();
 
         static::assertNotNull($documentType);
         static::assertInstanceOf(DocumentTypeEntity::class, $documentType);
@@ -459,7 +459,7 @@ class DocumentGeneratorTest extends TestCase
 
         $criteria = new Criteria([$documentId]);
         $criteria->addAssociation('documentMediaFile');
-        $document = $this->documentRepository->search($criteria, $this->context)->get($documentId);
+        $document = $this->documentRepository->search($criteria, $this->context)->getEntities()->get($documentId);
 
         static::assertNotNull($document?->getDocumentMediaFile());
         $filePath = $document->getDocumentMediaFile()->getPath();
@@ -490,7 +490,7 @@ class DocumentGeneratorTest extends TestCase
         $documentId = $this->documentGenerator->generate(InvoiceRenderer::TYPE, [$this->orderId => $operation], $this->context)->getSuccess()->first();
         static::assertNotNull($documentId);
 
-        $document = $this->documentRepository->search(new Criteria([$documentId->getId()]), Context::createDefaultContext())->first();
+        $document = $this->documentRepository->search(new Criteria([$documentId->getId()]), Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($document);
 
         $expectedConfig = array_merge($globalConfig, $salesChannelConfig);
@@ -531,7 +531,7 @@ class DocumentGeneratorTest extends TestCase
         $documentIdWithOverride = $this->documentGenerator->generate(InvoiceRenderer::TYPE, [$orderId => $operation], $this->context)->getSuccess()->first();
         static::assertNotNull($documentIdWithOverride);
 
-        $document = $this->documentRepository->search(new Criteria([$documentIdWithOverride->getId()]), Context::createDefaultContext())->first();
+        $document = $this->documentRepository->search(new Criteria([$documentIdWithOverride->getId()]), Context::createDefaultContext())->getEntities()->first();
         static::assertNotNull($document);
 
         $expectedConfig = array_merge($globalConfig, $salesChannelConfig, $overrides);
@@ -560,7 +560,7 @@ class DocumentGeneratorTest extends TestCase
             ->addAssociation('documentMediaFile');
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentInvoice->getId());
 
         static::assertNotNull($document);
@@ -608,7 +608,7 @@ class DocumentGeneratorTest extends TestCase
         $criteria->addAssociation('documentType')
             ->addAssociation('documentMediaFile');
 
-        $documents = $this->documentRepository->search($criteria, $this->context);
+        $documents = $this->documentRepository->search($criteria, $this->context)->getEntities();
 
         static::assertCount(2, $documents);
 
@@ -671,7 +671,7 @@ class DocumentGeneratorTest extends TestCase
         $criteria->addAssociation('documentType');
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentInvoice->getId());
 
         static::assertNotNull($document);
@@ -726,7 +726,7 @@ class DocumentGeneratorTest extends TestCase
         $document = $this->documentRepository->search(
             new Criteria([$invoiceStruct->getId()]),
             $this->context,
-        )->first();
+        )->getEntities()->first();
 
         $mediaId = $document?->getDocumentMediaFileId();
         static::assertNotNull($mediaId);
@@ -772,7 +772,7 @@ class DocumentGeneratorTest extends TestCase
         $document = $this->documentRepository->search(
             new Criteria([$documentId]),
             $this->context,
-        )->first();
+        )->getEntities()->first();
 
         $mediaId = $document?->getDocumentMediaFileId();
         static::assertNotNull($mediaId);
@@ -836,7 +836,7 @@ class DocumentGeneratorTest extends TestCase
                 ->addAssociation('documentA11yMediaFile');
 
             $documentRepository = static::getContainer()->get('document.repository');
-            $document = $documentRepository->search($criteria, $this->context)->get($documentId);
+            $document = $documentRepository->search($criteria, $this->context)->getEntities()->get($documentId);
 
             static::assertNotNull($document);
 
@@ -844,7 +844,7 @@ class DocumentGeneratorTest extends TestCase
             $mediaRepository = static::getContainer()->get('media.repository');
 
             /** @var MediaCollection $mediaFiles */
-            $mediaFiles = $mediaRepository->search(new Criteria([$documentMediaFileId, $documentA11yMediaFileId]), $this->context);
+            $mediaFiles = $mediaRepository->search(new Criteria([$documentMediaFileId, $documentA11yMediaFileId]), $this->context)->getEntities();
             static::assertNotNull($mediaFiles);
 
             /** @var MediaEntity $media */
@@ -888,7 +888,7 @@ class DocumentGeneratorTest extends TestCase
         $document = $this->documentRepository->search(
             new Criteria([$invoiceStruct->getId()]),
             $this->context,
-        )->first();
+        )->getEntities()->first();
 
         static::assertNotNull($document);
 
@@ -915,7 +915,7 @@ class DocumentGeneratorTest extends TestCase
             ->addAssociation('documentA11yMediaFile');
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentStruct->getId());
         static::assertNotNull($document);
 
@@ -929,7 +929,7 @@ class DocumentGeneratorTest extends TestCase
         ]], $versionContext);
 
         $document = $this->documentRepository
-            ->search($criteria, $this->context)
+            ->search($criteria, $this->context)->getEntities()
             ->get($documentStruct->getId());
         static::assertNotNull($document);
 
@@ -963,7 +963,7 @@ class DocumentGeneratorTest extends TestCase
             ->search(
                 (new Criteria())->addFilter(new EqualsFilter('technicalName', InvoiceRenderer::TYPE)),
                 $this->context
-            )
+            )->getEntities()
             ->first();
         static::assertInstanceOf(DocumentTypeEntity::class, $documentType);
 
@@ -989,7 +989,7 @@ class DocumentGeneratorTest extends TestCase
         ]], $this->context);
 
         $criteria = (new Criteria([$documentId]))->addAssociation('documentMediaFile');
-        $document = $this->documentRepository->search($criteria, $this->context)->get($documentId);
+        $document = $this->documentRepository->search($criteria, $this->context)->getEntities()->get($documentId);
         static::assertNotNull($document?->getDocumentMediaFile());
 
         $filePath = $document->getDocumentMediaFile()->getPath();
@@ -1012,12 +1012,12 @@ class DocumentGeneratorTest extends TestCase
             ->addAssociation('documentA11yMediaFile')
             ->addAssociation('documentType');
 
-        $document = $this->documentRepository->search($criteria, $this->context)->get($documentStruct->getId());
+        $document = $this->documentRepository->search($criteria, $this->context)->getEntities()->get($documentStruct->getId());
         static::assertNotNull($document);
 
         $this->documentGenerator->readDocument($document->getId(), $this->context);
 
-        $document = $this->documentRepository->search($criteria, $this->context)->get($documentStruct->getId());
+        $document = $this->documentRepository->search($criteria, $this->context)->getEntities()->get($documentStruct->getId());
         static::assertNotNull($document);
 
         return $document;

--- a/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentMergerTest.php
@@ -363,7 +363,7 @@ class DocumentMergerTest extends TestCase
 
         $order = static::getContainer()
             ->get('order.repository')
-            ->search(new Criteria([$this->orderId]), $this->context)
+            ->search(new Criteria([$this->orderId]), $this->context)->getEntities()
             ->first();
         static::assertNotNull($order);
         static::assertInstanceOf(OrderEntity::class, $order);

--- a/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
+++ b/tests/integration/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionStateHandlerTest.php
@@ -295,7 +295,7 @@ class OrderTransactionStateHandlerTest extends TestCase
         $criteria->addAssociation('stateMachineState');
 
         /** @var OrderTransactionEntity|null $transaction */
-        $transaction = $this->orderTransactionRepository->search($criteria, $this->context)->first();
+        $transaction = $this->orderTransactionRepository->search($criteria, $this->context)->getEntities()->first();
 
         return $transaction?->getStateMachineState()?->getTechnicalName();
     }

--- a/tests/integration/Core/Checkout/Order/OrderAddressServiceTest.php
+++ b/tests/integration/Core/Checkout/Order/OrderAddressServiceTest.php
@@ -299,7 +299,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -339,7 +339,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
 
         // Check that the billing address has been updated
@@ -393,7 +393,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -434,7 +434,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -488,7 +488,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -532,7 +532,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -584,7 +584,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -633,7 +633,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -694,7 +694,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -743,7 +743,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -803,7 +803,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -870,7 +870,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -936,7 +936,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -982,7 +982,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
 
@@ -1036,7 +1036,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
         $addresses = $order->getAddresses();
         static::assertNotNull($addresses);
@@ -1077,7 +1077,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
         static::assertNotNull($order);
 
         // Check that the first shipping address has been updated
@@ -1135,7 +1135,7 @@ class OrderAddressServiceTest extends TestCase
         $criteria->addAssociation('billingAddress');
         $criteria->addAssociation('addresses');
 
-        $order = $this->orderRepository->search($criteria, $context)->first();
+        $order = $this->orderRepository->search($criteria, $context)->getEntities()->first();
 
         static::assertNotNull($order);
 

--- a/tests/integration/Core/Checkout/Order/OrderRepositoryTest.php
+++ b/tests/integration/Core/Checkout/Order/OrderRepositoryTest.php
@@ -85,7 +85,7 @@ class OrderRepositoryTest extends TestCase
         $criteria = new Criteria([$orderId]);
 
         /** @var OrderEntity|null $order */
-        $order = $this->orderRepository->search($criteria, $defaultContext)->first();
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities()->first();
 
         static::assertNotNull($order);
         static::assertNotNull($order->getOrderCustomer());
@@ -117,7 +117,7 @@ class OrderRepositoryTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
 
-        $order = $this->orderRepository->search($criteria, $defaultContext);
+        $order = $this->orderRepository->search($criteria, $defaultContext)->getEntities();
         static::assertCount(0, $order);
     }
 

--- a/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/CancelOrderRouteTest.php
@@ -98,7 +98,7 @@ class CancelOrderRouteTest extends TestCase
         $criteria->addAssociation('stateMachineState');
 
         /** @var OrderEntity $order */
-        $order = static::getContainer()->get('order.repository')->search($criteria, Context::createDefaultContext())->first();
+        $order = static::getContainer()->get('order.repository')->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertNotNull($order->getStateMachineState());
         static::assertSame('cancelled', $order->getStateMachineState()->getTechnicalName());

--- a/tests/integration/Core/Checkout/Payment/Handler/PaymentHandlerRegistryTest.php
+++ b/tests/integration/Core/Checkout/Payment/Handler/PaymentHandlerRegistryTest.php
@@ -89,7 +89,7 @@ class PaymentHandlerRegistryTest extends TestCase
         $criteria->addAssociation('app');
 
         /** @var PaymentMethodEntity|null $method */
-        $method = $this->paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
+        $method = $this->paymentMethodRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         if (!$method) {
             $method = [
@@ -110,7 +110,7 @@ class PaymentHandlerRegistryTest extends TestCase
             $criteria->addAssociation('app');
 
             /** @var PaymentMethodEntity|null $method */
-            $method = $this->paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
+            $method = $this->paymentMethodRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         }
 
         static::assertNotNull($method);

--- a/tests/integration/Core/Checkout/Payment/PaymentMethodRepositoryTest.php
+++ b/tests/integration/Core/Checkout/Payment/PaymentMethodRepositoryTest.php
@@ -162,7 +162,7 @@ class PaymentMethodRepositoryTest extends TestCase
 
         $criteria = new Criteria([$this->paymentMethodId]);
 
-        $resultSet = $this->paymentRepository->search($criteria, $defaultContext);
+        $resultSet = $this->paymentRepository->search($criteria, $defaultContext)->getEntities();
 
         static::assertCount(0, $resultSet);
     }
@@ -190,7 +190,7 @@ class PaymentMethodRepositoryTest extends TestCase
 
         $criteria = new Criteria([$this->paymentMethodId]);
 
-        $resultSet = $this->paymentRepository->search($criteria, $defaultContext);
+        $resultSet = $this->paymentRepository->search($criteria, $defaultContext)->getEntities();
 
         static::assertCount(1, $resultSet);
     }

--- a/tests/integration/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
@@ -66,7 +66,7 @@ class PromotionProcessorTest extends TestCase
         $criteria = new Criteria([$promotionId]);
         $criteria->addAssociation('discounts');
 
-        $promotion = $this->promotionRepository->search($criteria, $context->getContext())->first();
+        $promotion = $this->promotionRepository->search($criteria, $context->getContext())->getEntities()->first();
         static::assertInstanceOf(PromotionEntity::class, $promotion);
 
         $discounts = $promotion->getDiscounts();

--- a/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
+++ b/tests/integration/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdaterTest.php
@@ -89,7 +89,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
         /** @var OrderEntity|null $order */
         $order = static::getContainer()
             ->get('order.repository')
-            ->search($criteria, $this->salesChannelContext->getContext())
+            ->search($criteria, $this->salesChannelContext->getContext())->getEntities()
             ->first();
 
         static::assertNotNull($order);
@@ -117,7 +117,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
         /** @var OrderEntity|null $order */
         $order = static::getContainer()
             ->get('order.repository')
-            ->search($criteria, Context::createDefaultContext())
+            ->search($criteria, Context::createDefaultContext())->getEntities()
             ->first();
 
         static::assertNotNull($order);
@@ -240,7 +240,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
 
         $promotionRepository = static::getContainer()->get('promotion.repository');
 
-        $promotionA = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+        $promotionA = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(PromotionEntity::class, $promotionA);
         static::assertIsArray($promotionA->getOrdersPerCustomerCount());
@@ -254,7 +254,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
             ->get('order_line_item.repository')
             ->delete([['id' => $this->ids->get('voucherA')]], Context::createDefaultContext());
 
-        $promotionALater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+        $promotionALater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(PromotionEntity::class, $promotionALater);
         static::assertIsArray($promotionALater->getOrdersPerCustomerCount());
@@ -267,7 +267,7 @@ class PromotionRedemptionUpdaterTest extends TestCase
             ->get('order_line_item.repository')
             ->delete([['id' => $secondOrderLineItemId]], Context::createDefaultContext());
 
-        $promotionAEvenLater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->first();
+        $promotionAEvenLater = $promotionRepository->search(new Criteria([$this->ids->get('voucherA')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(PromotionEntity::class, $promotionAEvenLater);
         static::assertSame(0, $promotionAEvenLater->getOrderCount());

--- a/tests/integration/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
+++ b/tests/integration/Core/Checkout/Promotion/Util/PromotionCodeServiceTest.php
@@ -136,7 +136,7 @@ class PromotionCodeServiceTest extends TestCase
             ->addAssociation('individualCodes');
 
         /** @var PromotionEntity|null $promotion */
-        $promotion = $promotionRepository->search($criteria, $context)->get($id);
+        $promotion = $promotionRepository->search($criteria, $context)->getEntities()->get($id);
 
         static::assertNotNull($promotion);
         static::assertNotNull($promotion->getIndividualCodes());
@@ -145,7 +145,7 @@ class PromotionCodeServiceTest extends TestCase
         $this->codesService->replaceIndividualCodes($id, 'newPattern_%d%d%s', 10, $context);
 
         /** @var PromotionEntity $promotion */
-        $promotion = $promotionRepository->search($criteria, $context)->first();
+        $promotion = $promotionRepository->search($criteria, $context)->getEntities()->first();
         static::assertNotNull($promotion->getIndividualCodes());
         $individualCodes = $promotion->getIndividualCodes()->getElements();
         static::assertCount(10, $individualCodes);
@@ -214,7 +214,7 @@ class PromotionCodeServiceTest extends TestCase
         $this->codesService->addIndividualCodes($id, $newCodeAmount, $salesChannelContext->getContext());
 
         /** @var PromotionEntity|null $promotion */
-        $promotion = $promotionRepository->search($criteria, $salesChannelContext->getContext())->first();
+        $promotion = $promotionRepository->search($criteria, $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertNotNull($promotion);
         static::assertNotNull($promotion->getIndividualCodes());

--- a/tests/integration/Core/Checkout/Shipping/ShippingMethodRepositoryTest.php
+++ b/tests/integration/Core/Checkout/Shipping/ShippingMethodRepositoryTest.php
@@ -125,7 +125,7 @@ class ShippingMethodRepositoryTest extends TestCase
 
         $criteria = new Criteria([$this->shippingMethodId]);
 
-        $resultSet = $this->shippingRepository->search($criteria, $defaultContext);
+        $resultSet = $this->shippingRepository->search($criteria, $defaultContext)->getEntities();
 
         static::assertCount(0, $resultSet);
     }
@@ -152,7 +152,7 @@ class ShippingMethodRepositoryTest extends TestCase
     {
         $defaultContext = Context::createDefaultContext();
 
-        $result = $this->shippingRepository->search(new Criteria([$this->shippingMethodId]), $defaultContext);
+        $result = $this->shippingRepository->search(new Criteria([$this->shippingMethodId]), $defaultContext)->getEntities();
 
         static::assertEmpty($result);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

`EntitySearchResult`'s inherited collection API (`first()`, `get()`, `count()`, iteration, …) is deprecated for v6.8 and throws under `FEATURE_ALL=major`, so the Core/Checkout integration tests still using the old idiom fail only in the integration-major nightly.

### 2. What does this change do, exactly?

- Migrates every deprecated accessor in `tests/integration/Core/Checkout/` to `->getEntities()->…` (74 files): chained calls after `->search(…)`, variable-held results, `assertCount`/`assertEmpty` on raw results, an `fmap()` in `CustomerVatIdentificationValidatorTest`, and `assertCount` wrapping multiline search calls in the cart rule tests.
- Where a variable's uses were purely collection-shaped, the conversion happens once at the assignment; `assertSame(N, $result->getTotal())` on such results became `assertCount(N, $result)`, and already-migrated use-sites in `MergeWishlistProductRouteTest` lost their now-redundant `getEntities()` calls.
- `IdSearchResult` calls (`searchIds()`) are untouched, as that API is not deprecated.

The checkout-owned production straggler named in the issue (`ConvertGuestController`) is fixed independently in #18420, together with three test-side calls in `ConvertGuestControllerTest` that sit on its verification path — the two PRs merge in any order and together complete the checkout slice.

Verified the whole `tests/integration/Core/Checkout` suite under `FEATURE_ALL=major` and with flags off, iterating until no `EntitySearchResult` deprecation throws remain: failing tests under major drop from 265 to 77 (the remainder are unrelated major-mode clusters, no new failures introduced), and the flags-off failing set is byte-identical to the baseline.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Core/Checkout` on trunk: 265 tests fail, most with `FeatureException: Tried to access deprecated functionality: … EntitySearchResult::…`.
2. With this change, no such throw remains in the suite.

### 4. Please link to the relevant issues (if any).

- closes #18396

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

