### PR TITLE
ci: make the explore-openapi snapshot uploads non-blocking

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -240,6 +240,8 @@ jobs:
 
       - name: Run OpenAPI Snapshot Action
         if: github.repository == 'shopware/shopware'
+        # informational upload to explore-openapi.dev — an outage there must not block the merge queue
+        continue-on-error: true
         uses: patzick/explore-openapi-snapshot@4cfd85875214ee1653e0680756b2dddaafde42f2 # v2.1.0
         with:
           schema-file: "./api-types/storeApiSchema.json"
@@ -267,6 +269,8 @@ jobs:
 
       - name: Run OpenAPI Snapshot Action for AdminAPI
         if: github.repository == 'shopware/shopware'
+        # informational upload to explore-openapi.dev — an outage there must not block the merge queue
+        continue-on-error: true
         uses: patzick/explore-openapi-snapshot@4cfd85875214ee1653e0680756b2dddaafde42f2 # v2.1.0
         with:
           schema-file: "./api-types/adminApiSchema.json"

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -22,29 +22,29 @@ on:
         default: ""
 
 jobs:
-   visual-tests:
+  visual-tests:
     runs-on: ubuntu-24.04
     steps:
       - name: Define environment
         shell: bash
         run: |
-            echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
-            echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
-            echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
-            echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
-            echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
-            echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
-            echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
+          echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
+          echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
+          echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
+          echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
+          echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
+          echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
+          echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-            env: prod
-            mysql-version: "builtin"
-            shopware-version: ${{ github.ref }}
-            shopware-repository: ${{ github.repository }}
-            install: true
-            install-admin: true
-            install-storefront: true
+          env: prod
+          mysql-version: "builtin"
+          shopware-version: ${{ github.ref }}
+          shopware-repository: ${{ github.repository }}
+          install: true
+          install-admin: true
+          install-storefront: true
 
       - name: Install Playwright dependencies
         working-directory: tests/acceptance
@@ -95,12 +95,12 @@ jobs:
         if: ${{ github.repository_owner == 'shopware' }}
         shell: bash
         run: |
-            if [ -z "${{ secrets.PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN }}" ]; then
-              echo "has_role_arn=false" >> "$GITHUB_OUTPUT"
-              echo "Secret PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN is empty or unavailable (likely a fork)." >&2
-            else
-              echo "has_role_arn=true" >> "$GITHUB_OUTPUT"
-            fi
+          if [ -z "${{ secrets.PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN }}" ]; then
+            echo "has_role_arn=false" >> "$GITHUB_OUTPUT"
+            echo "Secret PLAYWRIGHT_TRACES_UPLOAD_ROLE_ARN is empty or unavailable (likely a fork)." >&2
+          else
+            echo "has_role_arn=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure AWS credentials
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
@@ -115,40 +115,40 @@ jobs:
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
         shell: bash
         run: |
-              set -euo pipefail
-              RANDOM_STR=$(openssl rand -hex 6)
+          set -euo pipefail
+          RANDOM_STR=$(openssl rand -hex 6)
 
-              # build the destination prefix and export it for subsequent steps
-              REPORT_DEST="playwright-reports/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RANDOM_STR}"
+          # build the destination prefix and export it for subsequent steps
+          REPORT_DEST="playwright-reports/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${RANDOM_STR}"
 
-              aws s3 cp "playwright-report" "s3://shopware-ci-playwright-traces/${REPORT_DEST}/" --recursive
+          aws s3 cp "playwright-report" "s3://shopware-ci-playwright-traces/${REPORT_DEST}/" --recursive
 
-              echo "REPORT_DEST=${REPORT_DEST}" >> "$GITHUB_ENV"
-              echo "Uploaded to s3://shopware-ci-playwright-traces/${REPORT_DEST}/"
+          echo "REPORT_DEST=${REPORT_DEST}" >> "$GITHUB_ENV"
+          echo "Uploaded to s3://shopware-ci-playwright-traces/${REPORT_DEST}/"
 
       - name: Publish S3 Static Website URL
         if: ${{ steps.check-aws-allowed.outputs.has_role_arn == 'true' && hashFiles('tests/acceptance/playwright-report/*') }}
         shell: bash
         run: |
-              set -euo pipefail
+          set -euo pipefail
 
-              if [ -z "${REPORT_DEST:-}" ]; then
-                echo "REPORT_DEST not set (upload skipped or failed); skipping publish." >&2
-                exit 0
-              fi
+          if [ -z "${REPORT_DEST:-}" ]; then
+            echo "REPORT_DEST not set (upload skipped or failed); skipping publish." >&2
+            exit 0
+          fi
 
-              if ! aws s3 ls "s3://shopware-ci-playwright-traces/${REPORT_DEST}/index.html" >/dev/null 2>&1; then
-                echo "Index file not found ... skipping publish." >&2
-                exit 0
-              fi
+          if ! aws s3 ls "s3://shopware-ci-playwright-traces/${REPORT_DEST}/index.html" >/dev/null 2>&1; then
+            echo "Index file not found ... skipping publish." >&2
+            exit 0
+          fi
 
-              DOMAIN="${{ vars.PLAYWRIGHT_TRACES_DOMAIN }}"
-              URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
-              echo "${URL}"
+          DOMAIN="${{ vars.PLAYWRIGHT_TRACES_DOMAIN }}"
+          URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
+          echo "${URL}"
 
-              echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create token for PR
         if: ${{ inputs.update-snapshots }}

--- a/.github/workflows/visual-tests-docker.yml
+++ b/.github/workflows/visual-tests-docker.yml
@@ -28,13 +28,15 @@ jobs:
       - name: Define environment
         shell: bash
         run: |
-          echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
-          echo "MAILER_DSN=smtp://localhost:1025" >> $GITHUB_ENV
-          echo "MAILPIT_BASE_URL=http://localhost:8025" >> $GITHUB_ENV
-          echo "SHOPWARE_HTTP_CACHE_ENABLED=0" >> $GITHUB_ENV
-          echo "SHOPWARE_DISABLE_UPDATE_CHECK=true" >> $GITHUB_ENV
-          echo "BLUE_GREEN_DEPLOYMENT=1" >> $GITHUB_ENV
-          echo "ENABLE_SERVICES=0" >> $GITHUB_ENV
+          {
+            echo "REDIS_URL=redis://localhost:6379"
+            echo "MAILER_DSN=smtp://localhost:1025"
+            echo "MAILPIT_BASE_URL=http://localhost:8025"
+            echo "SHOPWARE_HTTP_CACHE_ENABLED=0"
+            echo "SHOPWARE_DISABLE_UPDATE_CHECK=true"
+            echo "BLUE_GREEN_DEPLOYMENT=1"
+            echo "ENABLE_SERVICES=0"
+          } >> "$GITHUB_ENV"
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
@@ -68,7 +70,7 @@ jobs:
             --ipc=host \
             --init \
             --network=host \
-            --user $(id -u):$(id -g) \
+            --user "$(id -u):$(id -g)" \
             -e APP_URL=http://localhost:8000 \
             -e SHOPWARE_ADMIN_USERNAME=admin \
             -e SHOPWARE_ADMIN_PASSWORD=shopware \
@@ -78,7 +80,7 @@ jobs:
             -v "$GITHUB_WORKSPACE:/app" \
             -w /app/tests/acceptance \
             "mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble" \
-            npx $ATS_CMD test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
+            npx "$ATS_CMD" test --project=Visual --workers=1 "$UPDATE_SNAPSHOTS" "$FILTER"
       - name: Upload visual test results
         if: always()
         continue-on-error: true
@@ -146,9 +148,11 @@ jobs:
           URL="https://${DOMAIN}/${REPORT_DEST}/index.html"
           echo "${URL}"
 
-          echo "### Playwright HTML Report" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- ${URL}" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Playwright HTML Report"
+            echo ""
+            echo "- ${URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create token for PR
         if: ${{ inputs.update-snapshots }}
@@ -163,7 +167,7 @@ jobs:
         if: ${{ inputs.update-snapshots }}
         id: diff
         shell: bash
-        run: git diff --exit-code tests/acceptance/tests/ || echo "changed=true" >> $GITHUB_OUTPUT
+        run: git diff --exit-code tests/acceptance/tests/ || echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: ${{ inputs.update-snapshots && steps.diff.outputs.changed == 'true' && steps.create-pr-token.outputs.token != '' }}


### PR DESCRIPTION
### 1. Why is this change necessary?

Since ~15:40 UTC today the explore-openapi.dev snapshot API returns `500 {"error":"Failed to verify project"}` for every upload, which fails the required `openapi-lint` job and blocks the merge queue for all PRs (#18449 was ejected three times; `chore/npm-audit-fix` fails identically). The snapshot upload is informational — it feeds the schema-diff PR comment — and the store-api upload even runs before the actual `redocly lint` steps, so a third-party outage prevents the real linting from running at all.

### 2. What does this change do, exactly?

Adds `continue-on-error: true` to the two "Run OpenAPI Snapshot Action" steps in `php.yml` (store-api and admin-api), with a comment explaining why. The actual schema gates — `redocly lint` for both APIs — remain required and unchanged.

Also carries the yamlfmt/shellcheck fixes for `visual-tests-docker.yml` (cherry-picked from #18496), since the Lint Actions job lints all workflow files and would otherwise fail this PR on that pre-existing debt.

### 3. Describe each step to reproduce the issue or behaviour.

Queue any PR while explore-openapi.dev is erroring — `openapi-lint` fails on the snapshot upload step and the PR is ejected from the merge queue, e.g. https://github.com/shopware/shopware/actions/runs/29846430579/job/88688166003.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them