### PR TITLE
fix(checkout): refresh cart transaction amount after tax provider adjustment

### DIFF
--- a/src/Core/Checkout/Cart/TaxProvider/TaxAdjustment.php
+++ b/src/Core/Checkout/Cart/TaxProvider/TaxAdjustment.php
@@ -12,6 +12,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTax;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\TaxProvider\Struct\TaxProviderResult;
+use Shopware\Core\Checkout\Cart\Transaction\TransactionProcessor;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -23,7 +24,8 @@ class TaxAdjustment
      */
     public function __construct(
         private readonly AmountCalculator $amountCalculator,
-        private readonly CashRounding $rounding
+        private readonly CashRounding $rounding,
+        private readonly TransactionProcessor $transactionProcessor
     ) {
     }
 
@@ -50,6 +52,18 @@ class TaxAdjustment
         }
 
         $cart->setPrice($price);
+
+        $this->adjustTransactions($cart, $context);
+    }
+
+    private function adjustTransactions(Cart $cart, SalesChannelContext $context): void
+    {
+        if ($cart->getTransactions()->count() === 0) {
+            return;
+        }
+
+        // The transactions were built before the tax provider ran; rebuild them from the adjusted cart price.
+        $cart->setTransactions($this->transactionProcessor->process($cart, $context));
     }
 
     private function applyCartPriceTaxes(CartPrice $price, CalculatedTaxCollection $taxes, SalesChannelContext $context): CartPrice

--- a/src/Core/Checkout/DependencyInjection/cart.php
+++ b/src/Core/Checkout/DependencyInjection/cart.php
@@ -375,6 +375,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->args([
             service('shopware.tax.adjustment_calculator'),
             service(CashRounding::class),
+            service(TransactionProcessor::class),
         ]);
 
     // Checkout gateway

--- a/tests/unit/Core/Checkout/Cart/TaxProvider/TaxAdjustmentTest.php
+++ b/tests/unit/Core/Checkout/Cart/TaxProvider/TaxAdjustmentTest.php
@@ -25,6 +25,10 @@ use Shopware\Core\Checkout\Cart\Tax\TaxCalculator;
 use Shopware\Core\Checkout\Cart\TaxProvider\Struct\TaxProviderResult;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxAdjustment;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxAdjustmentCalculator;
+use Shopware\Core\Checkout\Cart\Transaction\Struct\Transaction;
+use Shopware\Core\Checkout\Cart\Transaction\Struct\TransactionCollection;
+use Shopware\Core\Checkout\Cart\Transaction\TransactionProcessor;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
@@ -54,7 +58,8 @@ class TaxAdjustmentTest extends TestCase
                 new PercentageTaxRuleBuilder(),
                 new TaxAdjustmentCalculator()
             ),
-            new CashRounding()
+            new CashRounding(),
+            new TransactionProcessor()
         );
     }
 
@@ -150,6 +155,67 @@ class TaxAdjustmentTest extends TestCase
         static::assertSame(7.0, $lineItemPrice->getCalculatedTaxes()->getAmount());
         static::assertSame(7.0, $delivery->getShippingCosts()->getCalculatedTaxes()->getAmount());
         static::assertSame(7.0, $deliveryPosition->getPrice()->getCalculatedTaxes()->getAmount());
+    }
+
+    public function testAdjustRefreshesStaleTransactionAmount(): void
+    {
+        $result = new TaxProviderResult(
+            [
+                $this->ids->get('line-item-1') => new CalculatedTaxCollection([
+                    new CalculatedTax(
+                        7,
+                        7,
+                        100
+                    ),
+                ]),
+            ],
+            [
+                $this->ids->get('delivery-position-1') => new CalculatedTaxCollection([
+                    new CalculatedTax(
+                        7,
+                        7,
+                        100
+                    ),
+                ]),
+            ],
+        );
+
+        $cart = $this->createCart();
+
+        // The transaction the TransactionProcessor built before the tax provider ran still carries the
+        // pre-adjustment total.
+        $cart->setTransactions(new TransactionCollection([
+            new Transaction(
+                new CalculatedPrice(110.0, 110.0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                $this->ids->get('old-payment-method'),
+            ),
+        ]));
+
+        $paymentMethod = new PaymentMethodEntity();
+        $paymentMethod->setId($this->ids->get('payment-method'));
+
+        $context = static::createStub(SalesChannelContext::class);
+        $context
+            ->method('getTaxState')
+            ->willReturn(CartPrice::TAX_STATE_NET);
+        $context
+            ->method('getTotalRounding')
+            ->willReturn(new CashRoundingConfig(2, 0.01, true));
+        $context
+            ->method('getPaymentMethod')
+            ->willReturn($paymentMethod);
+
+        $this->adjustment->adjust($cart, $result, $context);
+
+        // The transactions are rebuilt from the adjusted cart total instead of keeping the stale 110.0.
+        static::assertSame(214.0, $cart->getPrice()->getTotalPrice());
+        static::assertCount(1, $cart->getTransactions());
+
+        $adjusted = $cart->getTransactions()->first();
+        static::assertNotNull($adjusted);
+        static::assertSame($cart->getPrice()->getTotalPrice(), $adjusted->getAmount()->getTotalPrice());
+        static::assertSame(214.0, $adjusted->getAmount()->getUnitPrice());
+        static::assertSame($this->ids->get('payment-method'), $adjusted->getPaymentMethodId());
     }
 
     public function testCalculateGross(): void

--- a/tests/unit/Core/Checkout/Cart/TaxProvider/TaxProviderProcessorTest.php
+++ b/tests/unit/Core/Checkout/Cart/TaxProvider/TaxProviderProcessorTest.php
@@ -27,6 +27,7 @@ use Shopware\Core\Checkout\Cart\TaxProvider\TaxAdjustment;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxAdjustmentCalculator;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderRegistry;
+use Shopware\Core\Checkout\Cart\Transaction\TransactionProcessor;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\TaxProvider\Payload\TaxProviderPayload;
@@ -69,7 +70,8 @@ class TaxProviderProcessorTest extends TestCase
                 new PercentageTaxRuleBuilder(),
                 new TaxAdjustmentCalculator()
             ),
-            new CashRounding()
+            new CashRounding(),
+            new TransactionProcessor()
         );
     }
 


### PR DESCRIPTION



<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
TaxAdjustment applies the adjusted cart price, but the cart transactions are built by the TransactionProcessor beforehand, so they kept the pre-adjustment total. The transaction amount is what payment handlers charge and what is persisted onto the order, so a tax provider changing the total (e.g. with net customer groups) left the charged amount stale

### 2. What does this change do, exactly?

Refresh the transaction amounts in place after adjusting the price, preserving other transaction data
### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- relates https://github.com/shopware/SwagPayPal/issues/722
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
