### PR TITLE
docs: add the test package attribute rule to the phpunit skill

### DIFF
--- a/.agents/skills/shopware-phpunit-tests/SKILL.md
+++ b/.agents/skills/shopware-phpunit-tests/SKILL.md
@@ -35,6 +35,13 @@ Tests should read like executable examples.
 - Simple struct-style classes with only public properties do not need unit tests; mark them with `@codeCoverageIgnore` instead.
 - Do not add `#[CoversClass]`, `#[CoversFunction]`, or `#[CoversNothing]` to integration tests. Shopware's PHPStan rule allows those attributes only on unit and migration tests.
 
+## Package Attribute
+
+- Give every test class a `#[Package('…')]` attribute (import `Shopware\Core\Framework\Log\Package`) so failing CI jobs — especially the nightlies — can be routed to the owning domain team. A Danger rule fails PRs that add test classes without it.
+- In unit and migration tests, copy the value from the `#[CoversClass]` target's `#[Package]`.
+- Integration tests carry no `#[CoversClass]`; use the dominant `#[Package]` value of the `src/` directory the test path mirrors (e.g. `tests/integration/Core/Checkout/Cart/…` → `src/Core/Checkout/Cart`).
+- When a change moves the covered class to another package, update the test's attribute in the same change so the two stay in sync.
+
 ## Data Providers
 
 - Use named `yield` cases in unit-test data providers instead of returning arrays, even for small providers. This keeps cases readable and avoids materializing large arrays as providers grow.

--- a/.agents/skills/shopware-phpunit-tests/SKILL.md
+++ b/.agents/skills/shopware-phpunit-tests/SKILL.md
@@ -18,7 +18,6 @@ Tests should read like executable examples.
 - Keep test helpers smaller than the code they replace.
 - Do not hide assertions or feature-flag toggling behind abstractions when direct assertions are just as readable.
 - Prefer one focused test per distinct exception or behavior over broad data providers when each case has its own meaning.
-- Add `#[Package('…')]` to every test class, using the same package as its covered production domain so CI failures route to the owning team.
 
 ## Assertions And Fixtures
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Every new test class must carry `#[Package('…')]` — the `MissingPackageAttributeInTests` Danger rule enforces it — but the `shopware-phpunit-tests` agent skill never mentions the attribute, so agents writing tests only learn about it when Danger fails the PR.

### 2. What does this change do, exactly?

Adds a **Package Attribute** section to `.agents/skills/shopware-phpunit-tests/SKILL.md`, mirroring the Danger rule's resolution logic:

- every test class gets `#[Package('…')]` so failing CI jobs can be routed to the owning domain team
- unit and migration tests copy the value from the `#[CoversClass]` target
- integration tests (which carry no `#[CoversClass]`) use the dominant `#[Package]` marker of the mirrored `src/` directory
- when the covered class moves to another package, the test attribute is updated in the same change

### 3. Describe each step to reproduce the issue or behaviour.

Ask an agent to write a new PHPUnit test — the skill gives no reason to add `#[Package]`, and the omission only surfaces as a Danger failure on the PR.

### 4. Please link to the relevant issues (if any).

- relates #18426

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them