### PR TITLE
ci: assign the framework project when the framework label is added

### DIFF
--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -2,6 +2,7 @@ name: Label Issues and PRs
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   issues:
   workflow_dispatch:
   schedule:
@@ -185,7 +186,10 @@ jobs:
 
   assign-framework-project:
     runs-on: ubuntu-24.04
-    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'domain/framework'
+    if: >
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'domain/framework' &&
+      (github.event_name == 'issues' || github.event_name == 'pull_request')
     needs: label
     permissions:
       contents: read
@@ -209,7 +213,8 @@ jobs:
           script: |
             const { addProjectItem, getProjectIdByNumber } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             const projectId = await getProjectIdByNumber(github, Number(process.env.PROJECT_NUMBER))
-            await addProjectItem(github, { projectId, issueId: context.payload.issue.node_id })
+            const contentId = (context.payload.issue ?? context.payload.pull_request).node_id
+            await addProjectItem(github, { projectId, issueId: contentId })
 
   sync-test-plan-sub-issue:
     runs-on: ubuntu-24.04

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -183,6 +183,34 @@ jobs:
             const { syncPriorities } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await syncPriorities({github, core, context})
 
+  assign-framework-project:
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'domain/framework'
+    needs: label
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: sts
+        continue-on-error: true
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: ManageProjects
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          PROJECT_NUMBER: 27 # Framework Group
+        with:
+          github-token: ${{ steps.sts.outputs.token }}
+          script: |
+            const { addProjectItem, getProjectIdByNumber } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            const projectId = await getProjectIdByNumber(github, Number(process.env.PROJECT_NUMBER))
+            await addProjectItem(github, { projectId, issueId: context.payload.issue.node_id })
+
   sync-test-plan-sub-issue:
     runs-on: ubuntu-24.04
     if: >


### PR DESCRIPTION
### 1. Why is this change necessary?

Issues and pull requests labeled `domain/framework` still have to be added to the Framework project board by hand.

### 2. What does this change do, exactly?

Adds an `assign-framework-project` job to `01-pr-issue-labeler.yml`: when the `domain/framework` label is added to an issue or a pull request, it is added to the Framework Group project (org project 27, the same one the stale-issue jobs already target). The job follows the existing `priority-sync` pattern — octo-sts `ManageProjects` token and the `@shopware-ag/gh-project-automation` helpers (`getProjectIdByNumber` + `addProjectItem`).

The workflow's `pull_request` trigger is extended with the `labeled` type; the bare trigger only fires on `opened`/`synchronize`/`reopened`.

### 3. Describe each step to reproduce the issue or behaviour.

Add the `domain/framework` label to any issue or PR — nothing happens today; it only shows up on the board after someone adds it manually.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them