### PR TITLE
fix(administration): use regular icons for module navigation

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.html.twig
@@ -105,7 +105,7 @@
     <slot name="empty-state">
         <mt-empty-state
             v-if="!total && !isLoading"
-            icon="solid-products"
+            icon="regular-products"
             :headline="emptyStateMessage"
         />
     </slot>

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/sw-advanced-selection-product.html.twig
@@ -7,7 +7,7 @@
     :entity-columns="productColumns"
     :entity-filters="productFilters"
     :entity-associations="productAssociations"
-    empty-icon="solid-products"
+    empty-icon="regular-products"
     v-bind="$attrs"
     @selection-submit="$emit('selection-submit', $event)"
     @modal-close="$emit('modal-close', $event)"

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-rule/sw-advanced-selection-rule.html.twig
@@ -11,7 +11,7 @@
     :entity-associations="associations"
     :is-record-selectable-callback="isRecordSelectable"
     :disable-previews="true"
-    empty-icon="solid-products"
+    empty-icon="regular-products"
     v-bind="$attrs"
     @selection-submit="$emit('selection-submit', $event)"
     @modal-close="$emit('modal-close', $event)"

--- a/src/Administration/Resources/app/administration/src/module/AGENTS.md
+++ b/src/Administration/Resources/app/administration/src/module/AGENTS.md
@@ -30,7 +30,7 @@ Module.register('sw-product', {
   entity: 'product',
   title: 'sw-product.general.mainMenuItemGeneral',
   color: '#57D9A3',
-  icon: 'solid-products',
+  icon: 'regular-products',
 
   routes: {
     index: {

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.html.twig
@@ -100,7 +100,7 @@
         {% block sw_bulk_edit_customer_empty_state %}
         <mt-empty-state
             v-if="selectedIds.length <= 0 && !isLoading"
-            icon="solid-users"
+            icon="regular-users"
             :headline="$t('sw-bulk-edit.customer.messageEmptyTitle')"
             :description="$t('sw-bulk-edit.customer.messageEmptySubline')"
         />

--- a/src/Administration/Resources/app/administration/src/module/sw-category/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/index.js
@@ -46,7 +46,7 @@ Module.register('sw-category', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: 'var(--color-module-green-500)',
-    icon: 'solid-products',
+    icon: 'regular-products',
     favicon: 'icon-module-products.png',
     entity: 'category',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/sw-category-detail-custom-entity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/sw-category-detail-custom-entity.spec.js
@@ -110,7 +110,7 @@ async function createWrapper() {
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -133,7 +133,7 @@
             >
                 <mt-empty-state
                     v-if="cmsBlocksBySelectedBlockCategory.length === 0 && currentBlockCategory === 'favorite'"
-                    icon="solid-heart"
+                    icon="regular-heart"
                     :headline="$t('sw-cms.detail.title.blockFavoriteEmptyState')"
                     :description="$t('sw-cms.detail.label.blockFavoriteEmptyState')"
                 />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec.js
@@ -112,7 +112,7 @@ async function createWrapper(activeTab = 'sorting') {
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.html.twig
@@ -343,7 +343,7 @@
                                 {% block sw_cms_element_product_listing_config_filter_empty_state %}
                             <mt-empty-state
                                 v-else
-                                icon="solid-products"
+                                icon="regular-products"
                                 :headline="$t('sw-cms.elements.productListing.config.filter.gridEmptyStateLabel')"
                                 :description="$t('sw-cms.elements.productListing.config.filter.gridEmptyStateHint')"
                             />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -111,7 +111,7 @@ async function createWrapper(
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.html.twig
@@ -62,7 +62,7 @@
             <mt-empty-state
                 v-else
                 class="sw-generic-custom-entity-list__content-empty-state"
-                icon="solid-image-text"
+                icon="regular-image-text"
                 :headline="emptyStateTitle"
                 :description="emptyStateSubline"
             />

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
@@ -104,7 +104,7 @@ async function createWrapper(query = {}) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                         query,

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/index.js
@@ -39,7 +39,7 @@ Module.register('sw-customer', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: 'var(--color-pumpkin-500)',
-    icon: 'solid-users',
+    icon: 'regular-users',
     favicon: 'icon-module-customers.png',
     entity: 'customer',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.spec.js
@@ -17,7 +17,7 @@ async function createWrapper(privileges = []) {
                     },
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -90,7 +90,7 @@
     {% block sw_customer_detail_order_card_grid_empty_state %}
     <template v-if="(!orders || orders.total === 0) && !isLoading && !term">
         <mt-empty-state
-            icon="solid-shopping-bag"
+            icon="regular-shopping-bag"
             :headline="emptyTitle"
             :description="$t('sw-customer.detailOrder.emptySubline')"
         >

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
@@ -111,7 +111,7 @@ async function createWrapper(privileges = [], props = {}) {
                     },
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.html.twig
@@ -165,7 +165,7 @@
     {% block sw_import_export_activity_empty_state %}
     <mt-empty-state
         v-if="showEmptyState"
-        icon="solid-database"
+        icon="regular-database"
         :headline="emptyStateTitle"
         :description="emptyStateSubLine"
         centered

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/index.js
@@ -20,7 +20,7 @@ Module.register('sw-integration', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'integration',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -139,7 +139,7 @@ async function createWrapper(privileges = [], integrations = null, options = {})
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/index.js
@@ -21,7 +21,7 @@ Module.register('sw-manufacturer', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#57D9A3',
-    icon: 'solid-products',
+    icon: 'regular-products',
     favicon: 'icon-module-products.png',
     entity: 'product_manufacturer',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-list/sw-manufacturer-list.spec.js
@@ -46,7 +46,7 @@ async function createWrapper(privileges = []) {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-media/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/index.js
@@ -40,7 +40,7 @@ Module.register('sw-media', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: 'var(--color-pink-500)',
-    icon: 'solid-image',
+    icon: 'regular-image',
     favicon: 'icon-module-content.png',
     entity: 'media',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/index.js
@@ -24,7 +24,7 @@ Module.register('sw-newsletter-recipient', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#FFD700',
-    icon: 'solid-megaphone',
+    icon: 'regular-megaphone',
     favicon: 'icon-module-marketing.png',
     entity: 'newsletter_recipient',
     entityDisplayProperty: 'email',

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.spec.js
@@ -184,7 +184,7 @@ async function createWrapper(options = {}) {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -231,7 +231,7 @@ async function createWrapper(props = defaultProps, routeName = 'sw.order.detail.
                     name: routeName,
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.html.twig
@@ -87,7 +87,7 @@
         {% block sw_order_line_items_grid_sales_channel_grid_no_items %}
         <mt-empty-state
             v-if="cartLineItems.length === 0"
-            icon="solid-products"
+            icon="regular-products"
             :headline="$t('sw-order.createBase.messageEmptyItem')"
         />
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/index.js
@@ -127,7 +127,7 @@ Module.register('sw-order', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: 'var(--color-purple-500)',
-    icon: 'solid-shopping-bag',
+    icon: 'regular-shopping-bag',
     favicon: 'icon-module-orders.png',
     entity: 'order',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -143,7 +143,7 @@ async function createWrapper() {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/index.js
@@ -28,7 +28,7 @@ Module.register('sw-product-stream', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#57D9A3',
-    icon: 'solid-products',
+    icon: 'regular-products',
     favicon: 'icon-module-products.png',
     entity: 'product_stream',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variant-modal/sw-product-variant-modal.spec.js
@@ -364,7 +364,7 @@ async function createWrapper() {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/index.js
@@ -122,7 +122,7 @@ Module.register('sw-product', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#57D9A3',
-    icon: 'solid-products',
+    icon: 'regular-products',
     favicon: 'icon-module-products.png',
     entity: 'product',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -236,7 +236,7 @@ async function createWrapper() {
                 meta: {
                     $module: {
                         entity: 'product',
-                        icon: 'solid-content',
+                        icon: 'regular-content',
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-reviews/sw-product-detail-reviews.spec.js
@@ -69,7 +69,7 @@ async function createWrapper(privileges = []) {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.spec.js
@@ -52,7 +52,7 @@ async function createWrapper(privileges = []) {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/index.js
@@ -68,7 +68,7 @@ Module.register('sw-promotion-v2', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#FFD700',
-    icon: 'solid-megaphone',
+    icon: 'regular-megaphone',
     favicon: 'icon-module-marketing.png',
     entity: 'promotion',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.spec.js
@@ -14,7 +14,7 @@ async function createWrapper() {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-property/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/index.js
@@ -25,7 +25,7 @@ Module.register('sw-property', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#57D9A3',
-    icon: 'solid-products',
+    icon: 'regular-products',
     favicon: 'icon-module-products.png',
     entity: 'property_group',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.spec.js
@@ -16,7 +16,7 @@ async function createWrapper() {
                     },
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-list/sw-review-list.html.twig
@@ -39,7 +39,7 @@
             {% block sw_review_list_empty_state %}
             <mt-empty-state
                 v-if="!isLoading && !total"
-                icon="solid-file-text"
+                icon="regular-file-text"
                 :centered="true"
                 :headline="$t('sw-review.list.messageEmpty')"
                 :description="$t('sw-review.list.messageEmptySubline')"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-product-assignment-categories/sw-sales-channel-product-assignment-categories.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-product-assignment-categories/sw-sales-channel-product-assignment-categories.html.twig
@@ -158,7 +158,7 @@
             {% block sw_sales_channel_product_assignment_categories_search_results_empty %}
             <mt-empty-state
                 v-else
-                icon="solid-products"
+                icon="regular-products"
                 :headline="$t('sw-sales-channel.detail.productAssignmentModal.categories.emptySearchResults')"
                 class="sw-sales-channel-product-assignment-categories__empty-state"
             />

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.html.twig
@@ -61,7 +61,7 @@
             {% block sw_sales_channel_products_assignment_single_products_primary_empty_state %}
             <mt-empty-state
                 v-else
-                icon="solid-products"
+                icon="regular-products"
                 :headline="$t('sw-sales-channel.detail.products.titleEmptyState')"
             />
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
@@ -88,7 +88,7 @@ async function createWrapper() {
                 $route: {
                     meta: {
                         $module: {
-                            icon: 'solid-content',
+                            icon: 'regular-content',
                         },
                     },
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
@@ -101,7 +101,7 @@ Module.register('sw-sales-channel', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: 'var(--color-module-green-500)',
-    icon: 'solid-server',
+    icon: 'regular-server',
     entity: 'sales_channel',
 
     searchMatcher: (regex, labelType, manifest) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-products/sw-sales-channel-detail-products.html.twig
@@ -152,7 +152,7 @@
                 {% block sw_sales_channel_detail_products_card_section_primary_empty_state %}
                 <mt-empty-state
                     v-else
-                    icon="solid-products"
+                    icon="regular-products"
                     :headline="$t('sw-sales-channel.detail.products.titleEmptyStateTable')"
                 />
 
@@ -169,7 +169,7 @@
     {% block sw_sales_channel_detail_products_empty_state %}
     <mt-empty-state
         v-if="products.length <= 0 && !searchTerm && !isLoading"
-        icon="solid-products"
+        icon="regular-products"
         :headline="$t('sw-sales-channel.detail.products.titleEmptyState')"
     >
         <template #button>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-state/sw-settings-country-state.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-state/sw-settings-country-state.spec.js
@@ -47,7 +47,7 @@ async function createWrapper(privileges = []) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/index.js
@@ -47,7 +47,7 @@ Module.register('sw-settings-country', {
     title: 'sw-settings-country.general.mainMenuItemGeneral',
     description: 'Country section in the settings module',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'country',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/index.js
@@ -22,7 +22,7 @@ Module.register('sw-settings-currency', {
     title: 'sw-settings-currency.general.mainMenuItemGeneral',
     description: 'Currency section in the settings module',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'currency',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/page/sw-settings-currency-detail/sw-settings-currency-detail.spec.js
@@ -69,7 +69,7 @@ async function createWrapper(privileges = []) {
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/sw-custom-field-list.spec.js
@@ -129,7 +129,7 @@ async function createWrapper(privileges = [], repo = mockCustomFieldRepository()
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/index.js
@@ -73,7 +73,7 @@ Module.register('sw-settings-custom-field', {
     title: 'sw-settings-custom-field.general.mainMenuItemGeneral',
     description: 'sw-settings-custom-field.general.description',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'custom-field-set',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-list/sw-settings-customer-group-list.spec.js
@@ -21,7 +21,7 @@ async function createWrapper(privileges = []) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/index.js
@@ -22,7 +22,7 @@ Module.register('sw-settings-number-range', {
     title: 'sw-settings-number-range.general.mainMenuItemGeneral',
     description: 'Number Range section in the settings module',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'number_range',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.spec.js
@@ -19,7 +19,7 @@ async function createWrapper(privileges = []) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/index.js
@@ -30,7 +30,7 @@ Module.register('sw-settings-payment', {
     title: 'sw-settings-payment.general.mainMenuItemGeneral',
     description: 'Payment section in the settings module',
     color: 'var(--color-icon-secondary-default)',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'payment_method',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-overview/sw-settings-payment-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-overview/sw-settings-payment-overview.spec.js
@@ -56,7 +56,7 @@ async function createWrapper(methods = [], cards = [], privileges = []) {
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/index.js
@@ -42,7 +42,7 @@ Module.register('sw-settings-rule', {
     title: 'sw-settings-rule.general.mainMenuItemGeneral',
     description: 'sw-settings-rule.general.descriptionTextModule',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'rule',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/index.spec.js
@@ -41,7 +41,7 @@ describe('src/module/sw-settings-rule/index.js', () => {
             title: 'sw-settings-rule.general.mainMenuItemGeneral',
             description: 'sw-settings-rule.general.descriptionTextModule',
             color: '#9AA8B5',
-            icon: 'solid-cog',
+            icon: 'regular-cog',
             favicon: 'icon-module-settings.png',
             entity: 'rule',
             routes: expect.any(Object),

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.spec.js
@@ -194,7 +194,7 @@ async function createWrapper(
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/index.js
@@ -29,7 +29,7 @@ Module.register('sw-settings-shipping', {
     title: 'sw-settings-shipping.general.mainMenuItemGeneral',
     description: 'sw-settings-shipping.general.descriptionTextModule',
     color: 'var(--color-icon-secondary-default)',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'shipping_method',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.spec.js
@@ -23,7 +23,7 @@ async function createWrapper(privileges = []) {
                         query: '',
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.ts
@@ -31,7 +31,7 @@ Module.register('sw-settings-shopware-updates', {
     version: '1.0.0',
     targetVersion: '1.0.0',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
 
     routes: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tag/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tag/index.js
@@ -21,7 +21,7 @@ Module.register('sw-settings-tag', {
     title: 'sw-settings-tag.general.mainMenuItemGeneral',
     description: 'Tag section in the settings module',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'tag',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/index.js
@@ -49,7 +49,7 @@ Module.register('sw-settings-tax', {
     title: 'sw-settings-tax.general.mainMenuItemGeneral',
     description: 'Tax section in the settings module',
     color: 'var(--color-icon-secondary-default)',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'tax',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.spec.js
@@ -18,7 +18,7 @@ async function createWrapper(privileges = [], additionalOptions = {}) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-units/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-units/index.js
@@ -17,7 +17,7 @@ Module.register('sw-settings-units', {
     title: 'sw-settings-units.general.mainMenuItemGeneral',
     description: 'Units section in the settings module',
     color: '#9AA8B5',
-    icon: 'solid-cog',
+    icon: 'regular-cog',
     favicon: 'icon-module-settings.png',
     entity: 'units',
 

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-role-listing/sw-users-permissions-role-listing.spec.js
@@ -42,7 +42,7 @@ async function createWrapper(privileges = [], isSso = { isSso: false }, deleteFu
                     $route: {
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.spec.js
@@ -78,7 +78,7 @@ async function createWrapper(privileges = []) {
                         },
                         meta: {
                             $module: {
-                                icon: 'solid-content',
+                                icon: 'regular-content',
                             },
                         },
                     },


### PR DESCRIPTION
### 1. Why is this change necessary?

The Administration used a mix of `solid-*` and `regular-*` Meteor icon variants
for the same purposes, which looked inconsistent. Module navigation icons should
use the `regular-*` variant, and empty states should match that variant instead
of rendering solid icons.

This is a scoped, reviewed subset of the community contribution #14821, limited
to the icon variant used for module navigation and empty states.

### 2. What does this change do, exactly?

- Switches the `icon` in `Module.register(...)` from `solid-*` to the matching
  `regular-*` variant across the admin modules, so module navigation and
  breadcrumb render the regular variant consistently. The corresponding
  `$module.icon` route-meta mocks in the affected Jest specs are updated too.
- Switches the hardcoded `solid-*` icons on `mt-empty-state` usages to their
  `regular-*` variant. Empty states that inherit the icon from
  `$route.meta.$module.icon` already render the regular variant through the
  module change above.
- No public API, configuration, or behaviour changes — this is a visual change
  to first-party module navigation and empty-state icons only. Semantic icons
  (rating stars, favorite toggles, status/warning indicators, etc.) intentionally
  keep the `solid-*` variant.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the Administration.
2. Observe that module navigation icons (e.g. Products, Customers, Orders,
   Settings entries) render with the `regular` variant.
3. Open a list/detail view with no data (e.g. an empty Products, Orders or
   Reviews listing) and observe that the empty-state icon now renders with the
   `regular` variant, matching the navigation.

### 4. Please link to the relevant issues (if any).

- relates #14821 (this PR supersedes it with a scoped subset)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
