### PR TITLE
docs(core): document 6.8 behavioral changes

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -57,10 +57,16 @@ Use `Shopware\Core\System\SystemConfig\SystemConfigService` directly in PHP code
 
 Twig templates can continue using the `config()` helper, which is now provided by the core Twig environment.
 
-## Tax Calculation for percentage discounts / surcharges, e.g. promotions
+## Tax calculation for percentage discounts, surcharges, and split line-item quantities
 
 Taxes of percentage prices are not recalculated anymore, but use the existing tax calculation of the referenced line items.
 This prevents rounding errors when calculating taxes for percentage prices.
+
+The same applies when a line item is split into multiple quantities, for example while distributing a promotion across line items.
+The calculated taxes of the original line item are now distributed proportionally instead of recalculating the taxes for each split quantity.
+This can change cent-level rounding compared to previous versions.
+
+If an extension relies on recalculated taxes for percentage prices or split line items, review the resulting taxes for mixed tax rates, net and gross prices, promotions, and partial quantities.
 
 ## Payment: Removal of Payment Method "Debit Payment"
 
@@ -73,6 +79,54 @@ Otherwise, the payment method will be disabled.
 For user interfaces that display only one delivery & transaction, there is now a new reference in the order for a `primaryOrderDelivery` or `primaryOrderTransaction`.
 If an extension modifies or adds new deliveries or transactions, this should be taken into account.
 To partly comply with old behaviour, primary deliveries are ordered first and primary transactions are ordered last wherever appropriate.
+
+## Flow Builder executions run after the main business process
+
+Flows triggered during an HTTP request, Messenger message, or console command are now buffered and executed after the current unit of work has finished.
+For HTTP requests, buffered flows run during kernel termination; for Messenger and console execution, they run after the message or command has been handled.
+The flows still run in the same process and are not automatically dispatched to a message queue.
+
+This changes the ordering of Flow Builder actions relative to synchronous event subscribers and the initiating business operation:
+
+- Code that dispatches a `FlowEventAware` event returns before matching flows have run.
+- For HTTP requests, the response can be sent before flow side effects are completed.
+- Entity data used by flow actions is restored after the main business operation and can therefore reflect the subsequently persisted state instead of the original in-memory entity state.
+- Request-scoped state and an open transaction from the initiating operation must not be assumed to still be available to a custom flow action.
+
+If an operation must happen synchronously as part of the business transaction, implement it in a synchronous event subscriber instead of relying on a Flow Builder action.
+Review integrations that expect mail delivery, state transitions, webhooks, or custom flow actions to have completed when the initiating call returns.
+Tests that dispatch flow-aware events directly must also trigger the corresponding termination phase before asserting flow side effects.
+
+### Replace `BeforeLoadStorableFlowDataEvent`
+
+The deprecated `Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent` and its dynamic event names are removed.
+To modify the criteria used to restore entity data for mail-related flow actions, subscribe to `Shopware\Core\Content\Shared\MailFlow\Event\MailFlowDataCriteriaEvent` instead.
+
+The dynamic event name changes as follows:
+
+```diff
+-flow.storer.<entity-name>.criteria.event
++mail-flow.data.<entity-name>.criteria.event
+```
+
+Use the public `$criteria` and `$entityName` properties and the `getContext()` method on `MailFlowDataCriteriaEvent`.
+
+## Cart is deleted immediately after the order is created
+
+During checkout, the persisted cart is now deleted directly after the order has been created and before `CheckoutOrderPlacedCriteriaEvent` and `CheckoutOrderPlacedEvent` are dispatched.
+Subscribers to these events can no longer reload the cart by its context token.
+
+Read required information from the created order instead.
+Associations needed by `CheckoutOrderPlacedEvent` can be added through `CheckoutOrderPlacedCriteriaEvent`.
+If information exists only in the cart, persist or transfer it during order conversion or before the order is placed instead of loading the cart from an order-placed subscriber.
+
+## Cart errors created during SalesChannelContext construction are deferred
+
+Cart errors that occur while the `SalesChannelContext` is constructed are now persisted with the cart.
+They remain available until the cart is processed by the next cart-related Store API request, so temporary errors are not consumed before a client can display them.
+
+Store API clients should process the errors returned by the next cart response even if the operation that originally caused the error happened while the sales-channel context was created.
+Custom cart persisters and processors must preserve existing cart errors until that subsequent cart processing has taken place.
 
 ## Standardized CLI JSON output flag
 
@@ -450,6 +504,18 @@ Following helper methods have been removed from the `EntityDefinitionQueryHelper
 `\Shopware\Core\Framework\Migration\AddColumnTrait::addColumn` still throws a `\Doctrine\DBAL\Exception\TableNotFoundException` for missing tables (from the executed `ALTER TABLE` statement).
 
 ## Cache improvements
+
+### Selected Store API routes now use the HTTP cache
+
+Cacheable GET Store API routes now participate in Shopware's regular HTTP cache and use the same cache policies and `sw-cache-hash` variations as the Storefront.
+This applies to routes marked with the `_httpCache` route attribute, including product, category, navigation, CMS, country, currency, language, salutation, and SEO data routes.
+
+This is separate from the old Store API route cache that was removed in 6.7.
+The removed configuration listed under [Removed Store-API Route caching configuration](#removed-store-api-route-caching-configuration) still has no replacement; selected Store API responses are now cached by the standard HTTP cache instead.
+
+If an extension adds context-dependent data to a cacheable Store API response, ensure every relevant variation is represented in the HTTP cache key or prevent the response from being cached.
+In particular, review data that depends on the current customer, cart, permissions, custom rules, system configuration, or external state.
+Custom Store API routes are only cached when they explicitly opt in through the `_httpCache` route attribute.
 
 ### Only rules relevant for product prices are considered in the `sw-cache-hash`
 
@@ -2049,6 +2115,7 @@ Use `app:shop-id:change` instead of `app:url-change:resolve`
 ## Removed Store-API Route caching configuration
 
 With 6.7 the Store-API caching layer was removed, therefore the configuration for it is not needed anymore and has been removed.
+In 6.8, selected cacheable Store API GET routes use the standard HTTP cache instead; see [Cache improvements](#cache-improvements).
 Concretely this means the following configuration options are removed:
 - `shopware.cache.invalidation.product_listing_route`
 - `shopware.cache.invalidation.product_detail_route`

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -86,6 +86,10 @@ Flows triggered during an HTTP request, Messenger message, or console command ar
 For HTTP requests, buffered flows run during kernel termination; for Messenger and console execution, they run after the message or command has been handled.
 The flows still run in the same process and are not automatically dispatched to a message queue.
 
+This protects the main business process from failures and unexpected state mutations caused by flow actions, and avoids delaying it with expensive actions such as sending mail.
+Keeping execution in the same process, but after the main unit of work, also avoids the unpredictable delay of dispatching every flow through the message queue.
+The motivation, considered alternatives, and consequences are described in the [architecture decision record](adr/2025-01-31-move-flow-execution-after-business-process.md) and the [public RFC discussion](https://github.com/shopware/shopware/discussions/6750).
+
 This changes the ordering of Flow Builder actions relative to synchronous event subscribers and the initiating business operation:
 
 - Code that dispatches a `FlowEventAware` event returns before matching flows have run.
@@ -101,6 +105,7 @@ Tests that dispatch flow-aware events directly must also trigger the correspondi
 
 The deprecated `Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent` and its dynamic event names are removed.
 To modify the criteria used to restore entity data for mail-related flow actions, subscribe to `Shopware\Core\Content\Shared\MailFlow\Event\MailFlowDataCriteriaEvent` instead.
+This replacement lets mail preview, direct mail sending, and mail-related flow actions use the same entity data providers and criteria extension point, keeping extension-added associations consistent across those paths.
 
 The dynamic event name changes as follows:
 
@@ -115,6 +120,8 @@ Use the public `$criteria` and `$entityName` properties and the `getContext()` m
 
 During checkout, the persisted cart is now deleted directly after the order has been created and before `CheckoutOrderPlacedCriteriaEvent` and `CheckoutOrderPlacedEvent` are dispatched.
 Subscribers to these events can no longer reload the cart by its context token.
+Deleting it at this point prevents the already-converted cart from remaining available if later order loading or an order-placed subscriber fails after the order was persisted.
+Otherwise, the cart and order lifecycle could become inconsistent.
 
 Read required information from the created order instead.
 Associations needed by `CheckoutOrderPlacedEvent` can be added through `CheckoutOrderPlacedCriteriaEvent`.
@@ -509,6 +516,7 @@ Following helper methods have been removed from the `EntityDefinitionQueryHelper
 
 Cacheable GET Store API routes now participate in Shopware's regular HTTP cache and use the same cache policies and `sw-cache-hash` variations as the Storefront.
 This applies to routes marked with the `_httpCache` route attribute, including product, category, navigation, CMS, country, currency, language, salutation, and SEO data routes.
+The change improves response times for headless storefronts while reusing the Storefront's configurable HTTP cache infrastructure instead of reintroducing a separate Store API caching layer.
 
 This is separate from the old Store API route cache that was removed in 6.7.
 The removed configuration listed under [Removed Store-API Route caching configuration](#removed-store-api-route-caching-configuration) still has no replacement; selected Store API responses are now cached by the standard HTTP cache instead.


### PR DESCRIPTION
### 1. Why is this change necessary?

Several broad behavioural changes planned for Shopware 6.8 are either missing from the upgrade guide or documented without their full migration impact. This makes it difficult for extension authors and Store API clients to identify the areas that require regression testing before upgrading.

### 2. What does this change do, exactly?

The 6.8 upgrade guide now documents:

- buffered Flow Builder execution after the main business process
- migration from `BeforeLoadStorableFlowDataEvent` to `MailFlowDataCriteriaEvent`
- deletion of the persisted cart before order-placed events
- deferred cart errors created during SalesChannelContext construction
- standard HTTP caching for selected Store API GET routes and its distinction from the removed legacy route cache
- proportional tax distribution when line-item quantities are split

Each entry explains the affected behavior and the required adaptation for extensions or API clients.

### 3. Describe each step to reproduce the issue or behaviour.

1. Review the 6.8 feature-flagged implementations for Flow execution, checkout cart handling, deferred cart errors, Store API HTTP caching, and tax calculation.
2. Compare those behavioral changes with `UPGRADE-6.8.md`.
3. Observe that the behaviors or their migration consequences are missing or ambiguous in the existing guide.

This is a documentation-only change and does not alter runtime behavior.

### 4. Please link to the relevant issues (if any).

No linked issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them