### PR TITLE
perf(core): batch existing-accessor lookup in CheapestPriceUpdater

### DIFF
--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -68,6 +68,10 @@ All existing `reason:*` BC-planning annotations in the core have been migrated t
 
 Cron-driven product export generation no longer derives the next run from `generatedAt`, which also anchors the cache validity of the generated feed file. A new `nextGenerationAt` field on the `product_export` entity is set when the first export chunk starts, and the scheduler prefers it over the legacy `generatedAt` + interval calculation. This keeps the schedule anchored to the export start time without making storefront requests treat in-flight exports as stale. The database column is added automatically by a migration; exports generated before the update fall back to the previous `generatedAt`-based scheduling until their next run. No action is required.
 
+### Batched accessor lookup in the cheapest-price indexer
+
+`CheapestPriceUpdater` no longer issues one `SELECT` per parent product to read the existing cheapest-price accessors of its variants. It now pre-loads the accessors for all parents of an indexing chunk in a single query, reducing the number of database round-trips during product (re)indexing and bulk imports. The computed accessors and the resulting `ProductIndexerEvent` are unchanged.
+
 ## Administration
 
 ## Storefront

--- a/RELEASE_INFO-6.7.md
+++ b/RELEASE_INFO-6.7.md
@@ -68,10 +68,6 @@ All existing `reason:*` BC-planning annotations in the core have been migrated t
 
 Cron-driven product export generation no longer derives the next run from `generatedAt`, which also anchors the cache validity of the generated feed file. A new `nextGenerationAt` field on the `product_export` entity is set when the first export chunk starts, and the scheduler prefers it over the legacy `generatedAt` + interval calculation. This keeps the schedule anchored to the export start time without making storefront requests treat in-flight exports as stale. The database column is added automatically by a migration; exports generated before the update fall back to the previous `generatedAt`-based scheduling until their next run. No action is required.
 
-### Batched accessor lookup in the cheapest-price indexer
-
-`CheapestPriceUpdater` no longer issues one `SELECT` per parent product to read the existing cheapest-price accessors of its variants. It now pre-loads the accessors for all parents of an indexing chunk in a single query, reducing the number of database round-trips during product (re)indexing and bulk imports. The computed accessors and the resulting `ProductIndexerEvent` are unchanged.
-
 ## Administration
 
 ## Storefront

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -56,13 +56,11 @@ class CheapestPriceUpdater
         // query, keyed by parent id, instead of issuing one SELECT per parent inside the loop below.
         $existingAccessorsByParent = [];
         if ($all !== []) {
-            $parentIdBytes = array_map(static fn (string $id): string => Uuid::fromHexToBytes($id), array_keys($all));
-
             $rows = $this->connection->fetchAllAssociative(
                 'SELECT LOWER(HEX(`parent_id`)) AS parentId, `id` AS id, `cheapest_price_accessor` AS accessor
                  FROM product
                  WHERE `parent_id` IN (:ids) AND `version_id` = :version',
-                ['ids' => $parentIdBytes, 'version' => $versionId],
+                ['ids' => Uuid::fromHexToBytesList(array_keys($all)), 'version' => $versionId],
                 ['ids' => ArrayParameterType::BINARY]
             );
 

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -52,6 +52,25 @@ class CheapestPriceUpdater
             $this->connection->prepare('UPDATE product SET cheapest_price_accessor = :accessor WHERE id = :id AND version_id = :version')
         );
 
+        // Pre-load the existing cheapest-price accessors of all variants for every parent in a single
+        // query, keyed by parent id, instead of issuing one SELECT per parent inside the loop below.
+        $existingAccessorsByParent = [];
+        if ($all !== []) {
+            $parentIdBytes = array_map(static fn (string $id): string => Uuid::fromHexToBytes($id), array_keys($all));
+
+            $rows = $this->connection->fetchAllAssociative(
+                'SELECT LOWER(HEX(`parent_id`)) AS parentId, `id` AS id, `cheapest_price_accessor` AS accessor
+                 FROM product
+                 WHERE `parent_id` IN (:ids) AND `version_id` = :version',
+                ['ids' => $parentIdBytes, 'version' => $versionId],
+                ['ids' => ArrayParameterType::BINARY]
+            );
+
+            foreach ($rows as $row) {
+                $existingAccessorsByParent[$row['parentId']][$row['id']] = $row['accessor'];
+            }
+        }
+
         $variantIdsUpdated = [];
 
         foreach ($all as $productId => $prices) {
@@ -69,10 +88,7 @@ class CheapestPriceUpdater
                 continue;
             }
 
-            $existingAccessors = $this->connection->fetchAllKeyValue(
-                'SELECT id, cheapest_price_accessor FROM product WHERE parent_id = :id AND version_id = :version',
-                ['id' => Uuid::fromHexToBytes($productId), 'version' => $versionId]
-            );
+            $existingAccessors = $existingAccessorsByParent[$productId] ?? [];
 
             foreach ($container->getVariantIds() as $variantId) {
                 $accessor = Json::encode($this->buildAccessor($container, $variantId));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us process your pull request.

Please make sure to fulfil our contribution guidelines (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be documented?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

`CheapestPriceUpdater::update()` runs during product (re)indexing and bulk imports. For each parent product in the processed chunk it issued a separate `SELECT id, cheapest_price_accessor FROM product WHERE parent_id = ?` to read the existing accessors of that parent's variants (used to skip writes when the accessor is unchanged). With the indexer chunk size of 50, that is up to 50 extra round-trips per indexing message, multiplied across a full reindex / large import.

### 2. What does this change do, exactly?

Pre-loads the existing cheapest-price accessors for **all** parents of the chunk in a single query, grouped by parent id, and looks them up in the loop instead of querying per parent:

```sql
SELECT LOWER(HEX(parent_id)) AS parentId, id, cheapest_price_accessor AS accessor
FROM product
WHERE parent_id IN (:ids) AND version_id = :version
```

The per-variant comparison and the `UPDATE`s are unchanged, the computed accessors are identical, and the dispatched `ProductIndexerEvent` is identical. Only the number of `SELECT`s drops from O(parents) to 1 per chunk.

### 3. Describe each step to reproduce the issue or behaviour.

Internal indexer optimization with no functional change:
1. Trigger a product reindex or a bulk product import with many configurable (parent) products.
2. Observe the query log: previously one accessor `SELECT` per parent, now one per indexing chunk.
3. Resulting `cheapest_price`/`cheapest_price_accessor` values and the emitted `ProductIndexerEvent` are unchanged.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

If the issue exists only in Jira, include a link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

_None._

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
  <!-- Behaviour-preserving optimization. The existing CheapestPriceUpdater unit test confirms compatibility with the changed query path; the existing integration test (tests/integration/.../CheapestPrice/CheapestPriceUpdaterTest) validates the real batched lookup end-to-end in CI. No behavioural change that would fail beforehand. -->
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  <!-- RELEASE_INFO-6.7.md updated (Core). Internal, backwards-compatible; no UPGRADE-6.8.md entry. -->
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them