### PR TITLE
fix(checkout): snap near-zero floating point residuals in price sums

### DIFF
--- a/src/Core/Checkout/Cart/Price/Struct/PriceCollection.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PriceCollection.php
@@ -90,14 +90,14 @@ class PriceCollection extends Collection
     {
         $prices = $this->map(static fn (CalculatedPrice $price) => $price->getUnitPrice());
 
-        return FloatComparator::cast(array_sum($prices));
+        return FloatComparator::sum($prices);
     }
 
     public function getTotalPriceAmount(): float
     {
         $prices = $this->map(static fn (CalculatedPrice $price) => $price->getTotalPrice());
 
-        return FloatComparator::cast(array_sum($prices));
+        return FloatComparator::sum($prices);
     }
 
     protected function getExpectedClass(): ?string

--- a/src/Core/Checkout/Cart/Tax/Struct/CalculatedTaxCollection.php
+++ b/src/Core/Checkout/Cart/Tax/Struct/CalculatedTaxCollection.php
@@ -57,7 +57,7 @@ class CalculatedTaxCollection extends Collection
             static fn (CalculatedTax $calculatedTax) => $calculatedTax->getTax()
         );
 
-        return FloatComparator::cast(array_sum($amounts));
+        return FloatComparator::sum($amounts);
     }
 
     public function merge(self $taxCollection): self

--- a/src/Core/Framework/Util/FloatComparator.php
+++ b/src/Core/Framework/Util/FloatComparator.php
@@ -27,6 +27,19 @@ class FloatComparator
         return (float) (string) $a;
     }
 
+    /**
+     * Sums the given floats, snapping a near-zero residual (e.g. -7.1E-15 from prices that cancel
+     * out to zero) to an exact 0.0, which {@see self::cast()} alone cannot do.
+     *
+     * @param array<float> $values
+     */
+    public static function sum(array $values): float
+    {
+        $sum = self::cast(array_sum($values));
+
+        return self::equals($sum, 0.0) ? 0.0 : $sum;
+    }
+
     public static function equals(float $a, float $b): bool
     {
         return abs($a - $b) < self::EPSILON;

--- a/tests/unit/Core/Checkout/Cart/Price/AmountCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/AmountCalculatorTest.php
@@ -95,6 +95,39 @@ class AmountCalculatorTest extends TestCase
         static::assertSame($expected->getNetPrice(), $cartPrice->getNetPrice());
     }
 
+    public function testCalculateGrossAmountSnapsFullyDiscountedCartToZero(): void
+    {
+        // a voucher zeroing the cart must yield an exact 0.0 position price, not a residual,
+        // and must not divide by a near-zero total when building the percentage tax rules
+        $context = static::createStub(SalesChannelContext::class);
+        $context->method('getSalesChannel')->willReturn(new SalesChannelEntity());
+        $context->method('getContext')->willReturn(Context::createDefaultContext());
+        $context->method('getTaxCalculationType')->willReturn(SalesChannelDefinition::CALCULATION_TYPE_VERTICAL);
+        $context->method('getItemRounding')->willReturn(new CashRoundingConfig(2, 0.01, true));
+        $context->method('getTotalRounding')->willReturn(new CashRoundingConfig(2, 0.01, true));
+        $context->method('getTaxState')->willReturn(CartPrice::TAX_STATE_GROSS);
+
+        $tax = new TaxRuleCollection([new TaxRule(19)]);
+        $prices = new PriceCollection([
+            new CalculatedPrice(169, 169, new CalculatedTaxCollection([new CalculatedTax(26.98, 19, 169)]), $tax),
+            new CalculatedPrice(-208.9, -208.9, new CalculatedTaxCollection([new CalculatedTax(-33.35, 19, -208.9)]), $tax),
+            new CalculatedPrice(39.9, 39.9, new CalculatedTaxCollection([new CalculatedTax(6.37, 19, 39.9)]), $tax),
+            new CalculatedPrice(0, 0, new CalculatedTaxCollection([new CalculatedTax(0, 19, 0)]), $tax),
+        ]);
+
+        $calculator = new AmountCalculator(
+            new CashRounding(),
+            new PercentageTaxRuleBuilder(),
+            new TaxCalculator()
+        );
+
+        $cartPrice = $calculator->calculate($prices, new PriceCollection(), $context);
+
+        static::assertSame(0.0, $cartPrice->getPositionPrice());
+        static::assertSame(0.0, $cartPrice->getTotalPrice());
+        static::assertSame(0.0, $cartPrice->getNetPrice());
+    }
+
     /**
      * @return iterable<string, array{0: CartPrice, 1: PriceCollection}>
      */

--- a/tests/unit/Core/Checkout/Cart/Price/Struct/PriceCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/Struct/PriceCollectionTest.php
@@ -62,6 +62,32 @@ class PriceCollectionTest extends TestCase
         static::assertSame(500.0, $collection->sum()->getTotalPrice());
     }
 
+    public function testTotalPriceAmountSnapsFloatingPointResidualToZero(): void
+    {
+        // a voucher zeroing the cart must not leave a residual like -7.1E-15 (order matters)
+        $collection = new PriceCollection([
+            new CalculatedPrice(169, 169, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(-208.9, -208.9, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(39.9, 39.9, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+        ]);
+
+        static::assertSame(0.0, $collection->getTotalPriceAmount());
+        static::assertSame(0.0, $collection->sum()->getTotalPrice());
+    }
+
+    public function testUnitPriceAmountSnapsFloatingPointResidualToZero(): void
+    {
+        $collection = new PriceCollection([
+            new CalculatedPrice(169, 169, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(-208.9, -208.9, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(39.9, 39.9, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            new CalculatedPrice(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+        ]);
+
+        static::assertSame(0.0, $collection->getUnitPriceAmount());
+    }
+
     public function testGetTaxesReturnsACalculatedTaxCollection(): void
     {
         $collection = new PriceCollection();

--- a/tests/unit/Core/Checkout/Cart/Tax/CalculatedTaxCollectionTest.php
+++ b/tests/unit/Core/Checkout/Cart/Tax/CalculatedTaxCollectionTest.php
@@ -69,6 +69,19 @@ class CalculatedTaxCollectionTest extends TestCase
         static::assertSame(13.2, $collection->getAmount());
     }
 
+    public function testTaxAmountSnapsFloatingPointResidualToZero(): void
+    {
+        // taxes that cancel out must not leave a residual; distinct rates keep all entries
+        $collection = new CalculatedTaxCollection([
+            new CalculatedTax(169, 19, 169),
+            new CalculatedTax(-208.9, 7, -208.9),
+            new CalculatedTax(39.9, 5, 39.9),
+            new CalculatedTax(0, 1, 0),
+        ]);
+
+        static::assertSame(0.0, $collection->getAmount());
+    }
+
     public function testIncrementFunctionAddsNewCalculatedTaxIfNotExist(): void
     {
         $collection = new CalculatedTaxCollection([

--- a/tests/unit/Core/Framework/Util/FloatComparatorTest.php
+++ b/tests/unit/Core/Framework/Util/FloatComparatorTest.php
@@ -138,6 +138,29 @@ class FloatComparatorTest extends TestCase
     }
 
     /**
+     * @param array<float> $values
+     */
+    #[DataProvider('sumDataProvider')]
+    public function testSum(array $values, float $expected): void
+    {
+        static::assertSame($expected, FloatComparator::sum($values));
+    }
+
+    /**
+     * @return iterable<string, array{0: array<float>, 1: float}>
+     */
+    public static function sumDataProvider(): iterable
+    {
+        yield 'empty list sums to zero' => [[], 0.0];
+        yield 'positive prices are summed exactly' => [[200.0, 300.0], 500.0];
+        yield 'negative total is preserved' => [[10.0, -15.5], -5.5];
+        yield 'representation error is normalized to a clean value' => [[0.1, 0.2], 0.3];
+        yield 'cart discounted to zero snaps the residual to zero' => [[169.0, -208.9, 39.9, 0.0], 0.0];
+        yield 'reversed order that already sums to zero stays zero' => [[169.0, 39.9, -208.9, 0.0], 0.0];
+        yield 'shipping cost discounted to zero snaps the residual to zero' => [[49.89, -49.89], 0.0];
+    }
+
+    /**
      * @return iterable<string, array{0: float, 1: float, 2: bool}>
      */
     public static function equalsDataProvider(): iterable


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Summing prices with `array_sum()` can leave a residual like -7.1E-15 when the values cancel out to zero (e.g. a voucher zeroing the cart or shipping costs). `FloatComparator::cast()` normalizes relative to magnitude, so it cannot collapse such a residual, which then leaked into unrounded aggregates like the order's `position_price` and summed `shipping_costs`

### 2. What does this change do, exactly?


Add `FloatComparator::sum()`, which snaps a near-zero result to an exact 0.0, and use it in `PriceCollection` and `CalculatedTaxCollection`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18020
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
