### PR TITLE
demo: prove the TestBootstrapper completion guard catches a silent exit(0) kill

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,6 +6,12 @@
 
 ## Core
 
+### PHPUnit runs fail when the process dies before the suite finishes
+
+Test suites bootstrapped through `Shopware\Core\TestBootstrapper` (including plugin and project suites) now force a failure exit code when the PHPUnit process terminates before the test runner finished — for example when code under test calls `exit()`/`die()`, such as a Symfony console `Application` with auto-exit enabled. Previously such a run stopped mid-suite with exit code 0 and looked green while most tests never executed, both locally and in CI.
+
+No action is needed for healthy suites: completed runs (including `--stop-on-failure`), ordinary test failures, fatal errors, and commands like `--list-tests` behave as before. If your suite starts failing with "PHPUnit terminated before the test runner finished the suite", a test is killing the PHPUnit process and was silently truncating your runs; fix it, e.g. by calling `setAutoExit(false)` on console applications under test.
+
 ### Built-in translation system configurable via `shopware.translation`
 
 The built-in translation system's configuration (previously only editable by decorating `AbstractTranslationConfigLoader`) can now be overridden through the standard Symfony configuration in `config/packages`. Add a `shopware.translation` section to override individual options; any option left unset falls back to the shipped defaults in `translation.yaml`:

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -6,12 +6,6 @@
 
 ## Core
 
-### PHPUnit runs fail when the process dies before the suite finishes
-
-Test suites bootstrapped through `Shopware\Core\TestBootstrapper` (including plugin and project suites) now force a failure exit code when the PHPUnit process terminates before the test runner finished — for example when code under test calls `exit()`/`die()`, such as a Symfony console `Application` with auto-exit enabled. Previously such a run stopped mid-suite with exit code 0 and looked green while most tests never executed, both locally and in CI.
-
-No action is needed for healthy suites: completed runs (including `--stop-on-failure`), ordinary test failures, fatal errors, and commands like `--list-tests` behave as before. If your suite starts failing with "PHPUnit terminated before the test runner finished the suite", a test is killing the PHPUnit process and was silently truncating your runs; fix it, e.g. by calling `setAutoExit(false)` on console applications under test.
-
 ### Built-in translation system configurable via `shopware.translation`
 
 The built-in translation system's configuration (previously only editable by decorating `AbstractTranslationConfigLoader`) can now be overridden through the standard Symfony configuration in `config/packages`. Add a `shopware.translation` section to override individual options; any option left unset falls back to the shipped defaults in `translation.yaml`:

--- a/src/Core/Test/PHPUnit/CompletionGuard/CompletionGuard.php
+++ b/src/Core/Test/PHPUnit/CompletionGuard/CompletionGuard.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\CompletionGuard;
+
+use PHPUnit\Event\EventFacadeIsSealedException;
+use PHPUnit\Event\Facade;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber\MarkExecutionFinishedSubscriber;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber\MarkExecutionStartedSubscriber;
+
+/**
+ * Forces a non-zero exit code when the PHPUnit process terminates before the
+ * test runner finished: code under test terminating the process (e.g. exit(0)
+ * from a console Application with auto-exit) skips the rest of the suite and
+ * would otherwise yield a green run with most of the tests never executed.
+ *
+ * Registered from TestBootstrapper::bootstrap(), which PHPUnit runs as its
+ * bootstrap script before the event facade is sealed — so every consumer of
+ * the bootstrapper (core suites, plugins, projects) is protected without any
+ * phpunit.xml wiring. The shutdown function is armed by ExecutionStarted and
+ * disarmed by ExecutionFinished, so commands that never execute tests
+ * (--list-tests, ...) and completed runs (including --stop-on-failure) are
+ * unaffected. Isolated child processes never see ExecutionStarted and stay
+ * inert. A fatal error already yields a non-zero exit code and keeps it.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class CompletionGuard
+{
+    public static bool $executionStarted = false;
+
+    public static bool $executionFinished = false;
+
+    private static bool $registered = false;
+
+    public static function register(): void
+    {
+        if (self::$registered || !class_exists(Facade::class)) {
+            return;
+        }
+
+        try {
+            $facade = Facade::instance();
+            $facade->registerSubscriber(new MarkExecutionStartedSubscriber());
+            $facade->registerSubscriber(new MarkExecutionFinishedSubscriber());
+        } catch (EventFacadeIsSealedException) {
+            // bootstrap() was called from inside an already-running test process; nothing to guard here
+            return;
+        }
+
+        self::$registered = true;
+
+        register_shutdown_function(static function (): void {
+            if (!self::shouldForceFailure(self::$executionStarted, self::$executionFinished, error_get_last())) {
+                return;
+            }
+
+            fwrite(
+                \STDERR,
+                \PHP_EOL . 'PHPUnit terminated before the test runner finished the suite — exit()/die() reached from code under test? Forcing a failure exit code.' . \PHP_EOL,
+            );
+
+            exit(1);
+        });
+    }
+
+    /**
+     * @param array{type: int, message: string, file: string, line: int}|null $lastError
+     */
+    public static function shouldForceFailure(bool $started, bool $finished, ?array $lastError): bool
+    {
+        if (!$started || $finished) {
+            return false;
+        }
+
+        // a fatal error already produces a non-zero exit code; keep it instead of overriding with ours
+        return $lastError === null || !\in_array($lastError['type'], [\E_ERROR, \E_PARSE, \E_CORE_ERROR, \E_COMPILE_ERROR], true);
+    }
+}

--- a/src/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionFinishedSubscriber.php
+++ b/src/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionFinishedSubscriber.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MarkExecutionFinishedSubscriber implements ExecutionFinishedSubscriber
+{
+    public function notify(ExecutionFinished $event): void
+    {
+        CompletionGuard::$executionFinished = true;
+    }
+}

--- a/src/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriber.php
+++ b/src/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriber.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber;
+
+use PHPUnit\Event\TestRunner\ExecutionStarted;
+use PHPUnit\Event\TestRunner\ExecutionStartedSubscriber;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class MarkExecutionStartedSubscriber implements ExecutionStartedSubscriber
+{
+    public function notify(ExecutionStarted $event): void
+    {
+        CompletionGuard::$executionStarted = true;
+    }
+}

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -52,6 +53,9 @@ class TestBootstrapper
         }
 
         $classLoader = $this->classLoader ?? require $this->getProjectDir() . '/vendor/autoload.php';
+
+        // registered before anything below can fail, so a broken bootstrap can never disarm the guard
+        CompletionGuard::register();
 
         if ($this->loadEnvFile) {
             $this->loadEnvFile();

--- a/tests/unit/CompletionGuardDemoKillerTest.php
+++ b/tests/unit/CompletionGuardDemoKillerTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal Demo for the TestBootstrapper completion guard — DO NOT MERGE.
+ * Simulates code under test terminating the PHPUnit process with a success
+ * exit code (the #18560 incident class): without the guard the unit job goes
+ * green after running only a random prefix of the suite.
+ */
+#[Package('framework')]
+class CompletionGuardDemoKillerTest extends TestCase
+{
+    public function testExitZeroKillsThePhpunitProcess(): void
+    {
+        exit(0);
+    }
+}

--- a/tests/unit/Core/Test/PHPUnit/CompletionGuard/CompletionGuardTest.php
+++ b/tests/unit/Core/Test/PHPUnit/CompletionGuard/CompletionGuardTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Test\PHPUnit\CompletionGuard;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(CompletionGuard::class)]
+class CompletionGuardTest extends TestCase
+{
+    /**
+     * @param array{type: int, message: string, file: string, line: int}|null $lastError
+     */
+    #[DataProvider('shutdownStateProvider')]
+    #[TestDox('shouldForceFailure is $expected for $_dataName')]
+    public function testShouldForceFailure(bool $started, bool $finished, ?array $lastError, bool $expected): void
+    {
+        static::assertSame($expected, CompletionGuard::shouldForceFailure($started, $finished, $lastError));
+    }
+
+    /**
+     * @return \Generator<string, array{bool, bool, array{type: int, message: string, file: string, line: int}|null, bool}>
+     */
+    public static function shutdownStateProvider(): \Generator
+    {
+        yield 'execution never started (--list-tests, bootstrap failure)' => [false, false, null, false];
+
+        yield 'execution finished normally' => [true, true, null, false];
+
+        yield 'execution started but never finished' => [true, false, null, true];
+
+        yield 'execution started but never finished, earlier warning' => [true, false, self::error(\E_WARNING), true];
+
+        yield 'fatal error keeps its own exit code' => [true, false, self::error(\E_ERROR), false];
+
+        yield 'compile error keeps its own exit code' => [true, false, self::error(\E_COMPILE_ERROR), false];
+
+        yield 'parse error keeps its own exit code' => [true, false, self::error(\E_PARSE), false];
+
+        yield 'core error keeps its own exit code' => [true, false, self::error(\E_CORE_ERROR), false];
+    }
+
+    /**
+     * @return array{type: int, message: string, file: string, line: int}
+     */
+    private static function error(int $type): array
+    {
+        return ['type' => $type, 'message' => 'whoops', 'file' => 'Some/File.php', 'line' => 42];
+    }
+}

--- a/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionFinishedSubscriberTest.php
+++ b/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionFinishedSubscriberTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Test\PHPUnit\CompletionGuard\Subscriber;
+
+use PHPUnit\Event\Telemetry\Duration;
+use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
+use PHPUnit\Event\Telemetry\HRTime;
+use PHPUnit\Event\Telemetry\Info;
+use PHPUnit\Event\Telemetry\MemoryUsage;
+use PHPUnit\Event\Telemetry\Snapshot;
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber\MarkExecutionFinishedSubscriber;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MarkExecutionFinishedSubscriber::class)]
+class MarkExecutionFinishedSubscriberTest extends TestCase
+{
+    private bool $previousState;
+
+    protected function setUp(): void
+    {
+        $this->previousState = CompletionGuard::$executionFinished;
+    }
+
+    protected function tearDown(): void
+    {
+        // leaving this true would disarm the guard for the very suite running this test; restore it
+        CompletionGuard::$executionFinished = $this->previousState;
+    }
+
+    public function testNotifyMarksExecutionAsFinished(): void
+    {
+        CompletionGuard::$executionFinished = false;
+
+        (new MarkExecutionFinishedSubscriber())->notify($this->buildEvent());
+
+        static::assertTrue(CompletionGuard::$executionFinished);
+    }
+
+    private function buildEvent(): ExecutionFinished
+    {
+        $time = HRTime::fromSecondsAndNanoseconds(0, 0);
+        $duration = Duration::fromSecondsAndNanoseconds(0, 0);
+        $memory = MemoryUsage::fromBytes(0);
+        $gc = new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0);
+        $snap = new Snapshot($time, $memory, $memory, $gc);
+
+        return new ExecutionFinished(new Info($snap, $duration, $memory, $duration, $memory));
+    }
+}

--- a/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriberTest.php
+++ b/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Test\PHPUnit\CompletionGuard\Subscriber;
 
+use PHPUnit\Event\Code\TestCollection;
 use PHPUnit\Event\Telemetry\Duration;
 use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
 use PHPUnit\Event\Telemetry\HRTime;
@@ -9,7 +10,6 @@ use PHPUnit\Event\Telemetry\Info;
 use PHPUnit\Event\Telemetry\MemoryUsage;
 use PHPUnit\Event\Telemetry\Snapshot;
 use PHPUnit\Event\TestRunner\ExecutionStarted;
-use PHPUnit\Event\Code\TestCollection;
 use PHPUnit\Event\TestSuite\TestSuiteWithName;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;

--- a/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriberTest.php
+++ b/tests/unit/Core/Test/PHPUnit/CompletionGuard/Subscriber/MarkExecutionStartedSubscriberTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Test\PHPUnit\CompletionGuard\Subscriber;
+
+use PHPUnit\Event\Telemetry\Duration;
+use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
+use PHPUnit\Event\Telemetry\HRTime;
+use PHPUnit\Event\Telemetry\Info;
+use PHPUnit\Event\Telemetry\MemoryUsage;
+use PHPUnit\Event\Telemetry\Snapshot;
+use PHPUnit\Event\TestRunner\ExecutionStarted;
+use PHPUnit\Event\Code\TestCollection;
+use PHPUnit\Event\TestSuite\TestSuiteWithName;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\CompletionGuard;
+use Shopware\Core\Test\PHPUnit\CompletionGuard\Subscriber\MarkExecutionStartedSubscriber;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MarkExecutionStartedSubscriber::class)]
+class MarkExecutionStartedSubscriberTest extends TestCase
+{
+    private bool $previousState;
+
+    protected function setUp(): void
+    {
+        $this->previousState = CompletionGuard::$executionStarted;
+    }
+
+    protected function tearDown(): void
+    {
+        // the guard is armed for the very suite running this test; restore whatever state it had
+        CompletionGuard::$executionStarted = $this->previousState;
+    }
+
+    public function testNotifyMarksExecutionAsStarted(): void
+    {
+        CompletionGuard::$executionStarted = false;
+
+        (new MarkExecutionStartedSubscriber())->notify($this->buildEvent());
+
+        static::assertTrue(CompletionGuard::$executionStarted);
+    }
+
+    private function buildEvent(): ExecutionStarted
+    {
+        $time = HRTime::fromSecondsAndNanoseconds(0, 0);
+        $duration = Duration::fromSecondsAndNanoseconds(0, 0);
+        $memory = MemoryUsage::fromBytes(0);
+        $gc = new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0);
+        $snap = new Snapshot($time, $memory, $memory, $gc);
+
+        return new ExecutionStarted(
+            new Info($snap, $duration, $memory, $duration, $memory),
+            new TestSuiteWithName('suite', 0, TestCollection::fromArray([])),
+        );
+    }
+}


### PR DESCRIPTION
**Demo for #18675 — do not merge.**

Adds one unit test whose `exit(0)` terminates the PHPUnit process with a success exit code, reproducing the #18560 incident class. On trunk today, the `PHPUnit for unit` job goes green after executing only the random-order prefix of the suite before this test (real occurrence: https://github.com/shopware/shopware/actions/runs/30081459294/job/89443973480).

This branch contains #18675's `TestBootstrapper` completion guard, so the expected outcome here is a **red** `PHPUnit for unit` job: the process exits 1 with "PHPUnit terminated before the test runner finished the suite" — no CI-side wiring involved.
