### PR TITLE
fix(core): allow dompdf patch updates (6.6.x)

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -10,6 +10,7 @@ const COMPOSER_PACKAGE_EXCEPTIONS = [
         '^symfony\/.*$' => 'We are too tightly coupled to symfony, therefore minor updates often cause breaks',
         '^php$' => 'PHP does not follow semantic versioning, therefore minor updates include breaks',
         '^doctrine\/dbal$' => 'Minor updates often introduce deprecations, which cause PHPStan to fail.',
+        '^dompdf\/dompdf$' => 'Minor updates of dompdf may change rendered documents, therefore only patch updates are allowed.',
     ],
     'strict' => [
         '^phpstan\/phpstan.*$' => 'Even patch updates for PHPStan may lead to a red CI pipeline, because of new static analysis errors',
@@ -18,7 +19,6 @@ const COMPOSER_PACKAGE_EXCEPTIONS = [
         '^symplify\/phpstan-rules$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
         '^rector\/type-perfect$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
         '^phpat\/phpat$' => 'Even patch updates for PHPStan plugins may lead to a red CI pipeline, because of new static analysis errors',
-        '^dompdf\/dompdf$' => 'Patch updates of dompdf have let to a lot of issues in the past, therefore it is pinned.',
         '^scssphp\/scssphp$' => 'Patch updates of scssphp might lead to UI breaks, therefore it is pinned.',
         '^shopware\/conflicts$' => 'The shopware conflicts packages should be required in any version, so use `*` constraint',
         '^shopware\/core$' => 'The shopware core packages should be required in any version, so use `*` constraint, the version constraint will be automatically synced during the release process',

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~3.10.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.6",
+        "dompdf/dompdf": "~3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -73,7 +73,7 @@
         "composer/semver": "^3.4.0",
         "doctrine/dbal": "~3.10.0",
         "doctrine/inflector": "^2.0",
-        "dompdf/dompdf": "3.1.6",
+        "dompdf/dompdf": "~3.1.6",
         "dragonmantank/cron-expression": "^3.3",
         "ezyang/htmlpurifier": "^4.16",
         "guzzlehttp/guzzle": "^7.5.0",


### PR DESCRIPTION
### 1. Why is this change necessary?

`dompdf/dompdf` is pinned to 3.1.6 on 6.6.x, preventing Composer from resolving security fixes released as later 3.1 patch versions without a Shopware patch release.

### 2. What does this change do, exactly?

Backports the dompdf constraint change to `~3.1.6` in the root and Core Composer manifests. Updates 6.6's main Danger configuration to require the same tilde range.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a 6.6.x release with Composer's advisory blocking enabled.
2. A security advisory affects the pinned dompdf version and is fixed by a later 3.1 patch release.
3. Composer cannot resolve the patched release because the exact pin is retained.

### 4. Please link to the relevant issues (if any).

- relates #18630
- backport of #18666

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them