### PR TITLE
fix: Admin ES customer listing breaks on deep pagination

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -324,6 +324,10 @@ Store API requests now remain stateless unless application or extension code exp
 
 ## Core
 
+### Admin Elasticsearch listings fall back to the database on deep pagination
+
+Admin Elasticsearch searches (`ENABLE_OPENSEARCH_FOR_ADMIN_API`) now fall back to the database searcher when a request's `offset + limit` exceeds the configured admin index `max_result_window`, instead of sending a request that OpenSearch rejects with `Result window is too large`. This previously broke listings such as the customer grid when jumping to a deep or last page.
+
 ### Product `descriptionTeaser` backfill runs once as a post-update indexer
 
 The `product.description_teaser.indexer` that fills `descriptionTeaser` for products predating the column (introduced in 6.7.12) is now a one-time post-update indexer: it runs once through the post-update flow after the update and is no longer executed by `bin/console dal:refresh:index`. It rebuilds each teaser from the current description and rewrites only the rows whose stored value is missing or out of date. Ongoing changes continue to be kept in sync synchronously on write by the product description-teaser subscriber.

--- a/src/Elasticsearch/Admin/AdminElasticsearchEntitySearcher.php
+++ b/src/Elasticsearch/Admin/AdminElasticsearchEntitySearcher.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Elasticsearch\Framework\DataAbstractionLayer\ElasticsearchEntitySearcher;
 use Shopware\Elasticsearch\Framework\Exception\EmptyQueryException;
 
 #[Package('framework')]
@@ -28,6 +29,7 @@ class AdminElasticsearchEntitySearcher implements EntitySearcherInterface
         private readonly AdminSearchRegistry $registry,
         private readonly AdminElasticsearchHelper $helper,
         private readonly AdminSearcher $searcher,
+        private readonly int $maxResultWindow = ElasticsearchEntitySearcher::MAX_LIMIT,
     ) {
     }
 
@@ -69,6 +71,10 @@ class AdminElasticsearchEntitySearcher implements EntitySearcherInterface
         }
 
         if ($criteria->getIds() !== []) {
+            return false;
+        }
+
+        if (($criteria->getOffset() ?? 0) + ($criteria->getLimit() ?? 0) > $this->maxResultWindow) {
             return false;
         }
 

--- a/src/Elasticsearch/DependencyInjection/services.php
+++ b/src/Elasticsearch/DependencyInjection/services.php
@@ -797,5 +797,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             service(AdminSearchRegistry::class),
             service(AdminElasticsearchHelper::class),
             service(AdminSearcher::class),
+            param('elasticsearch.administration.index_settings.max_result_window'),
         ]);
 };

--- a/tests/unit/Elasticsearch/Admin/AdminElasticsearchEntitySearcherTest.php
+++ b/tests/unit/Elasticsearch/Admin/AdminElasticsearchEntitySearcherTest.php
@@ -107,6 +107,88 @@ class AdminElasticsearchEntitySearcherTest extends TestCase
         });
     }
 
+    public function testFallsBackWhenPaginationExceedsMaxResultWindow(): void
+    {
+        $decorated = $this->createMock(EntitySearcherInterface::class);
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $helper = static::createStub(AdminElasticsearchHelper::class);
+        $searcher = $this->createMock(AdminSearcher::class);
+
+        $criteria = (new Criteria())->setTerm('search');
+        $criteria->setLimit(25);
+        $criteria->setOffset(500_000);
+        $context = new Context(new AdminApiSource('test', Uuid::randomHex()));
+        $definition = $this->createDefinition();
+
+        $helper->method('isEnabled')->willReturn(true);
+        $registry->method('hasIndexer')->willReturn(true);
+        $registry->method('getIndexer')->willReturn($this->createIndexer());
+
+        $expected = new IdSearchResult(0, [], $criteria, $context);
+
+        $decorated->expects($this->once())
+            ->method('search')
+            ->with($definition, $criteria, $context)
+            ->willReturn($expected);
+
+        $searcher->expects($this->never())->method('searchIds');
+
+        Feature::fake(['ENABLE_OPENSEARCH_FOR_ADMIN_API'], static function () use ($decorated, $registry, $helper, $searcher, $definition, $criteria, $context, $expected): void {
+            $entitySearcher = new AdminElasticsearchEntitySearcher(
+                $decorated,
+                $registry,
+                $helper,
+                $searcher,
+                500_000,
+            );
+
+            $result = $entitySearcher->search($definition, $criteria, $context);
+
+            static::assertSame($expected, $result);
+        });
+    }
+
+    public function testUsesAdminSearchWhenPaginationWithinMaxResultWindow(): void
+    {
+        $decorated = $this->createMock(EntitySearcherInterface::class);
+        $registry = static::createStub(AdminSearchRegistry::class);
+        $helper = static::createStub(AdminElasticsearchHelper::class);
+        $searcher = $this->createMock(AdminSearcher::class);
+
+        $criteria = (new Criteria())->setTerm('search');
+        $criteria->setLimit(25);
+        $criteria->setOffset(499_000);
+        $context = new Context(new AdminApiSource('test', Uuid::randomHex()));
+        $definition = $this->createDefinition();
+
+        $helper->method('isEnabled')->willReturn(true);
+        $registry->method('hasIndexer')->willReturn(true);
+        $registry->method('getIndexer')->willReturn($this->createIndexer());
+
+        $expected = new IdSearchResult(1, ['abc' => ['primaryKey' => 'abc', 'data' => ['id' => 'abc']]], $criteria, $context);
+
+        $searcher->expects($this->once())
+            ->method('searchIds')
+            ->with($definition->getEntityName(), $criteria, $context)
+            ->willReturn($expected);
+
+        $decorated->expects($this->never())->method('search');
+
+        Feature::fake(['ENABLE_OPENSEARCH_FOR_ADMIN_API'], static function () use ($decorated, $registry, $helper, $searcher, $definition, $criteria, $context, $expected): void {
+            $entitySearcher = new AdminElasticsearchEntitySearcher(
+                $decorated,
+                $registry,
+                $helper,
+                $searcher,
+                500_000,
+            );
+
+            $result = $entitySearcher->search($definition, $criteria, $context);
+
+            static::assertSame($expected, $result);
+        });
+    }
+
     private function createDefinition(): EntityDefinition
     {
         return new class extends EntityDefinition {


### PR DESCRIPTION
This pull request improves the handling of deep pagination in admin Elasticsearch listings by making the system automatically fall back to the database searcher when pagination exceeds the configured maximum result window. This prevents errors when users jump to deep or last pages in admin grids, such as the customer grid, and ensures more robust search functionality. The changes also include dependency injection updates and new unit tests to verify the fallback logic.

**Admin Elasticsearch pagination fallback improvements:**

* [`src/Elasticsearch/Admin/AdminElasticsearchEntitySearcher.php`](diffhunk://#diff-a1c1230b1f9b7e81152595b3364554fd58598de02ab18f9ce8369b1fc58eb5d5R77-R80): Added logic to check if the requested `offset + limit` exceeds the configured `max_result_window`, and if so, fall back to the database searcher instead of querying OpenSearch. This prevents errors when deep pagination is requested. [[1]](diffhunk://#diff-a1c1230b1f9b7e81152595b3364554fd58598de02ab18f9ce8369b1fc58eb5d5R77-R80) [[2]](diffhunk://#diff-a1c1230b1f9b7e81152595b3364554fd58598de02ab18f9ce8369b1fc58eb5d5R32)
* [`src/Elasticsearch/DependencyInjection/services.php`](diffhunk://#diff-70f71ffd31dc43a2d93a4262ff8d284ec96779f40ef558d607f55dd610444028R796): Injects the `max_result_window` configuration parameter into the `AdminElasticsearchEntitySearcher` to make the limit configurable.
* [`RELEASE_INFO-6.7.md`](diffhunk://#diff-819080d3452b5ad5bc86679c15267c543f1920c1f4dae27011f14ccd463ffcdcR63-R66): Documents the new fallback behavior for admin Elasticsearch listings when deep pagination is requested.

**Dependency updates:**

* [`src/Elasticsearch/Admin/AdminElasticsearchEntitySearcher.php`](diffhunk://#diff-a1c1230b1f9b7e81152595b3364554fd58598de02ab18f9ce8369b1fc58eb5d5R18): Imports the `ElasticsearchEntitySearcher` class to access the default `MAX_LIMIT` constant for the result window.