### PR TITLE
fix: Update stale storefront proxy url environment variable

### DIFF
--- a/src/Core/Installer/Configuration/EnvConfigWriter.php
+++ b/src/Core/Installer/Configuration/EnvConfigWriter.php
@@ -57,7 +57,7 @@ SHOPWARE_ADMIN_ES_REFRESH_INDICES=0
 ###< shopware/elasticsearch ###
 
 ###> shopware/storefront ###
-STOREFRONT_PROXY_URL=http://localhost
+PROXY_URL=http://localhost
 SHOPWARE_HTTP_CACHE_ENABLED=1
 SHOPWARE_HTTP_DEFAULT_TTL=7200
 ###< shopware/storefront ###


### PR DESCRIPTION
### 1. Why is this change necessary?
The variable was changed from `STOREFRONT_PROXY_URL` to `PROXY_URL`:
https://github.com/shopware/recipes/blob/f282a2222e0a1f1cc460152f6b287f2eca44cfe3/shopware/storefront/6.7/manifest.json#L11

### 2. What does this change do, exactly?
Update the generated config.

### 3. Describe each step to reproduce the issue or behaviour.
:shrug: 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
