### PR TITLE
fix(product): keep PropertyGroupSorter from mutating options into a cyclic graph

### DIFF
--- a/src/Core/Content/Product/PropertyGroupSorter.php
+++ b/src/Core/Content/Product/PropertyGroupSorter.php
@@ -57,9 +57,10 @@ class PropertyGroupSorter extends AbstractPropertyGroupSorter
                 $sorted[$groupId] = $group;
             }
 
+            // Never point the option back to the sorted group: the resulting cycle breaks
+            // every deep clone of the graph, as CloneTrait does not track visited objects.
             $normalizedOption = $this->normalizeOption($option);
             $normalizedOption->setGroupId($groupId);
-            $normalizedOption->setGroup($sorted[$groupId]);
 
             \assert($sorted[$groupId]->getOptions() instanceof PropertyGroupOptionCollection);
 
@@ -112,7 +113,8 @@ class PropertyGroupSorter extends AbstractPropertyGroupSorter
     private function normalizeOption(PropertyGroupOptionEntity|PartialEntity $entity): PropertyGroupOptionEntity
     {
         if ($entity instanceof PropertyGroupOptionEntity) {
-            return $entity;
+            // Shallow copy, so the caller's entity is not mutated by the assignments above
+            return PropertyGroupOptionEntity::createFrom($entity);
         }
 
         $normalized = new PropertyGroupOptionEntity();

--- a/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/integration/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -397,6 +397,45 @@ class ProductDetailRouteTest extends TestCase
         $this->assertArray($expected, $response);
     }
 
+    public function testRecursionEncodingWithLayoutAndSortedProperties(): void
+    {
+        // regression test for: #18525
+        $product = (new ProductBuilder($this->ids, 'with-layout-and-properties'))
+            ->price(100)
+            ->property('red', 'color')
+            ->property('blue', 'color')
+            ->visibility($this->ids->get('sales-channel'))
+            ->layout('l1')
+            ->build();
+
+        static::getContainer()->get('product.repository')
+            ->create([$product], Context::createDefaultContext());
+
+        $this->browser->request(
+            'POST',
+            $this->getUrl($this->ids->get('with-layout-and-properties')),
+            [
+                'associations' => [
+                    'properties' => [
+                        'associations' => [
+                            'group' => [],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $response = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertSame(Response::HTTP_OK, $this->browser->getResponse()->getStatusCode(), print_r($response, true));
+
+        $sortedProperties = $response['product']['sortedProperties'] ?? null;
+        static::assertIsArray($sortedProperties);
+        static::assertCount(1, $sortedProperties);
+        static::assertSame('color', $sortedProperties[0]['translated']['name'] ?? null);
+        static::assertCount(2, $sortedProperties[0]['options'] ?? []);
+    }
+
     public function testLoadProductCmsSlotConfigFromParentLanguageOverride(): void
     {
         $context = Context::createDefaultContext();

--- a/tests/unit/Core/Content/Product/PropertyGroupSorterTest.php
+++ b/tests/unit/Core/Content/Product/PropertyGroupSorterTest.php
@@ -166,7 +166,7 @@ class PropertyGroupSorterTest extends TestCase
      * @param class-string<PropertyGroupOptionEntity|PartialEntity> $entityType
      */
     #[DataProvider('optionEntityTypeProvider')]
-    public function testNormalizedOptionsHaveGroupReference(string $entityType, bool $partialGroups): void
+    public function testNormalizedOptionsKeepGroupIdWithoutBackReference(string $entityType, bool $partialGroups): void
     {
         $groupId = Uuid::randomHex();
         $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_POSITION, true, $partialGroups);
@@ -188,7 +188,92 @@ class PropertyGroupSorterTest extends TestCase
         $normalizedOption = $groupOptions->first();
         static::assertNotNull($normalizedOption);
         static::assertSame($groupId, $normalizedOption->getGroupId());
-        static::assertSame($sortedGroup, $normalizedOption->getGroup());
+
+        if ($entityType === PropertyGroupOptionEntity::class) {
+            static::assertSame($group, $normalizedOption->getGroup());
+        } else {
+            static::assertNull($normalizedOption->getGroup());
+        }
+    }
+
+    public function testInputOptionsAreNotMutated(): void
+    {
+        $groupId = Uuid::randomHex();
+        $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_POSITION, true);
+        \assert($group instanceof PropertyGroupEntity);
+
+        $option = $this->createPropertyGroupOption($groupId, 'red', 1, $group);
+
+        $sorter = new PropertyGroupSorter();
+        $result = $sorter->sortUsingLocaleCode($this->createOptionsCollection($option), 'en-GB');
+
+        static::assertSame($group, $option->getGroup());
+
+        $sortedGroup = $result->first();
+        static::assertNotNull($sortedGroup);
+
+        $groupOptions = $sortedGroup->getOptions();
+        static::assertInstanceOf(PropertyGroupOptionCollection::class, $groupOptions);
+
+        $normalizedOption = $groupOptions->first();
+        static::assertNotNull($normalizedOption);
+        static::assertNotSame($option, $normalizedOption);
+    }
+
+    /**
+     * The sorter must not wire options back to the sorted group: such a cycle makes every
+     * deep clone of the result graph recurse infinitely (CloneTrait has no cycle tracking).
+     *
+     * @param class-string<PropertyGroupOptionEntity|PartialEntity> $entityType
+     */
+    #[DataProvider('optionEntityTypeProvider')]
+    public function testResultGraphHasNoCycles(string $entityType, bool $partialGroups): void
+    {
+        $groupId = Uuid::randomHex();
+        $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_POSITION, true, $partialGroups);
+
+        $options = $this->createOptionsCollection(
+            $this->createOption($entityType, $groupId, 'blue', 2, $group),
+            $this->createOption($entityType, $groupId, 'red', 1, $group),
+        );
+
+        $sorter = new PropertyGroupSorter();
+        $result = $sorter->sortUsingLocaleCode($options, 'en-GB');
+
+        foreach ($result as $sortedGroup) {
+            $groupOptions = $sortedGroup->getOptions();
+            static::assertInstanceOf(PropertyGroupOptionCollection::class, $groupOptions);
+
+            foreach ($groupOptions as $normalizedOption) {
+                static::assertNotSame($sortedGroup, $normalizedOption->getGroup());
+            }
+        }
+    }
+
+    public function testSortingTwiceProducesSameResult(): void
+    {
+        $groupId = Uuid::randomHex();
+        $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_POSITION, true);
+        \assert($group instanceof PropertyGroupEntity);
+
+        $options = $this->createOptionsCollection(
+            $this->createPropertyGroupOption($groupId, 'blue', 2, $group),
+            $this->createPropertyGroupOption($groupId, 'red', 1, $group),
+        );
+
+        $sorter = new PropertyGroupSorter();
+
+        $firstResult = $sorter->sortUsingLocaleCode($options, 'en-GB');
+        $secondResult = $sorter->sortUsingLocaleCode($options, 'en-GB');
+
+        foreach ([$firstResult, $secondResult] as $result) {
+            $sortedGroup = $result->first();
+            static::assertNotNull($sortedGroup);
+
+            $groupOptions = $sortedGroup->getOptions();
+            static::assertInstanceOf(PropertyGroupOptionCollection::class, $groupOptions);
+            static::assertSame(['red', 'blue'], $this->extractOptionNames($groupOptions));
+        }
     }
 
     private function createGroup(string $id, string $sortingType, bool $visibleOnProductDetailPage, bool $partial = false): Entity


### PR DESCRIPTION
### 1. Why is this change necessary?

`PropertyGroupSorter::sortUsingLocaleCode()` mutates the option entities it receives: `normalizeOption()` returns the *same* instance for full `PropertyGroupOptionEntity` input, which then gets `setGroup($sorted[$groupId])` called on it and is added to the sorted group's options collection. That wires a reference cycle (option → group → options → option) into the caller's entities.

`CloneTrait` deep-clones without tracking visited objects, so any deep clone of such a graph recurses infinitely:

- Storefront/Store API: `ProductDetailRoute` clones the product for CMS resolution (`clone $product`, see NEXT-17603). A product detail page with properties and a CMS layout crashes the PHP worker (segfault from stack exhaustion). Reproduced locally on trunk.
- A second sort pass over the same entities (e.g. Commercial quote recalculation, #18525) hits `clone $entity` in `normalizeGroup()` on the already-mutated graph and loops in `CloneTrait`.

Regression from #15240 (`697d13f6be9`), which is not part of any release tag yet. Before that change the sorter never touched `option.group` and never mutated its input.

### 2. What does this change do, exactly?

- `normalizeOption()` now returns a shallow copy (`PropertyGroupOptionEntity::createFrom()`) for full entities instead of the original instance, so `setGroupId()` only affects the copy. A shallow copy avoids deep-cloning loaded associations (group, media, translations) that a `clone` would drag along.
- Removes the `setGroup($sorted[$groupId])` back-reference — the source of the cycle. Full options keep their original `group` reference (the pre-#15240 contract); options normalized from partial entities keep `group = null` with `groupId` set. Nothing in core reads `option.group` on sorted properties (templates iterate the groups themselves), and the back-reference only existed since #15240.
- Adjusts the sorter unit tests to the restored contract and adds regression tests: input entities are not mutated, the result graph is acyclic, sorting twice stays stable, and an integration test loading a product with properties **and** a CMS layout through `ProductDetailRoute` (exercises the `clone $product` path; segfaults without the fix).

### 3. Describe each step to reproduce the issue or behaviour.

1. On trunk, open a storefront product detail page for a product that has properties and a CMS layout (the default detail layout is enough), with the HTTP cache empty.
2. The request crashes with infinite recursion inside `CloneTrait::__clone()` (with Xdebug: "possible infinite loop … stack depth of 512"; without: worker dies with an empty reply).
3. Alternatively, follow #18525: recalculate a Commercial quote containing a product with properties — the second sort pass over the same entities triggers the same loop via `PropertyGroupSorter::normalizeGroup()`.

### 4. Please link to the relevant issues (if any).

- closes #18525

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Not needed: restores the pre-#15240 behaviour; the regression is not in any release tag.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
