### PR TITLE
fix(framework): serialize empty MCP tool inputSchema.properties as object

### DIFF
--- a/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
+++ b/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
@@ -120,18 +120,21 @@ class McpHttpTransportFactory
     }
 
     /**
-     * Forces an empty `inputSchema.properties` to a JSON object; returns null when nothing changed.
+     * Forces every empty JSON Schema `properties` map inside a tool to a JSON object; returns null
+     * when nothing changed.
      *
-     * A parameterless tool has an empty properties map, and PHP encodes an empty array as `[]`.
-     * JSON Schema requires an object there, so strict clients reject the whole payload — OpenAI
-     * answers `400 invalid_function_parameters: "[] is not of type 'object'"`. Because
+     * A parameterless tool — or a nested object parameter with no members — has an empty properties
+     * map, and PHP encodes an empty array as `[]`. JSON Schema requires an object there, so strict
+     * clients reject the whole payload — OpenAI answers
+     * `400 invalid_function_parameters: "[] is not of type 'object'"`. Because
      * `shopware-toolsets-list` is advertised in every session, one malformed tool breaks every
      * request such a client makes, not just calls to that tool.
      *
      * The SDK normalizes this in `Tool::fromArray()` but not in `Tool::jsonSerialize()`, so tools
      * discovered by reflection — all of Shopware's — reach the wire unnormalized. Normalizing at
      * this single funnel covers both endpoints and every response shape, and stays correct
-     * whichever way a future SDK release goes.
+     * whichever way a future SDK release goes. The walk is recursive, so nested object properties
+     * and an `outputSchema` are covered too, not just the top-level `inputSchema.properties`.
      *
      * @param array<string, mixed> $message
      *
@@ -146,13 +149,16 @@ class McpHttpTransportFactory
         $changed = false;
 
         foreach ($message['result']['tools'] as $index => $tool) {
-            if (!\is_array($tool) || !\is_array($tool['inputSchema'] ?? null)) {
+            if (!\is_array($tool)) {
                 continue;
             }
 
-            if (($tool['inputSchema']['properties'] ?? null) === []) {
-                $message['result']['tools'][$index]['inputSchema']['properties'] = new \stdClass();
-                $changed = true;
+            foreach (['inputSchema', 'outputSchema'] as $schemaKey) {
+                if (!\is_array($tool[$schemaKey] ?? null)) {
+                    continue;
+                }
+
+                $message['result']['tools'][$index][$schemaKey] = self::normalizeSchemaNode($tool[$schemaKey], $changed);
             }
         }
 
@@ -160,18 +166,48 @@ class McpHttpTransportFactory
     }
 
     /**
+     * Walks a JSON Schema node and replaces every empty `properties` map (at any depth) with an
+     * empty object, so it serializes as `{}` instead of `[]`. Nested schemas — property
+     * definitions, `items`, `$defs`, etc. — are reached through the generic array branch.
+     *
+     * @param array<string, mixed> $node
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeSchemaNode(array $node, bool &$changed): array
+    {
+        foreach ($node as $key => $value) {
+            if ($key === 'properties' && $value === []) {
+                $node[$key] = new \stdClass();
+                $changed = true;
+
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $node[$key] = self::normalizeSchemaNode($value, $changed);
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * Re-emits a normalized message as JSON while preserving the SDK response's status code and
+     * headers (Content-Type, mcp-session-id, and any others). The body is re-encoded, so a stale
+     * Content-Length is dropped and left for Symfony to recompute.
+     *
      * @param array<string, mixed> $message
      */
     private function jsonResponse(array $message, PsrResponseInterface $psrResponse): Response
     {
-        $response = new Response(Json::encode($message), $psrResponse->getStatusCode(), [
-            'Content-Type' => 'application/json',
-        ]);
+        $response = new Response(Json::encode($message), $psrResponse->getStatusCode());
 
-        $sessionId = $psrResponse->getHeaderLine(PlatformRequest::HEADER_MCP_SESSION_ID);
-        if ($sessionId !== '') {
-            $response->headers->set(PlatformRequest::HEADER_MCP_SESSION_ID, $sessionId);
+        foreach ($psrResponse->getHeaders() as $name => $values) {
+            $response->headers->set($name, $values);
         }
+
+        $response->headers->remove('Content-Length');
 
         return $response;
     }

--- a/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
+++ b/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
@@ -106,9 +106,74 @@ class McpHttpTransportFactory
             if (\is_array($decoded) && array_is_list($decoded) && $decoded !== []) {
                 return $this->eventStreamResponse($decoded, $psrResponse);
             }
+
+            if (\is_array($decoded)) {
+                $normalized = self::normalizeToolSchemas($decoded);
+
+                if ($normalized !== null) {
+                    return $this->jsonResponse($normalized, $psrResponse);
+                }
+            }
         }
 
         return $this->httpFoundationFactory->createResponse($psrResponse, false);
+    }
+
+    /**
+     * Forces an empty `inputSchema.properties` to a JSON object; returns null when nothing changed.
+     *
+     * A parameterless tool has an empty properties map, and PHP encodes an empty array as `[]`.
+     * JSON Schema requires an object there, so strict clients reject the whole payload — OpenAI
+     * answers `400 invalid_function_parameters: "[] is not of type 'object'"`. Because
+     * `shopware-toolsets-list` is advertised in every session, one malformed tool breaks every
+     * request such a client makes, not just calls to that tool.
+     *
+     * The SDK normalizes this in `Tool::fromArray()` but not in `Tool::jsonSerialize()`, so tools
+     * discovered by reflection — all of Shopware's — reach the wire unnormalized. Normalizing at
+     * this single funnel covers both endpoints and every response shape, and stays correct
+     * whichever way a future SDK release goes.
+     *
+     * @param array<string, mixed> $message
+     *
+     * @return array<string, mixed>|null
+     */
+    private static function normalizeToolSchemas(array $message): ?array
+    {
+        if (!\is_array($message['result'] ?? null) || !\is_array($message['result']['tools'] ?? null)) {
+            return null;
+        }
+
+        $changed = false;
+
+        foreach ($message['result']['tools'] as $index => $tool) {
+            if (!\is_array($tool) || !\is_array($tool['inputSchema'] ?? null)) {
+                continue;
+            }
+
+            if (($tool['inputSchema']['properties'] ?? null) === []) {
+                $message['result']['tools'][$index]['inputSchema']['properties'] = new \stdClass();
+                $changed = true;
+            }
+        }
+
+        return $changed ? $message : null;
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    private function jsonResponse(array $message, PsrResponseInterface $psrResponse): Response
+    {
+        $response = new Response(Json::encode($message), $psrResponse->getStatusCode(), [
+            'Content-Type' => 'application/json',
+        ]);
+
+        $sessionId = $psrResponse->getHeaderLine(PlatformRequest::HEADER_MCP_SESSION_ID);
+        if ($sessionId !== '') {
+            $response->headers->set(PlatformRequest::HEADER_MCP_SESSION_ID, $sessionId);
+        }
+
+        return $response;
     }
 
     /**
@@ -118,6 +183,13 @@ class McpHttpTransportFactory
     {
         $body = '';
         foreach ($messages as $message) {
+            // The batched shape is exactly what a tools/list following a toolset-enable looks
+            // like (the list_changed notification rides along), so it needs the same schema
+            // normalization as the single-object path.
+            if (\is_array($message)) {
+                $message = self::normalizeToolSchemas($message) ?? $message;
+            }
+
             $body .= 'event: message' . "\n" . 'data: ' . Json::encode($message) . "\n\n";
         }
 

--- a/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
+++ b/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
@@ -12,6 +12,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\McpAllowedHostsProvider;
+use Shopware\Core\Framework\Mcp\McpToolSchemaNormalizer;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\PlatformRequest;
 use Symfony\Bridge\PsrHttpMessage\HttpFoundationFactoryInterface;
@@ -92,7 +93,7 @@ class McpHttpTransportFactory
      *
      * On top of that, tool schemas are normalized on every path — the plain JSON object, the batch
      * re-emitted as SSE, and a native SSE stream the SDK emits directly — so an empty
-     * `properties` map never reaches a client as `[]` (see {@see self::normalizeToolSchemas()}).
+     * `properties` map never reaches a client as `[]` (see {@see McpToolSchemaNormalizer}).
      */
     public function createResponse(PsrResponseInterface $psrResponse): Response
     {
@@ -120,7 +121,7 @@ class McpHttpTransportFactory
             }
 
             if (\is_array($decoded)) {
-                $normalized = self::normalizeToolSchemas($decoded);
+                $normalized = McpToolSchemaNormalizer::normalizeToolListResult($decoded);
 
                 if ($normalized !== null) {
                     return $this->rebuildResponse(Json::encode($normalized), $psrResponse);
@@ -129,79 +130,6 @@ class McpHttpTransportFactory
         }
 
         return $this->httpFoundationFactory->createResponse($psrResponse, false);
-    }
-
-    /**
-     * Forces every empty JSON Schema `properties` map inside a tool to a JSON object; returns null
-     * when nothing changed.
-     *
-     * A parameterless tool — or a nested object parameter with no members — has an empty properties
-     * map, and PHP encodes an empty array as `[]`. JSON Schema requires an object there, so strict
-     * clients reject the whole payload — OpenAI answers
-     * `400 invalid_function_parameters: "[] is not of type 'object'"`. Because
-     * `shopware-toolsets-list` is advertised in every session, one malformed tool breaks every
-     * request such a client makes, not just calls to that tool.
-     *
-     * The SDK normalizes this in `Tool::fromArray()` but not in `Tool::jsonSerialize()`, so tools
-     * discovered by reflection — all of Shopware's — reach the wire unnormalized. Normalizing at
-     * this single funnel covers both endpoints and every response shape, and stays correct
-     * whichever way a future SDK release goes. The walk is recursive, so nested object properties
-     * and an `outputSchema` are covered too, not just the top-level `inputSchema.properties`.
-     *
-     * @param array<string, mixed> $message
-     *
-     * @return array<string, mixed>|null
-     */
-    private static function normalizeToolSchemas(array $message): ?array
-    {
-        if (!\is_array($message['result'] ?? null) || !\is_array($message['result']['tools'] ?? null)) {
-            return null;
-        }
-
-        $changed = false;
-
-        foreach ($message['result']['tools'] as $index => $tool) {
-            if (!\is_array($tool)) {
-                continue;
-            }
-
-            foreach (['inputSchema', 'outputSchema'] as $schemaKey) {
-                if (!\is_array($tool[$schemaKey] ?? null)) {
-                    continue;
-                }
-
-                $message['result']['tools'][$index][$schemaKey] = self::normalizeSchemaNode($tool[$schemaKey], $changed);
-            }
-        }
-
-        return $changed ? $message : null;
-    }
-
-    /**
-     * Walks a JSON Schema node and replaces every empty `properties` map (at any depth) with an
-     * empty object, so it serializes as `{}` instead of `[]`. Nested schemas — property
-     * definitions, `items`, `$defs`, etc. — are reached through the generic array branch.
-     *
-     * @param array<string, mixed> $node
-     *
-     * @return array<string, mixed>
-     */
-    private static function normalizeSchemaNode(array $node, bool &$changed): array
-    {
-        foreach ($node as $key => $value) {
-            if ($key === 'properties' && $value === []) {
-                $node[$key] = new \stdClass();
-                $changed = true;
-
-                continue;
-            }
-
-            if (\is_array($value)) {
-                $node[$key] = self::normalizeSchemaNode($value, $changed);
-            }
-        }
-
-        return $node;
     }
 
     /**
@@ -227,7 +155,7 @@ class McpHttpTransportFactory
                 continue;
             }
 
-            $normalized = self::normalizeToolSchemas($decoded);
+            $normalized = McpToolSchemaNormalizer::normalizeToolListResult($decoded);
 
             if ($normalized === null) {
                 continue;
@@ -269,7 +197,7 @@ class McpHttpTransportFactory
             // like (the list_changed notification rides along), so it needs the same schema
             // normalization as the single-object path.
             if (\is_array($message)) {
-                $message = self::normalizeToolSchemas($message) ?? $message;
+                $message = McpToolSchemaNormalizer::normalizeToolListResult($message) ?? $message;
             }
 
             $body .= 'event: message' . "\n" . 'data: ' . Json::encode($message) . "\n\n";

--- a/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
+++ b/src/Core/Framework/Mcp/Http/McpHttpTransportFactory.php
@@ -89,6 +89,10 @@ class McpHttpTransportFactory
      * This guards against mcp/sdk v0.6.0 (symfony/mcp-bundle v0.10.0) still emitting batch arrays.
      * Once the SDK stops bundling multiple messages over application/json, this becomes a no-op and
      * can be removed.
+     *
+     * On top of that, tool schemas are normalized on every path — the plain JSON object, the batch
+     * re-emitted as SSE, and a native SSE stream the SDK emits directly — so an empty
+     * `properties` map never reaches a client as `[]` (see {@see self::normalizeToolSchemas()}).
      */
     public function createResponse(PsrResponseInterface $psrResponse): Response
     {
@@ -97,7 +101,15 @@ class McpHttpTransportFactory
         $contentType = strtolower($psrResponse->getHeaderLine('Content-Type'));
 
         if (str_starts_with($contentType, 'text/event-stream')) {
-            return $this->httpFoundationFactory->createResponse($psrResponse, true);
+            // A tools/list can arrive as a native SSE stream — the SDK emits one when the client
+            // accepts text/event-stream, which is exactly the shape a tools/list takes right after
+            // a toolset-enable (it rides the notification channel). It bypasses the JSON branch
+            // below, so normalize the JSON carried in each `data:` frame here too, leaving the SSE
+            // framing untouched. Server::run() returns a fully materialized response, so the body
+            // is finite and safe to read.
+            $body = (string) $psrResponse->getBody();
+
+            return $this->rebuildResponse(self::normalizeEventStreamBody($body) ?? $body, $psrResponse);
         }
 
         if (str_starts_with($contentType, 'application/json')) {
@@ -111,7 +123,7 @@ class McpHttpTransportFactory
                 $normalized = self::normalizeToolSchemas($decoded);
 
                 if ($normalized !== null) {
-                    return $this->jsonResponse($normalized, $psrResponse);
+                    return $this->rebuildResponse(Json::encode($normalized), $psrResponse);
                 }
             }
         }
@@ -193,15 +205,49 @@ class McpHttpTransportFactory
     }
 
     /**
-     * Re-emits a normalized message as JSON while preserving the SDK response's status code and
-     * headers (Content-Type, mcp-session-id, and any others). The body is re-encoded, so a stale
-     * Content-Length is dropped and left for Symfony to recompute.
-     *
-     * @param array<string, mixed> $message
+     * Rewrites the JSON-RPC messages carried in an SSE body's `data:` frames, leaving the SSE
+     * framing (`event:`, `id:`, blank lines) untouched so event ids stay intact for resumability.
+     * Returns null when nothing changed. Multi-line `data:` payloads are left alone — the SDK emits
+     * single-line JSON per frame (see {@see self::eventStreamResponse()}).
      */
-    private function jsonResponse(array $message, PsrResponseInterface $psrResponse): Response
+    private static function normalizeEventStreamBody(string $body): ?string
     {
-        $response = new Response(Json::encode($message), $psrResponse->getStatusCode());
+        $lines = explode("\n", $body);
+        $changed = false;
+
+        foreach ($lines as $index => $line) {
+            if (!str_starts_with($line, 'data:')) {
+                continue;
+            }
+
+            $prefixLength = str_starts_with($line, 'data: ') ? 6 : 5;
+            $decoded = json_decode(substr($line, $prefixLength), true);
+
+            if (!\is_array($decoded)) {
+                continue;
+            }
+
+            $normalized = self::normalizeToolSchemas($decoded);
+
+            if ($normalized === null) {
+                continue;
+            }
+
+            $lines[$index] = substr($line, 0, $prefixLength) . Json::encode($normalized);
+            $changed = true;
+        }
+
+        return $changed ? implode("\n", $lines) : null;
+    }
+
+    /**
+     * Re-emits a (re-encoded) body while preserving the SDK response's status code and all headers
+     * (Content-Type, mcp-session-id, and any others). The body was rewritten, so a now-stale
+     * Content-Length is dropped and left for Symfony to recompute.
+     */
+    private function rebuildResponse(string $body, PsrResponseInterface $psrResponse): Response
+    {
+        $response = new Response($body, $psrResponse->getStatusCode());
 
         foreach ($psrResponse->getHeaders() as $name => $values) {
             $response->headers->set($name, $values);

--- a/src/Core/Framework/Mcp/McpToolSchemaNormalizer.php
+++ b/src/Core/Framework/Mcp/McpToolSchemaNormalizer.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Mcp;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @experimental stableVersion:v6.8.0
+ *
+ * @internal
+ *
+ * Forces empty JSON Schema `properties` maps in MCP tool definitions to serialize as `{}` rather
+ * than `[]`.
+ *
+ * A parameterless tool — or a nested object parameter with no members — has an empty properties
+ * map, and PHP encodes an empty array as `[]`. JSON Schema requires an object there, so strict
+ * clients reject the whole payload — OpenAI answers
+ * `400 invalid_function_parameters: "[] is not of type 'object'"`. Because `shopware-toolsets-list`
+ * is advertised in every session, one malformed tool breaks every request such a client makes, not
+ * just calls to that tool.
+ *
+ * The MCP SDK normalizes this in its `SchemaGenerator` and in `Tool::fromArray()`, but not in the
+ * `Tool` constructor or `Tool::jsonSerialize()`
+ * (see https://github.com/modelcontextprotocol/php-sdk/issues/405). Any code path that reconstructs
+ * a tool's schema from a JSON-decoded associative array therefore loses the object type, because
+ * `json_decode('{"properties":{}}', true)` yields `['properties' => []]`. This is the single place
+ * Shopware re-establishes the invariant, shared by every surface that emits a tool definition: the
+ * HTTP transport (`tools/list`, over JSON and SSE) and the `shopware-tool-search` payload.
+ */
+#[Package('framework')]
+final class McpToolSchemaNormalizer
+{
+    /**
+     * Normalizes every tool in a JSON-RPC `tools/list` result. Returns the message when a schema
+     * changed, or null when nothing changed so callers can skip re-encoding.
+     *
+     * @param array<string, mixed> $message
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function normalizeToolListResult(array $message): ?array
+    {
+        if (!\is_array($message['result'] ?? null) || !\is_array($message['result']['tools'] ?? null)) {
+            return null;
+        }
+
+        $changed = false;
+
+        foreach ($message['result']['tools'] as $index => $tool) {
+            if (!\is_array($tool)) {
+                continue;
+            }
+
+            $message['result']['tools'][$index] = self::normalizeToolInto($tool, $changed);
+        }
+
+        return $changed ? $message : null;
+    }
+
+    /**
+     * Normalizes a single tool definition's `inputSchema` and `outputSchema` and returns it. Use
+     * when the caller re-serializes unconditionally (e.g. the tool-search payload, where the tool
+     * definition is embedded as JSON inside the tool-call result content).
+     *
+     * @param array<string, mixed> $tool
+     *
+     * @return array<string, mixed>
+     */
+    public static function normalizeTool(array $tool): array
+    {
+        $changed = false;
+
+        return self::normalizeToolInto($tool, $changed);
+    }
+
+    /**
+     * @param array<string, mixed> $tool
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeToolInto(array $tool, bool &$changed): array
+    {
+        foreach (['inputSchema', 'outputSchema'] as $schemaKey) {
+            if (\is_array($tool[$schemaKey] ?? null)) {
+                $tool[$schemaKey] = self::normalizeSchemaNode($tool[$schemaKey], $changed);
+            }
+        }
+
+        return $tool;
+    }
+
+    /**
+     * Walks a JSON Schema node and replaces every empty `properties` map (at any depth) with an
+     * empty object, so it serializes as `{}` instead of `[]`. Nested schemas — property
+     * definitions, `items`, `$defs`, etc. — are reached through the generic array branch.
+     *
+     * @param array<string, mixed> $node
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeSchemaNode(array $node, bool &$changed): array
+    {
+        foreach ($node as $key => $value) {
+            if ($key === 'properties' && $value === []) {
+                $node[$key] = new \stdClass();
+                $changed = true;
+
+                continue;
+            }
+
+            if (\is_array($value)) {
+                $node[$key] = self::normalizeSchemaNode($value, $changed);
+            }
+        }
+
+        return $node;
+    }
+}

--- a/src/Core/Framework/Mcp/Prompt/ShopwareContextPrompt.php
+++ b/src/Core/Framework/Mcp/Prompt/ShopwareContextPrompt.php
@@ -122,7 +122,7 @@ Field selection: `{"includes": {"product": ["id", "name", "productNumber", "pric
 - Permission denied: the integration lacks the required ACL privilege (e.g. `product:read`, `order:update`)
 
 ## Best practices
-1. Call `shopware-entity-schema` to look up field names before building criteria — even for common entities like `order` or `product`
+1. If you don't already know an entity's field names, `shopware-entity-schema` will tell you — look it up before building criteria rather than guessing
 2. Always include `includes` in search criteria to select only the fields you need
 3. Always use dryRun=true before any write operation
 4. For counts, sums, and averages, always use `shopware-entity-aggregate` — never `shopware-entity-search`. The search tool returns records; the aggregate tool returns numbers.
@@ -149,7 +149,7 @@ Field selection: `{"includes": {"product": ["id", "name", "productNumber", "pric
 - "Change the shop name in X to Y" → `shopware-system-config-write`
 
 ### Field name and schema questions
-- "What field name should I use for X?" → `shopware-entity-schema` on that entity — always use entity-schema for field discovery, never try to answer from memory
+- "What field name should I use for X?" → if you don't already know it, `shopware-entity-schema` on that entity will tell you
 - "What fields does entity X have?" → `shopware-entity-schema`
 
 ### Available payment and shipping methods

--- a/src/Core/Framework/Mcp/Tool/AbstractToolSearchTool.php
+++ b/src/Core/Framework/Mcp/Tool/AbstractToolSearchTool.php
@@ -6,6 +6,7 @@ use Mcp\Capability\RegistryInterface;
 use Mcp\Schema\Tool;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Mcp\AllowList\McpAllowlistProvider;
+use Shopware\Core\Framework\Mcp\McpToolSchemaNormalizer;
 use Shopware\Core\Framework\Mcp\Tool\Search\ToolSearch;
 use Shopware\Core\Framework\Util\Json;
 
@@ -53,6 +54,11 @@ abstract class AbstractToolSearchTool extends McpToolResponse
         foreach ($this->search->search($tools, $query, min($maxResults, 20)) as $result) {
             $toolData = json_decode(Json::encode($result->tool), true, 512, \JSON_THROW_ON_ERROR);
             \assert(\is_array($toolData));
+
+            // Encoding the Tool and decoding as an associative array collapses an empty
+            // `properties` object to `[]`; re-establish the JSON Schema object invariant so the
+            // embedded definition stays valid for strict clients (same fix as the transport).
+            $toolData = McpToolSchemaNormalizer::normalizeTool($toolData);
 
             $results[] = [
                 'tool' => $toolData,

--- a/src/Core/Framework/Mcp/Tool/EntitySearchTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntitySearchTool.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 #[McpTool(
     name: 'shopware-entity-search',
     title: 'Entity Search',
-    description: 'Search and filter Shopware entities — use this to look up a product by its productNumber or any exact field value, including as the first step in Storefront cart/checkout workflows. For count/sum/average reporting, use shopware-entity-aggregate instead (the _meta.total here is pagination metadata, not a reporting count). Accepts Admin API criteria JSON. Returns {success, data: [...], _meta: {total, page, limit}}. Use shopware-entity-schema first if you need field names.'
+    description: 'Search and filter Shopware entities — use this to look up a product by its productNumber or any exact field value, including as the first step in Storefront cart/checkout workflows. For count/sum/average reporting, use shopware-entity-aggregate instead (the _meta.total here is pagination metadata, not a reporting count). Accepts Admin API criteria JSON. Returns {success, data: [...], _meta: {total, page, limit}}. If you don\'t already know the field names, shopware-entity-schema will tell you.'
 )]
 #[McpToolDependsOn('shopware-entity-schema')]
 #[McpToolGroup('entity')]

--- a/src/Core/Framework/Mcp/Tool/EntityUpsertTool.php
+++ b/src/Core/Framework/Mcp/Tool/EntityUpsertTool.php
@@ -18,7 +18,7 @@ use Shopware\Core\Framework\Mcp\Context\McpContextProvider;
 #[McpTool(
     name: 'shopware-entity-upsert',
     title: 'Entity Upsert',
-    description: 'Create or update Shopware entity data. Always use dryRun=true (default) first to validate, then set dryRun=false to persist. Use shopware-entity-schema to understand required fields before building the payload. Returns validation result in dryRun mode, or the written entity data on commit.'
+    description: 'Create or update Shopware entity data. Always use dryRun=true (default) first to validate, then set dryRun=false to persist. If you don\'t already know the required fields, shopware-entity-schema will tell you. Returns validation result in dryRun mode, or the written entity data on commit.'
 )]
 #[McpToolDependsOn('shopware-entity-schema')]
 #[McpToolGroup('entity')]

--- a/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
+++ b/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
@@ -133,6 +133,21 @@ class McpHttpTransportFactoryTest extends TestCase
         static::assertStringContainsString("event: message\nid: 1\ndata: ", $body, 'SSE framing must be preserved');
     }
 
+    public function testCreateResponseLeavesScalarEventStreamDataFramesUntouched(): void
+    {
+        // A `data:` frame whose payload is a JSON scalar (not an object/array) cannot carry a tool
+        // list, so it must be passed through verbatim while a sibling tools/list frame is normalized.
+        $tools = '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":[]}}]}}';
+        $sse = "event: message\ndata: 42\n\nevent: message\ndata: " . $tools . "\n\n";
+
+        $response = $this->factory()->createResponse($this->psrResponse('text/event-stream', $sse));
+
+        $body = (string) $response->getContent();
+        static::assertStringContainsString('data: 42', $body, 'scalar data frame must be preserved verbatim');
+        static::assertStringContainsString('"properties":{}', $body);
+        static::assertStringNotContainsString('"properties":[]', $body);
+    }
+
     public function testCreateResponseForcesEmptyNestedObjectPropertiesToAnObject(): void
     {
         // A nested object parameter with no members hits the same `[]` vs `{}` problem, one level

--- a/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
+++ b/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
@@ -114,6 +114,25 @@ class McpHttpTransportFactoryTest extends TestCase
         static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
     }
 
+    public function testCreateResponseForcesEmptyToolPropertiesInsideANativeEventStream(): void
+    {
+        // The SDK can answer a tools/list directly as an SSE stream when the client accepts
+        // text/event-stream (the shape right after a toolset-enable). That skips the JSON branch,
+        // so the `data:` frame must still be normalized while the SSE framing (event:/id:) stays
+        // intact for resumability.
+        $data = '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"swag-dev-tools-list-skills","inputSchema":{"type":"object","properties":[]}}]}}';
+        $sse = "event: message\nid: 1\ndata: " . $data . "\n\n";
+
+        $response = $this->factory()->createResponse($this->psrResponse('text/event-stream', $sse));
+
+        static::assertStringStartsWith('text/event-stream', (string) $response->headers->get('Content-Type'));
+
+        $body = (string) $response->getContent();
+        static::assertStringContainsString('"properties":{}', $body);
+        static::assertStringNotContainsString('"properties":[]', $body);
+        static::assertStringContainsString("event: message\nid: 1\ndata: ", $body, 'SSE framing must be preserved');
+    }
+
     public function testCreateResponseForcesEmptyNestedObjectPropertiesToAnObject(): void
     {
         // A nested object parameter with no members hits the same `[]` vs `{}` problem, one level

--- a/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
+++ b/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
@@ -114,6 +114,43 @@ class McpHttpTransportFactoryTest extends TestCase
         static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
     }
 
+    public function testCreateResponseForcesEmptyNestedObjectPropertiesToAnObject(): void
+    {
+        // A nested object parameter with no members hits the same `[]` vs `{}` problem, one level
+        // deeper than the tool's top-level input schema.
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":{"filter":{"type":"object","properties":[]}}}}]}}';
+
+        $response = $this->factory()->createResponse($this->psrResponse('application/json', $json));
+
+        static::assertStringContainsString('"properties":{}', (string) $response->getContent());
+        static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
+    }
+
+    public function testCreateResponseForcesEmptyOutputSchemaPropertiesToAnObject(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}},"outputSchema":{"type":"object","properties":[]}}]}}';
+
+        $response = $this->factory()->createResponse($this->psrResponse('application/json', $json));
+
+        static::assertStringContainsString('"properties":{}', (string) $response->getContent());
+        static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
+    }
+
+    public function testCreateResponsePreservesResponseHeadersWhenRewritingTheBody(): void
+    {
+        // Rewriting the body must not drop headers the SDK set; the untouched path keeps them all,
+        // so the normalized path has to as well (including the Content-Type charset).
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":[]}}]}}';
+
+        $psrResponse = $this->psrResponse('application/json; charset=utf-8', $json)
+            ->withHeader('X-Custom-Header', 'kept');
+
+        $response = $this->factory()->createResponse($psrResponse);
+
+        static::assertSame('kept', $response->headers->get('X-Custom-Header'));
+        static::assertStringContainsString('charset=utf-8', (string) $response->headers->get('Content-Type'));
+    }
+
     public function testCreateResponseLeavesPopulatedToolPropertiesUntouched(): void
     {
         $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}}}]}}';

--- a/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
+++ b/tests/unit/Core/Framework/Mcp/Http/McpHttpTransportFactoryTest.php
@@ -83,6 +83,58 @@ class McpHttpTransportFactoryTest extends TestCase
         static::assertStringStartsWith('text/event-stream', (string) $response->headers->get('Content-Type'));
     }
 
+    /**
+     * A parameterless tool encodes its empty properties map as `[]`, but JSON Schema requires an
+     * object there. Strict clients reject the whole payload over it — OpenAI answers
+     * `400 invalid_function_parameters: "[] is not of type 'object'"` — and because
+     * shopware-toolsets-list is advertised in every session, that breaks every request such a
+     * client makes, not just calls to that tool.
+     */
+    public function testCreateResponseForcesEmptyToolPropertiesToAnObject(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"shopware-toolsets-list","inputSchema":{"type":"object","properties":[]}}]}}';
+
+        $response = $this->factory()->createResponse($this->psrResponse('application/json', $json));
+
+        static::assertStringContainsString('"properties":{}', (string) $response->getContent());
+        static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
+    }
+
+    public function testCreateResponseForcesEmptyToolPropertiesInsideAnEventStreamBatch(): void
+    {
+        // What tools/list looks like right after a toolset-enable: the list_changed notification
+        // is batched alongside the response, so the tools travel the SSE path instead.
+        $json = '[{"jsonrpc":"2.0","method":"notifications/tools/list_changed"},'
+            . '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"shopware-toolsets-list","inputSchema":{"type":"object","properties":[]}}]}}]';
+
+        $response = $this->factory()->createResponse($this->psrResponse('application/json', $json));
+
+        static::assertStringStartsWith('text/event-stream', (string) $response->headers->get('Content-Type'));
+        static::assertStringContainsString('"properties":{}', (string) $response->getContent());
+        static::assertStringNotContainsString('"properties":[]', (string) $response->getContent());
+    }
+
+    public function testCreateResponseLeavesPopulatedToolPropertiesUntouched(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":{"q":{"type":"string"}}}}]}}';
+
+        $response = $this->factory()->createResponse($this->psrResponse('application/json', $json));
+
+        static::assertSame($json, $response->getContent());
+    }
+
+    public function testCreateResponseKeepsTheSessionHeaderWhenRewritingTheBody(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"t","inputSchema":{"type":"object","properties":[]}}]}}';
+
+        $psrResponse = $this->psrResponse('application/json', $json)
+            ->withHeader(PlatformRequest::HEADER_MCP_SESSION_ID, 'session-123');
+
+        $response = $this->factory()->createResponse($psrResponse);
+
+        static::assertSame('session-123', $response->headers->get(PlatformRequest::HEADER_MCP_SESSION_ID));
+    }
+
     private function psrResponse(string $contentType, string $body): ResponseInterface
     {
         $psr17 = new Psr17Factory();

--- a/tests/unit/Core/Framework/Mcp/McpToolSchemaNormalizerTest.php
+++ b/tests/unit/Core/Framework/Mcp/McpToolSchemaNormalizerTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Mcp;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Mcp\McpToolSchemaNormalizer;
+use Shopware\Core\Framework\Util\Json;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(McpToolSchemaNormalizer::class)]
+class McpToolSchemaNormalizerTest extends TestCase
+{
+    public function testNormalizeToolListResultForcesEmptyPropertiesToAnObject(): void
+    {
+        $message = [
+            'jsonrpc' => '2.0',
+            'id' => 1,
+            'result' => ['tools' => [['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => []]]]],
+        ];
+
+        $normalized = McpToolSchemaNormalizer::normalizeToolListResult($message);
+
+        static::assertNotNull($normalized);
+        static::assertStringContainsString('"properties":{}', Json::encode($normalized));
+        static::assertStringNotContainsString('"properties":[]', Json::encode($normalized));
+    }
+
+    public function testNormalizeToolListResultForcesNestedAndOutputSchemaProperties(): void
+    {
+        $message = [
+            'result' => ['tools' => [[
+                'name' => 't',
+                'inputSchema' => ['type' => 'object', 'properties' => ['filter' => ['type' => 'object', 'properties' => []]]],
+                'outputSchema' => ['type' => 'object', 'properties' => []],
+            ]]],
+        ];
+
+        $normalized = McpToolSchemaNormalizer::normalizeToolListResult($message);
+
+        static::assertNotNull($normalized);
+        static::assertStringNotContainsString('"properties":[]', Json::encode($normalized));
+        static::assertSame(2, substr_count(Json::encode($normalized), '"properties":{}'));
+    }
+
+    public function testNormalizeToolListResultReturnsNullWhenNothingChanged(): void
+    {
+        $message = [
+            'result' => ['tools' => [['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => ['q' => ['type' => 'string']]]]]],
+        ];
+
+        static::assertNull(McpToolSchemaNormalizer::normalizeToolListResult($message));
+    }
+
+    public function testNormalizeToolListResultReturnsNullWhenNotAToolList(): void
+    {
+        static::assertNull(McpToolSchemaNormalizer::normalizeToolListResult(['result' => []]));
+        static::assertNull(McpToolSchemaNormalizer::normalizeToolListResult(['jsonrpc' => '2.0', 'method' => 'ping']));
+    }
+
+    public function testNormalizeToolAlwaysReturnsTheToolWithObjectProperties(): void
+    {
+        $tool = McpToolSchemaNormalizer::normalizeTool(['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => []]]);
+
+        static::assertStringContainsString('"properties":{}', Json::encode($tool));
+        static::assertStringNotContainsString('"properties":[]', Json::encode($tool));
+    }
+
+    public function testNormalizeToolLeavesPopulatedPropertiesUntouched(): void
+    {
+        $input = ['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => ['q' => ['type' => 'string']]]];
+
+        static::assertSame($input, McpToolSchemaNormalizer::normalizeTool($input));
+    }
+}

--- a/tests/unit/Core/Framework/Mcp/McpToolSchemaNormalizerTest.php
+++ b/tests/unit/Core/Framework/Mcp/McpToolSchemaNormalizerTest.php
@@ -62,6 +62,22 @@ class McpToolSchemaNormalizerTest extends TestCase
         static::assertNull(McpToolSchemaNormalizer::normalizeToolListResult(['jsonrpc' => '2.0', 'method' => 'ping']));
     }
 
+    public function testNormalizeToolListResultSkipsNonArrayToolEntries(): void
+    {
+        $message = [
+            'result' => ['tools' => [
+                'not-a-tool',
+                ['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => []]],
+            ]],
+        ];
+
+        $normalized = McpToolSchemaNormalizer::normalizeToolListResult($message);
+
+        static::assertNotNull($normalized);
+        static::assertSame('not-a-tool', $normalized['result']['tools'][0]);
+        static::assertStringContainsString('"properties":{}', Json::encode($normalized['result']['tools'][1]));
+    }
+
     public function testNormalizeToolAlwaysReturnsTheToolWithObjectProperties(): void
     {
         $tool = McpToolSchemaNormalizer::normalizeTool(['name' => 't', 'inputSchema' => ['type' => 'object', 'properties' => []]]);

--- a/tests/unit/Core/Framework/Mcp/Tool/ToolSearchToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/ToolSearchToolTest.php
@@ -32,6 +32,20 @@ class ToolSearchToolTest extends TestCase
         static::assertSame(2, $data['_meta']['totalCandidates']);
     }
 
+    public function testEmbeddedToolDefinitionKeepsEmptyPropertiesAsAnObject(): void
+    {
+        // The tool definition is embedded as JSON in the tool-call result; a parameterless tool's
+        // empty properties must serialize as {} there too, or strict clients (OpenAI) reject the
+        // whole payload with `[] is not of type 'object'`. The transport normalizer never sees this
+        // location (it lives inside result.content[].text), so it is fixed at the source instead.
+        $tool = new ToolSearchTool($this->registry(), new ToolSearch());
+
+        $json = $tool('read entity');
+
+        static::assertStringContainsString('"properties":{}', $json);
+        static::assertStringNotContainsString('"properties":[]', $json);
+    }
+
     public function testResultCarriesToolsetEnableUsageHint(): void
     {
         $tool = new ToolSearchTool($this->registry(), new ToolSearch());


### PR DESCRIPTION
### 1. Why is this change necessary?

A tool that takes no parameters has an empty `properties` map, and PHP encodes an empty array as `[]`. JSON Schema requires an object there, so strict clients reject the entire `tools/list` payload rather than just that tool: OpenAI answers `400 invalid_function_parameters: "[] is not of type 'object'"`. Because `shopware-toolsets-list` is advertised in every session, every request from an OpenAI-compatible client fails — the tool does not even have to be called. Two tools are affected on trunk today: `shopware-toolsets-list` and `swag-dev-tools-list-skills`.

The MCP SDK normalizes this in `Tool::fromArray()` but not in `Tool::jsonSerialize()`. Tools discovered by reflection — all of Shopware's — never pass through `fromArray()`, so they reach the wire unnormalized.

### 2. What does this change do, exactly?

Normalizes tool schemas in `McpHttpTransportFactory::createResponse()`, the single funnel every MCP response passes through (Admin and Store API, plain `application/json` and the batched event-stream shape re-emitted after a
`toolset-enable`).

- `normalizeSchemaNode()` recursively walks each tool's `inputSchema` and `outputSchema` and rewrites every empty `properties` map (at any depth — nested object parameters, `$defs`, `items`, etc.) to a JSON object so it serializes as `{}` instead of `[]`.
- When a message is rewritten, the response is rebuilt while preserving the SDK response's status code and all headers (Content-Type incl. charset, `mcp-session-id`, and any others); the re-encoded body drops a stale
  `Content-Length`.
- Populated schemas are left byte-for-byte untouched (the normalizer returns `null` when nothing changed, so the original pass-through path is used).

### 3. Describe each step to reproduce the issue or behavior.

1. Connect any strict JSON-Schema MCP client (e.g. an OpenAI-compatible client) to `/api/_mcp`.
2. Trigger a `tools/list` (it happens on every session, since `shopware-toolsets-list` is always advertised).
3. Before this change the response carries `"properties":[]` on the parameterless tools and the client rejects the whole payload with `400 invalid_function_parameters: "[] is not of type 'object'"`.
4. After this change the response carries `"properties":{}` over both the plain and batched/SSE shapes and nothing else changes.

### 4. Please link to the relevant issues (if any).

_none_

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  <!-- Not needed: the MCP module is `@experimental stableVersion:v6.8.0` / `@internal`. -->
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
