### PR TITLE
chore: replace deprecated EntitySearchResult::filter() in CmsSlotsDataResolver

### DIFF
--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -359,9 +359,18 @@ class CmsSlotsDataResolver
                 }
 
                 $ids = $criteria->getIds();
-                $filtered = $entities[$definition]->filter(static fn (Entity $entity) => \in_array($entity->getUniqueIdentifier(), $ids, true));
+                $searchResult = $entities[$definition];
+                $filtered = $searchResult->getEntities()->filter(static fn (Entity $entity) => \in_array($entity->getUniqueIdentifier(), $ids, true));
 
-                $result->add($key, $filtered);
+                // ElementDataCollection expects the result wrapper, not the inner collection
+                $result->add($key, new EntitySearchResult(
+                    $this->definitionRegistry->get($definition)->getEntityName(),
+                    $filtered->count(),
+                    $filtered,
+                    $searchResult->getAggregations(),
+                    $searchResult->getCriteria(),
+                    $searchResult->getContext(),
+                ));
             }
         }
     }

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsDataResolverTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
 use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\Element\FormCmsElementResolver;
 use Shopware\Core\Content\Cms\DataResolver\Element\HtmlCmsElementResolver;
 use Shopware\Core\Content\Cms\DataResolver\Element\TextCmsElementResolver;
@@ -19,6 +20,7 @@ use Shopware\Core\Content\Cms\Extension\CmsSlotsDataEnrichExtension;
 use Shopware\Core\Content\Cms\Extension\CmsSlotsDataResolveExtension;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
@@ -181,6 +183,62 @@ class CmsSlotsDataResolverTest extends TestCase
             });
 
         $this->getCmsSlotsDataResolver()->resolve($slots, $resolverContext);
+    }
+
+    public function testResolveFiltersMergedDirectReadsPerSlot(): void
+    {
+        $slots = new CmsSlotCollection([
+            (new CmsSlotEntity())->assign([
+                'id' => 'slot-1',
+                'slot' => 'left',
+                'type' => 'form',
+            ]),
+        ]);
+
+        $collection = new CriteriaCollection();
+        $collection->add('criteria-1', ProductDefinition::class, new Criteria(['id-1']));
+
+        $this->formResolver->method('getType')->willReturn('form');
+        $this->formResolver->method('collect')->willReturn($collection);
+
+        $context = Generator::generateSalesChannelContext();
+        $resolverContext = new ResolverContext($context, new Request());
+
+        $wanted = (new SalesChannelProductEntity())->assign(['id' => 'id-1']);
+        $other = (new SalesChannelProductEntity())->assign(['id' => 'id-2']);
+
+        // the merged direct read fetches the ids of all slots at once, each slot only gets its own ids back
+        $this->productRepository->method('search')->willReturn(new EntitySearchResult(
+            'product',
+            2,
+            new SalesChannelProductCollection([$wanted, $other]),
+            null,
+            new Criteria(['id-1', 'id-2']),
+            $context->getContext(),
+        ));
+
+        $this->formResolver->expects($this->once())->method('enrich')
+            ->willReturnCallback(static function (CmsSlotEntity $slot, ResolverContext $resolverContext, ElementDataCollection $data) use ($wanted): void {
+                $filtered = $data->get('criteria-1');
+
+                static::assertInstanceOf(EntitySearchResult::class, $filtered);
+                static::assertSame(1, $filtered->getTotal());
+                static::assertInstanceOf(SalesChannelProductCollection::class, $filtered->getEntities());
+                static::assertSame(['id-1' => $wanted], $filtered->getEntities()->getElements());
+            });
+
+        $productDefinition = new ProductDefinition();
+        $productDefinition->compile($this->registry);
+        $this->registry->method('get')->willReturn($productDefinition);
+
+        $resolver = new CmsSlotsDataResolver(
+            [$this->formResolver, $this->htmlResolver, $this->textResolver],
+            ['product' => $this->productRepository],
+            $this->registry,
+            $this->extensions,
+        );
+
+        $resolver->resolve($slots, $resolverContext);
     }
 
     private function getCmsSlotsDataResolver(): CmsSlotsDataResolver


### PR DESCRIPTION
### 1. Why is this change necessary?

`CmsSlotsDataResolver::mapEntities()` is the last production call site of the `EntitySearchResult` accessors deprecated for v6.8: it filters merged direct reads via `EntitySearchResult::filter()`, which throws a `FeatureException` under the v6.8 feature flags — on every CMS page whose slots collect plain-id criteria. The mechanical `getEntities()` rewrite could not be applied here because `ElementDataCollection::add()` requires the result wrapper, not the inner collection.

⚠️ Note: this was not failing as `mapEntities()`  path was not visited in unit test for this class

### 2. What does this change do, exactly?

`mapEntities()` now filters the inner collection via `getEntities()->filter()` and re-wraps it in a new `EntitySearchResult` for `ElementDataCollection::add()`. The entity name is taken from the definition registry, since `getEntity()` is deprecated as well.

Adds a unit test that drives the merged direct-read path with a real search result. The existing tests stub the search result itself, so the deprecated call never executed under the majors-on unit suite — with the new test, a regression throws immediately in every pull-request pipeline.

### 3. Describe each step to reproduce the issue or behaviour.

Render a CMS page whose slots collect plain-id criteria (for example image elements) with `FEATURE_ALL=major`: `EntitySearchResult::filter()` throws `Tried to access deprecated functionality`. The new test reproduces exactly this without the fix.

### 4. Please link to the relevant issues (if any).

- relates #18655

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
