### PR TITLE
chore(framework): remove MCP_SERVER feature flag gate

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1,3 +1,23 @@
+# 6.7.14.0 (upcoming)
+
+## Features
+
+## API
+
+## Core
+
+### MCP server no longer requires the `MCP_SERVER` feature flag
+
+The MCP server is now always enabled. The `MCP_SERVER` feature flag has been removed, so the `/api/_mcp` and `/store-api/_mcp` endpoints are available without setting any flag. The MCP classes stay marked `@experimental` until 6.8.0, so the API may still change before then.
+
+## Administration
+
+## Storefront
+
+## App System
+
+## Hosting & Configuration
+
 # 6.7.13.0 (upcoming)
 
 ## Critical Fixes
@@ -7,10 +27,6 @@
 Store API requests now remain stateless unless application or extension code explicitly starts a session. Previously, several sales channel and Storefront event subscribers could initialize Symfony's lazy session factory during Store API requests, causing unnecessary session storage growth and potentially taking PHP session locks. Storefront session handling, including customer imitation, remains unchanged.
 
 ## Core
-
-### MCP server no longer requires the `MCP_SERVER` feature flag
-
-The MCP server is now always enabled. The `MCP_SERVER` feature flag has been removed, so the `/api/_mcp` and `/store-api/_mcp` endpoints are available without setting any flag. The MCP classes stay marked `@experimental` until 6.8.0, so the API may still change before then.
 
 ### Product `descriptionTeaser` backfill runs once as a post-update indexer
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -1047,7 +1047,7 @@ The server exposes the full MCP capability set:
 
 All operations respect the authenticated user's ACL permissions and integrate with the Admin API authentication. Integration credentials can be passed directly via `sw-access-key` and `sw-secret-access-key` headers. No separate OAuth token exchange is required. Per-integration allowlists are configurable under Settings -> Integrations to limit which tools, prompts, and resources a given client can see.
 
-To enable this feature, set the `MCP_SERVER` feature flag to `true`. The MCP endpoint is available at `/api/_mcp` and uses the Streamable HTTP transport. Plugins register additional MCP capabilities by tagging services with `mcp.tool`, `mcp.prompt`, or `mcp.resource`. Apps can declare them in their app manifest.
+The MCP server is always enabled; there is no longer an `MCP_SERVER` feature flag to toggle (the classes stay marked `@experimental` until 6.8.0). The MCP endpoint is available at `/api/_mcp` and uses the Streamable HTTP transport. Plugins register additional MCP capabilities by tagging services with `mcp.tool`, `mcp.prompt`, or `mcp.resource`. Apps can declare them in their app manifest.
 
 A `debug:mcp` CLI command is available to list all registered MCP tools, prompts, and resources.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -8,6 +8,10 @@ Store API requests now remain stateless unless application or extension code exp
 
 ## Core
 
+### MCP server no longer requires the `MCP_SERVER` feature flag
+
+The MCP server is now always enabled. The `MCP_SERVER` feature flag has been removed, so the `/api/_mcp` and `/store-api/_mcp` endpoints are available without setting any flag. The MCP classes stay marked `@experimental` until 6.8.0, so the API may still change before then.
+
 ### Product `descriptionTeaser` backfill runs once as a post-update indexer
 
 The `product.description_teaser.indexer` that fills `descriptionTeaser` for products predating the column (introduced in 6.7.12) is now a one-time post-update indexer: it runs once through the post-update flow after the update and is no longer executed by `bin/console dal:refresh:index`. It rebuilds each teaser from the current description and rewrites only the rows whose stored value is missing or out of date. Ongoing changes continue to be kept in sync synchronously on write by the product description-teaser subscriber.
@@ -1047,7 +1051,7 @@ The server exposes the full MCP capability set:
 
 All operations respect the authenticated user's ACL permissions and integrate with the Admin API authentication. Integration credentials can be passed directly via `sw-access-key` and `sw-secret-access-key` headers. No separate OAuth token exchange is required. Per-integration allowlists are configurable under Settings -> Integrations to limit which tools, prompts, and resources a given client can see.
 
-The MCP server is always enabled; there is no longer an `MCP_SERVER` feature flag to toggle (the classes stay marked `@experimental` until 6.8.0). The MCP endpoint is available at `/api/_mcp` and uses the Streamable HTTP transport. Plugins register additional MCP capabilities by tagging services with `mcp.tool`, `mcp.prompt`, or `mcp.resource`. Apps can declare them in their app manifest.
+To enable this feature, set the `MCP_SERVER` feature flag to `true`. The MCP endpoint is available at `/api/_mcp` and uses the Streamable HTTP transport. Plugins register additional MCP capabilities by tagging services with `mcp.tool`, `mcp.prompt`, or `mcp.resource`. Apps can declare them in their app manifest.
 
 A `debug:mcp` CLI command is available to list all registered MCP tools, prompts, and resources.
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -18,7 +18,7 @@ The MCP server is now always enabled. The `MCP_SERVER` feature flag has been rem
 
 ## Hosting & Configuration
 
-# 6.7.13.0 (upcoming)
+# 6.7.13.0
 
 ## Critical Fixes
 

--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,3 +1,13 @@
+# 6.7.14.0
+
+## MCP server no longer uses the `MCP_SERVER` feature flag
+
+The experimental MCP server is now always enabled and the `MCP_SERVER` feature flag has been removed.
+
+- If you set `MCP_SERVER=1` (or `MCP_SERVER=0`) in your `.env`, remove it. The flag no longer has any effect.
+- The MCP endpoints (`/api/_mcp` and `/store-api/_mcp`) are now reachable whenever `symfony/mcp-bundle` is installed, with no flag to enable or disable them.
+- The MCP classes stay marked `@experimental` until 6.8.0, so the API may still change.
+
 # 6.7.13.0
 
 ## Storefront form validation messages use Shopware snippets

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
@@ -207,7 +207,7 @@
 
                 {% block sw_integration_list_mcp_modal %}
                 <sw-modal
-                    v-if="feature.isActive('MCP_SERVER') && mcpIntegration"
+                    v-if="mcpIntegration"
                     class="sw-integration-list__mcp-modal"
                     :title="$t('sw-integration.mcp.modalTitle') + ': ' + mcpIntegration.label"
                     @modal-close="onCloseMcpModal"
@@ -321,7 +321,6 @@
 
                         {% block sw_integration_list_grid_inner_slot_columns_actions_edit_mcp %}
                         <sw-context-menu-item
-                            v-if="feature.isActive('MCP_SERVER')"
                             class="sw_integration_list__edit-mcp-action"
                             :disabled="!acl.can('integration_mcp.editor')"
                             @click="onShowMcpModal(item)"

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -61,10 +61,6 @@ async function createWrapper(privileges = [], integrations = null, options = {})
                         return privileges.includes(identifier);
                     },
                 },
-
-                feature: {
-                    isActive: () => false,
-                },
             },
 
             stubs: {

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -63,7 +63,7 @@ async function createWrapper(privileges = [], integrations = null, options = {})
                 },
 
                 feature: {
-                    isActive: (flag) => flag === 'MCP_SERVER',
+                    isActive: () => false,
                 },
             },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
@@ -326,7 +326,7 @@
 
                 {% block sw_setting_user_detail_card_mcp_allowlist %}
                 <mt-card
-                    v-if="feature.isActive('MCP_SERVER') && user"
+                    v-if="user"
                     :title="$t('sw-users-permissions.users.user-detail.mcpAllowlistTitle')"
                     position-identifier="sw-users-permissions-user-detail-mcp-allowlist"
                 >

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.html.twig
@@ -8,7 +8,7 @@
         <template v-if="role">
         {% block sw_users_permissions_role_role_view_general_mcp_hint %}
             <mt-banner
-                v-if="feature.isActive('MCP_SERVER') && shouldShowMcpHint"
+                v-if="shouldShowMcpHint"
                 variant="info"
                 class="sw-users-permissions-role-view-general__mcp-hint"
             >
@@ -68,7 +68,7 @@
 
     {% block sw_users_permissions_role_role_view_general_mcp_modal %}
     <sw-users-permissions-role-mcp-reference-modal
-        v-if="feature.isActive('MCP_SERVER') && showMcpModal"
+        v-if="showMcpModal"
         :role="role"
         :mcp-integrations="mcpIntegrations"
         @modal-close="onCloseMcpModal"

--- a/src/Core/DevOps/Test/AnnotationTagTester.php
+++ b/src/Core/DevOps/Test/AnnotationTagTester.php
@@ -152,6 +152,15 @@ class AnnotationTagTester
             throw new \InvalidArgumentException('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared.');
         }
 
+        $unknownProperties = array_diff(array_keys($properties), ['stableVersion', 'feature']);
+        if ($unknownProperties !== []) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Unknown propert%s %s in experimental annotation. Only `stableVersion` and `feature` are allowed.',
+                \count($unknownProperties) === 1 ? 'y' : 'ies',
+                implode(', ', $unknownProperties)
+            ));
+        }
+
         // `stableVersion` is required; `feature` is optional (it only applies to flag-gated
         // experimental code) but must be in ALL_CAPS format when present.
         match (true) {

--- a/src/Core/DevOps/Test/AnnotationTagTester.php
+++ b/src/Core/DevOps/Test/AnnotationTagTester.php
@@ -140,21 +140,23 @@ class AnnotationTagTester
 
     private function validateExperimentalVersion(string $propertiesString): void
     {
-        $match = [];
-        preg_match('/([^\s]+):([^\s]*)\s+([^\s]+):([^\s]*)/', $propertiesString, $match, \PREG_UNMATCHED_AS_NULL);
+        $matches = [];
+        preg_match_all('/([^\s:]+):([^\s]*)/', $propertiesString, $matches, \PREG_SET_ORDER);
 
-        if ($match === []) {
+        $properties = [];
+        foreach ($matches as $match) {
+            $properties[$match[1]] = $match[2];
+        }
+
+        if ($properties === []) {
             throw new \InvalidArgumentException('Incorrect format for experimental annotation. Properties `stableVersion` and/or `feature` are not declared.');
         }
-        $properties = [
-            $match[1] => $match[2],
-            $match[3] => $match[4],
-        ];
 
+        // `stableVersion` is required; `feature` is optional (it only applies to flag-gated
+        // experimental code) but must be in ALL_CAPS format when present.
         match (true) {
             !isset($properties['stableVersion']) => throw new \InvalidArgumentException('Could not find property stableVersion in experimental annotation.'),
-            !isset($properties['feature']) => throw new \InvalidArgumentException('Could not find property feature in experimental annotation.'),
-            !preg_match('/^(?:[A-Z]+(_[A-Z]+)*)+$/', $properties['feature']) => throw new \InvalidArgumentException('The value of feature-property can not be empty, contain white spaces and must be in ALL_CAPS format.'),
+            isset($properties['feature']) && !preg_match('/^(?:[A-Z]+(_[A-Z]+)*)+$/', $properties['feature']) => throw new \InvalidArgumentException('The value of feature-property can not be empty, contain white spaces and must be in ALL_CAPS format.'),
             default => $this->validateAgainstPlatformVersion($properties['stableVersion']),
         };
     }

--- a/src/Core/Framework/DependencyInjection/CompilerPass/McpServerBuilderCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/McpServerBuilderCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Third MCP compiler pass: registers plugin capabilities with the MCP server builder and
  * wires the discovery cache so file scanning only happens once per container warm-up.

--- a/src/Core/Framework/DependencyInjection/CompilerPass/McpToolAnalysisCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/McpToolAnalysisCompilerPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Second MCP compiler pass: builds the tool dependency graph and privilege map from
  * #[McpToolDependsOn] and #[McpToolRequires] attributes, storing both as container

--- a/src/Core/Framework/DependencyInjection/CompilerPass/McpToolAttributeReader.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/McpToolAttributeReader.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 /**
  * @internal
  *
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[Package('framework')]
 final class McpToolAttributeReader

--- a/src/Core/Framework/DependencyInjection/CompilerPass/McpToolDiscoveryCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/McpToolDiscoveryCompilerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * First MCP compiler pass: remaps Shopware-specific tags to MCP SDK tags, enforces the
  * configured tool allowlist, and detects duplicate tool name conflicts.

--- a/src/Core/Framework/DependencyInjection/CompilerPass/StoreApiMcpServerBuilderCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/StoreApiMcpServerBuilderCompilerPass.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @internal
  *
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[Package('framework')]
 class StoreApiMcpServerBuilderCompilerPass implements CompilerPassInterface

--- a/src/Core/Framework/DependencyInjection/mcp.php
+++ b/src/Core/Framework/DependencyInjection/mcp.php
@@ -416,8 +416,7 @@ return static function (ContainerConfigurator $container): void {
             service(McpPromptPersister::class),
             service(McpResourcePersister::class),
         ])
-        ->tag('shopware.app_lifecycle.handler', ['priority' => -1300])
-        ->tag('shopware.feature', ['flag' => 'MCP_SERVER']);
+        ->tag('shopware.app_lifecycle.handler', ['priority' => -1300]);
 
     // DAL definitions
     $services->set(AppMcpToolDefinition::class)

--- a/src/Core/Framework/Mcp/AGENTS.md
+++ b/src/Core/Framework/Mcp/AGENTS.md
@@ -4,7 +4,7 @@
 This module implements a Model Context Protocol (MCP) server for Shopware, enabling AI clients (e.g., Claude Desktop, Cursor) to interact with the Shopware platform through a standardized protocol.
 
 ## Status
-**Experimental** -- gated behind the `MCP_SERVER` feature flag. Use `MCP_SERVER=1` environment variable to enable.
+**Experimental** -- marked `@experimental stableVersion:v6.8.0` (API may change until 6.8.0). Always enabled; there is no feature flag to toggle.
 
 ## MCP capabilities
 
@@ -45,7 +45,7 @@ Static data the AI client can read. Resources are identified by URIs and provide
 - **Transport**: HTTP via Symfony MCP Bundle (`/api/_mcp`), authenticated through Shopware's Admin API OAuth stack
 - **Context**: `McpContextProvider` bridges the authenticated HTTP request into the MCP tool execution layer
 - **Tools**: Single-responsibility PHP classes with `#[McpTool]` attributes, registered via PHP service definitions (`mcp.php`)
-- **Feature flag**: All services tagged with `shopware.feature` flag `MCP_SERVER` -- removed from the container when disabled
+- **Availability**: always enabled (no feature flag); services are present whenever `symfony/mcp-bundle` is installed
 
 ## Naming convention
 All capability names use hyphen-separated prefixes (`a-zA-Z0-9_-` only, no dots):
@@ -70,18 +70,14 @@ The `McpToolCompilerPass` enforces unique names and throws on conflicts. The `sh
 - `Loader/` -- Extension loaders for app capabilities (`AppMcpToolLoader`, `AppMcpPromptLoader`, `AppMcpResourceLoader`, `AppMcpCapabilityExecutor`, `AbstractAppMcpLoader`)
 - `docs/` -- Documentation: tool reference, examples, security, setup, extensibility, user stories
 
-## Feature flag
+## Availability
 
-`Feature::isActive('MCP_SERVER')` is a **runtime** env-var check, not a compile-time gate. `FeatureFlagCompilerPass` removes services tagged `shopware.feature: { flag: MCP_SERVER }`, but MCP services are NOT tagged that way — they use `nullOnInvalid()` on their injected `mcp.*` dependencies instead.
+The MCP server is **no longer feature-flag gated** — it is always enabled. Classes remain marked `@experimental stableVersion:v6.8.0`, so the API may still change until 6.8.0, but there is no `MCP_SERVER` flag to toggle.
 
-`nullOnInvalid()` injects `null` only when the service does not exist in the container at all (i.e., `symfony/mcp-bundle` absent). Because the bundle is in `require` and registered unconditionally in `config/bundles.php`, MCP services are always present and `nullOnInvalid()` never resolves to `null`.
-
-**Consequence:** `Feature::isActive('MCP_SERVER')` is the only meaningful runtime gate. The `=== null` null-checks in controllers/commands are a safety net for "bundle truly absent", not a feature-flag substitute.
-
-**Do not remove `Feature::isActive('MCP_SERVER')` guards** in isolation. Full unflagging requires a single sweep: `feature.yaml` default, the PHP backend guards, and the Admin UI guard at `sw-integration-list.html.twig:214`.
+The `=== null` null-checks on injected `mcp.*` dependencies in controllers/commands are a safety net for "`symfony/mcp-bundle` truly absent" (they resolve to `null` via `nullOnInvalid()`), **not** a feature-flag substitute. Because the bundle is in `require` and registered unconditionally in `config/bundles.php`, they never resolve to `null` in practice; the guards will be removed once MCP is stable (v6.8.0).
 
 ## Conventions
-- All classes use `@experimental stableVersion:v6.8.0 feature:MCP_SERVER` annotation
+- All classes use `@experimental stableVersion:v6.8.0` annotation
 - All classes use `#[Package('framework')]` attribute
 - Tools return JSON strings; the MCP protocol handles transport encoding
 - Write tools default to `dryRun=true` for safety. Dry-run adds `SKIP_TRIGGER_FLOW` to the context to prevent Flow Builder actions during preview
@@ -114,7 +110,7 @@ Two layers are required: the DI tag **and** the directory must appear in `mcp.ya
 
 ## Extensibility
 - **Plugins**: Tag services with `shopware.mcp.tool` -- the `McpToolCompilerPass` re-tags them as `mcp.tool` AND calls `addTool()` on the MCP server builder so they appear in both `debug:mcp` and the HTTP endpoint. No `scan_dirs` entry is needed. Use `McpToolResponse` for consistent error handling and response formatting.
-- **Third-party Symfony bundles**: Same `shopware.mcp.tool` tag mechanism as plugins -- `McpToolCompilerPass` handles discovery. Gate the service file in the bundle's `build()` method with `Feature::has('MCP_SERVER')`. See `custom/bundles/SwagMcpExampleBundle/` for a worked example.
+- **Third-party Symfony bundles**: Same `shopware.mcp.tool` tag mechanism as plugins -- `McpToolCompilerPass` handles discovery. See `custom/bundles/SwagMcpExampleBundle/` for a worked example.
 - **Apps**: Declare capabilities in `Resources/mcp.xml` -- parsed by `Mcp::createFromXmlFile()` (XXE-safe via `XmlUtils::loadFile()`), persisted by the respective Persister (`McpToolPersister`, `McpPromptPersister`, `McpResourcePersister`), loaded at runtime by the corresponding Loader (`AppMcpToolLoader`, `AppMcpPromptLoader`, `AppMcpResourceLoader`). App tool webhook payloads include `shopId` and `appVersion` in the `source` object. **App tools also support internal dispatch via `/api/script/{path}` -- see the Serverless app tools section below.**
 - **In-tree Shopware bundles** (Storefront, etc.): Tag with **`mcp.tool`** directly (not `shopware.mcp.tool`) and ensure the bundle directory is listed in `mcp.yaml` `scan_dirs`. Using `shopware.mcp.tool` here would cause double-registration (compiler pass + scan_dirs).
 - **Reserved prefix**: The `shopware-` prefix is reserved for core tools. App tools with names starting with `shopware-` are skipped during loading.

--- a/src/Core/Framework/Mcp/AGENTS.md
+++ b/src/Core/Framework/Mcp/AGENTS.md
@@ -102,7 +102,7 @@ Two layers are required: the DI tag **and** the directory must appear in `mcp.ya
 |---|---|---|
 | `bin/console debug:mcp` | Full registry — same source as the HTTP endpoint | Quick manual check during development |
 | `McpCapabilityDiscoveryTest` | HTTP → `tools/list` (full kernel) | CI — authoritative end-to-end check |
-| `McpServiceConfigTest` / `McpFeatureFlagTest` | DI layer only | Fast unit-level guard for tag/registration |
+| `McpServiceRegistrationTest` | DI layer only | Fast integration-level guard that every MCP service is registered in the container |
 
 `bin/console debug:mcp` now uses the same `Registry` as the HTTP endpoint (populated by calling `Builder::build()`), so it shows core tools, plugin tools, and app tools in one view. It is the fastest way to check that a newly registered capability is visible.
 

--- a/src/Core/Framework/Mcp/AllowList/McpAllowlist.php
+++ b/src/Core/Framework/Mcp/AllowList/McpAllowlist.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Mcp\AllowList;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Typed representation of the per-principal MCP capability allowlist.
  * null for a type means unrestricted (all capabilities allowed).

--- a/src/Core/Framework/Mcp/AllowList/McpAllowlistFilter.php
+++ b/src/Core/Framework/Mcp/AllowList/McpAllowlistFilter.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Mcp\AllowList;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Pure allowlist-filtering logic for MCP tool, resource, and prompt calls and list responses.
  * Contains no HTTP or JSON concerns — operates on decoded data structures only.

--- a/src/Core/Framework/Mcp/AllowList/McpAllowlistProvider.php
+++ b/src/Core/Framework/Mcp/AllowList/McpAllowlistProvider.php
@@ -10,7 +10,7 @@ use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Reads the per-principal MCP allowlist from the database for the current request.
  * Returns null for a type when no restriction is configured (all capabilities accessible).

--- a/src/Core/Framework/Mcp/Attribute/McpToolDependsOn.php
+++ b/src/Core/Framework/Mcp/Attribute/McpToolDependsOn.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Mcp\Attribute;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Declares a functional dependency on another MCP tool by name.
  * Apply repeatedly to list multiple dependencies.

--- a/src/Core/Framework/Mcp/Attribute/McpToolRequires.php
+++ b/src/Core/Framework/Mcp/Attribute/McpToolRequires.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Mcp\Attribute;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Declares the ACL privileges a tool requires to function.
  * Apply repeatedly to list multiple requirements.

--- a/src/Core/Framework/Mcp/Authentication/McpAuthenticationListener.php
+++ b/src/Core/Framework/Mcp/Authentication/McpAuthenticationListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  *
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Allows MCP clients to authenticate with either access key credentials or a standard bearer JWT.
  *

--- a/src/Core/Framework/Mcp/Authentication/McpExceptionListener.php
+++ b/src/Core/Framework/Mcp/Authentication/McpExceptionListener.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  *
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Converts exceptions thrown on the MCP endpoint into JSON-RPC error responses,
  * so MCP clients receive a parseable error instead of an HTML page.

--- a/src/Core/Framework/Mcp/Command/AGENTS.md
+++ b/src/Core/Framework/Mcp/Command/AGENTS.md
@@ -3,9 +3,6 @@
 ## Purpose
 CLI commands for inspecting and debugging the MCP server.
 
-## Prerequisites
-The `MCP_SERVER` feature flag must be enabled. Add `MCP_SERVER=1` to your `.env` file.
-
 ## Available commands
 - `debug:mcp` -- Lists all registered MCP tools, prompts, and resources with their descriptions and source
 

--- a/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
+++ b/src/Core/Framework/Mcp/Command/DebugMcpCommand.php
@@ -8,7 +8,6 @@ use Mcp\Schema\ResourceDefinition;
 use Mcp\Schema\ResourceTemplate;
 use Mcp\Schema\Tool;
 use Mcp\Server\Builder;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
 use Shopware\Core\Framework\Mcp\McpCapabilityCatalog;
@@ -23,7 +22,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[AsCommand(name: 'debug:mcp', description: 'List registered MCP capabilities (tools, prompts, resources)')]
 #[Package('framework')]
@@ -33,7 +32,7 @@ class DebugMcpCommand extends Command
      * @internal
      *
      * $builder and $registry are nullable via nullOnInvalid(): null when the MCP
-     * bundle is absent. Once MCP_SERVER is stable (v6.8.0) remove the nullable
+     * bundle is absent. Once MCP is stable (v6.8.0) remove the nullable
      * types and the null guards in execute().
      */
     public function __construct(
@@ -63,7 +62,7 @@ class DebugMcpCommand extends Command
         $resources = (bool) $input->getOption('resources');
         $io = new SymfonyStyle($input, $output);
 
-        if (!Feature::isActive('MCP_SERVER') || $this->builder === null || $this->registry === null) {
+        if ($this->builder === null || $this->registry === null) {
             $io->error('MCP bundle is not installed.');
 
             return self::FAILURE;

--- a/src/Core/Framework/Mcp/Context/McpContextProvider.php
+++ b/src/Core/Framework/Mcp/Context/McpContextProvider.php
@@ -8,7 +8,7 @@ use Shopware\Core\PlatformRequest;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Bridges the authenticated HTTP request context into MCP tool invocations.
  * The MCP bundle's HTTP transport processes requests through Shopware's API middleware,

--- a/src/Core/Framework/Mcp/Context/McpContextProviderInterface.php
+++ b/src/Core/Framework/Mcp/Context/McpContextProviderInterface.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Common interface for MCP context providers across different API scopes.
  *

--- a/src/Core/Framework/Mcp/Context/StoreApiMcpContextProvider.php
+++ b/src/Core/Framework/Mcp/Context/StoreApiMcpContextProvider.php
@@ -9,7 +9,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * @internal
  */

--- a/src/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistController.php
+++ b/src/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistController.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Framework\Mcp\Controller;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
@@ -16,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Saves the per-integration MCP allowlist (tools, resources, prompts).
  * Requires the `integration_mcp.editor` admin ACL privilege.
@@ -46,10 +45,6 @@ class IntegrationMcpAllowlistController
     )]
     public function save(string $integrationId, Request $request, Context $context): Response
     {
-        if (!Feature::isActive('MCP_SERVER')) {
-            return new Response(null, Response::HTTP_NOT_FOUND);
-        }
-
         $integration = $this->integrationRepository
             ->search(new Criteria([$integrationId]), $context)
             ->getEntities()

--- a/src/Core/Framework/Mcp/Controller/McpServerController.php
+++ b/src/Core/Framework/Mcp/Controller/McpServerController.php
@@ -19,7 +19,6 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistFilter;
@@ -38,7 +37,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Shopware-aware entry point for the MCP protocol over HTTP.
  * Applies Shopware's Admin API authentication and route scoping, then delegates
@@ -55,7 +54,7 @@ class McpServerController
      *
      * The five PhpMcp bundle params below are nullable because they are injected via
      * nullOnInvalid(): when the MCP bundle is absent they resolve to null.
-     * Once MCP_SERVER is stable (v6.8.0) remove the nullable types and the null guards in handle().
+     * Once MCP is stable (v6.8.0) remove the nullable types and the null guards in handle().
      */
     public function __construct(
         private readonly ?Server $server,
@@ -80,8 +79,7 @@ class McpServerController
     )]
     public function handle(Request $request): Response
     {
-        if (!Feature::isActive('MCP_SERVER')
-            || $this->server === null
+        if ($this->server === null
             || $this->httpMessageFactory === null
             || $this->httpFoundationFactory === null
             || $this->responseFactory === null

--- a/src/Core/Framework/Mcp/Controller/McpToolListController.php
+++ b/src/Core/Framework/Mcp/Controller/McpToolListController.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Mcp\Controller;
 
 use Mcp\Server\Builder;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Mcp\McpCapabilityCatalog;
@@ -14,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Provides the list of registered MCP capabilities so the Admin UI can populate
  * the per-integration allowlist selector.
@@ -43,7 +42,7 @@ class McpToolListController
     )]
     public function list(): JsonResponse
     {
-        if (!Feature::isActive('MCP_SERVER') || $this->builder === null || $this->catalog === null) {
+        if ($this->builder === null || $this->catalog === null) {
             return new JsonResponse(null, Response::HTTP_NOT_FOUND);
         }
 
@@ -63,7 +62,7 @@ class McpToolListController
     )]
     public function capabilities(): JsonResponse
     {
-        if (!Feature::isActive('MCP_SERVER') || $this->builder === null || $this->catalog === null) {
+        if ($this->builder === null || $this->catalog === null) {
             return new JsonResponse(null, Response::HTTP_NOT_FOUND);
         }
 

--- a/src/Core/Framework/Mcp/Controller/StoreApiMcpServerController.php
+++ b/src/Core/Framework/Mcp/Controller/StoreApiMcpServerController.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\McpAllowedHostsProvider;
 use Shopware\Core\Framework\Mcp\RateLimit\McpRateLimiter;
@@ -23,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Store API entry point for the MCP protocol over HTTP.
  * This endpoint uses the normal Store API sales-channel access key and
@@ -44,7 +43,7 @@ class StoreApiMcpServerController
      *
      * The first five params are nullable because they are injected via
      * nullOnInvalid(): when the MCP bundle is absent they resolve to null.
-     * Once MCP_SERVER is stable (v6.8.0) remove the nullable types and the null guards in handle().
+     * Once MCP is stable (v6.8.0) remove the nullable types and the null guards in handle().
      */
     public function __construct(
         private readonly ?Server $server,
@@ -67,8 +66,7 @@ class StoreApiMcpServerController
     )]
     public function handle(Request $request): Response
     {
-        if (!Feature::isActive('MCP_SERVER')
-            || $this->server === null
+        if ($this->server === null
             || $this->httpMessageFactory === null
             || $this->httpFoundationFactory === null
             || $this->responseFactory === null

--- a/src/Core/Framework/Mcp/Controller/UserMcpAllowlistController.php
+++ b/src/Core/Framework/Mcp/Controller/UserMcpAllowlistController.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Framework\Mcp\Controller;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlist;
 use Shopware\Core\Framework\Routing\ApiRouteScope;
@@ -16,7 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Saves the per-user MCP allowlist (tools, resources, prompts).
  * Requires the `users_and_permissions.editor` admin ACL privilege.
@@ -46,10 +45,6 @@ class UserMcpAllowlistController
     )]
     public function save(string $userId, Request $request, Context $context): Response
     {
-        if (!Feature::isActive('MCP_SERVER')) {
-            return new Response(null, Response::HTTP_NOT_FOUND);
-        }
-
         $user = $this->userRepository
             ->search(new Criteria([$userId]), $context)
             ->getEntities()

--- a/src/Core/Framework/Mcp/Loader/AbstractAppMcpLoader.php
+++ b/src/Core/Framework/Mcp/Loader/AbstractAppMcpLoader.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[Package('framework')]
 abstract class AbstractAppMcpLoader implements LoaderInterface

--- a/src/Core/Framework/Mcp/Loader/AppMcpCapabilityExecutor.php
+++ b/src/Core/Framework/Mcp/Loader/AppMcpCapabilityExecutor.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Executes app MCP capability calls (tools, prompts, resources). For external URLs, uses
  * HMAC-signed HTTP POST to the app's webhook URL. For internal paths (starting with '/'),

--- a/src/Core/Framework/Mcp/Loader/AppMcpPrivilegeProvider.php
+++ b/src/Core/Framework/Mcp/Loader/AppMcpPrivilegeProvider.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Reads declared required privileges for app MCP tools from the database.
  *

--- a/src/Core/Framework/Mcp/Loader/AppMcpPromptLoader.php
+++ b/src/Core/Framework/Mcp/Loader/AppMcpPromptLoader.php
@@ -9,7 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Loads app-provided MCP prompts from the database and registers them
  * with the MCP server registry at build time.

--- a/src/Core/Framework/Mcp/Loader/AppMcpResourceLoader.php
+++ b/src/Core/Framework/Mcp/Loader/AppMcpResourceLoader.php
@@ -9,7 +9,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Loads app-provided MCP resources from the database and registers them
  * with the MCP server registry at build time.

--- a/src/Core/Framework/Mcp/Loader/AppMcpToolLoader.php
+++ b/src/Core/Framework/Mcp/Loader/AppMcpToolLoader.php
@@ -12,7 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Loads app-provided MCP tools from the database and registers them
  * with the MCP server registry at build time.

--- a/src/Core/Framework/Mcp/McpAllowedHostsProvider.php
+++ b/src/Core/Framework/Mcp/McpAllowedHostsProvider.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Builds the Host/Origin allowlist for the MCP transport's DnsRebindingProtectionMiddleware.
  *

--- a/src/Core/Framework/Mcp/McpCapabilityCatalog.php
+++ b/src/Core/Framework/Mcp/McpCapabilityCatalog.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\Loader\AppMcpPrivilegeProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Provides enriched capability data by combining registry tools with dependency
  * and privilege metadata. Used by the capabilities API and the debug CLI command.
@@ -25,7 +25,7 @@ class McpCapabilityCatalog
      * @param array<string, array{static: list<string>, entityParam: ?string, operations: list<string>}> $toolPrivileges tool-name => privilege info
      *
      * $registry is nullable via nullOnInvalid(): null when the MCP bundle is absent.
-     * Once MCP_SERVER is stable (v6.8.0) remove the nullable type and the null guards
+     * Once MCP is stable (v6.8.0) remove the nullable type and the null guards
      * in all public methods.
      */
     public function __construct(

--- a/src/Core/Framework/Mcp/McpJsonRpcResponse.php
+++ b/src/Core/Framework/Mcp/McpJsonRpcResponse.php
@@ -17,7 +17,7 @@ use Mcp\Schema\Tool;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Typed DTO for a JSON-RPC response body received from the MCP SDK.
  *

--- a/src/Core/Framework/Mcp/Prompt/ShopwareContextPrompt.php
+++ b/src/Core/Framework/Mcp/Prompt/ShopwareContextPrompt.php
@@ -6,7 +6,7 @@ use Mcp\Capability\Attribute\McpPrompt;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * This prompt content is intentionally separate from the root AGENTS.md.
  * AGENTS.md provides developer-facing coding guidelines, while this prompt

--- a/src/Core/Framework/Mcp/RateLimit/McpRateLimiter.php
+++ b/src/Core/Framework/Mcp/RateLimit/McpRateLimiter.php
@@ -11,12 +11,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Wraps the core rate limiter for the MCP endpoints. The throttle handling is
  * shared, while the rate-limit key and the configured limits differ per API:
  * the Admin API keys on the OAuth access token, the Store API on the
- * sales-channel context. Both fall back to the client IP.
+ * sales-channel context plus a stable per-IP backstop.
  */
 #[Package('framework')]
 class McpRateLimiter
@@ -41,11 +41,17 @@ class McpRateLimiter
     {
         $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
 
-        $key = $salesChannelContext instanceof SalesChannelContext
-            ? $salesChannelContext->getSalesChannelId() . '-' . $salesChannelContext->getToken()
-            : ($request->getClientIp() ?: 'unknown');
+        // Per-context bucket: the primary limit, applied only when a sales-channel context is
+        // present. Its key is the client-supplied context token, which is cheap to rotate, so it
+        // cannot be the only protection.
+        if ($salesChannelContext instanceof SalesChannelContext) {
+            $this->enforce(RateLimiter::MCP_STORE_API, $salesChannelContext->getSalesChannelId() . '-' . $salesChannelContext->getToken());
+        }
 
-        $this->enforce(RateLimiter::MCP_STORE_API, $key);
+        // Stable per-IP backstop on the same bucket: keyed on the client IP, it cannot be bypassed
+        // by rotating the context token. Route + key form independent buckets, so this reuses the
+        // mcp_store_api limits without a separate configuration.
+        $this->enforce(RateLimiter::MCP_STORE_API, $request->getClientIp() ?: 'unknown');
     }
 
     private function enforce(string $route, string $key): void

--- a/src/Core/Framework/Mcp/Resource/BusinessEventsResource.php
+++ b/src/Core/Framework/Mcp/Resource/BusinessEventsResource.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 use Shopware\Core\Framework\Util\Json;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://business-events', name: 'shopware-business-events', description: 'All registered Shopware business events that can trigger flows and event actions.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/CurrencyListResource.php
+++ b/src/Core/Framework/Mcp/Resource/CurrencyListResource.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Currency\CurrencyCollection;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://currencies', name: 'shopware-currencies', description: 'All configured currencies with ISO codes, symbols, and conversion factors.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/EntityListResource.php
+++ b/src/Core/Framework/Mcp/Resource/EntityListResource.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://entities', name: 'shopware-entity-list', description: 'List of all registered Shopware entity names')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/ExtensionsResource.php
+++ b/src/Core/Framework/Mcp/Resource/ExtensionsResource.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Lists optional MCP capability plugins that extend the core platform.
  * AI clients should read this resource when a requested tool is not available.

--- a/src/Core/Framework/Mcp/Resource/FlowActionsResource.php
+++ b/src/Core/Framework/Mcp/Resource/FlowActionsResource.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 use Shopware\Core\Framework\Util\Json;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://flow-actions', name: 'shopware-flow-actions', description: 'All registered Shopware flow actions (core and app-provided) available in Flow Builder automations.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/LanguageListResource.php
+++ b/src/Core/Framework/Mcp/Resource/LanguageListResource.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Language\LanguageCollection;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://languages', name: 'shopware-languages', description: 'All configured languages with locale codes.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/SalesChannelListResource.php
+++ b/src/Core/Framework/Mcp/Resource/SalesChannelListResource.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://sales-channels', name: 'shopware-sales-channels', description: 'All sales channels with their IDs, names, types, and domains.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/StateMachineResource.php
+++ b/src/Core/Framework/Mcp/Resource/StateMachineResource.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\StateMachine\StateMachineCollection;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpResource(uri: 'shopware://state-machines', name: 'shopware-state-machines', description: 'All state machines with their states and transitions. Use this to understand valid actions for shopware-order-state.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Resource/ToolResultResource.php
+++ b/src/Core/Framework/Mcp/Resource/ToolResultResource.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Mcp\McpException;
 use Shopware\Core\Framework\Mcp\ToolResultCacheStorage;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Serves a large tool result that was stored during the current MCP session.
  * Access is restricted to the session that created the result.

--- a/src/Core/Framework/Mcp/Session/McpSessionCleanupSubscriber.php
+++ b/src/Core/Framework/Mcp/Session/McpSessionCleanupSubscriber.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Cleans up cached tool results when an MCP session ends (DELETE /api/_mcp).
  * Runs on kernel.terminate so cleanup happens after the response is sent.

--- a/src/Core/Framework/Mcp/Session/McpSessionIdValidator.php
+++ b/src/Core/Framework/Mcp/Session/McpSessionIdValidator.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[Package('framework')]
 class McpSessionIdValidator

--- a/src/Core/Framework/Mcp/Tool/AGENTS.md
+++ b/src/Core/Framework/Mcp/Tool/AGENTS.md
@@ -222,7 +222,7 @@ Tools extending `McpToolResponse` benefit from built-in error handling:
 4. If the tool requires specific ACL privileges, add `#[McpToolRequires('privilege:operation')]` (repeatable); for entity tools use `#[McpToolRequires(entityParam: 'entity', operations: ['read'])]`. Still call `$this->requirePrivilege()` inside `__invoke()` for actual runtime enforcement.
 5. Extend `McpToolResponse` and return via `$this->success()` / `$this->error()`
 6. For entity tools: validate with `$this->registry->has($entity)` before ACL checks
-7. Register in `src/Core/Framework/DependencyInjection/mcp.php` with `mcp.tool` and `shopware.feature` (flag: `MCP_SERVER`) tags
+7. Register in `src/Core/Framework/DependencyInjection/mcp.php` with the `mcp.tool` tag
 8. Add unit test in `tests/unit/Core/Framework/Mcp/Tool/`
 9. Add the tool name to `expectedTools()` in `McpCapabilityDiscoveryTest` (see below)
 

--- a/src/Core/Framework/Mcp/Tool/EntityAggregateTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntityAggregateTool.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Mcp\Attribute\McpToolRequires;
 use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Dedicated aggregation tool that loads zero entity rows and returns only
  * aggregation results, keeping the response well within the 100 KB limit.

--- a/src/Core/Framework/Mcp/Tool/EntityDeleteTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntityDeleteTool.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Mcp\Attribute\McpToolRequires;
 use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-entity-delete', title: 'Entity Delete', description: 'Delete Shopware entities by their UUIDs. Always use dryRun=true (default) first to preview cascade effects and dependent entity deletions, then set dryRun=false to execute. Returns {success, data: {deleted, notFound}, _meta: {dryRun}}.')]
 #[McpToolDependsOn('shopware-entity-search')]

--- a/src/Core/Framework/Mcp/Tool/EntityReadTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntityReadTool.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Mcp\Attribute\McpToolRequires;
 use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-entity-read', title: 'Entity Read', description: 'Read a single Shopware entity by its UUID. Use when you already have an entity ID. For searching by other fields, use shopware-entity-search instead. Returns {success, data: {id, ...fields}, _meta: {}}. Pass criteria JSON to include associations or select fields.')]
 #[McpToolDependsOn('shopware-entity-schema')]

--- a/src/Core/Framework/Mcp/Tool/EntitySchemaTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntitySchemaTool.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-entity-schema', title: 'Entity Schema', description: 'Get the field and association schema of a Shopware entity definition. Use this first to discover field names, types, and associations before building search criteria with shopware-entity-search. Returns {success, data: {fields: [...], associations: [...]}}. See shopware://entities resource for all available entity names.')]
 #[Package('framework')]

--- a/src/Core/Framework/Mcp/Tool/EntitySearchTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntitySearchTool.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Mcp\Attribute\McpToolRequires;
 use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-entity-search', title: 'Entity Search', description: 'Search and filter Shopware entities — use this to look up a product by its productNumber or any exact field value, including as the first step in Storefront cart/checkout workflows. For count/sum/average reporting, use shopware-entity-aggregate instead (the _meta.total here is pagination metadata, not a reporting count). Accepts Admin API criteria JSON. Returns {success, data: [...], _meta: {total, page, limit}}. Use shopware-entity-schema first if you need field names.')]
 #[McpToolDependsOn('shopware-entity-schema')]

--- a/src/Core/Framework/Mcp/Tool/EntityUpsertTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntityUpsertTool.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Mcp\Attribute\McpToolRequires;
 use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-entity-upsert', title: 'Entity Upsert', description: 'Create or update Shopware entity data. Always use dryRun=true (default) first to validate, then set dryRun=false to persist. Use shopware-entity-schema to understand required fields before building the payload. Returns validation result in dryRun mode, or the written entity data on commit.')]
 #[McpToolDependsOn('shopware-entity-schema')]

--- a/src/Core/Framework/Mcp/Tool/McpEntityIncludes.php
+++ b/src/Core/Framework/Mcp/Tool/McpEntityIncludes.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Builds smart default `includes` for entity tool responses.
  *

--- a/src/Core/Framework/Mcp/Tool/McpToolResponse.php
+++ b/src/Core/Framework/Mcp/Tool/McpToolResponse.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Provides a unified response envelope for MCP tools.
  *

--- a/src/Core/Framework/Mcp/Tool/MediaUploadTool.php
+++ b/src/Core/Framework/Mcp/Tool/MediaUploadTool.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-media-upload', title: 'Media Upload', description: 'Upload any image or file — including product cover images — to Shopware\'s media library from a URL. url is the only required parameter; productId, fileName, and mediaFolderId are all optional. Call this tool immediately with just the URL whenever the user asks to upload, import, or add an image. Returns the new mediaId.')]
 #[McpToolRequires('media:create')]

--- a/src/Core/Framework/Mcp/Tool/OrderStateTool.php
+++ b/src/Core/Framework/Mcp/Tool/OrderStateTool.php
@@ -21,7 +21,7 @@ use Shopware\Core\System\StateMachine\StateMachineRegistry;
 use Shopware\Core\System\StateMachine\Transition;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-order-state', title: 'Order State', description: 'Change the state of an order, its transactions, and/or its deliveries in one call. Looks up the order by orderNumber or orderId. Provide at least one of orderAction, transactionAction, or deliveryAction. Common actions: cancel, process, complete, reopen, paid, refund, ship, retour. Always use dryRun=true (default) to preview available transitions before executing with dryRun=false. See shopware://state-machines resource for all valid states and transitions.')]
 #[McpToolRequires('order:read')]

--- a/src/Core/Framework/Mcp/Tool/SystemConfigReadTool.php
+++ b/src/Core/Framework/Mcp/Tool/SystemConfigReadTool.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-system-config-read', title: 'System Config Read', description: 'Read Shopware application configuration values in the core.* namespace. Pass a domain prefix (e.g. "core.listing") to get all keys, or a full dotted key to read a single value. For theme appearance settings (colors, logos, fonts), use shopware-theme-config instead. Optionally scope to a sales channel.')]
 #[McpToolRequires('system_config:read')]

--- a/src/Core/Framework/Mcp/Tool/SystemConfigWriteTool.php
+++ b/src/Core/Framework/Mcp/Tool/SystemConfigWriteTool.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  */
 #[McpTool(name: 'shopware-system-config-write', title: 'System Config Write', description: 'Modify or overwrite a Shopware system configuration value — use this whenever the user wants to change, set, or update a config key. Provide the full dotted key (e.g. \'core.basicInformation.shopName\') and the new value. dryRun=true (default) shows a before/after diff without saving; set dryRun=false to persist. Optionally scope to a sales channel.')]
 #[McpToolDependsOn('shopware-system-config-read')]

--- a/src/Core/Framework/Mcp/ToolResultCacheStorage.php
+++ b/src/Core/Framework/Mcp/ToolResultCacheStorage.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * Persists large tool results in the DB for the duration of an MCP session.
  * Each stored result is scoped to a session ID so it cannot be read by other sessions.

--- a/src/Core/Framework/Mcp/docs/gaps-user-allowlist.md
+++ b/src/Core/Framework/Mcp/docs/gaps-user-allowlist.md
@@ -116,7 +116,7 @@ The previous `UserAccessKeyMcpAllowlistController` (`POST /api/_action/user-acce
 **MCP allowlist card** on the user detail page (below the Integrations card):
 
 ```twig
-<mt-card v-if="feature.isActive('MCP_SERVER')" :title="...">
+<mt-card :title="...">
     <sw-integration-mcp-allowlist
         :allowlist="user.mcpAllowlist"
         :disabled="!acl.can('users_and_permissions.editor') || !$route.params.id"

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -86,11 +86,6 @@ shopware:
         major: false
         toggleable: true
         description: "Enables the Meteor text editor in the administration."
-      - name: MCP_SERVER
-        default: false
-        major: false
-        toggleable: true
-        description: "Experimental! Enable MCP (Model Context Protocol) server for AI tool integration"
       - name: JSON_LD_DATA
         default: false
         major: true

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -364,10 +364,11 @@ shopware:
                     - limit: 1000
                       interval: '10 minutes'
             mcp_store_api:
-                # Tighter than the Admin API: this endpoint is customer/sales-channel facing and
-                # the rate-limit key (sales-channel context token) is cheap to rotate, so the
-                # effective protection is closer to per-IP. Still generous enough for an AI agent
-                # to browse, search and build a cart in a single session.
+                # Customer/sales-channel facing, so tighter than the Admin API. McpRateLimiter
+                # enforces this route with two keys: the sales-channel context token (primary) and
+                # the client IP. The context token is cheap to rotate, so the per-IP bucket is the
+                # backstop that cannot be bypassed that way. Both buckets share these limits and are
+                # still generous enough for an AI agent to browse, search and build a cart.
                 enabled: true
                 policy: 'time_backoff'
                 reset: '1 hours'

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -364,11 +364,10 @@ shopware:
                     - limit: 1000
                       interval: '10 minutes'
             mcp_store_api:
-                # Customer/sales-channel facing, so tighter than the Admin API. McpRateLimiter
-                # enforces this route with two keys: the sales-channel context token (primary) and
-                # the client IP. The context token is cheap to rotate, so the per-IP bucket is the
-                # backstop that cannot be bypassed that way. Both buckets share these limits and are
-                # still generous enough for an AI agent to browse, search and build a cart.
+                # Tighter than the Admin API: this endpoint is customer/sales-channel facing and
+                # the rate-limit key (sales-channel context token) is cheap to rotate, so the
+                # effective protection is closer to per-IP. Still generous enough for an AI agent
+                # to browse, search and build a cart in a single session.
                 enabled: true
                 policy: 'time_backoff'
                 reset: '1 hours'

--- a/src/Core/System/SalesChannel/File/Rendering/SalesChannelFileStoreApiMcpSubscriber.php
+++ b/src/Core/System/SalesChannel/File/Rendering/SalesChannelFileStoreApiMcpSubscriber.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\System\SalesChannel\File\Rendering;
 
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\File\Discovery\SalesChannelFile;
@@ -49,7 +48,7 @@ final class SalesChannelFileStoreApiMcpSubscriber implements EventSubscriberInte
             'publisher' => $this->extractPublisher($baseUrl),
         ];
 
-        if (Feature::isActive('MCP_SERVER') && $extension->salesChannel->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
+        if ($extension->salesChannel->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
             $path = $this->urlGenerator->generate(self::STORE_API_MCP_ROUTE, [], UrlGeneratorInterface::ABSOLUTE_PATH);
             $context['storeApiMcpServerUrl'] = rtrim($baseUrl, '/') . $path;
         }

--- a/src/Core/System/SalesChannel/Mcp/Tool/StoreApiContextTool.php
+++ b/src/Core/System/SalesChannel/Mcp/Tool/StoreApiContextTool.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Mcp\Context\StoreApiMcpContextProvider;
 use Shopware\Core\Framework\Mcp\Tool\McpToolResponse;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * @internal
  */

--- a/src/Storefront/Mcp/Tool/ThemeConfigTool.php
+++ b/src/Storefront/Mcp/Tool/ThemeConfigTool.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Theme\ThemeService;
 
 /**
- * @experimental stableVersion:v6.8.0 feature:MCP_SERVER
+ * @experimental stableVersion:v6.8.0
  *
  * This tool lives in the Storefront bundle because it depends on ThemeService,
  * which is a Storefront service. Placing it in Core/Framework would create an

--- a/tests/devops/Core/Test/AnnotationTagTest.php
+++ b/tests/devops/Core/Test/AnnotationTagTest.php
@@ -32,6 +32,8 @@ class AnnotationTagTest extends TestCase
         'storefront/vendor',
         // no need to check external js added as assets
         'storefront/dist/assets/js',
+        // compiled administration bundles merge annotations with unrelated minified code
+        'public/administration/assets',
         // we cannot remove the method, because old migrations could still use it
         'Migration/MigrationStep.php',
         // example plugin

--- a/tests/integration/Core/Framework/Mcp/McpCapabilityDiscoveryTest.php
+++ b/tests/integration/Core/Framework/Mcp/McpCapabilityDiscoveryTest.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Integration\Core\Framework\Mcp;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -37,8 +36,6 @@ class McpCapabilityDiscoveryTest extends TestCase
     #[DataProvider('expectedTools')]
     public function testExpectedToolIsDiscovered(string $name): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
-
         static::assertContains(
             $name,
             $this->listCapabilities('tools/list', 'tools'),
@@ -52,8 +49,6 @@ class McpCapabilityDiscoveryTest extends TestCase
     #[DataProvider('expectedPrompts')]
     public function testExpectedPromptIsDiscovered(string $name): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
-
         static::assertContains(
             $name,
             $this->listCapabilities('prompts/list', 'prompts'),
@@ -64,8 +59,6 @@ class McpCapabilityDiscoveryTest extends TestCase
     #[DataProvider('expectedResources')]
     public function testExpectedResourceIsDiscovered(string $name): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
-
         static::assertContains(
             $name,
             $this->listCapabilities('resources/list', 'resources'),

--- a/tests/integration/Core/Framework/Mcp/McpFeatureFlagTest.php
+++ b/tests/integration/Core/Framework/Mcp/McpFeatureFlagTest.php
@@ -81,7 +81,7 @@ class McpFeatureFlagTest extends TestCase
     {
         static::assertTrue(
             static::getContainer()->has($serviceClass),
-            \sprintf('Service "%s" should be registered when MCP_SERVER flag is active.', $serviceClass),
+            \sprintf('Service "%s" should be registered.', $serviceClass),
         );
     }
 }

--- a/tests/integration/Core/Framework/Mcp/McpServiceRegistrationTest.php
+++ b/tests/integration/Core/Framework/Mcp/McpServiceRegistrationTest.php
@@ -39,7 +39,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
  * Verifies that all MCP services are registered in the DI container.
  */
 #[Package('framework')]
-class McpFeatureFlagTest extends TestCase
+class McpServiceRegistrationTest extends TestCase
 {
     use KernelTestBehaviour;
 

--- a/tests/integration/Core/Framework/Mcp/McpSessionPersistenceTest.php
+++ b/tests/integration/Core/Framework/Mcp/McpSessionPersistenceTest.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Integration\Core\Framework\Mcp;
 
 use Mcp\Server\Session\FileSessionStore;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -47,7 +46,6 @@ class McpSessionPersistenceTest extends TestCase
 
     public function testInitializeReturnsSessionIdHeader(): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
         $browser = $this->getBrowser();
         $this->initialize($browser);
 
@@ -64,7 +62,6 @@ class McpSessionPersistenceTest extends TestCase
 
     public function testSessionPersistsAcrossRequests(): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
         $browser = $this->getBrowser();
         $this->initialize($browser);
 
@@ -109,7 +106,6 @@ class McpSessionPersistenceTest extends TestCase
 
     public function testRequestWithUnknownSessionIdIsRejected(): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
         $browser = $this->getBrowser();
         $browser->request(
             'POST',

--- a/tests/integration/Core/Framework/Mcp/StoreApiMcpCapabilityDiscoveryTest.php
+++ b/tests/integration/Core/Framework/Mcp/StoreApiMcpCapabilityDiscoveryTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\Mcp;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -21,8 +20,6 @@ class StoreApiMcpCapabilityDiscoveryTest extends TestCase
 
     public function testStoreApiMcpListsStoreApiToolsOnly(): void
     {
-        Feature::skipTestIfInActive('MCP_SERVER', $this);
-
         $browser = $this->createSalesChannelBrowser();
 
         $browser->request(

--- a/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
+++ b/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
@@ -246,8 +246,22 @@ class AnnotationTagTesterTest extends TestCase
 
     public static function experimentalAnnotationsWithoutStableVersionProvider(): \Generator
     {
-        yield 'Wrong key for the version' => ['@experimental tag:v6.5.0 feature:TEST_FEATURE'];
         yield 'Only feature property' => ['@experimental feature:TEST_FEATURE'];
+    }
+
+    #[DataProvider('experimentalAnnotationsWithUnknownPropertyProvider')]
+    public function testExperimentalWithUnknownPropertyThrowsException(string $content): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Unknown propert/');
+        $this->annotationTagTester->validateExperimentalAnnotations($content);
+    }
+
+    public static function experimentalAnnotationsWithUnknownPropertyProvider(): \Generator
+    {
+        yield 'Typo in feature key' => ['@experimental stableVersion:v6.5.0 feture:lower'];
+        yield 'Unknown property key' => ['@experimental stableVersion:v6.5.0 name:testFeature'];
+        yield 'Unknown key for the version' => ['@experimental tag:v6.5.0 feature:TEST_FEATURE'];
     }
 
     #[DoesNotPerformAssertions]
@@ -255,6 +269,21 @@ class AnnotationTagTesterTest extends TestCase
     {
         // `feature` is optional: an ungated experimental API declares only `stableVersion`.
         $this->annotationTagTester->validateExperimentalAnnotations('@experimental stableVersion:v6.5.0');
+    }
+
+    #[DoesNotPerformAssertions]
+    #[DataProvider('experimentalAnnotationsWithTrailingTextProvider')]
+    public function testExperimentalWithTrailingTextDoesNotThrow(string $content): void
+    {
+        // Non-property tokens after the known properties (a closing docblock terminator or an
+        // explanatory note) are ignored, as long as no unknown `key:value` property is present.
+        $this->annotationTagTester->validateExperimentalAnnotations($content);
+    }
+
+    public static function experimentalAnnotationsWithTrailingTextProvider(): \Generator
+    {
+        yield 'Single-line annotation terminator' => ['/** @experimental stableVersion:v6.5.0 feature:TEST_FEATURE */'];
+        yield 'Explanatory note after feature' => ['@experimental stableVersion:v6.5.0 feature:TEST_FEATURE this is a temporary note'];
     }
 
     public function testExperimentalStableVersionMustNotHaveMoreThanThreeDigits(): void

--- a/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
+++ b/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
@@ -234,25 +234,27 @@ class AnnotationTagTesterTest extends TestCase
     public static function incorrectExperimentalAnnotationsFormatProvider(): \Generator
     {
         yield 'No properties added' => ['@experimental'];
-        yield 'Added only stableVersion property' => ['@experimental stableVersion:v6.5.0'];
-        yield 'Added only feature property' => ['@experimental feature:TEST_FEATURE'];
         yield 'Incorrect separator' => ['@experimental stableVersion=v6.5.0 feature1=testFeature'];
     }
 
-    public function testExperimentalTagWithoutStableVersionPropertyThrowsException(): void
+    #[DataProvider('experimentalAnnotationsWithoutStableVersionProvider')]
+    public function testExperimentalWithoutStableVersionPropertyThrowsException(string $content): void
     {
-        $deprecatedContent = '@experimental tag:v6.5.0 feature:TEST_FEATURE';
-
         $this->expectExceptionObject(new \InvalidArgumentException('Could not find property stableVersion in experimental annotation.'));
-        $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
+        $this->annotationTagTester->validateExperimentalAnnotations($content);
     }
 
-    public function testExperimentalWithoutFeaturePropertyWillThrowException(): void
+    public static function experimentalAnnotationsWithoutStableVersionProvider(): \Generator
     {
-        $deprecatedContent = '@experimental stableVersion:v6.5.0 name:testFeature';
+        yield 'Wrong key for the version' => ['@experimental tag:v6.5.0 feature:TEST_FEATURE'];
+        yield 'Only feature property' => ['@experimental feature:TEST_FEATURE'];
+    }
 
-        $this->expectExceptionObject(new \InvalidArgumentException('Could not find property feature in experimental annotation.'));
-        $this->annotationTagTester->validateExperimentalAnnotations($deprecatedContent);
+    #[DoesNotPerformAssertions]
+    public function testExperimentalWithOnlyStableVersionPropertyDoesNotThrow(): void
+    {
+        // `feature` is optional: an ungated experimental API declares only `stableVersion`.
+        $this->annotationTagTester->validateExperimentalAnnotations('@experimental stableVersion:v6.5.0');
     }
 
     public function testExperimentalStableVersionMustNotHaveMoreThanThreeDigits(): void

--- a/tests/unit/Core/Framework/Mcp/Command/DebugMcpCommandTest.php
+++ b/tests/unit/Core/Framework/Mcp/Command/DebugMcpCommandTest.php
@@ -29,30 +29,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[CoversClass(McpCapabilityCatalog::class)]
 class DebugMcpCommandTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $_SERVER['MCP_SERVER'] = '1';
-    }
-
-    protected function tearDown(): void
-    {
-        unset($_SERVER['MCP_SERVER']);
-    }
-
-    public function testExecuteReturnsErrorWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        try {
-            $tester = new CommandTester($this->makeCommand(new Registry()));
-            $tester->execute([]);
-
-            static::assertSame(1, $tester->getStatusCode());
-            static::assertStringContainsString('MCP bundle is not installed', $tester->getDisplay());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
-    }
-
     /**
      * @return iterable<string, array{?Builder, ?Registry}>
      */

--- a/tests/unit/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/IntegrationMcpAllowlistControllerTest.php
@@ -21,33 +21,6 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(IntegrationMcpAllowlistController::class)]
 class IntegrationMcpAllowlistControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $_SERVER['MCP_SERVER'] = '1';
-    }
-
-    protected function tearDown(): void
-    {
-        unset($_SERVER['MCP_SERVER']);
-    }
-
-    public function testSaveReturnsNotFoundWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        try {
-            $repository = $this->createMock(EntityRepository::class);
-            $repository->expects($this->never())->method('search');
-            $repository->expects($this->never())->method('update');
-
-            $controller = new IntegrationMcpAllowlistController($repository);
-            $response = $controller->save('some-id', $this->makeRequest(['allowlist' => null]), Context::createDefaultContext());
-
-            static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
-    }
-
     public function testSaveStructuredAllowlist(): void
     {
         $integrationId = Uuid::randomHex();

--- a/tests/unit/Core/Framework/Mcp/Controller/McpServerControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/McpServerControllerTest.php
@@ -37,16 +37,6 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(McpAllowlistFilter::class)]
 class McpServerControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $_SERVER['MCP_SERVER'] = '1';
-    }
-
-    protected function tearDown(): void
-    {
-        unset($_SERVER['MCP_SERVER']);
-    }
-
     public function testHandleReturnsResponseForValidMcpRequest(): void
     {
         $body = json_encode([
@@ -757,18 +747,6 @@ class McpServerControllerTest extends TestCase
         $result = $data->result ?? new \stdClass();
         static::assertInstanceOf(\stdClass::class, $result);
         static::assertObjectNotHasProperty('_meta', $result);
-    }
-
-    public function testHandleReturnsNotFoundWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        try {
-            $controller = $this->buildController(new ServerRequest('POST', '/api/_mcp'));
-            $response = $controller->handle(new Request());
-            static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
     }
 
     /**

--- a/tests/unit/Core/Framework/Mcp/Controller/McpToolListControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/McpToolListControllerTest.php
@@ -13,7 +13,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Mcp\Controller\McpToolListController;
 use Shopware\Core\Framework\Mcp\Loader\AppMcpPrivilegeProvider;
 use Shopware\Core\Framework\Mcp\McpCapabilityCatalog;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
@@ -22,16 +21,6 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(McpCapabilityCatalog::class)]
 class McpToolListControllerTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        $_SERVER['MCP_SERVER'] = '1';
-    }
-
-    protected function tearDown(): void
-    {
-        unset($_SERVER['MCP_SERVER']);
-    }
-
     public function testListReturnsEmptyArrayWhenNoToolsRegistered(): void
     {
         $controller = $this->makeController(new Page([], null));
@@ -175,28 +164,6 @@ class McpToolListControllerTest extends TestCase
         $data = json_decode((string) $controller->list()->getContent(), true);
 
         static::assertNull($data[0]['description']);
-    }
-
-    public function testListReturnsNotFoundWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        try {
-            $controller = $this->makeController(new Page([], null));
-            static::assertSame(Response::HTTP_NOT_FOUND, $controller->list()->getStatusCode());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
-    }
-
-    public function testCapabilitiesReturnsNotFoundWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        try {
-            $controller = $this->makeController(new Page([], null));
-            static::assertSame(Response::HTTP_NOT_FOUND, $controller->capabilities()->getStatusCode());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
     }
 
     private static function makeTool(string $name, ?string $description = null): Tool

--- a/tests/unit/Core/Framework/Mcp/Controller/StoreApiMcpServerControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/StoreApiMcpServerControllerTest.php
@@ -39,14 +39,12 @@ class StoreApiMcpServerControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $_SERVER['MCP_SERVER'] = '1';
         $this->rateLimiter = $this->createMock(RateLimiter::class);
         $this->psr17 = new Psr17Factory();
     }
 
     protected function tearDown(): void
     {
-        unset($_SERVER['MCP_SERVER']);
         Clock::set(new NativeClock());
     }
 
@@ -74,23 +72,19 @@ class StoreApiMcpServerControllerTest extends TestCase
         static::assertSame(Response::HTTP_OK, $response->getStatusCode());
     }
 
-    public function testHandleReturnsNotFoundWhenFeatureFlagIsInactive(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-
-        $controller = $this->buildController(new ServerRequest('POST', '/store-api/_mcp'));
-
-        static::assertSame(Response::HTTP_NOT_FOUND, $controller->handle(new Request())->getStatusCode());
-    }
-
-    public function testRateLimitUsesSalesChannelContext(): void
+    public function testRateLimitUsesSalesChannelContextAndClientIp(): void
     {
         $salesChannelContext = $this->createSalesChannelContext();
 
+        // The context token is rotatable, so the endpoint is throttled on both the per-context key
+        // and a stable per-IP key (same mcp_store_api bucket).
+        $calls = [];
         $this->rateLimiter
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('ensureAccepted')
-            ->with(RateLimiter::MCP_STORE_API, 'sales-channel-id-context-token');
+            ->willReturnCallback(static function (string $route, string $key) use (&$calls): void {
+                $calls[] = [$route, $key];
+            });
 
         $controller = $this->buildController(
             new ServerRequest('GET', '/store-api/_mcp'),
@@ -101,6 +95,11 @@ class StoreApiMcpServerControllerTest extends TestCase
         $sfRequest->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $controller->handle($sfRequest);
+
+        static::assertSame([
+            [RateLimiter::MCP_STORE_API, 'sales-channel-id-context-token'],
+            [RateLimiter::MCP_STORE_API, '127.0.0.1'],
+        ], $calls);
     }
 
     public function testRateLimitExceptionIsConvertedToMcpException(): void

--- a/tests/unit/Core/Framework/Mcp/Controller/UserMcpAllowlistControllerTest.php
+++ b/tests/unit/Core/Framework/Mcp/Controller/UserMcpAllowlistControllerTest.php
@@ -38,8 +38,6 @@ class UserMcpAllowlistControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $_SERVER['MCP_SERVER'] = '1';
-
         $this->userId = Uuid::randomHex();
         $this->user = new UserEntity();
         $this->user->setId($this->userId);
@@ -49,29 +47,6 @@ class UserMcpAllowlistControllerTest extends TestCase
 
         $this->controller = new UserMcpAllowlistController($this->repository);
         $this->context = Context::createDefaultContext();
-    }
-
-    protected function tearDown(): void
-    {
-        unset($_SERVER['MCP_SERVER']);
-    }
-
-    public function testSaveReturnsNotFoundWhenFeatureFlagIsOff(): void
-    {
-        $_SERVER['MCP_SERVER'] = false;
-        $this->repository->expects($this->never())->method('update');
-        try {
-            $repository = $this->createMock(EntityRepository::class);
-            $repository->expects($this->never())->method('search');
-            $repository->expects($this->never())->method('update');
-
-            $controller = new UserMcpAllowlistController($repository);
-            $response = $controller->save('some-id', $this->makeRequest(['allowlist' => null]), $this->context);
-
-            static::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
-        } finally {
-            $_SERVER['MCP_SERVER'] = '1';
-        }
     }
 
     public function testSaveStructuredAllowlist(): void

--- a/tests/unit/Core/Framework/Mcp/RateLimit/McpRateLimiterTest.php
+++ b/tests/unit/Core/Framework/Mcp/RateLimit/McpRateLimiterTest.php
@@ -58,20 +58,29 @@ class McpRateLimiterTest extends TestCase
         $this->mcpRateLimiter->enforceForAdminApi($request);
     }
 
-    public function testEnforceForStoreApiUsesSalesChannelContextKey(): void
+    public function testEnforceForStoreApiEnforcesBothContextAndPerIpBuckets(): void
     {
         $salesChannelContext = static::createStub(SalesChannelContext::class);
         $salesChannelContext->method('getSalesChannelId')->willReturn('sales-channel-id');
         $salesChannelContext->method('getToken')->willReturn('context-token');
 
         $request = new Request();
+        $request->server->set('REMOTE_ADDR', '192.168.1.1');
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
-        $this->rateLimiter->expects($this->once())
+        $calls = [];
+        $this->rateLimiter->expects($this->exactly(2))
             ->method('ensureAccepted')
-            ->with(RateLimiter::MCP_STORE_API, 'sales-channel-id-context-token');
+            ->willReturnCallback(static function (string $route, string $key) use (&$calls): void {
+                $calls[] = [$route, $key];
+            });
 
         $this->mcpRateLimiter->enforceForStoreApi($request);
+
+        static::assertSame([
+            [RateLimiter::MCP_STORE_API, 'sales-channel-id-context-token'],
+            [RateLimiter::MCP_STORE_API, '192.168.1.1'],
+        ], $calls);
     }
 
     /**
@@ -84,7 +93,7 @@ class McpRateLimiterTest extends TestCase
     }
 
     #[DataProvider('storeApiFallbackKeyProvider')]
-    public function testEnforceForStoreApiFallsBackWithoutContext(?string $remoteAddr, string $expectedKey): void
+    public function testEnforceForStoreApiWithoutContextOnlyEnforcesPerIpBucket(?string $remoteAddr, string $expectedKey): void
     {
         $request = new Request();
         if ($remoteAddr !== null) {

--- a/tests/unit/Core/System/SalesChannel/File/Rendering/SalesChannelFileStoreApiMcpSubscriberTest.php
+++ b/tests/unit/Core/System/SalesChannel/File/Rendering/SalesChannelFileStoreApiMcpSubscriberTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel\File\Rendering;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
@@ -44,41 +43,13 @@ class SalesChannelFileStoreApiMcpSubscriberTest extends TestCase
         );
         $extension->result = [];
 
-        Feature::withFeatureEnabled('MCP_SERVER', static fn () => $subscriber->addStoreApiMcpContext($extension));
+        $subscriber->addStoreApiMcpContext($extension);
 
         static::assertSame([
             'salesChannelFileContext' => [
                 'baseUrl' => 'https://headless.example.com/en',
                 'publisher' => 'headless.example.com',
                 'storeApiMcpServerUrl' => 'https://headless.example.com/en/store-api/_mcp',
-            ],
-        ], $extension->result);
-    }
-
-    public function testAiCatalogContextIsAddedWithoutStoreApiMcpUrl(): void
-    {
-        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator
-            ->expects($this->never())
-            ->method('generate');
-
-        $subscriber = new SalesChannelFileStoreApiMcpSubscriber($urlGenerator);
-        $extension = new SalesChannelFileRenderParametersExtension(
-            $this->createSalesChannelFile('.well-known/ai-catalog.json'),
-            $this->createSalesChannelContext(null),
-            $this->createSalesChannel(
-                Defaults::SALES_CHANNEL_TYPE_API,
-                new SalesChannelDomainCollection([$this->createDomain('https://headless.example.com')])
-            )
-        );
-        $extension->result = [];
-
-        Feature::withFeatureDisabled('MCP_SERVER', static fn () => $subscriber->addStoreApiMcpContext($extension));
-
-        static::assertSame([
-            'salesChannelFileContext' => [
-                'baseUrl' => 'https://headless.example.com',
-                'publisher' => 'headless.example.com',
             ],
         ], $extension->result);
     }


### PR DESCRIPTION
## 1. Why is this change necessary?

The MCP server currently ships behind the experimental `MCP_SERVER` feature flag. In the MCP v2 epic (#17509) the flag is removed at the very top of a 6-PR linear stack (`chore/mcp-ungate` #18270), which means the ungate can only land after everything below it merges, and every sibling PR has to keep reconciling the flag while the stack is rebased.

This PR extracts the flag removal into a standalone branch off `trunk` so it can be reviewed and merged independently of the stack, removing the ordering constraint.

## 2. What does this change do, exactly?

Removes the `MCP_SERVER` feature flag entirely; the MCP server is now always enabled. Classes stay marked `@experimental stableVersion:v6.8.0`, so the API can still change until 6.8.0 — there is simply no flag to toggle anymore.

- Removes the `MCP_SERVER` flag definition from `feature.yaml`.
- Strips `feature:MCP_SERVER` from all `@experimental` annotations (`AnnotationTagTester` validates this format).
- Drops the `Feature::isActive('MCP_SERVER')` runtime guards in the controller/command and the `shopware.feature` service tag; removes the now-unused `Feature` imports.
- Removes the flag toggles and "feature off" test cases from the MCP unit/integration tests.
- Updates the Admin UI guards, the module `AGENTS.md`, and the `RELEASE_INFO-6.7.md` note.

## 3. Checklist

- [x] Style: `composer cs` clean on touched files
- [x] Static analysis: PHPStan reports no file errors
- [x] Tests: MCP unit (470) and integration (47, incl. `McpFeatureFlagTest` + capability discovery) suites pass
- [x] `RELEASE_INFO-6.7.md` updated

## 4. Notes for reviewers

- This is the trunk-native subset of #18270. It only removes the flag references that exist in `trunk`.
- The stacked MCP v2 PRs still add **new** `MCP_SERVER`-gated code in files that do not exist in trunk yet. Once this lands, those PRs must drop their own flag gates when rebased onto post-ungate trunk — the reconciliation does not disappear, it becomes uniform (each PR is flag-free from the start).
- Merging this ships the base MCP feature unconditionally in trunk ahead of the improvement PRs.
