### PR TITLE
test: move Kernel container-dump tests to the integration suite

### DIFF
--- a/tests/integration/Core/KernelTest.php
+++ b/tests/integration/Core/KernelTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Covers the artifacts `Shopware\Core\Kernel::dumpContainer()` writes next to the generated cache
+ * folder. Both tests compile a real container, so they redirect the cache root away from the
+ * project's `var/cache` via `APP_CACHE_DIR` and boot their own kernel.
+ *
+ * @internal
+ */
+#[Package('framework')]
+class KernelTest extends TestCase
+{
+    use EnvTestBehaviour;
+
+    private string $appCacheDir;
+
+    /**
+     * `Kernel` derives this from `APP_CACHE_DIR` and writes both artifacts directly into it.
+     */
+    private string $cacheRootDir;
+
+    private Filesystem $filesystem;
+
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->appCacheDir = sys_get_temp_dir() . '/shopware-kernel-test-' . bin2hex(random_bytes(8));
+        $this->cacheRootDir = $this->appCacheDir . '/var/cache';
+
+        $this->setEnvVars(['APP_CACHE_DIR' => $this->appCacheDir]);
+    }
+
+    protected function tearDown(): void
+    {
+        // without this the redirected APP_CACHE_DIR leaks into every later test in the same process
+        $this->resetEnvVars();
+        $this->filesystem->remove($this->appCacheDir);
+    }
+
+    public function testBootDumpsCacheDirTagAndOpcachePreloadFile(): void
+    {
+        $kernel = KernelLifecycleManager::createKernel();
+
+        try {
+            $kernel->boot();
+
+            static::assertFileExists($this->cacheRootDir . '/CACHEDIR.TAG');
+
+            // the dumped container lives in a `ContainerXXXXXXX` sub namespace, its short name is the container class
+            $containerClass = basename(str_replace('\\', '/', $kernel->getContainer()::class));
+            $preloadedFile = basename($kernel->getCacheDir()) . '/' . $containerClass . '.preload.php';
+
+            static::assertSame(
+                "<?php\n\nrequire_once __DIR__ . '/" . $preloadedFile . '\';',
+                (string) file_get_contents($this->cacheRootDir . '/opcache-preload.php')
+            );
+
+            // `__DIR__` of the preload file is the cache root, so the relative require must resolve
+            static::assertFileExists($this->cacheRootDir . '/' . $preloadedFile);
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+
+    public function testBootIntoAWarmupCacheDirSkipsTheOpcachePreloadFile(): void
+    {
+        $kernel = KernelLifecycleManager::createKernel();
+
+        try {
+            // `reboot()` is how `cache:clear` warms up a container: the trailing underscore marks the
+            // build directory as a warmup directory and becomes the `kernel.cache_dir` parameter
+            $kernel->reboot($kernel->getCacheDir() . '_');
+
+            static::assertFileExists($this->cacheRootDir . '/CACHEDIR.TAG');
+            static::assertFileDoesNotExist($this->cacheRootDir . '/opcache-preload.php');
+        } finally {
+            $kernel->shutdown();
+        }
+    }
+}

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -11,88 +11,44 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Kernel;
-use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Routing\Loader\PhpFileLoader;
 use Symfony\UX\TwigComponent\TwigComponentBundle;
 
 /**
+ * The container dumping side of the kernel is covered by
+ * \Shopware\Tests\Integration\Core\KernelTest, as it requires a real boot.
+ *
  * @internal
  */
 #[Package('framework')]
 #[CoversClass(Kernel::class)]
 class KernelTest extends TestCase
 {
-    private string $tmpProjectDir;
+    /**
+     * A path that is never touched: the tests below only compose strings from it.
+     */
+    private const PROJECT_DIR = '/project-dir';
 
-    private Filesystem $filesystem;
+    private const PROJECT_WITHOUT_TWIG_COMPONENT_BUNDLE = __DIR__ . '/_fixtures/Kernel/project-without-twig-component-bundle';
 
-    protected function setUp(): void
-    {
-        $this->tmpProjectDir = __DIR__ . '/tmpToBeRemoved';
-        $this->filesystem = new Filesystem();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->filesystem->remove($this->tmpProjectDir);
-    }
+    private const PROJECT_WITH_TWIG_COMPONENT_BUNDLE = __DIR__ . '/_fixtures/Kernel/project-with-twig-component-bundle';
 
     public function testGetCacheDir(): void
     {
-        static::assertStringStartsWith($this->tmpProjectDir . '/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
-    }
-
-    public function testDumpContainerDumpsPreloadFile(): void
-    {
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc');
-        $containerBuilder->compile();
-
-        (new \ReflectionMethod(Kernel::class, 'dumpContainer'))->invoke(
-            $this->createKernel(),
-            new ConfigCache($this->tmpProjectDir . '/cache-file', true),
-            $containerBuilder,
-            'Shopware_Core_KernelDevDebugContainer',
-            'Container',
-        );
-
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
-    }
-
-    public function testDumpContainerDoesNotDumpPreloadFileIfWarmupCacheDirIsGiven(): void
-    {
-        $containerBuilder = new ContainerBuilder();
-        // An underscore at the end indicates a warmup cache directory
-        $containerBuilder->setParameter('kernel.cache_dir', $this->tmpProjectDir . '/var/cache/fooBar_h123abc_');
-        $containerBuilder->compile();
-
-        (new \ReflectionMethod(Kernel::class, 'dumpContainer'))->invoke(
-            $this->createKernel(),
-            new ConfigCache($this->tmpProjectDir . '/cache', true),
-            $containerBuilder,
-            'Shopware_Core_KernelDevDebugContainer',
-            'Container',
-        );
-
-        static::assertTrue($this->filesystem->exists($this->tmpProjectDir . '/var/cache/CACHEDIR.TAG'));
-
-        // Do not create the preload file in warmup cache
-        static::assertFalse($this->filesystem->exists($this->tmpProjectDir . '/var/cache/opcache-preload.php'));
+        static::assertStringStartsWith(self::PROJECT_DIR . '/var/cache/fooBar_h', $this->createKernel()->getCacheDir());
     }
 
     public function testRegisterBundlesAutoAddsTwigComponentBundleWhenMissingPreV68(): void
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
 
-        $this->writeBundlesConfig([]);
         $this->expectUserDeprecationMessageMatches('/TwigComponentBundle bundle should be added/');
 
-        $bundles = iterator_to_array($this->createKernel()->registerBundles());
+        $kernel = $this->createKernel(projectDir: self::PROJECT_WITHOUT_TWIG_COMPONENT_BUNDLE);
+
+        $bundles = iterator_to_array($kernel->registerBundles());
 
         static::assertSame([TwigComponentBundle::class], array_values(array_map(
             static fn (object $bundle): string => $bundle::class,
@@ -104,11 +60,9 @@ class KernelTest extends TestCase
     {
         Feature::skipTestIfActive('v6.8.0.0', $this);
 
-        $this->writeBundlesConfig([
-            TwigComponentBundle::class => ['all' => true],
-        ]);
+        $kernel = $this->createKernel(projectDir: self::PROJECT_WITH_TWIG_COMPONENT_BUNDLE);
 
-        $bundles = iterator_to_array($this->createKernel()->registerBundles());
+        $bundles = iterator_to_array($kernel->registerBundles());
 
         static::assertSame([TwigComponentBundle::class], array_values(array_map(
             static fn (object $bundle): string => $bundle::class,
@@ -118,7 +72,7 @@ class KernelTest extends TestCase
 
     public function testConfigureRoutesImportsProjectRoutesScopedToEnvironment(): void
     {
-        $confDir = $this->tmpProjectDir . '/config';
+        $confDir = self::PROJECT_DIR . '/config';
 
         $captured = $this->captureRouteImports('test');
 
@@ -129,7 +83,7 @@ class KernelTest extends TestCase
 
     public function testConfigureRoutesDoesNotImportForeignEnvironmentGlobs(): void
     {
-        $confDir = $this->tmpProjectDir . '/config';
+        $confDir = self::PROJECT_DIR . '/config';
 
         $captured = $this->captureRouteImports('prod');
 
@@ -137,7 +91,7 @@ class KernelTest extends TestCase
         static::assertNotContains([$confDir . '/{routes}/test/**/*' . Kernel::CONFIG_EXTS, 'glob'], $captured);
     }
 
-    private function createKernel(string $environment = 'fooBar'): Kernel
+    private function createKernel(string $environment = 'fooBar', string $projectDir = self::PROJECT_DIR): Kernel
     {
         return new Kernel(
             $environment,
@@ -146,7 +100,7 @@ class KernelTest extends TestCase
             'cacheId',
             '6.6.6',
             static::createStub(Connection::class),
-            $this->tmpProjectDir,
+            $projectDir,
         );
     }
 
@@ -175,18 +129,5 @@ class KernelTest extends TestCase
         $this->createKernel($environment)->loadRoutes($loader);
 
         return $captured;
-    }
-
-    /**
-     * @param array<string, array<string, bool>> $bundles
-     */
-    private function writeBundlesConfig(array $bundles): void
-    {
-        $configDir = $this->tmpProjectDir . '/config';
-        $this->filesystem->mkdir($configDir);
-        $this->filesystem->dumpFile(
-            $configDir . '/bundles.php',
-            "<?php\n\nreturn " . var_export($bundles, true) . ";\n"
-        );
     }
 }

--- a/tests/unit/Core/_fixtures/Kernel/project-with-twig-component-bundle/config/bundles.php
+++ b/tests/unit/Core/_fixtures/Kernel/project-with-twig-component-bundle/config/bundles.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+
+return [
+    TwigComponentBundle::class => ['all' => true],
+];

--- a/tests/unit/Core/_fixtures/Kernel/project-without-twig-component-bundle/config/bundles.php
+++ b/tests/unit/Core/_fixtures/Kernel/project-without-twig-component-bundle/config/bundles.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+return [];


### PR DESCRIPTION
### 1. Why is this change necessary?

Four of the seven tests in `tests/unit/Core/KernelTest.php` were not unit tests: two compiled a real container and asserted on real files on disk, and two wrote a config file into the test tree at runtime.

### 2. What does this change do, exactly?

- The two `dumpContainer` tests move to a new `tests/integration/Core/KernelTest.php`, where they boot a real kernel with `APP_CACHE_DIR` redirected to a throwaway directory. This drops the last reflection in the file, and the preload assertion now checks the file contents instead of its mere existence.
- The warmup-directory case uses the public `Kernel::reboot($warmupDir)`, the same entry point `cache:clear` uses.
- The two `registerBundles` tests now read committed `_fixtures` project directories instead of writing `config/bundles.php` at runtime.
- Nothing in the unit file writes to disk any more, so the `Filesystem` helper and its `tearDown()` are gone.

`tests/unit/Core/KernelTest.php` keeps `testGetCacheDir` and the two `configureRoutes` tests, which are genuinely unit: pure string composition and stubbed loaders.

### 3. Describe each step to reproduce the issue or behaviour.

`docker compose exec web vendor/bin/phpunit tests/unit/Core/KernelTest.php` passes in 0.1s, and `tests/integration/Core/KernelTest.php` passes in about 7s, the cost of the two container compiles. Running the new integration file together with a sibling integration test confirms the redirected `APP_CACHE_DIR` does not leak between tests.

### 4. Please link to the relevant issues (if any).

relates #18728

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)