### PR TITLE
fix: encode product export body URLs

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -31,9 +31,11 @@ shopware:
 
 List options (`plugins`, `excluded_locales`, `plugin_mapping`, `languages`) replace the shipped default entirely rather than merging; provide the full list you want. Setting a list to `[]` clears the shipped default. Decorating `AbstractTranslationConfigLoader` continues to work; a decorator that fully replaces `load()` bypasses these config overrides.
 
-### Product export body URLs are RFC 3986 encoded
+### Product export body media URLs are RFC 3986 encoded
 
-Product export body templates now receive RFC 3986-encoded absolute URLs from their data context. Invalid characters in paths, query strings, and other URL components are percent-encoded; existing percent-encoded sequences are retained. This applies to built-in and custom product export body templates, so feeds such as Google Merchant Center exports can use media and other URL values without manually encoding their paths.
+Product export body templates now receive RFC 3986-encoded `MediaEntity::url` and `MediaThumbnailEntity::url` values from their data context. This applies to media URLs such as `product.cover.media.url` and `product.media.*.media.url` in built-in and custom body templates, so feeds such as Google Merchant Center exports can use them without manually encoding their paths.
+
+Other URL-valued strings, including custom fields, are unchanged. Custom body templates that render those values can explicitly encode them with the `sw_encode_url` Twig filter.
 
 ### Polyfill packages are installed as declared dependencies
 

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -31,6 +31,10 @@ shopware:
 
 List options (`plugins`, `excluded_locales`, `plugin_mapping`, `languages`) replace the shipped default entirely rather than merging; provide the full list you want. Setting a list to `[]` clears the shipped default. Decorating `AbstractTranslationConfigLoader` continues to work; a decorator that fully replaces `load()` bypasses these config overrides.
 
+### Product export body URLs are RFC 3986 encoded
+
+Product export body templates now receive RFC 3986-encoded absolute URLs from their data context. Invalid characters in paths, query strings, and other URL components are percent-encoded; existing percent-encoded sequences are retained. This applies to built-in and custom product export body templates, so feeds such as Google Merchant Center exports can use media and other URL values without manually encoding their paths.
+
 ### Polyfill packages are installed as declared dependencies
 
 The `shopware/core` and `shopware/platform` package manifests no longer replace Symfony polyfill packages or `paragonie/random_compat`. Composer now installs the polyfills required by the resolved dependency graph instead of treating them as supplied by Shopware. Extension projects that depend on these packages continue to work; their production dependency tree can gain the required polyfill packages. Projects that guarantee the required native PHP functionality can add relevant packages to their own root `replace` section to avoid installing them and reduce their vendor directory size; they must not replace `symfony/polyfill-mbstring`, which Core requires for `mb_ltrim()` on PHP 8.2 and 8.3.

--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,5 +1,24 @@
 # 6.7.14.0
 
+## Product export templates: manual URL encoding no longer required
+
+`ProductExportRenderer::renderBody()` now automatically encodes absolute URLs in the body-template data context according to RFC 3986. Invalid characters in media paths, query strings, product URLs, and other absolute URL values are percent-encoded before the Twig template is rendered. Existing percent-encoded sequences (`%20`, `%2C`, …) pass through unchanged.
+
+**Action required if your custom body template already encodes URLs manually.**
+Templates that apply `|url_encode`, `|replace({' ': '%20'})`, or any other manual percent-encoding to a value that is already an absolute URL will now produce double-encoded output, for example `%20` becomes `%2520`.
+
+Remove the manual encoding from your template body:
+
+```twig
+{# Before — no longer needed, will double-encode #}
+<g:image_link>{{ product.cover.media.url|url_encode }}</g:image_link>
+
+{# After — encoding is applied automatically #}
+<g:image_link>{{ product.cover.media.url }}</g:image_link>
+```
+
+This affects the body template only. Header and footer templates, and any URLs assembled entirely inside a Twig expression rather than coming from the data context, are not changed.
+
 ## MCP server no longer uses the `MCP_SERVER` feature flag
 
 The experimental MCP server is now always enabled and the `MCP_SERVER` feature flag has been removed.

--- a/UPGRADE-6.7.md
+++ b/UPGRADE-6.7.md
@@ -1,11 +1,11 @@
 # 6.7.14.0
 
-## Product export templates: manual URL encoding no longer required
+## Product export templates: media URLs are encoded automatically
 
-`ProductExportRenderer::renderBody()` now automatically encodes absolute URLs in the body-template data context according to RFC 3986. Invalid characters in media paths, query strings, product URLs, and other absolute URL values are percent-encoded before the Twig template is rendered. Existing percent-encoded sequences (`%20`, `%2C`, …) pass through unchanged.
+`ProductExportRenderer::renderBody()` now automatically RFC 3986-encodes `MediaEntity::url` and `MediaThumbnailEntity::url` values in the body-template data context. This covers media URLs such as `product.cover.media.url` and `product.media.*.media.url`; other string values, including product descriptions, SEO URLs, and custom fields, are unchanged.
 
-**Action required if your custom body template already encodes URLs manually.**
-Templates that apply `|url_encode`, `|replace({' ': '%20'})`, or any other manual percent-encoding to a value that is already an absolute URL will now produce double-encoded output, for example `%20` becomes `%2520`.
+**Action required if your custom body template already encodes media URLs manually.**
+Templates that apply `|url_encode`, `|sw_encode_url`, `|sw_encode_media_url`, `|replace({' ': '%20'})`, or any other manual percent-encoding to a media URL will now produce double-encoded output, for example `%20` becomes `%2520`.
 
 Remove the manual encoding from your template body:
 
@@ -17,7 +17,13 @@ Remove the manual encoding from your template body:
 <g:image_link>{{ product.cover.media.url }}</g:image_link>
 ```
 
-This affects the body template only. Header and footer templates, and any URLs assembled entirely inside a Twig expression rather than coming from the data context, are not changed.
+For a URL-valued custom field or another non-media string, apply `sw_encode_url` explicitly:
+
+```twig
+<link>{{ product.customFields.external_url|sw_encode_url }}</link>
+```
+
+This affects the body template only. Header and footer templates, and URLs assembled entirely inside a Twig expression are not changed.
 
 ## MCP server no longer uses the `MCP_SERVER` feature flag
 

--- a/phpbench.json
+++ b/phpbench.json
@@ -2,7 +2,7 @@
     "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
     "core.extensions": ["Shopware\\Tests\\Bench\\BenchExtension"],
     "runner.bootstrap": "tests/performance/bench/BenchBootstrap.php",
-    "runner.path": ["tests/performance/bench/Storefront", "tests/performance/bench/Administration"],
+    "runner.path": ["tests/performance/bench/Core", "tests/performance/bench/Storefront", "tests/performance/bench/Administration"],
     "runner.file_pattern": "*Bench.php",
     "runner.iterations": 10,
     "runner.revs": 3,

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -112,7 +112,7 @@ class ProductExportRenderer implements ProductExportRendererInterface
         }
 
         if (!Feature::isActive('v6.8.0.0')) {
-            // @deprecated tag:v6.8.0.0 - MediaUrlGenerator encodes media paths.
+            // @deprecated tag:v6.8.0 - MediaUrlGenerator encodes media paths.
             $data = $this->encodeMediaUrls($data);
         }
 

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -14,6 +14,7 @@ use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -110,10 +111,14 @@ class ProductExportRenderer implements ProductExportRendererInterface
             throw ProductExportException::templateBodyNotSet();
         }
 
+        if (!Feature::isActive('v6.8.0.0')) {
+            // @deprecated tag:v6.8.0.0 - MediaUrlGenerator encodes media paths.
+            $data = $this->encodeMediaUrls($data);
+        }
+
         try {
             return $this->templateRenderer->render(
                 $bodyTemplate,
-                // $this->encodeMediaUrls($data),
                 $data,
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\Content\ProductExport\Service;
 
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Level;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
+use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderFooterContextEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderHeaderContextEvent;
@@ -111,7 +113,8 @@ class ProductExportRenderer implements ProductExportRendererInterface
         try {
             return $this->templateRenderer->render(
                 $bodyTemplate,
-                $this->encodeUrls($data),
+                // $this->encodeMediaUrls($data),
+                $data,
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;
         } catch (AdapterException $exception) {
@@ -127,10 +130,10 @@ class ProductExportRenderer implements ProductExportRendererInterface
      *
      * @return array<string, mixed>
      */
-    private function encodeUrls(array $data): array
+    private function encodeMediaUrls(array $data): array
     {
         foreach ($data as $key => $value) {
-            $encodedValue = $this->encodeUrl($value);
+            $encodedValue = $this->encodeMediaUrl($value);
 
             if ($encodedValue !== $value) {
                 $data[$key] = $encodedValue;
@@ -140,18 +143,10 @@ class ProductExportRenderer implements ProductExportRendererInterface
         return $data;
     }
 
-    private function encodeUrl(mixed $value): mixed
+    private function encodeMediaUrl(mixed $value): mixed
     {
-        if (\is_string($value) && preg_match('#^https?://[^/\s]#i', $value) === 1) {
-            try {
-                return (string) new Uri($value);
-            } catch (\InvalidArgumentException) {
-                return $value;
-            }
-        }
-
         if (\is_array($value)) {
-            return $this->encodeUrls($value);
+            return $this->encodeMediaUrls($value);
         }
 
         if (!$value instanceof Struct) {
@@ -159,7 +154,21 @@ class ProductExportRenderer implements ProductExportRendererInterface
         }
 
         $variables = $value->getVars();
-        $encodedVariables = $this->encodeUrls($variables);
+        $encodedVariables = $this->encodeMediaUrls($variables);
+
+        if ($value instanceof MediaEntity || $value instanceof MediaThumbnailEntity) {
+            $encodedUrl = $this->encodeUrl($value->getUrl());
+
+            if ($encodedVariables === $variables && $encodedUrl === $value->getUrl()) {
+                return $value;
+            }
+
+            $copy = clone $value;
+            $copy->assign($encodedVariables);
+            $copy->setUrl($encodedUrl);
+
+            return $copy;
+        }
 
         if ($encodedVariables === $variables) {
             return $value;
@@ -169,6 +178,15 @@ class ProductExportRenderer implements ProductExportRendererInterface
         $copy->assign($encodedVariables);
 
         return $copy;
+    }
+
+    private function encodeUrl(string $url): string
+    {
+        try {
+            return (string) new Uri($url);
+        } catch (\InvalidArgumentException) {
+            return $url;
+        }
     }
 
     private function logException(

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\ProductExport\Service;
 
+use GuzzleHttp\Psr7\Uri;
 use Monolog\Level;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderFooterContextEvent;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -109,7 +111,7 @@ class ProductExportRenderer implements ProductExportRendererInterface
         try {
             return $this->templateRenderer->render(
                 $bodyTemplate,
-                $data,
+                $this->encodeUrls($data),
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;
         } catch (AdapterException $exception) {
@@ -118,6 +120,55 @@ class ProductExportRenderer implements ProductExportRendererInterface
 
             throw $renderProductException;
         }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function encodeUrls(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            $encodedValue = $this->encodeUrl($value);
+
+            if ($encodedValue !== $value) {
+                $data[$key] = $encodedValue;
+            }
+        }
+
+        return $data;
+    }
+
+    private function encodeUrl(mixed $value): mixed
+    {
+        if (\is_string($value) && preg_match('#^https?://[^/\s]#i', $value) === 1) {
+            try {
+                return (string) new Uri($value);
+            } catch (\InvalidArgumentException) {
+                return $value;
+            }
+        }
+
+        if (\is_array($value)) {
+            return $this->encodeUrls($value);
+        }
+
+        if (!$value instanceof Struct) {
+            return $value;
+        }
+
+        $variables = $value->getVars();
+        $encodedVariables = $this->encodeUrls($variables);
+
+        if ($encodedVariables === $variables) {
+            return $value;
+        }
+
+        $copy = clone $value;
+        $copy->assign($encodedVariables);
+
+        return $copy;
     }
 
     private function logException(

--- a/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/tests/integration/Core/Content/ProductExport/Service/ProductExportGeneratorTest.php
@@ -81,6 +81,22 @@ class ProductExportGeneratorTest extends TestCase
         static::assertStringEqualsFile(__DIR__ . '/fixtures/test-export.csv', $exportResult->getContent());
     }
 
+    public function testExportEncodesMediaUrls(): void
+    {
+        $productExportId = $this->createTestEntity([
+            'bodyTemplate' => '{{ product.cover.media.url }}',
+        ]);
+
+        $criteria = $this->createProductExportCriteria($productExportId);
+        $productExport = $this->repository->search($criteria, $this->context)->getEntities()->first();
+        static::assertInstanceOf(ProductExportEntity::class, $productExport);
+
+        $exportResult = $this->service->generate($productExport, new ExportBehavior());
+
+        static::assertInstanceOf(ProductExportResult::class, $exportResult);
+        static::assertStringContainsString('product%20image.jpg', $exportResult->getContent());
+    }
+
     public function testProductExportGenerationEvents(): void
     {
         $productExportId = $this->createTestEntity();
@@ -436,6 +452,8 @@ class ProductExportGeneratorTest extends TestCase
 
         for ($i = 0; $i < 10; ++$i) {
             $groupId = Uuid::randomHex();
+            $productMediaId = Uuid::randomHex();
+            $mediaId = Uuid::randomHex();
 
             $products[] = [
                 'id' => Uuid::randomHex(),
@@ -447,6 +465,20 @@ class ProductExportGeneratorTest extends TestCase
                 'tax' => ['id' => $taxId, 'taxRate' => 17, 'name' => 'with id'],
                 'visibilities' => [
                     ['salesChannelId' => $salesChannelId, 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+                ],
+                'coverId' => $productMediaId,
+                'media' => [
+                    [
+                        'id' => $productMediaId,
+                        'position' => 1,
+                        'media' => [
+                            'id' => $mediaId,
+                            'fileName' => 'product image',
+                            'fileExtension' => 'jpg',
+                            'mimeType' => 'image/jpeg',
+                            'path' => 'media/product image.jpg',
+                        ],
+                    ],
                 ],
                 'options' => [
                     [

--- a/tests/performance/bench/Core/ProductExportRendererBench.php
+++ b/tests/performance/bench/Core/ProductExportRendererBench.php
@@ -36,16 +36,16 @@ class ProductExportRendererBench extends AbstractBenchCase
         $this->renderer->renderBody($this->productExport, $this->context, $this->data);
     }
 
-    #[BeforeMethods(['setUpWithoutUrlBenchmark'])]
+    #[BeforeMethods(['setUpWithCompliantMediaUrlBenchmark'])]
     #[AfterMethods(['tearDown'])]
-    public function bench_render_body_without_urls(): void
+    public function bench_render_body_with_compliant_media_url(): void
     {
         $this->renderer->renderBody($this->productExport, $this->context, $this->data);
     }
 
-    #[BeforeMethods(['setUpWithNestedUrlBenchmark'])]
+    #[BeforeMethods(['setUpWithUnencodedMediaUrlBenchmark'])]
     #[AfterMethods(['tearDown'])]
-    public function bench_render_body_with_nested_url(): void
+    public function bench_render_body_with_unencoded_media_url(): void
     {
         $this->renderer->renderBody($this->productExport, $this->context, $this->data);
     }
@@ -57,12 +57,12 @@ class ProductExportRendererBench extends AbstractBenchCase
         $this->data = ['name' => 'Simple product'];
     }
 
-    public function setUpWithoutUrlBenchmark(): void
+    public function setUpWithCompliantMediaUrlBenchmark(): void
     {
-        $this->setUpBenchmark('Product image.jpg');
+        $this->setUpBenchmark('https://example.com/media/Product%20image.jpg');
     }
 
-    public function setUpWithNestedUrlBenchmark(): void
+    public function setUpWithUnencodedMediaUrlBenchmark(): void
     {
         $this->setUpBenchmark('https://example.com/media/Product image.jpg');
     }

--- a/tests/performance/bench/Core/ProductExportRendererBench.php
+++ b/tests/performance/bench/Core/ProductExportRendererBench.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Bench\Core;
+
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Content\ProductExport\Service\ProductExportRenderer;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Tests\Bench\AbstractBenchCase;
+
+/**
+ * @internal - only for performance benchmarks
+ */
+class ProductExportRendererBench extends AbstractBenchCase
+{
+    private ProductExportRenderer $renderer;
+
+    private ProductExportEntity $productExport;
+
+    private ProductEntity $product;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $data;
+
+    #[BeforeMethods(['setUpScalarContextBenchmark'])]
+    #[AfterMethods(['tearDown'])]
+    public function bench_render_body_with_scalar_context(): void
+    {
+        $this->renderer->renderBody($this->productExport, $this->context, $this->data);
+    }
+
+    #[BeforeMethods(['setUpWithoutUrlBenchmark'])]
+    #[AfterMethods(['tearDown'])]
+    public function bench_render_body_without_urls(): void
+    {
+        $this->renderer->renderBody($this->productExport, $this->context, $this->data);
+    }
+
+    #[BeforeMethods(['setUpWithNestedUrlBenchmark'])]
+    #[AfterMethods(['tearDown'])]
+    public function bench_render_body_with_nested_url(): void
+    {
+        $this->renderer->renderBody($this->productExport, $this->context, $this->data);
+    }
+
+    public function setUpScalarContextBenchmark(): void
+    {
+        $this->setUpRendererBenchmark();
+        $this->productExport->setBodyTemplate('{{ name }}');
+        $this->data = ['name' => 'Simple product'];
+    }
+
+    public function setUpWithoutUrlBenchmark(): void
+    {
+        $this->setUpBenchmark('Product image.jpg');
+    }
+
+    public function setUpWithNestedUrlBenchmark(): void
+    {
+        $this->setUpBenchmark('https://example.com/media/Product image.jpg');
+    }
+
+    private function setUpBenchmark(string $mediaUrl): void
+    {
+        $this->setUpRendererBenchmark();
+        $this->productExport->setBodyTemplate('{{ product.name }}');
+
+        $this->product = new ProductEntity();
+        $this->product->setId(Uuid::randomHex());
+        $this->product->setName('Simple product');
+
+        $media = new MediaEntity();
+        $media->setUrl($mediaUrl);
+
+        $cover = new ProductMediaEntity();
+        $cover->setMedia($media);
+
+        $this->product->setCover($cover);
+        $this->product->addExtension('benchmark', new ArrayStruct([
+            'nodes' => array_map(
+                static fn (int $index): ArrayStruct => new ArrayStruct([
+                    'identifier' => 'node-' . $index,
+                    'metadata' => new ArrayStruct([
+                        'label' => 'Benchmark node ' . $index,
+                        'value' => $index,
+                    ]),
+                ]),
+                range(1, 100)
+            ),
+        ]));
+
+        $this->data = ['product' => $this->product];
+    }
+
+    private function setUpRendererBenchmark(): void
+    {
+        parent::setUp();
+
+        $this->renderer = static::getContainer()->get(ProductExportRenderer::class);
+        $this->productExport = new ProductExportEntity();
+    }
+}

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -6,6 +6,8 @@ use Monolog\Level;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderFooterContextEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderHeaderContextEvent;
@@ -15,6 +17,7 @@ use Shopware\Core\Content\ProductExport\Service\ProductExportRenderer;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -261,6 +264,126 @@ class ProductExportRendererTest extends TestCase
         $renderer->renderBody($productExport, $this->context, []);
     }
 
+    public function testRenderBodyEncodesUrlsInNestedData(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ custom.nested.url }}');
+
+        $rendered = $renderer->renderBody($productExport, $this->context, [
+            'custom' => [
+                'nested' => [
+                    'url' => 'https://example.com/media/My Image, Front.jpg?width=100#preview',
+                ],
+            ],
+        ]);
+
+        static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?width=100#preview' . \PHP_EOL, $rendered);
+    }
+
+    public function testRenderBodyEncodesUrlsInNestedStructsWithoutMutatingThem(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ cover.media.url }}');
+
+        $media = new MediaEntity();
+        $media->setUrl('https://example.com/media/My Image, Front.jpg');
+
+        $cover = new ProductMediaEntity();
+        $cover->setMedia($media);
+
+        $rendered = $renderer->renderBody($productExport, $this->context, ['cover' => $cover]);
+
+        static::assertSame('https://example.com/media/My%20Image,%20Front.jpg' . \PHP_EOL, $rendered);
+
+        static::assertSame('https://example.com/media/My Image, Front.jpg', $media->getUrl());
+        $coverMedia = $cover->getMedia();
+        static::assertNotNull($coverMedia);
+        static::assertSame('https://example.com/media/My Image, Front.jpg', $coverMedia->getUrl());
+    }
+
+    public function testRenderBodyKeepsUnchangedStructsByIdentity(): void
+    {
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ cover.media.url }}');
+
+        $media = new MediaEntity();
+        $media->setUrl('https://example.com/media/My Image.jpg');
+
+        $cover = new ProductMediaEntity();
+        $cover->setMedia($media);
+
+        $unchanged = new ArrayStruct(['label' => 'Product feed']);
+
+        $twigRenderer = $this->createMock(StringTemplateRenderer::class);
+        $twigRenderer->expects($this->once())->method('render')->willReturnCallback(
+            static function (string $template, array $data) use ($cover, $unchanged): string {
+                static::assertSame('{{ cover.media.url }}', $template);
+                static::assertNotSame($cover, $data['cover']);
+                static::assertSame($unchanged, $data['unchanged']);
+
+                return 'rendered';
+            }
+        );
+
+        $renderer = new ProductExportRenderer(
+            $twigRenderer,
+            static::createStub(EventDispatcherInterface::class),
+        );
+
+        static::assertSame('rendered' . \PHP_EOL, $renderer->renderBody($productExport, $this->context, [
+            'cover' => $cover,
+            'unchanged' => $unchanged,
+        ]));
+    }
+
+    public function testRenderBodyDoesNotDoubleEncodeUrls(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ url }}');
+
+        $rendered = $renderer->renderBody($productExport, $this->context, [
+            'url' => 'https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world',
+        ]);
+
+        static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world' . \PHP_EOL, $rendered);
+    }
+
+    public function testRenderBodyKeepsNonUrlAndUnparsableUrlValues(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ label }} {{ url }}');
+
+        $rendered = $renderer->renderBody($productExport, $this->context, [
+            'label' => 'Product feed',
+            'url' => 'https://',
+        ]);
+
+        static::assertSame('Product feed https://' . \PHP_EOL, $rendered);
+    }
+
+    public function testRenderBodyKeepsOriginalValueForInvalidUrls(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ url }}');
+
+        $rendered = $renderer->renderBody($productExport, $this->context, [
+            'url' => 'https://cdn.example.com:99999/image.jpg',
+        ]);
+
+        static::assertSame('https://cdn.example.com:99999/image.jpg' . \PHP_EOL, $rendered);
+    }
+
     /**
      * @return iterable<string, array<int, string|null>>
      */
@@ -308,5 +431,13 @@ class ProductExportRendererTest extends TestCase
             [],
             'http://en.test',
         ];
+    }
+
+    private function createRenderer(): ProductExportRenderer
+    {
+        return new ProductExportRenderer(
+            new StringTemplateRenderer(new Environment(new ArrayLoader()), sys_get_temp_dir()),
+            static::createStub(EventDispatcherInterface::class),
+        );
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -6,6 +6,7 @@ use Monolog\Level;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
@@ -264,22 +265,22 @@ class ProductExportRendererTest extends TestCase
         $renderer->renderBody($productExport, $this->context, []);
     }
 
-    public function testRenderBodyEncodesUrlsInNestedData(): void
+    public function testRenderBodyKeepsUrlLikeDescriptionsUnchanged(): void
     {
         $renderer = $this->createRenderer();
         $productExport = new ProductExportEntity();
         $productExport->setId(Uuid::randomHex());
-        $productExport->setBodyTemplate('{{ custom.nested.url }}');
+        $productExport->setBodyTemplate('{{ custom.nested.description }}');
 
         $rendered = $renderer->renderBody($productExport, $this->context, [
             'custom' => [
                 'nested' => [
-                    'url' => 'https://example.com/media/My Image, Front.jpg?width=100#preview',
+                    'description' => 'https://foo.com/barbaz is the address where you can find more about this product',
                 ],
             ],
         ]);
 
-        static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?width=100#preview' . \PHP_EOL, $rendered);
+        static::assertSame('https://foo.com/barbaz is the address where you can find more about this product' . \PHP_EOL, $rendered);
     }
 
     public function testRenderBodyEncodesUrlsInNestedStructsWithoutMutatingThem(): void
@@ -303,6 +304,24 @@ class ProductExportRendererTest extends TestCase
         $coverMedia = $cover->getMedia();
         static::assertNotNull($coverMedia);
         static::assertSame('https://example.com/media/My Image, Front.jpg', $coverMedia->getUrl());
+    }
+
+    public function testRenderBodyEncodesNestedThumbnailUrlsWithoutMutatingThem(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ media.thumbnail.url }}');
+
+        $thumbnail = new MediaThumbnailEntity();
+        $thumbnail->setUrl('https://example.com/thumbnail/My Image.jpg');
+
+        $media = new ArrayStruct(['thumbnail' => $thumbnail]);
+
+        $rendered = $renderer->renderBody($productExport, $this->context, ['media' => $media]);
+
+        static::assertSame('https://example.com/thumbnail/My%20Image.jpg' . \PHP_EOL, $rendered);
+        static::assertSame('https://example.com/thumbnail/My Image.jpg', $thumbnail->getUrl());
     }
 
     public function testRenderBodyKeepsUnchangedStructsByIdentity(): void
@@ -341,18 +360,22 @@ class ProductExportRendererTest extends TestCase
         ]));
     }
 
-    public function testRenderBodyDoesNotDoubleEncodeUrls(): void
+    public function testRenderBodyDoesNotDoubleEncodeMediaUrls(): void
     {
         $renderer = $this->createRenderer();
         $productExport = new ProductExportEntity();
         $productExport->setId(Uuid::randomHex());
-        $productExport->setBodyTemplate('{{ url }}');
+        $productExport->setBodyTemplate('{{ media.url }}');
+
+        $media = new MediaEntity();
+        $media->setUrl('https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world');
 
         $rendered = $renderer->renderBody($productExport, $this->context, [
-            'url' => 'https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world',
+            'media' => $media,
         ]);
 
         static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world' . \PHP_EOL, $rendered);
+        static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world', $media->getUrl());
     }
 
     public function testRenderBodyKeepsNonUrlAndUnparsableUrlValues(): void
@@ -370,15 +393,18 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('Product feed https://' . \PHP_EOL, $rendered);
     }
 
-    public function testRenderBodyKeepsOriginalValueForInvalidUrls(): void
+    public function testRenderBodyKeepsInvalidMediaUrlsUnchanged(): void
     {
         $renderer = $this->createRenderer();
         $productExport = new ProductExportEntity();
         $productExport->setId(Uuid::randomHex());
-        $productExport->setBodyTemplate('{{ url }}');
+        $productExport->setBodyTemplate('{{ media.url }}');
+
+        $media = new MediaEntity();
+        $media->setUrl('https://cdn.example.com:99999/image.jpg');
 
         $rendered = $renderer->renderBody($productExport, $this->context, [
-            'url' => 'https://cdn.example.com:99999/image.jpg',
+            'media' => $media,
         ]);
 
         static::assertSame('https://cdn.example.com:99999/image.jpg' . \PHP_EOL, $rendered);

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Core\Test\Generator;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
@@ -265,6 +266,7 @@ class ProductExportRendererTest extends TestCase
         $renderer->renderBody($productExport, $this->context, []);
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyKeepsUrlLikeDescriptionsUnchanged(): void
     {
         $renderer = $this->createRenderer();
@@ -283,6 +285,7 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('https://foo.com/barbaz is the address where you can find more about this product' . \PHP_EOL, $rendered);
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyEncodesUrlsInNestedStructsWithoutMutatingThem(): void
     {
         $renderer = $this->createRenderer();
@@ -306,6 +309,7 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('https://example.com/media/My Image, Front.jpg', $coverMedia->getUrl());
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyEncodesNestedThumbnailUrlsWithoutMutatingThem(): void
     {
         $renderer = $this->createRenderer();
@@ -324,6 +328,7 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('https://example.com/thumbnail/My Image.jpg', $thumbnail->getUrl());
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyKeepsUnchangedStructsByIdentity(): void
     {
         $productExport = new ProductExportEntity();
@@ -360,6 +365,7 @@ class ProductExportRendererTest extends TestCase
         ]));
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyDoesNotDoubleEncodeMediaUrls(): void
     {
         $renderer = $this->createRenderer();
@@ -378,6 +384,7 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('https://example.com/media/My%20Image,%20Front.jpg?foo=hello%20world', $media->getUrl());
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyKeepsNonUrlAndUnparsableUrlValues(): void
     {
         $renderer = $this->createRenderer();
@@ -393,6 +400,7 @@ class ProductExportRendererTest extends TestCase
         static::assertSame('Product feed https://' . \PHP_EOL, $rendered);
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testRenderBodyKeepsInvalidMediaUrlsUnchanged(): void
     {
         $renderer = $this->createRenderer();
@@ -408,6 +416,24 @@ class ProductExportRendererTest extends TestCase
         ]);
 
         static::assertSame('https://cdn.example.com:99999/image.jpg' . \PHP_EOL, $rendered);
+    }
+
+    public function testRenderBodyPassesThroughMediaUrlsWhenV68IsActive(): void
+    {
+        $renderer = $this->createRenderer();
+        $productExport = new ProductExportEntity();
+        $productExport->setId(Uuid::randomHex());
+        $productExport->setBodyTemplate('{{ media.url }}');
+
+        $media = new MediaEntity();
+        $media->setUrl('https://example.com/media/My Image.jpg');
+
+        $rendered = $renderer->renderBody($productExport, $this->context, [
+            'media' => $media,
+        ]);
+
+        static::assertSame('https://example.com/media/My Image.jpg' . \PHP_EOL, $rendered);
+        static::assertSame('https://example.com/media/My Image.jpg', $media->getUrl());
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Product export body templates should receive RFC 3986-encoded URLs so feeds can safely use media URLs containing spaces or other invalid URI characters.

### 2. What does this change do, exactly?

- RFC 3986-encodes media and thumbnail URLs in product export body templates before v6.8.0.0.
- Leaves unrelated URL-like values unchanged and avoids mutating the original render context.
- Removes the temporary renderer behavior in 6.8, where generated media paths are encoded centrally.

The scalar-context benchmark is the feature-free baseline: it matches the renderer with URL encoding disabled at about 3 μs. With copy-on-write URL encoding enabled:

- Scalar context / encoding-disabled baseline: ~3 μs
- Product context with a 100-node nested extension and an already encoded media URL: ~35 μs
- Same context with an unencoded media URL: ~117 μs

The benchmark confirms that the additional traversal is acceptable for product exports: a 100-node context without an unencoded URL adds about 32 μs per rendered product, while encoding one nested URL adds about 114 μs. The copy-on-write approach avoids cloning unrelated context branches.

Direct external URLs stored in `media.path` (for example through the Admin API) are passed through unchanged in v6.8, because `MediaUrlGenerator` treats them as already resolved URLs.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product export whose body template renders a URL from the product context, for example `{{ product.cover.media.url }}`.
2. Use media whose URL path contains a space.
3. Generate the export.
4. Verify that the rendered URL contains RFC 3986 percent-encoding, for example %20.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- closes #18486

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
