### PR TITLE
chore: Remove not needed parameter from app update method

### DIFF
--- a/src/Core/Framework/App/Lifecycle/AbstractAppLifecycle.php
+++ b/src/Core/Framework/App/Lifecycle/AbstractAppLifecycle.php
@@ -29,7 +29,7 @@ abstract class AbstractAppLifecycle
     abstract public function deactivate(string $appId, Context $context): void;
 
     /**
-     * @param array{id: string, roleId: string} $app
+     * @param array{id: string} $app
      */
     abstract public function update(Manifest $manifest, AppUpdateParameters $parameters, array $app, Context $context): void;
 

--- a/src/Core/Framework/App/Lifecycle/AppLifecycleIterator.php
+++ b/src/Core/Framework/App/Lifecycle/AppLifecycleIterator.php
@@ -63,7 +63,7 @@ class AppLifecycleIterator
                     $appLifecycle->update(
                         $manifest,
                         new AppUpdateParameters(acceptPermissions: $parameters->acceptPermissions),
-                        $app,
+                        ['id' => $app['id']],
                         $context
                     );
                 }

--- a/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
+++ b/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
@@ -129,8 +129,6 @@ class StoreAppLifecycleService extends AbstractStoreAppLifecycleService
             new AppUpdateParameters(),
             [
                 'id' => $app->getId(),
-                'version' => $app->getVersion(),
-                'roleId' => $app->getAclRoleId(),
             ],
             $context
         );

--- a/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
+++ b/tests/integration/Core/Content/Product/DataAbstractionLayer/Indexing/ProductRatingAverageIndexerTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -51,7 +52,7 @@ class ProductRatingAverageIndexerTest extends TestCase
 
     private Connection $connection;
 
-    private ProductIndexer $productIndexer;
+    private EntityIndexer $productIndexer;
 
     protected function setUp(): void
     {

--- a/tests/integration/Core/Content/ProductStream/Service/ProductStreamBuilderTest.php
+++ b/tests/integration/Core/Content/ProductStream/Service/ProductStreamBuilderTest.php
@@ -10,7 +10,9 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
 use Shopware\Core\Content\ProductStream\Exception\NoFilterException;
+use Shopware\Core\Content\ProductStream\Service\AbstractProductStreamBuilder;
 use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
+use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -48,7 +50,7 @@ class ProductStreamBuilderTest extends TestCase
 
     private SalesChannelContext $salesChannelContext;
 
-    private ProductStreamBuilder $service;
+    private AbstractProductStreamBuilder&ProductStreamBuilderInterface $service;
 
     protected function setUp(): void
     {

--- a/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
+use Shopware\Core\Framework\App\Lifecycle\AbstractAppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppLifecycle;
 use Shopware\Core\Framework\App\Lifecycle\AppManager;
 use Shopware\Core\Framework\App\Lifecycle\Parameters\AppInstallParameters;
@@ -28,7 +29,7 @@ class ThemeAppLifecycleHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;
 
-    private AppLifecycle $appLifecycle;
+    private AbstractAppLifecycle $appLifecycle;
 
     private AppManager $appManager;
 

--- a/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
+++ b/tests/unit/Core/Framework/App/Lifecycle/AppLifecycleTest.php
@@ -83,7 +83,7 @@ class AppLifecycleTest extends TestCase
 
         $appLifecycle = new AppLifecycle($appManager, new AppStorage(AppFixture::createAppRepository($app)));
 
-        $appLifecycle->update($manifest, $parameters, ['id' => 'app-id', 'roleId' => 'role-id'], $context);
+        $appLifecycle->update($manifest, $parameters, ['id' => 'app-id'], $context);
     }
 
     public function testUninstallLoadsAppAndDelegatesToAppManager(): void
@@ -107,7 +107,7 @@ class AppLifecycleTest extends TestCase
 
         static::expectException(AppException::class);
 
-        $appLifecycle->update(ManifestFixture::empty(), new AppUpdateParameters(), ['id' => 'missing', 'roleId' => 'role-id'], Context::createDefaultContext());
+        $appLifecycle->update(ManifestFixture::empty(), new AppUpdateParameters(), ['id' => 'missing'], Context::createDefaultContext());
     }
 
     public function testActivateThrowsWhenAppDoesNotExist(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

First preparation for PHPStan update https://github.com/shopware/shopware/pull/17661

### 2. What does this change do, exactly?

Remove not needed parameter from array shape. In newer PHPStan versions, array shapes are sealed and are not allowed to have additional keys than the declared ones. 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
