### PR TITLE
chore: bump shopware/conflicts to 0.6.2 (6.7.13.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.6.1",
+        "shopware/conflicts": "0.6.2",
         "shyim/opensearch-php-dsl": "^1.1.4",
         "squirrelphp/twig-php-syntax": "^1.13.0",
         "symfony/asset": "~7.4.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -106,7 +106,7 @@
         "ramsey/uuid": "^4.7",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.6.1",
+        "shopware/conflicts": "0.6.2",
         "squirrelphp/twig-php-syntax": "^1.13.0",
         "symfony/asset": "~7.4.0",
         "symfony/cache": "~7.4.12",


### PR DESCRIPTION
### 1. Why is this change necessary?

Backport of #18469 to the `6.7.13.0` release branch.

`shopware/conflicts` 0.6.2 is released, but this branch pins 0.6.1. The `shopware/saas` **Split off release branches** workflow resolves dependencies to highest and fails against `shopware/platform 6.7.13.0-dev` ([failing run](https://github.com/shopware/saas/actions/runs/29742680700)):

```
Problem 1
  - shopware/platform 6.7.13.0-dev requires shopware/conflicts 0.6.1
    -> found shopware/conflicts[0.6.1] but it conflicts with your root composer.json require (0.6.2).
```

### 2. What does this change do, exactly?

Bumps the pinned `shopware/conflicts` version from 0.6.1 to 0.6.2 in `composer.json` and `src/Core/composer.json` — same change as #18469 on trunk.

Note: 0.6.2 adds `"require": {"shopware/core": ">=6.7.12.1"}` — satisfied by this branch (6.7.13.0-dev).

### 3. Describe each step to reproduce the issue or behaviour.

Run the `shopware/saas` "Split off release branches" workflow against this branch — composer resolution fails as above.

### 4. Please link to the relevant issues (if any).

- relates #18469 (trunk)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them