### PR TITLE
chore: bump dompdf to 3.1.6 to clear the security advisories blocking CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.4",
+        "dompdf/dompdf": "3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -61,7 +61,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.4",
+        "dompdf/dompdf": "3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

2 security advisories against dompdf <= 3.1.4 (GHSA-7x2p-4jvh-6384, GHSA-wvh6-f5jh-8gw4) were published today. 

composer's advisory blocking refuses to load the exact-pinned 3.1.4, so every `composer install` in CI fails on every branch since ~21:10 UTC.
```
Install Composer dependencies
4s
Run ${GITHUB_ACTION_PATH}/bin/composer_install.sh \
      Loading composer repositories with package information
      Updating dependencies
      Your requirements could not be resolved to an installable set of packages.
      
        Problem 1
          - Root composer.json requires dompdf/dompdf 3.1.4 (exact version match: 3.1.4 or 3.1.4.0), found dompdf/dompdf[v3.1.4] but these were not loaded, because they are affected by security advisories ("^[]8;;[https://github.com/advisories/GHSA-7x2p-4jvh-6384^[\PKSA-hp6n-n4kz-21wk^[]8;;^[\](https://github.com/advisories/GHSA-7x2p-4jvh-6384%1B/PKSA-hp6n-n4kz-21wk%1B]8;;%1B/)", "^[]8;;[https://github.com/advisories/GHSA-wvh6-f5jh-8gw4^[\PKSA-mckv-s5hg-868k^[]8;;^[\](https://github.com/advisories/GHSA-wvh6-f5jh-8gw4%1B/PKSA-mckv-s5hg-868k%1B]8;;%1B/)"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add their IDs to the "policy.advisories.ignore-id" config or add the package to "policy.advisories.ignore". To turn the feature off entirely, you can set "policy.advisories.block" to false.
      
      Error: Your requirements could not be resolved to an installable set of packages.
      
        Problem 1
          - Root composer.json requires dompdf/dompdf 3.1.4 (exact version match: 3.1.4 or 3.1.4.0), found dompdf/dompdf[v3.1.4] but these were not loaded, because they are affected by security advisories ("^[]8;;[https://github.com/advisories/GHSA-7x2p-4jvh-6384^[\PKSA-hp6n-n4kz-21wk^[]8;;^[\](https://github.com/advisories/GHSA-7x2p-4jvh-6384%1B/PKSA-hp6n-n4kz-21wk%1B]8;;%1B/)", "^[]8;;[https://github.com/advisories/GHSA-wvh6-f5jh-8gw4^[\PKSA-mckv-s5hg-868k^[]8;;^[\](https://github.com/advisories/GHSA-wvh6-f5jh-8gw4%1B/PKSA-mckv-s5hg-868k%1B]8;;%1B/)"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add their IDs to the "policy.advisories.ignore-id" config or add the package to "policy.advisories.ignore". To turn the feature off entirely, you can set "policy.advisories.block" to false.
      
      Error: Process completed with exit code 2.
```

### 2. What does this change do, exactly?

- Bumps the `dompdf/dompdf` pin from 3.1.4 to 3.1.6 (the first patched version per the advisories) in the root `composer.json` and its mirror `src/Core/composer.json`
- 3.1.5 and 3.1.6 are patch releases: 3 rendering bugfixes + the security hardenings, no API changes
- Shopware configures dompdf with `isRemoteEnabled` only and embeds assets via URLs and data URIs, so the hardened local-file paths are not exercised

### 3. Describe each step to reproduce the issue or behaviour.

`composer install` on any current branch fails with `dompdf/dompdf[v3.1.4] ... affected by security advisories`. With the bump, resolution succeeds (`No security vulnerability advisories found`); `PdfRendererTest` (15 tests) and the document rendering suite incl. `DocumentRendererSnapshotTest` (38 tests, 344 assertions) stay green on 3.1.6.

⚠️ **Note on this PR's remaining red checks:** 

`BC check`, `PHP blue green` and `acceptance-update` install **historical states** (trunk baseline, previous major tags, released versions), whose composer.json still pins the blocked 3.1.4 — no PR can fix git history, so these need an admin bypass here and stay red on every PR until the maintained branches get the bump. All jobs installing this PR's own state are green, which is the fix working. A follow-up will disable advisory blocking for the historical-install steps only.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
