### PR TITLE
Remove redudant and flaky checks in RuleAssignment specs

### DIFF
--- a/tests/acceptance/tests/Settings/RuleAssignments.spec.ts
+++ b/tests/acceptance/tests/Settings/RuleAssignments.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@fixtures/AcceptanceTest';
 
 test(
-    'As an admin user, I want to have an overview of my assigned rules, so that I can easily see where they are used and easily assign new ones',
+    'As an admin user, I want to have an overview of my assigned rules, so that I can easily see where they are used',
     { tag: '@Rule' },
     async ({ TestDataService, ShopAdmin, AdminRuleDetail, AdminShippingDetail }) => {
         const rule = await TestDataService.createBasicRule();
@@ -21,8 +21,5 @@ test(
         await ShopAdmin.expects(AdminShippingDetail.header).toHaveText(shippingMethod.name);
         await ShopAdmin.expects(AdminShippingDetail.nameField).toHaveValue(shippingMethod.name);
         await ShopAdmin.expects(AdminShippingDetail.availabilityRuleField).toHaveText(rule.name);
-        await AdminShippingDetail.availabilityRuleField.click();
-        await AdminShippingDetail.page.waitForLoadState('domcontentloaded');
-        await ShopAdmin.expects(AdminShippingDetail.getRuleSelectionCheckmark(rule.name)).toBeVisible();
     },
 );


### PR DESCRIPTION
Updated test description for clarity and removed unnecessary checks.

### 1. Why is this change necessary?
The test is flaky, because it was checking if a rule in a dropdown list has a certain checkmark, if it is selected. Though, in SaaS we have more than 25 rules, which makes it likely that the rule name would never be listed initially (without further filtering of the dropdown list)

### 2. What does this change do, exactly?
Removed the flaky lines. 

Reason for removal: The validation if the rule is selected already happens sufficiently with line 23. The additional (now removed lines) were therefore redundant and only checking the dropdown component itself and not the real behaviour of the test case, that is supposed to be covered here. The behaviour of the dropdown component should be covered with its own component/unit test.

Also adjusted the wording of the test description. The test is never actually assigning rules to entities (in an E2E way). This is already covered by [RuleAssignmentsEntities.spec.ts](https://github.com/shopware/shopware/blob/trunk/tests/acceptance/tests/Settings/RuleAssignmentsEntities.spec.ts)

### 3. Describe each step to reproduce the issue or behaviour.
- Have a test environment with more than 25 rules
- execute test scenario RuleAssignment.spec.ts

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
