### PR TITLE
test: add the package attribute to all migration and devops test classes

### DIFF
--- a/tests/devops/Core/DefaultsTest.php
+++ b/tests/devops/Core/DefaultsTest.php
@@ -5,10 +5,12 @@ namespace Shopware\Tests\DevOps\Core;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DefaultsTest extends TestCase
 {
     private const CURRENT_AMOUNT_OF_DEFAULT_CONSTANTS = 11;

--- a/tests/devops/Core/DevOps/ADRValidationTest.php
+++ b/tests/devops/Core/DevOps/ADRValidationTest.php
@@ -3,11 +3,13 @@
 namespace Shopware\Tests\DevOps\Core\DevOps;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Finder\Finder;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ADRValidationTest extends TestCase
 {
     public function testADRValidation(): void

--- a/tests/devops/Core/DevOps/Docs/Command/App/DocsAppEventCommandTest.php
+++ b/tests/devops/Core/DevOps/Docs/Command/App/DocsAppEventCommandTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\Docs\Command\App;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Docs\App\DocsAppEventCommand;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DocsAppEventCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/devops/Core/DevOps/Docs/Command/Script/ScriptReferenceGeneratorTest.php
+++ b/tests/devops/Core/DevOps/Docs/Command/Script/ScriptReferenceGeneratorTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Docs\Script\ScriptReferenceDataCollector;
 use Shopware\Core\DevOps\Docs\Script\ScriptReferenceGenerator;
 use Shopware\Core\DevOps\Docs\Script\ScriptReferenceGeneratorCommand;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class ScriptReferenceGeneratorTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AbstractClassUsageRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AbstractClassUsageRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AbstractClassUsageRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<AbstractClassUsageRule>
  */
+#[Package('framework')]
 class AbstractClassUsageRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsHelperTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsHelperTest.php
@@ -5,10 +5,12 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsHelper;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class AclValidPermissionsHelperTest extends TestCase
 {
     public function testAclKeyValid(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsInMethodRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsInMethodRuleTest.php
@@ -7,12 +7,14 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsHelper;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsInMethodRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<AclValidPermissionsInMethodRule>
  */
+#[Package('framework')]
 class AclValidPermissionsInMethodRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsInRouteAttributesRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AclValidPermissionsInRouteAttributesRuleTest.php
@@ -7,12 +7,14 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsHelper;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AclValidPermissionsInRouteAttributesRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<AclValidPermissionsInRouteAttributesRule>
  */
+#[Package('framework')]
 class AclValidPermissionsInRouteAttributesRuleTest extends RuleTestCase
 {
     private static ?AclValidPermissionsInRouteAttributesRule $rule = null;

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AttributeFinalRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/AttributeFinalRuleTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\AttributeFinalRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<AttributeFinalRule>
  */
+#[Package('framework')]
 class AttributeFinalRuleTest extends RuleTestCase
 {
     public function testFinalAttributeClass(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CodeCoverageIgnoreEvaluationRuleTest.php
@@ -7,12 +7,14 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\CodeCoverageIgnoreEvaluationRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<CodeCoverageIgnoreEvaluationRule>
  */
+#[Package('framework')]
 class CodeCoverageIgnoreEvaluationRuleTest extends RuleTestCase
 {
     private const FIXTURE_DIR = __DIR__ . '/data/CodeCoverageIgnoreEvaluation/';

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversAttributeRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/CoversAttributeRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Configuration;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\CoversAttributeRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<CoversAttributeRule>
  */
+#[Package('framework')]
 class CoversAttributeRuleTest extends RuleTestCase
 {
     public function testAllowsConfiguredUnitTestNamespace(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DALFieldsMustBeRegisteredWithSchemaBuilderTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DALFieldsMustBeRegisteredWithSchemaBuilderTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\DALFieldsMustBeRegisteredWithSchemaBuilder;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<DALFieldsMustBeRegisteredWithSchemaBuilder>
  */
+#[Package('framework')]
 class DALFieldsMustBeRegisteredWithSchemaBuilderTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DeprecatedMethodsThrowDeprecationRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DeprecatedMethodsThrowDeprecationRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<DeprecatedMethodsThrowDeprecationRule>
  */
+#[Package('framework')]
 class DeprecatedMethodsThrowDeprecationRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DomainExceptionRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/DomainExceptionRuleTest.php
@@ -7,12 +7,14 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Configuration;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\DomainExceptionRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<DomainExceptionRule>
  */
+#[Package('framework')]
 class DomainExceptionRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/McpToolResponseTraitRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/McpToolResponseTraitRuleTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\McpToolResponseRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<McpToolResponseRule>
  */
+#[Package('framework')]
 class McpToolResponseTraitRuleTest extends RuleTestCase
 {
     public function testToolExtendingAbstractClassPasses(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/MessagesShouldNotUsePHPStanTypesTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/MessagesShouldNotUsePHPStanTypesTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\MessagesShouldNotUsePHPStanTypes;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<MessagesShouldNotUsePHPStanTypes>
  */
+#[Package('framework')]
 class MessagesShouldNotUsePHPStanTypesTest extends RuleTestCase
 {
     public function testFailsOnAsyncMessageUsingPHPStanType(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/AddColumnRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/AddColumnRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Migratio
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Migration\AddColumnRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<AddColumnRule>
  */
+#[Package('framework')]
 class AddColumnRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Migration/NoDropStatementInUpdateRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Migratio
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Migration\NoDropStatementInUpdateRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<NoDropStatementInUpdateRule>
  */
+#[Package('framework')]
 class NoDropStatementInUpdateRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NameConstantEntityDefinitionTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NameConstantEntityDefinitionTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NameConstantEntityDefinition;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<NameConstantEntityDefinition>
  */
+#[Package('framework')]
 class NameConstantEntityDefinitionTest extends RuleTestCase
 {
     public function testConstantIsPresentButIsNoEntityDefinition(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoDALAutoloadTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoDALAutoloadTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoDALAutoload;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<NoDALAutoload>
  */
+#[Package('framework')]
 class NoDALAutoloadTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoRouteOverrideInDecoratorsRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRouteOverrideInDecoratorsRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<NoRouteOverrideInDecoratorsRule>
  */
+#[Package('framework')]
 class NoRouteOverrideInDecoratorsRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoStaticRuntimeExceptionReturnRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoStaticRuntimeExceptionReturnRuleTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoRuntimeExceptionInDomainExceptionsRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<NoRuntimeExceptionInDomainExceptionsRule>
  */
+#[Package('framework')]
 class NoStaticRuntimeExceptionReturnRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/PropertyNativeTypeRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/PropertyNativeTypeRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\PropertyNativeTypeRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<PropertyNativeTypeRule>
  */
+#[Package('framework')]
 class PropertyNativeTypeRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/PublicServiceDecoratorRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/PublicServiceDecoratorRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\PublicServiceDecoratorRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<PublicServiceDecoratorRule>
  */
+#[Package('framework')]
 class PublicServiceDecoratorRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/RouteScopeRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/RouteScopeRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\RouteScopeRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<RouteScopeRule>
  */
+#[Package('framework')]
 class RouteScopeRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/ServiceDefinitionRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/ServiceDefinitionRuleTest.php
@@ -7,12 +7,14 @@ use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\ServiceDefinitionCollector;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\ServiceDefinitionRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<ServiceDefinitionRule>
  */
+#[Package('framework')]
 class ServiceDefinitionRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/ShopwareNamespaceStyleRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/ShopwareNamespaceStyleRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\ShopwareNamespaceStyleRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<ShopwareNamespaceStyleRule>
  */
+#[Package('framework')]
 class ShopwareNamespaceStyleRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Symplify/NoReturnSetterMethodWithFluentSettersRule/NoReturnSetterMethodWithFluentSettersRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Symplify/NoReturnSetterMethodWithFluentSettersRule/NoReturnSetterMethodWithFluentSettersRuleTest.php
@@ -7,6 +7,7 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Symplify\NoReturnSetterMethodWithFluentSettersRule;
+use Shopware\Core\Framework\Log\Package;
 use Symplify\PHPStanRules\Rules\NoReturnSetterMethodRule;
 
 /**
@@ -16,6 +17,7 @@ use Symplify\PHPStanRules\Rules\NoReturnSetterMethodRule;
  *
  * @internal
  */
+#[Package('framework')]
 class NoReturnSetterMethodWithFluentSettersRuleTest extends RuleTestCase
 {
     /**

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/TaggedServiceContractRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/TaggedServiceContractRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\TaggedServiceContractRule;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\TaggedServiceContractRule\Contract;
 use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\TaggedServiceContractRule\WrongContract;
 
@@ -14,6 +15,7 @@ use Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\data\TaggedSer
  *
  * @extends RuleTestCase<TaggedServiceContractRule>
  */
+#[Package('framework')]
 class TaggedServiceContractRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/DataProviderRowArityRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/DataProviderRowArityRuleTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Tests;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\DataProviderRowArityRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<DataProviderRowArityRule>
  */
+#[Package('framework')]
 class DataProviderRowArityRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/MockingSimpleObjectsNotAllowedRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/MockingSimpleObjectsNotAllowedRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Tests;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\MockingSimpleObjectsNotAllowedRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<MockingSimpleObjectsNotAllowedRule>
  */
+#[Package('framework')]
 class MockingSimpleObjectsNotAllowedRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoAssertsOnObjectsRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoAssertsOnObjectsRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Tests;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\NoAssertsOnObjectsRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends  RuleTestCase<NoAssertsOnObjectsRule>
  */
+#[Package('framework')]
 class NoAssertsOnObjectsRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoDependsWithDataProviderRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoDependsWithDataProviderRuleTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Tests;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\NoDependsWithDataProviderRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<NoDependsWithDataProviderRule>
  */
+#[Package('framework')]
 class NoDependsWithDataProviderRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoExpectExceptionMessageRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/NoExpectExceptionMessageRuleTest.php
@@ -7,12 +7,14 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Rules\Tests;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\NoExpectExceptionMessageRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<NoExpectExceptionMessageRule>
  */
+#[Package('framework')]
 class NoExpectExceptionMessageRuleTest extends RuleTestCase
 {
     public function testRule(): void

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/TestRuleHelperTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/Tests/TestRuleHelperTest.php
@@ -6,10 +6,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\TestReflectionClassInterface;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Tests\TestRuleHelper;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class TestRuleHelperTest extends TestCase
 {
     #[DataProvider('classProvider')]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/UseCLIContextRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/UseCLIContextRuleTest.php
@@ -6,12 +6,14 @@ use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\UseCLIContextRule;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  *
  * @extends RuleTestCase<UseCLIContextRule>
  */
+#[Package('framework')]
 class UseCLIContextRuleTest extends RuleTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Type/CollectionHasSpecifyingExtensionTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Type/CollectionHasSpecifyingExtensionTest.php
@@ -4,10 +4,12 @@ namespace Shopware\Tests\DevOps\Core\DevOps\StaticAnalyse\PHPStan\Type;
 
 use PHPStan\Testing\TypeInferenceTestCase;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class CollectionHasSpecifyingExtensionTest extends TypeInferenceTestCase
 {
     #[RunInSeparateProcess]

--- a/tests/devops/Core/Framework/Api/ApiAliasTest.php
+++ b/tests/devops/Core/Framework/Api/ApiAliasTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Aggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -15,6 +16,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 /**
  * @internal
  */
+#[Package('framework')]
 class ApiAliasTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/devops/Core/Framework/Mcp/McpDiscoveryScanDirsConfigTest.php
+++ b/tests/devops/Core/Framework/Mcp/McpDiscoveryScanDirsConfigTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\DevOps\Core\Framework\Mcp;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Framework;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Storefront;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,7 @@ use Symfony\Component\Filesystem\Path;
  *
  * @internal
  */
+#[Package('framework')]
 class McpDiscoveryScanDirsConfigTest extends TestCase
 {
     /**

--- a/tests/devops/Core/Installer/InstallerKernelTest.php
+++ b/tests/devops/Core/Installer/InstallerKernelTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\DevOps\Core\Installer;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Installer\Installer;
 use Shopware\Core\Installer\InstallerKernel;
@@ -15,6 +16,7 @@ use Symfony\Bundle\TwigBundle\TwigBundle;
 /**
  * @internal
  */
+#[Package('framework')]
 class InstallerKernelTest extends TestCase
 {
     use EnvTestBehaviour;

--- a/tests/devops/Core/Migration/MigrationIndexerSafeguardTest.php
+++ b/tests/devops/Core/Migration/MigrationIndexerSafeguardTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\DevOps\Core\Migration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationIndexerSafeguard;
 use Shopware\Core\Test\Assert\StrictEmpty;
 
@@ -27,6 +28,7 @@ use Shopware\Core\Test\Assert\StrictEmpty;
  *
  * @internal
  */
+#[Package('framework')]
 class MigrationIndexerSafeguardTest extends TestCase
 {
     /**

--- a/tests/devops/Core/Test/DataAbstractionLayerValidateCommandTest.php
+++ b/tests/devops/Core/Test/DataAbstractionLayerValidateCommandTest.php
@@ -4,12 +4,14 @@ namespace Shopware\Tests\DevOps\Core\Test;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\Command\DataAbstractionLayerValidateCommand;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
  * @internal
  */
+#[Package('framework')]
 class DataAbstractionLayerValidateCommandTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/migration/Core/V6_6/Migration1663402950SetDoubleOptinCustomerActiveTest.php
+++ b/tests/migration/Core/V6_6/Migration1663402950SetDoubleOptinCustomerActiveTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1663402950SetDoubleOptinCustomerActive;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1663402950SetDoubleOptinCustomerActive::class)]
 class Migration1663402950SetDoubleOptinCustomerActiveTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1673249981MigrateIsNewCustomerRuleTest.php
+++ b/tests/migration/Core/V6_6/Migration1673249981MigrateIsNewCustomerRuleTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1673249981MigrateIsNewCustomerRule;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1673249981MigrateIsNewCustomerRule::class)]
 class Migration1673249981MigrateIsNewCustomerRuleTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1673964565MigrateToReferencedColumnsTest.php
+++ b/tests/migration/Core/V6_6/Migration1673964565MigrateToReferencedColumnsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1673964565MigrateToReferencedColumns;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1673964565MigrateToReferencedColumns;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1673964565MigrateToReferencedColumns::class)]
 class Migration1673964565MigrateToReferencedColumnsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1676367607RemoveIntegrationWriteAccessColumnTest.php
+++ b/tests/migration/Core/V6_6/Migration1676367607RemoveIntegrationWriteAccessColumnTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1676367607RemoveIntegrationWriteAccessColumn;
@@ -11,6 +12,7 @@ use Shopware\Core\Migration\V6_6\Migration1676367607RemoveIntegrationWriteAccess
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1676367607RemoveIntegrationWriteAccessColumn::class)]
 class Migration1676367607RemoveIntegrationWriteAccessColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1679581138RemoveAssociationFieldsTest.php
+++ b/tests/migration/Core/V6_6/Migration1679581138RemoveAssociationFieldsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1679581138RemoveAssociationFields;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1679581138RemoveAssociationFields;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1679581138RemoveAssociationFields::class)]
 class Migration1679581138RemoveAssociationFieldsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1691662140MigrateAvailableStockTest.php
+++ b/tests/migration/Core/V6_6/Migration1691662140MigrateAvailableStockTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1691662140MigrateAvailableStock;
@@ -14,6 +15,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1691662140MigrateAvailableStock::class)]
 class Migration1691662140MigrateAvailableStockTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1696262484AddDefaultSendMailOptionsTest.php
+++ b/tests/migration/Core/V6_6/Migration1696262484AddDefaultSendMailOptionsTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1696262484AddDefaultSendMailOptions;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_6\Migration1696262484AddDefaultSendMailOptions;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1696262484AddDefaultSendMailOptions::class)]
 class Migration1696262484AddDefaultSendMailOptionsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1697788982ChangeColumnAvailabilityRuleIdFromShippingMethodToNullableTest.php
+++ b/tests/migration/Core/V6_6/Migration1697788982ChangeColumnAvailabilityRuleIdFromShippingMethodToNullableTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1697788982ChangeColumnAvailabilityRuleIdFromShippingMethodToNullable;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1697788982ChangeColumnAvailabilityRule
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1697788982ChangeColumnAvailabilityRuleIdFromShippingMethodToNullable::class)]
 class Migration1697788982ChangeColumnAvailabilityRuleIdFromShippingMethodToNullableTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1700746995ReplaceSortingOptionKeysWithSortingOptionIdsTest.php
+++ b/tests/migration/Core/V6_6/Migration1700746995ReplaceSortingOptionKeysWithSortingOptionIdsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1700746995ReplaceSortingOptionKeysWithSortingOptionIds;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1700746995ReplaceSortingOptionKeysWithSortingOptionIds::class)]
 class Migration1700746995ReplaceSortingOptionKeysWithSortingOptionIdsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1701677136RemovePluginChangelogFieldTest.php
+++ b/tests/migration/Core/V6_6/Migration1701677136RemovePluginChangelogFieldTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1701677136RemovePluginChangelogField;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1701677136RemovePluginChangelogField;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1701677136RemovePluginChangelogField::class)]
 class Migration1701677136RemovePluginChangelogFieldTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
+++ b/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1701688920FixDownloadLinkMail;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1701688920FixDownloadLinkMail::class)]
 class Migration1701688920FixDownloadLinkMailTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1702982372FixProductCrossSellingSortByPriceTest.php
+++ b/tests/migration/Core/V6_6/Migration1702982372FixProductCrossSellingSortByPriceTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1702982372FixProductCrossSellingSortByPrice;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_6\Migration1702982372FixProductCrossSellingSortBy
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1702982372FixProductCrossSellingSortByPrice::class)]
 class Migration1702982372FixProductCrossSellingSortByPriceTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1707064042CartRemoveFKTest.php
+++ b/tests/migration/Core/V6_6/Migration1707064042CartRemoveFKTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1707064042CartRemoveFK;
@@ -11,6 +12,7 @@ use Shopware\Core\Migration\V6_6\Migration1707064042CartRemoveFK;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1707064042CartRemoveFK::class)]
 class Migration1707064042CartRemoveFKTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1707807389ChangeAvailableDefaultTest.php
+++ b/tests/migration/Core/V6_6/Migration1707807389ChangeAvailableDefaultTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1707807389ChangeAvailableDefault;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1707807389ChangeAvailableDefault;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1707807389ChangeAvailableDefault::class)]
 class Migration1707807389ChangeAvailableDefaultTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlotsTest.php
+++ b/tests/migration/Core/V6_6/Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlotsTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlots;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlots::class)]
 class Migration1711418838ReplaceSortingOptionKeysWithSortingOptionIdsInCmsSlotsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1711461572ReplaceSortingOptionKeysWithSortingOptionIdsTest.php
+++ b/tests/migration/Core/V6_6/Migration1711461572ReplaceSortingOptionKeysWithSortingOptionIdsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1711461572ReplaceSortingOptionKeysWithSortingOptionIds;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1711461572ReplaceSortingOptionKeysWithSortingOptionIds::class)]
 class Migration1711461572ReplaceSortingOptionKeysWithSortingOptionIdsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1711461579FixDefaultMailFooterTest.php
+++ b/tests/migration/Core/V6_6/Migration1711461579FixDefaultMailFooterTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1711461579FixDefaultMailFooter;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1711461579FixDefaultMailFooter::class)]
 class Migration1711461579FixDefaultMailFooterTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1711461580SetSystemDefaultForDefaultMailFooterTest.php
+++ b/tests/migration/Core/V6_6/Migration1711461580SetSystemDefaultForDefaultMailFooterTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1711461580SetSystemDefaultForDefaultMailFooter;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1711461580SetSystemDefaultForDefaultMailFooter::class)]
 class Migration1711461580SetSystemDefaultForDefaultMailFooterTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1713345551AddAppManagedColumnTest.php
+++ b/tests/migration/Core/V6_6/Migration1713345551AddAppManagedColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1713345551AddAppManagedColumn;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1713345551AddAppManagedColumn;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1713345551AddAppManagedColumn::class)]
 class Migration1713345551AddAppManagedColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
+++ b/tests/migration/Core/V6_6/Migration1714659357CanonicalProductVersionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1714659357CanonicalProductVersion;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1714659357CanonicalProductVersion;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1714659357CanonicalProductVersion::class)]
 class Migration1714659357CanonicalProductVersionTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1715081559AdjustSentMailActionOnReviewSentTest.php
+++ b/tests/migration/Core/V6_6/Migration1715081559AdjustSentMailActionOnReviewSentTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1715081559AdjustSentMailActionOnReviewSent;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1715081559AdjustSentMailActionOnReviewSent::class)]
 class Migration1715081559AdjustSentMailActionOnReviewSentTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1716196653AddTechnicalNameToImportExportProfileTest.php
+++ b/tests/migration/Core/V6_6/Migration1716196653AddTechnicalNameToImportExportProfileTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_6\Migration1716196653AddTechnicalNameToImportExpo
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1716196653AddTechnicalNameToImportExportProfile::class)]
 class Migration1716196653AddTechnicalNameToImportExportProfileTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1716285861AddAppSourceTypeTest.php
+++ b/tests/migration/Core/V6_6/Migration1716285861AddAppSourceTypeTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1716285861AddAppSourceType;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1716285861AddAppSourceType;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1716285861AddAppSourceType::class)]
 class Migration1716285861AddAppSourceTypeTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1716968180AddAppSourceConfigTest.php
+++ b/tests/migration/Core/V6_6/Migration1716968180AddAppSourceConfigTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1716968180AddAppSourceConfig;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1716968180AddAppSourceConfig;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1716968180AddAppSourceConfig::class)]
 class Migration1716968180AddAppSourceConfigTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStornoTest.php
+++ b/tests/migration/Core/V6_6/Migration1717601705AddIntraCommunityLabelDocumentConfigToStornoTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1717601705AddIntraCommunityLabelDocumentConfigToStorno::class)]
 class Migration1717601705AddIntraCommunityLabelDocumentConfigToStornoTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1718615305AddEuToCountryTableTest.php
+++ b/tests/migration/Core/V6_6/Migration1718615305AddEuToCountryTableTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1718615305AddEuToCountryTable;
@@ -15,6 +16,7 @@ use Shopware\Core\Migration\V6_6\Migration1718615305AddEuToCountryTable;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1718615305AddEuToCountryTable::class)]
 class Migration1718615305AddEuToCountryTableTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNoteTest.php
+++ b/tests/migration/Core/V6_6/Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNoteTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNote::class)]
 class Migration1718635021AddIntraCommunityLabelDocumentConfigToCreditNoteTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1729843381AddDefaultSettingConfigValueForReviewListingPerPageTest.php
+++ b/tests/migration/Core/V6_6/Migration1729843381AddDefaultSettingConfigValueForReviewListingPerPageTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_6\Migration1729843381AddDefaultSettingConfigValueForReviewListingPerPage;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_6\Migration1729843381AddDefaultSettingConfigValue
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1729843381AddDefaultSettingConfigValueForReviewListingPerPage::class)]
 class Migration1729843381AddDefaultSettingConfigValueForReviewListingPerPageTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1730059142AddNewSitemapConfigForExcludingHiddenProductsTest.php
+++ b/tests/migration/Core/V6_6/Migration1730059142AddNewSitemapConfigForExcludingHiddenProductsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1730059142AddNewSitemapConfigForExcludingHiddenProducts;
 use Shopware\Tests\Migration\MigrationTestTrait;
@@ -12,6 +13,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1730059142AddNewSitemapConfigForExcludingHiddenProducts::class)]
 class Migration1730059142AddNewSitemapConfigForExcludingHiddenProductsTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1735112885AddDefaultSearchResultSortingTest.php
+++ b/tests/migration/Core/V6_6/Migration1735112885AddDefaultSearchResultSortingTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_6\Migration1735112885AddDefaultSearchResultSorting;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1735112885AddDefaultSearchResultSorting::class)]
 class Migration1735112885AddDefaultSearchResultSortingTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1736824370MigrationMailTemplateForDocumentTest.php
+++ b/tests/migration/Core/V6_6/Migration1736824370MigrationMailTemplateForDocumentTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_6\Migration1736824370MigrationMailTemplateForDocument;
@@ -16,6 +17,7 @@ use Shopware\Core\Migration\V6_6\Migration1736824370MigrationMailTemplateForDocu
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1736824370MigrationMailTemplateForDocument::class)]
 class Migration1736824370MigrationMailTemplateForDocumentTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfigTest.php
+++ b/tests/migration/Core/V6_6/Migration1736831335AddGenerateDocumentTypesForDocumentConfigTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Document\Service\HtmlRenderer;
 use Shopware\Core\Checkout\Document\Service\PdfRenderer;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_6\Migration1736831335AddGenerateDocumentTypesForDocumentConfig;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_6\Migration1736831335AddGenerateDocumentTypesForD
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1736831335AddGenerateDocumentTypesForDocumentConfig::class)]
 class Migration1736831335AddGenerateDocumentTypesForDocumentConfigTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1736866790AddDocumentA11yMediaFileIdForDocumentTableTest.php
+++ b/tests/migration/Core/V6_6/Migration1736866790AddDocumentA11yMediaFileIdForDocumentTableTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1736866790AddDocumentA11yMediaFileIdForDocumentTable;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1736866790AddDocumentA11yMediaFileIdFo
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1736866790AddDocumentA11yMediaFileIdForDocumentTable::class)]
 class Migration1736866790AddDocumentA11yMediaFileIdForDocumentTableTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_6\Migration1738661307AddMediaIndices;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1738661307AddMediaIndices;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1738661307AddMediaIndices::class)]
 class Migration1738661307AddMediaIndicesTest extends TestCase
 {

--- a/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
+++ b/tests/migration/Core/V6_6/Migration1776803396RegisterProductIndexerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_6\Migration1776803396RegisterProductIndexer;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_6\Migration1776803396RegisterProductIndexer;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1776803396RegisterProductIndexer::class)]
 class Migration1776803396RegisterProductIndexerTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1720603803RemoveDefaultPaymentMethodFlowsTest.php
+++ b/tests/migration/Core/V6_7/Migration1720603803RemoveDefaultPaymentMethodFlowsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1720603803RemoveDefaultPaymentMethodFl
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1720603803RemoveDefaultPaymentMethodFlows::class)]
 class Migration1720603803RemoveDefaultPaymentMethodFlowsTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1720603803RemoveDefaultPaymentMethodRuleTest.php
+++ b/tests/migration/Core/V6_7/Migration1720603803RemoveDefaultPaymentMethodRuleTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_7\Migration1720603803RemoveDefaultPaymentMethodRule;
@@ -13,6 +14,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1720603803RemoveDefaultPaymentMethodRule::class)]
 class Migration1720603803RemoveDefaultPaymentMethodRuleTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1720610755RemoveDefaultPaymentMethodFromCustomerTest.php
+++ b/tests/migration/Core/V6_7/Migration1720610755RemoveDefaultPaymentMethodFromCustomerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Util\Database\TableHelper;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_7\Migration1720610755RemoveDefaultPaymentMethodFr
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1720610755RemoveDefaultPaymentMethodFromCustomer::class)]
 class Migration1720610755RemoveDefaultPaymentMethodFromCustomerTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1726135997CreateMessengerStatsTableTest.php
+++ b/tests/migration/Core/V6_7/Migration1726135997CreateMessengerStatsTableTest.php
@@ -7,6 +7,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1726135997CreateMessengerStatsTable;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_7\Migration1726135997CreateMessengerStatsTable;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1726135997CreateMessengerStatsTable::class)]
 class Migration1726135997CreateMessengerStatsTableTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1733136208AddH1ToCmsCategoryListingTest.php
+++ b/tests/migration/Core/V6_7/Migration1733136208AddH1ToCmsCategoryListingTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_7\Migration1733136208AddH1ToCmsCategoryListing;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1733136208AddH1ToCmsCategoryListing;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1733136208AddH1ToCmsCategoryListing::class)]
 class Migration1733136208AddH1ToCmsCategoryListingTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1739197440ChangeCmsBlockDefaultMarginTest.php
+++ b/tests/migration/Core/V6_7/Migration1739197440ChangeCmsBlockDefaultMarginTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\Migration\V6_7\Migration1739197440ChangeCmsBlockDefaultMargin;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(Migration1739197440ChangeCmsBlockDefaultMargin::class)]
 class Migration1739197440ChangeCmsBlockDefaultMarginTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1749644517AddListingVariantNameSystemConfigOptionTest.php
+++ b/tests/migration/Core/V6_7/Migration1749644517AddListingVariantNameSystemConfigOptionTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1749644517AddListingVariantNameSystemConfigOption;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1749644517AddListingVariantNameSystemConfigOption::class)]
 class Migration1749644517AddListingVariantNameSystemConfigOptionTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068709FixCustomerAddressFirstNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068709FixCustomerAddressFirstNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068709FixCustomerAddressFirstNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068709FixCustomerAddressFirstNameL
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068709FixCustomerAddressFirstNameLength::class)]
 class Migration1756068709FixCustomerAddressFirstNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068710FixCustomerAddressLastNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068710FixCustomerAddressLastNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068710FixCustomerAddressLastNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068710FixCustomerAddressLastNameLe
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068710FixCustomerAddressLastNameLength::class)]
 class Migration1756068710FixCustomerAddressLastNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068711FixOrderAddressFirstNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068711FixOrderAddressFirstNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068711FixOrderAddressFirstNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068711FixOrderAddressFirstNameLeng
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068711FixOrderAddressFirstNameLength::class)]
 class Migration1756068711FixOrderAddressFirstNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068712FixOrderAddressLastNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068712FixOrderAddressLastNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068712FixOrderAddressLastNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068712FixOrderAddressLastNameLengt
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068712FixOrderAddressLastNameLength::class)]
 class Migration1756068712FixOrderAddressLastNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
+++ b/tests/migration/Core/V6_7/Migration1756305375AddCategoriesIndexToProductTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756305375AddCategoriesIndexToProduct;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1756305375AddCategoriesIndexToProduct;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1756305375AddCategoriesIndexToProduct::class)]
 class Migration1756305375AddCategoriesIndexToProductTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1760438732AddConsumedToPaymentTokenTest.php
+++ b/tests/migration/Core/V6_7/Migration1760438732AddConsumedToPaymentTokenTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1760438732AddConsumedToPaymentToken;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1760438732AddConsumedToPaymentToken;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1760438732AddConsumedToPaymentToken::class)]
 class Migration1760438732AddConsumedToPaymentTokenTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
+++ b/tests/migration/Core/V6_7/Migration1761739065IncreaseProductWeightPrecisionTest.php
@@ -5,12 +5,14 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_7\Migration1761739065IncreaseProductWeightPrecision;
 
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1761739065IncreaseProductWeightPrecision::class)]
 class Migration1761739065IncreaseProductWeightPrecisionTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1762356839AddInternalCommentToStateMachineHistoryTest.php
+++ b/tests/migration/Core/V6_7/Migration1762356839AddInternalCommentToStateMachineHistoryTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1762356839AddInternalCommentToStateMachineHistory;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1762356839AddInternalCommentToStateMac
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1762356839AddInternalCommentToStateMachineHistory::class)]
 class Migration1762356839AddInternalCommentToStateMachineHistoryTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
+++ b/tests/migration/Core/V6_7/Migration1763125891AddProductTypeColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1763125891AddProductTypeColumn;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1763125891AddProductTypeColumn;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1763125891AddProductTypeColumn::class)]
 class Migration1763125891AddProductTypeColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1763125902AddOrderLineItemProductTypePayloadTest.php
+++ b/tests/migration/Core/V6_7/Migration1763125902AddOrderLineItemProductTypePayloadTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Util\Json;
@@ -16,6 +17,7 @@ use Shopware\Core\Migration\V6_7\Migration1763125902AddOrderLineItemProductTypeP
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1763125902AddOrderLineItemProductTypePayload::class)]
 class Migration1763125902AddOrderLineItemProductTypePayloadTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1763316536ChangeProductManufacturerLinkTest.php
+++ b/tests/migration/Core/V6_7/Migration1763316536ChangeProductManufacturerLinkTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -17,6 +18,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1763316536ChangeProductManufacturerLink::class)]
 class Migration1763316536ChangeProductManufacturerLinkTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1765205483AddTrackOffcanvasCartToAnalyticsTest.php
+++ b/tests/migration/Core/V6_7/Migration1765205483AddTrackOffcanvasCartToAnalyticsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1765205483AddTrackOffcanvasCartToAnalytics;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1765205483AddTrackOffcanvasCartToAnaly
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1765205483AddTrackOffcanvasCartToAnalytics::class)]
 class Migration1765205483AddTrackOffcanvasCartToAnalyticsTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1765376847SetDefaultSystemConfigLoadPreviewsOnSearchTest.php
+++ b/tests/migration/Core/V6_7/Migration1765376847SetDefaultSystemConfigLoadPreviewsOnSearchTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1765376847SetDefaultSystemConfigLoadPreviewsOnSearch;
@@ -13,6 +14,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1765376847SetDefaultSystemConfigLoadPreviewsOnSearch::class)]
 class Migration1765376847SetDefaultSystemConfigLoadPreviewsOnSearchTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1768986102AddInternalColumnToProductStreamTest.php
+++ b/tests/migration/Core/V6_7/Migration1768986102AddInternalColumnToProductStreamTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1768986102AddInternalColumnToProductStream;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1768986102AddInternalColumnToProductSt
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1768986102AddInternalColumnToProductStream::class)]
 class Migration1768986102AddInternalColumnToProductStreamTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1772098113AddEnhancedConversionsToAnalyticsTest.php
+++ b/tests/migration/Core/V6_7/Migration1772098113AddEnhancedConversionsToAnalyticsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1772098113AddEnhancedConversionsToAnalytics;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1772098113AddEnhancedConversionsToAnal
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(Migration1772098113AddEnhancedConversionsToAnalytics::class)]
 class Migration1772098113AddEnhancedConversionsToAnalyticsTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1773329152AddAgenticAiSalesChannelTypeTest.php
+++ b/tests/migration/Core/V6_7/Migration1773329152AddAgenticAiSalesChannelTypeTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1773329152AddAgenticAiSalesChannelType;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1773329152AddAgenticAiSalesChannelType::class)]
 class Migration1773329152AddAgenticAiSalesChannelTypeTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1773824493AddProviderColumnToProductExportTest.php
+++ b/tests/migration/Core/V6_7/Migration1773824493AddProviderColumnToProductExportTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1773824493AddProviderColumnToProductExport;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1773824493AddProviderColumnToProductEx
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1773824493AddProviderColumnToProductExport::class)]
 class Migration1773824493AddProviderColumnToProductExportTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1773826242RenameAgenticCommerceSalesChannelTypeTest.php
+++ b/tests/migration/Core/V6_7/Migration1773826242RenameAgenticCommerceSalesChannelTypeTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1773826242RenameAgenticCommerceSalesChannelType;
@@ -14,6 +15,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1773826242RenameAgenticCommerceSalesChannelType::class)]
 class Migration1773826242RenameAgenticCommerceSalesChannelTypeTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1773829000MigrateLineItemProductStatesRuleConditionTest.php
+++ b/tests/migration/Core/V6_7/Migration1773829000MigrateLineItemProductStatesRuleConditionTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_7\Migration1773829000MigrateLineItemProductStates
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1773829000MigrateLineItemProductStatesRuleCondition::class)]
 class Migration1773829000MigrateLineItemProductStatesRuleConditionTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1773829001MigrateProductStreamProductStatesFilterTest.php
+++ b/tests/migration/Core/V6_7/Migration1773829001MigrateProductStreamProductStatesFilterTest.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\Migration\V6_7\Migration1773829001MigrateProductStreamProductS
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1773829001MigrateProductStreamProductStatesFilter::class)]
 class Migration1773829001MigrateProductStreamProductStatesFilterTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
+++ b/tests/migration/Core/V6_7/Migration1774345867AddProductOpenGraphFieldsTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1774345867AddProductOpenGraphFields;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1774345867AddProductOpenGraphFields;
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1774345867AddProductOpenGraphFields::class)]
 class Migration1774345867AddProductOpenGraphFieldsTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1775200001IncreaseProductDisplayGroupLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1775200001IncreaseProductDisplayGroupLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1775200001IncreaseProductDisplayGroupL
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1775200001IncreaseProductDisplayGroupLength::class)]
 class Migration1775200001IncreaseProductDisplayGroupLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1775208486AddUniqueIndexToProductCrossSellingAssignedProductsTest.php
+++ b/tests/migration/Core/V6_7/Migration1775208486AddUniqueIndexToProductCrossSellingAssignedProductsTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -18,6 +19,7 @@ use Shopware\Core\Migration\V6_7\Migration1775208486AddUniqueIndexToProductCross
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1775208486AddUniqueIndexToProductCrossSellingAssignedProducts::class)]
 class Migration1775208486AddUniqueIndexToProductCrossSellingAssignedProductsTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1775430000AddDisplayAsGroupToProductStreamTest.php
+++ b/tests/migration/Core/V6_7/Migration1775430000AddDisplayAsGroupToProductStreamTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1775430000AddDisplayAsGroupToProductStream;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1775430000AddDisplayAsGroupToProductSt
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1775430000AddDisplayAsGroupToProductStream::class)]
 class Migration1775430000AddDisplayAsGroupToProductStreamTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1776674347RegisterFlowIndexerForPaymentMethodChangedFlowTest.php
+++ b/tests/migration/Core/V6_7/Migration1776674347RegisterFlowIndexerForPaymentMethodChangedFlowTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_7\Migration1776674347RegisterFlowIndexerForPaymentMethodChangedFlow;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1776674347RegisterFlowIndexerForPaymen
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1776674347RegisterFlowIndexerForPaymentMethodChangedFlow::class)]
 class Migration1776674347RegisterFlowIndexerForPaymentMethodChangedFlowTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1776691515SetDefaultCmsPageIdForCategoriesTest.php
+++ b/tests/migration/Core/V6_7/Migration1776691515SetDefaultCmsPageIdForCategoriesTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1776691515SetDefaultCmsPageIdForCategories;
@@ -17,6 +18,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(Migration1776691515SetDefaultCmsPageIdForCategories::class)]
 class Migration1776691515SetDefaultCmsPageIdForCategoriesTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest.php
+++ b/tests/migration/Core/V6_7/Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1776827954AddExactSubfieldFlagToProductSearchConfigField;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1776827954AddExactSubfieldFlagToProduc
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1776827954AddExactSubfieldFlagToProductSearchConfigField::class)]
 class Migration1776827954AddExactSubfieldFlagToProductSearchConfigFieldTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1776848421RepairDigitalProductTypeTest.php
+++ b/tests/migration/Core/V6_7/Migration1776848421RepairDigitalProductTypeTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1776848421RepairDigitalProductType::class)]
 class Migration1776848421RepairDigitalProductTypeTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1777362745MigrateAgenticCommercePluginConfigTest.php
+++ b/tests/migration/Core/V6_7/Migration1777362745MigrateAgenticCommercePluginConfigTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Migration\V6_7\Migration1777362745MigrateAgenticCommercePluginConfig;
@@ -15,6 +16,7 @@ use Shopware\Tests\Migration\MigrationTestTrait;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(Migration1777362745MigrateAgenticCommercePluginConfig::class)]
 class Migration1777362745MigrateAgenticCommercePluginConfigTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1778573083ConvertCategoryNameBlockToDedicatedElementTest.php
+++ b/tests/migration/Core/V6_7/Migration1778573083ConvertCategoryNameBlockToDedicatedElementTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -15,6 +16,7 @@ use Shopware\Core\Migration\V6_7\Migration1778573083ConvertCategoryNameBlockToDe
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1778573083ConvertCategoryNameBlockToDedicatedElement::class)]
 class Migration1778573083ConvertCategoryNameBlockToDedicatedElementTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1779176196AddFeedLabelToProductExportTest.php
+++ b/tests/migration/Core/V6_7/Migration1779176196AddFeedLabelToProductExportTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1779176196AddFeedLabelToProductExport;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1779176196AddFeedLabelToProductExport;
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(Migration1779176196AddFeedLabelToProductExport::class)]
 class Migration1779176196AddFeedLabelToProductExportTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1780645634AddProductDescriptionTeaserTest.php
+++ b/tests/migration/Core/V6_7/Migration1780645634AddProductDescriptionTeaserTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Migration\MigrationStep;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -14,6 +15,7 @@ use Shopware\Core\Migration\V6_7\Migration1780645634AddProductDescriptionTeaser;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1780645634AddProductDescriptionTeaser::class)]
 class Migration1780645634AddProductDescriptionTeaserTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1743256470RemoveDebitPaymentTest.php
+++ b/tests/migration/Core/V6_8/Migration1743256470RemoveDebitPaymentTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1743256470RemoveDebitPayment::class)]
 class Migration1743256470RemoveDebitPaymentTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1763125892RemoveProductStatesColumnTest.php
+++ b/tests/migration/Core/V6_8/Migration1763125892RemoveProductStatesColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_8;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_8\Migration1763125892RemoveProductStatesColumn;
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1763125892RemoveProductStatesColumn::class)]
 class Migration1763125892RemoveProductStatesColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1763125903RemoveOrderLineItemStatesColumnTest.php
+++ b/tests/migration/Core/V6_8/Migration1763125903RemoveOrderLineItemStatesColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_8;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_8\Migration1763125903RemoveOrderLineItemStatesColumn;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_8\Migration1763125903RemoveOrderLineItemStatesCol
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1763125903RemoveOrderLineItemStatesColumn::class)]
 class Migration1763125903RemoveOrderLineItemStatesColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1769676545RemoveOrderAddressVatIdColumnTest.php
+++ b/tests/migration/Core/V6_8/Migration1769676545RemoveOrderAddressVatIdColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_8;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_8\Migration1769676545RemoveOrderAddressVatIdColumn;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_8\Migration1769676545RemoveOrderAddressVatIdColum
 /**
  * @internal
  */
+#[Package('framework')]
 #[CoversClass(Migration1769676545RemoveOrderAddressVatIdColumn::class)]
 class Migration1769676545RemoveOrderAddressVatIdColumnTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1773829002RemoveRepairedDigitalProductStatesFlagTest.php
+++ b/tests/migration/Core/V6_8/Migration1773829002RemoveRepairedDigitalProductStatesFlagTest.php
@@ -6,12 +6,14 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Storage\MySQLKeyValueStorage;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_8\Migration1773829002RemoveRepairedDigitalProductStatesFlag;
 
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1773829002RemoveRepairedDigitalProductStatesFlag::class)]
 class Migration1773829002RemoveRepairedDigitalProductStatesFlagTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1773829004RegisterProductStreamIndexerTest.php
+++ b/tests/migration/Core/V6_8/Migration1773829004RegisterProductStreamIndexerTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_8;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\IndexerQueuer;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Migration\V6_8\Migration1773829004RegisterProductStreamIndexer;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_8\Migration1773829004RegisterProductStreamIndexer
 /**
  * @internal
  */
+#[Package('inventory')]
 #[CoversClass(Migration1773829004RegisterProductStreamIndexer::class)]
 class Migration1773829004RegisterProductStreamIndexerTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1779977359RemoveMailTemplateTypeTemplateDataColumnTest.php
+++ b/tests/migration/Core/V6_8/Migration1779977359RemoveMailTemplateTypeTemplateDataColumnTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_8;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_8\Migration1779977359RemoveMailTemplateTypeTemplateDataColumn;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_8\Migration1779977359RemoveMailTemplateTypeTempla
 /**
  * @internal
  */
+#[Package('after-sales')]
 #[CoversClass(Migration1779977359RemoveMailTemplateTypeTemplateDataColumn::class)]
 class Migration1779977359RemoveMailTemplateTypeTemplateDataColumnTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

81 of 226 migration test classes and 42 of 55 devops test classes carry no `#[Package]` attribute, so failing CI jobs can't be routed to the owning domain team without guessing from paths.

### 2. What does this change do, exactly?

- Adds `#[Package('…')]` to every migration and devops test class that was missing it (123 files, insertion-only).
- Migration tests derive the value from their `#[CoversClass]` target's package (all 81 carry one); devops tests derive from the mirrored `src/` subtree, defaulting to `framework` for pure tooling tests without a src counterpart.
- Distribution: framework 92, inventory 13, after-sales 7, checkout 6, discovery 5.

Verified with cs-fixer, PHPStan over both trees, and full `--testsuite migration` (631 tests green) and `--testsuite devops` runs — the three devops problems (Commercial decorator, dev-DB schema drift, stale built admin assets) reproduce identically on trunk without this change.

### 3. Describe each step to reproduce the issue or behaviour.

1. `grep -rL "#[Package(" tests/migration tests/devops --include='*Test.php' | wc -l` on trunk → 123.
2. With this change → 0.

### 4. Please link to the relevant issues (if any).

- closes #18430

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
