### PR TITLE
ci: allow advisory-affected packages in historical-state installs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -270,6 +270,11 @@ jobs:
           - "9200:9200"
 
     steps:
+      # the previous major is a historical state whose pinned dependencies may have advisories
+      # published after the fact; those must not block the upgrade scenario. Same guard
+      # acceptance-update applies to old versions.
+      - name: Allow advisory-affected packages in the previous major install
+        run: composer config -g audit.block-insecure false
       - name: Setup previous major version
         uses: shopware/setup-shopware@main
         with:
@@ -351,6 +356,11 @@ jobs:
           - "9200:9200"
 
     steps:
+      # the previous major is a historical state whose pinned dependencies may have advisories
+      # published after the fact; those must not block the upgrade scenario. Same guard
+      # acceptance-update applies to old versions.
+      - name: Allow advisory-affected packages in the previous major install
+        run: composer config -g audit.block-insecure false
       - name: Setup previous major version
         uses: shopware/setup-shopware@main
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -179,6 +179,12 @@ jobs:
           set -e
           git remote add bc-checker-upstream https://github.com/shopware/platform.git
           git fetch bc-checker-upstream
+      # the comparison baseline installs a historical state (base branch or latest tag) whose
+      # pinned dependencies may have advisories published after the fact; those must not block
+      # the BC comparison. Same guard acceptance-update applies to old versions. Placed after
+      # the current-state install above so that one stays strictly checked.
+      - name: Allow advisory-affected packages in the comparison baseline
+        run: composer config -g audit.block-insecure false
       - name: BC Checker lastest tag
         if: github.event_name != 'pull_request'
         run: composer run bc-check


### PR DESCRIPTION
### 1. Why is this change necessary?

Composer 2.10 blocks advisory-affected versions at resolution time. Jobs that install historical states cannot be fixed by any PR when an advisory is published against a version pinned in git history, as the dompdf outage showed (#18588): the BC baseline and the blue-green previous-major installs stayed red on every branch and needed admin bypasses.

### 2. What does this change do, exactly?

- Sets `composer config -g audit.block-insecure false` before the historical-state installs, mirroring the guard `acceptance-update` already applies to old versions
- Covered spots: the BC checker baseline (placed after the current-state install, which stays strictly checked) and the two blue-green previous-major setups
- Current-state installs keep full advisory blocking everywhere; the dedicated `composer audit` job keeps reporting current-state advisories

### 3. Describe each step to reproduce the issue or behaviour.

Publish (or wait for) a security advisory against a version pinned by a maintained branch or the latest tag: `BC check` and `PHP blue green 6.6 -> 6.7 -> 6.6` fail on every PR with `... not loaded, because they are affected by security advisories`, and only admin bypasses or emergency releases unblock the pipeline.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them