### PR TITLE
fix: Add support for private media via s3

### DIFF
--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -340,6 +340,7 @@
             <argument type="service" id="shopware.filesystem.s3.client" on-invalid="null"/>
             <argument>%shopware.media.presigned_upload.expiration_minutes%</argument>
             <argument>%shopware.media.presigned_upload.enabled%</argument>
+            <argument>%shopware.filesystem.private%</argument>
         </service>
 
         <service id="Shopware\Core\Content\Media\Upload\PresignedUrlGeneratorInterface"

--- a/src/Core/Content/Media/Upload/PresignedMediaUploadService.php
+++ b/src/Core/Content/Media/Upload/PresignedMediaUploadService.php
@@ -63,7 +63,7 @@ readonly class PresignedMediaUploadService
     ): PresignedUploadPrepareResult {
         $this->fileNameValidator->validateFileName($payload->fileName);
 
-        ['mediaId' => $mediaId, 'uploadedAt' => $uploadedAt] = $this->resolveMediaForPrepare($payload, $context);
+        ['mediaId' => $mediaId, 'uploadedAt' => $uploadedAt, 'private' => $isPrivate] = $this->resolveMediaForPrepare($payload, $context);
 
         $isReplace = $payload->mediaId !== null;
 
@@ -73,7 +73,7 @@ readonly class PresignedMediaUploadService
         }
 
         try {
-            $result = $this->generatePresignedUrl($mediaId, $payload, $uploadedAt);
+            $result = $this->generatePresignedUrl($mediaId, $payload, $uploadedAt, $isPrivate);
         } catch (\Throwable $e) {
             if (!$isReplace) {
                 $this->deleteMediaEntity($mediaId, $context);
@@ -104,15 +104,16 @@ readonly class PresignedMediaUploadService
     ): void {
         $media = $this->findMediaWithThumbnails($mediaId, $context);
         $isReplace = $media->hasFile();
+        $isPrivate = $media->isPrivate();
 
         $this->validateFinalizeRequest($mediaId, $payload, $media, $context);
 
         try {
             if (!$isReplace) {
-                $this->ensureFileNameIsUnique($mediaId, $payload->fileName, $payload->extension, $media->isPrivate(), $context);
+                $this->ensureFileNameIsUnique($mediaId, $payload->fileName, $payload->extension, $isPrivate, $context);
             }
 
-            $s3Metadata = $this->verifyFileOnStorage($mediaId, $payload->path);
+            $s3Metadata = $this->verifyFileOnStorage($mediaId, $payload->path, $isPrivate);
 
             if ($isReplace) {
                 $this->cleanupOldMediaData($media, $payload->path, $context);
@@ -126,7 +127,7 @@ readonly class PresignedMediaUploadService
             $this->dispatchFinalizeEvents($mediaId, $payload->path, $mimeType, $context);
         } catch (\Throwable $e) {
             if (!$isReplace) {
-                $this->presignedUrlGenerator->deleteFromStorage($payload->path);
+                $this->presignedUrlGenerator->deleteFromStorage($payload->path, $isPrivate);
                 $this->deleteMediaEntity($mediaId, $context);
             }
 
@@ -140,7 +141,7 @@ readonly class PresignedMediaUploadService
     }
 
     /**
-     * @return array{mediaId: string, uploadedAt: \DateTimeImmutable}
+     * @return array{mediaId: string, uploadedAt: \DateTimeImmutable, private: bool}
      */
     private function resolveMediaForPrepare(PresignedUploadPreparePayload $payload, Context $context): array
     {
@@ -153,7 +154,7 @@ readonly class PresignedMediaUploadService
 
             $this->extensionValidator->validate($payload->extension, $media->isPrivate(), $context, $payload->mediaId);
 
-            return ['mediaId' => $payload->mediaId, 'uploadedAt' => $this->clock->now()];
+            return ['mediaId' => $payload->mediaId, 'uploadedAt' => $this->clock->now(), 'private' => $media->isPrivate()];
         }
 
         $this->extensionValidator->validate($payload->extension, $payload->private, $context);
@@ -175,10 +176,10 @@ readonly class PresignedMediaUploadService
             $this->mediaRepository->create([$data], $context);
         });
 
-        return ['mediaId' => $mediaId, 'uploadedAt' => $uploadedAt];
+        return ['mediaId' => $mediaId, 'uploadedAt' => $uploadedAt, 'private' => $payload->private];
     }
 
-    private function generatePresignedUrl(string $mediaId, PresignedUploadPreparePayload $payload, \DateTimeImmutable $uploadedAt): PresignedUrlResult
+    private function generatePresignedUrl(string $mediaId, PresignedUploadPreparePayload $payload, \DateTimeImmutable $uploadedAt, bool $private): PresignedUrlResult
     {
         $location = new MediaLocationStruct(
             $mediaId,
@@ -187,7 +188,7 @@ readonly class PresignedMediaUploadService
             $uploadedAt,
         );
 
-        return $this->presignedUrlGenerator->generate($location, $payload->mimeType);
+        return $this->presignedUrlGenerator->generate($location, $payload->mimeType, $private);
     }
 
     private function findMediaWithThumbnails(string $mediaId, Context $context): MediaEntity
@@ -214,9 +215,9 @@ readonly class PresignedMediaUploadService
         $this->validateExpectedPath($mediaId, $payload, $media);
     }
 
-    private function verifyFileOnStorage(string $mediaId, string $path): FileMetadataResult
+    private function verifyFileOnStorage(string $mediaId, string $path, bool $private): FileMetadataResult
     {
-        $s3Metadata = $this->presignedUrlGenerator->getFileMetadata($path);
+        $s3Metadata = $this->presignedUrlGenerator->getFileMetadata($path, $private);
 
         if ($s3Metadata === null) {
             $this->logger->error('Could not verify presigned upload for media "{mediaId}": file not found on storage at path "{path}"', [

--- a/src/Core/Content/Media/Upload/PresignedUploadUrlGenerator.php
+++ b/src/Core/Content/Media/Upload/PresignedUploadUrlGenerator.php
@@ -18,15 +18,20 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @internal
+ *
+ * @phpstan-type S3Target array{client: ?S3Client, bucket: ?string, root: string}
  */
 #[Package('discovery')]
 readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInterface
 {
+    /**
+     * @param S3Target $publicTarget
+     * @param S3Target $privateTarget
+     */
     private function __construct(
         private AbstractMediaPathStrategy $mediaPathStrategy,
-        private ?S3Client $s3Client,
-        private ?string $bucket,
-        private string $root,
+        private array $publicTarget,
+        private array $privateTarget,
         private LoggerInterface $logger,
         private ClockInterface $clock,
         private int $expirationMinutes,
@@ -35,39 +40,23 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
     }
 
     /**
-     * @param array<string, mixed> $filesystemConfig
+     * @param array<string, mixed> $publicFilesystemConfig config of the filesystem used for public media
+     * @param array<string, mixed> $privateFilesystemConfig config of the filesystem used for private media
      */
     public static function create(
         AbstractMediaPathStrategy $mediaPathStrategy,
-        array $filesystemConfig,
+        array $publicFilesystemConfig,
         LoggerInterface $logger,
         ClockInterface $clock,
         ?HttpClientInterface $httpClient = null,
         int $expirationMinutes = 5,
         bool $enabled = true,
+        array $privateFilesystemConfig = [],
     ): self {
-        $nonSupported = new self($mediaPathStrategy, null, null, '', $logger, $clock, $expirationMinutes, $enabled);
-
-        if (!$enabled || ($filesystemConfig['type'] ?? null) !== 'amazon-s3') {
-            return $nonSupported;
-        }
-
-        $s3Config = $filesystemConfig['config'] ?? [];
-        if (!\is_array($s3Config)) {
-            throw MediaException::presignedUploadInvalidConfiguration('Filesystem config must contain an array of S3 options.');
-        }
-
-        try {
-            $result = S3ClientFactory::create($s3Config, $httpClient);
-        } catch (\Throwable $e) {
-            throw MediaException::presignedUploadInvalidConfiguration($e->getMessage(), $e);
-        }
-
         return new self(
             $mediaPathStrategy,
-            $result['client'],
-            $result['bucket'],
-            trim($result['root'], '/'),
+            self::resolveTarget($publicFilesystemConfig, $enabled, $httpClient),
+            self::resolveTarget($privateFilesystemConfig, $enabled, $httpClient),
             $logger,
             $clock,
             $expirationMinutes,
@@ -75,13 +64,15 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
         );
     }
 
-    public function generate(MediaLocationStruct $location, string $mimeType): PresignedUrlResult
+    public function generate(MediaLocationStruct $location, string $mimeType, bool $private): PresignedUrlResult
     {
         if (!$this->isEnabled()) {
             throw MediaException::presignedUploadDisabled();
         }
 
-        if ($this->s3Client === null || $this->bucket === null) {
+        ['client' => $client, 'bucket' => $bucket, 'root' => $root] = $this->target($private);
+
+        if ($client === null || $bucket === null) {
             throw MediaException::presignedUploadNotSupported();
         }
 
@@ -95,7 +86,7 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
 
         $paths = $this->mediaPathStrategy->generate([$location]);
         $mediaPath = $paths[$location->id] ?? throw MediaException::strategyNotFound($this->mediaPathStrategy->name());
-        $s3Key = $this->ensureRootPrefix($mediaPath);
+        $s3Key = $this->ensureRootPrefix($mediaPath, $root);
 
         $expiresAt = $this->clock->now()->modify(\sprintf('+%d minutes', $this->expirationMinutes));
 
@@ -105,12 +96,12 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
             // same charset canonicalization before sending — see `withCharset()` in
             // src/Administration/Resources/app/administration/src/core/service/api/media-presigned-upload.api.service.js
             $request = new PutObjectRequest([
-                'Bucket' => $this->bucket,
+                'Bucket' => $bucket,
                 'Key' => $s3Key,
                 'ContentType' => FileInfoHelper::addCharset($mimeType),
             ]);
 
-            $url = $this->s3Client->presign($request, $expiresAt);
+            $url = $client->presign($request, $expiresAt);
         } catch (\Throwable $e) {
             throw MediaException::presignedUploadFailed($e);
         }
@@ -129,24 +120,28 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
 
     public function isSupported(): bool
     {
-        return $this->enabled && $this->s3Client !== null && $this->bucket !== null;
+        return $this->enabled
+            && $this->isTargetSupported($this->publicTarget)
+            && $this->isTargetSupported($this->privateTarget);
     }
 
-    public function getFileMetadata(string $path): ?FileMetadataResult
+    public function getFileMetadata(string $path, bool $private): ?FileMetadataResult
     {
-        if ($this->s3Client === null || $this->bucket === null) {
+        ['client' => $client, 'bucket' => $bucket, 'root' => $root] = $this->target($private);
+
+        if ($client === null || $bucket === null) {
             return null;
         }
 
         try {
-            $s3Key = $this->ensureRootPrefix($path);
+            $s3Key = $this->ensureRootPrefix($path, $root);
 
             $request = new HeadObjectRequest([
-                'Bucket' => $this->bucket,
+                'Bucket' => $bucket,
                 'Key' => $s3Key,
             ]);
 
-            $result = $this->s3Client->headObject($request);
+            $result = $client->headObject($request);
 
             $etag = $result->getEtag();
             if ($etag !== null) {
@@ -169,21 +164,23 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
         }
     }
 
-    public function deleteFromStorage(string $path): void
+    public function deleteFromStorage(string $path, bool $private): void
     {
-        if ($this->s3Client === null || $this->bucket === null) {
+        ['client' => $client, 'bucket' => $bucket, 'root' => $root] = $this->target($private);
+
+        if ($client === null || $bucket === null) {
             return;
         }
 
         try {
-            $s3Key = $this->ensureRootPrefix($path);
+            $s3Key = $this->ensureRootPrefix($path, $root);
 
             $request = new DeleteObjectRequest([
-                'Bucket' => $this->bucket,
+                'Bucket' => $bucket,
                 'Key' => $s3Key,
             ]);
 
-            $this->s3Client->deleteObject($request)->resolve();
+            $client->deleteObject($request)->resolve();
         } catch (\Throwable $e) {
             $this->logger->warning('Failed to delete orphaned presigned upload at path "{path}": {message}', [
                 'path' => $path,
@@ -193,16 +190,61 @@ readonly class PresignedUploadUrlGenerator implements PresignedUrlGeneratorInter
         }
     }
 
-    private function ensureRootPrefix(string $s3Key): string
+    /**
+     * @param array<string, mixed> $filesystemConfig
+     *
+     * @return S3Target
+     */
+    private static function resolveTarget(array $filesystemConfig, bool $enabled, ?HttpClientInterface $httpClient): array
     {
-        if ($this->root === '') {
+        if (!$enabled || ($filesystemConfig['type'] ?? null) !== 'amazon-s3') {
+            return ['client' => null, 'bucket' => null, 'root' => ''];
+        }
+
+        $s3Config = $filesystemConfig['config'] ?? [];
+        if (!\is_array($s3Config)) {
+            throw MediaException::presignedUploadInvalidConfiguration('Filesystem config must contain an array of S3 options.');
+        }
+
+        try {
+            $result = S3ClientFactory::create($s3Config, $httpClient);
+        } catch (\Throwable $e) {
+            throw MediaException::presignedUploadInvalidConfiguration($e->getMessage(), $e);
+        }
+
+        return [
+            'client' => $result['client'],
+            'bucket' => $result['bucket'],
+            'root' => trim($result['root'], '/'),
+        ];
+    }
+
+    /**
+     * @return S3Target
+     */
+    private function target(bool $private): array
+    {
+        return $private ? $this->privateTarget : $this->publicTarget;
+    }
+
+    /**
+     * @param S3Target $target
+     */
+    private function isTargetSupported(array $target): bool
+    {
+        return $target['client'] !== null && $target['bucket'] !== null;
+    }
+
+    private function ensureRootPrefix(string $s3Key, string $root): string
+    {
+        if ($root === '') {
             return $s3Key;
         }
 
-        if (str_starts_with($s3Key, $this->root . '/')) {
+        if (str_starts_with($s3Key, $root . '/')) {
             return $s3Key;
         }
 
-        return $this->root . '/' . ltrim($s3Key, '/');
+        return $root . '/' . ltrim($s3Key, '/');
     }
 }

--- a/src/Core/Content/Media/Upload/PresignedUrlGeneratorInterface.php
+++ b/src/Core/Content/Media/Upload/PresignedUrlGeneratorInterface.php
@@ -11,13 +11,13 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 interface PresignedUrlGeneratorInterface
 {
-    public function generate(MediaLocationStruct $location, string $mimeType): PresignedUrlResult;
+    public function generate(MediaLocationStruct $location, string $mimeType, bool $private): PresignedUrlResult;
 
     public function isEnabled(): bool;
 
     public function isSupported(): bool;
 
-    public function getFileMetadata(string $path): ?FileMetadataResult;
+    public function getFileMetadata(string $path, bool $private): ?FileMetadataResult;
 
-    public function deleteFromStorage(string $path): void;
+    public function deleteFromStorage(string $path, bool $private): void;
 }

--- a/tests/unit/Core/Content/Media/Upload/PresignedMediaUploadServiceTest.php
+++ b/tests/unit/Core/Content/Media/Upload/PresignedMediaUploadServiceTest.php
@@ -69,7 +69,8 @@ class PresignedMediaUploadServiceTest extends TestCase
             ->method('generate')
             ->with(
                 static::callback(fn (MediaLocationStruct $location): bool => $location->fileName === 'test-file' && $location->extension === 'jpg' && $location->uploadedAt !== null),
-                'image/jpeg'
+                'image/jpeg',
+                false
             )
             ->willReturn(new PresignedUrlResult(
                 url: 'https://s3.example.com/presigned-url',
@@ -233,7 +234,7 @@ class PresignedMediaUploadServiceTest extends TestCase
 
         $this->presignedUrlGenerator->expects($this->once())
             ->method('getFileMetadata')
-            ->with($path)
+            ->with($path, false)
             ->willReturn(new FileMetadataResult(
                 size: 12345,
                 lastModified: new \DateTimeImmutable(),
@@ -286,7 +287,7 @@ class PresignedMediaUploadServiceTest extends TestCase
         // S3 stores the canonical Content-Type incl. charset; the persisted entity mimeType must stay bare.
         $this->presignedUrlGenerator->expects($this->once())
             ->method('getFileMetadata')
-            ->with($path)
+            ->with($path, false)
             ->willReturn(new FileMetadataResult(
                 size: 42,
                 lastModified: new \DateTimeImmutable(),
@@ -340,7 +341,7 @@ class PresignedMediaUploadServiceTest extends TestCase
         // deleting on the submitted path is safe.
         $this->presignedUrlGenerator->expects($this->once())
             ->method('deleteFromStorage')
-            ->with($path);
+            ->with($path, false);
 
         $this->expectException(MediaException::class);
 
@@ -376,13 +377,13 @@ class PresignedMediaUploadServiceTest extends TestCase
 
         $this->presignedUrlGenerator->expects($this->once())
             ->method('getFileMetadata')
-            ->with($path)
+            ->with($path, false)
             ->willReturn(null);
 
         // Validation passed (path matches) — cleanup on the validated path is safe.
         $this->presignedUrlGenerator->expects($this->once())
             ->method('deleteFromStorage')
-            ->with($path);
+            ->with($path, false);
 
         $this->expectExceptionObject(MediaException::presignedUploadFinalizeFailed($mediaId));
 
@@ -520,7 +521,7 @@ class PresignedMediaUploadServiceTest extends TestCase
 
         $this->presignedUrlGenerator->expects($this->once())
             ->method('getFileMetadata')
-            ->with($newPath)
+            ->with($newPath, false)
             ->willReturn(new FileMetadataResult(
                 size: 5000,
                 lastModified: new \DateTimeImmutable(),
@@ -594,6 +595,69 @@ class PresignedMediaUploadServiceTest extends TestCase
         $service->finalize($mediaId, $payload, $context);
     }
 
+    public function testPreparePrivateUploadIsSignedAsPrivate(): void
+    {
+        // isFileNameTaken search — no duplicates.
+        [$repo, $service] = $this->createService([new MediaCollection()]);
+
+        $this->presignedUrlGenerator->expects($this->once())
+            ->method('generate')
+            ->with(static::anything(), 'application/pdf', true)
+            ->willReturn(new PresignedUrlResult(
+                url: 'https://private-bucket.s3.example.com/presigned-url',
+                path: 'media/ab/cd/secret.pdf',
+                expiresAt: new \DateTimeImmutable('+5 minutes'),
+            ));
+
+        $payload = new PresignedUploadPreparePayload(
+            fileName: 'secret',
+            extension: 'pdf',
+            mimeType: 'application/pdf',
+            private: true,
+        );
+
+        $result = $service->prepare($payload, Context::createDefaultContext());
+
+        static::assertTrue($repo->creates[0][0]['private']);
+        static::assertSame('https://private-bucket.s3.example.com/presigned-url', $result->url);
+    }
+
+    public function testFinalizePrivateUploadIsVerifiedAsPrivate(): void
+    {
+        $context = Context::createDefaultContext();
+        $mediaId = '0189b0a1-0000-0000-0000-0000000000dd';
+        $path = 'media/ab/cd/secret.pdf';
+
+        $media = $this->buildMedia($mediaId, true);
+
+        // 1st search: findMediaWithThumbnails. 2nd search: ensureFileNameIsUnique (non-replace).
+        [, $service] = $this->createService([
+            new MediaCollection([$media]),
+            new MediaCollection(),
+        ]);
+
+        $this->mediaPathStrategy->method('generate')->willReturn([$mediaId => $path]);
+
+        $this->presignedUrlGenerator->expects($this->once())
+            ->method('getFileMetadata')
+            ->with($path, true)
+            ->willReturn(new FileMetadataResult(
+                size: 2048,
+                lastModified: new \DateTimeImmutable(),
+                etag: 'd41d8cd98f00b204e9800998ecf8427e',
+                contentType: 'application/pdf',
+            ));
+
+        $payload = new PresignedUploadFinalizePayload(
+            fileName: 'secret',
+            extension: 'pdf',
+            mimeType: 'application/pdf',
+            path: $path,
+        );
+
+        $service->finalize($mediaId, $payload, $context);
+    }
+
     /**
      * @param list<MediaCollection> $searches
      *
@@ -619,12 +683,12 @@ class PresignedMediaUploadServiceTest extends TestCase
         return [$repo, $service];
     }
 
-    private function buildMedia(string $mediaId): MediaEntity
+    private function buildMedia(string $mediaId, bool $private = false): MediaEntity
     {
         $media = new MediaEntity();
         $media->setId($mediaId);
         $media->setUploadedAt(new \DateTime());
-        $media->setPrivate(false);
+        $media->setPrivate($private);
         $media->setThumbnails(new MediaThumbnailCollection());
 
         return $media;

--- a/tests/unit/Core/Content/Media/Upload/PresignedUploadUrlGeneratorTest.php
+++ b/tests/unit/Core/Content/Media/Upload/PresignedUploadUrlGeneratorTest.php
@@ -36,10 +36,11 @@ class PresignedUploadUrlGeneratorTest extends TestCase
     {
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            ['type' => 'amazon-s3', 'config' => ['bucket' => 'test', 'region' => 'eu-west-1']],
+            $this->s3Config('public-bucket'),
             new NullLogger(),
             new NativeClock(),
             enabled: false,
+            privateFilesystemConfig: $this->s3Config('private-bucket'),
         );
 
         static::assertFalse($generator->isEnabled());
@@ -53,48 +54,63 @@ class PresignedUploadUrlGeneratorTest extends TestCase
             ['type' => 'local'],
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: ['type' => 'local'],
         );
 
         static::assertTrue($generator->isEnabled());
         static::assertFalse($generator->isSupported());
     }
 
-    public function testCreateWithS3FilesystemIsSupported(): void
+    public function testCreateWithBothS3FilesystemsIsSupported(): void
     {
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                ],
-            ],
+            $this->s3Config('public-bucket'),
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket'),
         );
 
         static::assertTrue($generator->isEnabled());
         static::assertTrue($generator->isSupported());
     }
 
+    public function testIsSupportedIsFalseWhenOnlyPublicIsS3(): void
+    {
+        $generator = PresignedUploadUrlGenerator::create(
+            $this->mediaPathStrategy,
+            $this->s3Config('public-bucket'),
+            new NullLogger(),
+            new NativeClock(),
+            privateFilesystemConfig: ['type' => 'local'],
+        );
+
+        // The admin toggles presign globally with no per-upload fallback, so a half-configured setup must
+        // report unsupported and fall back to the regular upload path for every upload.
+        static::assertFalse($generator->isSupported());
+    }
+
+    public function testIsSupportedIsFalseWhenOnlyPrivateIsS3(): void
+    {
+        $generator = PresignedUploadUrlGenerator::create(
+            $this->mediaPathStrategy,
+            ['type' => 'local'],
+            new NullLogger(),
+            new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket'),
+        );
+
+        static::assertFalse($generator->isSupported());
+    }
+
     public function testCreateWithExplicitCredentials(): void
     {
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                    'credentials' => [
-                        'key' => 'access-key',
-                        'secret' => 'secret-key',
-                    ],
-                ],
-            ],
+            $this->s3Config('public-bucket', ['credentials' => ['key' => 'access-key', 'secret' => 'secret-key']]),
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket', ['credentials' => ['key' => 'access-key', 'secret' => 'secret-key']]),
         );
 
         static::assertTrue($generator->isSupported());
@@ -105,15 +121,10 @@ class PresignedUploadUrlGeneratorTest extends TestCase
         // No credentials provided - should use IAM role via default credential chain
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                ],
-            ],
+            $this->s3Config('public-bucket'),
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket'),
         );
 
         static::assertTrue($generator->isSupported());
@@ -123,17 +134,10 @@ class PresignedUploadUrlGeneratorTest extends TestCase
     {
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                    'endpoint' => 'http://localhost:9000',
-                    'use_path_style_endpoint' => true,
-                ],
-            ],
+            $this->s3Config('public-bucket', ['endpoint' => 'http://localhost:9000', 'use_path_style_endpoint' => true]),
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket', ['endpoint' => 'http://localhost:9000', 'use_path_style_endpoint' => true]),
         );
 
         static::assertTrue($generator->isSupported());
@@ -143,16 +147,10 @@ class PresignedUploadUrlGeneratorTest extends TestCase
     {
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                    'root' => 'shopware/media',
-                ],
-            ],
+            $this->s3Config('public-bucket', ['root' => 'shopware/media']),
             new NullLogger(),
             new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket', ['root' => 'shopware/media']),
         );
 
         static::assertTrue($generator->isSupported());
@@ -248,7 +246,7 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $this->expectExceptionObject(MediaException::presignedUploadDisabled());
 
-        $generator->generate($location, 'image/jpeg');
+        $generator->generate($location, 'image/jpeg', false);
     }
 
     public function testGenerateWhenNotSupported(): void
@@ -269,23 +267,34 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $this->expectExceptionObject(MediaException::presignedUploadNotSupported());
 
-        $generator->generate($location, 'image/jpeg');
+        $generator->generate($location, 'image/jpeg', false);
+    }
+
+    public function testGeneratePrivateThrowsWhenPrivateFilesystemIsNotS3(): void
+    {
+        $generator = PresignedUploadUrlGenerator::create(
+            $this->mediaPathStrategy,
+            $this->s3Config('public-bucket'),
+            new NullLogger(),
+            new NativeClock(),
+            privateFilesystemConfig: ['type' => 'local'],
+        );
+
+        $location = new MediaLocationStruct(
+            Uuid::randomHex(),
+            'jpg',
+            'test-file',
+            new \DateTimeImmutable()
+        );
+
+        $this->expectExceptionObject(MediaException::presignedUploadNotSupported());
+
+        $generator->generate($location, 'image/jpeg', true);
     }
 
     public function testGenerateWithNullFileName(): void
     {
-        $generator = PresignedUploadUrlGenerator::create(
-            $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                ],
-            ],
-            new NullLogger(),
-            new NativeClock(),
-        );
+        $generator = $this->createGeneratorWithBothBuckets();
 
         $location = new MediaLocationStruct(
             Uuid::randomHex(),
@@ -296,23 +305,12 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $this->expectExceptionObject(MediaException::invalidRequestParameter('fileName'));
 
-        $generator->generate($location, 'image/jpeg');
+        $generator->generate($location, 'image/jpeg', false);
     }
 
     public function testGenerateWithNullExtension(): void
     {
-        $generator = PresignedUploadUrlGenerator::create(
-            $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                ],
-            ],
-            new NullLogger(),
-            new NativeClock(),
-        );
+        $generator = $this->createGeneratorWithBothBuckets();
 
         $location = new MediaLocationStruct(
             Uuid::randomHex(),
@@ -323,7 +321,7 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $this->expectExceptionObject(MediaException::missingFileExtension());
 
-        $generator->generate($location, 'image/jpeg');
+        $generator->generate($location, 'image/jpeg', false);
     }
 
     public function testGenerateWithPathGenerationFailure(): void
@@ -334,18 +332,7 @@ class PresignedUploadUrlGeneratorTest extends TestCase
             ->method('generate')
             ->willReturn([]); // Returns empty array - no path generated
 
-        $generator = PresignedUploadUrlGenerator::create(
-            $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                ],
-            ],
-            new NullLogger(),
-            new NativeClock(),
-        );
+        $generator = $this->createGeneratorWithBothBuckets();
 
         $location = new MediaLocationStruct(
             $mediaId,
@@ -356,7 +343,37 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $this->expectExceptionObject(MediaException::strategyNotFound('test-strategy'));
 
-        $generator->generate($location, 'image/jpeg');
+        $generator->generate($location, 'image/jpeg', false);
+    }
+
+    public function testGeneratePublicUploadTargetsPublicBucket(): void
+    {
+        $mediaId = Uuid::randomHex();
+        $this->mediaPathStrategy->method('generate')->willReturn([$mediaId => 'media/ab/cd/file.jpg']);
+
+        $generator = $this->createGeneratorWithBothBuckets();
+
+        $location = new MediaLocationStruct($mediaId, 'jpg', 'file', new \DateTimeImmutable());
+
+        $result = $generator->generate($location, 'image/jpeg', false);
+
+        static::assertStringContainsString('public-bucket', $result->url);
+        static::assertStringNotContainsString('private-bucket', $result->url);
+    }
+
+    public function testGeneratePrivateUploadTargetsPrivateBucket(): void
+    {
+        $mediaId = Uuid::randomHex();
+        $this->mediaPathStrategy->method('generate')->willReturn([$mediaId => 'media/ab/cd/file.jpg']);
+
+        $generator = $this->createGeneratorWithBothBuckets();
+
+        $location = new MediaLocationStruct($mediaId, 'jpg', 'file', new \DateTimeImmutable());
+
+        $result = $generator->generate($location, 'image/jpeg', true);
+
+        static::assertStringContainsString('private-bucket', $result->url);
+        static::assertStringNotContainsString('public-bucket', $result->url);
     }
 
     public function testGetFileMetadataWhenNotSupported(): void
@@ -368,7 +385,7 @@ class PresignedUploadUrlGeneratorTest extends TestCase
             new NativeClock(),
         );
 
-        static::assertNull($generator->getFileMetadata('media/ab/cd/test.jpg'));
+        static::assertNull($generator->getFileMetadata('media/ab/cd/test.jpg', false));
     }
 
     public function testCreateWithCustomHttpClient(): void
@@ -385,22 +402,44 @@ class PresignedUploadUrlGeneratorTest extends TestCase
 
         $generator = PresignedUploadUrlGenerator::create(
             $this->mediaPathStrategy,
-            [
-                'type' => 'amazon-s3',
-                'config' => [
-                    'bucket' => 'test-bucket',
-                    'region' => 'eu-west-1',
-                    // Provide static credentials so the async-aws client does not fall back to the
-                    // EC2 instance-metadata credential provider, whose IMDSv2 token request is a PUT
-                    // and would be the first call hitting the mocked HTTP client instead of the HEAD.
-                    'credentials' => ['key' => 'test-key', 'secret' => 'test-secret'],
-                ],
-            ],
+            // Provide static credentials so the async-aws client does not fall back to the EC2
+            // instance-metadata credential provider, whose IMDSv2 token request is a PUT and would
+            // be the first call hitting the mocked HTTP client instead of the HEAD.
+            $this->s3Config('public-bucket', ['credentials' => ['key' => 'test-key', 'secret' => 'test-secret']]),
             new NullLogger(),
             new NativeClock(),
             httpClient: $httpClient,
         );
 
-        $generator->getFileMetadata('media/test.jpg');
+        $generator->getFileMetadata('media/test.jpg', false);
+    }
+
+    private function createGeneratorWithBothBuckets(): PresignedUploadUrlGenerator
+    {
+        $credentials = ['credentials' => ['key' => 'test-key', 'secret' => 'test-secret']];
+
+        return PresignedUploadUrlGenerator::create(
+            $this->mediaPathStrategy,
+            $this->s3Config('public-bucket', $credentials),
+            new NullLogger(),
+            new NativeClock(),
+            privateFilesystemConfig: $this->s3Config('private-bucket', $credentials),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $extraConfig
+     *
+     * @return array{type: string, config: array<string, mixed>}
+     */
+    private function s3Config(string $bucket, array $extraConfig = []): array
+    {
+        return [
+            'type' => 'amazon-s3',
+            'config' => array_merge([
+                'bucket' => $bucket,
+                'region' => 'eu-west-1',
+            ], $extraConfig),
+        ];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
-->

### 1. Why is this change necessary?
Private media can't be downloaded when the presigned direct-to-S3 upload flow is enabled.

### 2. What does this change do, exactly?
Makes the presigned upload flow visibility-aware

- `PresignedUploadUrlGenerator` now holds both the public and private filesystem S3 configurations and selects the correct one (client, bucket, root prefix) per call, based on the media's visibility.
- A bool $private parameter is threaded through the `@internal` `PresignedUrlGeneratorInterface` methods (generate, getFileMetadata, deleteFromStorage).
- `PresignedMediaUploadService` passes the visibility it already resolves: $payload->private for new uploads, $media->isPrivate() for replace and for finalize (metadata verification + orphan cleanup) so the object is HEAD-verified and cleaned up against the same bucket it was signed for.
- The private filesystem config is wired into the generator via a trailing create() argument in media.xml.
- isSupported() now requires both filesystems to be S3-backed. Because the Administration toggles presign via a single global flag with no per-upload fallback, a half-configured setup (only one filesystem on S3) reports the
feature as unsupported and degrades to the regular upload path for all uploads, rather than failing at runtime on the visibility that is not on S3.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
