### PR TITLE
fix(checkout): show clear error when a promo code was already redeemed

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
@@ -10,8 +10,17 @@ class PromotionNotEligibleError extends Error
 {
     private const KEY = 'promotion-not-eligible';
 
-    public function __construct(protected string $name)
-    {
+    /**
+     * @param list<string> $ruleIds Condition rule entity IDs to enable rule-specific snippet lookup
+     * @param bool $persistent Whether the error survives cart recalculation (true for once-raised
+     *                         collector errors, false for calculator errors re-evaluated each pass)
+     */
+    public function __construct(
+        protected string $name,
+        private readonly ?string $reason = null,
+        private readonly array $ruleIds = [],
+        private readonly bool $persistent = false
+    ) {
         $this->message = \sprintf('Promotion %s not eligible for cart!', $this->name);
 
         parent::__construct($this->message);
@@ -19,7 +28,7 @@ class PromotionNotEligibleError extends Error
 
     public function isPersistent(): bool
     {
-        return false;
+        return $this->persistent;
     }
 
     public function getId(): string
@@ -34,7 +43,7 @@ class PromotionNotEligibleError extends Error
 
     public function getMessageKey(): string
     {
-        return self::KEY;
+        return $this->reason !== null ? self::KEY . '-' . $this->reason : self::KEY;
     }
 
     public function getName(): string
@@ -52,5 +61,13 @@ class PromotionNotEligibleError extends Error
         return [
             'name' => $this->name,
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRuleIds(): array
+    {
+        return $this->ruleIds;
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartInformationTrait.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartInformationTrait.php
@@ -30,6 +30,14 @@ trait PromotionCartInformationTrait
     }
 
     /**
+     * Adds a persistent error when a promotion exists but has reached its redemption limit.
+     */
+    private function addPromotionAlreadyRedeemedError(string $code, Cart $cart): void
+    {
+        $cart->addErrors(new PromotionNotEligibleError($code, 'already-redeemed', [], true));
+    }
+
+    /**
      * function checks if the Original Cart contains the lineItem.
      * if not, an PromotionCartAddedInformationError is set in the calculated cart
      */

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -144,8 +144,15 @@ class PromotionCollector implements CartDataCollectorInterface
 
             $foundCodes = $discountLineItems->fmap(static fn (LineItem $item) => $item->getReferencedId());
 
+            // codes excluded because their redemption limit was reached
+            $redeemedCodes = [];
+
             foreach ($allPromotions->getPromotionCodeTuples() as $tuple) {
                 if (!$this->isEligible($tuple->getPromotion(), $context->getCustomerId(), $currentOrderId)) {
+                    if ($this->isRedemptionLimitReached($tuple->getPromotion(), $context->getCustomerId())) {
+                        $redeemedCodes[$tuple->getCode()] = true;
+                    }
+
                     continue;
                 }
 
@@ -179,7 +186,14 @@ class PromotionCollector implements CartDataCollectorInterface
             foreach (\array_diff($allCodes, \array_unique($foundCodes)) as $code) {
                 $cartExtension->removeCode((string) $code);
 
-                $this->addPromotionNotFoundError($this->htmlSanitizer->sanitize((string) $code, null, true), $original);
+                $sanitizedCode = $this->htmlSanitizer->sanitize((string) $code, null, true);
+
+                // valid code, no longer redeemable: clear reason instead of "not found"
+                if (isset($redeemedCodes[(string) $code])) {
+                    $this->addPromotionAlreadyRedeemedError($sanitizedCode, $original);
+                } else {
+                    $this->addPromotionNotFoundError($sanitizedCode, $original);
+                }
             }
 
             // when being in a recalculation, having notifications about the removal of automatic promotion is desired
@@ -376,6 +390,19 @@ class PromotionCollector implements CartDataCollectorInterface
         }
 
         return true;
+    }
+
+    /**
+     * Whether an ineligible promotion was excluded because its global or per-customer redemption
+     * limit was reached. Only valid after {@see isEligible} returned false (promotion not in the current order).
+     */
+    private function isRedemptionLimitReached(PromotionEntity $promotion, ?string $customerId): bool
+    {
+        if (!$promotion->isOrderCountValid()) {
+            return true;
+        }
+
+        return $customerId !== null && !$promotion->isOrderCountPerCustomerCountValid($customerId);
     }
 
     private function isUsedInCurrentOrder(string $promotionId, string $orderId): bool

--- a/src/Core/Framework/Resources/snippet/messages.de.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.de.base.json
@@ -14,6 +14,7 @@
         "promotion-not-found": "Gutscheincode \"%code%\" existiert nicht.",
         "auto-promotion-not-found": "Die Rabattaktion \"%name%\" ist nicht länger gültig!",
         "promotion-not-eligible": "Der Gutschein-Code wurde gespeichert, aber nicht auf den Warenkorb angewendet, da die Voraussetzungen dafür nicht zutreffen. Sobald die Voraussetzungen zutreffen, wird er automatisch hinzugefügt.",
+        "promotion-not-eligible-already-redeemed": "Der Gutscheincode \"%name%\" wurde bereits eingelöst.",
         "promotion-excluded": "Mindestens ein Rabatt wurde wegen Konflikten mit anderen Rabatten aus dem Warenkorb entfernt. Sobald die Bedingungen wieder zutreffen, wird der Rabatt automatisch hinzugefügt.",
         "promotions-on-cart-price-zero-error": "Die Rabattaktionen \"%promotions%\" wurden nicht im Warenkorb angewendet, da der Warenkorb kostenlos ist.",
         "shipping-address-blocked": "Lieferungen an die gewählte Lieferadresse sind nicht möglich.",

--- a/src/Core/Framework/Resources/snippet/messages.en.base.json
+++ b/src/Core/Framework/Resources/snippet/messages.en.base.json
@@ -14,6 +14,7 @@
         "promotion-not-found": "Promo code \"%code%\" could not be found.",
         "auto-promotion-not-found": "Promotion \"%name%\" no longer valid!",
         "promotion-not-eligible": "Promotion code valid - however, not all conditions were met and the discount was not applied. Once all conditions are met, the discount will be applied automatically.",
+        "promotion-not-eligible-already-redeemed": "The promo code \"%name%\" has already been redeemed.",
         "promotion-excluded": "One or more discounts have been removed from the shopping cart, due to conflicts with other discounts. Once the conditions are met again, the discounts will be applied automatically.",
         "promotions-on-cart-price-zero-error": "Promotions \"%promotions%\" were excluded for cart because the price of the cart is zero",
         "shipping-address-blocked": "Shipping to the selected shipping address is currently not possible.",

--- a/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionAlreadyRedeemedTest.php
+++ b/tests/integration/Core/Checkout/Cart/Promotion/Integration/PromotionAlreadyRedeemedTest.php
@@ -1,0 +1,189 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart\Promotion\Integration;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\DataAbstractionLayer\PromotionRedemptionUpdater;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Integration\Traits\Promotion\PromotionIntegrationTestBehaviour;
+use Shopware\Core\Test\Integration\Traits\Promotion\PromotionTestFixtureBehaviour;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PromotionAlreadyRedeemedTest extends TestCase
+{
+    use CountryAddToSalesChannelTestBehaviour;
+    use IntegrationTestBehaviour;
+    use PromotionIntegrationTestBehaviour;
+    use PromotionTestFixtureBehaviour;
+
+    /**
+     * @var EntityRepository<PromotionCollection>
+     */
+    private EntityRepository $promotionRepository;
+
+    private CartService $cartService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->promotionRepository = static::getContainer()->get('promotion.repository');
+        $this->cartService = static::getContainer()->get(CartService::class);
+        $this->addCountriesToSalesChannel();
+    }
+
+    /**
+     * Reproduces the reported issue: a promotion with a code that is redeemable only
+     * once per customer. After the customer redeems it and submits the order, applying
+     * the same code again in a new checkout must report a clear "already redeemed"
+     * reason instead of the misleading "promotion could not be found" error.
+     */
+    #[Group('promotions')]
+    public function testReapplyingAOnceRedeemedCodeReportsAlreadyRedeemed(): void
+    {
+        $productId = Uuid::randomHex();
+        $promotionId = Uuid::randomHex();
+        $promotionCode = 'TESTCODE';
+        $customerId = $this->createCustomer();
+
+        // a promotion with a fixed (global) code, redeemable once per customer, with a discount
+        $this->promotionRepository->create([[
+            'id' => $promotionId,
+            'name' => 'Once per customer',
+            'active' => true,
+            'code' => $promotionCode,
+            'useCodes' => true,
+            'useIndividualCodes' => false,
+            'maxRedemptionsPerCustomer' => 1,
+            'salesChannels' => [
+                ['salesChannelId' => TestDefaults::SALES_CHANNEL, 'priority' => 1],
+            ],
+            'discounts' => [
+                [
+                    'scope' => PromotionDiscountEntity::SCOPE_CART,
+                    'type' => PromotionDiscountEntity::TYPE_ABSOLUTE,
+                    'value' => 10,
+                    'considerAdvancedRules' => false,
+                ],
+            ],
+        ]], Context::createDefaultContext());
+
+        // 1) first checkout: redeem the code and submit the order
+        $firstContext = $this->createCustomerContext($customerId);
+        $this->createTestFixtureProduct($productId, 119, 19, static::getContainer(), $firstContext);
+
+        $cart = $this->cartService->getCart($firstContext->getToken(), $firstContext);
+        $cart = $this->addProduct($productId, 1, $cart, $this->cartService, $firstContext);
+        $cart = $this->addPromotionCode($promotionCode, $cart, $this->cartService, $firstContext);
+
+        // the promotion is eligible and applied on the first redemption
+        static::assertCount(
+            1,
+            $cart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE),
+            'Promotion should be applied on the first redemption'
+        );
+
+        $this->cartService->order($cart, $firstContext, new RequestDataBag());
+
+        // ensure the per-customer redemption count reflects the placed order
+        static::getContainer()->get(PromotionRedemptionUpdater::class)
+            ->update([$promotionId], Context::createDefaultContext());
+
+        // 2) new checkout with the same customer: applying the same code again is rejected clearly
+        $secondContext = $this->createCustomerContext($customerId);
+        $secondCart = $this->cartService->getCart($secondContext->getToken(), $secondContext);
+        $secondCart = $this->addProduct($productId, 1, $secondCart, $this->cartService, $secondContext);
+        $secondCart = $this->addPromotionCode($promotionCode, $secondCart, $this->cartService, $secondContext);
+
+        $error = $secondCart->getErrors()->get('promotion-not-eligible');
+        static::assertInstanceOf(
+            PromotionNotEligibleError::class,
+            $error,
+            'Expected a "not eligible" error on the second redemption attempt'
+        );
+        static::assertSame(
+            'promotion-not-eligible-already-redeemed',
+            $error->getMessageKey(),
+            'The error must carry the "already redeemed" reason'
+        );
+
+        static::assertFalse(
+            $secondCart->getErrors()->has('promotion-not-found'),
+            'The misleading "promotion not found" error must no longer be used for a redeemed code'
+        );
+
+        static::assertCount(
+            0,
+            $secondCart->getLineItems()->filterType(PromotionProcessor::LINE_ITEM_TYPE),
+            'The exhausted promotion must not be applied again'
+        );
+    }
+
+    private function createCustomerContext(string $customerId): SalesChannelContext
+    {
+        return static::getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [SalesChannelContextService::CUSTOMER_ID => $customerId]
+        );
+    }
+
+    private function createCustomer(): string
+    {
+        $customerId = Uuid::randomHex();
+        $addressId = Uuid::randomHex();
+
+        $customer = [
+            'id' => $customerId,
+            'number' => '1337',
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => 'Max',
+            'lastName' => 'Mustermann',
+            'customerNumber' => '1337',
+            'email' => Uuid::randomHex() . '@example.com',
+            'password' => TestDefaults::HASHED_PASSWORD,
+            'groupId' => TestDefaults::FALLBACK_CUSTOMER_GROUP,
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'defaultBillingAddressId' => $addressId,
+            'defaultShippingAddressId' => $addressId,
+            'addresses' => [
+                [
+                    'id' => $addressId,
+                    'customerId' => $customerId,
+                    'countryId' => $this->getValidCountryId(),
+                    'salutationId' => $this->getValidSalutationId(),
+                    'firstName' => 'Max',
+                    'lastName' => 'Mustermann',
+                    'street' => 'Ebbinghoff 10',
+                    'zipcode' => '48624',
+                    'city' => 'Schöppingen',
+                ],
+            ],
+        ];
+
+        static::getContainer()
+            ->get('customer.repository')
+            ->upsert([$customer], Context::createDefaultContext());
+
+        return $customerId;
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Error/PromotionNotEligibleErrorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Error/PromotionNotEligibleErrorTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Promotion\Cart\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(PromotionNotEligibleError::class)]
+class PromotionNotEligibleErrorTest extends TestCase
+{
+    public function testDefaultConstructor(): void
+    {
+        $error = new PromotionNotEligibleError('test-promotion');
+
+        static::assertSame('promotion-not-eligible', $error->getMessageKey());
+        static::assertSame('promotion-not-eligible', $error->getId());
+        static::assertSame([], $error->getRuleIds());
+        static::assertSame(Error::LEVEL_NOTICE, $error->getLevel());
+        static::assertFalse($error->isPersistent());
+        static::assertFalse($error->blockOrder());
+        static::assertSame(['name' => 'test-promotion'], $error->getParameters());
+    }
+
+    public function testReasonProducesReasonSpecificMessageKey(): void
+    {
+        $error = new PromotionNotEligibleError('my-promo', 'some-reason');
+
+        static::assertSame('promotion-not-eligible-some-reason', $error->getMessageKey());
+        static::assertSame('promotion-not-eligible', $error->getId());
+        static::assertFalse($error->isPersistent());
+    }
+
+    public function testAlreadyRedeemedReasonIsPersistent(): void
+    {
+        $error = new PromotionNotEligibleError('TESTCODE', 'already-redeemed', [], true);
+
+        static::assertSame('promotion-not-eligible-already-redeemed', $error->getMessageKey());
+        static::assertSame('promotion-not-eligible', $error->getId());
+        static::assertSame(['name' => 'TESTCODE'], $error->getParameters());
+        // must be persistent so a code removed by the collector survives cart recalculation
+        static::assertTrue($error->isPersistent());
+    }
+
+    public function testWithRuleIds(): void
+    {
+        $error = new PromotionNotEligibleError('my-promo', null, ['rule-id-1', 'rule-id-2']);
+
+        static::assertSame('promotion-not-eligible', $error->getMessageKey());
+        static::assertSame(['rule-id-1', 'rule-id-2'], $error->getRuleIds());
+    }
+}

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountCollection;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
 use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCollector;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
@@ -114,6 +115,7 @@ class PromotionCollectorTest extends TestCase
         $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
 
         static::assertNull($cartDataCollection->get(PromotionProcessor::DATA_KEY));
+        $this->assertAlreadyRedeemedError($cart);
     }
 
     public function testPromotionWithInvalidOrderCountPerCustomerCount(): void
@@ -126,6 +128,30 @@ class PromotionCollectorTest extends TestCase
         $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
 
         static::assertNull($cartDataCollection->get(PromotionProcessor::DATA_KEY));
+        $this->assertAlreadyRedeemedError($cart);
+    }
+
+    public function testUnknownPromotionCodeAddsNotFoundError(): void
+    {
+        $lineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE, Uuid::randomHex());
+
+        $cart = new Cart(Uuid::randomHex());
+        $cart->setLineItems(new LineItemCollection([$lineItem]));
+
+        $cartExtension = new CartExtension();
+        $cartExtension->addCode('unknown-code');
+        $cart->addExtension(CartExtension::KEY, $cartExtension);
+
+        // gateway finds no promotion for the code (global, individual and automatic lookups)
+        $this->gateway->method('get')->willReturn(new PromotionCollection());
+
+        $cartDataCollection = new CartDataCollection();
+
+        $this->promotionCollector->collect($cartDataCollection, $cart, $this->context, new CartBehavior());
+
+        static::assertNull($cartDataCollection->get(PromotionProcessor::DATA_KEY));
+        static::assertTrue($cart->getErrors()->has('promotion-not-found'));
+        static::assertFalse($cart->getErrors()->has('promotion-not-eligible'));
     }
 
     public function testPromotionWithoutDiscount(): void
@@ -274,6 +300,17 @@ class PromotionCollectorTest extends TestCase
         static::assertSame($promotionId, $promotionLast->getPayloadValue('promotionId'));
         static::assertSame($discountId2, $promotionLast->getPayloadValue('discountId'));
         static::assertNull($promotionLast->getExtension(OrderConverter::ORIGINAL_ID));
+    }
+
+    private function assertAlreadyRedeemedError(Cart $cart): void
+    {
+        static::assertFalse($cart->getErrors()->has('promotion-not-found'));
+
+        $error = $cart->getErrors()->get('promotion-not-eligible');
+        static::assertInstanceOf(PromotionNotEligibleError::class, $error);
+        static::assertSame('promotion-not-eligible-already-redeemed', $error->getMessageKey());
+        // must be persistent, otherwise the Processor drops it and the customer sees nothing
+        static::assertTrue($error->isPersistent());
     }
 
     private function createPromotionCollector(?Connection $connection = null): PromotionCollector


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a customer entered a promotion code whose global or per-customer redemption limit was already reached, the storefront showed the misleading "Promo code could not be found" message, because the `PromotionCollector` emitted a `PromotionNotFoundError` for every removed code regardless of the reason

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18413
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
