### PR TITLE
ci: detect markdown-only pull requests with paths-filter instead of git diff

### DIFF
--- a/.github/actions/markdown-only-changes/action.yaml
+++ b/.github/actions/markdown-only-changes/action.yaml
@@ -20,16 +20,19 @@ runs:
       continue-on-error: true
       uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       with:
-        # `every`: a file is non_docs only if it matches all patterns
+        # paths-filter can only answer "does any changed file match?", so ask
+        # the complement: did the PR touch anything that is not markdown?
+        # (`every` = a file only counts when it matches both negated patterns)
         predicate-quantifier: 'every'
         filters: |
-          non_docs:
+          non_markdown:
             - '!**/*.md'
             - '!**/*.MD'
 
-    # A skipped or failed filter step leaves the output empty, and
-    # '' == 'false' is false — do not simplify, this is the fail-open path.
+    # docs_only = files changed and none of them were non-markdown. A skipped
+    # or failed filter step leaves the output empty, and '' == 'false' is
+    # false — do not simplify, this is the fail-open path.
     - name: Report markdown-only result
       id: check
       shell: bash
-      run: echo "docs_only=${{ steps.filter.outputs.non_docs == 'false' }}" >> "$GITHUB_OUTPUT"
+      run: echo "docs_only=${{ steps.filter.outputs.non_markdown == 'false' }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/markdown-only-changes/action.yaml
+++ b/.github/actions/markdown-only-changes/action.yaml
@@ -9,40 +9,27 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    # Changed files come from the pulls.listFiles API (calling job needs
+    # `pull-requests: read`), so no full-history checkout is needed. Guards
+    # only ever err towards docs_only=false: the changed_files bound covers
+    # the API's silent 3000-file truncation, continue-on-error keeps an API
+    # failure from failing this job (which would skip all dependent jobs).
+    - name: Detect non-markdown changes
+      id: filter
+      if: github.event_name == 'pull_request' && github.event.pull_request.changed_files > 0 && github.event.pull_request.changed_files < 3000
+      continue-on-error: true
+      uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       with:
-        fetch-depth: 0
+        # `every`: a file is non_docs only if it matches all patterns
+        predicate-quantifier: 'every'
+        filters: |
+          non_docs:
+            - '!**/*.md'
+            - '!**/*.MD'
 
-    - name: Detect markdown-only pull requests
+    # A skipped or failed filter step leaves the output empty, and
+    # '' == 'false' is false — do not simplify, this is the fail-open path.
+    - name: Report markdown-only result
       id: check
       shell: bash
-      run: |
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
-          echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        base_sha="${{ github.event.pull_request.base.sha }}"
-        head_sha="${{ github.event.pull_request.head.sha }}"
-
-        if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
-          echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        if ! changed_files="$(git diff --name-only "$base_sha" "$head_sha")"; then
-          echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        # A here-string instead of a pipe: with `grep -q` closing the pipe on the
-        # first match, a piped writer can fail with SIGPIPE and `pipefail` would
-        # invert the result, wrongly marking the PR as markdown-only.
-        if [ -z "$changed_files" ] || grep -Eivq '\.md$' <<<"$changed_files"; then
-          echo "docs_only=false" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        echo "docs_only=true" >> "$GITHUB_OUTPUT"
+      run: echo "docs_only=${{ steps.filter.outputs.non_docs == 'false' }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -14,6 +14,7 @@ jobs:
   markdown-only-changes:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-24.04
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,6 +21,7 @@ jobs:
   markdown-only-changes:
     permissions:
       contents: read
+      pull-requests: read
     runs-on: ubuntu-24.04
     outputs:
       docs_only: ${{ steps.check.outputs.docs_only }}


### PR DESCRIPTION
### 1. Why is this change necessary?

Detecting changed files against path filters is a solved problem — `dorny/paths-filter` is the widely-used action for exactly this. Replacing our hand-rolled detection (an untested bash pipeline that already inverted its result once under `pipefail`, and needs a full-history checkout for its `git diff`) with it means no detection logic of our own to maintain.

### 2. What does this change do, exactly?

Structure:
- Rewrites `.github/actions/markdown-only-changes/action.yaml` to use `dorny/paths-filter` (pinned at v3.0.2) with a `non_markdown` filter (`predicate-quantifier: every`, patterns `!**/*.md` / `!**/*.MD`), followed by a step deriving `docs_only`. The consuming workflows keep `uses: ./.github/actions/markdown-only-changes` and their `docs_only` output unchanged.

Behaviour:
- Changed files come from the `pulls.listFiles` API (merge-base semantics, identical to the "Files changed" tab) instead of `git diff base.sha head.sha`, so the `fetch-depth: 0` full-history checkout inside the action is removed and unrelated base-branch movement no longer disables the skip. paths-filter reports renames as a deletion of the old path plus an addition of the new one, so a rename from code to markdown does not count as markdown-only.
- The action protects itself against paths-filter erroring, in the only safe direction (`docs_only=false`, run the full pipeline):
  - `continue-on-error: true` on the filter step, so an API failure cannot fail the gate job — a failed gate job would skip every dependent job instead of running them;
  - the filter step only runs on `pull_request` events with `0 < changed_files < 3000` — `pulls.listFiles` silently truncates at 3000 files, so a listing at the cap can never prove a PR is markdown-only;
  - `docs_only` is derived as `non_markdown == 'false'`, so a skipped or failed filter step (empty output) yields `false`.
- The `markdown-only-changes` jobs in `php.yml` and `admin.yml` gain `pull-requests: read` (a read scope the default token also has on fork PRs).

Trade-off: the fail-safe guarantees live in workflow expression semantics (`continue-on-error`, empty-output coercion, the `changed_files` guard) and cannot be covered by tests; the comments in the action mark the expressions that must not be simplified.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open a PR that only touches `.md` files: the `markdown-only-changes` job sets `docs_only=true` and the expensive jobs skip.
2. Open a PR touching any non-markdown file (or push while the API is unavailable): `docs_only=false` and the full pipeline runs.

### 4. Please link to the relevant issues (if any).

- closes #18628
- Alternative to #18629 — only one of the two should be merged.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
