### PR TITLE
fix(ci): avoid pipefail SIGPIPE race in markdown-only change detection

### DIFF
--- a/.github/actions/markdown-only-changes/action.yaml
+++ b/.github/actions/markdown-only-changes/action.yaml
@@ -37,7 +37,10 @@ runs:
           exit 0
         fi
 
-        if [ -z "$changed_files" ] || printf '%s\n' "$changed_files" | grep -Eivq '\.md$'; then
+        # A here-string instead of a pipe: with `grep -q` closing the pipe on the
+        # first match, a piped writer can fail with SIGPIPE and `pipefail` would
+        # invert the result, wrongly marking the PR as markdown-only.
+        if [ -z "$changed_files" ] || grep -Eivq '\.md$' <<<"$changed_files"; then
           echo "docs_only=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi


### PR DESCRIPTION
### 1. Why is this change necessary?

The `markdown-only-changes` gate can wrongly report `docs_only=true` for pull requests full of code, silently skipping all PHP and Admin checks while the required `check` jobs stay green.

### 2. What does this change do, exactly?

Replaces the `printf | grep -Eivq` pipeline in the detection step with a here-string (`grep -Eivq '\.md$' <<<"$changed_files"`).

The step runs under `bash -e -o pipefail`. `grep -q` exits on the first non-`.md` match and closes the pipe; when `printf` has not finished writing the file list yet, it fails with a broken-pipe write error, and `pipefail` turns that into the pipeline's exit status even though `grep` matched. The `if` condition then evaluates to false and the script falls through to `docs_only=true`.

The file list is a two-dot diff (`git diff base_sha head_sha`), so for branches behind their base it also contains every file the base changed since the branch point. Once the list exceeds the 64 KiB pipe buffer, `printf` blocks mid-write and the misfire is deterministic — every run and re-run of the gate produces `docs_only=true`. Below the buffer size it is a scheduling race.

The here-string removes the pipe entirely, so there is no writer left to fail regardless of list size.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a PR whose branch is far enough behind trunk that `git diff --name-only base_sha head_sha` exceeds 64 KiB (or hit the scheduling race on a smaller diff), with a non-`.md` file early in the list.
2. Run the "PHP checks" workflow; the `markdown-only-changes` job logs `printf: write error: Broken pipe`.
3. All PHP jobs (PHPStan, PHPUnit, lint, Rector, BC check, openapi-lint, composer audit) are skipped and `php-check` passes via `allowed-skips`.

### 4. Please link to the relevant issues (if any).

- closes #18583

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
