### PR TITLE
fix(checkout): keep delivery positions when editing orders with a shipping discount

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\Delivery;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPositionCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Cart\Order\IdStruct;
@@ -507,8 +508,9 @@ class PromotionDeliveryCalculator
         $idStruct = $delivery->getExtensionOfType(OrderConverter::ORIGINAL_ADDRESS_ID, IdStruct::class);
         $versionIdStruct = $delivery->getExtensionOfType(OrderConverter::ORIGINAL_ADDRESS_VERSION_ID, IdStruct::class);
 
+        // Own empty positions: never share the base delivery's order_delivery_position rows.
         $delivery = new Delivery(
-            $delivery->getPositions(),
+            new DeliveryPositionCollection(),
             $delivery->getDeliveryDate(),
             $delivery->getShippingMethod(),
             $delivery->getLocation(),

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -36,6 +36,7 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionDiscountUnknownConditionError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
 use Shopware\Core\Checkout\Shipping\Aggregate\ShippingMethodPrice\ShippingMethodPriceCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
@@ -870,6 +871,39 @@ class RecalculationServiceTest extends TestCase
         static::assertSame(-0.5, $newPromotionDelivery?->getShippingCosts()->getTotalPrice());
 
         static::assertNotSame($newPromotionDelivery->getId(), $promotionDelivery->getId());
+    }
+
+    public function testEditOrderWithFreeShippingPromotionKeepsDeliveryPositions(): void
+    {
+        // checkout an order with a 100% shipping discount promotion (shipping delivery + discount delivery)
+        $this->createShippingDiscount(100, 'FREESHIP');
+        $cart = $this->generateDemoCart();
+        $cart->add(static::getContainer()->get(PromotionItemBuilder::class)->buildPlaceholderItem('FREESHIP'));
+        $cart = static::getContainer()->get(Processor::class)->process($cart, $this->salesChannelContext, new CartBehavior());
+        $orderId = $this->persistCart($cart)['orderId'];
+
+        // admin edit: add a product and save (recalculate)
+        $versionContext = $this->context->createWithVersionId($this->createVersionedOrder($orderId));
+        $productId = $this->createProduct('new product', 10.0, 19.0);
+        static::getContainer()->get(RecalculationService::class)->addProductToOrder($orderId, $productId, 1, $versionContext);
+
+        $order = $this->orderRepository->search(
+            (new Criteria([$orderId]))->addAssociation('deliveries.positions'),
+            $versionContext
+        )->getEntities()->first();
+        static::assertNotNull($order);
+        $deliveries = $order->getDeliveries();
+        static::assertNotNull($deliveries);
+        static::assertCount(2, $deliveries);
+
+        $shipping = $deliveries->filter(static fn (OrderDeliveryEntity $delivery) => $delivery->getShippingCosts()->getTotalPrice() >= 0)->first();
+        $discount = $deliveries->filter(static fn (OrderDeliveryEntity $delivery) => $delivery->getShippingCosts()->getTotalPrice() < 0)->first();
+        static::assertNotNull($shipping);
+        static::assertNotNull($discount);
+
+        // both initial products plus the newly added one keep a shipping position; the discount delivery has none
+        static::assertCount(3, $shipping->getPositions() ?? []);
+        static::assertCount(0, $discount->getPositions() ?? []);
     }
 
     public function testRecalculationOfPinnedDisabledPromotion(): void


### PR DESCRIPTION



<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The shipping-discount delivery reused the base delivery's position collection by reference, so both deliveries claimed the same `order_delivery_position` rows

### 2. What does this change do, exactly?
Recalculating an order with a shipping discount (e.g. a 100% free-shipping promotion) then reassigned the product positions to the throwaway discount delivery and lost them when the old discount delivery was cascade-deleted, breaking the order (foreign key violation on `order_delivery_position` when saving). Give the discount delivery its own empty position collection instead


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18465 
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
