### PR TITLE
fix: avoid persisting product CMS element locks

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -118,7 +118,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         cmsSlotSettingsClasses() {
-            if (this.elementConfig?.defaultConfig && !this.element?.locked) {
+            if (this.elementConfig?.defaultConfig && !this.isElementLocked) {
                 return null;
             }
 
@@ -129,7 +129,7 @@ export default Shopware.Component.wrapComponentConfig({
             if (this.elementConfig?.disabledConfigInfoTextKey) {
                 return {
                     message: this.$t(this.elementConfig.disabledConfigInfoTextKey),
-                    disabled: !!this.elementConfig.defaultConfig && !this.element.locked,
+                    disabled: !!this.elementConfig.defaultConfig && !this.isElementLocked,
                 };
             }
 
@@ -141,6 +141,17 @@ export default Shopware.Component.wrapComponentConfig({
 
         modalVariant() {
             return this.element.type === 'html' ? 'full' : 'large';
+        },
+
+        isElementLocked() {
+            return (
+                this.element.locked ||
+                (Shopware.Store.get('cmsPage').currentPage?.type === 'product_detail' &&
+                    [
+                        'buy-box',
+                        'product-description-reviews',
+                    ].includes(this.element.type))
+            );
         },
     },
 
@@ -159,7 +170,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         onSettingsButtonClick() {
-            if (!this.elementConfig?.defaultConfig || this.element?.locked) {
+            if (!this.elementConfig?.defaultConfig || this.isElementLocked) {
                 return;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
@@ -172,18 +172,28 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         expect(customComponent.attributes().disabled).toBeUndefined();
     });
 
-    it('should lock product-specific elements on product detail pages without changing the slot', async () => {
+    it.each([
+        'buy-box',
+        'product-description-reviews',
+    ])('should lock %s on product detail pages without changing the slot', async (type) => {
         Shopware.Store.get('cmsPage').currentPage = { type: 'product_detail' };
 
         const wrapper = await createWrapper({
             element: {
-                type: 'product-description-reviews',
+                type,
                 locked: false,
             },
+            active: true,
         });
 
         expect(wrapper.vm.isElementLocked).toBe(true);
         expect(wrapper.props('element').locked).toBe(false);
+
+        expect(wrapper.find('.sw-cms-slot__settings-action').classes()).toContain('is--disabled');
+
+        wrapper.vm.onSettingsButtonClick();
+
+        expect(wrapper.vm.showElementSettings).toBe(false);
     });
 
     it('should show a tooltip when the element is not disabled', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.spec.js
@@ -172,6 +172,20 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         expect(customComponent.attributes().disabled).toBeUndefined();
     });
 
+    it('should lock product-specific elements on product detail pages without changing the slot', async () => {
+        Shopware.Store.get('cmsPage').currentPage = { type: 'product_detail' };
+
+        const wrapper = await createWrapper({
+            element: {
+                type: 'product-description-reviews',
+                locked: false,
+            },
+        });
+
+        expect(wrapper.vm.isElementLocked).toBe(true);
+        expect(wrapper.props('element').locked).toBe(false);
+    });
+
     it('should show a tooltip when the element is not disabled', async () => {
         const wrapper = await createWrapper();
         await wrapper.setProps({

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/component.spec.js
@@ -16,7 +16,7 @@ const productMock = {
     ],
 };
 
-async function createWrapper() {
+async function createWrapper(props = {}) {
     return mount(
         await wrapTestComponent('sw-cms-el-buy-box', {
             sync: true,
@@ -32,6 +32,7 @@ async function createWrapper() {
                         value: null,
                     },
                 },
+                ...props,
             },
             global: {
                 stubs: {
@@ -61,6 +62,20 @@ describe('module/sw-cms/elements/buy-box/component', () => {
         });
 
         expect((await createWrapper()).get('.sw-cms-el-buy-box__skeleton')).toBeTruthy();
+    });
+
+    it('should not change the persisted lock state on product detail pages', async () => {
+        const element = {
+            data: {},
+            config: {},
+        };
+        Shopware.Store.get('cmsPage').setCurrentPage({
+            type: 'product_detail',
+        });
+
+        await createWrapper({ element });
+
+        expect(element.locked).toBeUndefined();
     });
 
     it('should show dummy data initially if page type is not product page and no product config', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/buy-box/component/index.js
@@ -67,12 +67,6 @@ export default {
         },
     },
 
-    watch: {
-        pageType(newPageType) {
-            this.element.locked = newPageType === 'product_detail';
-        },
-    },
-
     created() {
         this.createdComponent();
     },
@@ -81,8 +75,6 @@ export default {
         createdComponent() {
             this.initElementConfig('buy-box');
             this.initElementData('buy-box');
-
-            this.element.locked = this.isProductPageType;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/component.spec.js
@@ -9,7 +9,7 @@ const productMock = {
     description: 'This product is awesome',
 };
 
-async function createWrapper() {
+async function createWrapper(props = {}) {
     return mount(
         await wrapTestComponent('sw-cms-el-product-description-reviews', {
             sync: true,
@@ -37,6 +37,7 @@ async function createWrapper() {
                         value: null,
                     },
                 },
+                ...props,
             },
         },
     );
@@ -74,6 +75,18 @@ describe('src/module/sw-cms/elements/product-description-reviews/component', () 
         await flushPromises();
 
         expect(wrapper.find('.sw-cms-el-product-description-reviews__placeholder').exists()).toBeTruthy();
+    });
+
+    it('should not change the persisted lock state on product detail pages', async () => {
+        const element = {
+            config: {},
+            data: {},
+        };
+        Shopware.Store.get('cmsPage').currentPage.type = 'product_detail';
+
+        await createWrapper({ element });
+
+        expect(element.locked).toBeUndefined();
     });
 
     it('should display data when product is selected', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-description-reviews/component/index.js
@@ -63,12 +63,6 @@ export default {
         },
     },
 
-    watch: {
-        pageType(newPageType) {
-            this.element.locked = newPageType === 'product_detail';
-        },
-    },
-
     created() {
         this.createdComponent();
     },
@@ -77,8 +71,6 @@ export default {
         createdComponent() {
             this.initElementConfig('product-description-reviews');
             this.initElementData('product-description-reviews');
-
-            this.element.locked = this.isProductPageType;
         },
     },
 };


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Opening a product CMS layout containing product description/reviews or buy-box can mark it as changed without user interaction, causing the unsaved-changes modal to appear.

### 2. What does this change do, exactly?

Derives the lock state for product-specific CMS elements in the Administration UI instead of mutating the persisted CMS slot during component initialization.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product CMS layout containing a product description/reviews element.
2. Close the layout without editing it.
3. Before this change, the unsaved-changes modal appears.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #8552

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
