### PR TITLE
fix: #18366 TypeError on 'set' promotion in cart (backport: 6.6.x)

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackager.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackage;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackageCollection;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackager;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -107,11 +108,24 @@ class SetScopeDiscountPackager extends DiscountPackager
                 $group['packagerKey'],
                 $group['value'],
                 $group['sorterKey'],
-                $group['rules']
+                $this->getRules($group['rules'] ?? null),
             );
         }
 
         return $definitions;
+    }
+
+    /**
+     * @param RuleCollection|array<mixed>|null $rules
+     */
+    private function getRules(RuleCollection|array|null $rules): RuleCollection
+    {
+        $rules ??= new RuleCollection();
+        if (!\is_array($rules)) {
+            return $rules;
+        }
+
+        return (new RuleCollection())->assignRecursive($rules);
     }
 
     /**

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -105,6 +105,11 @@ class PromotionCalculator
                 continue;
             }
 
+            // Pinned set promotions restored from an order have already been copied with their historical price.
+            if ($calculated->has($discountItem->getId())) {
+                continue;
+            }
+
             $isAutomaticDiscount = $this->isAutomaticDiscount($discountItem);
 
             // we have to verify if the line item is still valid

--- a/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
@@ -10,9 +10,12 @@ use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\CheckoutPermissions;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Error\AutoPromotionNotFoundError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
 use Shopware\Core\Checkout\Promotion\Exception\InvalidPriceDefinitionException;
+use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -74,6 +77,8 @@ class PromotionProcessor implements CartProcessorInterface
             /** @var LineItemCollection $discountLineItems */
             $discountLineItems = $data->get(self::DATA_KEY);
 
+            $this->preservePinnedSetPromotions($discountLineItems, $toCalculate, $behavior);
+
             if ($toCalculate->getPrice()->getTotalPrice() === 0.0) {
                 // We'll only display the `PromotionsOnCartPriceZeroError` if a promotion code is input and the cart price is zero. Auto-promotions are not considered in this case.
                 $discountPromotionsWithCode = $discountLineItems->filter(fn (LineItem $lineItem) => !$lineItem->hasPayloadValue('promotionCodeType') || $lineItem->getPayloadValue('promotionCodeType') !== PromotionItemBuilder::PROMOTION_TYPE_GLOBAL);
@@ -98,5 +103,55 @@ class PromotionProcessor implements CartProcessorInterface
 
             $this->promotionCalculator->calculate($items, $original, $toCalculate, $context, $behavior);
         }, 'cart');
+    }
+
+    private function preservePinnedSetPromotions(LineItemCollection $discountLineItems, Cart $calculated, CartBehavior $behavior): void
+    {
+        $pinManual = $behavior->hasPermission(CheckoutPermissions::PIN_MANUAL_PROMOTIONS);
+        $pinAutomatic = $behavior->hasPermission(CheckoutPermissions::PIN_AUTOMATIC_PROMOTIONS);
+
+        if (!$pinManual && !$pinAutomatic) {
+            return;
+        }
+
+        foreach ($discountLineItems as $lineItem) {
+            $isPinned = $lineItem->getReferencedId() ? $pinManual : $pinAutomatic;
+
+            if (!$isPinned || !$this->hasSerializedSetGroupRules($lineItem)) {
+                continue;
+            }
+
+            $calculated->add($lineItem);
+        }
+    }
+
+    private function hasSerializedSetGroupRules(LineItem $lineItem): bool
+    {
+        if (!$lineItem->hasPayloadValue('discountScope') || !$lineItem->hasPayloadValue('setGroups')) {
+            return false;
+        }
+
+        $scope = $lineItem->getPayloadValue('discountScope');
+        if (!\in_array($scope, [PromotionDiscountEntity::SCOPE_SET, PromotionDiscountEntity::SCOPE_SETGROUP], true)) {
+            return false;
+        }
+
+        $groups = $lineItem->getPayloadValue('setGroups');
+        if (!\is_array($groups)) {
+            return false;
+        }
+
+        foreach ($groups as $group) {
+            if (!\is_array($group)) {
+                return true;
+            }
+
+            $rules = $group['rules'] ?? null;
+            if ($rules !== null && $rules !== [] && !$rules instanceof RuleCollection) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
@@ -10,7 +10,6 @@ use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
-use Shopware\Core\Checkout\CheckoutPermissions;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Error\AutoPromotionNotFoundError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
@@ -107,8 +106,8 @@ class PromotionProcessor implements CartProcessorInterface
 
     private function preservePinnedSetPromotions(LineItemCollection $discountLineItems, Cart $calculated, CartBehavior $behavior): void
     {
-        $pinManual = $behavior->hasPermission(CheckoutPermissions::PIN_MANUAL_PROMOTIONS);
-        $pinAutomatic = $behavior->hasPermission(CheckoutPermissions::PIN_AUTOMATIC_PROMOTIONS);
+        $pinManual = $behavior->hasPermission(PromotionCollector::PIN_MANUAL_PROMOTIONS);
+        $pinAutomatic = $behavior->hasPermission(PromotionCollector::PIN_AUTOMATIC_PROMOTIONS);
 
         if (!$pinManual && !$pinAutomatic) {
             return;

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionCalculatorTest.php
@@ -127,6 +127,43 @@ class PromotionCalculatorTest extends TestCase
         static::assertEquals('Promotion second-promotion was excluded for cart.', $error->getMessage());
     }
 
+    public function testAlreadyPreservedPromotionIsNotRecalculated(): void
+    {
+        $discountItem = $this->getDiscountItem('promotion')
+            ->setPayloadValue('discountScope', PromotionDiscountEntity::SCOPE_SET);
+
+        $calculated = new Cart('calculated');
+        $calculated->add($discountItem);
+
+        $setScopeDiscountPackager = $this->createMock(DiscountPackager::class);
+        $setScopeDiscountPackager->expects($this->never())->method('getMatchingItems');
+
+        $calculator = new PromotionCalculator(
+            $this->createMock(AmountCalculator::class),
+            $this->createMock(AbsolutePriceCalculator::class),
+            $this->createMock(LineItemGroupBuilder::class),
+            $this->createMock(DiscountCompositionBuilder::class),
+            $this->createMock(PackageFilter::class),
+            $this->createMock(AdvancedPackagePicker::class),
+            $this->createMock(SetGroupScopeFilter::class),
+            $this->createMock(LineItemQuantitySplitter::class),
+            $this->createMock(PercentagePriceCalculator::class),
+            $this->createMock(DiscountPackager::class),
+            $this->createMock(DiscountPackager::class),
+            $setScopeDiscountPackager
+        );
+
+        $calculator->calculate(
+            new LineItemCollection([$discountItem]),
+            new Cart('original'),
+            $calculated,
+            $this->createMock(SalesChannelContext::class),
+            new CartBehavior()
+        );
+
+        static::assertSame($discountItem, $calculated->get($discountItem->getId()));
+    }
+
     public function testAddDiscountWithPackages(): void
     {
         $lineItem1 = new LineItem($this->ids->get('line-item-1'), LineItem::PRODUCT_LINE_ITEM_TYPE, $this->ids->get('line-item-1'));

--- a/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackagerTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/Discount/ScopePackager/SetScopeDiscountPackagerTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart\Discount\ScopePackager;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilderResult;
+use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupDefinition;
+use Shopware\Core\Checkout\Cart\Price\Struct\AbsolutePriceDefinition;
+use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
+use Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetScopeDiscountPackager;
+use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(SetScopeDiscountPackager::class)]
+class SetScopeDiscountPackagerTest extends TestCase
+{
+    public function testGroupDefinitionsBuiltFromPayload(): void
+    {
+        $ruleId = Uuid::randomHex();
+        $ruleCollection = new RuleCollection();
+
+        $builder = static::createStub(LineItemGroupBuilder::class);
+        $builder
+            ->method('findGroupPackages')
+            ->willReturnCallback(static function (array $groupDefinitions) use ($ruleCollection, $ruleId) {
+                static::assertCount(2, $groupDefinitions);
+                static::assertInstanceOf(LineItemGroupDefinition::class, $groupDefinitions[0]);
+                static::assertInstanceOf(LineItemGroupDefinition::class, $groupDefinitions[1]);
+                static::assertSame($ruleId, $groupDefinitions[0]->getRules()->first()?->getId());
+                static::assertSame($ruleCollection, $groupDefinitions[1]->getRules());
+                static::assertSame('COUNT', $groupDefinitions[0]->getPackagerKey());
+                static::assertSame(5.0, $groupDefinitions[0]->getValue());
+
+                return new LineItemGroupBuilderResult();
+            });
+
+        $payload = [
+            'discountScope' => 'set',
+            'discountType' => 'absolute',
+            'setGroups' => [
+                [
+                    'groupId' => Uuid::randomHex(),
+                    'packagerKey' => 'COUNT',
+                    'value' => 5,
+                    'sorterKey' => 'PRICE_ASC',
+                    'rules' => [['id' => $ruleId]],
+                ],
+                [
+                    'groupId' => Uuid::randomHex(),
+                    'packagerKey' => 'COUNT',
+                    'value' => 3,
+                    'sorterKey' => 'PRICE_ASC',
+                    'rules' => $ruleCollection,
+                ],
+            ],
+        ];
+
+        (new SetScopeDiscountPackager($builder))->getMatchingItems(
+            new DiscountLineItem('label', new AbsolutePriceDefinition(10), $payload, null),
+            new Cart('token'),
+            static::createStub(SalesChannelContext::class),
+        );
+    }
+}

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
@@ -10,9 +10,12 @@ use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\CheckoutPermissions;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
@@ -64,6 +67,71 @@ class PromotionProcessorTest extends TestCase
             );
 
         $promotionProcessor->process($data, $originalCart, $toCalculateCart, $context, $behavior);
+    }
+
+    public function testPinnedRestoredSetPromotionKeepsHistoricalPrice(): void
+    {
+        $promotionCalculator = $this->createMock(PromotionCalculator::class);
+        $promotionProcessor = new PromotionProcessor($promotionCalculator, static::createStub(LineItemGroupBuilder::class));
+
+        $promotion = $this->createRestoredSetPromotion();
+
+        $original = new Cart('original');
+        $original->add($promotion);
+
+        $calculated = new Cart('calculated');
+        $calculated->setPrice(new CartPrice(100, 100, 100, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET));
+
+        $data = new CartDataCollection();
+        $data->set(PromotionProcessor::DATA_KEY, new LineItemCollection([$promotion]));
+
+        $promotionCalculator->expects($this->once())
+            ->method('calculate')
+            ->willReturnCallback(static function (LineItemCollection $items, Cart $original, Cart $calculated): void {
+                static::assertTrue($items->has('promotion'));
+                static::assertSame($original->get('promotion'), $calculated->get('promotion'));
+            });
+
+        $promotionProcessor->process(
+            $data,
+            $original,
+            $calculated,
+            static::createStub(SalesChannelContext::class),
+            new CartBehavior([CheckoutPermissions::PIN_AUTOMATIC_PROMOTIONS => true]),
+        );
+
+        static::assertSame(-10.0, $calculated->get('promotion')?->getPrice()?->getTotalPrice());
+    }
+
+    public function testUnpinnedRestoredSetPromotionIsRecalculated(): void
+    {
+        $promotionCalculator = $this->createMock(PromotionCalculator::class);
+        $promotionProcessor = new PromotionProcessor($promotionCalculator, static::createStub(LineItemGroupBuilder::class));
+        $promotion = $this->createRestoredSetPromotion();
+
+        $original = new Cart('original');
+        $original->add($promotion);
+
+        $calculated = new Cart('calculated');
+        $calculated->setPrice(new CartPrice(100, 100, 100, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET));
+
+        $data = new CartDataCollection();
+        $data->set(PromotionProcessor::DATA_KEY, new LineItemCollection([$promotion]));
+
+        $promotionCalculator->expects($this->once())
+            ->method('calculate')
+            ->willReturnCallback(static function (LineItemCollection $items, Cart $original, Cart $calculated): void {
+                static::assertTrue($items->has('promotion'));
+                static::assertNull($calculated->get('promotion'));
+            });
+
+        $promotionProcessor->process(
+            $data,
+            $original,
+            $calculated,
+            static::createStub(SalesChannelContext::class),
+            new CartBehavior(),
+        );
     }
 
     public function testProcessWithCartZeroPriceAndPromotionIsGlobal(): void
@@ -125,5 +193,15 @@ class PromotionProcessorTest extends TestCase
 
         static::assertEquals(1, $toCalculateCart->getErrors()->count());
         static::assertInstanceOf(PromotionsOnCartPriceZeroError::class, $toCalculateCart->getErrors()->first());
+    }
+
+    private function createRestoredSetPromotion(): LineItem
+    {
+        return (new LineItem('promotion', PromotionProcessor::LINE_ITEM_TYPE))
+            ->setPayload([
+                'discountScope' => PromotionDiscountEntity::SCOPE_SET,
+                'setGroups' => [['rules' => [['id' => Uuid::randomHex()]]]],
+            ])
+            ->setPrice(new CalculatedPrice(-10, -10, new CalculatedTaxCollection(), new TaxRuleCollection()));
     }
 }

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionProcessorTest.php
@@ -14,10 +14,10 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
-use Shopware\Core\Checkout\CheckoutPermissions;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCollector;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Framework\Log\Package;
@@ -97,7 +97,7 @@ class PromotionProcessorTest extends TestCase
             $original,
             $calculated,
             static::createStub(SalesChannelContext::class),
-            new CartBehavior([CheckoutPermissions::PIN_AUTOMATIC_PROMOTIONS => true]),
+            new CartBehavior([PromotionCollector::PIN_AUTOMATIC_PROMOTIONS => true]),
         );
 
         static::assertSame(-10.0, $calculated->get('promotion')?->getPrice()?->getTotalPrice());


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/18372
Resolves: https://github.com/shopware/shopware/issues/18366

---

### 1. Why is this change necessary?

Orders containing set-scope promotions store their rule collections in JSON. Restoring such an order turns those collections into arrays, which caused a `TypeError` during cart processing. Loading current rules could also change an already placed order after a rule was edited or deleted.

### 2. What does this change do, exactly?

It backports #18372 to 6.6.x. Serialized rule arrays are normalized before building set definitions, and pinned set or set-group promotions retain their historical calculated price during order recalculation.

The backport uses the 6.6.x promotion permission constants and keeps the calculator regression test in the test path used by this branch.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a promotion with a set scope and a set-group rule.
2. Place an order for which the promotion applies.
3. Change or delete the referenced rule.
4. Restore or recalculate the order.

The restored order must keep the pinned promotion price and must not fail because persisted rules are arrays.

### 4. Please link to the relevant issues (if any).

- Backport of #18372
- relates #18366

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a changelog file with all necessary information about my changes, or the existing backport source covers the release documentation
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
