### PR TITLE
demo: major-php auto-label detection (do not merge)

### DIFF
--- a/tests/unit/Core/Framework/FeatureTest.php
+++ b/tests/unit/Core/Framework/FeatureTest.php
@@ -23,6 +23,8 @@ use Shopware\Core\Test\Annotation\DisabledFeatures;
 #[CoversClass(Feature::class)]
 class FeatureTest extends TestCase
 {
+    // demo marker for shopware/shopware#18586: a changed line quoting a major flag,
+    // e.g. Feature::isActive('v6.8.0.0'), must auto-apply the major-php label
     use EnvTestBehaviour;
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

Throwaway demo for #18586: proves the auto-label end to end on a real PR. Do not merge.

### 2. What does this change do, exactly?

- Branch is based on #18586 so the detection steps exist in this PR's workflow
- Adds one comment line to `tests/unit/Core/Framework/FeatureTest.php` quoting a major flag in a non-excluded path

Expected: the `label` job detects the quoted flag in the diff, applies `major-php` via the octo-sts token, and the `labeled` event starts the integration-major matrix without any human action.

### 3. Describe each step to reproduce the issue or behaviour.

Watch the `label` job on this PR, then the PR labels, then the integration-major run list.

### 4. Please link to the relevant issues (if any).

- relates #18585

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them