### PR TITLE
fix: annotate entity seo url classes as internal

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -170,5 +170,9 @@ return [
 
         // parent method has no type. not really a break
         preg_quote('CHANGED: The return type of Shopware\Core\Framework\Migration\Command\RefreshMigrationCommand#configure() changed from void to ', '/'),
+
+        // intended to be internal on release
+        preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntitySeoUrlRouteInterface was marked "@internal"', '/'),
+        preg_quote('CHANGED: Shopware\Core\Content\Seo\SeoUrlRoute\EntityRouteResolver was marked "@internal"', '/'),
     ],
 ];

--- a/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntityRouteResolver.php
@@ -7,6 +7,9 @@ use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Routing\RouterInterface;
 
+/**
+ * @internal
+ */
 #[Package('inventory')]
 class EntityRouteResolver
 {

--- a/src/Core/Content/Seo/SeoUrlRoute/EntitySeoUrlRouteInterface.php
+++ b/src/Core/Content/Seo/SeoUrlRoute/EntitySeoUrlRouteInterface.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Content\Seo\SeoUrlRoute;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @internal
+ */
 #[Package('discovery')]
 interface EntitySeoUrlRouteInterface
 {


### PR DESCRIPTION
### 1. Why is this change necessary?
Classes for the the entity seo url feature should be `@internal`

### 2. What does this change do, exactly?
Annotate the entity seo url feature as `@internal`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- relates #16850

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [ ] I have written or adjusted the documentation and agent skills according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them
