### PR TITLE
ci: skip the Codecov upload when PHPUnit never ran

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,14 +98,17 @@ jobs:
           php-version: ${{ matrix.php }}
           needs-opensearch: ${{ contains(matrix.test.path, 'Elasticsearch') }}
       - name: Run PHPUnit
+        id: phpunit
         uses: ./.github/actions/phpunit-run
         with:
           test-path: ${{ matrix.test.path }}
           test-testsuite: ${{ matrix.test.testsuite }}
       - name: Upload test results to Codecov
         uses: ./.github/actions/phpunit-upload
-        # !cancelled(): junit test results must upload even when the run failed
-        if: ${{ !cancelled() }}
+        # !cancelled(): junit test results must upload even when the run failed.
+        # conclusion != 'skipped': but not when PHPUnit never ran (e.g. service container setup
+        # failed), because then checkout never ran either and this local action cannot resolve.
+        if: ${{ !cancelled() && steps.phpunit.conclusion != 'skipped' }}
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -334,14 +334,17 @@ jobs:
         if: ${{ matrix.suite == 'unit' }}
         run: composer install -d vendor-bin/danger-php --no-interaction
       - name: Run PHPUnit with coverage
+        id: phpunit
         uses: ./.github/actions/phpunit-run
         with:
           test-testsuite: ${{ matrix.suite }}
           coverage: "true"
       - name: Upload coverage and test results to Codecov
         uses: ./.github/actions/phpunit-upload
-        # !cancelled(): junit test results must upload even when the run failed
-        if: ${{ !cancelled() }}
+        # !cancelled(): junit test results must upload even when the run failed.
+        # conclusion != 'skipped': but not when PHPUnit never ran (e.g. service container setup
+        # failed), because then checkout never ran either and this local action cannot resolve.
+        if: ${{ !cancelled() && steps.phpunit.conclusion != 'skipped' }}
         with:
           coverage: "true"
           coverage-flags: phpunit-${{ matrix.suite }}


### PR DESCRIPTION
### 1. Why is this change necessary?

When a PHPUnit matrix job dies during `Initialize containers`, GitHub skips every remaining step, **including `Checkout`**. The Codecov upload step carried a bare `if: ${{ !cancelled() }}`, so it fired anyway, against an empty workspace, and failed with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/shopware/shopware/.github/actions/phpunit-upload'.
Did you forget to run actions/checkout before running your local action?
```

That message is the only thing visible at the bottom of the job, and it points at the wrong thing entirely. It reads like a broken workflow definition or a missing action, when the real cause is one step higher up and unrelated.

Seen on PR #18713, job [`8.5 devops mariadb:11`](https://github.com/shopware/shopware/actions/runs/30338009296/job/90207175706), where the actual failure was a transient Docker Hub outage:

```
/usr/bin/docker pull alpine
Error response from daemon: Get "https://registry-1.docker.io/v2/":
net/http: request canceled while waiting for connection (Client.Timeout exceeded)
```

Three retries, all timed out. Nothing to do with the PR under test, but the reported error sent the investigation in the wrong direction.

### 2. What does this change do, exactly?

Adds `id: phpunit` to the PHPUnit step and gates the upload on that step not being skipped:

```yaml
if: ${{ !cancelled() && steps.phpunit.conclusion != 'skipped' }}
```

Applied in both places that use `./.github/actions/phpunit-upload` behind service containers:

- `.github/workflows/integration.yml` — the `phpunit` integration matrix
- `.github/workflows/php.yml` — the unit/migration coverage matrix

Uploading on **test failure** is deliberately preserved and unaffected: a run whose tests failed has conclusion `failure`, not `skipped`. Only a run that never executed is `skipped`. So junit results still reach Codecov Test Analytics on red tests, which is the whole point of the `!cancelled()` guard.

The failing job stays red either way. The difference is that its last error is now the genuine one.

### 3. Describe each step to reproduce the issue or behaviour.

The trigger is an infrastructure flake and cannot be forced on demand, but the mechanics are deterministic:

1. Any job in the `phpunit` matrix fails at `Initialize containers` (image pull timeout, unhealthy service, registry outage).
2. `Checkout`, `Setup and install Shopware` and `Run PHPUnit` are all reported as skipped.
3. Before: `Upload test results to Codecov` runs regardless and fails with the misleading `Can't find 'action.yml'` error.
4. After: the upload step is skipped too, and the job's only error is the container-setup failure.

Normal runs are unchanged. Verified against the checks on this PR: the upload steps still execute and stay green.

### 4. Please link to the relevant issues (if any).

Surfaced while triaging CI on #18713. No tracked issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
  - CI-only change to workflow conditions; there is no test surface for GitHub Actions `if:` expressions in this repo. `composer lint:actions` covers it.
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  - Not developer-facing: no runtime, API, or extension-point impact.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
  - The `conclusion != 'skipped'` guard is non-obvious, so the reason is spelled out inline next to it.
- [x] I have read the contribution requirements and fulfilled them