### PR TITLE
chore: bump shopware/conflicts to 0.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.6.1",
+        "shopware/conflicts": "0.6.2",
         "shyim/opensearch-php-dsl": "^1.1.4",
         "squirrelphp/twig-php-syntax": "^1.13.0",
         "symfony/asset": "~7.4.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -106,7 +106,7 @@
         "ramsey/uuid": "^4.7",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.6.1",
+        "shopware/conflicts": "0.6.2",
         "squirrelphp/twig-php-syntax": "^1.13.0",
         "symfony/asset": "~7.4.0",
         "symfony/cache": "~7.4.12",


### PR DESCRIPTION
### 1. Why is this change necessary?

`shopware/conflicts` 0.6.2 has been released, but platform still pins 0.6.1. Any consumer resolving dependencies to *highest* now picks 0.6.2, which makes `shopware/platform` uninstallable alongside it:

```
Problem 1
  - shopware/platform dev-trunk requires shopware/conflicts 0.6.1
    -> found shopware/conflicts[0.6.1] but it conflicts with your root composer.json require (0.6.2).
```

This currently breaks:
- `shopware/saas` **Facilitate SaaS updates** — failing nightly since 2026-07-08, no `chore: update dependencies (trunk)` PRs created since shopware/saas#696 ([latest failing run](https://github.com/shopware/saas/actions/runs/29667017041))
- `shopware/saas` **Split off release branches** ([failing run](https://github.com/shopware/saas/actions/runs/29742680700), against `shopware/platform 6.7.13.0-dev` — release/deployment branches may need this bump backported)
- likely the `shopware/saas` Nightly (failing since 2026-07-14)

### 2. What does this change do, exactly?

Bumps the pinned `shopware/conflicts` version from 0.6.1 to 0.6.2 in `composer.json` and `src/Core/composer.json`.

Note for review: 0.6.2 is not a pure conflict-rule update — it adds `"require": {"shopware/core": ">=6.7.12.1"}` and drops several rules (e.g. `twig >=3.21`, `symfony/framework-bundle`). Please double-check the dropped conflicts are intentional for trunk and the new `shopware/core` floor is compatible with all branches this lands on.

### 3. Describe each step to reproduce the issue or behaviour.

1. `composer require shopware/conflicts:0.6.2 shopware/platform:dev-trunk` (or run the `shopware/saas` dependency update, which resolves to highest)
2. Composer fails with the resolution error above.

### 4. Please link to the relevant issues (if any).

- relates shopware/saas#696 (last successfully created update PR before the nightly job started failing)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them