### PR TITLE
fix(storefront): stabilize guest login rate limit test

### DIFF
--- a/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
+++ b/tests/integration/Storefront/Controller/ControllerRateLimiterTest.php
@@ -193,7 +193,7 @@ class ControllerRateLimiterTest extends TestCase
 
         $errorContent = $crawler->filterXPath('//div[@class="flashbags container"]//div[@class="alert-content-container"]')->text();
 
-        static::assertStringContainsString($this->translator->trans('account.loginThrottled', ['%seconds%' => 5]), $errorContent);
+        static::assertStringContainsString($this->translator->trans('account.loginThrottled', ['%seconds%' => 5], 'messages', 'en-GB'), $errorContent);
     }
 
     public function testAuthControllerLoginShowsRateLimit(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

The guest-login rate-limit test is flaky in the major Storefront integration pipeline. In the [failing job](https://github.com/shopware/shopware/actions/runs/30268635647/job/89985428913), the global translator used by the assertion was left on the bare `en` locale and returned `account.loginThrottled`, while the request rendered the correct `en-GB` message.

### 2. What does this change do, exactly?

Pins the test expectation to the test sales channel's `en-GB` locale, matching the neighbouring login rate-limit test.

### 3. Describe each step to reproduce the issue or behaviour.

Run the Storefront major integration suite with `FEATURE_ALL=major`. The test is order-sensitive: when prior suite state leaves the global translator on `en`, the guest-login assertion expects `account.loginThrottled` while the rendered page correctly contains the English message. The exact observed failure is [Storefront in the major integration run](https://github.com/shopware/shopware/actions/runs/30268635647/job/89985428913).

### 4. Please link to the relevant issues (if any).

Relates to https://github.com/shopware/shopware/pull/17992 and the [failed major Storefront job](https://github.com/shopware/shopware/actions/runs/30268635647/job/89985428913).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
