### PR TITLE
test: sweep deprecated EntitySearchResult accessors from system integration tests

### DIFF
--- a/tests/integration/Core/System/Currency/CurrencyRuleTest.php
+++ b/tests/integration/Core/System/Currency/CurrencyRuleTest.php
@@ -87,7 +87,7 @@ class CurrencyRuleTest extends TestCase
             ],
         ], $this->context);
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
         $this->conditionRepository->delete([['id' => $id]], Context::createDefaultContext());
     }
 }

--- a/tests/integration/Core/System/CustomEntity/CustomEntityLifecycleServiceTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityLifecycleServiceTest.php
@@ -63,7 +63,7 @@ class CustomEntityLifecycleServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('appId', $app->getId()));
 
-        $customEntities = $this->customEntityRepository->search($criteria, $this->context);
+        $customEntities = $this->customEntityRepository->search($criteria, $this->context)->getEntities();
 
         static::assertTrue(TableHelper::tableExists($this->connection, 'custom_entity_test'));
         static::assertCount(1, $customEntities);
@@ -73,7 +73,7 @@ class CustomEntityLifecycleServiceTest extends TestCase
 
         $this->createLifecycleService($app)->removeApp($app, $this->context, true);
 
-        $customEntities = $this->customEntityRepository->search(new Criteria([$customEntity->getId()]), $this->context);
+        $customEntities = $this->customEntityRepository->search(new Criteria([$customEntity->getId()]), $this->context)->getEntities();
 
         $customEntity = $customEntities->first();
         static::assertNotNull($customEntity);
@@ -103,7 +103,7 @@ class CustomEntityLifecycleServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('appId', $app->getId()));
 
-        $customEntities = $this->customEntityRepository->search($criteria, $this->context);
+        $customEntities = $this->customEntityRepository->search($criteria, $this->context)->getEntities();
 
         static::assertTrue(TableHelper::tableExists($this->connection, 'custom_entity_test'));
         static::assertCount(1, $customEntities);
@@ -113,7 +113,7 @@ class CustomEntityLifecycleServiceTest extends TestCase
 
         $this->createLifecycleService($app)->removeApp($app, $this->context, false);
 
-        $customEntities = $this->customEntityRepository->search(new Criteria([$customEntity->getId()]), $this->context);
+        $customEntities = $this->customEntityRepository->search(new Criteria([$customEntity->getId()]), $this->context)->getEntities();
 
         static::assertFalse(TableHelper::tableExists($this->connection, 'custom_entity_test'));
         static::assertCount(0, $customEntities);

--- a/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
@@ -306,7 +306,7 @@ class CustomEntityTest extends TestCase
         $repo = $container->get('ce_product_with_defaults.repository');
         static::assertInstanceOf(EntityRepository::class, $repo);
         $repo->create([['id' => Uuid::randomHex()]], $context);
-        $entity = $repo->search(new Criteria(), $context)->first();
+        $entity = $repo->search(new Criteria(), $context)->getEntities()->first();
         static::assertInstanceOf(DALEntity::class, $entity);
 
         foreach ($expectedDefaults as $field => $defaultValue) {
@@ -488,7 +488,7 @@ class CustomEntityTest extends TestCase
         $criteria = new Criteria($ids->getList(['v1', 'v2']));
         $criteria->addAssociation('customEntityBlogInheritedProducts');
 
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         static::assertCount(2, $products);
         $v1 = $products->get($ids->get('v1'));
@@ -518,7 +518,7 @@ class CustomEntityTest extends TestCase
 
         $criteria = new Criteria($ids->getList(['v2']));
         $criteria->addAssociation('customEntityBlogInheritedProducts');
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         $v2 = $products->get($ids->get('v2'));
         static::assertInstanceOf(ProductEntity::class, $v2);
@@ -565,7 +565,7 @@ class CustomEntityTest extends TestCase
         $criteria = new Criteria($ids->getList(['one-to-one-1', 'one-to-one-2']));
         $criteria->addAssociation('customEntityBlogInheritedLinkProduct');
 
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         static::assertCount(2, $products);
         $v1 = $products->get($ids->get('one-to-one-1'));
@@ -588,7 +588,7 @@ class CustomEntityTest extends TestCase
 
         $criteria = new Criteria($ids->getList(['one-to-one-2']));
         $criteria->addAssociation('customEntityBlogInheritedLinkProduct');
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         $v2 = $products->get($ids->get('one-to-one-2'));
         static::assertInstanceOf(ProductEntity::class, $v2);
@@ -635,7 +635,7 @@ class CustomEntityTest extends TestCase
         $criteria = new Criteria($ids->getList(['many-to-one-1', 'many-to-one-2']));
         $criteria->addAssociation('customEntityBlogInheritedTopSeller');
 
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         static::assertCount(2, $products);
         $v1 = $products->get($ids->get('many-to-one-1'));
@@ -661,7 +661,7 @@ class CustomEntityTest extends TestCase
 
         $criteria = new Criteria($ids->getList(['many-to-one-2']));
         $criteria->addAssociation('customEntityBlogInheritedTopSeller');
-        $products = $container->get('product.repository')->search($criteria, $context);
+        $products = $container->get('product.repository')->search($criteria, $context)->getEntities();
 
         $v2 = $products->get($ids->get('many-to-one-2'));
         static::assertInstanceOf(ProductEntity::class, $v2);
@@ -831,7 +831,7 @@ class CustomEntityTest extends TestCase
         $criteria->addAssociation('linkProductSetNull');
         $criteria->addAssociation('linksSetNull');
 
-        $blogs = $repository->search($criteria, Context::createDefaultContext());
+        $blogs = $repository->search($criteria, Context::createDefaultContext())->getEntities();
 
         static::assertCount(1, $blogs);
         $blog = $blogs->first();
@@ -1283,7 +1283,7 @@ class CustomEntityTest extends TestCase
         $criteria->addFilter(new EqualsFilter('name', 'custom-entity-test'));
 
         $app = static::getContainer()->get('app.repository')
-            ->search($criteria, Context::createDefaultContext())
+            ->search($criteria, Context::createDefaultContext())->getEntities()
             ->first();
 
         static::assertInstanceOf(AppEntity::class, $app);

--- a/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
+++ b/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
@@ -45,10 +45,8 @@ class IntegrationRepositoryTest extends TestCase
 
         $this->repository->create($records, $context);
 
-        $entities = $this->repository->search(new Criteria([$id]), $context);
-        $entity = $entities
-            ->getEntities()
-            ->first();
+        $entities = $this->repository->search(new Criteria([$id]), $context)->getEntities();
+        $entity = $entities->first();
 
         static::assertNotNull($entity);
         static::assertCount(1, $entities);
@@ -72,10 +70,8 @@ class IntegrationRepositoryTest extends TestCase
 
         $this->repository->create($records, $context);
 
-        $entities = $this->repository->search(new Criteria([$id]), $context);
-        $entity = $entities
-            ->getEntities()
-            ->first();
+        $entities = $this->repository->search(new Criteria([$id]), $context)->getEntities();
+        $entity = $entities->first();
 
         static::assertNotNull($entity);
         static::assertCount(1, $entities);
@@ -101,10 +97,8 @@ class IntegrationRepositoryTest extends TestCase
 
         $this->repository->create($records, $context);
 
-        $entities = $this->repository->search(new Criteria([$id]), $context);
-        $entity = $entities
-            ->getEntities()
-            ->first();
+        $entities = $this->repository->search(new Criteria([$id]), $context)->getEntities();
+        $entity = $entities->first();
 
         static::assertNotNull($entity);
         static::assertCount(1, $entities);

--- a/tests/integration/Core/System/Language/LanguageRuleTest.php
+++ b/tests/integration/Core/System/Language/LanguageRuleTest.php
@@ -76,7 +76,7 @@ class LanguageRuleTest extends TestCase
             $ruleId
         );
 
-        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->get($id));
+        static::assertNotNull($this->conditionRepository->search(new Criteria([$id]), $this->context)->getEntities()->get($id));
     }
 
     /**

--- a/tests/integration/Core/System/Locale/Subscriber/LocaleValidatorTest.php
+++ b/tests/integration/Core/System/Locale/Subscriber/LocaleValidatorTest.php
@@ -67,7 +67,7 @@ class LocaleValidatorTest extends TestCase
 
     public function testItValidatesAllDefaultLocalesWithoutErrors(): void
     {
-        $locales = $this->localeRepository->search(new Criteria(), Context::createDefaultContext())->getElements();
+        $locales = $this->localeRepository->search(new Criteria(), Context::createDefaultContext())->getEntities()->getElements();
         $definition = $this->definitionInstanceRegistry->get(LocaleDefinition::class);
         $entityExistinceMock = $this->createMock(EntityExistence::class);
 

--- a/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -688,7 +688,7 @@ class CartRestorerTest extends TestCase
 
         $repo->create([$customer], Context::createDefaultContext());
 
-        $entity = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        $entity = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
         static::assertInstanceOf(CustomerEntity::class, $entity);
 
         return $entity;

--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextRestorerTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextRestorerTest.php
@@ -319,7 +319,7 @@ class SalesChannelContextRestorerTest extends TestCase
         $repo->create([$customer], Context::createDefaultContext());
 
         /** @var CustomerEntity|null $customer */
-        $customer = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->first();
+        $customer = $repo->search(new Criteria([$customerId]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertNotNull($customer);
 

--- a/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/SalesChannelContextTest.php
@@ -476,7 +476,7 @@ class SalesChannelContextTest extends TestCase
 
         /** @var EntityRepository<SalesChannelCollection> $repository */
         $repository = static::getContainer()->get('sales_channel.repository');
-        $salesChannel = $repository->search(new Criteria([$salesChannelContext->getSalesChannelId()]), $salesChannelContext->getContext())->first();
+        $salesChannel = $repository->search(new Criteria([$salesChannelContext->getSalesChannelId()]), $salesChannelContext->getContext())->getEntities()->first();
         static::assertNotNull($salesChannel);
 
         static::assertSame($salesChannel->getShippingMethodId(), $salesChannelContext->getSalesChannel()->getShippingMethodId());

--- a/tests/integration/Core/System/SalesChannel/Entity/SalesChannelDefinitionTest.php
+++ b/tests/integration/Core/System/SalesChannel/Entity/SalesChannelDefinitionTest.php
@@ -137,7 +137,7 @@ class SalesChannelDefinitionTest extends TestCase
         $criteria = new Criteria([$id]);
         $criteria->addAssociation('categories');
 
-        $products = $this->salesChannelProductRepository->search($criteria, $context);
+        $products = $this->salesChannelProductRepository->search($criteria, $context)->getEntities();
 
         static::assertCount(1, $products);
 
@@ -184,7 +184,7 @@ class SalesChannelDefinitionTest extends TestCase
      */
     private function getBusinessTimeZone(EntityRepository $repository, Context $context): ?string
     {
-        $salesChannel = $repository->search(new Criteria([TestDefaults::SALES_CHANNEL]), $context)->first();
+        $salesChannel = $repository->search(new Criteria([TestDefaults::SALES_CHANNEL]), $context)->getEntities()->first();
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
 
         return $salesChannel->getBusinessTimeZone();

--- a/tests/integration/Core/System/SalesChannel/File/SalesChannelFileRepositoryTest.php
+++ b/tests/integration/Core/System/SalesChannel/File/SalesChannelFileRepositoryTest.php
@@ -42,7 +42,7 @@ class SalesChannelFileRepositoryTest extends TestCase
             ],
         ], Context::createDefaultContext());
 
-        $entity = $repository->search(new Criteria([$id]), Context::createDefaultContext())->first();
+        $entity = $repository->search(new Criteria([$id]), Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(SalesChannelFileEntity::class, $entity);
         static::assertSame(TestDefaults::SALES_CHANNEL, $entity->getSalesChannelId());
@@ -75,7 +75,7 @@ class SalesChannelFileRepositoryTest extends TestCase
         ], Context::createDefaultContext());
 
         $criteria = (new Criteria([TestDefaults::SALES_CHANNEL]))->addAssociation('salesChannelFiles');
-        $salesChannel = $this->getSalesChannelRepository()->search($criteria, Context::createDefaultContext())->first();
+        $salesChannel = $this->getSalesChannelRepository()->search($criteria, Context::createDefaultContext())->getEntities()->first();
 
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
         static::assertNotNull($salesChannel->getSalesChannelFiles());

--- a/tests/integration/Core/System/SalesChannel/Repository/SalesChannelRepositoryTest.php
+++ b/tests/integration/Core/System/SalesChannel/Repository/SalesChannelRepositoryTest.php
@@ -123,7 +123,7 @@ class SalesChannelRepositoryTest extends TestCase
         $criteria1 = new Criteria([$salesChannelId]);
         $criteria1->addAssociation('type');
 
-        $salesChannel = $this->salesChannelRepository->search($criteria1, $context)->get($salesChannelId);
+        $salesChannel = $this->salesChannelRepository->search($criteria1, $context)->getEntities()->get($salesChannelId);
 
         static::assertInstanceOf(SalesChannelEntity::class, $salesChannel);
         static::assertSame($name, $salesChannel->getName());
@@ -140,27 +140,27 @@ class SalesChannelRepositoryTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('currency.salesChannels.id', $salesChannelId));
-        $currency = $this->currencyRepository->search($criteria, $context);
+        $currency = $this->currencyRepository->search($criteria, $context)->getEntities();
         static::assertCount(1, $currency);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('language.salesChannels.id', $salesChannelId));
-        $language = $this->languageRepository->search($criteria, $context);
+        $language = $this->languageRepository->search($criteria, $context)->getEntities();
         static::assertCount(1, $language);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('payment_method.salesChannels.id', $salesChannelId));
-        $paymentMethod = $this->paymentMethodRepository->search($criteria, $context);
+        $paymentMethod = $this->paymentMethodRepository->search($criteria, $context)->getEntities();
         static::assertCount(1, $paymentMethod);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('country.salesChannels.id', $salesChannelId));
-        $country = $this->countryRepository->search($criteria, $context);
+        $country = $this->countryRepository->search($criteria, $context)->getEntities();
         static::assertCount(1, $country);
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('shipping_method.salesChannels.id', $salesChannelId));
-        $shippingMethod = $this->shippingMethodRepository->search($criteria, $context);
+        $shippingMethod = $this->shippingMethodRepository->search($criteria, $context)->getEntities();
         static::assertCount(1, $shippingMethod);
     }
 
@@ -185,7 +185,7 @@ class SalesChannelRepositoryTest extends TestCase
 
         /** @var SalesChannelEntity $salesChannel */
         $salesChannel = $this->salesChannelRepository
-            ->search(new Criteria([$id]), Context::createDefaultContext())
+            ->search(new Criteria([$id]), Context::createDefaultContext())->getEntities()
             ->first();
 
         static::assertSame(SalesChannelDefinition::CALCULATION_TYPE_HORIZONTAL, $salesChannel->getTaxCalculationType());

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -329,7 +329,7 @@ class SalesChannelValidatorTest extends TestCase
             'id' => $id,
         ]], Context::createDefaultContext());
 
-        $result = $salesChannelRepository->search(new Criteria([$id]), $context);
+        $result = $salesChannelRepository->search(new Criteria([$id]), $context)->getEntities();
         static::assertCount(0, $result);
     }
 

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -140,7 +140,7 @@ class StateMachineActionControllerTest extends TestCase
         $criteria->addAssociation('fromStateMachineState');
         $criteria->addAssociation('toStateMachineState');
 
-        $history = $this->stateMachineHistoryRepository->search($criteria, $context);
+        $history = $this->stateMachineHistoryRepository->search($criteria, $context)->getEntities();
 
         static::assertCount(1, $history->getElements(), 'Expected history to be written');
         /** @var StateMachineHistoryEntity $historyEntry */
@@ -231,7 +231,7 @@ class StateMachineActionControllerTest extends TestCase
         $orderRepository = static::getContainer()->get('order.repository');
 
         /** @var OrderEntity $order */
-        $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->first();
+        $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertSame($order->getLanguageId(), $this->getDeDeLanguageId());
     }
@@ -295,7 +295,7 @@ class StateMachineActionControllerTest extends TestCase
         $orderRepository = static::getContainer()->get('order.repository');
 
         /** @var OrderEntity $order */
-        $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->first();
+        $order = $orderRepository->search(new Criteria([$orderId]), $salesChannelContext->getContext())->getEntities()->first();
 
         static::assertSame($order->getLanguageId(), Defaults::LANGUAGE_SYSTEM);
     }

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -188,7 +188,7 @@ EOF;
             ]
         );
 
-        $orderBefore = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->first();
+        $orderBefore = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->getEntities()->first();
         static::assertInstanceOf(OrderEntity::class, $orderBefore);
         static::assertNull($orderBefore->getUpdatedAt());
 
@@ -200,7 +200,7 @@ EOF;
         $toPlace = $stateCollection->get('toPlace');
         static::assertNotNull($toPlace);
 
-        $orderAfter = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->first();
+        $orderAfter = $orderRepo->search(new Criteria([$ids->get('o-1')]), $context)->getEntities()->first();
         static::assertInstanceOf(OrderEntity::class, $orderAfter);
 
         static::assertSame($toPlace->getId(), $orderAfter->getStateId());

--- a/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
+++ b/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
@@ -193,7 +193,7 @@ class SystemConfigFacadeTest extends TestCase
         $this->loadAppsFromDir($appDir);
 
         /** @var AppEntity $app */
-        $app = static::getContainer()->get('app.repository')->search(new Criteria(), Context::createDefaultContext())->first();
+        $app = static::getContainer()->get('app.repository')->search(new Criteria(), Context::createDefaultContext())->getEntities()->first();
 
         return new ScriptAppInformation(
             $app->getId(),

--- a/tests/integration/Core/System/User/Api/UserRecoveryControllerTest.php
+++ b/tests/integration/Core/System/User/Api/UserRecoveryControllerTest.php
@@ -98,7 +98,7 @@ class UserRecoveryControllerTest extends TestCase
         $userRecovery = static::getContainer()->get('user_recovery.repository')->search(
             $criteria,
             Context::createDefaultContext()
-        )->first();
+        )->getEntities()->first();
 
         static::assertNotNull($userRecovery);
         static::assertNotNull($dispatchedEvent);
@@ -114,7 +114,7 @@ class UserRecoveryControllerTest extends TestCase
         $logEntries = static::getContainer()->get('log_entry.repository')->search(
             $logCriteria,
             Context::createDefaultContext()
-        );
+        )->getEntities();
 
         static::assertCount(0, $logEntries);
 
@@ -138,7 +138,7 @@ class UserRecoveryControllerTest extends TestCase
         static::assertInstanceOf(UserRecoveryEntity::class, $recovery = static::getContainer()->get('user_recovery.repository')->search(
             $criteria,
             Context::createDefaultContext()
-        )->first());
+        )->getEntities()->first());
 
         return $recovery->getHash();
     }

--- a/tests/integration/Core/System/User/Recovery/UserRecoveryServiceTest.php
+++ b/tests/integration/Core/System/User/Recovery/UserRecoveryServiceTest.php
@@ -76,7 +76,7 @@ class UserRecoveryServiceTest extends TestCase
     {
         $this->createRecovery(self::VALID_EMAIL);
 
-        $userRecovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->first();
+        $userRecovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->getEntities()->first();
         static::assertInstanceOf(UserRecoveryEntity::class, $userRecovery);
     }
 
@@ -84,14 +84,14 @@ class UserRecoveryServiceTest extends TestCase
     {
         $this->createRecovery('foo@bar.com');
 
-        $userRecovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->first();
+        $userRecovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->getEntities()->first();
         static::assertNull($userRecovery);
     }
 
     #[DataProvider('dataProviderTestCheckHash')]
     public function testCheckHash(\DateInterval $timeInterval, string $hash, bool $expectedResult): void
     {
-        $user = $this->userRepo->search(new Criteria(), $this->context)->first();
+        $user = $this->userRepo->search(new Criteria(), $this->context)->getEntities()->first();
 
         static::assertInstanceOf(UserEntity::class, $user);
 
@@ -152,7 +152,7 @@ class UserRecoveryServiceTest extends TestCase
     {
         $this->createRecovery(self::VALID_EMAIL);
 
-        static::assertInstanceOf(UserRecoveryEntity::class, $recovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->first());
+        static::assertInstanceOf(UserRecoveryEntity::class, $recovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->getEntities()->first());
 
         $hash = $recovery->getHash();
 
@@ -178,7 +178,7 @@ class UserRecoveryServiceTest extends TestCase
         $criteria = new Criteria();
         $criteria->setLimit(1);
 
-        static::assertInstanceOf(UserRecoveryEntity::class, $recovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->first());
+        static::assertInstanceOf(UserRecoveryEntity::class, $recovery = $this->userRecoveryRepo->search(new Criteria(), $this->context)->getEntities()->first());
 
         $hash = $recovery->getHash();
 

--- a/tests/integration/Core/System/User/UserCrudTest.php
+++ b/tests/integration/Core/System/User/UserCrudTest.php
@@ -51,7 +51,7 @@ class UserCrudTest extends TestCase
 
         $userRepository->delete([['id' => $userId]], Context::createDefaultContext());
 
-        $user = $userRepository->search(new Criteria([$userId]), Context::createDefaultContext())->first();
+        $user = $userRepository->search(new Criteria([$userId]), Context::createDefaultContext())->getEntities()->first();
         static::assertNull($user);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

`EntitySearchResult`'s inherited collection API (`first()`, `get()`, `count()`, iteration, …) is deprecated for v6.8 and throws under `FEATURE_ALL=major`, so the Core/System integration tests still using the old idiom fail only in the integration-major nightly.

### 2. What does this change do, exactly?

- Migrates every deprecated accessor in `tests/integration/Core/System/` to `->getEntities()->…` (19 files): chained calls after `->search(…)` and variable-held results across CustomEntity, SalesChannel, StateMachine, Integration, User, Snippet, and NumberRange tests. Already-migrated use-sites in `IntegrationRepositoryTest` lost their now-redundant `getEntities()` calls after the assignment-level conversion.
- `IdSearchResult` calls (`searchIds()`) and `EntityWrittenEvent::getIds()` uses are untouched — neither API is deprecated.

Verified the whole `tests/integration/Core/System` suite under `FEATURE_ALL=major` and with flags off: failing tests under major drop from 58 to 15 with no new failures. One remaining `EntitySearchResult` throw comes from `tests/integration/Core/Framework/App/AppFixture.php`, which belongs to the framework slice and is already migrated in #18391 — it disappears when that PR lands. The flags-off failing set is byte-identical to the trunk baseline.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Core/System` on trunk: 58 tests fail, most with `FeatureException: Tried to access deprecated functionality: … EntitySearchResult::…`.
2. With this change, no test-side throw remains in this slice.

### 4. Please link to the relevant issues (if any).

- closes #18394

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
