### PR TITLE
chore: update deno

### DIFF
--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
         with:
-          deno-version: 1.29.1
+          deno-version: v2.9.4
 
       - name: Generate Release Info
         run: |


### PR DESCRIPTION
### 1. Why is this change necessary?

The "Generate Release Info" workflow (`05-publish-release.yml`) started failing with
`TypeError: URL.canParse is not a function`. The pinned Deno `1.29.1` predates `URL.canParse`
(added in Deno 1.39), which the now-updated `marked-base-url` dependency requires.

### 2. What does this change do, exactly?

Bumps the Deno version in the release workflow from `1.29.1` to `v2.9.4`, which provides
`URL.canParse`. Verified locally: the generator resolves the same dependency versions that
failed in CI (`marked-base-url@1.1.10`) and now runs successfully.

### 3. Describe each step to reproduce the issue or behaviour.

1. Publish a release (or trigger the workflow manually).
2. The "Generate Release Info" step fails at `release_info_generator.ts:121` with
   `URL.canParse is not a function`.

Example failing run: https://github.com/shopware/shopware/actions/runs/30003787757

### 4. Please link to the relevant issues (if any).

_None._

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
