### PR TITLE
fix(core): allow dompdf patch updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.6",
+        "dompdf/dompdf": "~3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/Core/DevOps/StaticAnalyze/Danger/Rules/ComposerVersionConstraints.php
+++ b/src/Core/DevOps/StaticAnalyze/Danger/Rules/ComposerVersionConstraints.php
@@ -20,6 +20,7 @@ class ComposerVersionConstraints
             '^symfony\/.*$' => 'We are too tightly coupled to symfony, therefore minor updates often cause breaks',
             '^php$' => 'PHP does not follow semantic versioning, therefore minor updates include breaks',
             '^doctrine\/dbal$' => 'Minor updates often introduce deprecations, which cause PHPStan to fail.',
+            '^dompdf\/dompdf$' => 'Minor updates of dompdf may change rendered documents, therefore only patch updates are allowed.',
         ],
         'strict' => [
             '^phpstan\/phpstan.*$' => 'Even patch updates for PHPStan may lead to a red CI pipeline, because of new static analysis errors',
@@ -27,7 +28,6 @@ class ComposerVersionConstraints
             '^symplify\/phpstan-rules$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
             '^rector\/type-perfect$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
             '^phpat\/phpat$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
-            '^dompdf\/dompdf$' => 'Patch updates of dompdf have let to a lot of issues in the past, therefore it is pinned.',
             '^scssphp\/scssphp$' => 'Patch updates of scssphp might lead to UI breaks, therefore it is pinned.',
             '^shopware\/conflicts$' => 'The shopware conflicts packages should be required in any version, so use `*` constraint',
             '^shopware\/core$' => 'The shopware core packages should be required in any version, so use `*` constraint, the version constraint will be automatically synced during the release process',

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -61,7 +61,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~4.4.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.6",
+        "dompdf/dompdf": "~3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ComposerVersionConstraintsTest.php
+++ b/tests/unit/Core/DevOps/StaticAnalyze/Danger/Rules/ComposerVersionConstraintsTest.php
@@ -21,7 +21,7 @@ use Shopware\Tests\Unit\Core\DevOps\StaticAnalyze\Danger\Stub\StubPullRequest;
 #[CoversClass(ComposerVersionConstraints::class)]
 class ComposerVersionConstraintsTest extends TestCase
 {
-    #[TestDox('Enforces caret by default, tilde for symfony-like packages, exact pins for pipeline-critical tools')]
+    #[TestDox('Enforces caret by default, tilde for compatibility-sensitive packages, exact pins for pipeline-critical tools')]
     #[DataProvider('constraintProvider')]
     public function testConstraintPolicy(string $package, string $constraint, ?string $expectedFailurePart): void
     {
@@ -48,6 +48,8 @@ class ComposerVersionConstraintsTest extends TestCase
         yield 'symfony package with caret fails' => ['symfony/console', '^7.4', 'tilde version range'];
         yield 'php with tilde passes' => ['php', '~8.2.0', null];
         yield 'doctrine/dbal with caret fails' => ['doctrine/dbal', '^4.0', 'tilde version range'];
+        yield 'dompdf with tilde passes' => ['dompdf/dompdf', '~3.1.6', null];
+        yield 'dompdf with caret fails' => ['dompdf/dompdf', '^3.1.6', 'tilde version range'];
         yield 'phpstan with exact pin passes' => ['phpstan/phpstan', '2.1.30', null];
         yield 'phpstan with caret fails' => ['phpstan/phpstan', '^2.1', 'pinned to a specific version'];
         yield 'cs-fixer with tilde fails' => ['friendsofphp/php-cs-fixer', '~3.1.0', 'pinned to a specific version'];


### PR DESCRIPTION
### 1. Why is this change necessary?

`dompdf/dompdf` was pinned to 3.1.6, so Composer could not resolve security fixes released as later 3.1 patch versions without a Shopware patch release.

### 2. What does this change do, exactly?

Allows dompdf 3.1 patch updates with `~3.1.6` in the root and Core Composer manifests. Updates the Danger constraint rule and coverage to require a tilde range for dompdf.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install Shopware with Composer's advisory blocking enabled.
2. A security advisory affects the pinned dompdf version and is fixed by a later 3.1 patch release.
3. Composer cannot resolve a compatible dompdf version because the exact pin prevents the patched release.

### 4. Please link to the relevant issues (if any).

- relates #18630

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them