### PR TITLE
fix(core): update dompdf to 3.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.4",
+        "dompdf/dompdf": "3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -61,7 +61,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.4",
+        "dompdf/dompdf": "3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

Dompdf 3.1.4 is affected by multiple security vulnerabilities that are resolved in 3.1.6. The vulnerable version also causes security checks to block pipelines.

### 2. What does this change do, exactly?

It updates the exact `dompdf/dompdf` version constraint from 3.1.4 to 3.1.6 in the root and Core Composer manifests.

The existing Document and DocumentV2 test coverage passes with the updated dependency: 402 unit tests and 59 renderer integration tests. Composer audit reports no security advisories after the update.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install the project dependencies with `dompdf/dompdf` pinned to 3.1.4.
2. Run the Composer security audit or a pipeline containing the dependency security check.
3. Observe the dompdf security advisories.
4. Update the pin to 3.1.6 and rerun the audit; the dompdf advisories are resolved.

### 4. Please link to the relevant issues (if any).

- Upstream security release: https://github.com/dompdf/dompdf/releases/tag/v3.1.6

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them