### PR TITLE
fix(checkout): restore delivery discount price definition for value "0"

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -140,7 +140,8 @@ class PromotionDeliveryCalculator
             $type = $item->getPayloadValue('discountType');
             $value = $item->getPayloadValue('value');
 
-            if (!$type || !$value) {
+            // "0" is a valid value (e.g. free shipping); skip only when unset or non-numeric
+            if ($type === null || !is_numeric($value)) {
                 continue;
             }
 

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionDeliveryCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionDeliveryCalculatorTest.php
@@ -148,6 +148,47 @@ class PromotionDeliveryCalculatorTest extends TestCase
         static::assertNotNull($cart->getErrors()->get('promotion-not-eligible'));
     }
 
+    public function testDeliveryDiscountWithZeroFixedUnitValueRestoresPriceDefinition(): void
+    {
+        $this->quantityPriceCalculator
+            ->method('calculate')
+            ->willReturnCallback(static function (QuantityPriceDefinition $definition, SalesChannelContext $context) {
+                return new CalculatedPrice($definition->getPrice(), $definition->getPrice(), new CalculatedTaxCollection(), new TaxRuleCollection());
+            });
+
+        // simulate a recalculation where the copied delivery discount line item
+        // still carries a QuantityPriceDefinition that needs to be restored. A
+        // "Fixed price per unit" discount with value "0" makes shipping free.
+        $discount = $this->getDiscountItem('free-shipping')
+            ->setPayloadValue('code', 'code-1')
+            ->setPayloadValue('discountType', PromotionDiscountEntity::TYPE_FIXED_UNIT)
+            ->setPayloadValue('value', '0')
+            ->setPriceDefinition(new QuantityPriceDefinition(0, new TaxRuleCollection(), 1));
+
+        $delivery = new Delivery(
+            new DeliveryPositionCollection(),
+            new DeliveryDate(new \DateTimeImmutable(), new \DateTimeImmutable()),
+            new ShippingMethodEntity(),
+            new ShippingLocation(new CountryEntity(), null, null),
+            new CalculatedPrice(5.0, 5.0, new CalculatedTaxCollection(), new TaxRuleCollection())
+        );
+
+        $cart = new Cart('promotion-test');
+        $cart->setDeliveries(new DeliveryCollection([$delivery]));
+
+        $this->promotionDeliveryCalculator->calculate(
+            new LineItemCollection([$discount]),
+            $cart,
+            $cart,
+            static::createStub(SalesChannelContext::class)
+        );
+
+        $priceDefinition = $discount->getPriceDefinition();
+        static::assertInstanceOf(AbsolutePriceDefinition::class, $priceDefinition);
+        static::assertSame(0.0, $priceDefinition->getPrice());
+        static::assertSame(0.0, $cart->getShippingCosts()->getTotalPrice());
+    }
+
     public function testPromotionPrioritySorting(): void
     {
         $lineItems = new LineItem($this->ids->get('line-item-1'), LineItem::PRODUCT_LINE_ITEM_TYPE);


### PR DESCRIPTION


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
A delivery-scope promotion discount with value "0" (e.g. a "Fixed price per unit" discount making shipping free) broke cart/order recalculation with an InvalidPriceDefinitionException

PromotionDeliveryCalculator::restorePriceDefinitions() guarded with `!$value`, and PHP treats the payload string "0" as falsy, so the QuantityPriceDefinition was never restored to an AbsolutePriceDefinition. calculateDeliveryPromotion() then threw for the fixed_unit/absolute cases

### 2. What does this change do, exactly?
Skip only when the type or value is actually absent (getPayloadValue() returns null for missing keys) instead of on any falsy value

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18352
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
