### PR TITLE
feat(admin): allow sw modal dialog content opt into hidden overflow

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/index.js
@@ -93,6 +93,12 @@ export default {
             required: false,
             default: true,
         },
+
+        overflowHidden: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
     },
 
     data() {
@@ -106,6 +112,7 @@ export default {
             return {
                 [`sw-modal--${this.variant}`]: this.variant && !this.size,
                 'sw-modal--has-sidebar': this.showHelpSidebar,
+                'sw-modal--overflow-hidden': this.overflowHidden,
             };
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.scss
@@ -50,6 +50,10 @@ $sw-modal-gap: var(--scale-size-64);
         max-width: 500px;
     }
 
+    &.sw-modal--overflow-hidden .sw-modal__dialog {
+        overflow: hidden;
+    }
+
     &--has-sidebar {
         z-index: $z-index-help-sidebar + 1;
     }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-modal/sw-modal.spec.js
@@ -176,6 +176,22 @@ describe('src/app/component/base/sw-modal/index.js', () => {
         expect(wrapper.get('.sw-modal').classes('sw-modal--has-sidebar')).toBe(true);
     });
 
+    it('should have sw-modal--overflow-hidden class if overflowHidden option is true', async () => {
+        await wrapper.setProps({
+            overflowHidden: true,
+        });
+
+        expect(wrapper.get('.sw-modal').classes('sw-modal--overflow-hidden')).toBe(true);
+    });
+
+    it('should not have sw-modal--overflow-hidden class if overflowHidden option is false', async () => {
+        await wrapper.setProps({
+            overflowHidden: false,
+        });
+
+        expect(wrapper.get('.sw-modal').classes('sw-modal--overflow-hidden')).toBe(false);
+    });
+
     it('should add classes for the modal body correctly', async () => {
         await wrapper.setProps({
             showFooter: false,

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-modals-renderer/sw-modals-renderer.html.twig
@@ -13,6 +13,7 @@
             :show-header="modal.showHeader"
             :show-footer="modal.showFooter"
             :variant="modal.variant"
+            :overflow-hidden="modal.overflowHidden"
             class="sw-modals-renderer__modal"
             :class="{ 'has-iframe': Boolean(modal.locationId) }"
             @modal-close="closeModal(modal.locationId)"

--- a/src/Administration/Resources/app/administration/src/app/store/modals.store.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/modals.store.spec.ts
@@ -38,6 +38,7 @@ describe('modals.store', () => {
                 textContent: undefined,
                 buttons: [],
                 baseUrl: 'https://example.com',
+                overflowHidden: undefined,
             },
         ]);
     });
@@ -64,6 +65,7 @@ describe('modals.store', () => {
                 textContent: 'Test content',
                 buttons: [],
                 baseUrl: 'https://example.com',
+                overflowHidden: undefined,
             },
         ]);
     });
@@ -128,6 +130,7 @@ describe('modals.store', () => {
                 textContent: 'Test content',
                 buttons: [],
                 baseUrl: 'https://example.com',
+                overflowHidden: undefined,
             },
             {
                 locationId: 'test',
@@ -139,6 +142,7 @@ describe('modals.store', () => {
                 textContent: undefined,
                 buttons: [],
                 baseUrl: 'https://example.com',
+                overflowHidden: undefined,
             },
         ]);
     });

--- a/src/Administration/Resources/app/administration/src/app/store/modals.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/modals.store.ts
@@ -7,6 +7,7 @@ import type { uiModalOpen } from '@shopware-ag/meteor-admin-sdk/es/ui/modal';
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export type ModalItemEntry = Omit<uiModalOpen, 'responseType'> & {
     baseUrl: string;
+    overflowHidden?: boolean;
 };
 
 const modalsStore = Shopware.Store.register({
@@ -27,6 +28,7 @@ const modalsStore = Shopware.Store.register({
             baseUrl,
             buttons,
             textContent,
+            overflowHidden,
         }: ModalItemEntry) {
             this.modals.push({
                 title,
@@ -38,6 +40,7 @@ const modalsStore = Shopware.Store.register({
                 buttons: buttons ?? [],
                 baseUrl,
                 textContent,
+                overflowHidden,
             });
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Adds an `overflowHidden` option to `sw-modal`, threaded through the modals store and `sw-modals-renderer`, so extension-rendered modal content (e.g. app iframes) can suppress overflow on `.sw-modal__dialog` instead of visually breaking out of the dialog bounds.

### 2. What does this change do, exactly?
Add a flag `overflowHidden` with style for overflow hidden to use `ui.modal.open()` now accepts an `overflowHidden` boolean option. When set, the modal dialog's content area gets `overflow: hidden` instead of allowing content (e.g. an app's iframe) to overflow the dialog bounds.

### 3. Describe each step to reproduce the issue or behaviour.
New optional flag for modal style

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
