### PR TITLE
fix: Add same media as attachment for different languages

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -699,7 +699,9 @@ export default {
 
         onDeleteMedia(mailTemplateMediaId) {
             const foundItem = this.mailTemplate.media.find(
-                (mailTemplateMedia) => mailTemplateMedia.mediaId === mailTemplateMediaId && mailTemplateMedia.languageId === Shopware.Context.api.languageId
+                (mailTemplateMedia) =>
+                    mailTemplateMedia.mediaId === mailTemplateMediaId &&
+                    mailTemplateMedia.languageId === Shopware.Context.api.languageId,
             );
 
             if (foundItem) {

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -666,7 +666,7 @@ export default {
         },
 
         successfulUpload({ targetId }) {
-            if (this.mailTemplate.media.find((mailTemplateMedia) => mailTemplateMedia.mediaId === targetId)) {
+            if (this._checkIfMediaIsAlreadyUsed(targetId)) {
                 return;
             }
 
@@ -699,8 +699,9 @@ export default {
 
         onDeleteMedia(mailTemplateMediaId) {
             const foundItem = this.mailTemplate.media.find(
-                (mailTemplateMedia) => mailTemplateMedia.mediaId === mailTemplateMediaId,
+                (mailTemplateMedia) => mailTemplateMedia.mediaId === mailTemplateMediaId && mailTemplateMedia.languageId === Shopware.Context.api.languageId
             );
+
             if (foundItem) {
                 this.mailTemplate.media.remove(foundItem.id);
                 this.getMailTemplateMedia();

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -43,6 +43,20 @@ const mediaMock = [
         mediaId: '30c0082ccb03494799b42f22c7fa07d9',
         position: 0,
     },
+    {
+        id: '88uy773yd1ssd299si1d837dy1ud628',
+        mailTemplateId: 'ed3866445dd744bb9e0f88f8f340141f',
+        languageId: '60a91bbbc83f42a3abedd20dd45b9fb0',
+        mediaId: '1svd4de52e6924d70ya5u75cd7ze4gd01',
+        position: 0,
+    },
+    {
+        id: 'ad3466455ed794bb9e0f28s8g3701s1z',
+        mailTemplateId: 'ed3866445dd744bb9e0f88f8f340141f',
+        languageId: '60a91bbbc83f42a3abedd20dd45b9fb0',
+        mediaId: '30c0082ccb03494799b42f22c7fa07d9',
+        position: 0,
+    },
 ];
 
 const mailTemplateMediaMock = {
@@ -286,6 +300,45 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
         expect(wrapper.vm.mailTemplate.media.some((media) => media.mediaId === mailTemplateMediaMock.id)).toBeTruthy();
     });
 
+    it('should be able to add an item to the attachment exist this item with different language', async () => {
+        const originalLanguageId = Shopware.Context.api.languageId;
+
+        const wrapper = await createWrapper();
+        await wrapper.setData({ mailTemplateMedia: [] });
+        wrapper.vm.createNotificationInfo = jest.fn();
+
+        // Add media
+        wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
+        expect(wrapper.vm.mailTemplate.media.some(
+            (media) => media.mediaId === mailTemplateMediaMock.id)
+        ).toBeTruthy();
+
+        // Add same media again and expect error
+        wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
+        expect(wrapper.vm.createNotificationInfo).toHaveBeenCalledWith({
+            message: 'sw-mail-template.list.errorMediaItemDuplicated',
+        });
+
+        // reset mock function to be sure error message is correct
+        wrapper.vm.createNotificationInfo = jest.fn();
+
+        // Switch language and add same media again and expect success
+        Shopware.Context.api.languageId = '9886595ca65447d6a812fe9de1096079';
+        wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
+
+        expect(wrapper.vm.mailTemplate.media.some(
+            (media) => media.mediaId === mailTemplateMediaMock.id)
+        ).toBeTruthy();
+
+        // Add same media again and expect error
+        wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
+        expect(wrapper.vm.createNotificationInfo).toHaveBeenCalledWith({
+            message: 'sw-mail-template.list.errorMediaItemDuplicated',
+        });
+
+        Shopware.Context.api.languageId = originalLanguageId;
+    });
+
     it('should be unable to add an item to the attachment exist this item', async () => {
         const wrapper = await createWrapper();
         wrapper.vm.createNotificationInfo = jest.fn();
@@ -360,15 +413,15 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
         });
 
         const hasMediaBeforeTest = wrapper.vm.mailTemplate.media.some(
-            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z',
+            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
         );
         expect(hasMediaBeforeTest).toBeTruthy();
 
         wrapper.vm.onDeleteSelectedMedia();
 
-        expect(wrapper.vm.mailTemplate.media).toHaveLength(mailTemplateMock.media.length);
+        expect(wrapper.vm.mailTemplate.media).toHaveLength(mediaMock.length - 1);
         const hasMediaAfterTest = wrapper.vm.mailTemplate.media.some(
-            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z',
+            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
         );
         expect(hasMediaAfterTest).toBeFalsy();
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -309,9 +309,7 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
         // Add media
         wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
-        expect(wrapper.vm.mailTemplate.media.some(
-            (media) => media.mediaId === mailTemplateMediaMock.id)
-        ).toBeTruthy();
+        expect(wrapper.vm.mailTemplate.media.some((media) => media.mediaId === mailTemplateMediaMock.id)).toBeTruthy();
 
         // Add same media again and expect error
         wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
@@ -326,9 +324,7 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
         Shopware.Context.api.languageId = '9886595ca65447d6a812fe9de1096079';
         wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
 
-        expect(wrapper.vm.mailTemplate.media.some(
-            (media) => media.mediaId === mailTemplateMediaMock.id)
-        ).toBeTruthy();
+        expect(wrapper.vm.mailTemplate.media.some((media) => media.mediaId === mailTemplateMediaMock.id)).toBeTruthy();
 
         // Add same media again and expect error
         wrapper.vm.onAddItemToAttachment(mailTemplateMediaMock);
@@ -413,7 +409,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
         });
 
         const hasMediaBeforeTest = wrapper.vm.mailTemplate.media.some(
-            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
+            (media) =>
+                media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
         );
         expect(hasMediaBeforeTest).toBeTruthy();
 
@@ -421,7 +418,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
 
         expect(wrapper.vm.mailTemplate.media).toHaveLength(mediaMock.length - 1);
         const hasMediaAfterTest = wrapper.vm.mailTemplate.media.some(
-            (media) => media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
+            (media) =>
+                media.id === 'ad3466455ed794bb9e0f28s8g3701s1z' && media.languageId === Shopware.Context.api.languageId,
         );
         expect(hasMediaAfterTest).toBeFalsy();
     });


### PR DESCRIPTION
closes: #18411

adds a check for languageId to make it possible to add the same media as an attachment for different languages.

The same media file is now reusable via drag & drop in multiple language tabs of the same mail template.

Additionally, I recognized an issue with deleting media. I also add a language check to prevent deleting the false media.