### PR TITLE
ci: sync linked issue status when a PR opens or gets reviewers

### DIFF
--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -120,9 +120,7 @@ jobs:
   linked-issues-status:
     runs-on: ubuntu-24.04
     if: >
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' || github.event.action == 'review_requested') &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'review_requested') && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       id-token: write
@@ -153,6 +151,7 @@ jobs:
                     closingIssuesReferences(first: 10) {
                       nodes {
                         number
+                        authorAssociation
                         repository { nameWithOwner }
                       }
                     }
@@ -160,8 +159,11 @@ jobs:
                 }
               }`, { owner: context.repo.owner, repo: context.repo.repo, number: context.payload.pull_request.number })
 
+            // externally authored issues are not touched; external PRs never reach this job (fork heads are filtered in the job condition)
+            const internalAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR']
             const linkedIssues = res.repository.pullRequest.closingIssuesReferences.nodes
               .filter(issue => issue.repository.nameWithOwner === `${context.repo.owner}/${context.repo.repo}`)
+              .filter(issue => internalAssociations.includes(issue.authorAssociation))
 
             for (const { number } of linkedIssues) {
               const issue = await findIssueWithProjectItems({github, core, context}, number)

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -116,6 +116,67 @@ jobs:
             const { setStatusInProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await setStatusInProjects({github, core, context}, { fromStatus: "Done", toStatus: "in progress" })
 
+  linked-issues-in-progress:
+    runs-on: ubuntu-24.04
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.action == 'opened' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: sts
+        continue-on-error: true
+        uses: shopware/octo-sts-action@main
+        with:
+          scope: shopware
+          identity: ManageProjects
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          github-token: ${{ steps.sts.outputs.token }}
+          script: |
+            const { findIssueWithProjectItems, getProjectInfo, setFieldValue } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+
+            const res = await github.graphql(`
+              query closingIssues($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        number
+                        repository { nameWithOwner }
+                      }
+                    }
+                  }
+                }
+              }`, { owner: context.repo.owner, repo: context.repo.repo, number: context.payload.pull_request.number })
+
+            const linkedIssues = res.repository.pullRequest.closingIssuesReferences.nodes
+              .filter(issue => issue.repository.nameWithOwner === `${context.repo.owner}/${context.repo.repo}`)
+
+            for (const { number } of linkedIssues) {
+              const issue = await findIssueWithProjectItems({github, core, context}, number)
+              for (const item of issue.projectItems) {
+                if (item.fieldValueByName?.name?.toLowerCase() === 'in progress') {
+                  continue
+                }
+                const projectInfo = await getProjectInfo({github, core, context}, { number: item.project.number })
+                const statusField = projectInfo.fields.find(field => field.name === 'Status')
+                const inProgress = statusField?.options.find(option => option.name.toLowerCase() === 'in progress')
+                if (!inProgress) {
+                  core.info(`No "In progress" status option in project ${item.project.number}, skipping`)
+                  continue
+                }
+                await setFieldValue({github, core, context}, { projectId: projectInfo.node_id, itemId: item.id, fieldId: statusField.id, valueId: inProgress.id })
+                core.info(`Issue #${number}: status set to "In progress" in project ${item.project.number}`)
+              }
+            }
+
   mark-stale-issues:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -2,6 +2,7 @@ name: Label Issues and PRs
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, review_requested]
   issues:
   workflow_dispatch:
   schedule:
@@ -116,11 +117,11 @@ jobs:
             const { setStatusInProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await setStatusInProjects({github, core, context}, { fromStatus: "Done", toStatus: "in progress" })
 
-  linked-issues-in-progress:
+  linked-issues-status:
     runs-on: ubuntu-24.04
     if: >
       github.event_name == 'pull_request' &&
-      github.event.action == 'opened' &&
+      (github.event.action == 'opened' || github.event.action == 'review_requested') &&
       github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
@@ -142,6 +143,9 @@ jobs:
           script: |
             const { findIssueWithProjectItems, getProjectInfo, setFieldValue } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
 
+            // opened -> "In progress"; a reviewer request moves the linked issues on to "In Review"
+            const targetStatus = context.payload.action === 'review_requested' ? 'in review' : 'in progress'
+
             const res = await github.graphql(`
               query closingIssues($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -162,18 +166,18 @@ jobs:
             for (const { number } of linkedIssues) {
               const issue = await findIssueWithProjectItems({github, core, context}, number)
               for (const item of issue.projectItems) {
-                if (item.fieldValueByName?.name?.toLowerCase() === 'in progress') {
+                if (item.fieldValueByName?.name?.toLowerCase() === targetStatus) {
                   continue
                 }
                 const projectInfo = await getProjectInfo({github, core, context}, { number: item.project.number })
                 const statusField = projectInfo.fields.find(field => field.name === 'Status')
-                const inProgress = statusField?.options.find(option => option.name.toLowerCase() === 'in progress')
-                if (!inProgress) {
-                  core.info(`No "In progress" status option in project ${item.project.number}, skipping`)
+                const targetOption = statusField?.options.find(option => option.name.toLowerCase() === targetStatus)
+                if (!targetOption) {
+                  core.info(`No "${targetStatus}" status option in project ${item.project.number}, skipping`)
                   continue
                 }
-                await setFieldValue({github, core, context}, { projectId: projectInfo.node_id, itemId: item.id, fieldId: statusField.id, valueId: inProgress.id })
-                core.info(`Issue #${number}: status set to "In progress" in project ${item.project.number}`)
+                await setFieldValue({github, core, context}, { projectId: projectInfo.node_id, itemId: item.id, fieldId: statusField.id, valueId: targetOption.id })
+                core.info(`Issue #${number}: status set to "${targetOption.name}" in project ${item.project.number}`)
               }
             }
 

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -22,29 +22,29 @@ on:
         default: ""
 
 jobs:
-   visual-tests:
+  visual-tests:
     runs-on: ubuntu-24.04
     steps:
       - name: Define environment
         shell: bash
         run: |
-            echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
-            echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
-            echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
-            echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
-            echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
-            echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
-            echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
+          echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
+          echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
+          echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
+          echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
+          echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
+          echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
+          echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-            env: prod
-            mysql-version: "builtin"
-            shopware-version: ${{ github.ref }}
-            shopware-repository: ${{ github.repository }}
-            install: true
-            install-admin: true
-            install-storefront: true
+          env: prod
+          mysql-version: "builtin"
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+          install: true
+          install-admin: true
+          install-storefront: true
 
       - name: Install Playwright dependencies
         working-directory: tests/acceptance
@@ -95,12 +95,12 @@ jobs:
         if: ${{ github.repository_owner == 'shopware' }}
         shell: bash
         run: |
-            if [ -z "${{ secrets.PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN }}" ]; then
-              echo "has_role_arn=false" >> "$GITHUB_OUTPUT"
-              echo "Secret PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN is empty or unavailable (likely a fork)." >&2
-            else
-              echo "has_role_arn=true" >> "$GITHUB_OUTPUT"
-            fi
+          if [ -z "${{ secrets.PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN }}" ]; then
+            echo "has_role_arn=false" >> "$GITHUB_OUTPUT"
+            echo "Secret PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN is empty or unavailable (likely a fork)." >&2
+          else
+            echo "has_role_arn=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure AWS credentials
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
@@ -115,40 +115,40 @@ jobs:
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
         shell: bash
         run: |
-              set -euo pipefail
-              RANDOM_STR=$(openssl rand -hex 6)
+          set -euo pipefail
+          RANDOM_STR=$(openssl rand -hex 6)
 
-              # build the destination prefix and export it for subsequent steps
-              REPORT_DEST="playwright-reports/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RANDOM_STR}"
+          # build the destination prefix and export it for subsequent steps
+          REPORT_DEST="playwright-reports/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RANDOM_STR}"
 
-              aws s3 cp "playwright-report" "s3://shopware-ci-playwright-traces/${REPORT_DEST}/" --recursive
+          aws s3 cp "playwright-report" "s3://shopware-ci-playwright-traces/${REPORT_DEST}/" --recursive
 
-              echo "REPORT_DEST=${REPORT_DEST}" >> "$GITHUB_ENV"
-              echo "Uploaded to s3://shopware-ci-playwright-traces/${REPORT_DEST}/"
+          echo "REPORT_DEST=${REPORT_DEST}" >> "$GITHUB_ENV"
+          echo "Uploaded to s3://shopware-ci-playwright-traces/${REPORT_DEST}/"
 
       - name: Publish S3 Static Website URL
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
         shell: bash
         run: |
-              set -euo pipefail
+          set -euo pipefail
 
-              if [ -z "${REPORT_DEST:-}" ]; then
-                echo "REPORT_DEST not set (upload skipped or failed); skipping publish." >&2
-                exit 0
-              fi
+          if [ -z "${REPORT_DEST:-}" ]; then
+            echo "REPORT_DEST not set (upload skipped or failed); skipping publish." >&2
+            exit 0
+          fi
 
-              if ! aws s3 ls "s3://shopware-ci-playwright-traces/${REPORT_DEST}/index.html" >/dev/null 2>&1; then
-                echo "Index file not found ... skipping publish." >&2
-                exit 0
-              fi
+          if ! aws s3 ls "s3://shopware-ci-playwright-traces/${REPORT_DEST}/index.html" >/dev/null 2>&1; then
+            echo "Index file not found ... skipping publish." >&2
+            exit 0
+          fi
 
-              DOMAIN="${{ vars.PLAYWRIGHT_TRACES_DOMAIN }}"
-              URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
-              echo "${URL}"
+          DOMAIN="${{ vars.PLAYWRIGHT_TRACES_DOMAIN }}"
+          URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
+          echo "${URL}"
 
-              echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create token for PR
         if: ${{ inputs.update-snapshots }}

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -28,13 +28,15 @@ jobs:
       - name: Define environment
         shell: bash
         run: |
-          echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
-          echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
-          echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
-          echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
-          echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
-          echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
-          echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
+          {
+            echo "REDIS_URL=redis://localhost:6379"
+            echo "MAILER_DSN=smtp://localhost:1025"
+            echo "MAILPIT_BASE_URL=http://localhost:8025"
+            echo "SHOPWARE_HTTP_CACHE_ENABLED=0"
+            echo "SHOPWARE_DISABLE_UPDATE_CHECK=true"
+            echo "BLUE_GREEN_DEPLOYMENT=1"
+            echo "ENABLE_SERVICES=0"
+          } >> "$GITHUB_ENV"
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
@@ -68,7 +70,7 @@ jobs:
             --ipc=host \
             --init \
             --network=host \
-            --user $(id -u):$(id -g) \
+            --user "$(id -u):$(id -g)" \
             -e APP_URL=http://localhost:8000 \
             -e SHOPWARE_ADMIN_USERNAME=admin \
             -e SHOPWARE_ADMIN_PASSWORD=shopware \
@@ -78,7 +80,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/app" \
             -w /app/tests/acceptance \
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-            npx $ATS_CMD test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
+            npx "$ATS_CMD" test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
       - name: Upload visual test results
         if: always()
         continue-on-error: true
@@ -146,9 +148,11 @@ jobs:
           URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
           echo "${URL}"
 
-          echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Playwright HTML Report"
+            echo ""
+            echo "- ${URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create token for PR
         if: ${{ inputs.update-snapshots }}
@@ -163,7 +167,7 @@ jobs:
         if: ${{ inputs.update-snapshots }}
         id: diff
         shell: bash
-        run: git diff --exit-code tests/acceptance/tests/ || echo "changed=true" >> $GITHUB_OUTPUT
+        run: git diff --exit-code tests/acceptance/tests/ || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: ${{ inputs.update-snapshots && steps.diff.outputs.changed == 'true' && steps.create-pr-token.outputs.token != '' }}


### PR DESCRIPTION
### 1. Why is this change necessary?

When work starts on a roadmap issue, its status on the project boards stays wherever triage left it until someone moves it by hand. GitHub's built-in project workflows cover PR merged / review states, but have no "linked pull request opened" or "review requested" trigger.

### 2. What does this change do, exactly?

Adds a `linked-issues-status` job to `01-pr-issue-labeler.yml`. For pull requests from same-repo branches it resolves the issues the PR closes (`closingIssuesReferences`, i.e. `closes #…` / the Development sidebar) and, for every project board each issue is already on, sets the Status field:

- PR **opened** → "In progress"
- reviewers **requested** → "In Review"

It uses the existing octo-sts `ManageProjects` identity and the `@shopware-ag/gh-project-automation` helpers (`findIssueWithProjectItems`, `getProjectInfo`, `setFieldValue`), the same machinery as the `move-to-wip` job. Items already at the target status are left untouched; boards without the target status option are skipped. The job does not add issues to any board — it only updates boards the issue is already on. Externally authored issues are skipped (`authorAssociation` outside MEMBER/OWNER/COLLABORATOR), and external PRs never trigger the job since fork heads are filtered out.

The workflow's `pull_request` trigger is extended with the `review_requested` type; the bare trigger only fires on `opened`/`synchronize`/`reopened`.

Note: since CODEOWNERS requests reviewers automatically on PR creation, linked issues will usually move straight to "In Review" when the PR opens.

### 3. Describe each step to reproduce the issue or behaviour.

Open a PR with `closes #<issue>` where the issue sits on a project board, or request reviewers on it — the board status stays unchanged until someone updates it manually.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

