### PR TITLE
test: sweep deprecated EntitySearchResult accessors from content integration tests

### DIFF
--- a/tests/integration/Core/Content/Category/SalesChannel/NavigationRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/NavigationRouteTest.php
@@ -395,7 +395,7 @@ class NavigationRouteTest extends TestCase
         $criteria->addFilter(new EqualsFilter('routeName', $routeName));
 
         $existingSeoUrls = $this->getContainer()->get('seo_url.repository')
-            ->search($criteria, Context::createDefaultContext());
+            ->search($criteria, Context::createDefaultContext())->getEntities();
 
         $data = [
             'salesChannelId' => $this->ids->get('sales-channel'),

--- a/tests/integration/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/integration/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -257,7 +257,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $criteria->addAssociation('categories');
 
         /** @var ProductEntity $product */
-        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
+        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         $this->createProductStreams();
         $this->createCategoryStreams();
@@ -473,7 +473,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $this->updateProductStream($this->ids->get('variant-product-3'), $this->ids->get('stream_id_1'));
 
         /** @var ProductEntity $mainProduct */
-        $mainProduct = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product')]), Context::createDefaultContext())->first();
+        $mainProduct = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product')]), Context::createDefaultContext())->getEntities()->first();
         $categoryMain = $this->breadcrumbBuilder->getProductSeoCategory($mainProduct, $this->salesChannelContext);
 
         static::assertInstanceOf(CategoryEntity::class, $categoryMain);
@@ -481,7 +481,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertSame('EN-AA', $categoryMain->getName());
 
         /** @var ProductEntity $variant1 */
-        $variant1 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-1')]), Context::createDefaultContext())->first();
+        $variant1 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-1')]), Context::createDefaultContext())->getEntities()->first();
         $categoryVariant1 = $this->breadcrumbBuilder->getProductSeoCategory($variant1, $this->salesChannelContext);
 
         static::assertInstanceOf(CategoryEntity::class, $categoryVariant1);
@@ -489,7 +489,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertSame('EN-BA', $categoryVariant1->getName());
 
         /** @var ProductEntity $variant2 */
-        $variant2 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-2')]), Context::createDefaultContext())->first();
+        $variant2 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-2')]), Context::createDefaultContext())->getEntities()->first();
         $categoryVariant2 = $this->breadcrumbBuilder->getProductSeoCategory($variant2, $this->salesChannelContext);
 
         static::assertInstanceOf(CategoryEntity::class, $categoryVariant2);
@@ -497,7 +497,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertSame('EN-B', $categoryVariant2->getName());
 
         /** @var ProductEntity $variant3 */
-        $variant3 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-3')]), Context::createDefaultContext())->first();
+        $variant3 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-3')]), Context::createDefaultContext())->getEntities()->first();
         $categoryVariant3 = $this->breadcrumbBuilder->getProductSeoCategory($variant3, $this->salesChannelContext);
 
         static::assertInstanceOf(CategoryEntity::class, $categoryVariant3);
@@ -505,7 +505,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         static::assertSame('EN-A', $categoryVariant3->getName());
 
         /** @var ProductEntity $variant4 */
-        $variant4 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-4')]), Context::createDefaultContext())->first();
+        $variant4 = $this->productRepository->search($this->createSeoCriteria([$this->ids->get('variant-product-4')]), Context::createDefaultContext())->getEntities()->first();
         $categoryVariant4 = $this->breadcrumbBuilder->getProductSeoCategory($variant4, $this->salesChannelContext);
 
         static::assertInstanceOf(CategoryEntity::class, $categoryVariant4);
@@ -533,7 +533,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $criteria = new Criteria([$this->ids->get('seo-product')]);
         $criteria->addAssociation('categories');
         /** @var ProductEntity $product */
-        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
+        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         // test if you get at least one category if both are active
         $seoCategory = $this->breadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);

--- a/tests/integration/Core/Content/Category/Subscriber/CategorySubscriberTest.php
+++ b/tests/integration/Core/Content/Category/Subscriber/CategorySubscriberTest.php
@@ -37,7 +37,7 @@ class CategorySubscriberTest extends TestCase
             ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
 
         $searchResult = static::getContainer()->get('sales_channel.category.repository')
-            ->search($criteria, $salesChannelContext);
+            ->search($criteria, $salesChannelContext)->getEntities();
 
         $category = $searchResult->get($ids->get('c.1'));
 

--- a/tests/integration/Core/Content/Category/Validation/EntryPointValidatorTest.php
+++ b/tests/integration/Core/Content/Category/Validation/EntryPointValidatorTest.php
@@ -92,7 +92,7 @@ class EntryPointValidatorTest extends TestCase
         ], $context);
 
         /** @var CategoryEntity|null $category */
-        $category = $this->categoryRepository->search(new Criteria([$categoryId]), $context)->first();
+        $category = $this->categoryRepository->search(new Criteria([$categoryId]), $context)->getEntities()->first();
         static::assertNotNull($category);
         static::assertSame(CategoryDefinition::TYPE_PAGE, $category->getType());
     }

--- a/tests/integration/Core/Content/Flow/AddCustomerAffiliateAndCampaignCodeActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddCustomerAffiliateAndCampaignCodeActionTest.php
@@ -79,7 +79,7 @@ class AddCustomerAffiliateAndCampaignCodeActionTest extends TestCase
 
         static::assertNotNull($this->customerRepository);
         /** @var CustomerEntity $customer */
-        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertSame($customer->getAffiliateCode(), $expectData['affiliateCode']);
         static::assertSame($customer->getCampaignCode(), $expectData['campaignCode']);

--- a/tests/integration/Core/Content/Flow/AddOrderAffiliateAndCampaignCodeActionTest.php
+++ b/tests/integration/Core/Content/Flow/AddOrderAffiliateAndCampaignCodeActionTest.php
@@ -75,7 +75,7 @@ class AddOrderAffiliateAndCampaignCodeActionTest extends TestCase
         $this->cancelOrder();
 
         /** @var OrderEntity $order */
-        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->ids->get('order')]), Context::createDefaultContext())->first();
+        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->ids->get('order')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertSame($order->getAffiliateCode(), $expectData['affiliateCode']);
         static::assertSame($order->getCampaignCode(), $expectData['campaignCode']);

--- a/tests/integration/Core/Content/Flow/ChangeCustomerGroupActionTest.php
+++ b/tests/integration/Core/Content/Flow/ChangeCustomerGroupActionTest.php
@@ -114,10 +114,10 @@ class ChangeCustomerGroupActionTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', 'Test group'));
         /** @var CustomerGroupEntity $customerGroupId */
-        $customerGroupId = static::getContainer()->get('customer_group.repository')->search($criteria, Context::createDefaultContext())->first();
+        $customerGroupId = static::getContainer()->get('customer_group.repository')->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         /** @var CustomerEntity $customer */
-        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertSame($customerGroupId->getId(), $customer->getGroupId());
     }

--- a/tests/integration/Core/Content/Flow/ChangeCustomerStatusActionTest.php
+++ b/tests/integration/Core/Content/Flow/ChangeCustomerStatusActionTest.php
@@ -113,7 +113,7 @@ class ChangeCustomerStatusActionTest extends TestCase
         $customer = $this->customerRepository->search(
             new Criteria([$this->ids->get('customer')]),
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertFalse($customer->getActive());
     }

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
@@ -198,7 +198,7 @@ class SetOrderStateActionTest extends TestCase
         $context = Generator::generateSalesChannelContext();
 
         $this->createOrder($customerId, ['deliveries' => $orderDeliveries, 'id' => $orderId]);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $context->getContext())->first();
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context->getContext())->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
 
@@ -218,7 +218,7 @@ class SetOrderStateActionTest extends TestCase
 
         $criteria = new Criteria([$IdForShippingCosts]);
         $criteria->addAssociation('stateMachineState');
-        $oderDeliveryForShippingCosts = $this->orderDeliveryRepository->search($criteria, $context->getContext())->first();
+        $oderDeliveryForShippingCosts = $this->orderDeliveryRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         static::assertInstanceOf(OrderDeliveryEntity::class, $oderDeliveryForShippingCosts);
         static::assertSame('shipped', $oderDeliveryForShippingCosts->getStateMachineState()?->getTechnicalName());

--- a/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
+++ b/tests/integration/Core/Content/Flow/GenerateDocumentActionTest.php
@@ -329,7 +329,7 @@ class GenerateDocumentActionTest extends TestCase
         // read versioned order
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('lineItems');
-        $order = $this->orderRepository->search($criteria, $context->createWithVersionId($versionId))->get($orderId);
+        $order = $this->orderRepository->search($criteria, $context->createWithVersionId($versionId))->getEntities()->get($orderId);
 
         static::assertNotEmpty($order);
     }
@@ -412,7 +412,7 @@ class GenerateDocumentActionTest extends TestCase
         ];
 
         $this->orderRepository->upsert([$order], $context);
-        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
 

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -128,7 +128,7 @@ class SendMailActionTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('transactions.stateMachineState');
-        $order = $orderRepository->search($criteria, $context->getContext())->first();
+        $order = $orderRepository->search($criteria, $context->getContext())->getEntities()->first();
         static::assertNotNull($order);
         $event = new CheckoutOrderPlacedEvent($context, $order);
 
@@ -181,7 +181,7 @@ class SendMailActionTest extends TestCase
         static::assertIsString($documentIdNewer);
         static::assertIsString($documentIdOlder);
         $criteria = new Criteria(array_filter([$documentIdOlder, $documentIdNewer]));
-        $documents = $documentRepository->search($criteria, $context->getContext());
+        $documents = $documentRepository->search($criteria, $context->getContext())->getEntities();
 
         $newDocument = $documents->get($documentIdNewer);
         static::assertNotNull($newDocument);
@@ -241,7 +241,7 @@ class SendMailActionTest extends TestCase
 
         if ($documentTypeIds !== []) {
             $criteria = new Criteria(array_filter([$documentIdOlder, $documentIdNewer]));
-            $documents = $documentRepository->search($criteria, $context->getContext());
+            $documents = $documentRepository->search($criteria, $context->getContext())->getEntities();
 
             $newDocument = $documents->get($documentIdNewer);
             static::assertNotNull($newDocument);
@@ -453,7 +453,7 @@ class SendMailActionTest extends TestCase
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('orderCustomer');
 
-        $order = static::getContainer()->get('order.repository')->search($criteria, $context->getContext())->get($orderId);
+        $order = static::getContainer()->get('order.repository')->search($criteria, $context->getContext())->getEntities()->get($orderId);
         static::assertInstanceOf(OrderEntity::class, $order);
         $event = new CheckoutOrderPlacedEvent($context, $order);
 
@@ -610,7 +610,7 @@ class SendMailActionTest extends TestCase
 
         $mailTemplate = static::getContainer()
             ->get('mail_template.repository')
-            ->search(new Criteria(), $salesChannelContext->getContext())
+            ->search(new Criteria(), $salesChannelContext->getContext())->getEntities()
             ->first();
 
         static::getContainer()->get(Connection::class)->executeStatement('UPDATE mail_template_type SET template_data = NULL');
@@ -619,7 +619,7 @@ class SendMailActionTest extends TestCase
         $customerId = $this->createCustomer($salesChannelContext->getContext());
         $customer = static::getContainer()
             ->get('customer.repository')
-            ->search(new Criteria([$customerId]), $salesChannelContext->getContext())
+            ->search(new Criteria([$customerId]), $salesChannelContext->getContext())->getEntities()
             ->first();
 
         static::assertInstanceOf(CustomerEntity::class, $customer);
@@ -667,7 +667,7 @@ class SendMailActionTest extends TestCase
 
         $templateType = static::getContainer()
             ->get('mail_template_type.repository')
-            ->search(new Criteria([$mailTemplate->getMailTemplateTypeId()]), $salesChannelContext->getContext())
+            ->search(new Criteria([$mailTemplate->getMailTemplateTypeId()]), $salesChannelContext->getContext())->getEntities()
             ->first();
 
         static::assertInstanceOf(MailTemplateTypeEntity::class, $templateType);

--- a/tests/integration/Core/Content/Flow/SetCustomerCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetCustomerCustomFieldActionTest.php
@@ -91,7 +91,7 @@ class SetCustomerCustomFieldActionTest extends TestCase
 
         static::assertNotNull($this->customerRepository);
         /** @var CustomerEntity $customer */
-        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->first();
+        $customer = $this->customerRepository->search(new Criteria([$this->ids->get('customer')]), Context::createDefaultContext())->getEntities()->first();
 
         $expect = $option === 'clear' ? null : [$customFieldName => $expectData];
         static::assertSame($customer->getCustomFields(), $expect);

--- a/tests/integration/Core/Content/Flow/SetCustomerGroupCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetCustomerGroupCustomFieldActionTest.php
@@ -100,7 +100,7 @@ class SetCustomerGroupCustomFieldActionTest extends TestCase
 
         /** @var CustomerGroupEntity $customerGroup */
         $customerGroup = static::getContainer()->get('customer_group.repository')
-            ->search(new Criteria([$this->ids->get('customer_group')]), Context::createDefaultContext())->first();
+            ->search(new Criteria([$this->ids->get('customer_group')]), Context::createDefaultContext())->getEntities()->first();
 
         $expect = $option === 'clear' ? null : [$customFieldName => $expectData];
         static::assertSame($customerGroup->getCustomFields(), $expect);

--- a/tests/integration/Core/Content/Flow/SetOrderCustomFieldActionTest.php
+++ b/tests/integration/Core/Content/Flow/SetOrderCustomFieldActionTest.php
@@ -87,7 +87,7 @@ class SetOrderCustomFieldActionTest extends TestCase
         $this->cancelOrder();
 
         /** @var OrderEntity $order */
-        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->ids->get('order')]), Context::createDefaultContext())->first();
+        $order = static::getContainer()->get('order.repository')->search(new Criteria([$this->ids->get('order')]), Context::createDefaultContext())->getEntities()->first();
 
         $expect = $option === 'clear' ? null : [$customFieldName => $expectData];
         static::assertSame($order->getCustomFields(), $expect);

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializerTest.php
@@ -279,7 +279,7 @@ class EntitySerializerTest extends TestCase
         // fetch a product with extension data
         $criteria = new Criteria([$productId]);
         $criteria->addAssociation('testExtension');
-        $exportData = $productRepo->search($criteria, Context::createDefaultContext())->first();
+        $exportData = $productRepo->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         // do the serialization
         /** @var EntityDefinition $productDefinition */

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/OrderSerializerTest.php
@@ -155,7 +155,7 @@ class OrderSerializerTest extends TestCase
             'transactions.shippingMethod',
         ]);
 
-        $order = $this->orderRepository->search($criteria, $this->context)->first();
+        $order = $this->orderRepository->search($criteria, $this->context)->getEntities()->first();
 
         static::assertInstanceOf(OrderEntity::class, $order);
 
@@ -205,13 +205,13 @@ class OrderSerializerTest extends TestCase
      */
     private function getTransactionData(array $orderData): array
     {
-        $paymentMethod = static::getContainer()->get('payment_method.repository')->search(new Criteria(), $this->context)->first();
+        $paymentMethod = static::getContainer()->get('payment_method.repository')->search(new Criteria(), $this->context)->getEntities()->first();
         $paymentMethodId = null;
         if ($paymentMethod instanceof PaymentMethodEntity) {
             $paymentMethodId = $paymentMethod->getId();
         }
 
-        $stateMachineState = static::getContainer()->get('state_machine_state.repository')->search(new Criteria(), $this->context)->first();
+        $stateMachineState = static::getContainer()->get('state_machine_state.repository')->search(new Criteria(), $this->context)->getEntities()->first();
         $stateMachineStateId = null;
         if ($stateMachineState instanceof StateMachineStateEntity) {
             $stateMachineStateId = $stateMachineState->getId();

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializerTest.php
@@ -347,7 +347,7 @@ class ProductSerializerTest extends TestCase
         $criteria->addAssociation('media.media');
         $criteria->getAssociation('media')->addSorting(new FieldSorting('position', FieldSorting::ASCENDING));
 
-        $product = $productRepository->search($criteria, Context::createDefaultContext())->first();
+        $product = $productRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(ProductEntity::class, $product);
 
         return $product;

--- a/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
+++ b/tests/integration/Core/Content/ImportExport/Repository/ImportExportFileRepositoryTest.php
@@ -144,7 +144,7 @@ class ImportExportFileRepositoryTest extends TestCase
 
         foreach ($data as $expect) {
             $id = $expect['id'];
-            $result = $this->repository->search(new Criteria([$id]), $this->context);
+            $result = $this->repository->search(new Criteria([$id]), $this->context)->getEntities();
             $importExportFile = $result->get($id);
             static::assertInstanceOf(ImportExportFileEntity::class, $importExportFile);
             static::assertCount(1, $result);
@@ -163,7 +163,7 @@ class ImportExportFileRepositoryTest extends TestCase
 
         $this->repository->create(array_values($data), $this->context);
 
-        $result = $this->repository->search(new Criteria([Uuid::randomHex()]), $this->context);
+        $result = $this->repository->search(new Criteria([Uuid::randomHex()]), $this->context)->getEntities();
         static::assertCount(0, $result);
     }
 

--- a/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
+++ b/tests/integration/Core/Content/ImportExport/Service/DeleteExpiredFilesServiceTest.php
@@ -115,13 +115,13 @@ class DeleteExpiredFilesServiceTest extends TestCase
 
         // Verify expired files are deleted
         foreach ($expiredIds as $id) {
-            $file = $this->fileRepository->search(new Criteria([$id]), $this->context)->first();
+            $file = $this->fileRepository->search(new Criteria([$id]), $this->context)->getEntities()->first();
             static::assertNull($file, "Expired file with ID {$id} should be deleted");
         }
 
         // Verify non-expired files still exist
         foreach ($nonExpiredIds as $id) {
-            $file = $this->fileRepository->search(new Criteria([$id]), $this->context)->first();
+            $file = $this->fileRepository->search(new Criteria([$id]), $this->context)->getEntities()->first();
             static::assertNotNull($file, "Non-expired file with ID {$id} should still exist");
         }
     }

--- a/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Api/MailActionControllerTest.php
@@ -55,7 +55,7 @@ class MailActionControllerTest extends TestCase
 
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('orderCustomer');
-        $order = static::getContainer()->get('order.repository')->search($criteria, $context)->get($orderId);
+        $order = static::getContainer()->get('order.repository')->search($criteria, $context)->getEntities()->get($orderId);
         static::assertInstanceOf(OrderEntity::class, $order);
 
         $documentId = $this->createDocumentWithFile($orderId, $context);
@@ -66,7 +66,7 @@ class MailActionControllerTest extends TestCase
         /** @var ?MailTemplateEntity $mailTemplate */
         $mailTemplate = static::getContainer()
             ->get('mail_template.repository')
-            ->search($criteria, $context)
+            ->search($criteria, $context)->getEntities()
             ->first();
         static::assertInstanceOf(MailTemplateEntity::class, $mailTemplate);
 
@@ -74,7 +74,7 @@ class MailActionControllerTest extends TestCase
         $criteria->setLimit(1);
         $salesChannel = static::getContainer()
             ->get('sales_channel.repository')
-            ->search($criteria, $context)
+            ->search($criteria, $context)->getEntities()
             ->first();
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
 
@@ -342,7 +342,7 @@ class MailActionControllerTest extends TestCase
 
         /** @var EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository */
         $mailTemplateTypeRepository = static::getContainer()->get('mail_template_type.repository');
-        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $context)->first();
+        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $context)->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateTypeEntity::class, $mailTemplateType);
 
@@ -359,7 +359,7 @@ class MailActionControllerTest extends TestCase
             'contentPlain' => 'Hello {{ customName }}',
         ]], $context);
 
-        $mailTemplate = $mailTemplateRepository->search(new Criteria([$mailTemplateId]), $context)->first();
+        $mailTemplate = $mailTemplateRepository->search(new Criteria([$mailTemplateId]), $context)->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateEntity::class, $mailTemplate);
 

--- a/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Repository/MailHeaderFooterRepositoryTest.php
@@ -122,7 +122,7 @@ class MailHeaderFooterRepositoryTest extends TestCase
 
         foreach ($data as $expect) {
             $id = $expect['id'];
-            $mailHeaderFooter = $this->repository->search(new Criteria([$id]), $this->context)->get($id);
+            $mailHeaderFooter = $this->repository->search(new Criteria([$id]), $this->context)->getEntities()->get($id);
             static::assertInstanceOf(MailHeaderFooterEntity::class, $mailHeaderFooter);
             static::assertSame($expect['systemDefault'], $mailHeaderFooter->getSystemDefault());
             static::assertSame($expect['name'], $mailHeaderFooter->getName());

--- a/tests/integration/Core/Content/MailTemplate/Service/MailTemplateSendServiceTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Service/MailTemplateSendServiceTest.php
@@ -78,7 +78,7 @@ class MailTemplateSendServiceTest extends TestCase
 
         /** @var EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository */
         $mailTemplateTypeRepository = static::getContainer()->get('mail_template_type.repository');
-        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $this->context)->first();
+        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $this->context)->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateTypeEntity::class, $mailTemplateType);
 
@@ -96,7 +96,7 @@ class MailTemplateSendServiceTest extends TestCase
         $mailTemplate = $this->mailTemplateRepository->search(
             new Criteria([$mailTemplateId]),
             $this->context
-        )->first();
+        )->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateEntity::class, $mailTemplate);
 

--- a/tests/integration/Core/Content/MailTemplate/Service/MailTemplateServiceTest.php
+++ b/tests/integration/Core/Content/MailTemplate/Service/MailTemplateServiceTest.php
@@ -176,7 +176,7 @@ class MailTemplateServiceTest extends TestCase
 
         /** @var EntityRepository<MailTemplateTypeCollection> $mailTemplateTypeRepository */
         $mailTemplateTypeRepository = static::getContainer()->get('mail_template_type.repository');
-        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $this->context)->first();
+        $mailTemplateType = $mailTemplateTypeRepository->search($typeCriteria, $this->context)->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateTypeEntity::class, $mailTemplateType);
 
@@ -194,7 +194,7 @@ class MailTemplateServiceTest extends TestCase
         $mailTemplate = $this->mailTemplateRepository->search(
             new Criteria([$mailTemplateId]),
             $this->context
-        )->first();
+        )->getEntities()->first();
 
         static::assertInstanceOf(MailTemplateEntity::class, $mailTemplate);
 

--- a/tests/integration/Core/Content/Media/Aggregate/MediaFolderConfigurationThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeTest.php
+++ b/tests/integration/Core/Content/Media/Aggregate/MediaFolderConfigurationThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeTest.php
@@ -48,7 +48,7 @@ class MediaFolderConfigurationMediaThumbnailSizeTest extends TestCase
         $criteria = new Criteria([$configurationId]);
         $criteria->addAssociation('mediaThumbnailSizes');
 
-        $read = $repository->search($criteria, $context);
+        $read = $repository->search($criteria, $context)->getEntities();
         $configuration = $read->get($configurationId);
 
         static::assertInstanceOf(MediaFolderConfigurationEntity::class, $configuration);

--- a/tests/integration/Core/Content/Media/Api/MediaFolderControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaFolderControllerTest.php
@@ -90,10 +90,10 @@ class MediaFolderControllerTest extends TestCase
         static::assertSame(204, $response->getStatusCode(), (string) $response->getContent());
         static::assertEmpty($response->getContent());
 
-        $folder = $this->mediaFolderRepo->search(new Criteria([$folderId]), $this->context)->get($folderId);
+        $folder = $this->mediaFolderRepo->search(new Criteria([$folderId]), $this->context)->getEntities()->get($folderId);
         static::assertNull($folder);
 
-        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->get($configId);
+        $config = $this->mediaFolderConfigRepo->search(new Criteria([$configId]), $this->context)->getEntities()->get($configId);
         static::assertNull($config);
     }
 }

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -187,7 +187,7 @@ class MediaUploadControllerTest extends TestCase
 
         $response = $this->getBrowser()->getResponse();
         $responseData = json_decode((string) $response->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->get($this->mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->getEntities()->get($this->mediaId);
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
@@ -226,7 +226,7 @@ class MediaUploadControllerTest extends TestCase
         );
         $response = $this->getBrowser()->getResponse();
 
-        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->get($this->mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->getEntities()->get($this->mediaId);
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), (string) $response->getContent());
@@ -291,7 +291,7 @@ class MediaUploadControllerTest extends TestCase
         ];
 
         $this->mediaRepository->create([$data], $context);
-        $media = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
+        $media = $this->mediaRepository->search(new Criteria([$id]), $context)->getEntities()->get($id);
 
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertNotEmpty($media->getPath());
@@ -315,7 +315,7 @@ class MediaUploadControllerTest extends TestCase
         $response = $this->getBrowser()->getResponse();
         static::assertSame(204, $response->getStatusCode());
 
-        $updated = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
+        $updated = $this->mediaRepository->search(new Criteria([$id]), $context)->getEntities()->get($id);
 
         static::assertInstanceOf(MediaEntity::class, $updated);
         static::assertNotSame($media->getFileName(), $updated->getFileName());
@@ -377,7 +377,7 @@ class MediaUploadControllerTest extends TestCase
 
     private function getMediaEntity(): MediaEntity
     {
-        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->get($this->mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$this->mediaId]), $this->context)->getEntities()->get($this->mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
         $response = $this->getBrowser()->getResponse();
 

--- a/tests/integration/Core/Content/Media/Api/MediaUploadV2ControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadV2ControllerTest.php
@@ -79,7 +79,7 @@ class MediaUploadV2ControllerTest extends TestCase
         static::assertArrayHasKey('id', $responseData);
         $mediaId = $responseData['id'];
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->first();
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->first();
 
         static::assertNotNull($media);
         static::assertSame('https://localhost:8000/Geschenktüte.jpg', $media->getPath());
@@ -90,7 +90,7 @@ class MediaUploadV2ControllerTest extends TestCase
 
         static::assertSame(2, $thumbnails->getTotal());
 
-        $urls = $thumbnails->map(static fn ($t) => $t->getPath());
+        $urls = $thumbnails->getEntities()->map(static fn ($t) => $t->getPath());
         static::assertContains('https://localhost:8000/Geschenktüte-200.jpg', $urls);
         static::assertContains('https://localhost:8000/Geschenktüte-400.jpg', $urls);
     }

--- a/tests/integration/Core/Content/Media/Api/MediaVideoCoverControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaVideoCoverControllerTest.php
@@ -111,7 +111,7 @@ class MediaVideoCoverControllerTest extends TestCase
 
     private function getMediaEntity(string $id): MediaEntity
     {
-        $entity = $this->mediaRepository->search(new Criteria([$id]), $this->context)->first();
+        $entity = $this->mediaRepository->search(new Criteria([$id]), $this->context)->getEntities()->first();
 
         static::assertNotNull($entity, \sprintf('Media entity "%s" not found', $id));
         static::assertInstanceOf(MediaEntity::class, $entity);

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderIndexerTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderIndexerTest.php
@@ -106,7 +106,7 @@ class MediaFolderIndexerTest extends TestCase
         ], $this->context);
 
         /** @var MediaFolderEntity $folder */
-        $folder = $this->mediaFolderRepository->search(new Criteria([$parentId]), $this->context)->first();
+        $folder = $this->mediaFolderRepository->search(new Criteria([$parentId]), $this->context)->getEntities()->first();
 
         static::assertSame(1, $folder->getChildCount());
     }

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
@@ -63,7 +63,7 @@ class MediaFolderRepositoryTest extends TestCase
         $folderRepository = $this->folderRepository;
         $media = null;
         $this->context->scope(Context::USER_SCOPE, static function (Context $context) use (&$media, $folderId, $folderRepository): void {
-            $media = $folderRepository->search(new Criteria([$folderId]), $context);
+            $media = $folderRepository->search(new Criteria([$folderId]), $context)->getEntities();
         });
 
         static::assertNotNull($media);
@@ -83,7 +83,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
         ], $this->context);
 
-        $media = $this->folderRepository->search(new Criteria([$folderId]), $this->context);
+        $media = $this->folderRepository->search(new Criteria([$folderId]), $this->context)->getEntities();
 
         static::assertCount(1, $media);
     }
@@ -114,7 +114,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $this->context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $mediaPath = $media->getPath();
@@ -175,7 +175,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context);
+        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getEntities();
 
         $childMedia = $media->get($childMediaId);
         static::assertInstanceOf(MediaEntity::class, $childMedia);
@@ -246,7 +246,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context);
+        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getEntities();
 
         $childMedia = $media->get($childMediaId);
         static::assertInstanceOf(MediaEntity::class, $childMedia);
@@ -264,8 +264,8 @@ class MediaFolderRepositoryTest extends TestCase
 
         $this->folderRepository->delete([['id' => $childFolderId]], $this->context);
 
-        static::assertArrayHasKey($parentFolderId, $this->folderRepository->search(new Criteria([$parentFolderId, $childFolderId]), $this->context)->getIds());
-        static::assertArrayHasKey($parentMediaId, $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getIds());
+        static::assertArrayHasKey($parentFolderId, $this->folderRepository->search(new Criteria([$parentFolderId, $childFolderId]), $this->context)->getEntities()->getIds());
+        static::assertArrayHasKey($parentMediaId, $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getEntities()->getIds());
 
         $this->runWorker();
 
@@ -315,7 +315,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context);
+        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getEntities();
 
         $childMedia = $media->get($childMediaId);
         static::assertInstanceOf(MediaEntity::class, $childMedia);
@@ -384,7 +384,7 @@ class MediaFolderRepositoryTest extends TestCase
             ],
             $this->context
         );
-        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context);
+        $media = $this->mediaRepository->search(new Criteria([$childMediaId, $parentMediaId]), $this->context)->getEntities();
 
         $childMedia = $media->get($childMediaId);
         static::assertInstanceOf(MediaEntity::class, $childMedia);

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
@@ -85,7 +85,7 @@ class MediaThumbnailRepositoryTest extends TestCase
         ], Context::createDefaultContext());
 
         $media = static::getContainer()->get('media.repository')
-            ->search(new Criteria([$mediaId]), Context::createDefaultContext())
+            ->search(new Criteria([$mediaId]), Context::createDefaultContext())->getEntities()
             ->get($mediaId);
 
         static::assertInstanceOf(MediaEntity::class, $media);

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -103,7 +103,7 @@ SVG;
             }
         }
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $path = $media->getPath();
@@ -132,7 +132,7 @@ SVG;
             $filesystem->remove($tempFile);
         }
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
         static::assertTrue($this->getPublicFilesystem()->has($media->getPath()));
     }
@@ -202,7 +202,7 @@ SVG;
             }
         }
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $path = $media->getPath();
@@ -242,7 +242,7 @@ SVG;
                 unlink($tempFile);
             }
         }
-        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $context)->get($media->getId());
+        $media = $this->mediaRepository->search(new Criteria([$media->getId()]), $context)->getEntities()->get($media->getId());
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $path = $media->getPath();
@@ -287,7 +287,7 @@ SVG;
             }
         }
 
-        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->get($mediaId);
+        $media = $this->mediaRepository->search(new Criteria([$mediaId]), $context)->getEntities()->get($mediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $path = $media->getPath();
@@ -331,7 +331,7 @@ SVG;
             }
         }
 
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
         static::assertInstanceOf(MediaEntity::class, $updatedMedia);
         static::assertIsString($updatedMedia->getFileName());
         static::assertStringEndsWith($png->getFileName(), $updatedMedia->getFileName());
@@ -418,7 +418,7 @@ SVG;
             }
         }
 
-        $media = $this->mediaRepository->search(new Criteria([$newMediaId]), $context)->get($newMediaId);
+        $media = $this->mediaRepository->search(new Criteria([$newMediaId]), $context)->getEntities()->get($newMediaId);
         static::assertInstanceOf(MediaEntity::class, $media);
 
         $path = $media->getPath();
@@ -534,7 +534,7 @@ SVG;
         $this->mediaRepository->create($data, $context);
 
         $png = $this->mediaRepository
-            ->search(new Criteria([$ids->get('png')]), $context)
+            ->search(new Criteria([$ids->get('png')]), $context)->getEntities()
             ->get($ids->get('png'));
 
         static::assertInstanceOf(MediaEntity::class, $png);
@@ -543,7 +543,7 @@ SVG;
         $this->fileSaver->renameMedia($ids->get('png'), 'txtFile', $context);
 
         $updatedMedia = $this->mediaRepository
-            ->search(new Criteria([$ids->get('png')]), $context)
+            ->search(new Criteria([$ids->get('png')]), $context)->getEntities()
             ->get($ids->get('png'));
 
         static::assertInstanceOf(MediaEntity::class, $updatedMedia);
@@ -587,7 +587,7 @@ SVG;
 
         $this->mediaRepository->create([$data], $context);
 
-        $png = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
+        $png = $this->mediaRepository->search(new Criteria([$id]), $context)->getEntities()->get($id);
         static::assertInstanceOf(MediaEntity::class, $png);
 
         $thumbnailId = Uuid::randomHex();
@@ -617,7 +617,7 @@ SVG;
             new MediaIndexingMessage([$png->getId()])
         );
 
-        $png = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $png = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
         static::assertInstanceOf(MediaEntity::class, $png);
 
         static::assertNotNull($png->getThumbnails());
@@ -633,7 +633,7 @@ SVG;
 
         $this->fileSaver->renameMedia($png->getId(), 'new destination', $context);
 
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
         static::assertInstanceOf(MediaEntity::class, $updatedMedia);
         static::assertFalse($this->getPublicFilesystem()->has($oldMediaPath));
         static::assertTrue($this->getPublicFilesystem()->has($updatedMedia->getPath()));
@@ -687,7 +687,7 @@ SVG;
 
         $this->mediaRepository->create([$data], $context);
 
-        $png = $this->mediaRepository->search(new Criteria([$id]), $context)->get($id);
+        $png = $this->mediaRepository->search(new Criteria([$id]), $context)->getEntities()->get($id);
         static::assertInstanceOf(MediaEntity::class, $png);
 
         $dispatcher = static::getContainer()->get('event_dispatcher');
@@ -697,7 +697,7 @@ SVG;
 
         static::getContainer()->get(MediaIndexer::class)->handle(new MediaIndexingMessage([$png->getId()]));
 
-        $png = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $png = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
         static::assertInstanceOf(MediaEntity::class, $png);
 
         static::assertNotNull($png->getThumbnails());
@@ -717,7 +717,7 @@ SVG;
 
         static::assertFalse($this->getPublicFilesystem()->has($oldThumbnailPath));
 
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
 
         static::assertNotNull($updatedMedia?->getThumbnails());
         static::assertCount(2, $updatedMedia->getThumbnails());
@@ -773,7 +773,7 @@ SVG;
         $this->getPublicFilesystem()->write($mediaPath, 'test file');
 
         $fileSaverWithFailingRepository->renameMedia($png->getId(), 'new file name', $context);
-        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->get($png->getId());
+        $updatedMedia = $this->mediaRepository->search(new Criteria([$png->getId()]), $context)->getEntities()->get($png->getId());
 
         static::assertInstanceOf(MediaEntity::class, $updatedMedia);
         static::assertSame($png->getFileName(), $updatedMedia->getFileName());

--- a/tests/integration/Core/Content/Media/Subscriber/MediaVisibilityRestrictionSubscriberTest.php
+++ b/tests/integration/Core/Content/Media/Subscriber/MediaVisibilityRestrictionSubscriberTest.php
@@ -176,10 +176,10 @@ class MediaVisibilityRestrictionSubscriberTest extends TestCase
             )
         );
         $result = $this->mediaRepository->search($criteria, $this->salesChannelContext);
-        static::assertCount(2, $result);
+        static::assertCount(2, $result->getEntities());
 
-        static::assertTrue($result->has($this->ids->get('public-media.1')));
-        static::assertTrue($result->has($this->ids->get('public-media.2')));
+        static::assertTrue($result->getEntities()->has($this->ids->get('public-media.1')));
+        static::assertTrue($result->getEntities()->has($this->ids->get('public-media.2')));
 
         $countResult = $result->getAggregations()->get('public-media-count');
         static::assertInstanceOf(CountResult::class, $countResult);

--- a/tests/integration/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriberTest.php
+++ b/tests/integration/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriberTest.php
@@ -150,7 +150,7 @@ class VideoCoverCleanupSubscriberTest extends TestCase
     private function getMediaEntity(string $id): MediaEntity
     {
         $entity = $this->mediaRepository
-            ->search(new Criteria([$id]), $this->context)
+            ->search(new Criteria([$id]), $this->context)->getEntities()
             ->first();
 
         static::assertNotNull($entity, \sprintf('Media entity "%s" not found', $id));

--- a/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/integration/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -84,7 +84,7 @@ class UnusedMediaPurgerTest extends TestCase
                 $withManufacturer->getId(),
             ]),
             $this->context
-        );
+        )->getEntities();
 
         static::assertNull($result->get($txt->getId()));
         static::assertNull($result->get($png->getId()));
@@ -123,7 +123,7 @@ class UnusedMediaPurgerTest extends TestCase
                 $pdf->getId(),
             ]),
             $this->context
-        );
+        )->getEntities();
 
         static::assertNull($result->get($txt->getId()));
         static::assertNull($result->get($png->getId()));
@@ -165,7 +165,7 @@ class UnusedMediaPurgerTest extends TestCase
         static::assertSame(0, $deleted);
 
         $stillExisting = $this->mediaRepo
-            ->search(new Criteria([$txt->getId()]), $this->context)
+            ->search(new Criteria([$txt->getId()]), $this->context)->getEntities()
             ->get($txt->getId());
         static::assertNotNull($stillExisting);
     }
@@ -241,7 +241,7 @@ class UnusedMediaPurgerTest extends TestCase
                 $unusedMedia->getId(),
             ]),
             $this->context
-        );
+        )->getEntities();
 
         static::assertNotNull($result->get($usedByA11yDocument->getId()));
         static::assertNull($result->get($unusedMedia->getId()));

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
@@ -159,8 +159,8 @@ class ProductListingTest extends TestCase
             ->getResult();
 
         static::assertSame(7, $listing->getTotal());
-        static::assertFalse($listing->has($this->productIdWidth100));
-        static::assertTrue($listing->has($this->productIdWidth150));
+        static::assertFalse($listing->getEntities()->has($this->productIdWidth100));
+        static::assertTrue($listing->getEntities()->has($this->productIdWidth150));
     }
 
     public function testListingWithProductStreamAndAdditionalCriteria(): void

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -552,10 +552,10 @@ class ProductSearchRouteTest extends TestCase
 
             static::assertSame(
                 $shouldBeFound,
-                $result->getListingResult()->has($ids->get($productNumber)),
+                $result->getListingResult()->getEntities()->has($ids->get($productNumber)),
                 \sprintf(
                     'Product was%s found, but should%s be found for term "%s".',
-                    $result->getListingResult()->has($ids->get($productNumber)) ? '' : ' not',
+                    $result->getListingResult()->getEntities()->has($ids->get($productNumber)) ? '' : ' not',
                     $shouldBeFound ? '' : ' not',
                     $searchTerm
                 )
@@ -569,10 +569,10 @@ class ProductSearchRouteTest extends TestCase
 
             static::assertSame(
                 $shouldBeFound,
-                $result->getListingResult()->has($ids->get($productNumber)),
+                $result->getListingResult()->getEntities()->has($ids->get($productNumber)),
                 \sprintf(
                     'Product was%s found, but should%s be found for term "%s".',
-                    $result->getListingResult()->has($ids->get($productNumber)) ? '' : ' not',
+                    $result->getListingResult()->getEntities()->has($ids->get($productNumber)) ? '' : ' not',
                     $shouldBeFound ? '' : ' not',
                     $searchTerm
                 )

--- a/tests/integration/Core/Content/Rule/DataAbstractionLayer/RulePayloadIndexerTest.php
+++ b/tests/integration/Core/Content/Rule/DataAbstractionLayer/RulePayloadIndexerTest.php
@@ -218,7 +218,7 @@ class RulePayloadIndexerTest extends TestCase
 
         $this->indexer->handle(new EntityIndexingMessage([$id, $rule2Id]));
 
-        $rules = $this->ruleRepository->search(new Criteria([$id, $rule2Id]), $this->context);
+        $rules = $this->ruleRepository->search(new Criteria([$id, $rule2Id]), $this->context)->getEntities();
         $rule = $rules->get($id);
         static::assertInstanceOf(RuleEntity::class, $rule);
         static::assertInstanceOf(Rule::class, $rule->getPayload());
@@ -288,7 +288,7 @@ class RulePayloadIndexerTest extends TestCase
 
         $this->ruleRepository->create($data, $this->context);
 
-        $rules = $this->ruleRepository->search(new Criteria([$id, $rule2Id]), $this->context);
+        $rules = $this->ruleRepository->search(new Criteria([$id, $rule2Id]), $this->context)->getEntities();
         $rule = $rules->get($id);
         static::assertInstanceOf(RuleEntity::class, $rule);
         static::assertInstanceOf(Rule::class, $rule->getPayload());

--- a/tests/integration/Core/Content/Rule/DataAbstractionLayer/RulePayloadSubscriberTest.php
+++ b/tests/integration/Core/Content/Rule/DataAbstractionLayer/RulePayloadSubscriberTest.php
@@ -182,7 +182,7 @@ class RulePayloadSubscriberTest extends TestCase
             ->setParameter('createdAt', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT))
             ->executeStatement();
 
-        $rule = static::getContainer()->get('rule.repository')->search(new Criteria([$id]), $this->context)->get($id);
+        $rule = static::getContainer()->get('rule.repository')->search(new Criteria([$id]), $this->context)->getEntities()->get($id);
         static::assertInstanceOf(RuleEntity::class, $rule);
         static::assertNotNull($rule->getPayload());
         static::assertInstanceOf(AndRule::class, $rule->getPayload());
@@ -221,7 +221,7 @@ class RulePayloadSubscriberTest extends TestCase
             ->setParameter('createdAt', (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT))
             ->executeStatement();
 
-        $rule = static::getContainer()->get('rule.repository')->search(new Criteria([$id]), $this->context)->get($id);
+        $rule = static::getContainer()->get('rule.repository')->search(new Criteria([$id]), $this->context)->getEntities()->get($id);
         static::assertInstanceOf(RuleEntity::class, $rule);
         static::assertNull($rule->getPayload());
         static::assertTrue($rule->isInvalid());

--- a/tests/integration/Core/Content/Seo/SeoUrlUpdaterTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlUpdaterTest.php
@@ -145,7 +145,7 @@ class SeoUrlUpdaterTest extends TestCase
         $seoUrl = static::getContainer()->get('seo_url.repository')->search(
             $criteria,
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         // Check if seo url was created
         static::assertNotNull($seoUrl);
@@ -160,7 +160,7 @@ class SeoUrlUpdaterTest extends TestCase
         $seoUrl = static::getContainer()->get('seo_url.repository')->search(
             $criteria,
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         // Check that no seo url was created.
         static::assertNull($seoUrl);

--- a/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/LandingPageUrlProviderTest.php
@@ -157,7 +157,7 @@ class LandingPageUrlProviderTest extends TestCase
         $seuUrlRepository = static::getContainer()->get('seo_url.repository');
 
         /** @var SeoUrlEntity|null $seoUrl */
-        $seoUrl = $seuUrlRepository->search($criteria, $this->salesChannelContext->getContext())->first();
+        $seoUrl = $seuUrlRepository->search($criteria, $this->salesChannelContext->getContext())->getEntities()->first();
 
         static::assertNotNull($seoUrl);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`EntitySearchResult`'s inherited collection API (`first()`, `get()`, `count()`, iteration, …) is deprecated for v6.8 and throws under `FEATURE_ALL=major`, so the Core/Content integration tests still using the old idiom fail only in the integration-major nightly.

### 2. What does this change do, exactly?

- Migrates every deprecated accessor in `tests/integration/Core/Content/` to `->getEntities()->…` (41 files): chained calls after `->search(…)`, variable-held results across ImportExport, Media, Rule, Flow, and Sitemap tests, a `map()` in `MediaUploadV2ControllerTest`, and `has()` on `ProductListingResult` in the product listing/search route tests. Variables also asserting `getTotal()` or aggregations keep the `EntitySearchResult` and convert at the point of use.
- `IdSearchResult` calls (`searchIds()`) are untouched, as that API is not deprecated.
- The production straggler named in the issue (`LandingPageRoute`) was already fixed in #18420 — during verification this sweep additionally uncovered a second content-owned straggler missed by both #17101 and the tracking issue: `SitemapGenerateCommand` iterates a search result directly. That fix is added to #18420 as well.

Verified the whole `tests/integration/Core/Content` suite under `FEATURE_ALL=major` and with flags off: failing tests under major drop from 567 to 23 with no new failures — the only remaining `EntitySearchResult` throws come from the two production code paths above and disappear once #18420 lands; the flags-off failing set is byte-identical to the trunk baseline.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Core/Content` on trunk: 567 tests fail, most with `FeatureException: Tried to access deprecated functionality: … EntitySearchResult::…` (including large ImportExport cascades).
2. With this change, no test-side throw remains in the suite.

### 4. Please link to the relevant issues (if any).

- closes #18393

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
