### PR TITLE
test: sweep deprecated EntitySearchResult accessors from service, administration and elasticsearch integration tests

### DIFF
--- a/tests/integration/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
+++ b/tests/integration/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
@@ -197,7 +197,7 @@ class SystemLanguageChangedSubscriberTest extends TestCase
             ], $this->context);
         }
 
-        $app = $this->appRepository->search(new Criteria([$id]), $this->context)->first();
+        $app = $this->appRepository->search(new Criteria([$id]), $this->context)->getEntities()->first();
         \assert($app instanceof AppEntity);
 
         return $app;

--- a/tests/integration/Administration/Notification/Repository/NotificationRepositoryTest.php
+++ b/tests/integration/Administration/Notification/Repository/NotificationRepositoryTest.php
@@ -72,7 +72,7 @@ class NotificationRepositoryTest extends TestCase
             return;
         }
 
-        $result = $this->notificationRepository->search(new Criteria([$id]), $this->context);
+        $result = $this->notificationRepository->search(new Criteria([$id]), $this->context)->getEntities();
 
         /** @var NotificationEntity $notification */
         $notification = $result->get($id);

--- a/tests/integration/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/integration/Core/Service/Api/ServiceControllerTest.php
@@ -46,7 +46,7 @@ class ServiceControllerTest extends TestCase
         $browser->jsonRequest('POST', '/api/service/uninstall/' . $serviceName);
 
         static::assertSame(Response::HTTP_NO_CONTENT, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
-        static::assertNull($this->appRepository->search(new Criteria([$appId]), Context::createDefaultContext())->first());
+        static::assertNull($this->appRepository->search(new Criteria([$appId]), Context::createDefaultContext())->getEntities()->first());
     }
 
     public function testServiceCannotUninstallAnotherService(): void
@@ -62,7 +62,7 @@ class ServiceControllerTest extends TestCase
         $browser->jsonRequest('POST', '/api/service/uninstall/' . $otherServiceName);
 
         static::assertSame(Response::HTTP_NOT_FOUND, $browser->getResponse()->getStatusCode(), (string) $browser->getResponse()->getContent());
-        static::assertNotNull($this->appRepository->search(new Criteria([$otherAppId]), Context::createDefaultContext())->first());
+        static::assertNotNull($this->appRepository->search(new Criteria([$otherAppId]), Context::createDefaultContext())->getEntities()->first());
     }
 
     /**

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -2312,7 +2312,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-1')];
 
         $criteria = new Criteria([$ids->get('dal-1')]);
-        $dalProduct = $this->productRepository->search($criteria, $context)->first();
+        $dalProduct = $this->productRepository->search($criteria, $context)->getEntities()->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
         static::assertSame((string) $dalProduct->getTranslation('name'), (string) $esProduct['name'][Defaults::LANGUAGE_SYSTEM]);
@@ -2327,7 +2327,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-1')];
 
         $criteria = new Criteria([$ids->get('dal-1')]);
-        $dalProduct = $this->productRepository->search($criteria, $languageContext)->first();
+        $dalProduct = $this->productRepository->search($criteria, $languageContext)->getEntities()->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
         static::assertSame((string) $dalProduct->getTranslation('name'), (string) $esProduct['name'][$ids->get('language-1')]);
@@ -2342,7 +2342,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-1')];
 
         $criteria = new Criteria([$ids->get('dal-1')]);
-        $dalProduct = $this->productRepository->search($criteria, $languageContext)
+        $dalProduct = $this->productRepository->search($criteria, $languageContext)->getEntities()
             ->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
@@ -2362,7 +2362,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-2.1')];
 
         $criteria = new Criteria([$ids->get('dal-2.1')]);
-        $dalProduct = $this->productRepository->search($criteria, $languageContext)->first();
+        $dalProduct = $this->productRepository->search($criteria, $languageContext)->getEntities()->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
         static::assertSame((string) $dalProduct->getTranslation('name'), (string) $esProduct['name'][$ids->get('language-2')]);
@@ -2381,7 +2381,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-2.2')];
 
         $criteria = new Criteria([$ids->get('dal-2.2')]);
-        $dalProduct = $this->productRepository->search($criteria, $languageContext)->first();
+        $dalProduct = $this->productRepository->search($criteria, $languageContext)->getEntities()->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
         static::assertSame((string) $dalProduct->getTranslation('name'), (string) $esProduct['name'][$ids->get('language-2')]);
@@ -2400,7 +2400,7 @@ class ElasticsearchProductTest extends TestCase
         $esProduct = $esProducts[$ids->get('dal-2.2')];
 
         $criteria = new Criteria([$ids->get('dal-2.2')]);
-        $dalProduct = $this->productRepository->search($criteria, $languageContext)->first();
+        $dalProduct = $this->productRepository->search($criteria, $languageContext)->getEntities()->first();
 
         static::assertInstanceOf(ProductEntity::class, $dalProduct);
         static::assertSame((string) $dalProduct->getTranslation('name'), (string) $esProduct['name'][$ids->get('language-1')]);


### PR DESCRIPTION
### 1. Why is this change necessary?

`EntitySearchResult`'s inherited collection API (`first()`, `get()`, `count()`, iteration, …) is deprecated for v6.8 and throws under `FEATURE_ALL=major`, so the remaining integration tests still using the old idiom fail only in the integration-major nightly. This is the final slice of the sweep.

### 2. What does this change do, exactly?

- Migrates every deprecated accessor in `tests/integration/Core/Service/`, `tests/integration/Administration/`, and `tests/integration/Elasticsearch/` to `->getEntities()->…` (4 files).
- Untouched on purpose: `IdSearchResult` from `searchIds()` **and from the entity searcher** — `$searcher->search($definition, $criteria, $context)` in the Elasticsearch product tests returns `IdSearchResult`, whose API is not deprecated; the Administration/Elasticsearch `AdminSearcher::search()` results are plain arrays.

Verified all three trees under `FEATURE_ALL=major` and with flags off. Under major, the previously failing `ElasticsearchProductTest::testLanguageFieldsWorkSimilarToDAL` now passes; the remaining errors are pre-existing and unrelated: five `Core/Service` subscriber tests throw via `tests/integration/Core/Framework/App/AppFixture.php` (migrated in the framework slice #18391, green once that lands), two `AdminSearcherTest` errors reproduce identically with flags off on trunk (local admin-search environment issue), and the remaining Elasticsearch failures are the known OpenSearch-version-sensitive relevance cases, identical to the trunk baseline.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Core/Service tests/integration/Administration tests/integration/Elasticsearch` on trunk.
2. Tests throw `FeatureException: Tried to access deprecated functionality: … EntitySearchResult::…`; with this change no test-side throw remains in these trees.

### 4. Please link to the relevant issues (if any).

- closes #18395

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
