### PR TITLE
test: add the package attribute to all integration test classes

### DIFF
--- a/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminExtensionApiControllerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\App\Hmac\QuerySigner;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class AdminExtensionApiControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Administration/Controller/AdminProductStreamControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminProductStreamControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
@@ -14,6 +15,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class AdminProductStreamControllerTest extends TestCase
 {

--- a/tests/integration/Administration/Controller/AdminSearchControllerTest.php
+++ b/tests/integration/Administration/Controller/AdminSearchControllerTest.php
@@ -8,12 +8,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\OAuth\Scope\UserVerifiedScope;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class AdminSearchControllerTest extends TestCase
 {

--- a/tests/integration/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/integration/Administration/Controller/AdministrationControllerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class AdministrationControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Administration/Controller/UserConfigControllerTest.php
+++ b/tests/integration/Administration/Controller/UserConfigControllerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\OAuth\Scope\UserVerifiedScope;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class UserConfigControllerTest extends TestCase
 {

--- a/tests/integration/Administration/Dashboard/OrderAmountServiceTest.php
+++ b/tests/integration/Administration/Dashboard/OrderAmountServiceTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
@@ -20,6 +21,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('after-sales')]
 class OrderAmountServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Administration/Elasticsearch/StreamConditionPropertyMappingTest.php
+++ b/tests/integration/Administration/Elasticsearch/StreamConditionPropertyMappingTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
@@ -15,6 +16,7 @@ use Shopware\Elasticsearch\Product\ElasticsearchProductDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class StreamConditionPropertyMappingTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
+++ b/tests/integration/Administration/Framework/App/Subscriber/SystemLanguageChangedSubscriberTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Maintenance\System\Service\ShopConfigurator;
@@ -21,6 +22,7 @@ use Shopware\Core\Maintenance\System\Service\SystemLanguageChangeEvent;
 /**
  * @internal
  */
+#[Package('framework')]
 class SystemLanguageChangedSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Administration/Notification/Repository/NotificationRepositoryTest.php
+++ b/tests/integration/Administration/Notification/Repository/NotificationRepositoryTest.php
@@ -9,6 +9,7 @@ use Shopware\Administration\Notification\NotificationEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 /**
  * @internal
  */
+#[Package('framework')]
 class NotificationRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Administration/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Administration/RateLimiter/RateLimiterTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\RateLimiter\DisableRateLimiterCompilerPass;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Test\Integration\Traits\CustomerTestTrait;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class RateLimiterTest extends TestCase
 {

--- a/tests/integration/Administration/Service/AdminSearcherTest.php
+++ b/tests/integration/Administration/Service/AdminSearcherTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class AdminSearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Administration/System/SalesChannel/Subscriber/SalesChannelUserConfigSubscriberTest.php
+++ b/tests/integration/Administration/System/SalesChannel/Subscriber/SalesChannelUserConfigSubscriberTest.php
@@ -8,6 +8,7 @@ use Shopware\Administration\System\SalesChannel\Subscriber\SalesChannelUserConfi
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class SalesChannelUserConfigSubscriberTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -19,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('checkout')]
 class ConvertGuestRouteTest extends TestCase
 {
     use CountryAddToSalesChannelTestBehaviour;

--- a/tests/integration/Core/Checkout/Order/Api/OrderActionControllerTest.php
+++ b/tests/integration/Core/Checkout/Order/Api/OrderActionControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Checkout\Order\Api;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 /**
  * @internal
  */
+#[Package('checkout')]
 class OrderActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdaterTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdaterTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CategoryBreadcrumbUpdaterTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerQueryAmplificationTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerQueryAmplificationTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ChildCountUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\TreeUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -32,6 +33,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * @internal
  */
+#[Package('discovery')]
 class CategoryIndexerQueryAmplificationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ChildCountUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\TreeUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -33,6 +34,7 @@ use Symfony\Component\Messenger\TraceableMessageBus;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CategoryIndexerTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerVersioningTest.php
+++ b/tests/integration/Core/Content/Category/DataAbstractionLayer/CategoryIndexerVersioningTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Category\DataAbstractionLayer\CategoryIndexer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CategoryIndexerVersioningTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Category/Event/NavigationLoadedEventTest.php
+++ b/tests/integration/Core/Content/Category/Event/NavigationLoadedEventTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\Event\NavigationLoadedEvent;
 use Shopware\Core\Content\Category\Service\NavigationLoader;
 use Shopware\Core\Content\Category\Service\NavigationLoaderInterface;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('discovery')]
 class NavigationLoadedEventTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Category/Repository/CategoryRepositoryTest.php
+++ b/tests/integration/Core/Content/Category/Repository/CategoryRepositoryTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeletedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class CategoryRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Category/SalesChannel/CategoryListRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/CategoryListRouteTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -15,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('store-api')]
 class CategoryListRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Category/SalesChannel/NavigationRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/NavigationRouteTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -20,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('store-api')]
 class NavigationRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Category/Service/NavigationLoaderTest.php
+++ b/tests/integration/Core/Content/Category/Service/NavigationLoaderTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Content\Category\Tree\TreeItem;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
@@ -22,6 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 /**
  * @internal
  */
+#[Package('discovery')]
 class NavigationLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Category/Subscriber/CategorySubscriberTest.php
+++ b/tests/integration/Core/Content/Category/Subscriber/CategorySubscriberTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Category\SalesChannel\SalesChannelCategoryEntity;
 use Shopware\Core\Content\Test\Category\CategoryBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CategorySubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Category/Validation/EntryPointValidatorTest.php
+++ b/tests/integration/Core/Content/Category/Validation/EntryPointValidatorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('discovery')]
 class EntryPointValidatorTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Content/Cms/CmsEntityTest.php
+++ b/tests/integration/Core/Content/Cms/CmsEntityTest.php
@@ -21,12 +21,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class CmsEntityTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
+++ b/tests/integration/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -31,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CmsSlotsDataResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Cms/SalesChannel/CmsRouteTest.php
+++ b/tests/integration/Core/Content/Cms/SalesChannel/CmsRouteTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Cms\SalesChannel;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -13,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('store-api')]
 class CmsRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoaderTest.php
+++ b/tests/integration/Core/Content/Cms/SalesChannel/SalesChannelCmsPageLoaderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoaderInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class SalesChannelCmsPageLoaderTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
+++ b/tests/integration/Core/Content/ContactForm/ContactFormServiceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\ContactForm\SalesChannel\ContactFormRoute;
 use Shopware\Core\Content\Flow\Dispatching\BufferedFlowExecutor;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\MailTemplateTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -20,6 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 /**
  * @internal
  */
+#[Package('framework')]
 class ContactFormServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ImportExport/Processing/Pipe/DefaultMappingsTest.php
+++ b/tests/integration/Core/Content/ImportExport/Processing/Pipe/DefaultMappingsTest.php
@@ -16,12 +16,14 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('fundamentals@after-sales')]
 class DefaultMappingsTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/LandingPage/Repository/LandingPageRepositoryTest.php
+++ b/tests/integration/Core/Content/LandingPage/Repository/LandingPageRepositoryTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -16,6 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class LandingPageRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Mail/Service/EmailSenderTest.php
+++ b/tests/integration/Core/Content/Mail/Service/EmailSenderTest.php
@@ -6,6 +6,7 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Mail\Service\MailFactory;
 use Shopware\Core\Content\Mail\Service\MailSender;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -16,6 +17,7 @@ use Symfony\Component\Mime\Email;
 /**
  * @internal
  */
+#[Package('after-sales')]
 class EmailSenderTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Mail/Service/MailServiceTest.php
+++ b/tests/integration/Core/Content/Mail/Service/MailServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\MailTemplate\Service\MailTemplateContentBuilder;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,6 +30,7 @@ use Twig\Environment;
 /**
  * @internal
  */
+#[Package('after-sales')]
 class MailServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/MeasurementSystem/TwigExtension/MeasurementConvertUnitTwigFilterTest.php
+++ b/tests/integration/Core/Content/MeasurementSystem/TwigExtension/MeasurementConvertUnitTwigFilterTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Core\Content\MeasurementSystem\TwigExtension;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Twig\Environment;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class MeasurementConvertUnitTwigFilterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Aggregate/MediaFolder/MediaFolderTest.php
+++ b/tests/integration/Core/Content/Media/Aggregate/MediaFolder/MediaFolderTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Content\Media\Aggregate\MediaFolderConfiguration\MediaFolderCo
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Aggregate/MediaFolderConfigurationThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeTest.php
+++ b/tests/integration/Core/Content/Media/Aggregate/MediaFolderConfigurationThumbnailSize/MediaFolderConfigurationMediaThumbnailSizeTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeE
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderConfigurationMediaThumbnailSizeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Api/MediaFolderControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaFolderControllerTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaUploadControllerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('needsWebserver')]
 class MediaUploadControllerTest extends TestCase
 {

--- a/tests/integration/Core/Content/Media/Api/MediaVideoCoverControllerTest.php
+++ b/tests/integration/Core/Content/Media/Api/MediaVideoCoverControllerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaVideoCoverControllerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Media/Command/GenerateThumbnailsCommandTest.php
+++ b/tests/integration/Core/Content/Media/Command/GenerateThumbnailsCommandTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\MessageBus\CollectingMessageBus;
 use Symfony\Component\Console\Command\Command;
@@ -24,6 +25,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('discovery')]
 class GenerateThumbnailsCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Commands/GenerateMediaTypesCommandTest.php
+++ b/tests/integration/Core/Content/Media/Commands/GenerateMediaTypesCommandTest.php
@@ -14,12 +14,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class GenerateMediaTypesCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Core/Application/MediaPathUpdaterTest.php
+++ b/tests/integration/Core/Content/Media/Core/Application/MediaPathUpdaterTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Content\Media\Core\Application\MediaPathUpdater;
 use Shopware\Core\Content\Media\Core\Strategy\FilenamePathStrategy;
 use Shopware\Core\Content\Media\Core\Strategy\PlainPathStrategy;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaPathUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderConfigIndexerTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderConfigIndexerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Media\DataAbstractionLayer\MediaFolderIndexer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -17,6 +18,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderConfigIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderIndexerTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/Indexing/MediaFolderIndexerTest.php
@@ -8,12 +8,14 @@ use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('slow')]
 class MediaFolderRepositoryTest extends TestCase
 {

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -40,6 +41,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('slow')]
 class MediaRepositoryTest extends TestCase
 {

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaThumbnailRepositoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaThumbnailRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/File/FileLoaderTest.php
+++ b/tests/integration/Core/Content/Media/File/FileLoaderTest.php
@@ -12,12 +12,14 @@ use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 final class FileLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/File/FileNameProviderTest.php
+++ b/tests/integration/Core/Content/Media/File/FileNameProviderTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class FileNameProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/File/FileSaverTest.php
+++ b/tests/integration/Core/Content/Media/File/FileSaverTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -34,6 +35,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
+#[Package('discovery')]
 class FileSaverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Infrastructure/Command/UpdatePathTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Command/UpdatePathTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Media\Core\Strategy\PlainPathStrategy;
 use Shopware\Core\Content\Media\Infrastructure\Command\UpdatePathCommand;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Output\NullOutput;
 /**
  * @internal
  */
+#[Package('discovery')]
 class UpdatePathTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Media/Infrastructure/Path/MediaLocationBuilderTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Path/MediaLocationBuilderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
 use Shopware\Core\Content\Media\Infrastructure\Path\SqlMediaLocationBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaLocationBuilderTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathPostUpdaterTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathPostUpdaterTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaPathPostUpdaterTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathStorageTest.php
+++ b/tests/integration/Core/Content/Media/Infrastructure/Path/MediaPathStorageTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Infrastructure\Path\SqlMediaPathStorage;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -14,6 +15,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaPathStorageTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Media/MediaEntityTest.php
+++ b/tests/integration/Core/Content/Media/MediaEntityTest.php
@@ -12,11 +12,13 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaEntityTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/MediaFolderServiceTest.php
+++ b/tests/integration/Core/Content/Media/MediaFolderServiceTest.php
@@ -15,12 +15,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class MediaFolderServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Message/DeleteFileHandlerTest.php
+++ b/tests/integration/Core/Content/Media/Message/DeleteFileHandlerTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Integration\Core\Content\Media\Message;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Message\DeleteFileHandler;
 use Shopware\Core\Content\Media\Message\DeleteFileMessage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class DeleteFileHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
+++ b/tests/integration/Core/Content/Media/Message/GenerateThumbnailsHandlerTest.php
@@ -15,11 +15,13 @@ use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class GenerateThumbnailsHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Message/UpdateThumbnailsMessageTest.php
+++ b/tests/integration/Core/Content/Media/Message/UpdateThumbnailsMessageTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Content\Media\Message;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Message\UpdateThumbnailsMessage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class UpdateThumbnailsMessageTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriberTest.php
+++ b/tests/integration/Core/Content/Media/Subscriber/VideoCoverCleanupSubscriberTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class VideoCoverCleanupSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/integration/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -34,6 +35,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[Group('slow')]
 class ThumbnailServiceTest extends TestCase
 {

--- a/tests/integration/Core/Content/Media/TypeDetector/ImageTypeDetectorTest.php
+++ b/tests/integration/Core/Content/Media/TypeDetector/ImageTypeDetectorTest.php
@@ -10,11 +10,13 @@ use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Media\MediaType\VideoType;
 use Shopware\Core\Content\Media\TypeDetector\ImageTypeDetector;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 class ImageTypeDetectorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductCartProcessorTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryCollection;
@@ -43,6 +44,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductCartProcessorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cart/ProductCartTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductCartTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Integration\Traits\TestShortHands;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
  * @internal
  * This test is used as "good" reference integration tests inside our guidelines.
  */
+#[Package('inventory')]
 class ProductCartTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
+++ b/tests/integration/Core/Content/Product/Cart/ProductLineItemCommandValidatorTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
@@ -33,6 +34,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductLineItemCommandValidatorTest extends TestCase
 {
     use CountryAddToSalesChannelTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandlerTest.php
+++ b/tests/integration/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandlerTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Product\Cleanup\CleanupProductKeywordDictionaryTaskHan
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 class CleanupProductKeywordDictionaryTaskHandlerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductListingStruct;
 use Shopware\Core\Content\Product\Cms\ProductListingCmsElementResolver;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingEntity;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class ProductListingCmsElementResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/Type/BuyBoxTypeDataResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/Type/BuyBoxTypeDataResolverTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -35,6 +36,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class BuyBoxTypeDataResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/Type/CrossSellingTypeDataResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/Type/CrossSellingTypeDataResolverTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Content\Product\SalesChannel\CrossSelling\CrossSellingElementC
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRouteResponse;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class CrossSellingTypeDataResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/Type/ManufacturerLogoTypeCmsResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/Type/ManufacturerLogoTypeCmsResolverTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class ManufacturerLogoTypeCmsResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/Type/ProductDetailCmsElementResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/Type/ProductDetailCmsElementResolverTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class ProductDetailCmsElementResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Cms/Type/ProductNameTypeCmsElementResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/Type/ProductNameTypeCmsElementResolverTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Cms\SalesChannel\Struct\TextStruct;
 use Shopware\Core\Content\Product\Cms\ProductNameCmsElementResolver;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('discovery')]
 class ProductNameTypeCmsElementResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Util\StatementHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -32,6 +33,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class CheapestPriceTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/CheapestPrice/CheapestPriceUpdaterTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPriceUpdater;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Assert\Serialization;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -18,6 +19,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class CheapestPriceUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class ProductRatingAverageIndexerTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/VariantListingIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/VariantListingIndexerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -18,6 +19,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class VariantListingIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductDescriptionTeaserIndexerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -17,6 +18,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductDescriptionTeaserIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductIndexerTest.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\InheritanceUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ManyToManyIdFieldUpdater;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -39,6 +40,7 @@ use Symfony\Component\Messenger\TraceableMessageBus;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductIndexerTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
@@ -7,12 +7,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Exception\DuplicateProductSearchConfigFieldException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductSearchConfigFieldExceptionHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -33,6 +34,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductStreamUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1775460999AddParentNameToProductSearchConfig;
@@ -28,6 +29,7 @@ use Symfony\Component\Clock\MockClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class SearchKeywordUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/VariantListingUpdaterTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/VariantListingUpdaterTest.php
@@ -8,12 +8,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\DataAbstractionLayer\VariantListingUpdater;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class VariantListingUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/ProductFeatureSet/ProductFeatureSetCrudTest.php
+++ b/tests/integration/Core/Content/Product/ProductFeatureSet/ProductFeatureSetCrudTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
@@ -17,6 +18,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductFeatureSetCrudTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/ProductFeatureSet/ProductFeatureSetPropertyTest.php
+++ b/tests/integration/Core/Content/Product/ProductFeatureSet/ProductFeatureSetPropertyTest.php
@@ -7,11 +7,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Test\Product\ProductFeatureSet\ProductFeatureSetFixtures;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductFeatureSetPropertyTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Repository/ProductCrossSellingAssignedProductsRepositoryTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductCrossSellingAssignedProductsRepositoryTest.php
@@ -7,12 +7,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductCrossSellingAssignedProductsRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Repository/ProductRepositoryTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductRepositoryTest.php
@@ -41,6 +41,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\ParentRelationValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
@@ -55,6 +56,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 class ProductRepositoryTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/Repository/ProductSearchKeywordTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductSearchKeywordTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSearchKeywordTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Repository/ProductSearchScoringTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductSearchScoringTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\EntityScoreQueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchPattern;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchTerm;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSearchScoringTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Repository/ProductTagTest.php
+++ b/tests/integration/Core/Content/Product/Repository/ProductTagTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductTagTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
@@ -41,6 +42,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 #[Group('store-api')]
 class CrossSellingRouteTest extends TestCase

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,6 +25,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class AvailableCombinationLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorOrderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorOrderTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductConfiguratorOrderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('store-api')]
 class ProductDetailRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRouteTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\SalesChannel\FindVariant\FindProductVariantRou
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class FindProductVariantRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/Processor/CompositeProcessorTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/Processor/CompositeProcessorTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Listing\P
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class CompositeProcessorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingLoaderTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -36,6 +37,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 class ProductListingLoaderTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingPartialLoadingTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingPartialLoadingTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductListingPartialLoadingTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Listing/ProductListingRouteTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\MaxResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\StatsResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -31,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('store-api')]
 class ProductListingRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListRouteTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('store-api')]
 class ProductListRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListingFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListingFilterOutOfStockTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductListingFilterOutOfStockTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductListingTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 class ProductListingTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchFilterOutOfStockTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSearchFilterOutOfStockTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSearchRouteTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Annotation\CriteriaValueResolver;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -47,6 +48,7 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('store-api')]
 class ProductSearchRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/ProductSuggestFilterOutOfStockTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/ProductSuggestFilterOutOfStockTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSuggestFilterOutOfStockTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Util\FloatComparator;
@@ -16,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[Group('store-api')]
 class ProductReviewRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\EventDispatcherBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[Group('store-api')]
 class ProductReviewSaveRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzerTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchKeywordAnalyzerTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
@@ -25,6 +26,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSearchKeywordAnalyzerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchPattern;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchTerm;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\ArrayNormalizer;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,6 +23,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSearchTermInterpreterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Subscriber/ProductDescriptionTeaserSubscriberTest.php
+++ b/tests/integration/Core/Content/Product/Subscriber/ProductDescriptionTeaserSubscriberTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\CloneBehavior;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductDescriptionTeaserSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
+++ b/tests/integration/Core/Content/Product/Subscriber/ProductLoadedSubscriberTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -36,6 +37,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductLoadedSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Product/Subscriber/ProductSubscriberBeforeDeleteIntegrationTest.php
+++ b/tests/integration/Core/Content/Product/Subscriber/ProductSubscriberBeforeDeleteIntegrationTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -14,6 +15,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductSubscriberBeforeDeleteIntegrationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/Api/ProductExportControllerTest.php
+++ b/tests/integration/Core/Content/ProductExport/Api/ProductExportControllerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExportControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
+++ b/tests/integration/Core/Content/ProductExport/Command/ProductExportGenerateCommandTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,6 +28,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExportGenerateCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
+++ b/tests/integration/Core/Content/ProductExport/EventListener/ProductExportEventListenerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
@@ -21,6 +22,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 class ProductExportEventListenerTest extends TestCase
 {

--- a/tests/integration/Core/Content/ProductExport/ProductExportRepositoryTest.php
+++ b/tests/integration/Core/Content/ProductExport/ProductExportRepositoryTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExportRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
+++ b/tests/integration/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandlerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -30,6 +31,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('slow')]
 class ProductExportGenerateTaskHandlerTest extends TestCase
 {

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
@@ -44,6 +45,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExportGeneratorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportValidatorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportValidatorTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
@@ -25,6 +26,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExportValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExporterTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
@@ -28,6 +29,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductExporterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
+++ b/tests/integration/Core/Content/Seo/HreflangLoaderTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Content\Test\TestProductSeoUrlRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -29,6 +30,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('inventory')]
 class HreflangLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Seo/SalesChannel/SeoUrlRouteTest.php
+++ b/tests/integration/Core/Content/Seo/SalesChannel/SeoUrlRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\TestNavigationSeoUrlRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -15,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[Group('store-api')]
 class SeoUrlRouteTest extends TestCase
 {

--- a/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlRoute/EntityRouteResolverTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver;
 use Shopware\Core\Content\Seo\SeoUrlRoute\LandingPageStoreApiUrlRoute;
 use Shopware\Core\Content\Seo\SeoUrlRoute\ProductStoreApiUrlRoute;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
@@ -22,6 +23,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
+#[Package('inventory')]
 class EntityRouteResolverTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Seo/SeoUrlTwigFactoryTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlTwigFactoryTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Core\Content\Seo;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Seo\SeoUrlGenerator;
 use Shopware\Core\Content\Test\Seo\Twig\LastLetterBigTwigFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\Environment;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class SeoUrlTwigFactoryTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Content/Seo/SeoUrlUpdaterTest.php
+++ b/tests/integration/Core/Content/Seo/SeoUrlUpdaterTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 class SeoUrlUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorage;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Backtrace\BacktraceCollector;
 use Shopware\Core\Framework\Util\Backtrace\Frame;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('framework')]
 class CacheInvalidationSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -6,12 +6,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class CacheResponseSubscriberTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
@@ -11,11 +11,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\MySQLInvalidatorStorage;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class MySQLInvalidatorStorageTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/RedisInvalidatorStorageTest.php
@@ -7,10 +7,12 @@ use Psr\Log\NullLogger;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorage;
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class RedisInvalidatorStorageTest extends TestCase
 {
     private RedisInvalidatorStorage $storage;

--- a/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/RedisConnectionFactoryTest.php
@@ -6,10 +6,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class RedisConnectionFactoryTest extends TestCase
 {
     #[DataProvider('prefixProvider')]

--- a/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -14,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptCacheInvalidationSubscriberTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
+++ b/tests/integration/Core/Framework/Adapter/Command/CacheWatchDelayedCommandTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Command;
 
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Symfony\Component\Process\Process;
 
@@ -14,6 +15,7 @@ use Symfony\Component\Process\Process;
  *
  * @internal
  */
+#[Package('framework')]
 class CacheWatchDelayedCommandTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchInputFactoryTest.php
+++ b/tests/integration/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchInputFactoryTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Filesystem\Plugin;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInputFactory;
+use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class CopyBatchInputFactoryTest extends TestCase
 {
     public function testCopyBatchInputFactoryUsingDirectory(): void

--- a/tests/integration/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Storage/MySQLKeyValueStorageTest.php
@@ -7,11 +7,13 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Storage\AbstractKeyValueStorage;
 use Shopware\Core\Framework\Adapter\Storage\MySQLKeyValueStorage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class MySQLKeyValueStorageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/AppTemplateIteratorTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/AppTemplateIteratorTest.php
@@ -7,11 +7,13 @@ use Shopware\Core\Framework\Adapter\Twig\AppTemplateIterator;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppTemplateIteratorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/BackwardCompatibleIntlExtensionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\BackwardCompatibleIntlExtension;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\Environment;
 use Twig\Extra\Intl\IntlExtension;
@@ -15,6 +16,7 @@ use Twig\Loader\ArrayLoader;
  *
  * @deprecated tag:v6.8.0 - Will be removed, because we don't support invalid locales anymore
  */
+#[Package('framework')]
 class BackwardCompatibleIntlExtensionTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/DisabledTwigCacheWarmupTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/DisabledTwigCacheWarmupTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DisabledTwigCacheWarmupTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/EntityTemplateLoaderTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Adapter\Twig\EntityTemplateLoader;
 use Shopware\Core\Framework\App\Template\TemplateCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Twig\Error\LoaderError;
@@ -14,6 +15,7 @@ use Twig\Error\LoaderError;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityTemplateLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/Extension/MediaExtensionTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/Extension/MediaExtensionTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Twig\Loader\ArrayLoader;
@@ -11,6 +12,7 @@ use Twig\Loader\ArrayLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class MediaExtensionTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/Extension/SwSanitizeTwigFilterTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/Extension/SwSanitizeTwigFilterTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Extension\SwSanitizeTwigFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class SwSanitizeTwigFilterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/BundleHierarchyBuilderTest.php
@@ -7,11 +7,13 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuild
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class BundleHierarchyBuilderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilderTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilderTest.php
@@ -7,11 +7,13 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBu
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class NamespaceHierarchyBuilderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/ReplaceRecursiveFilterTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/ReplaceRecursiveFilterTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Filter\ReplaceRecursiveFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\TwigFilter;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ReplaceRecursiveFilterTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/ReturnNodeTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/ReturnNodeTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ReturnNodeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Core\Framework\Adapter\Twig;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\Extension\CoreExtension;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class StringTemplateRendererTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigCacheTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigCacheTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuild
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Kernel;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
@@ -18,6 +19,7 @@ use Twig\Environment;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('cache')]
 class TwigCacheTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigFieldVisibilityTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigFieldVisibilityTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Twig\Environment;
@@ -25,6 +26,7 @@ use Twig\Loader\ArrayLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class TwigFieldVisibilityTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigSwExtendsTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigSwExtendsTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuild
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Kernel;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
@@ -21,6 +22,7 @@ use Twig\Loader\FilesystemLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class TwigSwExtendsTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Adapter/Twig/TwigSwIncludeTest.php
+++ b/tests/integration/Core/Framework/Adapter/Twig/TwigSwIncludeTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBu
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
 use Shopware\Core\Framework\Adapter\Twig\TwigEnvironment;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Kernel;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
@@ -19,6 +20,7 @@ use Twig\Loader\FilesystemLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class TwigSwIncludeTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Acl/AclAnnotationValidatorTest.php
+++ b/tests/integration/Core/Framework/Api/Acl/AclAnnotationValidatorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Api\Exception\MissingPrivilegeException;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Api\Acl\fixtures\AclTestController;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 /**
  * @internal
  */
+#[Package('framework')]
 class AclAnnotationValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiAwareTest.php
+++ b/tests/integration/Core/Framework/Api/ApiAwareTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Notification\NotificationDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -18,6 +19,7 @@ use Shopware\Storefront\Theme\ThemeDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiAwareTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGeneratorTest.php
+++ b/tests/integration/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGeneratorTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\Generator;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\EntityDefinition\SimpleDefinition;
 
 /**
  * @internal
  */
+#[Package('framework')]
 final class EntitySchemaGeneratorTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilderTest.php
+++ b/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi/OpenApiDefinitionSchemaBuilderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\Generator\
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi\OpenApiDefinitionSchemaBuilder;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\EntityDefinition\SimpleDefinition;
@@ -13,6 +14,7 @@ use Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\EntityDefinition
 /**
  * @internal
  */
+#[Package('framework')]
 class OpenApiDefinitionSchemaBuilderTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Test.php
+++ b/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Test.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\Generator;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannel\StoreApiInfoController;
 use Symfony\Component\HttpFoundation\Request;
@@ -10,6 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class OpenApi3Test extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/AccessKeyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AccessKeyControllerTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AccessKeyControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerAggregateTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerAggregateTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerAggregateTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerCloneTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerCloneTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerCloneTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerCreateTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerCreateTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerCreateTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerDeleteTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerDeleteTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerDeleteTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerDetailTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerDetailTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerDetailTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerListTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerListTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerListTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchIdsTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchIdsTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerSearchIdsTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerSearchTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerSearchTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Route\ApiRouteLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerUpdateTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerUpdateTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerUpdateTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/ApiControllerVersionTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/ApiControllerVersionTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiControllerVersionTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class AuthControllerTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\Controller;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomSnippetFormatControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\LogAware;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\Stats\StatsService;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
@@ -40,6 +41,7 @@ use Symfony\Component\Messenger\Envelope;
 /**
  * @internal
  */
+#[Package('framework')]
 class InfoControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/PromotionControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/PromotionControllerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class PromotionControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SalesChannelProxyControllerTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Api\EventListener\Acl\CreditOrderLineItemListener;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Collector\RuleConditionRegistry;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
@@ -41,6 +42,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class SalesChannelProxyControllerTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/SyncControllerTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Controller\SyncController;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class SyncControllerTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Api/EventListener/SalesChannelAuthenticationListenerTest.php
+++ b/tests/integration/Core/Framework/Api/EventListener/SalesChannelAuthenticationListenerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\ApiException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class SalesChannelAuthenticationListenerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
+++ b/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Integration\IntegrationCollection;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ClientRepositoryTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
+++ b/tests/integration/Core/Framework/Api/ResponseTypeRegistryTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 /**
  * @internal
  */
+#[Package('framework')]
 class ResponseTypeRegistryTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
+++ b/tests/integration/Core/Framework/Api/Serializer/JsonApiEncoderTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\AssociationExtension;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldPlainTestDefinition;
@@ -45,6 +46,7 @@ use Shopware\Tests\Integration\Core\Framework\Api\Serializer\fixtures\TestMainRe
 /**
  * @internal
  */
+#[Package('framework')]
 class JsonApiEncoderTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/integration/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class SyncServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Api/TranslationTest.php
+++ b/tests/integration/Core/Framework/Api/TranslationTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingSystemTranslationException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class TranslationTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Api/VersionTest.php
+++ b/tests/integration/Core/Framework/Api/VersionTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Api;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,6 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class VersionTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
+++ b/tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\Generator\OpenApi3Generator;
 use Shopware\Core\Framework\Api\ApiDefinition\Generator\StoreApiGenerator;
 use Shopware\Core\Framework\Api\Controller\ApiController;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\System\CustomEntity\Api\CustomEntityApiController;
@@ -22,6 +23,7 @@ use Symfony\Component\Routing\RouterInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiRoutesHaveASchemaTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ActionButtonLoaderTest.php
@@ -7,12 +7,14 @@ use Shopware\Core\Framework\App\ActionButton\ActionButtonLoader;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ActionButtonLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\AppSystemTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppActionLoaderTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/ActiveAppsLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActiveAppsLoaderTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Framework\App;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ActiveAppsLoaderTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/Api/AppActionControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppActionControllerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -18,6 +19,7 @@ use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\Api;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
@@ -10,6 +11,7 @@ use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppCmsControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/App/AppLocaleProviderTest.php
+++ b/tests/integration/Core/Framework/App/AppLocaleProviderTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\App\AppLocaleProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppLocaleProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/AppServiceTest.php
+++ b/tests/integration/Core/Framework/App/AppServiceTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -24,6 +25,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppServiceTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\App\ShopIdChangeResolver\MoveShopPermanentlyStrategy
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 /**
  * @internal
  */
+#[Package('framework')]
 class MoveShopPermanentlyStrategyTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\App\ShopIdChangeResolver\ReinstallAppsStrategy;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 /**
  * @internal
  */
+#[Package('framework')]
 class ReinstallAppsStrategyTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/Command/InstallAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/InstallAppCommandTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
 use Shopware\Core\Framework\App\Validation\ManifestValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -18,6 +19,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class InstallAppCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\Validation\ManifestValidator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -20,6 +21,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class RefreshAppCommandTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/Command/UninstallAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/UninstallAppCommandTest.php
@@ -7,12 +7,14 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\Command\UninstallAppCommand;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class UninstallAppCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Command/ValidateAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/ValidateAppCommandTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Command;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Command\ValidateAppCommand;
 use Shopware\Core\Framework\App\Validation\ManifestValidator;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ValidateAppCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Cookie/CookieGroupCollectListenerTest.php
+++ b/tests/integration/Core/Framework/App/Cookie/CookieGroupCollectListenerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Cookie\Struct\CookieEntryCollection;
 use Shopware\Core\Content\Cookie\Struct\CookieGroup;
 use Shopware\Core\Content\Cookie\Struct\CookieGroupCollection;
 use Shopware\Core\Framework\App\Cookie\AppCookieCollectListener;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class CookieGroupCollectListenerTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/DeletedApps/DeletedAppsGatewayTest.php
+++ b/tests/integration/Core/Framework/App/DeletedApps/DeletedAppsGatewayTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Integration\Core\Framework\App\DeletedApps;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\DeletedApps\DeletedAppsGateway;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DeletedAppsGatewayTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Delta/AppConfirmationDeltaProviderTest.php
+++ b/tests/integration/Core/Framework/App/Delta/AppConfirmationDeltaProviderTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Delta\AppConfirmationDeltaProvider;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppConfirmationDeltaProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Delta/DomainsDeltaProviderTest.php
+++ b/tests/integration/Core/Framework/App/Delta/DomainsDeltaProviderTest.php
@@ -13,11 +13,13 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DomainsDeltaProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Delta/PermissionsDeltaProviderTest.php
+++ b/tests/integration/Core/Framework/App/Delta/PermissionsDeltaProviderTest.php
@@ -13,11 +13,13 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class PermissionsDeltaProviderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Flow/FlowAction/AppFlowActionLoadedSubscriberTest.php
+++ b/tests/integration/Core/Framework/App/Flow/FlowAction/AppFlowActionLoadedSubscriberTest.php
@@ -7,12 +7,14 @@ use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppFlowActionLoadedSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Flow/FlowAction/FlowActionTranslationTest.php
+++ b/tests/integration/Core/Framework/App/Flow/FlowAction/FlowActionTranslationTest.php
@@ -7,12 +7,14 @@ use Shopware\Core\Framework\App\Aggregate\FlowAction\AppFlowActionCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class FlowActionTranslationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Hmac/Guzzle/AuthMiddlewareTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/Guzzle/AuthMiddlewareTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\App\AppLocaleProvider;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Hmac\RequestSigner;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -22,6 +23,7 @@ use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class AuthMiddlewareTest extends TestCase
 {
     use GuzzleTestClientBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLoaderTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppLoaderTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppManagerTest.php
@@ -40,6 +40,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Script\Execution\Script;
 use Shopware\Core\Framework\Script\Execution\ScriptLoader;
@@ -53,6 +54,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppManagerTest extends TestCase
 {
     use GuzzleTestClientBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/AppSecretRotationServiceTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppSecretRotationServiceTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Integration\IntegrationCollection;
 use Shopware\Core\System\Integration\IntegrationEntity;
@@ -21,6 +22,7 @@ use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppSecretRotationServiceTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/CustomFieldLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/CustomFieldLifecycleHandlerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Filesystem;
@@ -23,6 +24,7 @@ use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldLifecycleHandlerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/FlowActionLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/FlowActionLifecycleHandlerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\App\Lifecycle\Handler\FlowActionLifecycleHandler;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Tests\Unit\Core\Framework\App\Manifest\ManifestFixture;
 /**
  * @internal
  */
+#[Package('framework')]
 class FlowActionLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/FlowEventLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/FlowEventLifecycleHandlerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\App\Flow\Event\Event;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\App\Lifecycle\Handler\FlowEventLifecycleHandler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Filesystem;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -20,6 +21,7 @@ use Shopware\Tests\Unit\Core\Framework\App\Manifest\ManifestFixture;
 /**
  * @internal
  */
+#[Package('framework')]
 class FlowEventLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/PaymentMethodLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/PaymentMethodLifecycleHandlerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\App\Lifecycle\Handler\PaymentMethodLifecycleHandler;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Filesystem;
@@ -16,6 +17,7 @@ use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
 /**
  * @internal
  */
+#[Package('framework')]
 class PaymentMethodLifecycleHandlerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/RuleConditionLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/RuleConditionLifecycleHandlerTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\AppFixture;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class RuleConditionLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/ScriptLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/ScriptLifecycleHandlerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Handler;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Lifecycle\Handler\ScriptLifecycleHandler;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Store\ExtensionBehaviour;
 use Shopware\Core\Framework\Test\Store\ServiceBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptLifecycleHandlerTest extends TestCase
 {
     use ExtensionBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/ShippingMethodLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/ShippingMethodLifecycleHandlerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Store\ExtensionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class ShippingMethodLifecycleHandlerTest extends TestCase
 {
     use ExtensionBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Handler/WebhookLifecycleHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Handler/WebhookLifecycleHandlerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\Lifecycle\Context\AppPersistContext;
 use Shopware\Core\Framework\App\Lifecycle\Handler\WebhookLifecycleHandler;
 use Shopware\Core\Framework\App\Manifest\Xml\Webhook\Webhook;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Webhook\Service\WebhookManager;
 use Shopware\Core\Test\Stub\Framework\Util\StaticFilesystem;
@@ -18,6 +19,7 @@ use Shopware\Tests\Unit\Core\Framework\App\Manifest\ManifestFixture;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/AppRegistrationServiceTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
@@ -34,6 +35,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppRegistrationServiceTest extends TestCase
 {
     use GuzzleTestClientBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\App\ShopId\Fingerprint\AppUrl;
 use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -26,6 +27,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class HandshakeFactoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/PrivateHandshakeTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/PrivateHandshakeTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle\Registration;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Lifecycle\Registration\PrivateHandshake;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Kernel;
@@ -12,6 +13,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class PrivateHandshakeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/StoreHandshakeTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/StoreHandshakeTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Lifecycle\Registration\StoreHandshake;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Test\Store\StoreClientBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -18,6 +19,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class StoreHandshakeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Lifecycle/Update/DefaultAppUpdaterTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Update/DefaultAppUpdaterTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\Lifecycle\Update\AbstractAppUpdater;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Store\ExtensionBehaviour;
 use Shopware\Core\Framework\Test\Store\StoreClientBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -17,6 +18,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
+#[Package('framework')]
 class DefaultAppUpdaterTest extends TestCase
 {
     use ExtensionBehaviour;

--- a/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Manifest/ModuleLoaderTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\App\ShopId\ShopId;
 use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -21,6 +22,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
  *
  * @phpstan-import-type AppModule from ModuleLoader
  */
+#[Package('framework')]
 class ModuleLoaderTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppAsyncPaymentHandlerTest.php
@@ -15,12 +15,14 @@ use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payment\Response\PaymentResponse;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionActions;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppAsyncPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     final public const REDIRECT_URL = 'http://payment.app/do/something';

--- a/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppPreparedPaymentHandlerTest.php
@@ -8,6 +8,7 @@ use Psr\Http\Message\RequestInterface;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payment\Response\ValidateResponse;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Test\Generator;
@@ -15,6 +16,7 @@ use Shopware\Core\Test\Generator;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppPreparedPaymentHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     public function testValidate(): void

--- a/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
+++ b/tests/integration/Core/Framework/App/Payment/AppRefundHandlerTest.php
@@ -9,10 +9,12 @@ use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Hmac\Guzzle\AuthMiddleware;
 use Shopware\Core\Framework\App\Payment\Response\RefundResponse;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppRefundHandlerTest extends AbstractAppPaymentHandlerTestCase
 {
     public function testRefund(): void

--- a/tests/integration/Core/Framework/App/Privileges/PrivilegesTest.php
+++ b/tests/integration/Core/Framework/App/Privileges/PrivilegesTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Privileges\Privileges;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class PrivilegesTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
+++ b/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\App\ScheduledTask\DeleteCascadeAppsTask;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -22,6 +23,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class DeleteCascadeAppsHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Subscriber/AppLoadedSubscriberTest.php
+++ b/tests/integration/Core/Framework/App/Subscriber/AppLoadedSubscriberTest.php
@@ -8,12 +8,14 @@ use Shopware\Core\Framework\App\Subscriber\AppLoadedSubscriber;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AppLoadedSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Subscriber/CustomFieldProtectionSubscriberTest.php
+++ b/tests/integration/Core/Framework/App/Subscriber/CustomFieldProtectionSubscriberTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldProtectionSubscriberTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/App/Validation/ConfigValidatorTest.php
+++ b/tests/integration/Core/Framework/App/Validation/ConfigValidatorTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Validation\ConfigValidator;
 use Shopware\Core\Framework\App\Validation\Error\ConfigurationError;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ConfigValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Validation/HookableEventDescriberValidationTest.php
+++ b/tests/integration/Core/Framework/App/Validation/HookableEventDescriberValidationTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\Validation\HookableValidator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventCollector;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\Webhook\Hookable\HookableEventDescription;
 /**
  * @internal
  */
+#[Package('framework')]
 class HookableEventDescriberValidationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Validation/HookableValidatorTest.php
+++ b/tests/integration/Core/Framework/App/Validation/HookableValidatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\App\Validation\Error\MissingPermissionError;
 use Shopware\Core\Framework\App\Validation\Error\NotHookableError;
 use Shopware\Core\Framework\App\Validation\HookableValidator;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Service\Event\CommercialLicenseProvidedEvent;
@@ -15,6 +16,7 @@ use Shopware\Core\Service\Event\CommercialLicenseProvidedEvent;
 /**
  * @internal
  */
+#[Package('framework')]
 class HookableValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/App/Validation/ManifestValidatorTest.php
+++ b/tests/integration/Core/Framework/App/Validation/ManifestValidatorTest.php
@@ -8,11 +8,13 @@ use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Validation\Error\ErrorCollection;
 use Shopware\Core\Framework\App\Validation\ManifestValidator;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ManifestValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/CustomField/Api/CustomFieldSetActionControllerTest.php
+++ b/tests/integration/Core/Framework/CustomField/Api/CustomFieldSetActionControllerTest.php
@@ -4,11 +4,13 @@ namespace Shopware\Tests\Integration\Core\Framework\CustomField\Api;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class CustomFieldSetActionControllerTest extends TestCase
 {

--- a/tests/integration/Core/Framework/CustomField/CustomFieldRepositoryTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldRepositoryTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldCollection;
@@ -15,6 +16,7 @@ use Shopware\Core\System\CustomField\CustomFieldDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/CustomField/CustomFieldServiceTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldServiceTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldCollection;
@@ -22,6 +23,7 @@ use Shopware\Core\System\CustomField\CustomFieldTypes;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/CustomField/CustomFieldSetRepositoryTest.php
+++ b/tests/integration/Core/Framework/CustomField/CustomFieldSetRepositoryTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
@@ -17,6 +18,7 @@ use Shopware\Core\System\CustomField\CustomFieldDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldSetRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -49,6 +50,7 @@ use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\Strin
 /**
  * @internal
  */
+#[Package('framework')]
 class AttributeEntityIntegrationTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Commands/RefreshIndexCommandTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Commands/RefreshIndexCommandTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
@@ -19,6 +20,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class RefreshIndexCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ChildCountIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ChildCountIndexerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ChildCountUpdater;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class ChildCountIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilderTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Product\SalesChannel\Listing\ResolveCriteriaProductLis
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class CriteriaQueryBuilderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryHelperTest.php
@@ -16,12 +16,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Tax\TaxCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class CriteriaQueryHelperTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
@@ -8,11 +8,13 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\ProductStream\ProductStreamDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityDefinitionQueryHelperTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolverTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -29,6 +30,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityForeignKeyResolverTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
@@ -24,12 +24,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityReaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
@@ -20,12 +20,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class EntitySearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGatewayTest.php
@@ -31,6 +31,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryCollection;
@@ -42,6 +43,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityWriteGatewayTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/PriceFieldAccessorBuilderTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\PriceFieldAccessorBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class PriceFieldAccessorBuilderTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -35,6 +36,7 @@ use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 class ManyToOneAssociationFieldResolverTest extends TestCase
 {
     use DocumentTrait;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Tax\TaxDefinition;
@@ -26,6 +27,7 @@ use Shopware\Core\System\Tax\TaxDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class ManyToManyAssociationFieldTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigCollection;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class RepositoryIteratorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TranslatedVersionsTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TranslatedVersionsTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -25,6 +26,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class TranslatedVersionsTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TreeIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/TreeIndexerTest.php
@@ -12,12 +12,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class TreeIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Doctrine/Doctrine/MultiInsertQueryQueueTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Doctrine/Doctrine/MultiInsertQueryQueueTest.php
@@ -8,12 +8,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class MultiInsertQueryQueueTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityDefinitionHasSinceTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityDefinitionHasSinceTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityDefinitionHasSinceTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityDefinitionTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateDefinition;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateTranslationDefinition;
@@ -32,6 +33,7 @@ use Shopware\Core\System\StateMachine\StateMachineTranslationDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityDefinitionTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionReadTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionReadTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
@@ -29,6 +30,7 @@ use Shopware\Core\System\Language\LanguageEntity;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityExtensionReadTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisterTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductManufacturerDefinition;
@@ -20,6 +21,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegis
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityExtensionRegisterTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisteredTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisteredTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Integration\IntegrationDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
@@ -11,6 +12,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityExtensionRegisteredTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\AssociationExtension;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendableDefinition;
@@ -43,6 +44,7 @@ use Shopware\Core\System\Tax\TaxEntity;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityExtensionTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\EntityProtection\_fixtures\PluginProtectionExtension;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\EntityProtection\_fixtures\SystemConfigExtension;
@@ -24,6 +25,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityProtectionValidatorTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityRepositoryTest.php
@@ -44,6 +44,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\CloneBehavior;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Container\AndRule;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
@@ -59,6 +60,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -21,6 +22,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityLoadedEventFactoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEventSerializationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEventSerializationTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityWrittenEventSerializationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/ExcludeFieldsReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/ExcludeFieldsReaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class ExcludeFieldsReaderTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacade;
 use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacadeHookFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\SumResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\Script;
 use Shopware\Core\Framework\Script\Execution\ScriptAppInformation;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class RepositoryFacadeTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryWriterFacadeHookFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\Script;
 use Shopware\Core\Framework\Script\Execution\ScriptAppInformation;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class RepositoryWriterFacadeTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacadeTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Facade\SalesChannelRepositoryFa
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\SumResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\Script;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Struct\ArrayStruct;
@@ -30,6 +31,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class SalesChannelRepositoryFacadeTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CalculatedPriceFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CalculatedPriceFieldTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -22,6 +23,7 @@ use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Version\Calcu
 /**
  * @internal
  */
+#[Package('framework')]
 class CalculatedPriceFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/ConfigJsonFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/ConfigJsonFieldTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ConfigJsonDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class ConfigJsonFieldTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreateAtAndUpdatedAtFieldTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\DateTimeDefinition;
@@ -24,6 +25,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class CreateAtAndUpdatedAtFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CreatedByFieldTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,6 +25,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class CreatedByFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestDefinition;
@@ -35,6 +36,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/CustomFieldTranslationTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterfac
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\CustomFieldTestTranslationDefinition;
@@ -31,6 +32,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldTranslationTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/DateFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/DateFieldTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\DateDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class DateFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareFlagTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/ApiAwareFlagTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiAwareFlagTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtectedFlagTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtectedFlagTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\WriteProtectedDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\WriteProtectedRelationDefinition;
@@ -22,6 +23,7 @@ use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 /**
  * @internal
  */
+#[Package('framework')]
 class WriteProtectedFlagTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/JsonFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/JsonFieldTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\JsonDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\NestedDefinition;
@@ -29,6 +30,7 @@ use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 /**
  * @internal
  */
+#[Package('framework')]
 class JsonFieldTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/ListFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/ListFieldTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ListDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -19,6 +20,7 @@ use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelType\SalesChannelTyp
 /**
  * @internal
  */
+#[Package('framework')]
 class ListFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/OneToOneAssociationFieldTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\RootDefinition;
@@ -32,6 +33,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class OneToOneAssociationFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/PriceFieldTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\PriceFieldDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class PriceFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/RemoteAddressFieldTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -28,6 +29,7 @@ use Symfony\Component\HttpFoundation\IpUtils;
 /**
  * @internal
  */
+#[Package('framework')]
 class RemoteAddressFieldTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/UpdatedByFieldTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -24,6 +25,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class UpdatedByFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Field/WasModifiedByUserFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Field/WasModifiedByUserFieldTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterfac
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\WasModifiedByUserFieldDefinition;
@@ -24,6 +25,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class WasModifiedByUserFieldTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ReferenceVersionFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/ReferenceVersionFieldSerializerTest.php
@@ -7,12 +7,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ReferenceVersionFieldSerializerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineSateFieldSerializerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,6 +24,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class StateMachineSateFieldSerializerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/InheritanceIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/InheritanceIndexerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -18,6 +19,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class InheritanceIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldIndexerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldIndexerTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ManyToManyIdFieldIndexerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TreePathField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\TreeUpdater;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class TreeUpdaterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -43,6 +43,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotEqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ConsistsOfManyToManyDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\NonIdFieldNamePrimaryKeyTestDefinition;
@@ -59,6 +60,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityReaderTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\RangeAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\RangeResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class RangeAggregationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/AntiJoinSearchTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/AntiJoinSearchTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -23,6 +24,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class AntiJoinSearchTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntityAggregatorTest.php
@@ -41,6 +41,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Search\TestAggregation;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Search\Util\DateHistogramCase;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -50,6 +51,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class EntityAggregatorTest extends TestCase
 {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/EntitySearcherTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Tax\TaxDefinition;
@@ -31,6 +32,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntitySearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/FkFieldPrimarySearcherTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Search\Definition\FkFieldPrimaryTestDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Search\Definition\MultiFkFieldPrimaryTestDefinition;
@@ -28,6 +29,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class FkFieldPrimarySearcherTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/GroupByTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/GroupByTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Search\Definition\GroupByTestDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -28,6 +29,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class GroupByTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/JoinFilterTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -37,6 +38,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
  *
  * @see MultiJoinFilterLimitationTest for edge cases and limitations of multi join filters
  */
+#[Package('framework')]
 class JoinFilterTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/MultiJoinFilterLimitationTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -33,6 +34,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
  *
  * @see JoinFilterTest for the tests for all valid cases that are part of the public API.
  */
+#[Package('framework')]
 class MultiJoinFilterLimitationTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/NaturalSortingTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/NaturalSortingTest.php
@@ -12,12 +12,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class NaturalSortingTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/AggregationParserTest.php
@@ -18,11 +18,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\AggregationParser;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AggregationParserTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -28,6 +29,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class SqlQueryParserTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreBuilderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreBuilderTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\EntityScoreQueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchPattern;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchTerm;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\TestDefaults;
@@ -28,6 +29,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityScoreBuilderTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilterTest.php
@@ -8,11 +8,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\SearchConfigLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\TokenFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class TokenFilterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterfac
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LocaleCollection;
@@ -24,6 +25,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityExistsValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityNotExists;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\FrameworkException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Locale\LocaleCollection;
@@ -26,6 +27,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityNotExistsValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/CleanupVersionTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/CleanupVersionTaskHandlerTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Version\Cleanup\CleanupVersionTaskHandler;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,6 +15,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class CleanupVersionTaskHandlerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningCustomFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningCustomFieldTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class VersioningCustomFieldTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Version/VersioningTest.php
@@ -45,6 +45,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterfac
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Collector\RuleConditionRegistry;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
@@ -65,6 +66,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class VersioningTest extends TestCase
 {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\CloneBehavior;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ManyToOneProductDefinition;
@@ -31,6 +32,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class VersionManagerTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueueTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueueTest.php
@@ -12,12 +12,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\JsonUpdateCommand
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class WriteCommandQueueTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/DeleteTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/DeleteTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Write\Fixture\Delete\DeleteCascadeChildDefinition;
@@ -17,6 +18,7 @@ use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Write\Fixture
 /**
  * @internal
  */
+#[Package('framework')]
 class DeleteTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/EntityWriterTest.php
@@ -34,6 +34,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField\NonUuidFkFieldSerializer;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField\TestEntityOneDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField\TestEntityTwoDefinition;
@@ -45,6 +46,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class EntityWriterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/ParentChildTest.php
@@ -9,12 +9,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ParentChildTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/ProductTypeImmutableTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/ProductTypeImmutableTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -21,6 +22,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductTypeImmutableTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/SetNullOnDeleteTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -30,6 +31,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class SetNullOnDeleteTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/TranslationTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingTranslationLan
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\Aggregate\CurrencyTranslation\CurrencyTranslationDefinition;
@@ -41,6 +42,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class TranslationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidatorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/Validation/LockValidatorTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\LockValidator;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Validation\TestDefinition\TestDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 /**
  * @internal
  */
+#[Package('framework')]
 class LockValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelpe
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsChildDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsChildTranslationDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsDefinition;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class WriteCommandExtractorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriterExtensionTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Write/WriterExtensionTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
@@ -22,6 +23,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class WriterExtensionTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommandTest.php
+++ b/tests/integration/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommandTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Demodata\PersonalData\CleanPersonalDataCommand;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -28,6 +29,7 @@ use Symfony\Component\Console\Output\BufferedOutput;
 /**
  * @internal
  */
+#[Package('framework')]
 class CleanPersonalDataCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/IdleFeatureFlagTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\FeatureFlag;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Tests\Unit\Core\Framework\FeatureTest;
 use Symfony\Component\Finder\Finder;
@@ -11,6 +12,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * @internal
  */
+#[Package('framework')]
 class IdleFeatureFlagTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
+++ b/tests/integration/Core/Framework/Increment/Controller/IncrementApiControllerTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class IncrementApiControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/Increment/IncrementerGatewayRegistryTest.php
+++ b/tests/integration/Core/Framework/Increment/IncrementerGatewayRegistryTest.php
@@ -7,11 +7,13 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\Exception\IncrementGatewayNotFoundException;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class IncrementerGatewayRegistryTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/MySQLIncrementerTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Core\Framework\Increment;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Increment\MySQLIncrementer;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Clock\NativeClock;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class MySQLIncrementerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Increment/RedisIncrementerTest.php
+++ b/tests/integration/Core/Framework/Increment/RedisIncrementerTest.php
@@ -7,10 +7,12 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\RedisConnectionFactory;
 use Shopware\Core\Framework\Increment\RedisIncrementer;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class RedisIncrementerTest extends TestCase
 {
     private string $redisUrl;

--- a/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
+++ b/tests/integration/Core/Framework/Language/LanguageValidatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -16,6 +17,7 @@ use Shopware\Core\System\Language\LanguageValidator;
 /**
  * @internal
  */
+#[Package('framework')]
 class LanguageValidatorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/Log/ScheduledTask/LogCleanupTaskHandlerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\LogEntryCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Log\ScheduledTask\LogCleanupTask;
 use Shopware\Core\Framework\Log\ScheduledTask\LogCleanupTaskHandler;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
@@ -22,6 +23,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 /**
  * @internal
  */
+#[Package('framework')]
 class LogCleanupTaskHandlerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/RegisterScheduledTaskTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/RegisterScheduledTaskTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\MessageQueue\ScheduledTask;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\Command\RegisterScheduledTasksCommand;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -11,6 +12,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class RegisterScheduledTaskTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
@@ -25,6 +26,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScheduledTaskHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskEntity;
@@ -28,6 +29,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class TaskSchedulerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/TaskRegistryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskCollection;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
@@ -20,6 +21,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 /**
  * @internal
  */
+#[Package('framework')]
 class TaskRegistryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/MessageQueue/Subscriber/MessageQueueStatsSubscriberTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/Subscriber/MessageQueueStatsSubscriberTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Increment\AbstractIncrementer;
 use Shopware\Core\Framework\Increment\IncrementGatewayRegistry;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\MessageQueue\fixtures\BarMessage;
 use Shopware\Core\Framework\Test\MessageQueue\fixtures\FooMessage;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -18,6 +19,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
  *
  * @internal
  */
+#[Package('framework')]
 class MessageQueueStatsSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Migration/IndexerQueuerTest.php
+++ b/tests/integration/Core/Framework/Migration/IndexerQueuerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Migration;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 class IndexerQueuerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Migration/MigrationCollectionRuntimeTest.php
+++ b/tests/integration/Core/Framework/Migration/MigrationCollectionRuntimeTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Result;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationRuntime;
@@ -18,6 +19,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class MigrationCollectionRuntimeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Migration/MigrationCommandTest.php
+++ b/tests/integration/Core/Framework/Migration/MigrationCommandTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Migration;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\Command\MigrationCommand;
 use Shopware\Core\Framework\Migration\Command\MigrationDestructiveCommand;
 use Shopware\Core\Framework\Migration\MigrationCollection;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class MigrationCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Migration/MigrationLoaderTest.php
+++ b/tests/integration/Core/Framework/Migration/MigrationLoaderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Migration;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\Exception\UnknownMigrationSourceException;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationException;
@@ -14,6 +15,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class MigrationLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Migration/MigrationStepTest.php
+++ b/tests/integration/Core/Framework/Migration/MigrationStepTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
@@ -13,6 +14,7 @@ use Shopware\Core\Framework\Util\Database\TableHelper;
 /**
  * @internal
  */
+#[Package('framework')]
 class MigrationStepTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Notification/Api/NotificationControllerTest.php
+++ b/tests/integration/Core/Framework/Notification/Api/NotificationControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Notification\NotificationCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class NotificationControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
+++ b/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Source\SourceResolver;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\BundleConfigGenerator;
 use Shopware\Core\Framework\Plugin\BundleConfigGeneratorInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -13,6 +14,7 @@ use Shopware\Storefront\Theme\StorefrontPluginRegistry;
 /**
  * @internal
  */
+#[Package('framework')]
 class BundleConfigGeneratorTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/ExtensionExtractorTest.php
+++ b/tests/integration/Core/Framework/Plugin/ExtensionExtractorTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\ExtensionExtractor;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginManagementService;
@@ -14,6 +15,7 @@ use Symfony\Component\Filesystem\Filesystem;
 /**
  * @internal
  */
+#[Package('framework')]
 class ExtensionExtractorTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
@@ -42,6 +43,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class KernelPluginIntegrationTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoaderTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin\KernelPluginLoader;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Composer\ComposerInfoProvider;
 use Shopware\Core\Framework\Adapter\Composer\ComposerPackage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Test\Plugin\PluginIntegrationTestBehaviour;
 use SwagTestComposerLoaded\SwagTestComposerLoaded;
@@ -13,6 +14,7 @@ use SwagTestComposerLoaded\SwagTestComposerLoaded;
 /**
  * @internal
  */
+#[Package('framework')]
 class ComposerPluginLoaderTest extends TestCase
 {
     use PluginIntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoaderTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin\KernelPluginLoader;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Test\Plugin\PluginIntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DbalKernelPluginLoaderTest extends TestCase
 {
     use PluginIntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Plugin\KernelPluginLoader;
 use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginException;
@@ -20,6 +21,7 @@ use Symfony\Component\DependencyInjection\Definition;
 /**
  * @internal
  */
+#[Package('framework')]
 class StaticKernelPluginLoaderTest extends TestCase
 {
     use PluginIntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationSource;
@@ -38,6 +39,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class PluginLifecycleServiceMigrationTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\Event\PluginPostInstallEvent;
@@ -56,6 +57,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class PluginLifecycleServiceTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheClearer;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\ExtensionExtractor;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginManagementService;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class PluginManagementServiceTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
@@ -29,6 +30,7 @@ use SwagTestPlugin\SwagTestPlugin;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class PluginServiceTest extends TestCase
 {

--- a/tests/integration/Core/Framework/RateLimiter/Policy/TimeBackoffLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/Policy/TimeBackoffLimiterTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\RateLimiter\Policy;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Policy\TimeBackoff;
 use Shopware\Core\Framework\RateLimiter\RateLimiterFactory;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\RateLimiter\Util\TimeUtil;
 /**
  * @internal
  */
+#[Package('framework')]
 class TimeBackoffLimiterTest extends TestCase
 {
     use CustomerTestTrait;

--- a/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Controller\AuthController as AdminAuthController;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\RateLimiter\RateLimiterFactory;
 use Shopware\Core\Framework\Test\RateLimiter\DisableRateLimiterCompilerPass;
@@ -43,6 +44,7 @@ use Symfony\Component\RateLimiter\Storage\CacheStorage;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class RateLimiterTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,6 +23,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiRequestContextResolverAppTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRequestContextResolver;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\RequestContextResolverInterface;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiRequestContextResolverTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Routing/ApiRouteScopeTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRouteScopeTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Api\Context\ContextSource;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiRouteScopeTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Routing/CoreSubscriberTest.php
+++ b/tests/integration/Core/Framework/Routing/CoreSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Routing;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Administration\Controller\AdministrationController;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\PlatformRequest;
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CoreSubscriberTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Routing/RouteScopeListenerTest.php
+++ b/tests/integration/Core/Framework/Routing/RouteScopeListenerTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Api\Context\ContextSource;
 use Shopware\Core\Framework\Api\Context\SalesChannelApiSource;
 use Shopware\Core\Framework\Api\Controller\ApiController;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
 use Shopware\Core\Framework\Routing\Exception\InvalidRouteScopeException;
 use Shopware\Core\Framework\Routing\RouteScopeListener;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class RouteScopeListenerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
+++ b/tests/integration/Core/Framework/Routing/SalesChannelRequestContextResolverTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Event\SalesChannelContextResolvedEvent;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Routing\SalesChannelRequestContextResolver;
@@ -36,6 +37,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 /**
  * @internal
  */
+#[Package('framework')]
 class SalesChannelRequestContextResolverTest extends TestCase
 {
     use CustomerTestTrait;

--- a/tests/integration/Core/Framework/Script/Api/ResponseHookTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ResponseHookTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Script\Api;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ResponseHookTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptApiRouteTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptStoreApiRouteTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
+++ b/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Facade\RepositoryFacadeHookFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\ScriptExecutor;
 use Shopware\Core\Framework\Script\ScriptException;
 use Shopware\Core\Framework\Struct\ArrayStruct;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptExecutorTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/integration/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\Script\Execution;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Execution\ScriptLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -10,6 +11,7 @@ use Shopware\Core\Test\AppSystemTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptLoaderTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/SeoUrlRepositoryTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
@@ -21,6 +22,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class SeoUrlRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Seo/SeoUrl/StorefrontSeoUrlRepositoryTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrl/StorefrontSeoUrlRepositoryTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,6 +18,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 /**
  * @internal
  */
+#[Package('framework')]
 class StorefrontSeoUrlRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPersisterTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -35,6 +36,7 @@ use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 /**
  * @internal
  */
+#[Package('framework')]
 class SeoUrlPersisterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Seo/SeoUrlPlaceholderHandlerTest.php
+++ b/tests/integration/Core/Framework/Seo/SeoUrlPlaceholderHandlerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Bundle\FrameworkBundle\Routing\Router;
 /**
  * @internal
  */
+#[Package('framework')]
 class SeoUrlPlaceholderHandlerTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/DatabaseTransactionBehaviourTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class DatabaseTransactionBehaviourTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/Framework/TestCaseBase/KernelLifecycleManagerTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/KernelLifecycleManagerTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Kernel;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class KernelLifecycleManagerTest extends TestCase
 {
     public function testARebootIsPossible(): void

--- a/tests/integration/Core/Framework/TestCaseBase/KernelTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/KernelTestBehaviourTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class KernelTestBehaviourTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/TestCaseBase/QueueTestBehaviourTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/QueueTestBehaviourTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class QueueTestBehaviourTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Translation/TranslatorTest.php
+++ b/tests/integration/Core/Framework/Translation/TranslatorTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Util\StatementHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\SalesChannelRequest;
@@ -32,6 +33,7 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class TranslatorTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/Framework/Update/Services/FilesystemTest.php
+++ b/tests/integration/Core/Framework/Update/Services/FilesystemTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Update\Services;
 
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Services\Filesystem;
 
 /**
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Update\Services\Filesystem;
  * Exercises real directory permissions, so it lives in the integration suite (the
  * runner is non-root, so the write/permission branches are genuinely reachable).
  */
+#[Package('framework')]
 class FilesystemTest extends TestCase
 {
     private string $baseDir;

--- a/tests/integration/Core/Framework/Util/Database/TableHelperTest.php
+++ b/tests/integration/Core/Framework/Util/Database/TableHelperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\Column;
 use Shopware\Core\Framework\Util\Database\Index;
@@ -27,6 +28,7 @@ use Shopware\Tests\Integration\Core\Framework\Util\Database\TableHelper\Exceptio
 /**
  * @internal
  */
+#[Package('framework')]
 class TableHelperTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Util/HtmlSanitizerTest.php
+++ b/tests/integration/Core/Framework/Util/HtmlSanitizerTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Shopware\Tests\Integration\Core\Framework\Util;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\HtmlSanitizer;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class HtmlSanitizerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/BusinessEventEncoderTest.php
+++ b/tests/integration/Core/Framework/Webhook/BusinessEventEncoderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Event\BusinessEventRegistry;
 use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\Webhook\_fixtures\BusinessEvents\ArrayBusinessEvent;
 use Shopware\Core\Framework\Test\Webhook\_fixtures\BusinessEvents\CollectionBusinessEvent;
@@ -26,6 +27,7 @@ use Shopware\Core\System\Tax\TaxEntity;
 /**
  * @internal
  */
+#[Package('framework')]
 class BusinessEventEncoderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
+++ b/tests/integration/Core/Framework/Webhook/Command/WebhookDrainToAsyncCommandTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\App\AppLocaleProvider;
 use Shopware\Core\Framework\App\Payload\AppPayloadServiceHelper;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\Command\WebhookDrainToAsyncCommand;
@@ -34,6 +35,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookDrainToAsyncCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Hookable/HookableEventCollectorTest.php
+++ b/tests/integration/Core/Framework/Webhook/Hookable/HookableEventCollectorTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Webhook\Hookable\CoreHookableEventDescriber;
 use Shopware\Core\Framework\Webhook\Hookable\HookableEventCollector;
@@ -24,6 +25,7 @@ use Shopware\Core\Framework\Webhook\Hookable\HookableEventCollector;
 /**
  * @internal
  */
+#[Package('framework')]
 class HookableEventCollectorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
+++ b/tests/integration/Core/Framework/Webhook/Hookable/HookableEventFactoryTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\Hookable\HookableBusinessEvent;
@@ -26,6 +27,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class HookableEventFactoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Outbox/StreamLockServiceTest.php
+++ b/tests/integration/Core/Framework/Webhook/Outbox/StreamLockServiceTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,6 +18,7 @@ use Symfony\Component\Clock\MockClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class StreamLockServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Outbox/WebhookOutboxStoreTest.php
+++ b/tests/integration/Core/Framework/Webhook/Outbox/WebhookOutboxStoreTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -22,6 +23,7 @@ use Symfony\Component\Clock\MockClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookOutboxStoreTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Service/RelatedWebhooksTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/RelatedWebhooksTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Webhook\Service\RelatedWebhooks;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -15,6 +16,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class RelatedWebhooksTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookCleanupTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookCleanupTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Webhook\Service;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,6 +18,7 @@ use Symfony\Component\Clock\MockClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookCleanupTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookHealthServiceTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookHealthServiceTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\Service\WebhookHealthService;
@@ -15,6 +16,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookHealthServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookLoaderTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookLoaderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Store\ExtensionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookLoaderTest extends TestCase
 {
     use ExtensionBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
+++ b/tests/integration/Core/Framework/Webhook/Service/WebhookManagerTest.php
@@ -35,6 +35,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Webhook\EventLog\WebhookEventLogDefinition;
@@ -57,6 +58,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookManagerTest extends TestCase
 {
     use GuzzleTestClientBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriberTest.php
+++ b/tests/integration/Core/Framework/Webhook/Subscriber/RetryWebhookMessageFailedSubscriberTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -33,6 +34,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 /**
  * @internal
  */
+#[Package('framework')]
 class RetryWebhookMessageFailedSubscriberTest extends TestCase
 {
     use GuzzleTestClientBehaviour;

--- a/tests/integration/Core/Framework/Webhook/Transport/WebhookTransportTest.php
+++ b/tests/integration/Core/Framework/Webhook/Transport/WebhookTransportTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Webhook\Transport;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Webhook\Message\WebhookEventMessage;
 use Shopware\Core\Framework\Webhook\Transport\WebhookTransport;
@@ -15,6 +16,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class WebhookTransportTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Installer/Configuration/ShopConfigurationServiceTest.php
+++ b/tests/integration/Core/Installer/Configuration/ShopConfigurationServiceTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Installer\Configuration;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Installer\Configuration\ShopConfigurationService;
@@ -13,6 +14,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class ShopConfigurationServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Maintenance/System/Service/SetupDatabaseAdapterTest.php
+++ b/tests/integration/Core/Maintenance/System/Service/SetupDatabaseAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Maintenance\System\Service;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Maintenance\System\Service\DatabaseConnectionFactory;
 use Shopware\Core\Maintenance\System\Service\SetupDatabaseAdapter;
 use Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation;
@@ -10,6 +11,7 @@ use Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation;
 /**
  * @internal
  */
+#[Package('framework')]
 class SetupDatabaseAdapterTest extends TestCase
 {
     public function testInitialize(): void

--- a/tests/integration/Core/Migration/Traits/ImportTranslationTraitTest.php
+++ b/tests/integration/Core/Migration/Traits/ImportTranslationTraitTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Migration\Traits;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\Traits\ImportTranslationsTrait;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 class ImportTranslationTraitTest extends TestCase
 {
     use ImportTranslationsTrait;

--- a/tests/integration/Core/Service/Api/PermissionControllerTest.php
+++ b/tests/integration/Core/Service/Api/PermissionControllerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Service\Api;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Service\Permission\PermissionsConsent;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class PermissionControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Service/Api/ServiceControllerTest.php
+++ b/tests/integration/Core/Service/Api/ServiceControllerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ServiceControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Service/PermissionsServiceTest.php
+++ b/tests/integration/Core/Service/PermissionsServiceTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Service;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Service\Event\PermissionsGrantedEvent;
 use Shopware\Core\Service\Event\PermissionsRevokedEvent;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 /**
  * @internal
  */
+#[Package('framework')]
 class PermissionsServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Service/Subscriber/ServiceWriteProtectionSubscriberTest.php
+++ b/tests/integration/Core/Service/Subscriber/ServiceWriteProtectionSubscriberTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ServiceWriteProtectionSubscriberTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/System/Consent/Api/ConsentControllerTest.php
+++ b/tests/integration/Core/System/Consent/Api/ConsentControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\System\Consent\Api;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
@@ -10,6 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('data-services')]
 class ConsentControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/Consent/ConsentRepositoryTest.php
+++ b/tests/integration/Core/System/Consent/ConsentRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\System\Consent;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Consent\ConsentRepository;
@@ -15,6 +16,7 @@ use Shopware\Core\System\Consent\DTO\ConsentStateRecord;
 /**
  * @internal
  */
+#[Package('data-services')]
 class ConsentRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/Consent/Log/DatabaseLogTest.php
+++ b/tests/integration/Core/System/Consent/Log/DatabaseLogTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\System\Consent\Log;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Consent\ConsentStatus;
 use Shopware\Core\System\Consent\Log\DatabaseLog;
@@ -11,6 +12,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('data-services')]
 class DatabaseLogTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
+++ b/tests/integration/Core/System/Currency/Repository/CurrencyRepositoryTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\EntityScoreQueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\SearchTermInterpreter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -20,6 +21,7 @@ use Shopware\Core\System\Currency\CurrencyDefinition;
 /**
  * @internal
  */
+#[Package('fundamentals@framework')]
 class CurrencyRepositoryTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/System/Currency/SalesChannel/CurrencyRouteTest.php
+++ b/tests/integration/Core/System/Currency/SalesChannel/CurrencyRouteTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -14,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('fundamentals@framework')]
 #[Group('store-api')]
 class CurrencyRouteTest extends TestCase
 {

--- a/tests/integration/Core/System/CustomEntity/Api/CustomEntityApiControllerTest.php
+++ b/tests/integration/Core/System/CustomEntity/Api/CustomEntityApiControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\System\CustomEntity\Api;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Tests\Integration\Core\System\CustomEntity\CustomEntityTest;
@@ -11,6 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomEntityApiControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/CustomEntity/CustomEntityLifecycleServiceTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityLifecycleServiceTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Util\Filesystem;
@@ -25,6 +26,7 @@ use Symfony\Component\Clock\NativeClock;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomEntityLifecycleServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
@@ -40,6 +40,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -74,6 +75,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomEntityTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
+++ b/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\PluginService;
@@ -26,6 +27,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class CmsAwareAndAdminUiTest extends TestCase
 {

--- a/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
+++ b/tests/integration/Core/System/Integration/IntegrationRepositoryTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Integration\IntegrationCollection;
@@ -14,6 +15,7 @@ use Shopware\Core\System\Integration\IntegrationCollection;
 /**
  * @internal
  */
+#[Package('fundamentals@framework')]
 class IntegrationRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/Language/SalesChannel/LanguageRouteTest.php
+++ b/tests/integration/Core/System/Language/SalesChannel/LanguageRouteTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -14,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('fundamentals@discovery')]
 #[Group('store-api')]
 class LanguageRouteTest extends TestCase
 {

--- a/tests/integration/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinitionTest.php
+++ b/tests/integration/Core/System/NumberRange/Aggregate/NumberRangeSalesChannel/NumberRangeSalesChannelDefinitionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeSalesChannel\NumberRangeSalesChannelCollection;
@@ -17,6 +18,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class NumberRangeSalesChannelDefinitionTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/NumberRange/Command/MigrateIncrementStorageCommandTest.php
+++ b/tests/integration/Core/System/NumberRange/Command/MigrateIncrementStorageCommandTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\System\NumberRange\Command;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Command\MigrateIncrementStorageCommand;
@@ -16,6 +17,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 /**
  * @internal
  */
+#[Package('framework')]
 class MigrateIncrementStorageCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
+++ b/tests/integration/Core/System/NumberRange/NumberRangeValueGeneratorTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\Aggregate\NumberRangeType\NumberRangeTypeCollection;
@@ -22,6 +23,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('framework')]
 class NumberRangeValueGeneratorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
+++ b/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementSqlStorageTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\System\NumberRange\ValueGenerator;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementSqlStorage;
@@ -11,6 +12,7 @@ use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\Inc
 /**
  * @internal
  */
+#[Package('framework')]
 class IncrementSqlStorageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementStorageRegistryTest.php
+++ b/tests/integration/Core/System/NumberRange/ValueGenerator/IncrementStorageRegistryTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\System\NumberRange\ValueGenerator;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementSqlStorage;
@@ -14,6 +15,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 /**
  * @internal
  */
+#[Package('framework')]
 class IncrementStorageRegistryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
+++ b/tests/integration/Core/System/SalesChannel/Context/CartRestorerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -38,6 +39,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @internal
  */
+#[Package('framework')]
 class CartRestorerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelMaintenanceIpAllowlistSyncSubscriberTest.php
+++ b/tests/integration/Core/System/SalesChannel/Subscriber/SalesChannelMaintenanceIpAllowlistSyncSubscriberTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 /**
  * @internal
  */
+#[Package('discovery')]
 class SalesChannelMaintenanceIpAllowlistSyncSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
+++ b/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Source\SourceResolver;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -23,6 +24,7 @@ use Shopware\Core\Test\AppSystemTestBehaviour;
 /**
  * @internal
  */
+#[Package('discovery')]
 class AppSnippetFileLoaderTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Core/System/Snippet/SnippetServiceTest.php
+++ b/tests/integration/Core/System/Snippet/SnippetServiceTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -26,6 +27,7 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 /**
  * @internal
  */
+#[Package('discovery')]
 class SnippetServiceTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -41,6 +42,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('checkout')]
 class StateMachineActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -34,6 +35,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('checkout')]
 class StateMachineRegistryTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
+++ b/tests/integration/Core/System/Tag/Service/FilterTagIdsServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\CountSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('fundamentals@framework')]
 class FilterTagIdsServiceTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
+++ b/tests/integration/Core/System/UsageData/Services/EntityDefinitionServiceTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\System\UsageData\Services;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\UsageData\Services\EntityDefinitionService;
 use Shopware\Core\System\UsageData\Services\UsageDataAllowListService;
@@ -11,6 +12,7 @@ use Shopware\Core\System\UsageData\Services\UsageDataAllowListService;
 /**
  * @internal
  */
+#[Package('data-services')]
 class EntityDefinitionServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/System/User/UserCrudTest.php
+++ b/tests/integration/Core/System/User/UserCrudTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Integration\Core\System\User;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('fundamentals@framework')]
 class UserCrudTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('inventory')]
 class AdminSearchControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
 use Shopware\Core\Framework\Event\NestedEventCollection;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -30,6 +31,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
+#[Package('inventory')]
 class AdminSearchRegistryTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Elasticsearch/Admin/AdminSearcherTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearcherTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
@@ -23,6 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('inventory')]
 class AdminSearcherTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Command/ElasticsearchAdminResetCommandTest.php
+++ b/tests/integration/Elasticsearch/Framework/Command/ElasticsearchAdminResetCommandTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchAdminResetCommand;
@@ -16,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ElasticsearchAdminResetCommandTest extends TestCase
 {
     use AdminElasticsearchTestBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Command/ElasticsearchResetCommandTest.php
+++ b/tests/integration/Elasticsearch/Framework/Command/ElasticsearchResetCommandTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
 use Shopware\Elasticsearch\Framework\Command\ElasticsearchResetCommand;
@@ -16,6 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ElasticsearchResetCommandTest extends TestCase
 {
     use AdminElasticsearchTestBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Elasticsearch\Framework\Indexing;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer;
@@ -13,6 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ElasticsearchIndexerTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Indexing/IndexManagerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/IndexManagerTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Elasticsearch\Framework\Indexing;
 
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Elasticsearch\Framework\Indexing\IndexManager;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class IndexManagerTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Elasticsearch/Migration/Traits/ElasticsearchTriggerTraitTest.php
+++ b/tests/integration/Elasticsearch/Migration/Traits/ElasticsearchTriggerTraitTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Integration\Elasticsearch\Migration\Traits;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Elasticsearch\Migration\Traits\ElasticsearchTriggerTrait;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 class ElasticsearchTriggerTraitTest extends TestCase
 {
     use ElasticsearchTriggerTrait;

--- a/tests/integration/Elasticsearch/Product/CustomFieldSetGatewayTest.php
+++ b/tests/integration/Elasticsearch/Product/CustomFieldSetGatewayTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Elasticsearch\Product;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
@@ -13,6 +14,7 @@ use Shopware\Elasticsearch\Product\CustomFieldSetGateway;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldSetGatewayTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Elasticsearch/Product/CustomFieldUpdaterTest.php
+++ b/tests/integration/Elasticsearch/Product/CustomFieldUpdaterTest.php
@@ -7,6 +7,7 @@ use OpenSearch\Client;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -22,6 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomFieldUpdaterTest extends TestCase
 {
     use ElasticsearchTestTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -60,6 +60,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\CountSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ProductExtension;
@@ -95,6 +96,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ElasticsearchProductTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/ProductCustomFieldsUsedUpdaterTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductCustomFieldsUsedUpdaterTest.php
@@ -7,6 +7,7 @@ use OpenSearch\Client;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
@@ -23,6 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductCustomFieldsUsedUpdaterTest extends TestCase
 {
     use ElasticsearchTestTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/ProductSortingStreamSearchTest.php
+++ b/tests/integration/Elasticsearch/Product/ProductSortingStreamSearchTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
@@ -35,6 +36,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductSortingStreamSearchTest extends TestCase
 {
     use ElasticsearchTestTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/SearchCasesTest.php
+++ b/tests/integration/Elasticsearch/Product/SearchCasesTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\FilesystemBehaviour;
@@ -24,6 +25,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class SearchCasesTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/StopwordTokenFilterTest.php
+++ b/tests/integration/Elasticsearch/Product/StopwordTokenFilterTest.php
@@ -6,12 +6,14 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Elasticsearch\Product\StopwordTokenFilter;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class StopwordTokenFilterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/ContextControllerContextTest.php
+++ b/tests/integration/Storefront/Controller/ContextControllerContextTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextSwitchEvent;
@@ -15,6 +16,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ContextControllerContextTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Adapter\Translation\ConstraintViolationTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Test\RateLimiter\DisableRateLimiterCompilerPass;
@@ -67,6 +68,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class ControllerRateLimiterTest extends TestCase
 {

--- a/tests/integration/Storefront/Controller/CookieControllerTest.php
+++ b/tests/integration/Storefront/Controller/CookieControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CookieControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
+++ b/tests/integration/Storefront/Controller/MaintenanceControllerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -21,6 +22,7 @@ use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class MaintenanceControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/integration/Storefront/Controller/NavigationControllerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -20,6 +21,7 @@ use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class NavigationControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -40,6 +41,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/ScriptControllerTest.php
+++ b/tests/integration/Storefront/Controller/ScriptControllerTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptControllerTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Storefront/Controller/SitemapControllerTest.php
+++ b/tests/integration/Storefront/Controller/SitemapControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Sitemap\SitemapPageLoadedHook;
@@ -11,6 +12,7 @@ use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class SitemapControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/integration/Storefront/Controller/StorefrontControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\RequestStackTestBehaviour;
@@ -15,6 +16,7 @@ use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class StorefrontControllerTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Storefront/Controller/StorefrontRoutingTest.php
+++ b/tests/integration/Storefront/Controller/StorefrontRoutingTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageEntity;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Exception\InvalidRouteScopeException;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class StorefrontRoutingTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Storefront/Controller/WellKnownControllerTest.php
+++ b/tests/integration/Storefront/Controller/WellKnownControllerTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class WellKnownControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Controller/WishlistControllerTest.php
+++ b/tests/integration/Storefront/Controller/WishlistControllerTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -35,6 +36,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 /**
  * @internal
  */
+#[Package('framework')]
 class WishlistControllerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
+++ b/tests/integration/Storefront/Event/Subscriber/CartMergedSubscriberTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -26,6 +27,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class CartMergedSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/App/AppLifecycleThemeTest.php
+++ b/tests/integration/Storefront/Framework/App/AppLifecycleThemeTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\AppSystemTestBehaviour;
@@ -29,6 +30,7 @@ use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 /**
  * @internal
  */
+#[Package('framework')]
 class AppLifecycleThemeTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('cache')]
 class HttpCacheIntegrationTest extends TestCase
 {

--- a/tests/integration/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGeneratorTest.php
+++ b/tests/integration/Storefront/Framework/Captcha/BasicCaptcha/BasicCaptchaGeneratorTest.php
@@ -3,12 +3,14 @@
 namespace Shopware\Tests\Integration\Storefront\Framework\Captcha\BasicCaptcha;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Storefront\Framework\Captcha\BasicCaptcha\BasicCaptchaGenerator;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class BasicCaptchaGeneratorTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Framework/Captcha/CaptchaRouteListenerTest.php
+++ b/tests/integration/Storefront/Framework/Captcha/CaptchaRouteListenerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\System\Salutation\SalutationCollection;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class CaptchaRouteListenerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Captcha/HoneypotCaptchaTest.php
+++ b/tests/integration/Storefront/Framework/Captcha/HoneypotCaptchaTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Framework\Captcha;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Storefront\Framework\Captcha\HoneypotCaptcha;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,6 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class HoneypotCaptchaTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Framework/Controller/XmlHttpRequestableInterfaceTest.php
+++ b/tests/integration/Storefront/Framework/Controller/XmlHttpRequestableInterfaceTest.php
@@ -3,11 +3,13 @@
 namespace Shopware\Tests\Integration\Storefront\Framework\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class XmlHttpRequestableInterfaceTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductDetailReadinessCheckTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -20,6 +21,7 @@ use Shopware\Storefront\Framework\SystemCheck\ProductDetailReadinessCheck;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductDetailReadinessCheckTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/ProductListingReadinessCheckTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -23,6 +24,7 @@ use Shopware\Storefront\Framework\SystemCheck\ProductListingReadinessCheck;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductListingReadinessCheckTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SalesChannelsReadinessCheckTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\SystemCheck\Check\Status;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('framework')]
 class SalesChannelsReadinessCheckTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/RequestTransformerTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformer as CoreRequestTransformer;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,6 +28,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @phpstan-type SalesChannel array{id: string, name: string, active: bool, languages: array{id: string}[], domains: array{id: string, url: string, languageId: string, currencyId: string, snippetSetId: string}[]}
  */
+#[Package('framework')]
 class RequestTransformerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Routing/ResponseHeaderListenerTest.php
+++ b/tests/integration/Storefront/Framework/Routing/ResponseHeaderListenerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Framework\Routing;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
@@ -13,6 +14,7 @@ use Shopware\Storefront\Framework\Routing\NotFound\NotFoundSubscriber;
 /**
  * @internal
  */
+#[Package('framework')]
 class ResponseHeaderListenerTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
+++ b/tests/integration/Storefront/Framework/Routing/StorefrontRoutingTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RequestTransformer as CoreRequestTransformer;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -30,6 +31,7 @@ use Symfony\Component\Routing\RequestContext;
 /**
  * @internal
  */
+#[Package('framework')]
 #[Group('slow')]
 class StorefrontRoutingTest extends TestCase
 {

--- a/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Seo\SeoUrlGenerator;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -17,6 +18,7 @@ use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 /**
  * @internal
  */
+#[Package('inventory')]
 class ProductPageSeoUrlRouteTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Twig/Extension/SlugifyExtensionTwigFilterTest.php
+++ b/tests/integration/Storefront/Framework/Twig/Extension/SlugifyExtensionTwigFilterTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\Integration\Storefront\Framework\Twig\Extension;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Twig\Loader\ArrayLoader;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class SlugifyExtensionTwigFilterTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
+++ b/tests/integration/Storefront/Framework/Twig/ThumbnailExtensionTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuild
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
@@ -39,6 +40,7 @@ use Twig\Loader\FilesystemLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThumbnailExtensionTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Twig/TwigAppVariableTest.php
+++ b/tests/integration/Storefront/Framework/Twig/TwigAppVariableTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Framework\Twig;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Storefront\Framework\Twig\TwigAppVariable;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class TwigAppVariableTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/AccountOrderPageLoaderTest.php
+++ b/tests/integration/Storefront/Page/Account/AccountOrderPageLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class AccountOrderPageLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/CustomerGroupRegistrationTest.php
+++ b/tests/integration/Storefront/Page/Account/CustomerGroupRegistrationTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class CustomerGroupRegistrationTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
+++ b/tests/integration/Storefront/Page/Account/EditOrderPageTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -29,6 +30,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class EditOrderPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/LoginPageTest.php
+++ b/tests/integration/Storefront/Page/Account/LoginPageTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Account;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
 use Shopware\Storefront\Page\Account\Login\AccountLoginPageLoadedEvent;
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class LoginPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/OrderDetailPageTest.php
+++ b/tests/integration/Storefront/Page/Account/OrderDetailPageTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Page\Account;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * @deprecated tag:v6.8.0 - will be removed
  */
+#[Package('framework')]
 class OrderDetailPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/OrderPageTest.php
+++ b/tests/integration/Storefront/Page/Account/OrderPageTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Account;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Account\Order\AccountOrderPageLoadedEvent;
 use Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class OrderPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/OverviewPageTest.php
+++ b/tests/integration/Storefront/Page/Account/OverviewPageTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Account\Overview\AccountOverviewPageLoadedEvent;
 use Shopware\Storefront\Page\Account\Overview\AccountOverviewPageLoader;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class OverviewPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Account/ProfilePageTest.php
+++ b/tests/integration/Storefront/Page/Account/ProfilePageTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Page\Account;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Account\Profile\AccountProfilePageLoadedEvent;
 use Shopware\Storefront\Page\Account\Profile\AccountProfilePageLoader;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProfilePageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Checkout/CartPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/CartPageTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Gateway\SalesChannel\CheckoutGatewayRouteResponse;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Country\SalesChannel\CountryRoute;
 use Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade;
@@ -22,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class CartPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Checkout/ConfirmPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/ConfirmPageTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Page\Checkout\Confirm\CheckoutConfirmPageLoadedEvent;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ConfirmPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Checkout/FinishPageTest.php
+++ b/tests/integration/Storefront/Page/Checkout/FinishPageTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Storefront\Page\Checkout;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPage;
 use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoadedEvent;
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class FinishPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/ErrorPageTest.php
+++ b/tests/integration/Storefront/Page/ErrorPageTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Cms\CmsPageCollection;
 use Shopware\Core\Content\Cms\DataResolver\FieldConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ErrorPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/GuestWishlistPageTest.php
+++ b/tests/integration/Storefront/Page/GuestWishlistPageTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Page;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Wishlist\GuestWishlistPageLoadedEvent;
 use Shopware\Storefront\Page\Wishlist\GuestWishlistPageLoader;
@@ -12,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class GuestWishlistPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/NavigationPageTest.php
+++ b/tests/integration/Storefront/Page/NavigationPageTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedEvent;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoader;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class NavigationPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
+++ b/tests/integration/Storefront/Page/Product/QuickView/MinimalQuickViewPageTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageCriteriaEvent;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class MinimalQuickViewPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/ProductPageTest.php
+++ b/tests/integration/Storefront/Page/ProductPageTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\ProductException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class ProductPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Page/WishlistPageTest.php
+++ b/tests/integration/Storefront/Page/WishlistPageTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class WishlistPageTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Pagelet/HeaderPageletLoaderTest.php
+++ b/tests/integration/Storefront/Pagelet/HeaderPageletLoaderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageCollection;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('framework')]
 class HeaderPageletLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/Command/ThemeChangeCommandTest.php
+++ b/tests/integration/Storefront/Theme/Command/ThemeChangeCommandTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeChangeCommandTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\Util\StaticFilesystem;
@@ -25,6 +26,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeDumpCommandTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
+++ b/tests/integration/Storefront/Theme/ConfigLoader/DatabaseConfigLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader;
@@ -20,6 +21,7 @@ use Shopware\Storefront\Theme\ThemeCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 class DatabaseConfigLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/Mail/MailThemeIdLoaderTest.php
+++ b/tests/integration/Storefront/Theme/Mail/MailThemeIdLoaderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,6 +15,7 @@ use Shopware\Storefront\Theme\Mail\MailThemeIdLoader;
 /**
  * @internal
  */
+#[Package('framework')]
 class MailThemeIdLoaderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactoryTest.php
+++ b/tests/integration/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactoryTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Theme\StorefrontPluginConfigurat
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Framework\ThemeInterface;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\AbstractStorefrontPluginConfigurationFactory;
@@ -13,6 +14,7 @@ use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConf
 /**
  * @internal
  */
+#[Package('framework')]
 class StorefrontPluginConfigurationFactoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/StorefrontPluginRegistryTest.php
+++ b/tests/integration/Storefront/Theme/StorefrontPluginRegistryTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Theme;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
@@ -11,6 +12,7 @@ use Shopware\Storefront\Theme\StorefrontPluginRegistry;
 /**
  * @internal
  */
+#[Package('framework')]
 class StorefrontPluginRegistryTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Storefront/Theme/Subscriber/PluginLifecycleSubscriberTest.php
+++ b/tests/integration/Storefront/Theme/Subscriber/PluginLifecycleSubscriberTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Theme\Subscriber;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
@@ -27,6 +28,7 @@ use SwagTestPlugin\SwagTestPlugin;
 /**
  * @internal
  */
+#[Package('framework')]
 class PluginLifecycleSubscriberTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/Subscriber/UpdateSubscriberTest.php
+++ b/tests/integration/Storefront/Theme/Subscriber/UpdateSubscriberTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
@@ -20,6 +21,7 @@ use Shopware\Storefront\Theme\ThemeService;
 /**
  * @internal
  */
+#[Package('framework')]
 class UpdateSubscriberTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
@@ -16,12 +16,14 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\ThemeCollection;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeAppLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeCompilerDirectUsageTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerDirectUsageTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInputFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Storefront\Theme\CompilerConfiguration;
 use Shopware\Storefront\Theme\MD5ThemePathBuilder;
@@ -27,6 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeCompilerDirectUsageTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeCompilerEventSubscriberTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerEventSubscriberTest.php
@@ -9,6 +9,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInputFactory;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Event\ThemeCompilerConcatenatedStylesEvent;
@@ -29,6 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeCompilerEventSubscriberTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeCompilerPluginConfigurationTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerPluginConfigurationTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Kernel;
@@ -27,6 +28,7 @@ use Shopware\Tests\Integration\Storefront\Theme\fixtures\SimplePlugin\SimplePlug
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeCompilerPluginConfigurationTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
@@ -50,6 +51,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeCompilerTest extends TestCase
 {
     use AppSystemTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeInheritanceBuilderTest.php
+++ b/tests/integration/Storefront/Theme/ThemeInheritanceBuilderTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Storefront\Theme;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Bundle;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Storefront;
 use Shopware\Storefront\Test\Theme\ThemeRuntimeConfigTestService;
@@ -22,6 +23,7 @@ use Shopware\Tests\Integration\Storefront\Theme\fixtures\ThemeWithoutStorefront\
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeInheritanceBuilderTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleHandlerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
@@ -38,6 +39,7 @@ use Shopware\Tests\Integration\Storefront\Theme\fixtures\SimpleTheme\SimpleTheme
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
+++ b/tests/integration/Storefront/Theme/ThemeLifecycleServiceTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\CloneBehavior;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
@@ -42,6 +43,7 @@ use Shopware\Tests\Integration\Storefront\Theme\fixtures\ThemeWithLabels\ThemeWi
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeLifecycleServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeRuntimeConfigStorageTest.php
+++ b/tests/integration/Storefront/Theme/ThemeRuntimeConfigStorageTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -19,6 +20,7 @@ use Shopware\Storefront\Theme\ThemeRuntimeConfigStorage;
  *
  * @phpstan-import-type ThemeRuntimeConfigArrayOverrides from ThemeRuntimeConfig
  */
+#[Package('framework')]
 class ThemeRuntimeConfigStorageTest extends TestCase
 {
     use DatabaseTransactionBehaviour;

--- a/tests/integration/Storefront/Theme/ThemeTest.php
+++ b/tests/integration/Storefront/Theme/ThemeTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Notification\NotificationService;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -47,6 +48,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 /**
  * @internal
  */
+#[Package('framework')]
 class ThemeTest extends TestCase
 {
     use IntegrationTestBehaviour;


### PR DESCRIPTION
### 1. Why is this change necessary?

494 of 953 integration test classes carry no `#[Package]` attribute, so failing CI jobs — especially the nightlies — can't be routed to the owning domain team without guessing from paths.

### 2. What does this change do, exactly?

- Adds `#[Package('…')]` to every integration test class that was missing it (494 files, insertion-only). The value is the dominant `#[Package]` marker of the `src/` subtree mirrored by the test's path (walking up path segments when a test directory has no direct src counterpart); tests carrying `#[CoversClass]` use the covered class's package directly.
- Distribution of assigned values: framework 370, discovery 54, inventory 50, fundamentals@framework 5, after-sales 5, data-services 4, checkout 4, fundamentals@discovery 1, fundamentals@after-sales 1.

Verified with cs-fixer and a full-tree PHPStan pass over `tests/integration` (the only findings are pre-existing local SwagCommercial decorator noise that does not occur in CI), plus a smoke run of annotated suites.

### 3. Describe each step to reproduce the issue or behaviour.

1. `grep -rL "#[Package(" tests/integration --include='*Test.php' | wc -l` on trunk → 494.
2. With this change → 0.

### 4. Please link to the relevant issues (if any).

- closes #18429

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
