### PR TITLE
fix(storefront): allow null theme config values in the v6.8 type narrowing

### DIFF
--- a/src/Storefront/Theme/ThemeConfigField.php
+++ b/src/Storefront/Theme/ThemeConfigField.php
@@ -34,9 +34,9 @@ class ThemeConfigField extends Struct
     protected ?string $type = null;
 
     /**
-     * @deprecated tag:v6.8.0 - Property will be typed natively as array|bool|float|int|string
+     * @deprecated tag:v6.8.0 - Property will be typed natively as array|bool|float|int|string|null
      *
-     * @var array<mixed>|bool|float|int|string
+     * @var array<mixed>|bool|float|int|string|null
      *
      * @phpstan-ignore shopware.propertyNativeType (Will be natively typed with next major)
      */
@@ -132,24 +132,24 @@ class ThemeConfigField extends Struct
     }
 
     /**
-     * @return array<mixed>|bool|float|int|string
+     * @return array<mixed>|bool|float|int|string|null
      */
-    #[ReturnTypeWidening(version: 'v6.8.0', newType: 'array|bool|float|int|string')]
+    #[ReturnTypeWidening(version: 'v6.8.0', newType: 'array|bool|float|int|string|null')]
     public function getValue()
     {
         return $this->value;
     }
 
     /**
-     * @param array<mixed>|bool|float|int|string $value
+     * @param array<mixed>|bool|float|int|string|null $value
      */
-    #[ParameterTypeNarrowing(version: 'v6.8.0', parameterName: 'value', newType: 'array|bool|float|int|string')]
+    #[ParameterTypeNarrowing(version: 'v6.8.0', parameterName: 'value', newType: 'array|bool|float|int|string|null')]
     public function setValue($value): void
     {
-        if (!\is_array($value) && !\is_scalar($value)) {
+        if ($value !== null && !\is_array($value) && !\is_scalar($value)) {
             Feature::triggerDeprecationOrThrow(
                 'v6.8.0.0',
-                'Passing a value that is neither an array, boolean, float, integer, nor string is deprecated and will not be allowed in v6.8.0.0.'
+                'Passing a value that is neither an array, boolean, float, integer, string, nor null is deprecated and will not be allowed in v6.8.0.0.'
             );
         }
 

--- a/tests/unit/Storefront/Theme/ThemeConfigFieldTest.php
+++ b/tests/unit/Storefront/Theme/ThemeConfigFieldTest.php
@@ -33,12 +33,13 @@ class ThemeConfigFieldTest extends TestCase
         yield 'float' => [1.5];
         yield 'integer' => [1];
         yield 'string' => ['value'];
+        yield 'null for an emptied value' => [null];
     }
 
     public function testSetValueRejectsUnsupportedValueWhenFeatureActive(): void
     {
         $this->expectExceptionObject(FeatureException::error(
-            'Tried to access deprecated functionality: Passing a value that is neither an array, boolean, float, integer, nor string is deprecated and will not be allowed in v6.8.0.0.'
+            'Tried to access deprecated functionality: Passing a value that is neither an array, boolean, float, integer, string, nor null is deprecated and will not be allowed in v6.8.0.0.'
         ));
 
         // @phpstan-ignore argument.type (Intentional legacy value that must fail when the feature is active.)


### PR DESCRIPTION
### 1. Why is this change necessary?

The Nightly Major run fails in `integration-major / Storefront`: [run 30236596766](https://github.com/shopware/shopware/actions/runs/30236596766/job/89885501012).

`ThemeTest::testThemeServiceReturnsCorrectConfigAfterEmptyingThemeMedia` errors because #18561 introduced a runtime deprecation in `ThemeConfigField::setValue()` that plans to narrow the value type to `array|bool|float|int|string` in v6.8.0.0 — excluding `null`. But `null` is a legitimate value: it is the untyped property's default, and emptying a theme media field (e.g. clearing a logo in the Administration) stores `value: null` in the theme's `configValues`, which `ThemeMergedConfigBuilder` passes through `ThemeConfigFieldFactory` into `setValue()`. With the major flags active the deprecation throws, and after the planned narrowing the native type could not represent the emptied state at all.

### 2. What does this change do, exactly?

- Includes `null` in the planned v6.8 type of `ThemeConfigField::$value`: the property docblock, the `ReturnTypeWidening` / `ParameterTypeNarrowing` attributes, and the runtime guard in `setValue()` now use `array|bool|float|int|string|null`. Objects and resources remain deprecated.
- Updates the deprecation message accordingly.
- Adds a `null` case to the `ThemeConfigFieldTest` value provider and aligns the expected rejection message.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run `FEATURE_ALL=major vendor/bin/phpunit tests/integration/Storefront/Theme/ThemeTest.php --filter testThemeServiceReturnsCorrectConfigAfterEmptyingThemeMedia`.
2. Without this change it errors with `FeatureException: Tried to access deprecated functionality: Passing a value that is neither an array, boolean, float, integer, nor string is deprecated…`; with this change it passes (in default flag mode as well).

### 4. Please link to the relevant issues (if any).

- relates #18561

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
