### PR TITLE
chore: exempt PHP routing config files from the danger unit-test rule

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTests.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTests.php
@@ -150,6 +150,11 @@ class MissingUnitTests
             return true;
         }
 
+        // Routing config files (PHP closures using RoutingConfigurator) need no unit tests.
+        if (preg_match('#/Resources/config/routes(?:_[^/]*)?\.php$#', $file->name) === 1 && str_contains($content, 'RoutingConfigurator')) {
+            return true;
+        }
+
         // process phpunit code coverage exclude lists
         if (\in_array($file->name, $excludedFiles, true)) {
             return true;

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTestsTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/MissingUnitTestsTest.php
@@ -95,6 +95,14 @@ class MissingUnitTestsTest extends TestCase
             'src/Core/Framework/DependencyInjection/services.php',
             "<?php\nreturn static function (ContainerConfigurator \$configurator): void {\n};",
         ];
+        yield 'routing config file' => [
+            'src/Core/Framework/Resources/config/routes.php',
+            "<?php\nreturn static function (RoutingConfigurator \$routes): void {\n};",
+        ];
+        yield 'env-specific routing config file' => [
+            'src/Core/Framework/Resources/config/routes_dev.php',
+            "<?php\nreturn static function (RoutingConfigurator \$routes): void {\n};",
+        ];
         yield 'file inside a coverage-excluded directory' => [
             'src/Core/DevOps/StaticAnalyze/SomeService.php',
             "<?php\nclass SomeService\n{\n}",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The routes [PR](https://github.com/shopware/shopware/pull/18577) (XML → PHP RoutingConfigurator) fails Danger's MissingUnitTests rule: the new routes*.php files are declarative routing wiring, not testable code. The rule already exempts PHP DI wiring files for exactly  this reason — routing config needs the same treatment.

### 2. What does this change do, exactly?
Adds one exemption to the MissingUnitTests Danger rule: files matching Resources/config/routes*.php (incl. env variants like routes_dev.php) that actually use RoutingConfigurator are skipped — mirroring the existing ContainerConfigurator exemption. Plus two data-provider cases in the rule's unit test covering both file shapes.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
