### PR TITLE
feat(framework): add parameter default value change

### DIFF
--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/BCChangeAttributeUsageRule.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Deprecation\BCChange\CallSiteCompatibilityChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ExceptionChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ExtenderCompatibilityChange;
 use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterNameChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeNarrowing;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeWidening;
@@ -63,6 +64,7 @@ class BCChangeAttributeUsageRule implements Rule
 
     private const PARAMETER_SCOPED = [
         NewOptionalParameter::class,
+        ParameterDefaultValueChange::class,
         ParameterNameChange::class,
         ParameterTypeNarrowing::class,
         ParameterTypeWidening::class,
@@ -222,6 +224,10 @@ class BCChangeAttributeUsageRule implements Rule
             }
         }
 
+        if ($attributeClass === ParameterDefaultValueChange::class) {
+            return $this->validateParameterDefaultValueChange($attribute, $method, $symbol, $line);
+        }
+
         if (!\in_array($attributeClass, self::PARAMETER_SCOPED, true)) {
             return [];
         }
@@ -231,7 +237,7 @@ class BCChangeAttributeUsageRule implements Rule
             return [];
         }
 
-        $parameterExists = $this->parameterExists($method, ltrim($parameterName, '$'));
+        $parameterExists = $this->parameterExists($method, \ltrim($parameterName, '$'));
 
         if ($attributeClass === NewOptionalParameter::class && $parameterExists) {
             return [$this->error($line, \sprintf(
@@ -244,6 +250,48 @@ class BCChangeAttributeUsageRule implements Rule
         if ($attributeClass !== NewOptionalParameter::class && !$parameterExists) {
             return [$this->error($line, \sprintf(
                 '%s on "%s": parameter "%s" does not exist.',
+                $this->shortName($attribute),
+                $symbol,
+                $parameterName
+            ))];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function validateParameterDefaultValueChange(ReflectionAttribute|FakeReflectionAttribute $attribute, \ReflectionMethod $method, string $symbol, int $line): array
+    {
+        $parameterName = $this->argument($attribute, 'parameterName', 1);
+        if (!\is_string($parameterName)) {
+            return [];
+        }
+
+        $parameter = $this->parameter($method, \ltrim($parameterName, '$'));
+        if ($parameter === null) {
+            return [$this->error($line, \sprintf(
+                '%s on "%s": parameter "%s" does not exist.',
+                $this->shortName($attribute),
+                $symbol,
+                $parameterName
+            ))];
+        }
+
+        if (!$parameter->isOptional() || !$parameter->isDefaultValueAvailable()) {
+            return [$this->error($line, \sprintf(
+                '%s on "%s": parameter "%s" has no current default value.',
+                $this->shortName($attribute),
+                $symbol,
+                $parameterName
+            ))];
+        }
+
+        $newDefaultValue = $this->argument($attribute, 'newDefaultValue', 2);
+        if ($parameter->getDefaultValue() === $newDefaultValue) {
+            return [$this->error($line, \sprintf(
+                '%s on "%s": announced default value for parameter "%s" is already current.',
                 $this->shortName($attribute),
                 $symbol,
                 $parameterName
@@ -364,13 +412,18 @@ class BCChangeAttributeUsageRule implements Rule
 
     private function parameterExists(\ReflectionMethod $method, string $parameterName): bool
     {
+        return $this->parameter($method, $parameterName) !== null;
+    }
+
+    private function parameter(\ReflectionMethod $method, string $parameterName): ?\ReflectionParameter
+    {
         foreach ($method->getParameters() as $parameter) {
             if ($parameter->getName() === $parameterName) {
-                return true;
+                return $parameter;
             }
         }
 
-        return false;
+        return null;
     }
 
     private function argument(ReflectionAttribute|FakeReflectionAttribute $attribute, string $name, int $position): mixed

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/NoBCPlanningDeprecationRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/Deprecation/NoBCPlanningDeprecationRule.php
@@ -30,6 +30,7 @@ class NoBCPlanningDeprecationRule implements Rule
         'reason:return-type-change' => 'Use the #[ReturnTypeNarrowing] or #[ReturnTypeWidening] attribute instead.',
         'reason:parameter-type-change' => 'Use the #[ParameterTypeNarrowing] attribute instead.',
         'reason:parameter-type-extension' => 'Use the #[ParameterTypeWidening] attribute instead.',
+        'reason:parameter-default-change' => 'Use the #[ParameterDefaultValueChange] attribute instead.',
         'reason:new-optional-parameter' => 'Use the #[NewOptionalParameter] attribute instead.',
         'reason:parameter-name-change' => 'Use the #[ParameterNameChange] attribute instead.',
         'reason:becomes-internal' => 'Use the #[BecomesInternal] attribute instead.',

--- a/src/Core/DevOps/Test/AnnotationTagTester.php
+++ b/src/Core/DevOps/Test/AnnotationTagTester.php
@@ -28,7 +28,7 @@ class AnnotationTagTester
     /**
      * short names of all BC-change attributes, see Shopware\Core\Framework\Deprecation\BCChange
      */
-    private const BC_CHANGE_ATTRIBUTES = 'ReturnTypeNarrowing|ReturnTypeWidening|ParameterTypeNarrowing|ParameterTypeWidening|ExceptionChange|NewOptionalParameter|NewRequiredParameter|ParameterNameChange|ParameterRemoval|BecomesAbstract|BecomesInternal|BecomesFinal|ClassHierarchyChange|VisibilityChange';
+    private const BC_CHANGE_ATTRIBUTES = 'ReturnTypeNarrowing|ReturnTypeWidening|ParameterTypeNarrowing|ParameterTypeWidening|ExceptionChange|NewOptionalParameter|NewRequiredParameter|ParameterDefaultValueChange|ParameterNameChange|ParameterRemoval|BecomesAbstract|BecomesInternal|BecomesFinal|ClassHierarchyChange|VisibilityChange';
 
     public function __construct(
         private readonly string $shopwareVersion,

--- a/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CreatedByFieldSerializer;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
@@ -18,10 +19,9 @@ class CreatedByField extends FkField
     private readonly array $allowedWriteScopes;
 
     /**
-     * @deprecated tag:v6.8.0 - reason:parameter-default-change - omitting $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]
-     *
      * @param list<string> $allowedWriteScopes
      */
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'allowedWriteScopes', newDefaultValue: [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE])]
     public function __construct(array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
     {
         parent::__construct('created_by_id', 'createdById', UserDefinition::class);

--- a/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\UpdatedByFieldSerializer;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\User\UserDefinition;
@@ -18,10 +19,9 @@ class UpdatedByField extends FkField
     private readonly array $allowedWriteScopes;
 
     /**
-     * @deprecated tag:v6.8.0 - reason:parameter-default-change - omitting $allowedWriteScopes will default to [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE]
-     *
      * @param list<string> $allowedWriteScopes
      */
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'allowedWriteScopes', newDefaultValue: [Context::SYSTEM_SCOPE, Context::CRUD_API_SCOPE])]
     public function __construct(array $allowedWriteScopes = [Context::SYSTEM_SCOPE])
     {
         parent::__construct('updated_by_id', 'updatedById', UserDefinition::class);

--- a/src/Core/Framework/Deprecation/BCChange/ParameterDefaultValueChange.php
+++ b/src/Core/Framework/Deprecation/BCChange/ParameterDefaultValueChange.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Deprecation\BCChange;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ *
+ * Signals that the default value of a parameter will change in the given version.
+ *
+ * Call sites omitting the parameter can observe the announced default value instead. Calls that
+ * pass the parameter explicitly and overriding declarations are not affected. Tooling can identify
+ * call sites that omit the parameter and may need an explicit value to retain their current behavior.
+ */
+#[Package('framework')]
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class ParameterDefaultValueChange implements CallSiteCompatibilityChange
+{
+    /**
+     * @param string $parameterName the name of the parameter, without the leading `$`
+     * @param mixed $newDefaultValue the default value the parameter will use in the announced version
+     */
+    public function __construct(
+        public readonly string $version,
+        public readonly string $parameterName,
+        public readonly mixed $newDefaultValue,
+        public readonly ?string $description = null,
+    ) {
+    }
+}

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/BCChangeAttributeUsageRuleTest.php
@@ -22,71 +22,83 @@ class BCChangeAttributeUsageRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php'], [
             [
                 'BecomesFinal on "AlreadyFinalClass": the class is already final.',
-                17,
+                18,
             ],
             [
                 'BecomesInternal on "WrongVersionFormatClass": version "6.8.0" must match the format "v6.8.0".',
-                22,
+                23,
             ],
             [
                 'BecomesInternal on "AlreadyInternalClass": the class is already @internal.',
-                30,
+                31,
             ],
             [
                 'NewOptionalParameter on "MethodLevelViolations::leadingDollar()": parameter name "$states" must be given without the leading "$".',
-                37,
+                38,
             ],
             [
                 'NewOptionalParameter on "MethodLevelViolations::alreadyExistingParameter()": parameter "existing" already exists.',
-                42,
+                43,
             ],
             [
                 'ParameterNameChange on "MethodLevelViolations::missingParameter()": parameter "missing" does not exist.',
-                47,
+                48,
             ],
             [
                 'BecomesAbstract on "MethodLevelViolations::alreadyAbstract()": the method is already abstract.',
-                52,
+                53,
             ],
             [
                 'VisibilityChange on "MethodLevelViolations::alreadyProtected()": announced visibility "protected" is not narrower than the current visibility.',
-                55,
+                56,
             ],
             [
                 'ReturnTypeNarrowing on "SealedClass::narrowingOnFinalClass()": the class is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                83,
+                84,
             ],
             [
                 'NewOptionalParameter on "SoftSealedClass::newParameterOnSoftFinalClass()": the class is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                100,
+                101,
             ],
             [
                 'ParameterTypeWidening on "ClassWithFinalMethod::wideningOnFinalMethod()": the method is final, so no extenders can exist. Apply the announced change directly instead of announcing it.',
-                108,
+                109,
             ],
             [
                 'ParameterTypeNarrowing on "RuntimeDetectableViolations::narrowingWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                116,
+                117,
             ],
             [
                 'BecomesAbstract on "RuntimeDetectableViolations::becomesAbstractWithoutTrigger()": the legacy usage is detectable at runtime, but the method does not call "Feature::triggerDeprecationOrThrow". Trigger a deprecation when the method is used in a way that breaks with the announced change.',
-                121,
+                122,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::narrowingIsCovered()": every announced exception is already covered by the current "@throws" contract. Throwing narrower exceptions is not a BC change; apply it directly instead of announcing it.',
-                161,
+                162,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::unchangedIsCovered()": every announced exception is already covered by the current "@throws" contract. Throwing narrower exceptions is not a BC change; apply it directly instead of announcing it.',
-                169,
+                170,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::notAThrowable()": announced class "ArrayObject" is not a Throwable.',
-                177,
+                178,
             ],
             [
                 'ExceptionChange on "ExceptionChangeCases::unresolvableExceptionClass()": announced exception "UnimportedException" is not a resolvable class. Reference exception classes via ::class.',
-                185,
+                186,
+            ],
+            [
+                'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::missingParameter()": parameter "missing" does not exist.',
+                202,
+            ],
+            [
+                'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::requiredParameter()": parameter "required" has no current default value.',
+                207,
+            ],
+            [
+                'ParameterDefaultValueChange on "ParameterDefaultValueChangeCases::unchangedDefault()": announced default value for parameter "value" is already current.',
+                212,
             ],
         ]);
     }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoBCPlanningDeprecationRuleTest.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/NoBCPlanningDeprecationRuleTest.php
@@ -33,8 +33,12 @@ class NoBCPlanningDeprecationRuleTest extends RuleTestCase
                 21,
             ],
             [
+                'The deprecation reason "reason:parameter-default-change" is a BC-planning note, not a deprecation. Remove the deprecation annotation. Use the #[ParameterDefaultValueChange] attribute instead.',
+                28,
+            ],
+            [
                 'The deprecation reason "reason:exception-change" is a BC-planning note, not a deprecation. Remove the deprecation annotation. Use the #[ExceptionChange] attribute instead.',
-                35,
+                42,
             ],
         ]);
     }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/BCChangeAttributeUsageRule/BCChangeAttributeUsage.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Deprecation\BCChange\BecomesFinal;
 use Shopware\Core\Framework\Deprecation\BCChange\BecomesInternal;
 use Shopware\Core\Framework\Deprecation\BCChange\ExceptionChange;
 use Shopware\Core\Framework\Deprecation\BCChange\NewOptionalParameter;
+use Shopware\Core\Framework\Deprecation\BCChange\ParameterDefaultValueChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterNameChange;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeNarrowing;
 use Shopware\Core\Framework\Deprecation\BCChange\ParameterTypeWidening;
@@ -192,6 +193,34 @@ class ExceptionChangeCases
      */
     #[ExceptionChange(version: 'v6.8.0', newExceptions: [])]
     public function removedExceptionIsARealChange(): void
+    {
+    }
+}
+
+class ParameterDefaultValueChangeCases
+{
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'missing', newDefaultValue: 'new')]
+    public function missingParameter(string $value = 'old'): void
+    {
+    }
+
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'required', newDefaultValue: 'new')]
+    public function requiredParameter(string $required): void
+    {
+    }
+
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'value', newDefaultValue: 'old')]
+    public function unchangedDefault(string $value = 'old'): void
+    {
+    }
+
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'value', newDefaultValue: null)]
+    public function defaultChangesToNull(?string $value = 'old'): void
+    {
+    }
+
+    #[ParameterDefaultValueChange(version: 'v6.8.0', parameterName: 'scopes', newDefaultValue: ['system', 'crud'])]
+    public function defaultChangesToArray(array $scopes = ['system']): void
     {
     }
 }

--- a/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoBCPlanningDeprecationRule/BCPlanningDeprecations.php
+++ b/tests/devops/Core/DevOps/StaticAnalyse/PHPStan/Rules/data/NoBCPlanningDeprecationRule/BCPlanningDeprecations.php
@@ -23,6 +23,13 @@ class BCPlanningDeprecations
     }
 
     /**
+     * @deprecated tag:v6.8.0 - reason:parameter-default-change - parameter $scope will use a new default value
+     */
+    public function parameterDefaultChange(): void
+    {
+    }
+
+    /**
      * @deprecated tag:v6.8.0 - reason:remove-subscriber - Subscriber will be removed
      */
     public function actualDeprecationIsAllowed(): void

--- a/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
+++ b/tests/unit/Core/DevOps/Test/AnnotationTagTesterTest.php
@@ -139,6 +139,15 @@ class AnnotationTagTesterTest extends TestCase
         );
     }
 
+    public function testParameterDefaultValueChangeWithLiveVersionThrowsException(): void
+    {
+        $this->expectExceptionObject(new \InvalidArgumentException('The version you used for deprecation or experimental annotation is already live.'));
+
+        $this->annotationTagTester->validateBCChangeAttributeVersions(
+            '#[ParameterDefaultValueChange(version: \'v6.4.0\', parameterName: \'value\', newDefaultValue: \'new\')]'
+        );
+    }
+
     public function testBCChangeAttributeWithMalformedVersionThrowsException(): void
     {
         $this->expectExceptionObject(new \InvalidArgumentException('The tag version should start with `v` and comprise 3 digits separated by periods.'));


### PR DESCRIPTION
### 1. Why is this change necessary?

Existing `reason:parameter-default-change` deprecations only describe a planned signature change in prose. The BC-attribute migration needs structured metadata for tooling and a rule that validates its use.

### 2. What does this change do, exactly?

- Adds the internal `ParameterDefaultValueChange` call-site compatibility attribute.
- Validates that the annotated parameter exists, currently has a default, and announces a different default value.
- Migrates the `CreatedByField` and `UpdatedByField` deprecations.
- Rejects remaining `reason:parameter-default-change` annotations.

### 3. Describe each step to reproduce the issue or behaviour.

Not applicable.

### 4. Please link to the relevant issues (if any).

- Relates to #17992

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
