### PR TITLE
fix: prevent customer group registration SEO URLs from returning 404

### DIFF
--- a/src/Storefront/Checkout/Customer/CustomerGroupSubscriber.php
+++ b/src/Storefront/Checkout/Customer/CustomerGroupSubscriber.php
@@ -183,6 +183,7 @@ class CustomerGroupSubscriber implements EventSubscriberInterface
                         'routeName' => self::ROUTE_NAME,
                         'pathInfo' => '/customer-group-registration/' . $group->getId(),
                         'isCanonical' => true,
+                        'isDeleted' => false,
                         'seoPathInfo' => '/' . $this->slugify->slugify($title),
                     ];
                 }

--- a/tests/integration/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
+++ b/tests/integration/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Storefront\Checkout\Customer;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
@@ -86,6 +87,41 @@ class CustomerGroupSubscriberTest extends TestCase
         static::assertSame($id, $url->getForeignKey());
         static::assertSame('frontend.account.customer-group-registration.page', $url->getRouteName());
         static::assertSame('test', $url->getSeoPathInfo());
+    }
+
+    public function testUrlsAreNotDeletedForAllAssignedSalesChannels(): void
+    {
+        $salesChannelIds = [
+            $this->createSalesChannel()['id'],
+            $this->createSalesChannel()['id'],
+        ];
+
+        $id = Uuid::randomHex();
+
+        $this->customerGroupRepository->create([
+            [
+                'id' => $id,
+                'name' => 'Test',
+                'registrationActive' => true,
+                'registrationTitle' => 'test',
+                'registrationSalesChannels' => array_map(
+                    static fn (string $salesChannelId): array => ['id' => $salesChannelId],
+                    $salesChannelIds
+                ),
+            ],
+        ], Context::createDefaultContext());
+
+        $urls = $this->getSeoUrlsById($id);
+
+        static::assertCount(2, $urls);
+        static::assertEqualsCanonicalizing(
+            $salesChannelIds,
+            array_values(array_map(static fn (SeoUrlEntity $url): ?string => $url->getSalesChannelId(), $urls->getElements()))
+        );
+
+        foreach ($urls as $url) {
+            static::assertFalse($url->getIsDeleted());
+        }
     }
 
     public function testUrlsAreForHeadlessSalesChannelAreHanldedCorrectly(): void

--- a/tests/unit/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
+++ b/tests/unit/Storefront/Checkout/Customer/CustomerGroupSubscriberTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Checkout\Customer;
+
+use Cocur\Slugify\SlugifyInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroupTranslation\CustomerGroupTranslationCollection;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroupTranslation\CustomerGroupTranslationEntity;
+use Shopware\Core\Content\Seo\SeoUrlPersister;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Storefront\Checkout\Customer\CustomerGroupSubscriber;
+
+/**
+ * @internal
+ */
+#[CoversClass(CustomerGroupSubscriber::class)]
+class CustomerGroupSubscriberTest extends TestCase
+{
+    public function testGeneratedUrlsAreActive(): void
+    {
+        $context = Context::createDefaultContext();
+        $customerGroupId = Uuid::randomHex();
+        $languageId = Uuid::randomHex();
+
+        $language = new LanguageEntity();
+        $language->setId($languageId);
+        $language->setActive(true);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+        $salesChannel->setTypeId(Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
+        $salesChannel->setLanguages(new LanguageCollection([$language]));
+
+        $translation = new CustomerGroupTranslationEntity();
+        $translation->setId(Uuid::randomHex());
+        $translation->setLanguageId($languageId);
+        $translation->setRegistrationTitle('Registration');
+
+        $customerGroup = new CustomerGroupEntity();
+        $customerGroup->setId($customerGroupId);
+        $customerGroup->setRegistrationActive(true);
+        $customerGroup->setRegistrationSalesChannels(new SalesChannelCollection([$salesChannel]));
+        $customerGroup->setTranslations(new CustomerGroupTranslationCollection([$translation]));
+
+        /** @var StaticEntityRepository<CustomerGroupCollection> $customerGroupRepository */
+        $customerGroupRepository = new StaticEntityRepository([new CustomerGroupCollection([$customerGroup])]);
+
+        /** @var StaticEntityRepository<LanguageCollection> $languageRepository */
+        $languageRepository = new StaticEntityRepository([new LanguageCollection([$language])]);
+
+        $persister = $this->createMock(SeoUrlPersister::class);
+        $persister->expects($this->once())
+            ->method('updateSeoUrls')
+            ->with(
+                static::isInstanceOf(Context::class),
+                'frontend.account.customer-group-registration.page',
+                [$customerGroupId],
+                static::callback(static function (iterable $seoUrls): bool {
+                    foreach ($seoUrls as $seoUrl) {
+                        if ($seoUrl['isDeleted'] !== false) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }),
+                static::isInstanceOf(SalesChannelEntity::class)
+            );
+
+        $slugify = static::createStub(SlugifyInterface::class);
+        $slugify->method('slugify')->willReturn('registration');
+
+        $subscriber = new CustomerGroupSubscriber(
+            $customerGroupRepository,
+            static::createStub(EntityRepository::class),
+            $languageRepository,
+            $persister,
+            $slugify
+        );
+
+        /** @var array<string, string> $primaryKey */
+        $primaryKey = ['customerGroupId' => $customerGroupId];
+
+        $subscriber->newSalesChannelAddedToCustomerGroup(new EntityWrittenEvent(
+            'customer_group_registration_sales_channels',
+            [new EntityWriteResult(
+                $primaryKey,
+                [],
+                'customer_group_registration_sales_channels',
+                EntityWriteResult::OPERATION_INSERT
+            )],
+            $context
+        ));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Customer group registration SEO URLs were marked as deleted when generated for multiple sales channels, causing storefront 404s.

### 2. What does this change do, exactly?

Explicitly marks generated customer group registration SEO URLs as active and adds regression coverage for multiple sales channels.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable customer group registration.
2. Assign the registration to multiple sales channels sharing a language.
3. Set a registration title and save.
4. Visit the generated SEO URL on each sales channel.
5. Previously, all but one URL returned a 404.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18348

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
