### PR TITLE
fix: integration admin save (backport: 6.6.x)

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
@@ -19,6 +19,15 @@ class IntegrationApiService extends ApiService {
      * @param {Object} [additionalHeaders = {}]
      * @returns {Promise<T>}
      */
+
+    updateAdmin(integrationId, admin, additionalHeaders = {}) {
+        const headers = this.getBasicHeaders(additionalHeaders);
+
+        return this.httpClient.patch(this.getApiBasePath(integrationId), { admin }, { headers }).then((response) => {
+            return ApiService.handleResponse(response);
+        });
+    }
+
     generateKey(additionalParams = {}, additionalHeaders = {}, user = false) {
         const params = additionalParams;
         const headers = this.getBasicHeaders(additionalHeaders);

--- a/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.spec.js
@@ -1,0 +1,51 @@
+/**
+ * @sw-package fundamentals@framework
+ */
+
+import createLoginService from 'src/core/service/login.service';
+import createHTTPClient from 'src/core/factory/http.factory';
+import MockAdapter from 'axios-mock-adapter';
+import IntegrationApiService from './integration.api.service';
+
+function getIntegrationApiService() {
+    const client = createHTTPClient();
+    const clientMock = new MockAdapter(client);
+    const loginService = createLoginService(client, Shopware.Context.api);
+
+    const integrationApiService = new IntegrationApiService(client, loginService);
+    return { integrationApiService, clientMock };
+}
+
+describe('integrationApiService', () => {
+    it('is registered correctly', () => {
+        const { integrationApiService } = getIntegrationApiService();
+        expect(integrationApiService).toBeInstanceOf(IntegrationApiService);
+        expect(integrationApiService.name).toBe('integrationService');
+    });
+
+    it('generateKey sends request to correct endpoint', async () => {
+        const { integrationApiService, clientMock } = getIntegrationApiService();
+
+        clientMock.onGet('/_action/access-key/intergration').reply(200, {
+            accessKey: 'SWIA123',
+            secretAccessKey: 'secret123',
+        });
+
+        const response = await integrationApiService.generateKey();
+
+        expect(response.accessKey).toBe('SWIA123');
+        expect(response.secretAccessKey).toBe('secret123');
+    });
+
+    it('updateAdmin sends PATCH to integration endpoint', async () => {
+        const { integrationApiService, clientMock } = getIntegrationApiService();
+        const integrationId = 'abc123';
+
+        clientMock.onPatch(`integration/${integrationId}`).reply(204, null);
+
+        await expect(integrationApiService.updateAdmin(integrationId, true)).resolves.not.toThrow();
+
+        expect(clientMock.history.patch).toHaveLength(1);
+        expect(JSON.parse(clientMock.history.patch[0].data)).toEqual({ admin: true });
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -195,7 +195,6 @@ const missingTests = [
     'src/core/service/api/flow-actions.api.service.js',
     'src/core/service/api/import-export.api.service.js',
     'src/core/service/api/index.ts',
-    'src/core/service/api/integration.api.service.js',
     'src/core/service/api/known-ips.api.service.js',
     'src/core/service/api/language-plugin.api.service.js',
     'src/core/service/api/media-folder.api.service.js',

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/index.js
@@ -93,7 +93,7 @@ export default {
         getList() {
             this.isLoading = true;
 
-            this.integrationRepository
+            return this.integrationRepository
                 .search(this.integrationCriteria)
                 .then((integrations) => {
                     this.integrations = integrations;
@@ -119,9 +119,16 @@ export default {
 
         updateIntegration(integration) {
             this.isModalLoading = true;
+            const shouldSaveAdminFlag = this.shouldSaveAdminFlag(integration);
 
             this.integrationRepository
                 .save(integration)
+                .then(() => {
+                    return this.updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag);
+                })
+                .then(() => {
+                    return this.getList();
+                })
                 .then(() => {
                     this.createSavedSuccessNotification();
                     this.onCloseDetailModal();
@@ -139,12 +146,19 @@ export default {
             }
 
             this.isModalLoading = true;
+            const integration = this.currentIntegration;
+            const shouldSaveAdminFlag = this.shouldSaveAdminFlag(integration);
 
             this.integrationRepository
-                .save(this.currentIntegration)
+                .save(integration)
+                .then(() => {
+                    return this.updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag);
+                })
+                .then(() => {
+                    return this.getList();
+                })
                 .then(() => {
                     this.createSavedSuccessNotification();
-                    this.getList();
                 })
                 .catch(() => {
                     this.createSavedErrorNotification();
@@ -154,6 +168,24 @@ export default {
                         this.onCloseDetailModal();
                     });
                 });
+        },
+
+        shouldSaveAdminFlag(integration) {
+            if (!integration || typeof integration.getOrigin !== 'function') {
+                return false;
+            }
+
+            const origin = integration.getOrigin();
+
+            return Boolean(origin?.admin) !== Boolean(integration.admin);
+        },
+
+        updateAdminFlagIfNecessary(integration, shouldSaveAdminFlag) {
+            if (!shouldSaveAdminFlag) {
+                return Promise.resolve();
+            }
+
+            return this.integrationService.updateAdmin(integration.id, integration.admin);
         },
 
         createSavedSuccessNotification() {

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -4,7 +4,11 @@
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-integration/page/sw-integration-list';
 
-async function createWrapper(privileges = []) {
+async function createWrapper(privileges = [], integrations = null, options = {}) {
+    const defaultIntegrations = integrations ?? [{ id: '44de136acf314e7184401d36406c1e90' }];
+    const saveMock = options.saveMock ?? jest.fn().mockResolvedValue();
+    const searchMock = options.searchMock ?? jest.fn().mockResolvedValue(defaultIntegrations);
+    const updateAdminMock = options.updateAdminMock ?? jest.fn().mockResolvedValue();
     const wrapper = mount(await wrapTestComponent('sw-integration-list', { sync: true }), {
         global: {
             provide: {
@@ -16,17 +20,9 @@ async function createWrapper(privileges = []) {
                             });
                         },
 
-                        search: () => {
-                            return Promise.resolve([
-                                {
-                                    id: '44de136acf314e7184401d36406c1e90',
-                                },
-                            ]);
-                        },
+                        search: searchMock,
 
-                        save: () => {
-                            return Promise.resolve();
-                        },
+                        save: saveMock,
 
                         delete: () => {
                             return Promise.resolve();
@@ -41,6 +37,7 @@ async function createWrapper(privileges = []) {
                             secretAccessKey: 'YzFnaFprUjdaZUI4WkJsSmVOcHNOTnI5bUNqc2o4YUx0WmFIb3Y',
                         });
                     },
+                    updateAdmin: updateAdminMock,
                 },
 
                 acl: {
@@ -219,6 +216,70 @@ describe('module/sw-integration/page/sw-integration-list', () => {
 
         const modalAfterSave = wrapper.find('.sw-modal.sw-integration-list__detail');
         expect(modalAfterSave.exists()).toBeFalsy();
+    });
+
+    it('should update the admin flag through the integration service', async () => {
+        const integration = {
+            id: '44de136acf314e7184401d36406c1e90',
+            label: 'Test integration',
+            admin: true,
+            aclRoles: [],
+            getOrigin: () => {
+                return { admin: false };
+            },
+        };
+        const saveMock = jest.fn().mockResolvedValue();
+        const updateAdminMock = jest.fn().mockResolvedValue();
+        const searchMock = jest.fn().mockResolvedValue([integration]);
+
+        const wrapper = await createWrapper(
+            [
+                'admin',
+                'integration.editor',
+            ],
+            [integration],
+            {
+                saveMock,
+                searchMock,
+                updateAdminMock,
+            },
+        );
+
+        await wrapper.vm.updateIntegration(integration);
+        await flushPromises();
+
+        expect(saveMock).toHaveBeenCalledWith(integration);
+        expect(updateAdminMock).toHaveBeenCalledWith(integration.id, true);
+        expect(searchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not update the admin flag when it was not changed', async () => {
+        const integration = {
+            id: '44de136acf314e7184401d36406c1e90',
+            label: 'Test integration',
+            admin: false,
+            aclRoles: [],
+            getOrigin: () => {
+                return { admin: false };
+            },
+        };
+        const updateAdminMock = jest.fn().mockResolvedValue();
+
+        const wrapper = await createWrapper(
+            [
+                'admin',
+                'integration.editor',
+            ],
+            [integration],
+            {
+                updateAdminMock,
+            },
+        );
+
+        await wrapper.vm.updateIntegration(integration);
+        await flushPromises();
+
+        expect(updateAdminMock).not.toHaveBeenCalled();
     });
 
     it('should be able to delete a integration', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

The administrator flag of integrations is write-protected in the DAL. In 6.6, editing the flag in Administration only changes the local entity; the repository save omits it, so no PATCH request is sent and the change is not persisted.

### 2. What does this change do, exactly?

Backports #16978 to 6.6.x. The Administration explicitly PATCHes the integration when its administrator flag changes, then reloads the list to reflect persisted state. Focused regression tests cover the API call and save flow.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an integration with Administrator disabled.
2. Reopen it, enable Administrator, and save.
3. Reopen the integration: the flag remains disabled without this change.

### 4. Please link to the relevant issues (if any).

- Backport of #16978
- Fixes #18565

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them