### PR TITLE
fix(core): prevent infinite clone recursion in sorted product properties

### DIFF
--- a/src/Core/Content/Product/PropertyGroupSorter.php
+++ b/src/Core/Content/Product/PropertyGroupSorter.php
@@ -59,7 +59,6 @@ class PropertyGroupSorter extends AbstractPropertyGroupSorter
 
             $normalizedOption = $this->normalizeOption($option);
             $normalizedOption->setGroupId($groupId);
-            $normalizedOption->setGroup($sorted[$groupId]);
 
             \assert($sorted[$groupId]->getOptions() instanceof PropertyGroupOptionCollection);
 

--- a/tests/unit/Core/Content/Product/PropertyGroupSorterTest.php
+++ b/tests/unit/Core/Content/Product/PropertyGroupSorterTest.php
@@ -166,7 +166,7 @@ class PropertyGroupSorterTest extends TestCase
      * @param class-string<PropertyGroupOptionEntity|PartialEntity> $entityType
      */
     #[DataProvider('optionEntityTypeProvider')]
-    public function testNormalizedOptionsHaveGroupReference(string $entityType, bool $partialGroups): void
+    public function testNormalizedOptionsExposeGroupIdWithoutReferencingTheirGroup(string $entityType, bool $partialGroups): void
     {
         $groupId = Uuid::randomHex();
         $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_POSITION, true, $partialGroups);
@@ -188,7 +188,44 @@ class PropertyGroupSorterTest extends TestCase
         $normalizedOption = $groupOptions->first();
         static::assertNotNull($normalizedOption);
         static::assertSame($groupId, $normalizedOption->getGroupId());
-        static::assertSame($sortedGroup, $normalizedOption->getGroup());
+
+        // The option must never point back to the group that already contains it. Such a
+        // group <-> option cycle makes Entity::__clone() recurse infinitely, see
+        // testSortedResultCanBeClonedWithoutInfiniteRecursion().
+        static::assertNotSame($sortedGroup, $normalizedOption->getGroup());
+    }
+
+    /**
+     * @param class-string<PropertyGroupOptionEntity|PartialEntity> $entityType
+     */
+    #[DataProvider('optionEntityTypeProvider')]
+    public function testSortedResultCanBeClonedWithoutInfiniteRecursion(string $entityType, bool $partialGroups): void
+    {
+        $groupId = Uuid::randomHex();
+        $group = $this->createGroup($groupId, PropertyGroupDefinition::SORTING_TYPE_ALPHANUMERIC, true, $partialGroups);
+
+        $options = $this->createOptionsCollection(
+            $this->createOption($entityType, $groupId, 'red', 2, $group),
+            $this->createOption($entityType, $groupId, 'blue', 1, $group),
+        );
+
+        $sorter = new PropertyGroupSorter();
+        $result = $sorter->sortUsingLocaleCode($options, 'en-GB');
+
+        // Regression guard for the storefront product detail page crash: the sorted collection is
+        // attached to the product as `sortedProperties` and later cloned while the product graph is
+        // copied. A cyclic group <-> option graph made Entity::__clone() (CloneTrait, no cycle
+        // detection) recurse until the call stack overflowed. Cloning must terminate and copy the
+        // options.
+        $clonedResult = clone $result;
+
+        $clonedGroup = $clonedResult->first();
+        static::assertNotNull($clonedGroup);
+        static::assertNotSame($result->first(), $clonedGroup);
+
+        $clonedOptions = $clonedGroup->getOptions();
+        static::assertInstanceOf(PropertyGroupOptionCollection::class, $clonedOptions);
+        static::assertSame(['blue', 'red'], $this->extractOptionNames($clonedOptions));
     }
 
     private function createGroup(string $id, string $sortingType, bool $visibleOnProductDetailPage, bool $partial = false): Entity


### PR DESCRIPTION
### 1. Why is this change necessary?

The storefront product detail page crashes with HTTP 500 (`Maximum call stack size ... reached. Infinite recursion?`).

`PropertyGroupSorter::sortUsingLocaleCode()` (introduced in #15240) sets each sorted option's `group` back to the group that already contains it, creating a `group -> options -> option -> group` cycle. `Entity::__clone()` (`CloneTrait`) copies object graphs without cycle detection, so cloning the product graph while rendering the detail page recurses until the call stack overflows.

### 2. What does this change do, exactly?

Removes the `option -> group` back-reference in `sortUsingLocaleCode()`. The scalar `groupId` is still set and the group stays reachable through the owning `PropertyGroupCollection`, so consumers are unaffected (the storefront reads `group -> options`, never `option -> group`). Adds a regression test that clones the sorted result and one that asserts the option no longer references its containing group.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a product detail page for a product that has visible properties.
2. Before this change: HTTP 500 `Maximum call stack size ... Infinite recursion?`.
3. After this change: the page renders and the properties table is shown.

### 4. Please link to the relevant issues (if any).

relates #15240

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
