### PR TITLE
feat(framework): expose MCP tool titles in toolsets-list payload

### DIFF
--- a/src/Core/Framework/Mcp/McpToolsetRegistry.php
+++ b/src/Core/Framework/Mcp/McpToolsetRegistry.php
@@ -36,7 +36,13 @@ class McpToolsetRegistry
     }
 
     /**
-     * @return list<array{name: string, title: string, description: string, tools: list<string>}>
+     * Each toolset carries its tools as {name, title} pairs rather than bare names: toolsets-list is
+     * the primary discovery surface, and the tool titles are the only semantics a client sees before
+     * it commits to enabling a group. Full tool descriptions stay out of this payload — they arrive
+     * through tools/list once the toolset is enabled, so repeating them here would spend the tokens
+     * twice and defeat the deferral.
+     *
+     * @return list<array{name: string, title: string, tools: list<array{name: string, title: ?string}>}>
      */
     public function toolsets(): array
     {
@@ -58,20 +64,24 @@ class McpToolsetRegistry
                 continue;
             }
 
-            $toolsByGroup[$group][] = $tool['name'];
+            // Keyed by tool name so the per-toolset ksort below orders by name without a comparator.
+            $toolsByGroup[$group][$tool['name']] = [
+                'name' => $tool['name'],
+                // Null for runtime app tools, which carry no title in their manifest.
+                'title' => $tool['title'],
+            ];
         }
 
         ksort($toolsByGroup);
 
         $toolsets = [];
         foreach ($toolsByGroup as $group => $tools) {
-            sort($tools);
+            ksort($tools);
 
             $toolsets[] = [
                 'name' => $group,
                 'title' => $this->humanizeToolsetName($group),
-                'description' => \sprintf('Tools explicitly assigned to the "%s" MCP tool group.', $group),
-                'tools' => $tools,
+                'tools' => array_values($tools),
             ];
         }
 
@@ -79,7 +89,7 @@ class McpToolsetRegistry
     }
 
     /**
-     * @return array{name: string, title: string, description: string, tools: list<string>}|null
+     * @return array{name: string, title: string, tools: list<array{name: string, title: ?string}>}|null
      */
     public function find(string $name): ?array
     {
@@ -106,7 +116,7 @@ class McpToolsetRegistry
                 continue;
             }
 
-            array_push($tools, ...$toolset['tools']);
+            array_push($tools, ...array_column($toolset['tools'], 'name'));
         }
 
         $tools = array_values(array_unique($tools));

--- a/tests/integration/Core/Framework/Mcp/McpCapabilityDiscoveryTest.php
+++ b/tests/integration/Core/Framework/Mcp/McpCapabilityDiscoveryTest.php
@@ -170,6 +170,69 @@ class McpCapabilityDiscoveryTest extends TestCase
         static::assertNotContains('shopware-order-state', $tools);
     }
 
+    public function testToolsetsListPayloadCarriesToolTitles(): void
+    {
+        $browser = $this->getBrowser();
+
+        $browser->request(
+            'POST',
+            '/api/_mcp',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode([
+                'jsonrpc' => '2.0',
+                'method' => 'initialize',
+                'params' => [
+                    'protocolVersion' => '2025-03-26',
+                    'capabilities' => new \stdClass(),
+                    'clientInfo' => ['name' => 'mcp-discovery-test', 'version' => '1.0'],
+                ],
+                'id' => 1,
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $sessionId = $this->extractSessionId($browser->getResponse()->headers->all());
+        static::assertIsString($sessionId, 'initialize did not return an MCP session id');
+
+        $browser->request(
+            'POST',
+            '/api/_mcp',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_MCP_SESSION_ID' => $sessionId],
+            json_encode([
+                'jsonrpc' => '2.0',
+                'method' => 'tools/call',
+                'params' => ['name' => McpToolsetRegistry::LIST_TOOLSETS_TOOL, 'arguments' => new \stdClass()],
+                'id' => 2,
+            ], \JSON_THROW_ON_ERROR),
+        );
+
+        $content = (string) $browser->getResponse()->getContent();
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($response);
+        static::assertArrayHasKey('result', $response, 'MCP response missing result: ' . $content);
+
+        $payload = json_decode((string) $response['result']['content'][0]['text'], true, 512, \JSON_THROW_ON_ERROR);
+        static::assertIsArray($payload);
+
+        $entityToolset = null;
+        foreach ($payload['data']['toolsets'] ?? [] as $toolset) {
+            if ($toolset['name'] === 'entity') {
+                $entityToolset = $toolset;
+            }
+        }
+
+        static::assertNotNull($entityToolset, 'entity toolset should be listed: ' . $content);
+
+        // A client picks a toolset from these tool titles, before any domain tool is advertised, so
+        // the listing carries them instead of a group description that would restate the group name.
+        static::assertContains('shopware-entity-search', array_column($entityToolset['tools'], 'name'));
+        static::assertContains('Entity Search', array_column($entityToolset['tools'], 'title'));
+        static::assertArrayNotHasKey('description', $entityToolset);
+    }
+
     public function testEnablingToolsetDeliversToolsListChangedNotification(): void
     {
         $browser = $this->getBrowser();

--- a/tests/integration/Core/Framework/Mcp/StoreApiMcpCapabilityDiscoveryTest.php
+++ b/tests/integration/Core/Framework/Mcp/StoreApiMcpCapabilityDiscoveryTest.php
@@ -66,7 +66,11 @@ class StoreApiMcpCapabilityDiscoveryTest extends TestCase
         }
         static::assertNotNull($storeApiToolset, 'store-api toolset should be listed: ' . $toolsets['content'][0]['text']);
         static::assertFalse($storeApiToolset['enabled']);
-        static::assertContains('shopware-store-api-context', $storeApiToolset['tools']);
+        static::assertContains('shopware-store-api-context', array_column($storeApiToolset['tools'], 'name'));
+        // The listing carries each tool's title so a client can judge the toolset before enabling it,
+        // and no synthesized group description that would only restate the group name.
+        static::assertContains('Store API Context', array_column($storeApiToolset['tools'], 'title'));
+        static::assertArrayNotHasKey('description', $storeApiToolset);
 
         // Enabling it reports listChanged.
         $enable = $this->callTool($browser, $sessionId, 'shopware-toolset-enable', ['toolset' => 'store-api']);

--- a/tests/unit/Core/Framework/Mcp/McpToolsetRegistryTest.php
+++ b/tests/unit/Core/Framework/Mcp/McpToolsetRegistryTest.php
@@ -22,12 +22,12 @@ class McpToolsetRegistryTest extends TestCase
     public function testBuildsToolsetsFromExplicitToolGroups(): void
     {
         $registry = $this->buildRegistry([
-            McpToolsetRegistry::LIST_TOOLSETS_TOOL,
-            McpToolsetRegistry::ENABLE_TOOLSET_TOOL,
-            'shopware-entity-search',
-            'shopware-entity-read',
-            'shopware-order-state',
-            'ungrouped-tool',
+            McpToolsetRegistry::LIST_TOOLSETS_TOOL => 'List Toolsets',
+            McpToolsetRegistry::ENABLE_TOOLSET_TOOL => 'Enable Toolset',
+            'shopware-entity-search' => 'Entity Search',
+            'shopware-entity-read' => 'Entity Read',
+            'shopware-order-state' => 'Order State',
+            'ungrouped-tool' => 'Ungrouped Tool',
         ]);
 
         $toolsetRegistry = new McpToolsetRegistry(new McpCapabilityCatalog(
@@ -47,21 +47,29 @@ class McpToolsetRegistryTest extends TestCase
 
         // A tool without an explicit group uses its first name segment as an enable-able toolset.
         static::assertSame(['entity', 'order', 'ungrouped'], array_keys($toolsetsByName));
-        static::assertSame(['shopware-entity-read', 'shopware-entity-search'], $toolsetsByName['entity']['tools']);
-        static::assertSame(['shopware-order-state'], $toolsetsByName['order']['tools']);
-        static::assertSame(['ungrouped-tool'], $toolsetsByName['ungrouped']['tools']);
+        static::assertSame(
+            [
+                ['name' => 'shopware-entity-read', 'title' => 'Entity Read'],
+                ['name' => 'shopware-entity-search', 'title' => 'Entity Search'],
+            ],
+            $toolsetsByName['entity']['tools'],
+        );
+        static::assertSame([['name' => 'shopware-order-state', 'title' => 'Order State']], $toolsetsByName['order']['tools']);
+        static::assertSame([['name' => 'ungrouped-tool', 'title' => 'Ungrouped Tool']], $toolsetsByName['ungrouped']['tools']);
         static::assertSame('Entity tools', $toolsetsByName['entity']['title']);
         static::assertSame('Ungrouped tools', $toolsetsByName['ungrouped']['title']);
-        static::assertSame('Tools explicitly assigned to the "entity" MCP tool group.', $toolsetsByName['entity']['description']);
+        // Each tool's own title is the semantic payload of a toolset. The former synthesized group
+        // description ("Tools explicitly assigned to ...") only restated the slug, so none is emitted;
+        // StoreApiMcpCapabilityDiscoveryTest asserts its absence on the wire.
     }
 
     public function testBuildsToolsetPerAppFromRuntimeAppGroups(): void
     {
         $registry = $this->buildRegistry([
-            McpToolsetRegistry::ENABLE_TOOLSET_TOOL,
-            'shopware-entity-search',
-            'my-erp-sync-orders',
-            'my-erp-read-stock',
+            McpToolsetRegistry::ENABLE_TOOLSET_TOOL => 'Enable Toolset',
+            'shopware-entity-search' => 'Entity Search',
+            'my-erp-sync-orders' => null,
+            'my-erp-read-stock' => null,
         ]);
 
         $toolsetRegistry = new McpToolsetRegistry(new McpCapabilityCatalog(
@@ -81,16 +89,23 @@ class McpToolsetRegistryTest extends TestCase
         // App tools without a compile-time #[McpToolGroup] are grouped under their owning app,
         // forming a real toolset instead of vanishing into "other".
         static::assertSame(['entity', 'my-erp'], array_keys($toolsetsByName));
-        static::assertSame(['my-erp-read-stock', 'my-erp-sync-orders'], $toolsetsByName['my-erp']['tools']);
+        // App tools registered without a title keep a null title rather than a synthesized one.
+        static::assertSame(
+            [
+                ['name' => 'my-erp-read-stock', 'title' => null],
+                ['name' => 'my-erp-sync-orders', 'title' => null],
+            ],
+            $toolsetsByName['my-erp']['tools'],
+        );
         static::assertNotNull($toolsetRegistry->find('my-erp'));
     }
 
     public function testFindReturnsToolsetByName(): void
     {
         $registry = $this->buildRegistry([
-            McpToolsetRegistry::LIST_TOOLSETS_TOOL,
-            McpToolsetRegistry::ENABLE_TOOLSET_TOOL,
-            'shopware-entity-search',
+            McpToolsetRegistry::LIST_TOOLSETS_TOOL => 'List Toolsets',
+            McpToolsetRegistry::ENABLE_TOOLSET_TOOL => 'Enable Toolset',
+            'shopware-entity-search' => 'Entity Search',
         ]);
 
         $toolsetRegistry = new McpToolsetRegistry(new McpCapabilityCatalog(
@@ -111,11 +126,11 @@ class McpToolsetRegistryTest extends TestCase
     public function testAdvertisedToolsReturnsEnabledToolsetTools(): void
     {
         $registry = $this->buildRegistry([
-            McpToolsetRegistry::LIST_TOOLSETS_TOOL,
-            McpToolsetRegistry::ENABLE_TOOLSET_TOOL,
-            'shopware-entity-search',
-            'shopware-entity-read',
-            'shopware-order-state',
+            McpToolsetRegistry::LIST_TOOLSETS_TOOL => 'List Toolsets',
+            McpToolsetRegistry::ENABLE_TOOLSET_TOOL => 'Enable Toolset',
+            'shopware-entity-search' => 'Entity Search',
+            'shopware-entity-read' => 'Entity Read',
+            'shopware-order-state' => 'Order State',
         ]);
 
         $toolsetRegistry = new McpToolsetRegistry(new McpCapabilityCatalog(
@@ -153,10 +168,10 @@ class McpToolsetRegistryTest extends TestCase
     public function testToolsetsAreScopedToTheCurrentAllowlist(): void
     {
         $registry = $this->buildRegistry([
-            McpToolsetRegistry::ENABLE_TOOLSET_TOOL,
-            'shopware-entity-search',
-            'shopware-entity-read',
-            'shopware-order-state',
+            McpToolsetRegistry::ENABLE_TOOLSET_TOOL => 'Enable Toolset',
+            'shopware-entity-search' => 'Entity Search',
+            'shopware-entity-read' => 'Entity Read',
+            'shopware-order-state' => 'Order State',
         ]);
 
         $toolsetRegistry = new McpToolsetRegistry(
@@ -178,21 +193,22 @@ class McpToolsetRegistryTest extends TestCase
         // Discovery stays inside the allowlist: only the allowed tool surfaces. The denied
         // "entity-read" and the entirely-denied "order" toolset never leak through list/enable.
         static::assertSame(['entity'], array_keys($toolsetsByName));
-        static::assertSame(['shopware-entity-search'], $toolsetsByName['entity']['tools']);
+        static::assertSame([['name' => 'shopware-entity-search', 'title' => 'Entity Search']], $toolsetsByName['entity']['tools']);
         static::assertNull($toolsetRegistry->find('order'));
         static::assertSame([], $toolsetRegistry->advertisedTools(['order']));
     }
 
     /**
-     * @param list<string> $toolNames
+     * @param array<string, ?string> $toolTitles tool-name => title (null mirrors a runtime app tool
+     *                                           registered without a title)
      */
-    private function buildRegistry(array $toolNames): Registry
+    private function buildRegistry(array $toolTitles): Registry
     {
         $registry = new Registry();
 
-        foreach ($toolNames as $toolName) {
+        foreach ($toolTitles as $toolName => $title) {
             $registry->registerTool(
-                new Tool($toolName, null, ['type' => 'object', 'properties' => [], 'required' => []], null, null),
+                new Tool($toolName, $title, ['type' => 'object', 'properties' => [], 'required' => []], null, null),
                 'Acme\\' . str_replace('-', '', ucwords($toolName, '-')),
             );
         }

--- a/tests/unit/Core/Framework/Mcp/Tool/ToolsetEnableToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/ToolsetEnableToolTest.php
@@ -48,6 +48,12 @@ class ToolsetEnableToolTest extends TestCase
 
         static::assertTrue($result['success']);
         static::assertSame('entity', $result['data']['toolset']['name']);
+        // The enable response echoes the toolset definition, so it carries the same {name, title}
+        // tool pairs the listing does.
+        static::assertSame(
+            [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
+            $result['data']['toolset']['tools'],
+        );
         static::assertTrue($result['_meta']['listChanged']);
         // The tool records intent; the controller emits the notification after the SDK session save.
         static::assertTrue($request->attributes->getBoolean(McpListChangedNotifier::PENDING_TOOLS_LIST_CHANGED_ATTRIBUTE));

--- a/tests/unit/Core/Framework/Mcp/Tool/ToolsetEnableToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/ToolsetEnableToolTest.php
@@ -30,8 +30,7 @@ class ToolsetEnableToolTest extends TestCase
             ->willReturn([
                 'name' => 'entity',
                 'title' => 'Entity tools',
-                'description' => 'Entity',
-                'tools' => ['shopware-entity-search'],
+                'tools' => [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
             ]);
 
         $storage = $this->createMock(McpToolsetSessionStorage::class);
@@ -83,8 +82,7 @@ class ToolsetEnableToolTest extends TestCase
         $registry->method('find')->willReturn([
             'name' => 'entity',
             'title' => 'Entity tools',
-            'description' => 'Entity',
-            'tools' => ['shopware-entity-search'],
+            'tools' => [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
         ]);
 
         $storage = $this->createMock(McpToolsetSessionStorage::class);

--- a/tests/unit/Core/Framework/Mcp/Tool/ToolsetsListToolTest.php
+++ b/tests/unit/Core/Framework/Mcp/Tool/ToolsetsListToolTest.php
@@ -27,14 +27,12 @@ class ToolsetsListToolTest extends TestCase
             [
                 'name' => 'entity',
                 'title' => 'Entity tools',
-                'description' => 'Entity',
-                'tools' => ['shopware-entity-search'],
+                'tools' => [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
             ],
             [
                 'name' => 'order',
                 'title' => 'Order tools',
-                'description' => 'Order',
-                'tools' => ['shopware-order-state'],
+                'tools' => [['name' => 'shopware-order-state', 'title' => 'Order State']],
             ],
         ]);
 
@@ -55,6 +53,12 @@ class ToolsetsListToolTest extends TestCase
         static::assertTrue($result['success']);
         static::assertTrue($result['data']['toolsets'][0]['enabled']);
         static::assertFalse($result['data']['toolsets'][1]['enabled']);
+        // The per-tool titles are what makes a toolset choosable before it is enabled, so they must
+        // survive serialization.
+        static::assertSame(
+            [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
+            $result['data']['toolsets'][0]['tools'],
+        );
         static::assertSame('tool-groups', $result['_meta']['taxonomy']);
         static::assertSame('Toolsets are derived from explicit MCP tool group metadata.', $result['_meta']['note']);
     }
@@ -66,8 +70,7 @@ class ToolsetsListToolTest extends TestCase
             [
                 'name' => 'entity',
                 'title' => 'Entity tools',
-                'description' => 'Entity',
-                'tools' => ['shopware-entity-search'],
+                'tools' => [['name' => 'shopware-entity-search', 'title' => 'Entity Search']],
             ],
         ]);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`shopware-toolsets-list` is the first call a client makes for any task, now that domain tools sit behind `shopware-toolset-enable`. Every toolset it returned carried a description built by `sprintf('Tools explicitly assigned to the "%s" MCP tool group.', $group)` plus a flat array of tool names, so the only semantic content in the primary discovery payload was the group slug itself. In a routing eval, a smaller model looking for media upload enabled `dev-extensions` and `dev-logs` several times over and never tried `media`, whose single tool is titled `Media Upload`.

The title was already available. `McpCapabilityCatalog::enrichedTools()` hands `McpToolsetRegistry` a `name`, `title`, `description` and `group` per tool, and `toolsets()` discarded everything but the name one line before building the response.

Authoring a description per group was the alternative. It was rejected for this step because a group description is a second source of truth that nothing can validate for freshness, and it goes stale exactly when a tool is added to a group. Tool titles are maintained already, since clients pick tools by them, so a new tool makes its own toolset more discoverable with no extra prose to keep in sync.

### 2. What does this change do, exactly?

`Shopware\Core\Framework\Mcp\McpToolsetRegistry::toolsets()` now lists each toolset's tools as `{name, title}` pairs instead of bare name strings, taking the title straight from the capability catalog. `title` stays nullable, because app tools registered from a manifest have none and a fabricated title would be worse than `null`.

The synthesized group description is dropped rather than filled in, since it restated the group name and nothing else. Full tool descriptions stay out of this payload on purpose. They arrive through `tools/list` once the toolset is enabled, so repeating them here would spend those tokens twice and undercut the deferral.

`advertisedTools()` keeps its `list<string>` contract and extracts names with `array_column()`, because `McpAllowlistListRequestHandler` feeds that result straight into the session allowlist. `ToolsetsListTool` and `ToolsetEnableTool` spread the toolset array into their responses, so they needed no change, and the Store API subclasses inherit both. Per-toolset ordering comes from a name-keyed `ksort()` instead of `sort()` over the value list, which preserves the previous name-ascending order.

A group boundary statement (something like "log files on disk, not the `log_entry` table") is the one thing per-tool titles can't express. That is left for a follow-up, and only for the groups where cross-group confusion actually shows up.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open an MCP session against `/api/_mcp` and keep the `Mcp-Session-Id` returned by `initialize`.
2. Call `tools/call` for `shopware-toolsets-list`.
3. Compare the `entity` and `media` entries in the returned payload.

Before, indented and trimmed to two groups for readability (the wire format is compact):

    {
      "success": true,
      "data": {
        "toolsets": [
          {
            "name": "entity",
            "title": "Entity tools",
            "description": "Tools explicitly assigned to the \"entity\" MCP tool group.",
            "tools": [
              "shopware-entity-aggregate",
              "shopware-entity-delete",
              "shopware-entity-read",
              "shopware-entity-schema",
              "shopware-entity-search",
              "shopware-entity-upsert"
            ],
            "enabled": false
          },
          {
            "name": "media",
            "title": "Media tools",
            "description": "Tools explicitly assigned to the \"media\" MCP tool group.",
            "tools": ["shopware-media-upload"],
            "enabled": false
          }
        ]
      },
      "_meta": {
        "taxonomy": "tool-groups",
        "note": "Toolsets are derived from explicit MCP tool group metadata."
      }
    }

After:

    {
      "success": true,
      "data": {
        "toolsets": [
          {
            "name": "entity",
            "title": "Entity tools",
            "tools": [
              { "name": "shopware-entity-aggregate", "title": "Entity Aggregate" },
              { "name": "shopware-entity-delete", "title": "Entity Delete" },
              { "name": "shopware-entity-read", "title": "Entity Read" },
              { "name": "shopware-entity-schema", "title": "Entity Schema" },
              { "name": "shopware-entity-search", "title": "Entity Search" },
              { "name": "shopware-entity-upsert", "title": "Entity Upsert" }
            ],
            "enabled": false
          },
          {
            "name": "media",
            "title": "Media tools",
            "tools": [
              { "name": "shopware-media-upload", "title": "Media Upload" }
            ],
            "enabled": false
          }
        ]
      },
      "_meta": {
        "taxonomy": "tool-groups",
        "note": "Toolsets are derived from explicit MCP tool group metadata."
      }
    }

Then call `shopware-toolset-enable` with `media`. The response echoes the same toolset shape plus `enabled`, and the tools advertised by the following `tools/list` are unchanged.

### 4. Please link to the relevant issues (if any).

Based on `fix/mcp-empty-tool-properties-object`, blocked by #18713.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers
  <!-- Not needed: the MCP module is `@experimental stableVersion:v6.8.0` / `@internal`. -->
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

### 6. Comment

This change needs to be validated with Shopware MCP evals before it gets merged ⚠️ 