### PR TITLE
test(checkout): replace reflection on non-public methods with public-API assertions

### DIFF
--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -471,7 +471,7 @@ class RecalculationServiceTest extends TestCase
         static::assertSame($this->getDeDeLanguageId(), $order->getLanguageId());
     }
 
-    public function testFetchOrder(): void
+    public function testRecalculateLiveVersionIsNotAllowed(): void
     {
         // create order
         $cart = $this->generateDemoCart();
@@ -479,11 +479,7 @@ class RecalculationServiceTest extends TestCase
 
         $this->expectExceptionObject(OrderException::canNotRecalculateLiveVersion($orderId));
 
-        $service = static::getContainer()->get(RecalculationService::class);
-
-        (new \ReflectionClass($service))
-            ->getMethod('fetchOrder')
-            ->invoke($service, $orderId, $this->context);
+        static::getContainer()->get(RecalculationService::class)->recalculate($orderId, $this->context);
     }
 
     public function testRecalculationWithDeletedCustomer(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Tests in this domain invoked private and protected methods via reflection, coupling them to implementation details instead of behaviour.

### 2. What does this change do, exactly?

- `RecalculationServiceTest` reaches the order lookup through the public `recalculate()`, which starts with that lookup, so the expected exception still pins message and code.
- No reflection on non-public methods remains in this file.

No production code is touched.

### 3. Describe each step to reproduce the issue or behaviour.

The touched file passes in Docker.

### 4. Please link to the relevant issues (if any).

relates #18723

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)