### PR TITLE
demo: prove the phpunit junit.xml guard catches a silent exit(0) kill

### DIFF
--- a/tests/unit/GuardDemoKillerTest.php
+++ b/tests/unit/GuardDemoKillerTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal Demo for the junit.xml completeness guard — DO NOT MERGE.
+ * Simulates code under test terminating the PHPUnit process with a success
+ * exit code (the #18560 incident class): without the guard the unit job goes
+ * green after running only a random prefix of the suite.
+ */
+#[Package('framework')]
+class GuardDemoKillerTest extends TestCase
+{
+    public function testExitZeroKillsThePhpunitProcess(): void
+    {
+        exit(0);
+    }
+}


### PR DESCRIPTION
**Demo for #18654 — do not merge.**

Adds one unit test whose `exit(0)` terminates the PHPUnit process with a success exit code, reproducing the #18560 incident class. On trunk today, the `PHPUnit for unit` job goes green after executing only the random-order prefix of the suite before this test (real occurrence: https://github.com/shopware/shopware/actions/runs/30081459294/job/89443973480).

This branch contains #18654's guard, so the expected outcome here is a **red** `PHPUnit for unit` job failing with "junit.xml is missing or incomplete: the PHPUnit process terminated before finishing the suite."
