### PR TITLE
test: add the package attribute to checkout-domain tests

### DIFF
--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -19,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 /**
  * @internal
  */
+#[Package('checkout')]
 class ConvertGuestRouteTest extends TestCase
 {
     use CountryAddToSalesChannelTestBehaviour;

--- a/tests/integration/Core/Checkout/Order/Api/OrderActionControllerTest.php
+++ b/tests/integration/Core/Checkout/Order/Api/OrderActionControllerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Integration\Core\Checkout\Order\Api;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
@@ -11,6 +12,7 @@ use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
 /**
  * @internal
  */
+#[Package('checkout')]
 class OrderActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
+++ b/tests/integration/Core/System/StateMachine/Api/StateMachineActionControllerTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -41,6 +42,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @internal
  */
+#[Package('checkout')]
 class StateMachineActionControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/integration/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -34,6 +35,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('checkout')]
 class StateMachineRegistryTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/migration/Core/V6_7/Migration1756068709FixCustomerAddressFirstNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068709FixCustomerAddressFirstNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068709FixCustomerAddressFirstNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068709FixCustomerAddressFirstNameL
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068709FixCustomerAddressFirstNameLength::class)]
 class Migration1756068709FixCustomerAddressFirstNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068710FixCustomerAddressLastNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068710FixCustomerAddressLastNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068710FixCustomerAddressLastNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068710FixCustomerAddressLastNameLe
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068710FixCustomerAddressLastNameLength::class)]
 class Migration1756068710FixCustomerAddressLastNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068711FixOrderAddressFirstNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068711FixOrderAddressFirstNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068711FixOrderAddressFirstNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068711FixOrderAddressFirstNameLeng
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068711FixOrderAddressFirstNameLength::class)]
 class Migration1756068711FixOrderAddressFirstNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1756068712FixOrderAddressLastNameLengthTest.php
+++ b/tests/migration/Core/V6_7/Migration1756068712FixOrderAddressLastNameLengthTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1756068712FixOrderAddressLastNameLength;
@@ -13,6 +14,7 @@ use Shopware\Core\Migration\V6_7\Migration1756068712FixOrderAddressLastNameLengt
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1756068712FixOrderAddressLastNameLength::class)]
 class Migration1756068712FixOrderAddressLastNameLengthTest extends TestCase
 {

--- a/tests/migration/Core/V6_7/Migration1762356839AddInternalCommentToStateMachineHistoryTest.php
+++ b/tests/migration/Core/V6_7/Migration1762356839AddInternalCommentToStateMachineHistoryTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_7;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Util\Database\TableHelper;
 use Shopware\Core\Migration\V6_7\Migration1762356839AddInternalCommentToStateMachineHistory;
@@ -12,6 +13,7 @@ use Shopware\Core\Migration\V6_7\Migration1762356839AddInternalCommentToStateMac
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1762356839AddInternalCommentToStateMachineHistory::class)]
 class Migration1762356839AddInternalCommentToStateMachineHistoryTest extends TestCase
 {

--- a/tests/migration/Core/V6_8/Migration1743256470RemoveDebitPaymentTest.php
+++ b/tests/migration/Core/V6_8/Migration1743256470RemoveDebitPaymentTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -16,6 +17,7 @@ use Shopware\Core\Test\TestDefaults;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(Migration1743256470RemoveDebitPayment::class)]
 class Migration1743256470RemoveDebitPaymentTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/CartBehaviorTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartBehaviorTest.php
@@ -8,10 +8,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\CheckoutPermissions;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(CartBehavior::class)]
 class CartBehaviorTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Facade/ProductsFacadeTest.php
+++ b/tests/unit/Core/Checkout/Cart/Facade/ProductsFacadeTest.php
@@ -13,12 +13,14 @@ use Shopware\Core\Checkout\Cart\Facade\ProductsFacade;
 use Shopware\Core\Checkout\Cart\Facade\ScriptPriceStubs;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(ProductsFacade::class)]
 class ProductsFacadeTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Cart/Order/OrderConversionContextTest.php
+++ b/tests/unit/Core/Checkout/Cart/Order/OrderConversionContextTest.php
@@ -6,10 +6,12 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Order\OrderConversionContext;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(OrderConversionContext::class)]
 class OrderConversionContextTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/ConvertGuestRouteTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\ConvertGuestRoute;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerEmailUnique;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
@@ -27,6 +28,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(ConvertGuestRoute::class)]
 class ConvertGuestRouteTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/LoginRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/LoginRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
 use Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(LoginRoute::class)]
 class LoginRouteTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -30,6 +31,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(ResetPasswordRoute::class)]
 class ResetPasswordRouteTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Customer/Validation/PasswordValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/PasswordValidationFactoryTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\Checkout\Customer\Validation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Validation\PasswordValidationFactory;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Validator\Constraints\Length;
@@ -13,6 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(PasswordValidationFactory::class)]
 class PasswordValidationFactoryTest extends TestCase
 {

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionRedemptionLockerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Extension\LockExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionRedemptionLocker;
 use Shopware\Core\Checkout\Promotion\PromotionException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Test\Generator;
 use Symfony\Component\Lock\LockFactory;
@@ -19,6 +20,7 @@ use Symfony\Component\Lock\SharedLockInterface;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(PromotionRedemptionLocker::class)]
 class PromotionRedemptionLockerTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/Cart/ProductLineItemValidatorTest.php
+++ b/tests/unit/Core/Content/Product/Cart/ProductLineItemValidatorTest.php
@@ -11,12 +11,14 @@ use Shopware\Core\Checkout\Cart\LineItemFactoryHandler\ProductLineItemFactory;
 use Shopware\Core\Checkout\Cart\PriceDefinitionFactory;
 use Shopware\Core\Content\Product\Cart\ProductCartProcessor;
 use Shopware\Core\Content\Product\Cart\ProductLineItemValidator;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(ProductLineItemValidator::class)]
 class ProductLineItemValidatorTest extends TestCase
 {

--- a/tests/unit/Core/Content/Product/Hook/Pricing/CheapestPriceFacadeTest.php
+++ b/tests/unit/Core/Content/Product/Hook/Pricing/CheapestPriceFacadeTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -34,6 +35,7 @@ use Shopware\Core\Test\Stub\Framework\IdsCollection;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(CheapestPriceFacade::class)]
 class CheapestPriceFacadeTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,6 +15,7 @@ use Twig\Node\Expression\AbstractExpression;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AdapterException::class)]
 class AdapterExceptionTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/InAppPurchaseExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/InAppPurchaseExtensionTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Extension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Extension\InAppPurchaseExtension;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Store\StaticInAppPurchaseFactory;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(InAppPurchaseExtension::class)]
 class InAppPurchaseExtensionTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/CustomSnippetFormatControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Controller\CustomSnippetFormatController;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Tests\Unit\Core\Framework\Api\Controller\Fixtures\BundleWithCustomSnippet\BundleWithCustomSnippet;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,6 +15,7 @@ use Twig\Environment;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(CustomSnippetFormatController::class)]
 class CustomSnippetFormatControllerTest extends TestCase
 {

--- a/tests/unit/Core/Framework/App/Manifest/Xml/Tax/TaxProviderTest.php
+++ b/tests/unit/Core/Framework/App/Manifest/Xml/Tax/TaxProviderTest.php
@@ -7,10 +7,12 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\App\Manifest\Xml\Tax\TaxProvider;
+use Shopware\Core\Framework\Log\Package;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(TaxProvider::class)]
 class TaxProviderTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/Services/ExtensionListingLoaderTest.php
+++ b/tests/unit/Core/Framework/Store/Services/ExtensionListingLoaderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\ExtensionListingLoader;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
@@ -17,6 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(ExtensionListingLoader::class)]
 class ExtensionListingLoaderTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/Services/RetryFailedStoreRequestMiddlewareTest.php
+++ b/tests/unit/Core/Framework/Store/Services/RetryFailedStoreRequestMiddlewareTest.php
@@ -9,11 +9,13 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\RetryFailedStoreRequestMiddleware;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(RetryFailedStoreRequestMiddleware::class)]
 class RetryFailedStoreRequestMiddlewareTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/Services/StoreAppLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Store/Services/StoreAppLifecycleServiceTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\App\Delta\AppConfirmationDeltaProvider;
 use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Services\StoreAppLifecycleService;
 use Shopware\Core\Framework\Store\Services\StoreClient;
 use Shopware\Core\Framework\Store\StoreException;
@@ -19,6 +20,7 @@ use Shopware\Tests\Unit\Core\Framework\App\AppFixture;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(StoreAppLifecycleService::class)]
 class StoreAppLifecycleServiceTest extends TestCase
 {

--- a/tests/unit/Core/Framework/Store/Struct/FrwStateTest.php
+++ b/tests/unit/Core/Framework/Store/Struct/FrwStateTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Unit\Core\Framework\Store\Struct;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Struct\FrwState;
 
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(FrwState::class)]
 class FrwStateTest extends TestCase
 {

--- a/tests/unit/Core/System/StateMachine/StateMachineLockerTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineLockerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateCollection;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\System\StateMachine\StateMachineEntity;
@@ -20,6 +21,7 @@ use Symfony\Component\Lock\Store\InMemoryStore;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(StateMachineLocker::class)]
 #[CoversClass(StateMachineTransitionResult::class)]
 class StateMachineLockerTest extends TestCase

--- a/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
+++ b/tests/unit/Core/System/StateMachine/StateMachineRegistryTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StateMachineStateField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineHistory\StateMachineHistoryCollection;
@@ -40,6 +41,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(StateMachineRegistry::class)]
 #[CoversClass(StateMachineTransitionResult::class)]
 class StateMachineRegistryTest extends TestCase

--- a/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/tests/unit/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -28,6 +28,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -43,6 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(StorefrontCartFacade::class)]
 class StorefrontCartFacadeTest extends TestCase
 {

--- a/tests/unit/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcherTest.php
+++ b/tests/unit/Storefront/Checkout/Payment/BlockedPaymentMethodSwitcherTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRouteResponse;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(BlockedPaymentMethodSwitcher::class)]
 class BlockedPaymentMethodSwitcherTest extends TestCase
 {

--- a/tests/unit/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcherTest.php
+++ b/tests/unit/Storefront/Checkout/Shipping/BlockedShippingMethodSwitcherTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Generator;
@@ -24,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(BlockedShippingMethodSwitcher::class)]
 class BlockedShippingMethodSwitcherTest extends TestCase
 {

--- a/tests/unit/Storefront/Controller/DownloadControllerTest.php
+++ b/tests/unit/Storefront/Controller/DownloadControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\SalesChannel\DownloadRoute;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Controller\DownloadController;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,6 +20,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(DownloadController::class)]
 class DownloadControllerTest extends TestCase
 {

--- a/tests/unit/Storefront/Framework/AffiliateTracking/AffiliateTrackingListenerTest.php
+++ b/tests/unit/Storefront/Framework/AffiliateTracking/AffiliateTrackingListenerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\KernelListenerPriorities;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
 use Shopware\Core\PlatformRequest;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AffiliateTrackingListener::class)]
 class AffiliateTrackingListenerTest extends TestCase
 {

--- a/tests/unit/Storefront/Page/Account/Login/AccountLoginPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Login/AccountLoginPageLoaderTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryDefinition;
@@ -34,6 +35,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AccountLoginPageLoader::class)]
 class AccountLoginPageLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderEditPageLoaderTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\Test\Generator;
@@ -43,6 +44,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AccountEditOrderPageLoader::class)]
 class AccountOrderEditPageLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Page/Account/Order/AccountOrderPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Order/AccountOrderPageLoaderTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
@@ -28,6 +29,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AccountOrderPageLoader::class)]
 class AccountOrderPageLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Page/Account/Overview/AccountOverviewPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Overview/AccountOverviewPageLoaderTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\EventDispatcher\CollectingEventDispatcher;
@@ -32,6 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AccountOverviewPageLoader::class)]
 class AccountOverviewPageLoaderTest extends TestCase
 {

--- a/tests/unit/Storefront/Page/Account/Profile/AccountProfilePageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Account/Profile/AccountProfilePageLoaderTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Salutation\SalesChannel\SalutationRoute;
@@ -32,6 +33,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
+#[Package('checkout')]
 #[CoversClass(AccountProfilePageLoader::class)]
 class AccountProfilePageLoaderTest extends TestCase
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

Test classes without `#[Package]` can't be easily routed to the owning domain team (without checking the source) when CI jobs fail. This is the checkout-domain slice of the repo-wide backfill (split per domain so each team reviews only its own files).

### 2. What does this change do, exactly?

- Adds `#[Package('…')]` to 40 test classes (insertion-only). Values are derived from the covered class's own package (`#[CoversClass]` targets) or, where no covers target exists, from the dominant package marker of the mirrored `src/` subtree.

Verified via cs-fixer, PHPStan, and suite runs on the pre-split branches (#18433/#18434/#18435, superseded by this per-domain split).

### 3. Describe each step to reproduce the issue or behaviour.

1. `grep -rL "#[Package(" <the files of this PR>` on trunk → all listed.
2. With this change → none.

### 4. Please link to the relevant issues (if any).

- relates #18426

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
