### PR TITLE
fix(storefront): keep customer in checkout flow on failed login

### DIFF
--- a/changelog/_unreleased/2026-07-27-keep-customer-in-checkout-flow-on-failed-login.md
+++ b/changelog/_unreleased/2026-07-27-keep-customer-in-checkout-flow-on-failed-login.md
@@ -1,0 +1,9 @@
+---
+title: Keep the customer in the checkout flow when login fails during checkout
+author: Chuc Le Manh
+author_email: c.lemanh@shopware.com
+---
+# Storefront
+* Changed `Shopware\Storefront\Controller\AuthController::login()` so a failed login started from the checkout register page (`/checkout/register`) is forwarded back to `frontend.checkout.register.page` instead of the standalone account login page. The origin is detected from the submitted `redirectTo`, so customers who enter wrong credentials during checkout stay within the checkout flow.
+* Changed `Shopware\Storefront\Controller\RegisterController::checkoutRegisterPage()` to pass the `loginError`, `errorSnippet` and `waitTime` parameters to the template, so the login error is rendered inline on the checkout register page.
+* Changed `Resources/views/storefront/page/checkout/address/index.html.twig` to expand the collapsed login panel (`#loginCollapse`) automatically when `loginError` is set, so the wrong-credentials message and the login form are visible on load instead of hidden inside the collapsed panel.

--- a/changelog/_unreleased/2026-07-27-keep-customer-in-checkout-flow-on-failed-login.md
+++ b/changelog/_unreleased/2026-07-27-keep-customer-in-checkout-flow-on-failed-login.md
@@ -1,9 +1,0 @@
----
-title: Keep the customer in the checkout flow when login fails during checkout
-author: Chuc Le Manh
-author_email: c.lemanh@shopware.com
----
-# Storefront
-* Changed `Shopware\Storefront\Controller\AuthController::login()` so a failed login started from the checkout register page (`/checkout/register`) is forwarded back to `frontend.checkout.register.page` instead of the standalone account login page. The origin is detected from the submitted `redirectTo`, so customers who enter wrong credentials during checkout stay within the checkout flow.
-* Changed `Shopware\Storefront\Controller\RegisterController::checkoutRegisterPage()` to pass the `loginError`, `errorSnippet` and `waitTime` parameters to the template, so the login error is rendered inline on the checkout register page.
-* Changed `Resources/views/storefront/page/checkout/address/index.html.twig` to expand the collapsed login panel (`#loginCollapse`) automatically when `loginError` is set, so the wrong-credentials message and the login form are visible on load instead of hidden inside the collapsed panel.

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -236,9 +236,7 @@ class AuthController extends StorefrontController
             $data->set('password', null);
         }
 
-        // A login started from the checkout register page must return there instead of the
-        // standalone account login page, so the customer stays within the checkout flow. The
-        // submitted redirectTo (e.g. frontend.checkout.confirm.page) tells us where it came from.
+        // Keep a failed login within the checkout flow instead of forwarding to the account login page.
         $redirectTo = $request->request->getString('redirectTo');
         $errorRoute = str_starts_with($redirectTo, 'frontend.checkout')
             ? 'frontend.checkout.register.page'

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -236,8 +236,16 @@ class AuthController extends StorefrontController
             $data->set('password', null);
         }
 
+        // A login started from the checkout register page must return there instead of the
+        // standalone account login page, so the customer stays within the checkout flow. The
+        // submitted redirectTo (e.g. frontend.checkout.confirm.page) tells us where it came from.
+        $redirectTo = $request->request->getString('redirectTo');
+        $errorRoute = str_starts_with($redirectTo, 'frontend.checkout')
+            ? 'frontend.checkout.register.page'
+            : 'frontend.account.login.page';
+
         return $this->forwardToRoute(
-            'frontend.account.login.page',
+            $errorRoute,
             [
                 'loginError' => true,
                 'errorSnippet' => $errorSnippet ?? null,

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -186,6 +186,9 @@ class RegisterController extends StorefrontController
             [
                 'redirectTo' => $redirect,
                 'errorRoute' => $errorRoute,
+                'loginError' => $request->attributes->getBoolean('loginError'),
+                'errorSnippet' => $request->attributes->get('errorSnippet'),
+                'waitTime' => $request->attributes->get('waitTime'),
                 'page' => $page,
                 'header' => $header,
                 'footer' => $footer,

--- a/src/Storefront/Resources/views/storefront/page/checkout/address/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/address/index.html.twig
@@ -18,13 +18,13 @@
                 <a href="#loginCollapse"
                    class="login-collapse-toggle"
                    data-bs-toggle="collapse"
-                   aria-expanded="false">
+                   aria-expanded="{{ loginError ? 'true' : 'false' }}">
                     <strong>{{ 'checkout.addressLoginToggle'|trans|sw_sanitize }}</strong> </a>
             </div>
         {% endblock %}
 
         {% block page_checkout_address_login %}
-            <div class="collapse" id="loginCollapse">
+            <div class="collapse{% if loginError %} show{% endif %}" id="loginCollapse">
                 {% block page_checkout_address_login_card %}
                     {% sw_include '@Storefront/storefront/component/account/login.html.twig' with {
                         cardTitle: 'account.loginHeader'|trans|sw_sanitize

--- a/tests/integration/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/integration/Storefront/Controller/RegisterControllerTest.php
@@ -311,14 +311,13 @@ class RegisterControllerTest extends TestCase
         $productNumber = 'test-checkout-login';
         $this->createProduct(Uuid::randomHex(), $productNumber);
 
-        // Put a product in the cart using the same browser session as the login request below.
+        // Add a product to the cart, then submit the checkout login form with wrong credentials.
         $this->request(
             'POST',
             '/checkout/product/add-by-number',
             $this->tokenize('frontend.checkout.product.add-by-number', ['number' => $productNumber])
         );
 
-        // Submit the checkout login form (redirectTo points into the checkout flow) with wrong credentials.
         $response = $this->request(
             'POST',
             '/account/login',
@@ -332,9 +331,8 @@ class RegisterControllerTest extends TestCase
         static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
         $content = (string) $response->getContent();
 
-        // The customer stays on the checkout register page and sees the wrong-credentials error ...
+        // Error shown on the checkout register page, with the login panel expanded.
         static::assertStringContainsString('Could not find an account', $content);
-        // ... with the otherwise-collapsed login panel expanded so the error is visible on load.
         static::assertStringContainsString('class="collapse show" id="loginCollapse"', $content);
     }
 

--- a/tests/integration/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/integration/Storefront/Controller/RegisterControllerTest.php
@@ -306,6 +306,38 @@ class RegisterControllerTest extends TestCase
         static::assertArrayHasKey(CheckoutRegisterPageLoadedHook::HOOK_NAME, $traces);
     }
 
+    public function testCheckoutLoginWithWrongCredentialsStaysOnCheckoutRegister(): void
+    {
+        $productNumber = 'test-checkout-login';
+        $this->createProduct(Uuid::randomHex(), $productNumber);
+
+        // Put a product in the cart using the same browser session as the login request below.
+        $this->request(
+            'POST',
+            '/checkout/product/add-by-number',
+            $this->tokenize('frontend.checkout.product.add-by-number', ['number' => $productNumber])
+        );
+
+        // Submit the checkout login form (redirectTo points into the checkout flow) with wrong credentials.
+        $response = $this->request(
+            'POST',
+            '/account/login',
+            $this->tokenize('frontend.account.login', [
+                'username' => 'does-not-exist@example.com',
+                'password' => 'wrong-password',
+                'redirectTo' => 'frontend.checkout.confirm.page',
+            ])
+        );
+
+        static::assertSame(200, $response->getStatusCode(), (string) $response->getContent());
+        $content = (string) $response->getContent();
+
+        // The customer stays on the checkout register page and sees the wrong-credentials error ...
+        static::assertStringContainsString('Could not find an account', $content);
+        // ... with the otherwise-collapsed login panel expanded so the error is visible on load.
+        static::assertStringContainsString('class="collapse show" id="loginCollapse"', $content);
+    }
+
     /**
      * @param array<string|int, mixed> $customerData
      */

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Storefront\Controller;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -168,7 +169,8 @@ class AuthControllerTest extends TestCase
         static::assertArrayHasKey('frontend.account.logout.page', $this->controller->redirected);
     }
 
-    public function testLoginWithBadCredentialsFromCheckoutForwardsToCheckoutRegister(): void
+    #[DataProvider('loginRedirectProvider')]
+    public function testLoginWithBadCredentialsForwardsToCorrectRoute(?string $redirectTo, string $expectedRoute): void
     {
         $loginRoute = static::createStub(AbstractLoginRoute::class);
         $loginRoute->method('login')->willThrowException(new BadCredentialsException());
@@ -179,28 +181,27 @@ class AuthControllerTest extends TestCase
         $context->assign(['customer' => null]);
 
         $request = new Request();
-        $request->request->set('redirectTo', 'frontend.checkout.confirm.page');
+        if ($redirectTo !== null) {
+            $request->request->set('redirectTo', $redirectTo);
+        }
 
         $controller->login($request, new RequestDataBag(), $context);
 
-        static::assertSame('frontend.checkout.register.page', $controller->forwardToRoute);
+        static::assertSame($expectedRoute, $controller->forwardToRoute);
         static::assertTrue($controller->forwardToRouteAttributes['loginError']);
     }
 
-    public function testLoginWithBadCredentialsFromAccountForwardsToLoginPage(): void
+    /**
+     * @return array<string, array{0: string|null, 1: string}>
+     */
+    public static function loginRedirectProvider(): array
     {
-        $loginRoute = static::createStub(AbstractLoginRoute::class);
-        $loginRoute->method('login')->willThrowException(new BadCredentialsException());
-
-        $controller = $this->createController(loginRoute: $loginRoute);
-
-        $context = Generator::generateSalesChannelContext();
-        $context->assign(['customer' => null]);
-
-        $controller->login(new Request(), new RequestDataBag(), $context);
-
-        static::assertSame('frontend.account.login.page', $controller->forwardToRoute);
-        static::assertTrue($controller->forwardToRouteAttributes['loginError']);
+        return [
+            'from checkout' => ['frontend.checkout.confirm.page', 'frontend.checkout.register.page'],
+            'unexpected route (wishlist)' => ['frontend.account.wishlist.page', 'frontend.account.login.page'],
+            'external url attack' => ['https://www.shopware.com', 'frontend.account.login.page'],
+            'empty/null fallback' => [null, 'frontend.account.login.page'],
+        ];
     }
 
     public function testGenerateAccountRecoveryThrowsConstraintException(): void

--- a/tests/unit/Storefront/Controller/AuthControllerTest.php
+++ b/tests/unit/Storefront/Controller/AuthControllerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractConvertGuestRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractImitateCustomerRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractLoginRoute;
@@ -167,6 +168,41 @@ class AuthControllerTest extends TestCase
         static::assertArrayHasKey('frontend.account.logout.page', $this->controller->redirected);
     }
 
+    public function testLoginWithBadCredentialsFromCheckoutForwardsToCheckoutRegister(): void
+    {
+        $loginRoute = static::createStub(AbstractLoginRoute::class);
+        $loginRoute->method('login')->willThrowException(new BadCredentialsException());
+
+        $controller = $this->createController(loginRoute: $loginRoute);
+
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $request = new Request();
+        $request->request->set('redirectTo', 'frontend.checkout.confirm.page');
+
+        $controller->login($request, new RequestDataBag(), $context);
+
+        static::assertSame('frontend.checkout.register.page', $controller->forwardToRoute);
+        static::assertTrue($controller->forwardToRouteAttributes['loginError']);
+    }
+
+    public function testLoginWithBadCredentialsFromAccountForwardsToLoginPage(): void
+    {
+        $loginRoute = static::createStub(AbstractLoginRoute::class);
+        $loginRoute->method('login')->willThrowException(new BadCredentialsException());
+
+        $controller = $this->createController(loginRoute: $loginRoute);
+
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+
+        $controller->login(new Request(), new RequestDataBag(), $context);
+
+        static::assertSame('frontend.account.login.page', $controller->forwardToRoute);
+        static::assertTrue($controller->forwardToRouteAttributes['loginError']);
+    }
+
     public function testGenerateAccountRecoveryThrowsConstraintException(): void
     {
         $request = new Request();
@@ -244,9 +280,10 @@ class AuthControllerTest extends TestCase
     private function createController(
         ?AccountLoginPageLoader $accountLoginPageLoader = null,
         ?AbstractSendPasswordRecoveryMailRoute $passwordRecoveryPageLoader = null,
+        ?AbstractLoginRoute $loginRoute = null,
     ): AuthControllerTestClass {
         $resetPasswordRoute = static::createStub(AbstractResetPasswordRoute::class);
-        $loginRoute = static::createStub(AbstractLoginRoute::class);
+        $loginRoute ??= static::createStub(AbstractLoginRoute::class);
         $logoutRoute = static::createStub(AbstractLogoutRoute::class);
         $imitateCustomerRoute = static::createStub(AbstractImitateCustomerRoute::class);
         $cartFacade = static::createStub(StorefrontCartFacade::class);

--- a/tests/unit/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/unit/Storefront/Controller/RegisterControllerTest.php
@@ -133,7 +133,35 @@ class RegisterControllerTest extends TestCase
         static::assertSame($dataBag, $controller->renderStorefrontParameters['data']);
         static::assertSame('frontend.checkout.confirm.page', $controller->renderStorefrontParameters['redirectTo'] ?? '');
         static::assertSame('frontend.checkout.register.page', $controller->renderStorefrontParameters['errorRoute'] ?? '');
+        static::assertFalse($controller->renderStorefrontParameters['loginError'] ?? null);
         static::assertInstanceOf(CheckoutRegisterPageLoadedHook::class, $controller->calledHook);
+    }
+
+    public function testCheckoutRegisterForwardsLoginError(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+        $context->assign(['customer' => null]);
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.checkout.register.page');
+        $request->attributes->set('loginError', true);
+        $request->attributes->set('waitTime', 5);
+        $dataBag = new RequestDataBag();
+        $page = new CheckoutRegisterPage();
+        $cart = new Cart(Uuid::randomHex());
+        $cart->add(new LineItem('test', 'test'));
+
+        $checkoutRegisterPageLoader = $this->createMock(CheckoutRegisterPageLoader::class);
+        $checkoutRegisterPageLoader->method('load')->willReturn($page);
+
+        $cartService = $this->createMock(CartService::class);
+        $cartService->method('getCart')->willReturn($cart);
+
+        $controller = $this->createController(cartService: $cartService, checkoutRegisterPageLoader: $checkoutRegisterPageLoader);
+
+        $controller->checkoutRegisterPage($request, $dataBag, $context);
+
+        static::assertTrue($controller->renderStorefrontParameters['loginError'] ?? null);
+        static::assertSame(5, $controller->renderStorefrontParameters['waitTime'] ?? null);
     }
 
     public function testCustomerGroupRegistration(): void

--- a/tests/unit/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/unit/Storefront/Controller/RegisterControllerTest.php
@@ -150,10 +150,10 @@ class RegisterControllerTest extends TestCase
         $cart = new Cart(Uuid::randomHex());
         $cart->add(new LineItem('test', 'test'));
 
-        $checkoutRegisterPageLoader = $this->createMock(CheckoutRegisterPageLoader::class);
+        $checkoutRegisterPageLoader = static::createStub(CheckoutRegisterPageLoader::class);
         $checkoutRegisterPageLoader->method('load')->willReturn($page);
 
-        $cartService = $this->createMock(CartService::class);
+        $cartService = static::createStub(CartService::class);
         $cartService->method('getCart')->willReturn($cart);
 
         $controller = $this->createController(cartService: $cartService, checkoutRegisterPageLoader: $checkoutRegisterPageLoader);


### PR DESCRIPTION




<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a guest entered wrong credentials in the login form on the checkout register page (`/checkout/register`), `AuthController::login()` always forwarded to the standalone account login page, throwing the customer out of the checkout flow; a subsequent successful login then landed on `/account` instead of continuing checkout

### 2. What does this change do, exactly?
`login()` now detects a checkout origin from the submitted redirectTo and forwards the failed login back to `frontend.checkout.register.page`. `checkoutRegisterPage()` passes `loginError/errorSnippet/waitTime` to the view so the error renders inline, and the otherwise-collapsed login panel is expanded when a login error occurred so it is visible on load
<img width="1400" height="2200" alt="image" src="https://github.com/user-attachments/assets/1ed985be-276d-4ada-989c-ea9034523f35" />

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #18461 
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfilled them
