### PR TITLE
feat: Truncate author in `plugin:list` command

### DIFF
--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -124,7 +124,7 @@ class PluginListCommand extends Command
                 $plugin->getComposerName() ?? '',
                 $plugin->getVersion(),
                 $pluginUpgradeable,
-                $plugin->getAuthor(),
+                mb_strimwidth($plugin->getAuthor(), 0, 40, '...'),
                 $pluginInstalled ? 'Yes' : 'No',
                 $pluginActive ? 'Yes' : 'No',
                 $pluginUpgradeable ? 'Yes' : 'No',

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -124,7 +124,7 @@ class PluginListCommand extends Command
                 $plugin->getComposerName() ?? '',
                 $plugin->getVersion(),
                 $pluginUpgradeable,
-                mb_strimwidth($plugin->getAuthor(), 0, 40, '...'),
+                mb_strimwidth($plugin->getAuthor() ?? '', 0, 40, '...'),
                 $pluginInstalled ? 'Yes' : 'No',
                 $pluginActive ? 'Yes' : 'No',
                 $pluginUpgradeable ? 'Yes' : 'No',

--- a/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
@@ -153,6 +153,48 @@ class PluginListCommandTest extends TestCase
         static::assertStringContainsString('Filtering for: ' . $filterValue, trim($commandTester->getDisplay()));
     }
 
+    public function testTruncatesAuthorAndSupportsMissingAuthor(): void
+    {
+        $pluginWithLongAuthor = new PluginEntity();
+        $pluginWithLongAuthor->setUniqueIdentifier('1');
+        $pluginWithLongAuthor->assign([
+            'active' => false,
+            'name' => 'PluginWithLongAuthor',
+            'label' => 'Plugin with long author',
+            'version' => '1.0.0',
+            'author' => str_repeat('a', 41),
+        ]);
+
+        $pluginWithoutAuthor = new PluginEntity();
+        $pluginWithoutAuthor->setUniqueIdentifier('2');
+        $pluginWithoutAuthor->assign([
+            'active' => false,
+            'name' => 'PluginWithoutAuthor',
+            'label' => 'Plugin without author',
+            'version' => '1.0.0',
+        ]);
+
+        $pluginWithLongMultibyteAuthor = new PluginEntity();
+        $pluginWithLongMultibyteAuthor->setUniqueIdentifier('3');
+        $pluginWithLongMultibyteAuthor->assign([
+            'active' => false,
+            'name' => 'PluginWithLongMultibyteAuthor',
+            'label' => 'Plugin with long multibyte author',
+            'version' => '1.0.0',
+            'author' => str_repeat('ä', 41),
+        ]);
+
+        $this->setupEntityCollection([$pluginWithLongAuthor, $pluginWithoutAuthor, $pluginWithLongMultibyteAuthor]);
+        $this->setupComposerPluginLoaderMock([]);
+
+        $commandTester = $this->executeCommand([]);
+
+        static::assertSame(0, $commandTester->getStatusCode());
+        static::assertStringContainsString(str_repeat('a', 37) . '...', $commandTester->getDisplay());
+        static::assertStringContainsString('PluginWithoutAuthor', $commandTester->getDisplay());
+        static::assertStringContainsString(str_repeat('ä', 37) . '...', $commandTester->getDisplay());
+    }
+
     public function testFormatJsonOutput(): void
     {
         $entities = [


### PR DESCRIPTION
### 1. Why is this change necessary?
The author is a text field inside the `composer.json` which can be arbitrary long. In one case I had a list of lot names listed there (which is valid), however this breaks the complete table layout.

### 2. What does this change do, exactly?
Truncate the author, similar to the plugin name.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
