### PR TITLE
refactor(framework): remove unreachable paths guards from StoreApiGenerator

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -342,10 +342,6 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
      */
     private function resolveParameterGroups(array &$specs): void
     {
-        if (!isset($specs['paths']) || !\is_array($specs['paths'])) {
-            return;
-        }
-
         // this is a custom extension that is not supported by the OpenAPI spec
         // it has to be processed and removed before the final output
         $parameterGroups = $specs['components']['x-parameter-groups'] ?? [];
@@ -437,10 +433,6 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
      */
     private function enrichPathsWithAssociations(array &$specs, array $definitions): void
     {
-        if (!isset($specs['paths']) || !\is_array($specs['paths'])) {
-            return;
-        }
-
         // Build a map of entity names to their association documentation
         $associationDocs = [];
         foreach ($definitions as $def) {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php
@@ -712,37 +712,6 @@ class StoreApiGeneratorTest extends TestCase
         static::assertArrayHasKey('infoConfigResponse', $schema['components']['schemas']);
     }
 
-    public function testEnrichPathsWithAssociationsHandlesNonArrayPaths(): void
-    {
-        $reflection = new \ReflectionClass($this->generator);
-        $method = $reflection->getMethod('enrichPathsWithAssociations');
-
-        // Test with non-array paths - should return early without errors
-        $specs = ['paths' => null];
-        $definitions = [];
-
-        // Should not throw an exception when paths is not an array
-        $method->invoke($this->generator, $specs, $definitions);
-
-        // If we get here, the method handled the null value gracefully
-        static::assertArrayHasKey('paths', $specs);
-    }
-
-    public function testEnrichPathsWithAssociationsHandlesMissingPaths(): void
-    {
-        $reflection = new \ReflectionClass($this->generator);
-        $method = $reflection->getMethod('enrichPathsWithAssociations');
-
-        // Test with no paths key
-        $specs = [];
-        $definitions = [];
-
-        $method->invoke($this->generator, $specs, $definitions);
-
-        // Should handle gracefully
-        static::assertArrayNotHasKey('paths', $specs);
-    }
-
     public function testSwLanguageIdHeaderIsInjectedOrKeptWithoutDuplicationPerOperation(): void
     {
         $bundle = new BundleWithPredeclaredSwLanguageId();


### PR DESCRIPTION
### 1. Why is this change necessary?

Unusual: removing some tests due to dead code

The `paths` guards in `StoreApiGenerator` protect against a state its only caller cannot produce, and the two tests covering them needed reflection into the private method to reach them at all.

### 2. What does this change do, exactly?

- Removes the `!isset($specs['paths']) || !\is_array($specs['paths'])` early returns from `resolveParameterGroups()` and `enrichPathsWithAssociations()`. Both run at the tail of `generate()`, which guarantees the invariant twice over: `OpenApiFileLoader` starts every spec from a `'paths' => []` baseline, and `generate()` does `$data['paths'] ??= []` after decoding. `injectLanguageIdHeader()` already iterates `$specs['paths']` unguarded between the two, so a violating state would fatal before either guard was reached. The `OpenApiSpec` type declares `paths` as a non-optional array.
- Deletes the two tests that fed the guard `['paths' => null]` and `[]` via reflection, inputs outside the method's declared parameter type. The observable behaviour, an empty path list surviving the whole pipeline, stays pinned by `testGenerationForABundleWithoutAnyPathDefinitionYieldsAnEmptyPathList`.

Stacked on the framework reflection sweep (#18736), whose rewrite of this test file it builds on; retarget to trunk once that merges.

### 3. Describe each step to reproduce the issue or behaviour.

`docker compose exec web vendor/bin/phpunit tests/unit/Core/Framework/Api/ApiDefinition/Generator/StoreApiGeneratorTest.php` passes. Reverting only the production change leaves the suite green as well, since no reachable input distinguishes the two: that is the unreachability this PR removes.

### 4. Please link to the relevant issues (if any).

relates #18723

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (not applicable: this PR deletes unreachable code and the reflection-only tests bound to it, see section 3)
- [x] I have updated developer-facing release notes if this change is **relevant** for external developers:
  - Add a short entry to `RELEASE_INFO-6.<major>.md` under “Upcoming” for informational changes, including the consequences of the change and how it affects external developers.
  - Add an `UPGRADE` section in `UPGRADE-6.<next-major>.md` for breaking changes (what/why/impact/how to adapt).
  - See the [Documenting a Release Process](https://github.com/shopware/shopware/blob/trunk/delivery-process/documenting-a-release.md) for details.
- [x] I have written or adjusted the documentation and agent skills according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
